### PR TITLE
RPC: add new `listmempooltransactions`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -257,6 +257,7 @@ BITCOIN_CORE_H = \
   rpc/mempool.h \
   rpc/mining.h \
   rpc/protocol.h \
+  rpc/rawtransaction.h \
   rpc/rawtransaction_util.h \
   rpc/register.h \
   rpc/request.h \

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -641,6 +641,45 @@ static bool rest_deploymentinfo(const std::any& context, HTTPRequest* req, const
 
 }
 
+static bool rest_mempool_transactions(const std::any& context, HTTPRequest* req, const std::string& str_uri_part)
+{
+    if (!CheckWarmup(req))
+        return false;
+
+    std::string param;
+    const RESTResponseFormat rf = ParseDataFormat(param, str_uri_part);
+    if (param != "contents" && param != "info") {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/mempool/transactions/<info|contents>.json");
+    }
+
+    const CTxMemPool* mempool = GetMemPool(context, req);
+    if (!mempool) return false;
+
+    switch (rf) {
+    case RESTResponseFormat::JSON: {
+        std::string str_json;
+        std::string raw_sequence_start;
+        const bool verbose = param == "contents";
+
+        try {
+            raw_sequence_start = req->GetQueryParameter("sequence_start").value_or("0");
+        } catch (const std::runtime_error& e) {
+            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+
+        const auto sequence_start{ToIntegral<uint64_t>(raw_sequence_start)};
+        str_json = MempoolTxsToJSON(*mempool, verbose, sequence_start.value()).write() + "\n";
+
+        req->WriteHeader("Content-Type", "application/json");
+        req->WriteReply(HTTP_OK, str_json);
+        return true;
+    }
+    default: {
+        return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: json)");
+    }
+    }
+}
+
 static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::string& str_uri_part)
 {
     if (!CheckWarmup(req))
@@ -1009,6 +1048,7 @@ static const struct {
       {"/rest/blockfilterheaders/", rest_filter_header},
       {"/rest/chaininfo", rest_chaininfo},
       {"/rest/mempool/", rest_mempool},
+      {"/rest/mempool/transactions", rest_mempool_transactions},
       {"/rest/headers/", rest_headers},
       {"/rest/getutxos", rest_getutxos},
       {"/rest/deploymentinfo/", rest_deploymentinfo},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -302,6 +302,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmsgtopeer", 0, "peer_id" },
     { "stop", 0, "wait" },
     { "addnode", 2, "v2transport" },
+    { "listmempooltransactions", 0, "start_sequence"},
+    { "listmempooltransactions", 1, "verbose"},
 };
 // clang-format on
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -14,6 +14,8 @@
 #include <policy/rbf.h>
 #include <policy/settings.h>
 #include <primitives/transaction.h>
+#include <rpc/rawtransaction.h>
+#include <rpc/mempool.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>
@@ -373,6 +375,100 @@ UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose, bool include_mempoo
             return o;
         }
     }
+}
+
+static RPCHelpMan listmempooltransactions()
+{
+    return RPCHelpMan{"listmempooltransactions",
+        "\nReturns all transactions in the mempool. Can be filtered by mempool_sequence\n"
+        "\nAllows for syncing with current mempool entries via polling (not zmq).",
+        {
+            {"start_sequence", RPCArg::Type::NUM, RPCArg::Default{0}, "The mempool_sequence to start the results to. Defaults to 0 (zero, all transactions)."},
+            {"verbose", RPCArg::Type::BOOL, RPCArg::Default{false}, "True for a json object, false for array of transaction ids"},
+        },
+        {
+            RPCResult{"for verbose = false",
+                RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::NUM, "mempool_sequence", "The current max mempool sequence value."},
+                    {RPCResult::Type::ARR, "txs", "",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                        {
+                            {RPCResult::Type::NUM, "entry_sequence", "The mempool sequence value for this transaction entry."},
+                            {RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+                        }},
+                    }},
+                }},
+            RPCResult{"for verbose = true",
+                RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::NUM, "mempool_sequence", "The current max mempool sequence value."},
+                    {RPCResult::Type::ARR, "txs", "",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                        {
+                         Cat<std::vector<RPCResult>>(
+                            {
+                                {RPCResult::Type::NUM, "entry_sequence", "The mempool sequence value for this transaction entry."},
+                            },
+                            DecodeTxDoc(/*txid_field_doc=*/"The transaction id of the mempool transaction")),
+                        }},
+                    }},
+                }},
+        },
+        RPCExamples{
+            HelpExampleCli("listmempooltransactions", "true")
+            + HelpExampleRpc("listmempooltransactions", "true")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            uint64_t start_mempool_sequence = 0;
+            if (!request.params[0].isNull()) {
+                start_mempool_sequence = request.params[0].getInt<uint64_t>();
+            }
+
+            bool fVerbose = false;
+            if (!request.params[1].isNull())
+                fVerbose = request.params[1].get_bool();
+
+            return MempoolTxsToJSON(EnsureAnyMemPool(request.context), fVerbose, start_mempool_sequence);
+        },
+    };
+}
+
+UniValue MempoolTxsToJSON(const CTxMemPool& pool, bool verbose, uint64_t sequence_start)
+{
+    uint64_t mempool_sequence;
+
+    LOCK(pool.cs);
+    mempool_sequence = pool.GetSequence();
+
+    UniValue o(UniValue::VOBJ);
+    o.pushKV("mempool_sequence", mempool_sequence);
+
+    UniValue a(UniValue::VARR);
+    for (const CTxMemPoolEntry& e : pool.entryAll()) {
+        UniValue txentry(UniValue::VOBJ);
+
+        // We skip anything not requested.
+        if (e.GetSequence() < sequence_start)
+            continue;
+
+        txentry.pushKV("entry_sequence", e.GetSequence());
+
+        if (verbose) {
+            // We could also calculate fees etc for this transaction, but yolo.
+            TxToUniv(e.GetTx(), /*block_hash=*/uint256::ZERO, /*entry=*/txentry, /*inclue_hex=*/false);
+        } else {
+            txentry.pushKV("txid", e.GetTx().GetHash().ToString());
+        }
+
+        a.push_back(txentry);
+    }
+
+    o.pushKV("txs", a);
+    return o;
 }
 
 static RPCHelpMan getrawmempool()
@@ -1004,6 +1100,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
         {"blockchain", &importmempool},
         {"blockchain", &savemempool},
         {"rawtransactions", &submitpackage},
+        {"rawtransactions", &listmempooltransactions},
     };
     for (const auto& c : commands) {
         t.appendCommand(c.name, &c);

--- a/src/rpc/mempool.h
+++ b/src/rpc/mempool.h
@@ -14,4 +14,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool);
 /** Mempool to JSON */
 UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose = false, bool include_mempool_sequence = false);
 
+/** Mempool Txs to JSON */
+UniValue MempoolTxsToJSON(const CTxMemPool& pool, bool verbose = false, uint64_t sequence_start = 0);
+
 #endif // BITCOIN_RPC_MEMPOOL_H

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -23,6 +23,7 @@
 #include <psbt.h>
 #include <random.h>
 #include <rpc/blockchain.h>
+#include <rpc/rawtransaction.h>
 #include <rpc/rawtransaction_util.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
@@ -92,7 +93,7 @@ static std::vector<RPCResult> ScriptPubKeyDoc() {
          };
 }
 
-static std::vector<RPCResult> DecodeTxDoc(const std::string& txid_field_doc)
+std::vector<RPCResult> DecodeTxDoc(const std::string& txid_field_doc)
 {
     return {
         {RPCResult::Type::STR_HEX, "txid", txid_field_doc},

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_RAWTRANSACTION_H
+#define BITCOIN_RPC_RAWTRANSACTION_H
+
+#include <string>
+
+struct RPCResult;
+
+std::vector<RPCResult> DecodeTxDoc(const std::string& txid_field_doc);
+
+#endif // BITCOIN_RPC_RAWTRANSACTION_H

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -153,6 +153,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "invalidateblock",
     "joinpsbts",
     "listbanned",
+    "listmempooltransactions",
     "logging",
     "mockscheduler",
     "ping",


### PR DESCRIPTION
## Proposed Update

Add a new RPC endpoint, `listmempooltransactions`. Takes as args a `start_sequence` and `verbose`.

Returns: 
- if verbose false, list of txids + their `entry_sequence` where each entry's `entry_sequence` >= the provided `start_sequence.
- if verbose true, raw tx output info including each entry's `entry_sequence`.


Builds on work done in #19572.

## Rationale
The current mempool RPCs are lacking an ability to scan for updates in a more efficient manner. You can subscribe for updates via the ZMQ pipeline, but even this is inefficient to recover from if your consumer app falls offline.

ZMQ also is a push protocol, and doesn't provide a rate-limiting mechanism.

In the case of core-lightning, we don't assume access to bitcoin-core/ZMQ, so we're unable to do efficient mempool querying. There have been some recent CVEs come to light where having optional access to mempool updates may prove useful.

Paging, filtering by last seen, and the addition of full tx data in the call makes mempool data more readily available to any client app. This is good for self-sovereignty as it reduces the need for additional dependencies and app data sources to efficiently query and parse mempool data. 


## Other Things I Considered
My initial attempt at this modified `getrawmempool` to 
- take a `start_sequence` to allow for filtering, and
- adding the txdata (inputs outpoints + outputs (amount + scriptPubKeys)). 

That was pretty ugly however, given that the current data model for `getrawmempool` is around a concept of "mempool entry" data. This new RPC in contrast only returns transaction data (and does not report on information about other mempool dependencies etc; for that you should still call `getrawmempool` or `getmempoolentry`). 

You could add a `start_sequence` to the existing `getrawmempool` to help with entry data paging/querying but that's secondary to my goals for fetching relevant txdata from the mempool.

## Additions/Changes

This PR could be further improved by
- Add a `page_size` argument which allows a calling application to limit the number of results returned.


## Future Work
The current RPC only supports finding *added* mempool transactions. It'd be interesting to experiment with keeping track of evicted/not mined transactions and adding them to the results.

This would require:
- An additional memory buffer (perhaps a configurable memory limited ring buffer?) for evicted tx data and the mempool sequence of the eviction.
- Adding a `sequence_action` field for results, which indicates whether the sequence is for the tx's `addition` or `eviction`.

You could also keep track of tx movements into blocks, but this seems less useful/urgent in general.

## Usage
You can see an example of this implemented and used in CLN for finding paid onchain invoices in this branch: https://github.com/ElementsProject/lightning/compare/master...niftynei:lightning:nifty/mempool-scan

Note that the CLN implementation doesn't currently keep the mempool_sequence in disk, so it'll reload/rescan the mempool at start. This *may* be desirable?

Here's how a caller would use this

```
1) start node
2) listmempooltransactions 0 to get backlog
3) call listmempooltransactions again with `start_sequence` set to `mempool_sequence` result from last call
```

Note that this works well with ZMQ as the `mempool_sequence` number is identical.