### PR TITLE
mempool: Don't sort in entryAll

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -829,13 +829,7 @@ static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator
 std::vector<CTxMemPoolEntryRef> CTxMemPool::entryAll() const
 {
     AssertLockHeld(cs);
-
-    std::vector<CTxMemPoolEntryRef> ret;
-    ret.reserve(mapTx.size());
-    for (const auto& it : GetSortedDepthAndScore()) {
-        ret.emplace_back(*it);
-    }
-    return ret;
+    return {mapTx.begin(), mapTx.end()};
 }
 
 std::vector<TxMempoolInfo> CTxMemPool::infoAll() const


### PR DESCRIPTION
Current call sites of entryAll do not require the entries to be sorted, so iterate through mapTx directly to retrieve the entries instead of using SortedDepthAndScore.

This is a follow up to #28391 and was noted here https://github.com/bitcoin/bitcoin/pull/28391#discussion_r1418261403.
