### PR TITLE
Ephemeral Anchors

### DIFF
--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -11,7 +11,8 @@ their in-mempool descendants (together, "original transactions") if, in addition
 other consensus and policy rules, each of the following conditions are met:
 
 1. The directly conflicting transactions all signal replaceability explicitly. A transaction is
-   signaling replaceability if any of its inputs have an nSequence number less than (0xffffffff - 1).
+   signaling replaceability if any of its inputs have an nSequence number less than (0xffffffff - 1)
+   or if its nVersion field is set to 3. See [version 3 policies](./version3_transactions.md).
 
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).

--- a/doc/policy/packages.md
+++ b/doc/policy/packages.md
@@ -48,8 +48,13 @@ The following rules are enforced for all packages:
      heavily connected, i.e. some transaction in the package is the ancestor or descendant of all
      the other transactions.
 
-The following rules are only enforced for packages to be submitted to the mempool (not enforced for
-test accepts):
+* [CPFP Carve Out](./mempool-limits.md#CPFP-Carve-Out) is disabled. (#21800)
+
+   - *Rationale*: This carve out cannot be accurately applied when there are multiple transactions'
+     ancestors and descendants being considered at the same time.
+
+The following rules are only enforced for packages to be submitted to the mempool (not
+enforced for test accepts):
 
 * Packages must be child-with-unconfirmed-parents packages. This also means packages must contain at
   least 2 transactions. (#22674)

--- a/doc/policy/version3_transactions.md
+++ b/doc/policy/version3_transactions.md
@@ -1,0 +1,121 @@
+# Transactions with nVersion 3
+
+A transaction with its `nVersion` field set to 3 ("V3 transactions") is allowed in mempool and
+transaction relay, with additional policies described below.
+
+The goal with V3 is to create a policy that is DoS-resistant and makes fee-bumping more robust by
+avoiding specific RBF pinning attacks. Contracting protocols in which transactions are signed by
+untrusted counterparties before broadcast time, e.g. the Lightning Network (LN), may benefit from
+opting in to these policies.
+
+## V3 Rationale: RBF Pinning Attacks
+
+Since contracting transactions are shared between multiple parties and mempool congestion is
+difficult to predict, [RBF policy](./mempool-replacements.md) restrictions may accidentally allow a
+malicious party to "pin" a transaction, making it impossible or difficult to replace.
+
+### "Rule 3" Pinning
+
+Imagine that counterparties Alice (honest) and Mallory (malicious) have conflicting transactions A
+and B, respectively.  RBF rules require the replacement transaction pay a higher absolute fee than
+the aggregate fees paid by all original transactions. This means Mallory may increase the fees
+required to replace B by:
+
+1. Adding transaction(s) that descend from B and pay a feerate too low to fee-bump B through CPFP.
+   For example, assuming the default descendant size limit is 101KvB and B is 1000vB paying a
+feerate of 2sat/vB, adding a 100KvB, 2sat/vB child increases the cost to replace B by 200Ksat.
+
+2. Adding a high-fee descendant of B that also spends from a large, low-feerate mempool transaction,
+   C. The child may pay a very large fee but not actually be fee-bumping B if its overall ancestor
+feerate is still lower than B's individual feerate. For example, assuming the default ancestor size
+limit is 101KvB, B is 1000vB paying 2sat/vB, and C is 99KvB paying 1sat/vB, adding a 1000vB child of
+B and C increases the cost to replace B by 101Ksat.
+
+### "Rule 5" Pinning
+
+RBF rules requires that no replacement trigger the removal of more than 100 transactions. This
+number includes the descendants of the conflicted mempool transactions. Mallory can make it more
+difficult to replace transactions by attaching lots of descendants to them. For example, if Alice
+wants to replace 4 transactions and each one has 25 or more descendants, the replacement will be
+rejected regardless of its fees.
+
+## Version 3 Rules
+
+All existing standardness rules and policies apply to V3. The following set of additional
+rules apply to V3 transactions:
+
+1. A v3 transaction signals replaceability, even if it does not signal BIP125 replaceability. Other
+   conditions apply, see [RBF rules](./mempool-replacements.md) and [Package RBF
+rules][./packages.md#Package-Replace-By-Fee].
+
+2. Any descendant of an unconfirmed V3 transaction must also be V3.
+
+*Rationale*: Combined with Rule 1, this gives us the property of "inherited signaling" when
+descendants of unconfirmed transactions are created. Additionally, checking whether a transaction
+signals replaceability this way does not require mempool traversal, and does not change based on
+what transactions are mined.
+
+*Note*: A V3 transaction can spend outputs from *confirmed* non-V3 transactions.
+
+*Note*: This rule is enforced during reorgs. Transactions violating this rule are removed from the
+mempool.
+
+3. A V3 transaction's unconfirmed ancestors must all be V3.
+
+*Rationale*: Ensure the ancestor feerate rule does not underestimate a to-be-replaced V3 mempool
+transaction's incentive compatibility. Imagine the original transaction, A, has a child B and
+co-parent C (i.e. B spends from A and C). C also has another child, D. B is one of the original
+transactions and thus its ancestor feerate must be lower than the package's. However, this may be an
+underestimation because D can bump C without B's help. This is resolved if V3 transactions can only
+have V3 ancestors, as then C cannot have another child.
+
+*Note*: This rule is enforced during reorgs. Transactions violating this rule are removed from the
+mempool.
+
+4. A V3 transaction cannot have more than 1 unconfirmed descendant.
+
+Also, [CPFP Carve Out](./mempool-limits.md#CPFP-Carve-Out) does not apply to V3 transactions.
+
+*Rationale*: (upper bound) the larger the descendant limit, the more transactions may need to be
+replaced. This is a problematic pinning attack, i.e., a malicious counterparty prevents the
+transaction from being replaced by adding many descendant transactions that aren't fee-bumping.
+See example #1 in ["Rule 3" Pining](#Rule-3-Pinning) section above.
+
+*Rationale*: (lower bound) at least 1 descendant is required to allow CPFP of the presigned
+transaction. The contract protocol can create presigned transactions paying 0 fees and 1 output for
+attaching a CPFP at broadcast time ("anchor output"). Without package RBF, multiple anchor outputs
+would be required to allow each counterparty to fee-bump any presigned transaction. With package
+RBF, since the presigned transactions can replace each other, 1 anchor output is sufficient.
+
+5. A V3 transaction that has an unconfirmed V3 ancestor cannot have a sigop-adjusted virtual size
+   larger than 1000vB.
+
+*Rationale*: (upper bound) the larger the descendant size limit, the more vbytes may need to be
+replaced. With default limits, if the child is e.g. 100,000vB, that might be an additional
+100,000sats (at 1sat/vbyte) or more, depending on the feerate. Restricting all children to 4000Wu
+(at most 1000vB) bounds the potential fees by at least 1/100.
+
+*Rationale*: (lower bound) the smaller this limit, the fewer UTXOs a child may use to fund this
+fee-bump. For example, only allowing the V3 child to have 2 inputs would require L2 protocols to
+manage a wallet with high-value UTXOs and make batched fee-bumping impossible. However, as the
+fee-bumping child only needs to fund fees (as opposed to payments), just a few UTXOs should suffice.
+
+*Rationale*: With a limit of 4000 weight units, depending on the output types, the child can have
+6-15 UTXOs, which should be enough to fund a fee-bump without requiring a carefully-managed UTXO
+pool. With this descendant limit, the cost to replace a V3 transaction has much lower variance.
+
+*Rationale*: This makes the rule very easily "tacked on" to existing logic for policy and wallets.
+A transaction may be up to 100KvB on its own (`MAX_STANDARD_TX_WEIGHT`) and 101KvB with descendants
+(`DEFAULT_DESCENDANT_SIZE_LIMIT_KVB`). If an existing V3 transaction in the mempool is 100KvB, its
+descendant cannot be more than 1000vB, even if the policy is 10KvB.
+
+6. A V3 transaction cannot have more than 1 unconfirmed ancestor.
+
+*Rationale*: Prevent the child of an unconfirmed V3 transaction from "bringing in" more unconfirmed
+ancestors. See example #2 in ["Rule 3" Pining](#Rule-3-Pinning) section above.
+
+7. An individual V3 transaction is permitted to be below the mempool min relay feerate, assuming it
+   is considered within a [package](./packages.md#Package-Feerate) that meets all feerate requirements.
+
+*Rationale*: This allows for contracting protocols that create presigned transactions
+with 0 fees and bump them at broadcast time.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -238,6 +238,7 @@ BITCOIN_CORE_H = \
   node/validation_cache_args.h \
   noui.h \
   outputtype.h \
+  policy/v3_policy.h \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
@@ -439,6 +440,7 @@ libbitcoin_node_a_SOURCES = \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \
   noui.cpp \
+  policy/v3_policy.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
   policy/packages.cpp \
@@ -694,6 +696,7 @@ libbitcoin_common_a_SOURCES = \
   netbase.cpp \
   net_permissions.cpp \
   outputtype.cpp \
+  policy/v3_policy.cpp \
   policy/feerate.cpp \
   policy/policy.cpp \
   protocol.cpp \
@@ -953,6 +956,7 @@ libbitcoinkernel_la_SOURCES = \
   node/blockstorage.cpp \
   node/chainstate.cpp \
   node/utxo_snapshot.cpp \
+  policy/v3_policy.cpp \
   policy/feerate.cpp \
   policy/packages.cpp \
   policy/policy.cpp \

--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -87,10 +87,10 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = tap;
         return true;
     }
-    case TxoutType::WITNESS_UNKNOWN: {
+    case TxoutType::WITNESS_UNKNOWN:
+    case TxoutType::ANCHOR:
         addressRet = WitnessUnknown{vSolutions[0][0], vSolutions[1]};
         return true;
-    }
     case TxoutType::MULTISIG:
     case TxoutType::NULL_DATA:
     case TxoutType::NONSTANDARD:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -620,6 +620,8 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ephemeralanchors", strprintf("Relay transactions with ephemeral anchors (default: %u)", DEFAULT_PERMIT_EA), ArgsManager::ALLOW_ANY,
+                   OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -206,6 +206,9 @@ public:
     //! Check if transaction has descendants in mempool.
     virtual bool hasDescendantsInMempool(const uint256& txid) = 0;
 
+    //! Check if ephemeral anchors are allowed.
+    virtual bool allowsEphemeralAnchors() = 0;
+
     //! Transaction is added to memory pool, if the transaction fee is below the
     //! amount specified by max_tx_fee, and broadcast to all peers if relay is set to true.
     //! Return false if the transaction could not be added due to the fee or for another reason.

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -52,6 +52,7 @@ struct MemPoolOptions {
      */
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
+    bool permit_ephemeral_anchors{DEFAULT_PERMIT_EA};
     bool require_standard{true};
     bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -654,6 +654,12 @@ public:
         if (entry == nullptr) return false;
         return entry->GetCountWithDescendants() > 1;
     }
+    bool allowsEphemeralAnchors() override
+    {
+        if (!m_node.mempool) return false;
+        LOCK(m_node.mempool->cs);
+        return m_node.mempool->m_permit_anchors;
+    }
     bool broadcastTransaction(const CTransactionRef& tx,
         const CAmount& max_tx_fee,
         bool relay,

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -80,6 +80,8 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.permit_bare_multisig = argsman.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
 
+    mempool_opts.permit_ephemeral_anchors = argsman.GetBoolArg("-ephemeralanchors", DEFAULT_PERMIT_EA);
+
     if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
         mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
     } else {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -225,6 +225,11 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         // get the scriptPubKey corresponding to this input:
         CScript prevScript = prev.scriptPubKey;
 
+        // witness stuffing detected
+        if (prevScript.IsPayToAnchor()) {
+            return false;
+        }
+
         bool p2sh = false;
         if (prevScript.IsPayToScriptHash()) {
             std::vector <std::vector<unsigned char> > stack;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -313,6 +313,16 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
+size_t HasPayToAnchor(const CTransaction& tx)
+{
+    for (const CTxOut& txout : tx.vout) {
+        if (txout.scriptPubKey.IsPayToAnchor()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop)
 {
     return (std::max(nWeight, nSigOpCost * bytes_per_sigop) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -131,7 +131,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
 // allowing the new transaction version in the wallet/RPC.
-static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{2};
+static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{3};
 
 /**
 * Check for standard transaction types

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -155,6 +155,11 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 */
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
 
+/**
+* Check if given transaction has a IsPayToAnchor output.
+**/
+size_t HasPayToAnchor(const CTransaction& tx);
+
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);
 int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,8 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
+/** Default for -ephemeralanchors */
+static constexpr bool DEFAULT_PERMIT_EA{true};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */
@@ -137,7 +139,7 @@ static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{3};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, bool permit_ephemeral_anchors, std::string& reason);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -115,11 +115,11 @@ std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx,
 }
 
 std::optional<std::string> EntriesAndTxidsDisjoint(const CTxMemPool::setEntries& ancestors,
-                                                   const std::set<uint256>& direct_conflicts,
+                                                   const std::set<Txid>& direct_conflicts,
                                                    const uint256& txid)
 {
     for (CTxMemPool::txiter ancestorIt : ancestors) {
-        const uint256& hashAncestor = ancestorIt->GetTx().GetHash();
+        const Txid& hashAncestor = ancestorIt->GetTx().GetHash();
         if (direct_conflicts.count(hashAncestor)) {
             return strprintf("%s spends conflicting transaction %s",
                              txid.ToString(),

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -181,3 +181,36 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
     }
     return std::nullopt;
 }
+
+std::optional<std::string> CheckMinerScores(CAmount replacement_fees,
+                                            int64_t replacement_vsize,
+                                            const CTxMemPool::setEntries& direct_conflicts,
+                                            const CTxMemPool::setEntries& original_transactions)
+{
+        // Note that this assumes no in-mempool ancestors
+        const CFeeRate replacement_miner_score(replacement_fees, replacement_vsize);
+
+        for (const auto& entry : direct_conflicts) {
+            const bool conflict_is_v3{entry->GetSharedTx()->nVersion == 3};
+            CFeeRate original_score(entry->GetModifiedFee(), entry->GetTxSize());
+            // If the original transaction is v3, we can calculate the exact miner score and avoid overestimating.
+            if (conflict_is_v3) {
+                original_score = std::min(original_score, CFeeRate(entry->GetModFeesWithAncestors(), entry->GetSizeWithAncestors()));
+            }
+            if (replacement_miner_score < original_score) {
+                return strprintf("replacement miner score lower than %s miner score of direct conflict; %s < %s",
+                                 conflict_is_v3 ? "calculated" : "estimated",
+                                 replacement_miner_score.ToString(),
+                                 original_score.ToString());
+            }
+        }
+        for (const auto& entry : original_transactions) {
+            const CFeeRate original_ancestor_feerate(entry->GetModFeesWithAncestors(), entry->GetSizeWithAncestors());
+            if (replacement_miner_score < original_ancestor_feerate) {
+                return strprintf("replacement miner score lower than ancestor feerate of original tx; %s < %s",
+                                 replacement_miner_score.ToString(),
+                                 original_ancestor_feerate.ToString());
+            }
+        }
+        return std::nullopt;
+}

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -80,7 +80,7 @@ std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx, const CTx
  * @returns error message if the sets intersect, std::nullopt if they are disjoint.
  */
 std::optional<std::string> EntriesAndTxidsDisjoint(const CTxMemPool::setEntries& ancestors,
-                                                   const std::set<uint256>& direct_conflicts,
+                                                   const std::set<Txid>& direct_conflicts,
                                                    const uint256& txid);
 
 /** Check that the feerate of the replacement transaction(s) is higher than the feerate of each

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -106,4 +106,15 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
                                       CFeeRate relay_fee,
                                       const uint256& txid);
 
+/** Attempt to ensure replacement transactions are more incentive compatible to mine than the
+ * transactions they are replacing. Currently, this function requires that feerate
+ * of the replacement transaction(s) be higher than the individual feerates of
+ * all directly conflicting transactions and the ancestor feerates of all original transactions.
+ * If the direct conflict is v3, we calculate the miner score instead.
+ * */
+std::optional<std::string> CheckMinerScores(CAmount replacement_fees,
+                                            int64_t replacement_vsize,
+                                            const CTxMemPool::setEntries& direct_conflicts,
+                                            const CTxMemPool::setEntries& original_transactions);
+
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/policy/v3_policy.cpp
+++ b/src/policy/v3_policy.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/v3_policy.h>
+
+#include <coins.h>
+#include <consensus/amount.h>
+#include <logging.h>
+#include <tinyformat.h>
+
+#include <numeric>
+#include <vector>
+
+std::optional<std::tuple<Wtxid, Wtxid, bool>> CheckV3Inheritance(const Package& package)
+{
+    assert(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}));
+    // If all transactions are V3, we can stop here.
+    if (std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx->nVersion == 3;})) {
+        return std::nullopt;
+    }
+    // If all transactions are non-V3, we can stop here.
+    if (std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx->nVersion != 3;})) {
+        return std::nullopt;
+    }
+    // Look for a V3 transaction spending a non-V3 or vice versa.
+    std::unordered_map<Txid, Wtxid, SaltedTxidHasher> v3_txid_to_wtxid;
+    std::unordered_map<Txid, Wtxid, SaltedTxidHasher> non_v3_txid_to_wtxid;
+    for (const auto& tx : package) {
+        if (tx->nVersion == 3) {
+            v3_txid_to_wtxid.emplace(tx->GetHash(), tx->GetWitnessHash());
+        } else {
+            non_v3_txid_to_wtxid.emplace(tx->GetHash(), tx->GetWitnessHash());
+        }
+    }
+    for (const auto& tx : package) {
+        if (tx->nVersion == 3) {
+            for (const auto& input : tx->vin) {
+                if (auto it = non_v3_txid_to_wtxid.find(input.prevout.hash); it != non_v3_txid_to_wtxid.end()) {
+                    return std::make_tuple(it->second, tx->GetWitnessHash(), true);
+                }
+            }
+        } else {
+            for (const auto& input : tx->vin) {
+                if (auto it = v3_txid_to_wtxid.find(input.prevout.hash); it != v3_txid_to_wtxid.end()) {
+                    return std::make_tuple(it->second, tx->GetWitnessHash(), false);
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> CheckV3Inheritance(const CTransactionRef& ptx,
+                                              const CTxMemPool::setEntries& ancestors)
+{
+    for (const auto& entry : ancestors) {
+        if (ptx->nVersion != 3 && entry->GetTx().nVersion == 3) {
+            return strprintf("tx that spends from %s must be nVersion=3",
+                             entry->GetTx().GetWitnessHash().ToString());
+        } else if (ptx->nVersion == 3 && entry->GetTx().nVersion != 3) {
+            return strprintf("v3 tx cannot spend from %s which is not nVersion=3",
+                             entry->GetTx().GetWitnessHash().ToString());
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> ApplyV3Rules(const CTransactionRef& ptx,
+                                        const CTxMemPool::setEntries& ancestors,
+                                        const std::set<Txid>& direct_conflicts,
+                                        int64_t vsize)
+{
+    // This function is specialized for these limits, and must be reimplemented if they ever change.
+    static_assert(V3_ANCESTOR_LIMIT == 2);
+    static_assert(V3_DESCENDANT_LIMIT == 2);
+
+    // These rules only apply to transactions with nVersion=3.
+    if (ptx->nVersion != 3) return std::nullopt;
+
+    if (ancestors.size() + 1 > V3_ANCESTOR_LIMIT) {
+        return strprintf("tx %s would have too many ancestors", ptx->GetWitnessHash().ToString());
+    }
+    if (ancestors.empty()) {
+        return std::nullopt;
+    }
+    // If this transaction spends V3 parents, it cannot be too large.
+    if (vsize > V3_CHILD_MAX_VSIZE) {
+        return strprintf("v3 child tx is too big: %u > %u virtual bytes", vsize, V3_CHILD_MAX_VSIZE);
+    }
+    // Any ancestor of a V3 transaction must also be V3.
+    const auto& parent_entry = *ancestors.begin();
+    if (parent_entry->GetTx().nVersion != 3) {
+        return strprintf("v3 tx cannot spend from %s which is not nVersion=3",
+                         parent_entry->GetTx().GetWitnessHash().ToString());
+    }
+    // If there are any ancestors, this is the only child allowed. The parent cannot have any
+    // other descendants.
+    const auto& children = parent_entry->GetMemPoolChildrenConst();
+    // Don't double-count a transaction that is going to be replaced. This logic assumes that
+    // any descendant of the V3 transaction is a direct child, which makes sense because a V3
+    // transaction can only have 1 descendant.
+    const bool child_will_be_replaced = !children.empty() &&
+        std::any_of(children.cbegin(), children.cend(),
+            [&direct_conflicts](const CTxMemPoolEntry& child){return direct_conflicts.count(child.GetTx().GetHash()) > 0;});
+    if (parent_entry->GetCountWithDescendants() + 1 > V3_DESCENDANT_LIMIT && !child_will_be_replaced) {
+        return strprintf("tx %u would exceed descendant count limit", parent_entry->GetTx().GetHash().ToString());
+    }
+    return std::nullopt;
+}

--- a/src/policy/v3_policy.cpp
+++ b/src/policy/v3_policy.cpp
@@ -88,6 +88,66 @@ bool CheckValidEphemeralTx(const CTransaction& tx, TxValidationState& state, CAm
     return true;
 }
 
+std::optional<uint256> CheckEphemeralSpends(const Package& package)
+{
+    assert(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}));
+
+    // Only size one or two are possible to violate ephemeral spend checks
+    if (package.empty() || package.size() > V3_ANCESTOR_LIMIT) {
+        return std::nullopt;
+    }
+    static_assert(V3_ANCESTOR_LIMIT == 2, "value of V3_ANCESTOR_LIMIT changed");
+
+    const auto& parent = package.front();
+
+    for (uint32_t i=0; i<parent->vout.size(); i++) {
+        // Once we find an anchor, it must be spent by child
+        if (parent->vout[i].scriptPubKey.IsPayToAnchor()) {
+            if (package.size() == V3_ANCESTOR_LIMIT) {
+                for (const auto& child_input : package.back()->vin) {
+                    if (child_input.prevout == COutPoint(parent->GetHash(), i)) {
+                        return std::nullopt;
+                    }
+                }
+            }
+            return parent->GetWitnessHash();
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> CheckEphemeralSpends(const CTransactionRef& ptx,
+                                                const CTxMemPool::setEntries& ancestors)
+{
+    /* Ephemeral anchors are disallowed already, no need to check */
+    if (ptx->nVersion != 3) {
+        return std::nullopt;
+    }
+
+    std::unordered_set<COutPoint, SaltedOutpointHasher> unspent_ephemeral_outputs;
+
+    // Note that all ancestors are direct parents due to V3
+    for (const auto& entry : ancestors) {
+        const auto& tx = entry->GetTx();
+        for (uint32_t i=0; i<tx.vout.size(); i++) {
+            if (tx.vout[i].scriptPubKey.IsPayToAnchor()) {
+                unspent_ephemeral_outputs.insert(COutPoint(tx.GetHash(), i));
+            }
+        }
+    }
+
+    for (const auto& input : ptx->vin) {
+        unspent_ephemeral_outputs.erase(input.prevout);
+    }
+
+    if (!unspent_ephemeral_outputs.empty()) {
+        return strprintf("tx does not spend all parent ephemeral anchors");
+    }
+
+    return std::nullopt;
+}
+
 std::optional<std::string> ApplyV3Rules(const CTransactionRef& ptx,
                                         const CTxMemPool::setEntries& ancestors,
                                         const std::set<Txid>& direct_conflicts,

--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -48,6 +48,13 @@ bool CheckValidEphemeralTx(const CTransaction& tx,
                            CAmount& txfee,
                            bool package_context);
 
+/** Any V3 transaction package must have all ephemeral anchors spent by the child since the child is alone. */
+std::optional<uint256> CheckEphemeralSpends(const Package& package);
+
+/** Any V3 transaction must spend all in-mempool parent's ephemeral anchors since the child is alone.  */
+std::optional<std::string> CheckEphemeralSpends(const CTransactionRef& ptx,
+                                                const CTxMemPool::setEntries& ancestors);
+
 /** The following rules apply to V3 transactions:
  * 1. Tx with all of its ancestors must be within V3_ANCESTOR_SIZE_LIMIT_KVB.
  * 2. Tx with all of its ancestors must be within V3_ANCESTOR_LIMIT.

--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_V3_POLICY_H
+#define BITCOIN_POLICY_V3_POLICY_H
+
+#include <consensus/amount.h>
+#include <policy/packages.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <txmempool.h>
+
+#include <string>
+
+// This module enforces rules for transactions with nVersion=3 ("V3 transactions") which help make
+// RBF abilities more robust.
+
+// V3 only allows 1 parent and 1 child.
+/** Maximum number of transactions including an unconfirmed tx and its descendants. */
+static constexpr unsigned int V3_DESCENDANT_LIMIT{2};
+/** Maximum number of transactions including a V3 tx and all its mempool ancestors. */
+static constexpr unsigned int V3_ANCESTOR_LIMIT{2};
+
+/** Maximum sigop-adjusted virtual size of a tx which spends from an unconfirmed v3 transaction. */
+static constexpr int64_t V3_CHILD_MAX_VSIZE{1000};
+// Since these limits are within the default ancestor/descendant limits, there is no need to
+// additionally check ancestor/descendant limits for V3 transactions.
+static_assert(V3_CHILD_MAX_VSIZE + MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR <= DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * 1000);
+static_assert(V3_CHILD_MAX_VSIZE + MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR <= DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * 1000);
+
+/** Any two unconfirmed transactions with a dependency relationship must either both be V3 or both
+ * non-V3. Check this rule for any list of unconfirmed transactions.
+ * @returns a tuple (parent wtxid, child wtxid, bool) where one is V3 but the other is not, if at
+ * least one such pair exists. The bool represents whether the child is v3 or not. There may be
+ * other such pairs that are not returned.
+ * Otherwise std::nullopt.
+ */
+std::optional<std::tuple<Wtxid, Wtxid, bool>> CheckV3Inheritance(const Package& package);
+
+/** Every transaction that spends an unconfirmed V3 transaction must also be V3. */
+std::optional<std::string> CheckV3Inheritance(const CTransactionRef& ptx,
+                                              const CTxMemPool::setEntries& ancestors);
+
+/** The following rules apply to V3 transactions:
+ * 1. Tx with all of its ancestors must be within V3_ANCESTOR_SIZE_LIMIT_KVB.
+ * 2. Tx with all of its ancestors must be within V3_ANCESTOR_LIMIT.
+ *
+ * If a V3 tx has V3 ancestors,
+ * 1. Each V3 ancestor and its descendants must be within V3_DESCENDANT_LIMIT.
+ * 2. The tx vsize must be within V3_CHILD_MAX_VSIZE.
+ *
+ * @returns an error string if any V3 rule was violated, otherwise std::nullopt.
+ */
+std::optional<std::string> ApplyV3Rules(const CTransactionRef& ptx,
+                                        const CTxMemPool::setEntries& ancestors,
+                                        const std::set<Txid>& direct_conflicts,
+                                        int64_t vsize);
+
+#endif // BITCOIN_POLICY_V3_POLICY_H

--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -42,6 +42,12 @@ std::optional<std::tuple<Wtxid, Wtxid, bool>> CheckV3Inheritance(const Package& 
 std::optional<std::string> CheckV3Inheritance(const CTransactionRef& ptx,
                                               const CTxMemPool::setEntries& ancestors);
 
+/** If the tx has an ephemeral anchor, do the package context-less checks */
+bool CheckValidEphemeralTx(const CTransaction& tx,
+                           TxValidationState& state,
+                           CAmount& txfee,
+                           bool package_context);
+
 /** The following rules apply to V3 transactions:
  * 1. Tx with all of its ancestors must be within V3_ANCESTOR_SIZE_LIMIT_KVB.
  * 2. Tx with all of its ancestors must be within V3_ANCESTOR_LIMIT.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -163,6 +163,11 @@ static std::vector<RPCArg> CreateTxDoc()
                         {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A key-value pair. The key must be \"data\", the value is hex-encoded data"},
                     },
                 },
+                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {
+                        {"anchor", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Creates an ephemeral anchor. A key-value pair. The key must be \"anchor\", the value is the amount in " + CURRENCY_UNIT},
+                    },
+                },
             },
          RPCArgOptions{.skip_type_check = true}},
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -558,6 +558,7 @@ static RPCHelpMan decodescript()
         case TxoutType::SCRIPTHASH:
         case TxoutType::WITNESS_UNKNOWN:
         case TxoutType::WITNESS_V1_TAPROOT:
+        case TxoutType::ANCHOR:
             // Should not be wrapped
             return false;
         } // no default case, so the compiler can warn about missing cases
@@ -600,6 +601,7 @@ static RPCHelpMan decodescript()
             case TxoutType::WITNESS_V0_KEYHASH:
             case TxoutType::WITNESS_V0_SCRIPTHASH:
             case TxoutType::WITNESS_V1_TAPROOT:
+            case TxoutType::ANCHOR:
                 // Should not be wrapped
                 return false;
             } // no default case, so the compiler can warn about missing cases

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1943,6 +1943,9 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             }
             return set_success(serror);
         }
+    } else if (witversion == 1 && program.size() == 2 && program[0] == 0x4e && program[1] == 0x73) {
+        // Ephemeral anchor
+        return true;
     } else {
         if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM) {
             return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -204,6 +204,15 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     return subscript.GetSigOpCount(true);
 }
 
+bool CScript::IsPayToAnchor() const
+{
+    return (this->size() == 4 &&
+        (*this)[0] == OP_TRUE &&
+        (*this)[1] == 0x02 &&
+        (*this)[2] == 0x4e &&
+        (*this)[3] == 0x73);
+}
+
 bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -533,6 +533,11 @@ public:
      */
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
+    /*
+     * OP_TRUE <0x4e73>
+     */
+    bool IsPayToAnchor() const;
+
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -412,6 +412,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TxoutType::NONSTANDARD:
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
+    case TxoutType::ANCHOR:
         return false;
     case TxoutType::PUBKEY:
         if (!CreateSig(creator, sigdata, provider, sig, CPubKey(vSolutions[0]), scriptPubKey, sigversion)) return false;

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -24,6 +24,7 @@ std::string GetTxnOutputType(TxoutType t)
     case TxoutType::SCRIPTHASH: return "scripthash";
     case TxoutType::MULTISIG: return "multisig";
     case TxoutType::NULL_DATA: return "nulldata";
+    case TxoutType::ANCHOR: return "anchor";
     case TxoutType::WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
     case TxoutType::WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
     case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
@@ -164,6 +165,11 @@ TxoutType Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned c
         if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE) {
             vSolutionsRet.push_back(std::move(witnessprogram));
             return TxoutType::WITNESS_V1_TAPROOT;
+        }
+        if (scriptPubKey.IsPayToAnchor()) {
+            vSolutionsRet.push_back(std::vector<unsigned char>{(unsigned char)witnessversion});
+            vSolutionsRet.push_back(std::move(witnessprogram));
+            return TxoutType::ANCHOR;
         }
         if (witnessversion != 0) {
             vSolutionsRet.push_back(std::vector<unsigned char>{(unsigned char)witnessversion});

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -22,6 +22,7 @@ template <typename C> class Span;
 enum class TxoutType {
     NONSTANDARD,
     // 'standard' transaction types:
+    ANCHOR, //!< anyonecanspendable script
     PUBKEY,
     PUBKEYHASH,
     SCRIPTHASH,

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -6,6 +6,7 @@
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
+#include <policy/v3_policy.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -171,7 +172,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
             // Create transaction to add to the mempool
             const CTransactionRef tx = [&] {
                 CMutableTransaction tx_mut;
-                tx_mut.nVersion = CTransaction::CURRENT_VERSION;
+                tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ? CTransaction::CURRENT_VERSION : 3;
                 tx_mut.nLockTime = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<uint32_t>();
                 // Last tx will sweep all outpoints in package
                 const auto num_in = last_tx ? package_outpoints.size()  : fuzzed_data_provider.ConsumeIntegralInRange<int>(1, mempool_outpoints.size());
@@ -261,7 +262,6 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
         std::set<CTransactionRef> added;
         auto txr = std::make_shared<TransactionsDelta>(added);
         RegisterSharedValidationInterface(txr);
-        const bool bypass_limits = fuzzed_data_provider.ConsumeBool();
 
         // When there are multiple transactions in the package, we call ProcessNewPackage(txs, test_accept=false)
         // and AcceptToMemoryPool(txs.back(), test_accept=true). When there is only 1 transaction, we might flip it
@@ -271,7 +271,10 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
         const auto result_package = WITH_LOCK(::cs_main,
                                     return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit));
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(), bypass_limits, /*test_accept=*/!single_submit));
+        // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
+        // can be a source of divergence.
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+                                   /*bypass_limits=*/false, /*test_accept=*/!single_submit));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
 
         SyncWithValidationInterfaceQueue();
@@ -300,5 +303,21 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
     UnregisterSharedValidationInterface(outpoints_updater);
 
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
+    LOCK(tx_pool.cs);
+    for (const auto& tx_info : tx_pool.infoAll()) {
+        const auto& entry = *Assert(tx_pool.GetEntry(tx_info.tx->GetHash()));
+        if (tx_info.tx->nVersion == 3) {
+            // Check that special v3 ancestor/descendant limits and rules are always respected
+            Assert(entry.GetCountWithDescendants() <= V3_DESCENDANT_LIMIT);
+            Assert(entry.GetCountWithAncestors() <= V3_ANCESTOR_LIMIT);
+            if (entry.GetCountWithAncestors() > 1) {
+                Assert(entry.GetTxSize() <= V3_CHILD_MAX_VSIZE);
+            }
+        }
+        // Transactions with fees of 0 or lower should be proactively trimmed.
+        if (tx_pool.m_min_relay_feerate.GetFeePerK() > 0) {
+            Assert(entry.GetModFeesWithDescendants() > 0);
+        }
+    }
 }
 } // namespace

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -76,11 +76,13 @@ FUZZ_TARGET(script, .init = initialize_script)
         assert(which_type == TxoutType::PUBKEY ||
                which_type == TxoutType::NONSTANDARD ||
                which_type == TxoutType::NULL_DATA ||
-               which_type == TxoutType::MULTISIG);
+               which_type == TxoutType::MULTISIG ||
+               which_type == TxoutType::ANCHOR);
     }
     if (which_type == TxoutType::NONSTANDARD ||
         which_type == TxoutType::NULL_DATA ||
-        which_type == TxoutType::MULTISIG) {
+        which_type == TxoutType::MULTISIG ||
+        which_type == TxoutType::ANCHOR) {
         assert(!extract_destination_ret);
     }
 
@@ -94,6 +96,7 @@ FUZZ_TARGET(script, .init = initialize_script)
     (void)Solver(script, solutions);
 
     (void)script.HasValidOps();
+    (void)script.IsPayToAnchor();
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -59,8 +59,8 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, /* permit_ephemeral_anchors= */ true, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, /* permit_ephemeral_anchors= */ true, reason);
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -135,8 +135,6 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     // Tests for EntriesAndTxidsDisjoint
     BOOST_CHECK(EntriesAndTxidsDisjoint(empty_set, {tx1->GetHash()}, unused_txid) == std::nullopt);
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx3->GetHash()}, unused_txid) == std::nullopt);
-    // EntriesAndTxidsDisjoint uses txids, not wtxids.
-    BOOST_CHECK(EntriesAndTxidsDisjoint({entry2}, {tx2->GetWitnessHash()}, unused_txid) == std::nullopt);
     BOOST_CHECK(EntriesAndTxidsDisjoint({entry2}, {tx2->GetHash()}, unused_txid).has_value());
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx1->GetHash()}, unused_txid).has_value());
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx2->GetHash()}, unused_txid).has_value());

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -110,6 +110,7 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     CTxMemPool::setEntries set_12_normal{entry1_normal, entry2_normal};
     CTxMemPool::setEntries set_34_cpfp{entry3_low, entry4_high};
     CTxMemPool::setEntries set_56_low{entry5_low, entry6_low_prioritised};
+    CTxMemPool::setEntries set_78_high{entry7_high, entry8_high};
     CTxMemPool::setEntries all_entries{entry1_normal, entry2_normal, entry3_low, entry4_high,
                                        entry5_low, entry6_low_prioritised, entry7_high, entry8_high};
     CTxMemPool::setEntries empty_set;
@@ -225,6 +226,36 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
 
     const auto spends_conflicting_confirmed = make_tx({m_coinbase_txns[0], m_coinbase_txns[1]}, {45 * CENT});
     BOOST_CHECK(HasNoNewUnconfirmed(*spends_conflicting_confirmed.get(), pool, {entry1_normal, entry3_low}) == std::nullopt);
+
+    // Tests for CheckMinerScores
+
+    // These tests use modified fees (including prioritisation), not base fees.
+    BOOST_CHECK(CheckMinerScores(entry5_low->GetFee() + entry6_low_prioritised->GetFee() + 1,
+                                 entry5_low->GetTxSize() + entry6_low_prioritised->GetTxSize(),
+                                 {entry5_low},
+                                 set_56_low).has_value());
+    BOOST_CHECK(CheckMinerScores(entry5_low->GetModifiedFee() + entry6_low_prioritised->GetModifiedFee() + 1,
+                                 entry5_low->GetTxSize() + entry6_low_prioritised->GetTxSize(),
+                                 {entry5_low},
+                                 set_56_low) == std::nullopt);
+
+    // High-feerate ancestors don't help raise the replacement's miner score.
+    BOOST_CHECK(CheckMinerScores(entry1_normal->GetFee() - 1,
+                                 entry1_normal->GetTxSize(),
+                                 set_12_normal,
+                                 set_12_normal).has_value());
+
+    // Replacement must be higher than the individual feerate of direct conflicts.
+    // Note entry4_high's individual feerate is higher than its ancestor feerate
+    BOOST_CHECK(CheckMinerScores(entry4_high->GetFee() - 1,
+                                 entry4_high->GetTxSize(),
+                                 {entry4_high},
+                                 {entry4_high}).has_value());
+
+    BOOST_CHECK(CheckMinerScores(entry4_high->GetFee() - 1,
+                                 entry4_high->GetTxSize(),
+                                 {entry3_low},
+                                 set_34_cpfp) == std::nullopt);
 
 }
 

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -89,28 +89,29 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     const auto tx8 = make_tx(/*inputs=*/ {m_coinbase_txns[4]}, /*output_values=*/ {999 * CENT});
     pool.addUnchecked(entry.Fee(high_fee).FromTx(tx8));
 
-    const auto entry1 = pool.GetIter(tx1->GetHash()).value();
-    const auto entry2 = pool.GetIter(tx2->GetHash()).value();
-    const auto entry3 = pool.GetIter(tx3->GetHash()).value();
-    const auto entry4 = pool.GetIter(tx4->GetHash()).value();
-    const auto entry5 = pool.GetIter(tx5->GetHash()).value();
-    const auto entry6 = pool.GetIter(tx6->GetHash()).value();
-    const auto entry7 = pool.GetIter(tx7->GetHash()).value();
-    const auto entry8 = pool.GetIter(tx8->GetHash()).value();
+    const auto entry1_normal = pool.GetIter(tx1->GetHash()).value();
+    const auto entry2_normal = pool.GetIter(tx2->GetHash()).value();
+    const auto entry3_low = pool.GetIter(tx3->GetHash()).value();
+    const auto entry4_high = pool.GetIter(tx4->GetHash()).value();
+    const auto entry5_low = pool.GetIter(tx5->GetHash()).value();
+    const auto entry6_low_prioritised = pool.GetIter(tx6->GetHash()).value();
+    const auto entry7_high = pool.GetIter(tx7->GetHash()).value();
+    const auto entry8_high = pool.GetIter(tx8->GetHash()).value();
 
-    BOOST_CHECK_EQUAL(entry1->GetFee(), normal_fee);
-    BOOST_CHECK_EQUAL(entry2->GetFee(), normal_fee);
-    BOOST_CHECK_EQUAL(entry3->GetFee(), low_fee);
-    BOOST_CHECK_EQUAL(entry4->GetFee(), high_fee);
-    BOOST_CHECK_EQUAL(entry5->GetFee(), low_fee);
-    BOOST_CHECK_EQUAL(entry6->GetFee(), low_fee);
-    BOOST_CHECK_EQUAL(entry7->GetFee(), high_fee);
-    BOOST_CHECK_EQUAL(entry8->GetFee(), high_fee);
+    BOOST_CHECK_EQUAL(entry1_normal->GetFee(), normal_fee);
+    BOOST_CHECK_EQUAL(entry2_normal->GetFee(), normal_fee);
+    BOOST_CHECK_EQUAL(entry3_low->GetFee(), low_fee);
+    BOOST_CHECK_EQUAL(entry4_high->GetFee(), high_fee);
+    BOOST_CHECK_EQUAL(entry5_low->GetFee(), low_fee);
+    BOOST_CHECK_EQUAL(entry6_low_prioritised->GetFee(), low_fee);
+    BOOST_CHECK_EQUAL(entry7_high->GetFee(), high_fee);
+    BOOST_CHECK_EQUAL(entry8_high->GetFee(), high_fee);
 
-    CTxMemPool::setEntries set_12_normal{entry1, entry2};
-    CTxMemPool::setEntries set_34_cpfp{entry3, entry4};
-    CTxMemPool::setEntries set_56_low{entry5, entry6};
-    CTxMemPool::setEntries all_entries{entry1, entry2, entry3, entry4, entry5, entry6, entry7, entry8};
+    CTxMemPool::setEntries set_12_normal{entry1_normal, entry2_normal};
+    CTxMemPool::setEntries set_34_cpfp{entry3_low, entry4_high};
+    CTxMemPool::setEntries set_56_low{entry5_low, entry6_low_prioritised};
+    CTxMemPool::setEntries all_entries{entry1_normal, entry2_normal, entry3_low, entry4_high,
+                                       entry5_low, entry6_low_prioritised, entry7_high, entry8_high};
     CTxMemPool::setEntries empty_set;
 
     const auto unused_txid{GetRandHash()};
@@ -118,29 +119,29 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     // Tests for PaysMoreThanConflicts
     // These tests use feerate, not absolute fee.
     BOOST_CHECK(PaysMoreThanConflicts(/*iters_conflicting=*/set_12_normal,
-                                      /*replacement_feerate=*/CFeeRate(entry1->GetModifiedFee() + 1, entry1->GetTxSize() + 2),
+                                      /*replacement_feerate=*/CFeeRate(entry1_normal->GetModifiedFee() + 1, entry1_normal->GetTxSize() + 2),
                                       /*txid=*/unused_txid).has_value());
     // Replacement must be strictly greater than the originals.
-    BOOST_CHECK(PaysMoreThanConflicts(set_12_normal, CFeeRate(entry1->GetModifiedFee(), entry1->GetTxSize()), unused_txid).has_value());
-    BOOST_CHECK(PaysMoreThanConflicts(set_12_normal, CFeeRate(entry1->GetModifiedFee() + 1, entry1->GetTxSize()), unused_txid) == std::nullopt);
+    BOOST_CHECK(PaysMoreThanConflicts(set_12_normal, CFeeRate(entry1_normal->GetModifiedFee(), entry1_normal->GetTxSize()), unused_txid).has_value());
+    BOOST_CHECK(PaysMoreThanConflicts(set_12_normal, CFeeRate(entry1_normal->GetModifiedFee() + 1, entry1_normal->GetTxSize()), unused_txid) == std::nullopt);
     // These tests use modified fees (including prioritisation), not base fees.
-    BOOST_CHECK(PaysMoreThanConflicts({entry5}, CFeeRate(entry5->GetModifiedFee() + 1, entry5->GetTxSize()), unused_txid) == std::nullopt);
-    BOOST_CHECK(PaysMoreThanConflicts({entry6}, CFeeRate(entry6->GetFee() + 1, entry6->GetTxSize()), unused_txid).has_value());
-    BOOST_CHECK(PaysMoreThanConflicts({entry6}, CFeeRate(entry6->GetModifiedFee() + 1, entry6->GetTxSize()), unused_txid) == std::nullopt);
+    BOOST_CHECK(PaysMoreThanConflicts({entry5_low}, CFeeRate(entry5_low->GetModifiedFee() + 1, entry5_low->GetTxSize()), unused_txid) == std::nullopt);
+    BOOST_CHECK(PaysMoreThanConflicts({entry6_low_prioritised}, CFeeRate(entry6_low_prioritised->GetFee() + 1, entry6_low_prioritised->GetTxSize()), unused_txid).has_value());
+    BOOST_CHECK(PaysMoreThanConflicts({entry6_low_prioritised}, CFeeRate(entry6_low_prioritised->GetModifiedFee() + 1, entry6_low_prioritised->GetTxSize()), unused_txid) == std::nullopt);
     // PaysMoreThanConflicts checks individual feerate, not ancestor feerate. This test compares
-    // replacement_feerate and entry4's feerate, which are the same. The replacement_feerate is
-    // considered too low even though entry4 has a low ancestor feerate.
-    BOOST_CHECK(PaysMoreThanConflicts(set_34_cpfp, CFeeRate(entry4->GetModifiedFee(), entry4->GetTxSize()), unused_txid).has_value());
+    // replacement_feerate and entry4_high's feerate, which are the same. The replacement_feerate is
+    // considered too low even though entry4_high has a low ancestor feerate.
+    BOOST_CHECK(PaysMoreThanConflicts(set_34_cpfp, CFeeRate(entry4_high->GetModifiedFee(), entry4_high->GetTxSize()), unused_txid).has_value());
 
     // Tests for EntriesAndTxidsDisjoint
     BOOST_CHECK(EntriesAndTxidsDisjoint(empty_set, {tx1->GetHash()}, unused_txid) == std::nullopt);
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx3->GetHash()}, unused_txid) == std::nullopt);
-    BOOST_CHECK(EntriesAndTxidsDisjoint({entry2}, {tx2->GetHash()}, unused_txid).has_value());
+    BOOST_CHECK(EntriesAndTxidsDisjoint({entry2_normal}, {tx2->GetHash()}, unused_txid).has_value());
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx1->GetHash()}, unused_txid).has_value());
     BOOST_CHECK(EntriesAndTxidsDisjoint(set_12_normal, {tx2->GetHash()}, unused_txid).has_value());
     // EntriesAndTxidsDisjoint does not calculate descendants of iters_conflicting; it uses whatever
-    // the caller passed in. As such, no error is returned even though entry2 is a descendant of tx1.
-    BOOST_CHECK(EntriesAndTxidsDisjoint({entry2}, {tx1->GetHash()}, unused_txid) == std::nullopt);
+    // the caller passed in. As such, no error is returned even though entry2_normal is a descendant of tx1.
+    BOOST_CHECK(EntriesAndTxidsDisjoint({entry2_normal}, {tx1->GetHash()}, unused_txid) == std::nullopt);
 
     // Tests for PaysForRBF
     const CFeeRate incremental_relay_feerate{DEFAULT_INCREMENTAL_RELAY_FEE};
@@ -163,8 +164,8 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     BOOST_CHECK(PaysForRBF(low_fee, high_fee + 99999999, 99999999, incremental_relay_feerate, unused_txid) == std::nullopt);
 
     // Tests for GetEntriesForConflicts
-    CTxMemPool::setEntries all_parents{entry1, entry3, entry5, entry7, entry8};
-    CTxMemPool::setEntries all_children{entry2, entry4, entry6};
+    CTxMemPool::setEntries all_parents{entry1_normal, entry3_low, entry5_low, entry7_high, entry8_high};
+    CTxMemPool::setEntries all_children{entry2_normal, entry4_high, entry6_low_prioritised};
     const std::vector<CTransactionRef> parent_inputs({m_coinbase_txns[0], m_coinbase_txns[1], m_coinbase_txns[2],
                                                 m_coinbase_txns[3], m_coinbase_txns[4]});
     const auto conflicts_with_parents = make_tx(parent_inputs, {50 * CENT});
@@ -215,15 +216,16 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     BOOST_CHECK(HasNoNewUnconfirmed(/*tx=*/ *spends_unconfirmed.get(),
                                     /*pool=*/ pool,
                                     /*iters_conflicting=*/ all_entries) == std::nullopt);
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_unconfirmed.get(), pool, {entry2}) == std::nullopt);
+    BOOST_CHECK(HasNoNewUnconfirmed(*spends_unconfirmed.get(), pool, {entry2_normal}) == std::nullopt);
     BOOST_CHECK(HasNoNewUnconfirmed(*spends_unconfirmed.get(), pool, empty_set).has_value());
 
     const auto spends_new_unconfirmed = make_tx({tx1, tx8}, {36 * CENT});
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_new_unconfirmed.get(), pool, {entry2}).has_value());
+    BOOST_CHECK(HasNoNewUnconfirmed(*spends_new_unconfirmed.get(), pool, {entry2_normal}).has_value());
     BOOST_CHECK(HasNoNewUnconfirmed(*spends_new_unconfirmed.get(), pool, all_entries).has_value());
 
     const auto spends_conflicting_confirmed = make_tx({m_coinbase_txns[0], m_coinbase_txns[1]}, {45 * CENT});
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_conflicting_confirmed.get(), pool, {entry1, entry3}) == std::nullopt);
+    BOOST_CHECK(HasNoNewUnconfirmed(*spends_conflicting_confirmed.get(), pool, {entry1_normal, entry3_low}) == std::nullopt);
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -20,7 +20,7 @@
 // Helpers:
 static bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, DEFAULT_PERMIT_BAREMULTISIG, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, DEFAULT_PERMIT_BAREMULTISIG, CFeeRate{DUST_RELAY_TX_FEE}, DEFAULT_PERMIT_EA, reason);
 }
 
 static std::vector<unsigned char> Serialize(const CScript& s)

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -128,6 +128,14 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK(solutions[0] == std::vector<unsigned char>{16});
     BOOST_CHECK(solutions[1] == ToByteVector(uint256::ONE));
 
+    // TxoutType::ANCHOR
+    std::vector<unsigned char> anchor_bytes{0x4e, 0x73};
+    s.clear();
+    s << OP_1 << anchor_bytes;
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::ANCHOR);
+    BOOST_CHECK(solutions[0] == std::vector<unsigned char>{1});
+    BOOST_CHECK(solutions[1] == anchor_bytes);
+
     // TxoutType::NONSTANDARD
     s.clear();
     s << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
@@ -188,6 +196,16 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
     s.clear();
     s << OP_0 << std::vector<unsigned char>(19, 0x01);
     BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::NONSTANDARD);
+
+    // TxoutType::ANCHOR but wrong witness version
+    s.clear();
+    s << OP_2 << std::vector<unsigned char>{0x4e, 0x73};
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::WITNESS_UNKNOWN);
+
+    // TxoutType::ANCHOR but wrong 2-byte data push
+    s.clear();
+    s << OP_1 << std::vector<unsigned char>{0xff, 0xff};
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::WITNESS_UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.nVersion = 0;
     CheckIsNotStandard(t, "version");
 
-    t.nVersion = 3;
+    t.nVersion = 4;
     CheckIsNotStandard(t, "version");
 
     // Allowed nVersion
@@ -798,6 +798,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsStandard(t);
 
     t.nVersion = 2;
+    CheckIsStandard(t);
+
+    t.nVersion = 3;
     CheckIsStandard(t);
 
     // Check dust with odd relay fee to verify rounding:

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -993,6 +993,13 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
         t.vout[0].nValue = 239;
         CheckIsNotStandard(t, "dust");
     }
+
+    // Check anchor outputs (no dust allowed still)
+    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>{0x4e, 0x73};
+    t.vout[0].nValue = 500;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 0;
+    CheckIsNotStandard(t, "dust");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -42,6 +42,7 @@ typedef std::vector<unsigned char> valtype;
 
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
+static bool g_permit_anchor{DEFAULT_PERMIT_EA};
 
 static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
@@ -762,12 +763,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     constexpr auto CheckIsStandard = [](const auto& t) {
         std::string reason;
-        BOOST_CHECK(IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, g_permit_anchor, reason));
         BOOST_CHECK(reason.empty());
     };
     constexpr auto CheckIsNotStandard = [](const auto& t, const std::string& reason_in) {
         std::string reason;
-        BOOST_CHECK(!IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(!IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, g_permit_anchor, reason));
         BOOST_CHECK_EQUAL(reason_in, reason);
     };
 
@@ -994,12 +995,18 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
         CheckIsNotStandard(t, "dust");
     }
 
-    // Check anchor outputs (no dust allowed still)
+    // Check anchor outputs allow dust
     t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>{0x4e, 0x73};
-    t.vout[0].nValue = 500;
-    CheckIsStandard(t);
     t.vout[0].nValue = 0;
-    CheckIsNotStandard(t, "dust");
+    CheckIsStandard(t);
+    t.vout[0].nValue = 1; // Not just 0
+    CheckIsStandard(t);
+
+    // Turn off ephemeral anchors
+    g_permit_anchor = false;
+    CheckIsNotStandard(t, "ephemeral-anchor");
+    t.vout[0].nValue = MAX_MONEY;
+    CheckIsNotStandard(t, "ephemeral-anchor");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -4,11 +4,14 @@
 
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <policy/v3_policy.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <random.h>
 #include <script/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -48,4 +51,196 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "coinbase");
     BOOST_CHECK(result.m_state.GetResult() == TxValidationResult::TX_CONSENSUS);
 }
+
+// Generate a number of random, nonexistent outpoints.
+static inline std::vector<COutPoint> random_outpoints(size_t num_outpoints) {
+    std::vector<COutPoint> outpoints;
+    for (size_t i{0}; i < num_outpoints; ++i) {
+        outpoints.emplace_back(Txid::FromUint256(GetRandHash()), 0);
+    }
+    return outpoints;
+}
+
+static inline std::vector<CPubKey> random_keys(size_t num_keys) {
+    std::vector<CPubKey> keys;
+    keys.reserve(num_keys);
+    for (size_t i{0}; i < num_keys; ++i) {
+        CKey key;
+        key.MakeNewKey(true);
+        keys.emplace_back(key.GetPubKey());
+    }
+    return keys;
+}
+
+// Creates a placeholder tx (not valid) with 25 outputs. Specify the nVersion and the inputs.
+static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, int32_t version)
+{
+    CMutableTransaction mtx = CMutableTransaction{};
+    mtx.nVersion = version;
+    mtx.vin.resize(inputs.size());
+    mtx.vout.resize(25);
+    for (size_t i{0}; i < inputs.size(); ++i) {
+        mtx.vin[i].prevout = inputs[i];
+    }
+    for (auto i{0}; i < 25; ++i) {
+        mtx.vout[i].scriptPubKey = CScript() << OP_TRUE;
+        mtx.vout[i].nValue = 10000;
+    }
+    return MakeTransactionRef(mtx);
+}
+
+BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
+{
+    // Test V3 policy helper functions
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    LOCK2(cs_main, pool.cs);
+    TestMemPoolEntryHelper entry;
+    std::set<Txid> empty_conflicts_set;
+
+    auto mempool_tx_v3 = make_tx(random_outpoints(1), /*version=*/3);
+    pool.addUnchecked(entry.FromTx(mempool_tx_v3));
+    auto mempool_tx_v2 = make_tx(random_outpoints(1), /*version=*/2);
+    pool.addUnchecked(entry.FromTx(mempool_tx_v2));
+    // These two transactions are unrelated, so CheckV3Inheritance should pass.
+    BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3}) == std::nullopt);
+    // Default values.
+    CTxMemPool::Limits m_limits{};
+
+    // Cannot spend from an unconfirmed v3 transaction unless this tx is also v3.
+    {
+        auto tx_v2_from_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2_from_v3{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v3, *ancestors_v2_from_v3).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v3, tx_v2_from_v3}).has_value());
+        auto tx_v2_from_v2_and_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}, COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2_from_both{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v2_and_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v2_and_v3, *ancestors_v2_from_both).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3, tx_v2_from_v2_and_v3}).value() ==
+                    std::make_tuple(mempool_tx_v3->GetWitnessHash(), tx_v2_from_v2_and_v3->GetWitnessHash(), false));
+    }
+
+    // V3 cannot spend from an unconfirmed non-v3 transaction.
+    {
+        auto tx_v3_from_v2 = make_tx({COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3_from_v2{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v2), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v2, *ancestors_v3_from_v2).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, tx_v3_from_v2}).value() ==
+                    std::make_tuple(mempool_tx_v2->GetWitnessHash(), tx_v3_from_v2->GetWitnessHash(), true));
+        auto tx_v3_from_v2_and_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}, COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3_from_both{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v2_and_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v2_and_v3, *ancestors_v3_from_both).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3, tx_v3_from_v2_and_v3}).value() ==
+                    std::make_tuple(mempool_tx_v2->GetWitnessHash(), tx_v3_from_v2_and_v3->GetWitnessHash(), true));
+    }
+    // V3 from V3 is ok, and non-V3 from non-V3 is ok.
+    {
+        auto tx_v3_from_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance({tx_v3_from_v3, mempool_tx_v3}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v3, tx_v3_from_v3}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v3, *ancestors_v3) == std::nullopt);
+
+        auto tx_v2_from_v2 = make_tx({COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v2), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance({tx_v2_from_v2, mempool_tx_v2}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, tx_v2_from_v2}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v2, *ancestors_v2) == std::nullopt);
+    }
+
+    // Tx spending v3 cannot have too many mempool ancestors
+    // Configuration where the tx has multiple direct parents.
+    {
+        std::vector<COutPoint> mempool_outpoints;
+        mempool_outpoints.emplace_back(mempool_tx_v3->GetHash(), 0);
+        mempool_outpoints.resize(2);
+        for (size_t i{0}; i < 2; ++i) {
+            auto mempool_tx = make_tx(random_outpoints(1), /*version=*/2);
+            pool.addUnchecked(entry.FromTx(mempool_tx));
+            mempool_outpoints.emplace_back(mempool_tx->GetHash(), 0);
+        }
+        auto tx_v3_multi_parent = make_tx(mempool_outpoints, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_multi_parent), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_multi_parent, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_v3_multi_parent)).has_value());
+    }
+
+    // Configuration where the tx is in a multi-generation chain.
+    auto last_outpoint{random_outpoints(1)[0]};
+    for (size_t i{0}; i < 2; ++i) {
+        auto mempool_tx = make_tx({last_outpoint}, /*version=*/2);
+        pool.addUnchecked(entry.FromTx(mempool_tx));
+        last_outpoint = COutPoint{mempool_tx->GetHash(), 0};
+    }
+    {
+        auto tx_v3_multi_gen = make_tx({last_outpoint}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_multi_gen), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_multi_gen, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_v3_multi_gen)).has_value());
+    }
+
+    // Tx spending v3 cannot be too large in weight.
+    auto many_inputs{random_outpoints(100)};
+    many_inputs.emplace_back(mempool_tx_v3->GetHash(), 0);
+    {
+        auto tx_v3_child_big = make_tx(many_inputs, /*version=*/3);
+        BOOST_CHECK(GetTransactionWeight(*tx_v3_child_big) > V3_CHILD_MAX_VSIZE * WITNESS_SCALE_FACTOR);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_child_big), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child_big, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_v3_child_big)).has_value());
+    }
+
+    // Tx spending v3 cannot have too many sigops.
+    auto multisig_outpoints{random_outpoints(3)};
+    multisig_outpoints.emplace_back(mempool_tx_v3->GetHash(), 0);
+    auto keys{random_keys(2)};
+    CScript script_multisig;
+    script_multisig << OP_1;
+    for (const auto& key : keys) {
+        script_multisig << ToByteVector(key);
+    }
+    script_multisig << OP_2 << OP_CHECKMULTISIG;
+    {
+        CMutableTransaction mtx_many_sigops = CMutableTransaction{};
+        mtx_many_sigops.nVersion = 3;
+        for (const auto& outpoint : multisig_outpoints) {
+            mtx_many_sigops.vin.emplace_back(outpoint, script_multisig);
+        }
+        mtx_many_sigops.vout.resize(1);
+        mtx_many_sigops.vout.back().scriptPubKey = CScript() << OP_TRUE;
+        mtx_many_sigops.vout.back().nValue = 10000;
+        auto tx_many_sigops{MakeTransactionRef(mtx_many_sigops)};
+
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_many_sigops), m_limits)};
+        // legacy uses fAccurate = false, and the maximum number of multisig keys is used
+        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetSigOpCount(/*fAccurate=*/false))};
+        BOOST_CHECK_EQUAL(total_sigops, tx_many_sigops->vin.size() * MAX_PUBKEYS_PER_MULTISIG);
+        const int64_t bip141_vsize{GetVirtualTransactionSize(*tx_many_sigops)};
+        // Weight limit is not reached...
+        BOOST_CHECK(ApplyV3Rules(tx_many_sigops, *ancestors, empty_conflicts_set, bip141_vsize) == std::nullopt);
+        // ...but sigop limit is.
+        BOOST_CHECK(ApplyV3Rules(tx_many_sigops, *ancestors, empty_conflicts_set, std::max(total_sigops * DEFAULT_BYTES_PER_SIGOP, bip141_vsize)).has_value());
+    }
+
+    // Parent + child with v3 in the mempool. Child is allowed as long as it is under V3_CHILD_MAX_VSIZE.
+    auto tx_mempool_v3_child = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/3);
+    {
+        BOOST_CHECK(GetTransactionWeight(*tx_mempool_v3_child) <= V3_CHILD_MAX_VSIZE * WITNESS_SCALE_FACTOR);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_mempool_v3_child), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_mempool_v3_child, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_mempool_v3_child)) == std::nullopt);
+        pool.addUnchecked(entry.FromTx(tx_mempool_v3_child));
+    }
+
+    // A v3 transaction cannot have more than 1 descendant.
+    {
+        auto tx_v3_child2 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 1}}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_child2), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child2, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_v3_child2)).has_value());
+        // If replacing the child, make sure there is no double-counting.
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child2, *ancestors, {tx_mempool_v3_child->GetHash()}, GetVirtualTransactionSize(*tx_v3_child2)) == std::nullopt);
+    }
+
+    {
+        auto tx_v3_grandchild = make_tx({COutPoint{tx_mempool_v3_child->GetHash(), 0}}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_grandchild), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_grandchild, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_v3_grandchild)).has_value());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -351,9 +351,11 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
                                                                                   const std::vector<CKey>& input_signing_keys,
                                                                                   const std::vector<CTxOut>& outputs,
                                                                                   const std::optional<CFeeRate>& feerate,
-                                                                                  const std::optional<uint32_t>& fee_output)
+                                                                                  const std::optional<uint32_t>& fee_output,
+                                                                                  uint32_t version)
 {
     CMutableTransaction mempool_txn;
+    mempool_txn.nVersion = version;
     mempool_txn.vin.reserve(inputs.size());
     mempool_txn.vout.reserve(outputs.size());
 
@@ -415,9 +417,10 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::
                                                                      int input_height,
                                                                      const std::vector<CKey>& input_signing_keys,
                                                                      const std::vector<CTxOut>& outputs,
-                                                                     bool submit)
+                                                                     bool submit,
+                                                                     uint32_t version)
 {
-    CMutableTransaction mempool_txn = CreateValidTransaction(input_transactions, inputs, input_height, input_signing_keys, outputs, std::nullopt, std::nullopt).first;
+    CMutableTransaction mempool_txn = CreateValidTransaction(input_transactions, inputs, input_height, input_signing_keys, outputs, std::nullopt, std::nullopt, version).first;
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
@@ -433,7 +436,8 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
                                                                      CKey input_signing_key,
                                                                      CScript output_destination,
                                                                      CAmount output_amount,
-                                                                     bool submit)
+                                                                     bool submit,
+                                                                     uint32_t version)
 {
     COutPoint input{input_transaction->GetHash(), input_vout};
     CTxOut output{output_amount, output_destination};
@@ -442,7 +446,8 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
                                          /*input_height=*/input_height,
                                          /*input_signing_keys=*/{input_signing_key},
                                          /*outputs=*/{output},
-                                         /*submit=*/submit);
+                                         /*submit=*/submit,
+                                         /*version=*/version);
 }
 
 std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit)

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -142,7 +142,8 @@ struct TestChain100Setup : public TestingSetup {
                                                                    const std::vector<CKey>& input_signing_keys,
                                                                    const std::vector<CTxOut>& outputs,
                                                                    const std::optional<CFeeRate>& feerate,
-                                                                   const std::optional<uint32_t>& fee_output);
+                                                                   const std::optional<uint32_t>& fee_output,
+                                                                   uint32_t version);
     /**
      * Create a transaction and, optionally, submit to the mempool.
      *
@@ -158,7 +159,8 @@ struct TestChain100Setup : public TestingSetup {
                                                       int input_height,
                                                       const std::vector<CKey>& input_signing_keys,
                                                       const std::vector<CTxOut>& outputs,
-                                                      bool submit = true);
+                                                      bool submit = true,
+                                                      uint32_t version = 2);
 
     /**
      * Create a 1-in-1-out transaction and, optionally, submit to the mempool.
@@ -177,7 +179,8 @@ struct TestChain100Setup : public TestingSetup {
                                                       CKey input_signing_key,
                                                       CScript output_destination,
                                                       CAmount output_amount = CAmount(1 * COIN),
-                                                      bool submit = true);
+                                                      bool submit = true,
+                                                      uint32_t version = 2);
 
     /** Create transactions spending from m_coinbase_txns. These transactions will only spend coins
      * that exist in the current chain, but may be premature coinbase spends, have missing

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -454,7 +454,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    std::set<uint256> setParentTransactions;
+    std::set<Txid> setParentTransactions;
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, &tx));
         setParentTransactions.insert(tx.vin[i].prevout.hash);
@@ -969,7 +969,7 @@ std::optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
     return std::nullopt;
 }
 
-CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) const
+CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<Txid>& hashes) const
 {
     CTxMemPool::setEntries ret;
     for (const auto& h : hashes) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -408,6 +408,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_min_relay_feerate{opts.min_relay_feerate},
       m_dust_relay_feerate{opts.dust_relay_feerate},
       m_permit_bare_multisig{opts.permit_bare_multisig},
+      m_permit_anchors{opts.permit_ephemeral_anchors},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
       m_require_standard{opts.require_standard},
       m_full_rbf{opts.full_rbf},

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -522,7 +522,7 @@ public:
     /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups.
      * Does not require that all of the hashes correspond to actual transactions in the mempool,
      * only returns the ones that exist. */
-    setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    setEntries GetIterSet(const std::set<Txid>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Translate a list of hashes into a list of mempool iterators to avoid repeated lookups.
      * The nth element in txids becomes the nth element in the returned vector. If any of the txids

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -440,6 +440,7 @@ public:
     const CFeeRate m_min_relay_feerate;
     const CFeeRate m_dust_relay_feerate;
     const bool m_permit_bare_multisig;
+    const bool m_permit_anchors;
     const std::optional<unsigned> m_max_datacarrier_bytes;
     const bool m_require_standard;
     const bool m_full_rbf;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -582,7 +582,7 @@ private:
     struct Workspace {
         explicit Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
         /** Txids of mempool transactions that this transaction directly conflicts with. */
-        std::set<uint256> m_conflicts;
+        std::set<Txid> m_conflicts;
         /** Iterators to mempool entries that this transaction directly conflicts with. */
         CTxMemPool::setEntries m_iters_conflicting;
         /** Iterators to all mempool entries that would be replaced by this transaction, including

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -895,7 +895,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // We check for ephemeral tx properties now that we have access to ws.m_base_fees,
     // have set ws.m_modified_fees and ws.m_vsize, and will potentially return a TX_RECONSIDERABLE
     // which require the various fee and size for reporting.
-    if (!CheckValidEphemeralTx(tx, state, ws.m_base_fees, args.m_package_submission)) {
+    if (!bypass_limits && !CheckValidEphemeralTx(tx, state, ws.m_base_fees, args.m_package_submission)) {
         return false; // state filled in by CheckValidEphemeralTx
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -465,6 +465,9 @@ public:
          */
         const bool m_package_feerates;
 
+        /** Whether CPFP carveout and RBF carveout are granted. */
+        const bool m_allow_carveouts;
+
         /** Parameters for single transaction mempool validation. */
         static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
                                      bool bypass_limits, std::vector<COutPoint>& coins_to_uncache,
@@ -477,6 +480,7 @@ public:
                             /* m_allow_replacement */ true,
                             /* m_package_submission */ false,
                             /* m_package_feerates */ false,
+                            /* m_allow_carveouts */ true,
             };
         }
 
@@ -491,6 +495,7 @@ public:
                             /* m_allow_replacement */ false,
                             /* m_package_submission */ false, // not submitting to mempool
                             /* m_package_feerates */ false,
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -505,6 +510,7 @@ public:
                             /* m_allow_replacement */ false,
                             /* m_package_submission */ true,
                             /* m_package_feerates */ true,
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -518,6 +524,7 @@ public:
                             /* m_allow_replacement */ true,
                             /* m_package_submission */ true, // do not LimitMempoolSize in Finalize()
                             /* m_package_feerates */ false, // only 1 transaction
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -531,7 +538,8 @@ public:
                  bool test_accept,
                  bool allow_replacement,
                  bool package_submission,
-                 bool package_feerates)
+                 bool package_feerates,
+                 bool allow_carveouts)
             : m_chainparams{chainparams},
               m_accept_time{accept_time},
               m_bypass_limits{bypass_limits},
@@ -539,7 +547,8 @@ public:
               m_test_accept{test_accept},
               m_allow_replacement{allow_replacement},
               m_package_submission{package_submission},
-              m_package_feerates{package_feerates}
+              m_package_feerates{package_feerates},
+              m_allow_carveouts{allow_carveouts}
         {
         }
     };
@@ -886,7 +895,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     CTxMemPool::Limits maybe_rbf_limits = m_pool.m_limits;
 
     // Calculate in-mempool ancestors, up to a limit.
-    if (ws.m_conflicts.size() == 1) {
+    if (ws.m_conflicts.size() == 1 && args.m_allow_carveouts) {
         // In general, when we receive an RBF transaction with mempool conflicts, we want to know whether we
         // would meet the chain limits after the conflicts have been removed. However, there isn't a practical
         // way to do this short of calculating the ancestor and descendant sets with an overlay cache of
@@ -923,7 +932,14 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     auto ancestors{m_pool.CalculateMemPoolAncestors(*entry, maybe_rbf_limits)};
     if (!ancestors) {
-        // If CalculateMemPoolAncestors fails second time, we want the original error string.
+        // If CalculateMemPoolAncestors fails a second time, we want the original error string.
+        const auto error_message{util::ErrorString(ancestors).original};
+
+        // Carve-out is not allowed in this context; fail
+        if (!args.m_allow_carveouts) {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
+        }
+
         // Contracting/payment channels CPFP carve-out:
         // If the new transaction is relatively small (up to 40k weight)
         // and has at most one ancestor (ie ancestor limit of 2, including
@@ -941,7 +957,6 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             .descendant_count = maybe_rbf_limits.descendant_count + 1,
             .descendant_size_vbytes = maybe_rbf_limits.descendant_size_vbytes + EXTRA_DESCENDANT_TX_SIZE_LIMIT,
         };
-        const auto error_message{util::ErrorString(ancestors).original};
         if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
         }
@@ -1371,11 +1386,8 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             MempoolAcceptResult::FeeFailure(placeholder_state, CFeeRate(m_total_modified_fees, m_total_vsize), all_package_wtxids)}});
     }
 
-    // Apply package mempool ancestor/descendant limits. Skip if there is only one transaction,
-    // because it's unnecessary. Also, CPFP carve out can increase the limit for individual
-    // transactions, but this exemption is not extended to packages in CheckPackageLimits().
-    std::string err_string;
-    if (txns.size() > 1 && !PackageMempoolChecks(txns, m_total_vsize, package_state)) {
+    // Apply package mempool ancestor/descendant limits.
+    if (!PackageMempoolChecks(txns, m_total_vsize, package_state)) {
         return PackageMempoolAcceptResult(package_state, std::move(results));
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -750,7 +750,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (m_pool.m_require_standard && !IsStandardTx(tx, m_pool.m_max_datacarrier_bytes, m_pool.m_permit_bare_multisig, m_pool.m_dust_relay_feerate, reason)) {
+    if (m_pool.m_require_standard && !IsStandardTx(tx, m_pool.m_max_datacarrier_bytes, m_pool.m_permit_bare_multisig, m_pool.m_dust_relay_feerate, m_pool.m_permit_anchors, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -507,7 +507,7 @@ public:
                             /* m_bypass_limits */ false,
                             /* m_coins_to_uncache */ coins_to_uncache,
                             /* m_test_accept */ false,
-                            /* m_allow_replacement */ false,
+                            /* m_allow_replacement */ true,
                             /* m_package_submission */ true,
                             /* m_package_feerates */ true,
                             /* m_allow_carveouts */ false,
@@ -628,12 +628,14 @@ private:
     // only tests that are fast should be done here (to avoid CPU DoS).
     bool PreChecks(ATMPArgs& args, Workspace& ws) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
 
-    // Run checks for mempool replace-by-fee.
+    // Run checks for mempool replace-by-fee, only used in AcceptSingleTransaction.
     bool ReplacementChecks(Workspace& ws) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
 
     // Enforce package mempool ancestor/descendant limits (distinct from individual
-    // ancestor/descendant limits done in PreChecks).
-    bool PackageMempoolChecks(const std::vector<CTransactionRef>& txns,
+    // ancestor/descendant limits done in PreChecks) and run Package RBF checks.
+    bool PackageMempoolChecks(const ATMPArgs& args,
+                              const std::vector<CTransactionRef>& txns,
+                              std::vector<Workspace>& workspaces,
                               int64_t total_vsize,
                               PackageValidationState& package_state) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
 
@@ -945,6 +947,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // the ancestor limits should be the same for both our new transaction and any conflicts).
         // We don't bother incrementing m_limit_descendants by the full removal count as that limit never comes
         // into force here (as we're only adding a single transaction).
+        //
+        // This carve out is NOT granted in package RBF (see m_allow_carveouts in ATMPArgs ctors) because, during
+        // package acceptance, we may call PreChecks for multiple transactions that conflict with different mempool
+        // entries that don't share ancestry. It would be a bug to keep increasing the descendant limit each time.
         assert(ws.m_iters_conflicting.size() == 1);
         CTxMemPool::txiter conflict = *ws.m_iters_conflicting.begin();
 
@@ -1032,10 +1038,10 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     //   descendant transaction of a direct conflict to pay a higher feerate than the transaction that
     //   might replace them, under these rules.
     if (const auto err_string{PaysMoreThanConflicts(ws.m_iters_conflicting, newFeeRate, hash)}) {
-        // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
-        // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
-        // This must be changed if package RBF is enabled.
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
+        // This fee-related failure is TX_RECONSIDERABLE because validating in a package may change
+        // the result.
+        return state.Invalid(TxValidationResult::TX_RECONSIDERABLE,
+                             "insufficient fee", *err_string);
     }
 
     // Calculate all conflicting entries and enforce Rule #5.
@@ -1057,15 +1063,16 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     }
     if (const auto err_string{PaysForRBF(m_conflicting_fees, ws.m_modified_fees, ws.m_vsize,
                                          m_pool.m_incremental_relay_feerate, hash)}) {
-        // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
-        // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
-        // This must be changed if package RBF is enabled.
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
+        // Result may change in another package
+        return state.Invalid(TxValidationResult::TX_RECONSIDERABLE,
+                             "insufficient fee", *err_string);
     }
     return true;
 }
 
-bool MemPoolAccept::PackageMempoolChecks(const std::vector<CTransactionRef>& txns,
+bool MemPoolAccept::PackageMempoolChecks(const ATMPArgs& args,
+                                         const std::vector<CTransactionRef>& txns,
+                                         std::vector<Workspace>& workspaces,
                                          const int64_t total_vsize,
                                          PackageValidationState& package_state)
 {
@@ -1081,7 +1088,75 @@ bool MemPoolAccept::PackageMempoolChecks(const std::vector<CTransactionRef>& txn
         // This is a package-wide error, separate from an individual transaction error.
         return package_state.Invalid(PackageValidationResult::PCKG_POLICY, "package-mempool-limits", err_string);
     }
-   return true;
+
+    // No conflicts means we're finished. Further checks are all RBF-only.
+    if (!m_rbf) return true;
+
+    // We're in package RBF context; replacement proposal must be size 2
+    if (workspaces.size() != 2) {
+        return package_state.Invalid(PackageValidationResult::PCKG_POLICY, "package RBF failed: replacing cluster not size two");
+    }
+
+    // If the package has in-mempool ancestors, we won't consider a package RBF
+    // since it would result in a cluster larger than 2
+    for (const auto& ws : workspaces) {
+        if (!ws.m_ancestors.empty()) {
+            return package_state.Invalid(PackageValidationResult::PCKG_POLICY, "package RBF failed: replacing cluster with ancestors not size two");
+        }
+    }
+
+    // Aggregate all conflicts into one set.
+    CTxMemPool::setEntries direct_conflict_iters;
+    for (Workspace& ws : workspaces) {
+        // Aggregate all conflicts into one set.
+        direct_conflict_iters.merge(ws.m_iters_conflicting);
+    }
+
+
+    // Calculate all conflicting entries and enforce Rules 2 and 5.
+    for (Workspace& ws : workspaces) {
+        // The aggregated set of conflicts cannot exceed 100.
+        if (const auto err_string{GetEntriesForConflicts(*ws.m_ptx, m_pool, direct_conflict_iters,
+                                                         m_all_conflicts)}) {
+            return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
+                                         "package RBF failed: too many potential replacements", *err_string);
+        }
+    }
+
+    const auto& parent_ws = workspaces[0];
+    const auto& child_ws = workspaces[1];
+
+    // Ensure this two transaction package is a "chunk" on its own; we don't want the child
+    // to be only paying anti-DoS fees
+    const CFeeRate parent_feerate(parent_ws.m_modified_fees, parent_ws.m_vsize);
+    const CFeeRate child_feerate(child_ws.m_modified_fees, child_ws.m_vsize);
+    if (parent_feerate >= child_feerate) {
+        return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
+                                     "package RBF failed: parent paying for child anti-DoS", "");
+    }
+
+    // Check if it's economically rational to mine this package rather than the ones it replaces.
+    if (const auto err_string{CheckMinerScores(m_total_modified_fees, m_total_vsize, direct_conflict_iters,
+                                               m_all_conflicts)}) {
+        return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
+                                     "package RBF failed: insufficient feerate", *err_string);
+    }
+    m_conflicting_fees = 0;
+    m_conflicting_size = 0;
+    for (CTxMemPool::txiter it : m_all_conflicts) {
+        m_conflicting_fees += it->GetModifiedFee();
+        m_conflicting_size += it->GetTxSize();
+    }
+
+    // Use the child as the transaction for attributing errors to.
+    const Txid child_hash = child_ws.m_ptx->GetHash();
+    if (const auto err_string{PaysForRBF(m_conflicting_fees, m_total_modified_fees, m_total_vsize,
+                                         m_pool.m_incremental_relay_feerate, child_hash)}) {
+        return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
+                                     "package RBF failed: insufficient anti-DoS fees", *err_string);
+    }
+
+    return true;
 }
 
 bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
@@ -1155,6 +1230,7 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
     const bool bypass_limits = args.m_bypass_limits;
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
 
+    if (!m_all_conflicts.empty()) Assume(args.m_allow_replacement);
     // Remove conflicting transactions from the mempool
     for (CTxMemPool::txiter it : m_all_conflicts)
     {
@@ -1292,7 +1368,13 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
         return MempoolAcceptResult::Failure(ws.m_state);
     }
 
-    if (m_rbf && !ReplacementChecks(ws)) return MempoolAcceptResult::Failure(ws.m_state);
+    if (m_rbf && !ReplacementChecks(ws)) {
+        if (ws.m_state.GetResult() == TxValidationResult::TX_RECONSIDERABLE) {
+            // Failed for incentives-based fee reasons. Provide the effective feerate and which tx was included.
+            return MempoolAcceptResult::FeeFailure(ws.m_state, CFeeRate(ws.m_modified_fees, ws.m_vsize), single_wtxid);
+        }
+        return MempoolAcceptResult::Failure(ws.m_state);
+    }
 
     // Perform the inexpensive checks first and avoid hashing and signature verification unless
     // those checks pass, to mitigate CPU exhaustion denial-of-service attacks.
@@ -1376,11 +1458,10 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             return PackageMempoolAcceptResult(package_state, std::move(results));
         }
         // Make the coins created by this transaction available for subsequent transactions in the
-        // package to spend. Since we already checked conflicts in the package and we don't allow
-        // replacements, we don't need to track the coins spent. Note that this logic will need to be
-        // updated if package replace-by-fee is allowed in the future.
-        assert(!args.m_allow_replacement);
-        assert(!m_rbf);
+        // package to spend. Since we already checked conflicts, no transaction can spend a coin
+        // needed by another transaction in the package. We also need to make sure that no package
+        // tx replaces (or replaces the ancestor of) the parent of another package tx. As long as we
+        // check these two things, we don't need to track the coins spent.
         m_viewmempool.PackageAddTransaction(ws.m_ptx);
     }
 
@@ -1410,8 +1491,9 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             MempoolAcceptResult::FeeFailure(placeholder_state, CFeeRate(m_total_modified_fees, m_total_vsize), all_package_wtxids)}});
     }
 
-    // Apply package mempool ancestor/descendant limits.
-    if (!PackageMempoolChecks(txns, m_total_vsize, package_state)) {
+    // Apply package mempool ancestor/descendant limits and RBF checks.
+    std::string err_string;
+    if (!PackageMempoolChecks(args, txns, workspaces, m_total_vsize, package_state)) {
         return PackageMempoolAcceptResult(package_state, std::move(results));
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -890,6 +890,13 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                                     fSpendsCoinbase, nSigOpsCost, lock_points.value()));
     ws.m_vsize = entry->GetTxSize();
 
+    // We check for ephemeral tx properties now that we have access to ws.m_base_fees,
+    // have set ws.m_modified_fees and ws.m_vsize, and will potentially return a TX_RECONSIDERABLE
+    // which require the various fee and size for reporting.
+    if (!CheckValidEphemeralTx(tx, state, ws.m_base_fees, args.m_package_submission)) {
+        return false; // state filled in by CheckValidEphemeralTx
+    }
+
     if (nSigOpsCost > MAX_STANDARD_TX_SIGOPS_COST)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
                 strprintf("%d", nSigOpsCost));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -866,10 +866,12 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // while a tx could be package CPFP'd when entering the mempool, we do not have a DoS-resistant
     // method of ensuring the tx remains bumped. For example, the fee-bumping child could disappear
     // due to a replacement.
-    if (!bypass_limits && ws.m_modified_fees < m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)) {
+    // The only exception is v3 transactions.
+    if (!bypass_limits && ws.m_ptx->nVersion != 3 && ws.m_modified_fees < m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)) {
         // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
         // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
+        return state.Invalid(ws.m_ptx->nVersion == 3 ? TxValidationResult::TX_RECONSIDERABLE : TxValidationResult::TX_MEMPOOL_POLICY,
+                             "min relay fee not met",
                              strprintf("%d < %d", ws.m_modified_fees, m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)));
     }
     // No individual transactions are allowed below the mempool min feerate except from disconnected

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -29,6 +29,7 @@
 #include <logging/timer.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
+#include <policy/v3_policy.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>
@@ -328,11 +329,12 @@ void Chainstate::MaybeUpdateMempoolForReorg(
     m_mempool->UpdateTransactionsFromBlock(vHashUpdate);
 
     // Predicate to use for filtering transactions in removeForReorg.
+    // Checks whether a non-v3 transaction spends v3 and or vice versa.
     // Checks whether the transaction is still final and, if it spends a coinbase output, mature.
     // Also updates valid entries' cached LockPoints if needed.
     // If false, the tx is still valid and its lockpoints are updated.
     // If true, the tx would be invalid in the next block; remove this entry and all of its descendants.
-    const auto filter_final_and_mature = [this](CTxMemPool::txiter it)
+    const auto filter_valid_after_reorg = [&](CTxMemPool::txiter it)
         EXCLUSIVE_LOCKS_REQUIRED(m_mempool->cs, ::cs_main) {
         AssertLockHeld(m_mempool->cs);
         AssertLockHeld(::cs_main);
@@ -371,12 +373,10 @@ void Chainstate::MaybeUpdateMempoolForReorg(
                 }
             }
         }
-        // Transaction is still valid and cached LockPoints are updated.
         return false;
     };
-
     // We also need to remove any now-immature transactions
-    m_mempool->removeForReorg(m_chain, filter_final_and_mature);
+    m_mempool->removeForReorg(m_chain, filter_valid_after_reorg);
     // Re-limit mempool size, in case we added any transactions
     LimitMempoolSize(*m_mempool, this->CoinsTip());
 }
@@ -760,9 +760,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // check all unconfirmed ancestors; otherwise an opt-in ancestor
                 // might be replaced, causing removal of this descendant.
                 //
-                // If replaceability signaling is ignored due to node setting,
-                // replacement is always allowed.
-                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
+                // All V3 transactions are considered replaceable.
+                //
+                // Replaceability signaling of the original transactions may be
+                // ignored due to node setting.
+                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting) && ptxConflicting->nVersion != 3) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 
@@ -946,6 +948,16 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     ws.m_ancestors = *ancestors;
+    if (const auto err_string{CheckV3Inheritance(ws.m_ptx, ws.m_ancestors)}) {
+        if (ws.m_ptx->nVersion == 3) {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-spends-non-v3", *err_string);
+        } else {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "non-v3-tx-spends-v3", *err_string);
+        }
+    }
+    if (const auto err_string{ApplyV3Rules(ws.m_ptx, ws.m_ancestors, ws.m_conflicts, ws.m_vsize)}) {
+        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-nonstandard", *err_string);
+    }
 
     // A transaction that spends outputs that would be replaced by it is invalid. Now
     // that we have the set of all ancestors we can detect this
@@ -1287,6 +1299,31 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     std::transform(txns.cbegin(), txns.cend(), std::back_inserter(workspaces),
                    [](const auto& tx) { return Workspace(tx); });
     std::map<uint256, MempoolAcceptResult> results;
+
+    if (const auto v3_violation{CheckV3Inheritance(txns)}) {
+        const auto [parent_wtxid, child_wtxid, child_v3] = v3_violation.value();
+        TxValidationState child_state;
+        if (child_v3) {
+            child_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-spends-non-v3",
+                          strprintf("tx that spends from %s cannot be nVersion=3", parent_wtxid.ToString()));
+        } else {
+            child_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "non-v3-tx-spends-v3",
+                          strprintf("tx that spends from %s must be nVersion=3", parent_wtxid.ToString()));
+        }
+        package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+        results.emplace(child_wtxid, MempoolAcceptResult::Failure(child_state));
+        return PackageMempoolAcceptResult(package_state, std::move(results));
+    }
+    // fixme: make ApplyV3Rules take package instead of just entries
+    if (!txns.empty() && txns.size() > V3_CHILD_MAX_VSIZE && txns.back()->nVersion == 3) {
+        const auto& child_wtxid = txns.back()->GetWitnessHash();
+        TxValidationState child_state;
+        child_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-spends-non-v3",
+            strprintf("tx %s would have too many ancestors", child_wtxid.ToString()));
+        package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+        results.emplace(child_wtxid, MempoolAcceptResult::Failure(child_state));
+        return PackageMempoolAcceptResult(package_state, std::move(results));
+    }
 
     LOCK(m_pool.cs);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1013,6 +1013,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-nonstandard", *err_string);
     }
 
+    // FIXME V3 checks preclude this being hit(?); can only be hit in case where
+    // anchor *isn't* RBF'd, which implies existence of another child of parent. remove? make an Assume()?
     if (auto err_string{CheckEphemeralSpends(ws.m_ptx, ws.m_ancestors)}) {
         return state.Invalid(TxValidationResult::TX_RECONSIDERABLE, "ephemeral-anchor-unspent", *err_string);
     }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -917,6 +917,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
     case TxoutType::NONSTANDARD:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::ANCHOR:
         return "unrecognized script";
     } // no default case, so the compiler can warn about missing cases
     NONFATAL_UNREACHABLE();

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -973,6 +973,11 @@ static std::vector<RPCArg> OutputsDoc()
                 {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A key-value pair. The key must be \"data\", the value is hex-encoded data"},
             },
         },
+        {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+            {
+                {"anchor", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Creates an ephemeral anchor. A key-value pair. The key must be \"anchor\", the value is the amount in " + CURRENCY_UNIT},
+            },
+        },
     };
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -109,6 +109,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::ANCHOR:
         break;
     case TxoutType::PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1086,6 +1086,11 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         if (IsDust(txout, wallet.chain().relayDustFee())) {
             return util::Error{_("Transaction amount too small")};
         }
+
+        if (txout.scriptPubKey.IsPayToAnchor() && !wallet.chain().allowsEphemeralAnchors()) {
+            return util::Error{_("Anchor outputs are not allowed for relay: check -ephemeralanchors option")};
+        }
+
         txNew.vout.push_back(txout);
     }
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -271,7 +271,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         self.log.info('Some nonstandard transactions')
         tx = tx_from_hex(raw_tx_reference)
-        tx.nVersion = 3  # A version currently non-standard
+        tx.nVersion = 4  # A version currently non-standard
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'version'}],
             rawtxs=[tx.serialize().hex()],

--- a/test/functional/mempool_accept_v3.py
+++ b/test/functional/mempool_accept_v3.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.messages import (
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+def cleanup(func):
+    def wrapper(self):
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            # Reset config options
+            self.restart_node(0)
+    return wrapper
+
+class MempoolAcceptV3(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def check_mempool(self, txids):
+        """Assert exact contents of the node's mempool (by txid)."""
+        mempool_contents = self.nodes[0].getrawmempool()
+        assert_equal(len(txids), len(mempool_contents))
+        assert all([txid in txids for txid in mempool_contents])
+
+    @cleanup
+    def test_v3_acceptance(self):
+        node = self.nodes[0]
+        self.log.info("Test a child of a V3 transaction cannot be more than 1000vB")
+        self.restart_node(0, extra_args=["-datacarriersize=1000"])
+        tx_v3_parent_normal = self.wallet.send_self_transfer(from_node=node, version=3)
+        self.check_mempool([tx_v3_parent_normal["txid"]])
+        tx_v3_child_heavy = self.wallet.create_self_transfer(
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=4004,
+            version=3
+        )
+        assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), 1000)
+        assert_raises_rpc_error(-26, "v3-tx-nonstandard, v3 child tx is too big", node.sendrawtransaction, tx_v3_child_heavy["hex"])
+        self.check_mempool([tx_v3_parent_normal["txid"]])
+        # tx has no descendants
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 1)
+
+        self.log.info("Test that, during replacements, only the new transaction counts for V3 descendant limit")
+        tx_v3_child_almost_heavy = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=3987,
+            version=3
+        )
+        assert_greater_than_or_equal(1000, tx_v3_child_almost_heavy["tx"].get_vsize())
+        self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
+        tx_v3_child_almost_heavy_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=3500,
+            version=3
+        )
+        assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(), 1000)
+        self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy_rbf["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
+
+    @cleanup
+    def test_v3_replacement(self):
+        node = self.nodes[0]
+        self.log.info("Test V3 transactions may be replaced by V3 transactions")
+        utxo_v3_bip125 = self.wallet.get_utxo()
+        tx_v3_bip125 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_bip125,
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125["txid"]])
+
+        tx_v3_bip125_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=utxo_v3_bip125,
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125_rbf["txid"]])
+
+        self.log.info("Test V3 transactions may be replaced by V2 transactions")
+        tx_v3_bip125_rbf_v2 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 3,
+            utxo_to_spend=utxo_v3_bip125,
+            version=2
+        )
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"]])
+
+        self.log.info("Test that replacements cannot cause violation of inherited V3")
+        utxo_v3_parent = self.wallet.get_utxo()
+        tx_v3_parent = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_parent,
+            version=3
+        )
+        tx_v3_child = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=tx_v3_parent["new_utxo"],
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
+
+        tx_v3_child_rbf_v2 = self.wallet.create_self_transfer(
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=tx_v3_parent["new_utxo"],
+            version=2
+        )
+        assert_raises_rpc_error(-26, "non-v3-tx-spends-v3", node.sendrawtransaction, tx_v3_child_rbf_v2["hex"])
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
+
+
+    @cleanup
+    def test_v3_bip125(self):
+        node = self.nodes[0]
+        self.log.info("Test V3 transactions that don't signal BIP125 are replaceable")
+        assert_equal(node.getmempoolinfo()["fullrbf"], False)
+        utxo_v3_no_bip125 = self.wallet.get_utxo()
+        tx_v3_no_bip125 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_no_bip125,
+            sequence=MAX_BIP125_RBF_SEQUENCE + 1,
+            version=3
+        )
+
+        self.check_mempool([tx_v3_no_bip125["txid"]])
+        assert not node.getmempoolentry(tx_v3_no_bip125["txid"])["bip125-replaceable"]
+        tx_v3_no_bip125_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=utxo_v3_no_bip125,
+            version=3
+        )
+        self.check_mempool([tx_v3_no_bip125_rbf["txid"]])
+
+    @cleanup
+    def test_v3_reorg(self):
+        node = self.nodes[0]
+        self.restart_node(0, extra_args=["-datacarriersize=40000"])
+        self.log.info("Test that, during a reorg, v3 rules are not enforced")
+        tx_v2_block = self.wallet.send_self_transfer(from_node=node, version=2)
+        tx_v3_block = self.wallet.send_self_transfer(from_node=node, version=3)
+        tx_v3_block2 = self.wallet.send_self_transfer(from_node=node, version=3)
+        assert_equal(set(node.getrawmempool()), set([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"]]))
+
+        block = self.generate(node, 1)
+        assert_equal(node.getrawmempool(), [])
+        tx_v2_from_v3 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block["new_utxo"], version=2)
+        tx_v3_from_v2 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v2_block["new_utxo"], version=3)
+        tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_weight=5000, version=3)
+        assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], 1000)
+        assert_equal(set(node.getrawmempool()), set([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]]))
+        node.invalidateblock(block[0])
+        assert_equal(set(node.getrawmempool()), set([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"], tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]]))
+        # This is needed because generate() will create the exact same block again.
+        node.reconsiderblock(block[0])
+
+
+    @cleanup
+    def test_nondefault_package_limits(self):
+        """
+        Max standard tx size + V3 rules imply the ancestor/descendant rules (at their default
+        values), but those checks must not be skipped. Ensure both sets of checks are done by
+        changing the ancestor/descendant limit configurations.
+        """
+        node = self.nodes[0]
+        self.log.info("Test that a decreased limitdescendantsize also applies to V3 child")
+        self.restart_node(0, extra_args=["-limitdescendantsize=10", "-datacarriersize=40000"])
+        tx_v3_parent_large1 = self.wallet.send_self_transfer(from_node=node, target_weight=99900, version=3)
+        tx_v3_child_large1 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large1["new_utxo"], version=3)
+        # Child is within V3 limits
+        assert_greater_than(1000, tx_v3_child_large1["tx"].get_vsize())
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", node.sendrawtransaction,
+                tx_v3_child_large1["hex"])
+        self.check_mempool([tx_v3_parent_large1["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_large1["txid"])["descendantcount"], 1)
+        self.generate(node, 1)
+
+        self.log.info("Test that a decreased limitancestorsize also applies to V3 parent")
+        self.restart_node(0, extra_args=["-limitancestorsize=10", "-datacarriersize=40000"])
+        tx_v3_parent_large2 = self.wallet.send_self_transfer(from_node=node, target_weight=99900, version=3)
+        tx_v3_child_large2 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large2["new_utxo"], version=3)
+        # Child is within V3 limits
+        assert_greater_than_or_equal(1000, tx_v3_child_large2["tx"].get_vsize())
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", node.sendrawtransaction,
+                tx_v3_child_large2["hex"])
+        self.check_mempool([tx_v3_parent_large2["txid"]])
+
+    @cleanup
+    def test_fee_dependency_replacements(self):
+        """
+        Since v3 introduces the possibility of 0-fee (i.e. below min relay feerate) transactions in
+        the mempool, it's possible for these transactions' sponsors to disappear due to RBF. In
+        those situations, the 0-fee transaction must be evicted along with the replacements.
+        """
+        node = self.nodes[0]
+        self.log.info("Test that below-min-relay-feerate transactions are removed in RBF")
+        tx_0fee_parent = self.wallet.create_self_transfer(fee=0, fee_rate=0, version=3)
+        utxo_confirmed = self.wallet.get_utxo()
+        tx_child_replacee = self.wallet.create_self_transfer_multi(utxos_to_spend=[tx_0fee_parent["new_utxo"], utxo_confirmed], version=3)
+        node.submitpackage([tx_0fee_parent["hex"], tx_child_replacee["hex"]])
+        self.check_mempool([tx_0fee_parent["txid"], tx_child_replacee["txid"]])
+        tx_replacer = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=utxo_confirmed, fee_rate=DEFAULT_FEE * 10)
+        self.check_mempool([tx_replacer["txid"]])
+
+    def run_test(self):
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 110)
+        self.test_v3_acceptance()
+        self.test_v3_replacement()
+        self.test_v3_bip125()
+        self.test_v3_reorg()
+        self.test_nondefault_package_limits()
+        self.test_fee_dependency_replacements()
+
+
+if __name__ == "__main__":
+    MempoolAcceptV3().main()

--- a/test/functional/mempool_ephemeral_anchor.py
+++ b/test/functional/mempool_ephemeral_anchor.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import copy
+from decimal import Decimal
+
+from test_framework.messages import (
+    COIN,
+    CTxInWitness,
+    CTxOut,
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+ANCHOR_SCRIPT = CScript([OP_TRUE, b'\x4e\x73'])
+
+class EphemeralAnchorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[
+            "-whitelist=noban@127.0.0.1",  # immediate tx relay
+        ]] * self.num_nodes
+        self.setup_clean_chain = True
+
+    def assert_mempool_contents(self, expected=None, unexpected=None):
+        """Assert that all transactions in expected are in the mempool,
+        and all transactions in unexpected are not in the mempool.
+        """
+        if not expected:
+            expected = []
+        if not unexpected:
+            unexpected = []
+        assert set(unexpected).isdisjoint(expected)
+        mempool = self.nodes[0].getrawmempool(verbose=False)
+        for tx in expected:
+            assert tx.rehash() in mempool
+        for tx in unexpected:
+            assert tx.rehash() not in mempool
+
+    def insert_additional_outputs(self, parent_result, additional_outputs):
+        # Modify transaction as needed to add ephemeral anchor
+        parent_tx = parent_result["tx"]
+        additional_sum = 0
+        for additional_output in additional_outputs:
+            parent_tx.vout.append(additional_output)
+            additional_sum += additional_output.nValue
+
+        # Steal value from destination and recompute fields
+        parent_tx.vout[0].nValue -= additional_sum
+        parent_result["txid"] = parent_tx.rehash()
+        parent_result["wtxid"] = parent_tx.getwtxid()
+        parent_result["hex"] = parent_tx.serialize().hex()
+        parent_result["new_utxo"] = {**parent_result["new_utxo"],  "txid": parent_result["txid"], "value": Decimal(parent_tx.vout[0].nValue)/COIN}
+
+
+    def spend_ephemeral_anchor_witness(self, child_result, child_inputs):
+        child_tx = child_result["tx"]
+        child_tx.wit.vtxinwit = [copy.deepcopy(child_tx.wit.vtxinwit[0]) if "anchor" not in x else CTxInWitness() for x in child_inputs]
+        child_result["hex"] = child_tx.serialize().hex()
+
+
+    def create_simple_package(self, parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, spend_anchor=1, additional_outputs=None, version=3):
+        """Create a 1 parent 1 child package using the coin passed in as the parent's input. The
+        parent has 1 output, used to fund 1 child transaction.
+        All transactions signal BIP125 replaceability, but nSequence changes based on self.ctr. This
+        prevents identical txids between packages when the parents spend the same coin and have the
+        same fee (i.e. 0sat).
+
+        returns tuple (hex serialized txns, CTransaction objects)
+        """
+
+        if additional_outputs is None:
+            additional_outputs=[CTxOut(0, ANCHOR_SCRIPT)]
+
+        child_inputs = []
+        self.ctr += 1
+        # Use fee_rate=0 because create_self_transfer will use the default fee_rate value otherwise.
+        # Passing in fee>0 overrides fee_rate, so this still works for non-zero parent_fee.
+        parent_result = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=parent_fee,
+            utxo_to_spend=parent_coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            version=version,
+        )
+
+        self.insert_additional_outputs(parent_result, additional_outputs)
+
+        # Add inputs to child, depending on spend arg
+        child_inputs.append(parent_result["new_utxo"])
+        if spend_anchor:
+            for vout, output in enumerate(additional_outputs):
+                child_inputs.append({**parent_result["new_utxo"], 'vout': 1+vout, 'value': Decimal(output.nValue)/COIN, 'anchor': True})
+
+
+        child_result = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=child_inputs,
+            num_outputs=1,
+            fee_per_output=int(child_fee * COIN),
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            version=version,
+        )
+
+        if spend_anchor:
+            self.spend_ephemeral_anchor_witness(child_result, child_inputs)
+
+        package_hex = [parent_result["hex"], child_result["hex"]]
+        package_txns = [parent_result["tx"], child_result["tx"]]
+        return package_hex, package_txns
+
+    def run_test(self):
+        # Counter used to count the number of times we constructed packages. Since we're constructing parent transactions with the same
+        # coins (to create conflicts), and giving them the same fee (i.e. 0, since their respective children are paying), we might
+        # accidentally just create the exact same transaction again. To prevent this, set nSequences to MAX_BIP125_RBF_SEQUENCE - self.ctr.
+        self.ctr = 0
+
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 160)
+        self.coins = self.wallet.get_utxos(mark_as_spent=False)
+        # Mature coinbase transactions
+        self.generate(self.wallet, 100)
+        self.address = self.wallet.get_address()
+
+        self.test_sponsor_swap()
+        self.test_node_restart()
+        self.test_fee_having_parent()
+        self.test_multianchor()
+        self.test_nonzero_anchor()
+        self.test_prioritise_parent()
+        self.test_non_v3()
+        self.test_unspent_ephemeral()
+        self.test_xor_rbf()
+
+    def test_node_restart(self):
+        self.log.info("Test that an ephemeral package is accepted on restart due to bypass_limits load")
+        node = self.nodes[0]
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        # Enters mempool
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        # Node restart; doesn't allow allow ephemeral transaction back in due to individual submission
+        self.restart_node(0)
+        assert_equal(node.getrawmempool(), [])
+
+    def test_fee_having_parent(self):
+        self.log.info("Test that a transaction with ephemeral anchor may not have base fee")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=1, child_fee=DEFAULT_FEE)
+        res = node.submitpackage(package_hex0)
+        assert_equal(res["tx-results"][package_txns0[0].getwtxid()]["error"], "invalid-ephemeral-fee")
+        assert_equal(node.getrawmempool(), [])
+
+        # But works with no parent fee
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        self.generate(node, 1)
+
+    def test_multianchor(self):
+        self.log.info("Test that a transaction with multiple ephemeral anchors is nonstandard")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, additional_outputs=[CTxOut(0, ANCHOR_SCRIPT)] * 2)
+        res = node.submitpackage(package_hex0)
+        assert_equal(res["tx-results"][package_txns0[0].getwtxid()]["error"], "too-many-ephemeral-anchors")
+        assert_equal(node.getrawmempool(), [])
+
+        self.generate(node, 1)
+
+    def test_nonzero_anchor(self):
+        def inner_test_anchor_value(output_value):
+            node = self.nodes[0]
+            # Reuse the same coins so that the transactions conflict with one another.
+            parent_coin = self.coins[-1]
+            del self.coins[-1]
+
+            package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, additional_outputs=[CTxOut(output_value, ANCHOR_SCRIPT)])
+            node.submitpackage(package_hex0)
+            self.assert_mempool_contents(expected=package_txns0, unexpected=[])
+
+            self.generate(node, 1)
+
+        self.log.info("Test that a transaction with ephemeral anchor may have any otherwise legal satoshi value")
+        for i in range(5):
+            inner_test_anchor_value(int(i*COIN/4))
+
+    def test_prioritise_parent(self):
+        self.log.info("Test that prioritizing a parent transaction with ephemeral anchor doesn't cause mempool rejection due to non-0 parent fee")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        # De-prioritising to 0-fee doesn't matter; it's just the base fee that matters
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=1, child_fee=DEFAULT_FEE)
+        parent_txid = node.decoderawtransaction(package_hex0[0])['txid']
+        node.prioritisetransaction(txid=parent_txid, dummy=0, fee_delta=COIN)
+        res = node.submitpackage(package_hex0)
+        assert_equal(res["tx-results"][package_txns0[0].getwtxid()]["error"], "invalid-ephemeral-fee")
+        assert_equal(node.getrawmempool(), [])
+
+        # Also doesn't make it invalid if applied to the parent
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        parent_txid = node.decoderawtransaction(package_hex1[0])['txid']
+        node.prioritisetransaction(txid=parent_txid, dummy=0, fee_delta=COIN)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        self.generate(node, 1)
+
+    def test_non_v3(self):
+        self.log.info("Test that v2 EA-having transaction is rejected")
+        # N.B. Currently we never actually hit the "wrong version" check but min relay restriction
+        # may be relaxed in the future for non-V3.
+
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        package_hex, package_txns = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, version=2)
+        res = node.submitpackage(package_hex)
+        assert_equal(res["tx-results"][package_txns[0].getwtxid()]["error"], "wrong-ephemeral-nversion")
+        assert_equal(node.getrawmempool(), [])
+
+    def test_unspent_ephemeral(self):
+        self.log.info("Test that ephemeral outputs of any value are disallowed if not spent in a package")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        # Submit whole package, but anchor are unspent
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, spend_anchor=
+0)
+        res = node.submitpackage(package_hex0)
+        assert "missing-ephemeral-spends" in res["tx-results"][package_txns0[0].getwtxid()]["error"]
+        assert_equal(node.getrawmempool(), [])
+
+        # Individual submission also fails
+        hex0_txid = node.decoderawtransaction(package_hex0[0])["txid"]
+        node.prioritisetransaction(hex0_txid, 0, COIN)
+        assert_raises_rpc_error(-26, "missing-ephemeral-spends", node.sendrawtransaction, package_hex0[0])
+        assert_equal(node.getrawmempool(), [])
+
+        # One more time
+        package_hex3, package_txns3 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex3)
+        self.assert_mempool_contents(expected=package_txns3, unexpected=[])
+
+        self.generate(node, 1)
+
+    def test_xor_rbf(self):
+        self.log.info("Test some child RBF behavior")
+        node = self.nodes[0]
+        num_parents = 2
+        # Coins to create parents
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+
+        # Coin to RBF own child
+        child_coin = self.coins[0]
+        del self.coins[0]
+
+        package_hex = []
+        package_txns = []
+
+
+        child_inputs = []
+        # Make two parents with one normal and one ephemeral output each
+        for i, coin in enumerate(parent_coins):
+            parent_result = self.wallet.create_self_transfer(
+                fee_rate=0,
+                fee=0,
+                utxo_to_spend=parent_coins[i],
+                sequence=MAX_BIP125_RBF_SEQUENCE,
+                version=3
+            )
+
+            self.insert_additional_outputs(parent_result, [CTxOut(0, ANCHOR_SCRIPT)])
+
+            child_inputs.append(parent_result["new_utxo"])
+            child_inputs.append({**parent_result["new_utxo"], 'vout': 1, 'value': 0, 'anchor': True})
+
+            package_hex.append(parent_result["hex"])
+            package_txns.append(parent_result["tx"])
+
+
+        # Append child_coin to possible spends
+        child_inputs.append(child_coin)
+
+        assert_equal(len(child_inputs), 5)
+
+        # First child spends first parent's two inputs
+        child_one = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=child_inputs[:2],
+            num_outputs=1,
+            fee_per_output=int(COIN),
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        self.spend_ephemeral_anchor_witness(child_one, child_inputs[:2])
+
+        # Submit first parent and child together
+        first_package_hex = [package_hex[0], child_one["hex"]]
+        first_package_txns = [package_txns[0], child_one["tx"]]
+        node.submitpackage(first_package_hex)
+        self.assert_mempool_contents(expected=first_package_txns, unexpected=[])
+
+        # Second child RBF spends first parent's two inputs, plus their own confirmed input
+        second_inputs = child_inputs[:2] + [child_inputs[-1]]
+        child_two = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=second_inputs,
+            num_outputs=1,
+            fee_per_output=int(COIN)*2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        self.spend_ephemeral_anchor_witness(child_two, second_inputs)
+
+        second_package_hex = [package_hex[0], child_two["hex"]]
+        second_package_txns = [package_txns[0], child_two["tx"]]
+        node.submitpackage(second_package_hex)
+        self.assert_mempool_contents(expected=second_package_txns, unexpected=[])
+
+        # Third makes first parent childless via child's confirmed input double-spend
+        # spending the second parent's ephemeral anchor and not the other output
+        third_inputs = [child_inputs[3], child_inputs[-1]]
+        child_three = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=third_inputs,
+            num_outputs=1,
+            fee_per_output=int(COIN)*3,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        self.spend_ephemeral_anchor_witness(child_three, third_inputs)
+
+        third_package_hex = [package_hex[1], child_three["hex"]]
+        third_package_txns = [package_txns[1], child_three["tx"]]
+
+        node.submitpackage(third_package_hex)
+        # First parent not in mempool because it has been trimmed
+        self.assert_mempool_contents(expected=third_package_txns, unexpected=[package_txns[0]])
+
+        # This bump exercises the v3 section of CheckMinerScores
+        fourth_inputs = child_inputs[:2] + [child_inputs[-1]]
+        child_four = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=fourth_inputs,
+            num_outputs=1,
+            fee_per_output=int(COIN)*4,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        self.spend_ephemeral_anchor_witness(child_four, fourth_inputs)
+
+        fourth_package_hex = [package_hex[0], child_four["hex"]]
+        fourth_package_txns = [package_txns[0], child_four["tx"]]
+        node.submitpackage(fourth_package_hex)
+        self.assert_mempool_contents(expected=fourth_package_txns, unexpected=[child_three["tx"]])
+
+        # Mining everything
+        self.generate(node, 1)
+        assert_equal(node.getrawmempool(), [])
+
+
+    def test_sponsor_swap(self):
+        self.log.info("Test that EA txn is evicted when sponsoring tx doesn't spend anchor itself")
+        node = self.nodes[0]
+
+        # Coin to create 0-fee parent
+        parent_coin = self.coins[0]
+        del self.coins[0]
+
+        # Fee coin for sponsor which will be RBF'd
+        sponsor_coin = self.coins[0]
+        del self.coins[0]
+
+        package_hex = []
+        package_txns = []
+
+        parent_result = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=0,
+            utxo_to_spend=parent_coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            version=3
+        )
+
+        self.insert_additional_outputs(parent_result, [CTxOut(0, ANCHOR_SCRIPT)])
+
+        non_ea_coin = parent_result["new_utxo"]
+        ea_coin = {**parent_result["new_utxo"], 'vout': 1, 'value': 0, 'anchor': True}
+
+        package_hex.append(parent_result["hex"])
+        package_txns.append(parent_result["tx"])
+
+        # First child spends ephemeral anchor and sponsor
+        first_spend = [ea_coin, sponsor_coin]
+        child_one = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=first_spend,
+            num_outputs=1,
+            fee_per_output=int(COIN),
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        self.spend_ephemeral_anchor_witness(child_one, first_spend)
+
+        # Submit parent and child together
+        first_package_hex = [package_hex[0], child_one["hex"]]
+        first_package_txns = [package_txns[0], child_one["tx"]]
+        node.submitpackage(first_package_hex)
+        self.assert_mempool_contents(expected=first_package_txns, unexpected=[])
+
+        # Now we need to stage:
+        # (a) 1-input-1-output spend of non_ea_coin
+        # (b) 1-input-1-output double-spend of sponsor_coin
+        # (c) 2-input-1-output spend of (a) and (b)
+        #
+        # This creates an ancestor package will would pass
+        # ancestor package sanity checks to trigger package evaluation,
+        # but (a) should be rejected for not spending ea_coin using
+        # mempool-contextual checks. This is to catch
+        # sub-package evaluation of just (a) allowing it through.
+
+        a_spend = [non_ea_coin]
+        child_a = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=a_spend,
+            num_outputs=1,
+            fee_per_output=int(COIN)*2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        b_spend = [sponsor_coin]
+        child_b = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=b_spend,
+            num_outputs=1,
+            fee_per_output=int(COIN)*2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        # This tx should never work because of v3 package limits, but that's not
+        # the error we're interested in exercising here
+        c_spend = [child_a["new_utxos"][0], child_b["new_utxos"][0]]
+        child_c = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=c_spend,
+            num_outputs=1,
+            fee_per_output=int(COIN)*2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - 1,
+            version=3
+        )
+
+        # Submit a + b + c ancestor package
+        node.submitpackage([child_a["hex"], child_b["hex"], child_c["hex"]])
+
+        # Only the sponsor RBF makes it into mempool, parent is evicted and other pkg tx have been rejected for V3 violations
+        assert_equal(node.getrawmempool(), [child_b["txid"]])
+
+        # Mining everything
+        self.generate(node, 1)
+        assert_equal(node.getrawmempool(), [])
+
+
+if __name__ == "__main__":
+    EphemeralAnchorTest().main()

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from decimal import Decimal
+
+from test_framework.messages import (
+    COIN,
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+    assert_equal,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+class PackageRBFTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def assert_mempool_contents(self, expected=None, unexpected=None):
+        """Assert that all transactions in expected are in the mempool,
+        and all transactions in unexpected are not in the mempool.
+        """
+        if not expected:
+            expected = []
+        if not unexpected:
+            unexpected = []
+        assert set(unexpected).isdisjoint(expected)
+        mempool = self.nodes[0].getrawmempool(verbose=False)
+        for tx in expected:
+            assert tx.rehash() in mempool
+        for tx in unexpected:
+            assert tx.rehash() not in mempool
+
+    def create_simple_package(self, parent_coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE, heavy_child=False):
+        """Create a 1 parent 1 child package using the coin passed in as the parent's input. The
+        parent has 1 output, used to fund 1 child transaction.
+        All transactions signal BIP125 replaceability, but nSequence changes based on self.ctr. This
+        prevents identical txids between packages when the parents spend the same coin and have the
+        same fee (i.e. 0sat).
+
+        returns tuple (hex serialized txns, CTransaction objects)
+        """
+        self.ctr += 1
+        # Use fee_rate=0 because create_self_transfer will use the default fee_rate value otherwise.
+        # Passing in fee>0 overrides fee_rate, so this still works for non-zero parent_fee.
+        parent_result = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=parent_fee,
+            utxo_to_spend=parent_coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        num_child_outputs = 10 if heavy_child else 1
+        child_result = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent_result["new_utxo"]],
+            num_outputs=num_child_outputs,
+            fee_per_output=int(child_fee * COIN // num_child_outputs),
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+        package_hex = [parent_result["hex"], child_result["hex"]]
+        package_txns = [parent_result["tx"], child_result["tx"]]
+        return package_hex, package_txns
+
+    def run_test(self):
+        # Counter used to count the number of times we constructed packages. Since we're constructing parent transactions with the same
+        # coins (to create conflicts), and giving them the same fee (i.e. 0, since their respective children are paying), we might
+        # accidentally just create the exact same transaction again. To prevent this, set nSequences to MAX_BIP125_RBF_SEQUENCE - self.ctr.
+        self.ctr = 0
+
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 160)
+        self.coins = self.wallet.get_utxos(mark_as_spent=False)
+        # Mature coinbase transactions
+        self.generate(self.wallet, 100)
+        self.address = self.wallet.get_address()
+
+        self.test_package_rbf_basic()
+        self.test_package_rbf_additional_fees()
+        self.test_package_rbf_max_conflicts()
+        self.test_package_rbf_conflicting_conflicts()
+        self.test_package_rbf_partial()
+        self.test_too_numerous_ancestors()
+        self.test_too_numerous_pkg()
+        self.test_insufficient_feerate()
+
+    def test_package_rbf_basic(self):
+        self.log.info("Test that a child can pay to replace its parents' conflicts")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(parent_coin, DEFAULT_FEE, DEFAULT_FEE * 5)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+
+        submitres = node.submitpackage(package_hex2)
+        submitres["replaced-transactions"] == [tx.rehash() for tx in package_txns1]
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        self.generate(node, 1)
+
+    def test_package_rbf_additional_fees(self):
+        self.log.info("Check Package RBF must increase the absolute fee")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+
+        # avoid parent pays for child anti-DoS checks
+        fee_delta = DEFAULT_FEE / 2
+
+        package_hex1, package_txns1 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE - fee_delta, child_fee=DEFAULT_FEE + fee_delta, heavy_child=True)
+        assert_greater_than_or_equal(1000, package_txns1[-1].get_vsize())
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+
+        # Package 2 has a higher feerate but lower absolute fee
+        package_hex2, package_txns2 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE - fee_delta, child_fee=DEFAULT_FEE + fee_delta - Decimal("0.000000001"))
+        pkg_results2 = node.submitpackage(package_hex2)
+        assert_equal(pkg_results2["package_msg"], 'package RBF failed: insufficient anti-DoS fees')
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        # Package 3 has a higher feerate and absolute fee
+        package_hex3, package_txns3 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE * 3)
+        node.submitpackage(package_hex3)
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns1 + package_txns2)
+        self.generate(node, 1)
+
+        self.log.info("Check Package RBF must pay for the entire package's bandwidth")
+        coin = self.coins.pop()
+        package_hex4, package_txns4 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex4)
+        self.assert_mempool_contents(expected=package_txns4, unexpected=[])
+        package_hex5, package_txns5 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE - fee_delta, child_fee=DEFAULT_FEE + fee_delta + Decimal("0.000000001"))
+        pkg_results5 = node.submitpackage(package_hex5)
+        assert_equal(pkg_results5["package_msg"], 'package RBF failed: insufficient anti-DoS fees')
+
+        self.assert_mempool_contents(expected=package_txns4, unexpected=package_txns5)
+        self.generate(node, 1)
+
+        self.log.info("Check Package RBF must have strict cpfp structure")
+        coin = self.coins.pop()
+        package_hex5, package_txns5 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex5)
+        self.assert_mempool_contents(expected=package_txns5, unexpected=[])
+        package_hex6, package_txns6 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE + fee_delta, child_fee=DEFAULT_FEE - (fee_delta / 2))
+        pkg_results6 = node.submitpackage(package_hex6)
+        assert_equal(pkg_results6["package_msg"], 'package RBF failed: parent paying for child anti-DoS')
+
+        self.assert_mempool_contents(expected=package_txns5, unexpected=package_txns6)
+        self.generate(node, 1)
+
+
+    def test_package_rbf_max_conflicts(self):
+        node = self.nodes[0]
+        self.log.info("Check Package RBF cannot replace more than 100 transactions")
+        num_coins = 5
+        parent_coins = self.coins[:num_coins]
+        del self.coins[:num_coins]
+        # Original transactions: 5 transactions with 24 descendants each.
+        for coin in parent_coins:
+            self.wallet.send_self_transfer_chain(from_node=node, chain_length=25, utxo_to_spend=coin)
+
+        # Replacement package: 1 parent which conflicts with 5 * (1 + 24) = 125 mempool transactions.
+        package_parent = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_coins)
+        package_child = self.wallet.create_self_transfer(fee_rate=50*DEFAULT_FEE, utxo_to_spend=package_parent["new_utxos"][0])
+
+        pkg_results = node.submitpackage([package_parent["hex"], package_child["hex"]])
+        assert_equal(pkg_results["package_msg"], "package RBF failed: too many potential replacements")
+        self.generate(node, 1)
+
+    def test_package_rbf_conflicting_conflicts(self):
+        node = self.nodes[0]
+        self.log.info("Check that different package transactions cannot share the same conflicts")
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(coin, Decimal("0.00009"), DEFAULT_FEE * 2)
+        package_hex3, package_txns3 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE * 5)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+        # The first two transactions have the same conflicts
+        package_duplicate_conflicts_hex = [package_hex2[0]] + package_hex3
+        # Note that this won't actually go into the RBF logic, because static package checks will
+        # detect that two package transactions conflict with each other. Either way, this must fail.
+        assert_raises_rpc_error(-25, "package topology disallowed", node.submitpackage, package_duplicate_conflicts_hex)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2 + package_txns3)
+        # The RBFs should otherwise work.
+        submitres2 = node.submitpackage(package_hex2)
+        assert_equal(sorted(submitres2["replaced-transactions"]),sorted( [tx.rehash() for tx in package_txns1]))
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        submitres3 = node.submitpackage(package_hex3)
+        assert_equal(sorted(submitres3["replaced-transactions"]), sorted([tx.rehash() for tx in package_txns2]))
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns2)
+
+    def test_package_rbf_partial(self):
+        self.log.info("Test that package RBF works when a transaction was already submitted")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(coin, DEFAULT_FEE * 3, DEFAULT_FEE * 3)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        # Submit parent on its own. It should have no trouble replacing the previous
+        # transaction(s) because the fee is tripled.
+        node.sendrawtransaction(package_hex2[0])
+        node.submitpackage(package_hex2)
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        self.generate(node, 1)
+
+    def test_too_numerous_ancestors(self):
+        self.log.info("Test that package RBF doesn't work with packages larger than 2 due to ancestors")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        # Double-spends the original package
+        self.ctr += 1
+        parent_result1 = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        coin2 = self.coins.pop()
+
+        # Added to make package too large for package RBF;
+        # it will enter mempool individually
+        self.ctr += 1
+        parent_result2 = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        # Child that spends both, violating cluster size rule due
+        # to in-mempool ancestry
+        self.ctr += 1
+        child_result = self.wallet.create_self_transfer_multi(
+            fee_per_output=int(DEFAULT_FEE * 5 * COIN),
+            utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        package_hex2 = [parent_result1["hex"], parent_result2["hex"], child_result["hex"]]
+        package_txns2_fail = [parent_result1["tx"], child_result["tx"]]
+        package_txns2_succeed = [parent_result2["tx"]]
+
+        pkg_result = node.submitpackage(package_hex2)
+        assert_equal(pkg_result["package_msg"], 'package RBF failed: replacing cluster with ancestors not size two')
+        self.assert_mempool_contents(expected=package_txns1 + package_txns2_succeed, unexpected=package_txns2_fail)
+        self.generate(node, 1)
+
+    def test_too_numerous_pkg(self):
+        self.log.info("Test that package RBF doesn't work with packages larger than 2 due to pkg size")
+        node = self.nodes[0]
+        coin1 = self.coins.pop()
+        coin2 = self.coins.pop()
+
+        # Two packages to require multiple direct conflicts, easier to set up illicit pkg size
+        package_hex1, package_txns1 = self.create_simple_package(coin1, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(coin2, DEFAULT_FEE, DEFAULT_FEE)
+
+        node.submitpackage(package_hex1)
+        node.submitpackage(package_hex2)
+
+        self.assert_mempool_contents(expected=package_txns1 + package_txns2, unexpected=[])
+        assert_equal(len(node.getrawmempool()), 4)
+
+        # Double-spends the first package
+        self.ctr += 1
+        parent_result1 = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin1,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        # Double-spends the second package
+        self.ctr += 1
+        parent_result2 = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin2,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        # Child that spends both, violating cluster size rule due
+        # to pkg size
+        self.ctr += 1
+        child_result = self.wallet.create_self_transfer_multi(
+            fee_per_output=int(DEFAULT_FEE * 5 * COIN),
+            utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        package_hex3 = [parent_result1["hex"], parent_result2["hex"], child_result["hex"]]
+        package_txns3_fail = [parent_result1["tx"], parent_result2["tx"], child_result["tx"]]
+
+        pkg_result = node.submitpackage(package_hex3)
+        assert_equal(pkg_result["package_msg"], 'package RBF failed: replacing cluster not size two')
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns3_fail)
+        self.generate(node, 1)
+
+    def test_insufficient_feerate(self):
+        self.log.info("Check Package RBF must neat feerate of direct conflict")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+
+        # avoid parent pays for child anti-DoS checks
+        fee_delta = DEFAULT_FEE / 2
+
+        package_hex1, package_txns1 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE + fee_delta, child_fee=DEFAULT_FEE - fee_delta)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+
+        # Package 2 feerate is below the rate of directly conflicted parent, even though
+        # total fees are higher than the original package
+        package_hex2, package_txns2 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE + fee_delta)
+        pkg_results2 = node.submitpackage(package_hex2)
+        assert_equal(pkg_results2["package_msg"], 'package RBF failed: insufficient feerate')
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        self.generate(node, 1)
+
+if __name__ == "__main__":
+    PackageRBFTest().main()

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -925,3 +925,5 @@ def taproot_construct(pubkey, scripts=None, treat_internal_as_infinity=False):
 
 def is_op_success(o):
     return o == 0x50 or o == 0x62 or o == 0x89 or o == 0x8a or o == 0x8d or o == 0x8e or (o >= 0x7e and o <= 0x81) or (o >= 0x83 and o <= 0x86) or (o >= 0x95 and o <= 0x99) or (o >= 0xbb and o <= 0xfe)
+
+EPHEMERAL_ANCHOR_SCRIPT = CScript([OP_TRUE, b'\x4e\x73'])

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -290,7 +290,8 @@ class MiniWallet:
         sequence=0,
         fee_per_output=1000,
         target_weight=0,
-        confirmed_only=False
+        confirmed_only=False,
+        version=2
     ):
         """
         Create and return a transaction that spends the given UTXOs and creates a
@@ -314,6 +315,7 @@ class MiniWallet:
         tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend, seq in zip(utxos_to_spend, sequence)]
         tx.vout = [CTxOut(amount_per_output, bytearray(self._scriptPubKey)) for _ in range(num_outputs)]
         tx.nLockTime = locktime
+        tx.nVersion = version
 
         self.sign_tx(tx)
 
@@ -344,7 +346,8 @@ class MiniWallet:
             locktime=0,
             sequence=0,
             target_weight=0,
-            confirmed_only=False
+            confirmed_only=False,
+            version=2
     ):
         """Create and return a tx with the specified fee. If fee is 0, use fee_rate, where the resulting fee may be exact or at most one satoshi higher than needed."""
         utxo_to_spend = utxo_to_spend or self.get_utxo(confirmed_only=confirmed_only)
@@ -360,7 +363,14 @@ class MiniWallet:
         send_value = utxo_to_spend["value"] - (fee or (fee_rate * vsize / 1000))
 
         # create tx
-        tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value), target_weight=target_weight)
+        tx = self.create_self_transfer_multi(
+            utxos_to_spend=[utxo_to_spend],
+            locktime=locktime,
+            sequence=sequence,
+            amount_per_output=int(COIN * send_value),
+            target_weight=target_weight,
+            version=version
+        )
         if not target_weight:
             assert_equal(tx["tx"].get_vsize(), vsize)
         tx["new_utxo"] = tx.pop("new_utxos")[0]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -260,6 +260,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_tx.py --v2transport',
     'p2p_v2_transport.py',
     'example_test.py',
+    'mempool_accept_v3.py',
     'wallet_txn_doublespend.py --legacy-wallet',
     'wallet_multisig_descriptor_psbt.py --descriptors',
     'wallet_txn_doublespend.py --descriptors',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -276,6 +276,7 @@ BASE_SCRIPTS = [
     'mempool_packages.py',
     'mempool_package_onemore.py',
     'mempool_package_limits.py',
+    'mempool_package_rbf.py',
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -388,6 +388,7 @@ BASE_SCRIPTS = [
     'feature_dirsymlinks.py',
     'feature_help.py',
     'feature_shutdown.py',
+    'mempool_ephemeral_anchor.py',
     'wallet_migration.py',
     'p2p_ibd_txrelay.py',
     # Don't append tests at the end to avoid merge conflicts


### PR DESCRIPTION
Depends on https://github.com/bitcoin/bitcoin/pull/28948 and https://github.com/bitcoin/bitcoin/pull/28984

Replaces https://github.com/bitcoin/bitcoin/pull/26403 to refresh the conversation.

BIP text here: https://github.com/instagibbs/bips/blob/ephemeral_anchor/bip-ephemeralanchors.mediawiki

Example usage:
https://github.com/instagibbs/bolts/commits/zero_fee_commitment
https://github.com/instagibbs/lightning/commits/commit_zero_fees

TODO:
1) figure out what precisely to do in a reorg when ephemeral transactions are trying to enter the mempool(and write a test)
2) restrict ephemeral anchor value to 0 (future relaxation possible with more work/motivation)
3) rebased on top of master, add in trim ephemeral anchor tx functionality when they are at 0-fee package feerate