### PR TITLE
test: doc: follow-up #28368

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -301,7 +301,7 @@ void Shutdown(NodeContext& node)
         DumpMempool(*node.mempool, MempoolPath(*node.args));
     }
 
-    // Drop transactions we were still watching, record fee estimations and Unregister
+    // Drop transactions we were still watching, record fee estimations and unregister
     // fee estimator from validation interface.
     if (node.fee_estimator) {
         node.fee_estimator->Flush();

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -226,7 +226,7 @@ struct NewMempoolTransactionInfo {
      * This boolean indicates whether the transaction was added
      * without enforcing mempool fee limits.
      */
-    const bool m_from_disconnected_block;
+    const bool m_mempool_limit_bypassed;
     /* This boolean indicates whether the transaction is part of a package. */
     const bool m_submitted_in_package;
     /*
@@ -239,11 +239,11 @@ struct NewMempoolTransactionInfo {
 
     explicit NewMempoolTransactionInfo(const CTransactionRef& tx, const CAmount& fee,
                                        const int64_t vsize, const unsigned int height,
-                                       const bool from_disconnected_block, const bool submitted_in_package,
+                                       const bool mempool_limit_bypassed, const bool submitted_in_package,
                                        const bool chainstate_is_current,
                                        const bool has_no_mempool_parents)
         : info{tx, fee, vsize, height},
-          m_from_disconnected_block{from_disconnected_block},
+          m_mempool_limit_bypassed{mempool_limit_bypassed},
           m_submitted_in_package{submitted_in_package},
           m_chainstate_is_current{chainstate_is_current},
           m_has_no_mempool_parents{has_no_mempool_parents} {}

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -612,7 +612,7 @@ void CBlockPolicyEstimator::processTransaction(const NewMempoolTransactionInfo& 
     // - the node is not behind
     // - the transaction is not dependent on any other transactions in the mempool
     // - it's not part of a package.
-    const bool validForFeeEstimation = !tx.m_from_disconnected_block && !tx.m_submitted_in_package && tx.m_chainstate_is_current && tx.m_has_no_mempool_parents;
+    const bool validForFeeEstimation = !tx.m_mempool_limit_bypassed && !tx.m_submitted_in_package && tx.m_chainstate_is_current && tx.m_has_no_mempool_parents;
 
     // Only want to be updating estimates when our blockchain is synced,
     // otherwise we'll miscalculate how many blocks its taking to get included.

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -47,10 +47,10 @@ FUZZ_TARGET(policy_estimator, .init = initialize_policy_estimator)
                 const CTxMemPoolEntry& entry = ConsumeTxMemPoolEntry(fuzzed_data_provider, tx);
                 const auto tx_info = NewMempoolTransactionInfo(entry.GetSharedTx(), entry.GetFee(),
                                                                entry.GetTxSize(), entry.GetHeight(),
-                                                               /* m_from_disconnected_block */ false,
-                                                               /* m_submitted_in_package */ false,
-                                                               /* m_chainstate_is_current */ true,
-                                                               /* m_has_no_mempool_parents */ fuzzed_data_provider.ConsumeBool());
+                                                               /*mempool_limit_bypassed=*/false,
+                                                               /*submitted_in_package=*/false,
+                                                               /*chainstate_is_current=*/true,
+                                                               /*has_no_mempool_parents=*/fuzzed_data_provider.ConsumeBool());
                 block_policy_estimator.processTransaction(tx_info);
                 if (fuzzed_data_provider.ConsumeBool()) {
                     (void)block_policy_estimator.removeTx(tx.GetHash());

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -45,12 +45,14 @@ FUZZ_TARGET(policy_estimator, .init = initialize_policy_estimator)
                 }
                 const CTransaction tx{*mtx};
                 const CTxMemPoolEntry& entry = ConsumeTxMemPoolEntry(fuzzed_data_provider, tx);
+                const auto tx_submitted_in_package = fuzzed_data_provider.ConsumeBool();
+                const auto tx_has_mempool_parents = fuzzed_data_provider.ConsumeBool();
                 const auto tx_info = NewMempoolTransactionInfo(entry.GetSharedTx(), entry.GetFee(),
                                                                entry.GetTxSize(), entry.GetHeight(),
                                                                /*mempool_limit_bypassed=*/false,
-                                                               /*submitted_in_package=*/false,
+                                                               tx_submitted_in_package,
                                                                /*chainstate_is_current=*/true,
-                                                               /*has_no_mempool_parents=*/fuzzed_data_provider.ConsumeBool());
+                                                               tx_has_mempool_parents);
                 block_policy_estimator.processTransaction(tx_info);
                 if (fuzzed_data_provider.ConsumeBool()) {
                     (void)block_policy_estimator.removeTx(tx.GetHash());

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -112,6 +112,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         }
     }
 
+    // Wait for fee estimator to catch up
+    SyncWithValidationInterfaceQueue();
+
     std::vector<CAmount> origFeeEst;
     // Highest feerate is 10*baseRate and gets in all blocks,
     // second highest feerate is 9*baseRate and gets in 9/10 blocks = 90%,

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -70,10 +70,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                                                                                       feeV[j],
                                                                                       virtual_size,
                                                                                       entry.nHeight,
-                                                                                      /* m_from_disconnected_block */ false,
-                                                                                      /* m_submitted_in_package */ false,
-                                                                                      /* m_chainstate_is_current */ true,
-                                                                                      /* m_has_no_mempool_parents */ true)};
+                                                                                      /*mempool_limit_bypassed=*/false,
+                                                                                      /*submitted_in_package=*/false,
+                                                                                      /*chainstate_is_current=*/true,
+                                                                                      /*has_no_mempool_parents=*/true)};
                     GetMainSignals().TransactionAddedToMempool(tx_info, mpool.GetAndIncrementSequence());
                 }
                 uint256 hash = tx.GetHash();
@@ -171,10 +171,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                                                                                       feeV[j],
                                                                                       virtual_size,
                                                                                       entry.nHeight,
-                                                                                      /* m_from_disconnected_block */ false,
-                                                                                      /* m_submitted_in_package */ false,
-                                                                                      /* m_chainstate_is_current */ true,
-                                                                                      /* m_has_no_mempool_parents */ true)};
+                                                                                      /*mempool_limit_bypassed=*/false,
+                                                                                      /*submitted_in_package=*/false,
+                                                                                      /*chainstate_is_current=*/true,
+                                                                                      /*has_no_mempool_parents=*/true)};
                     GetMainSignals().TransactionAddedToMempool(tx_info, mpool.GetAndIncrementSequence());
                 }
                 uint256 hash = tx.GetHash();
@@ -235,10 +235,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                                                                                       feeV[j],
                                                                                       virtual_size,
                                                                                       entry.nHeight,
-                                                                                      /* m_from_disconnected_block */ false,
-                                                                                      /* m_submitted_in_package */ false,
-                                                                                      /* m_chainstate_is_current */ true,
-                                                                                      /* m_has_no_mempool_parents */ true)};
+                                                                                      /*mempool_limit_bypassed=*/false,
+                                                                                      /*submitted_in_package=*/false,
+                                                                                      /*chainstate_is_current=*/true,
+                                                                                      /*has_no_mempool_parents=*/true)};
                     GetMainSignals().TransactionAddedToMempool(tx_info, mpool.GetAndIncrementSequence());
                 }
                 uint256 hash = tx.GetHash();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -150,7 +150,7 @@ protected:
     virtual void BlockConnected(ChainstateRole role, const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
     /**
      * Notifies listeners of a block being disconnected
-     *  Provides the block that was connected.
+     * Provides the block that was disconnected.
      *
      * Called on a background thread. Only called for the active chainstate, since
      * background chainstates should never disconnect blocks.


### PR DESCRIPTION
This is a simple PR that does two things
1.   Fixes #29000 by waiting for the fee estimator to catch up after `removeForBlock` calls before calling `estimateFee` in the `BlockPolicyEstimates` unit test.

2. Addressed some outstanding review comments from #28368 
- Updated `NewMempoolTransactionInfo::m_from_disconnected_block` to `NewMempoolTransactionInfo::m_mempool_limit_bypassed` which now correctly indicates what the boolean does.
- Changed  input of `processTransaction`'s tx_info  `m_submitted_in_package` input from false to fuzz data provider boolean.
- Fixed some typos, and update incorrect comment