### PR TITLE
fuzz: Avoid timeout in bitdeque

### DIFF
--- a/src/test/fuzz/bitdeque.cpp
+++ b/src/test/fuzz/bitdeque.cpp
@@ -53,21 +53,11 @@ FUZZ_TARGET(bitdeque, .init = InitRandData)
         --initlen;
     }
 
-    LIMITED_WHILE(provider.remaining_bytes() > 0, 900)
+    const auto iter_limit{maxlen > 6000 ? 90U : 900U};
+    LIMITED_WHILE(provider.remaining_bytes() > 0, iter_limit)
     {
-        {
-            assert(deq.size() == bitdeq.size());
-            auto it = deq.begin();
-            auto bitit = bitdeq.begin();
-            auto itend = deq.end();
-            while (it != itend) {
-                assert(*it == *bitit);
-                ++it;
-                ++bitit;
-            }
-        }
-
-        CallOneOf(provider,
+        CallOneOf(
+            provider,
             [&] {
                 // constructor()
                 deq = std::deque<bool>{};
@@ -535,7 +525,17 @@ FUZZ_TARGET(bitdeque, .init = InitRandData)
                     assert(it == deq.begin() + before);
                     assert(bitit == bitdeq.begin() + before);
                 }
-            }
-        );
+            });
+    }
+    {
+        assert(deq.size() == bitdeq.size());
+        auto it = deq.begin();
+        auto bitit = bitdeq.begin();
+        auto itend = deq.end();
+        while (it != itend) {
+            assert(*it == *bitit);
+            ++it;
+            ++bitit;
+        }
     }
 }


### PR DESCRIPTION
Avoid timeouts such as https://github.com/bitcoin/bitcoin/issues/28812#issuecomment-1842914664

This is done by:

* Limiting the maximum number of iterations if the maximum size of the container is "large" (see the magic numbers in the code).
* Check the equality only once. This should be fine, because if a crash were to happen in the equality check, but the crash doesn't happen if further iterations were run, the fuzz engine should eventually find the crash by truncating the fuzz input.