### PR TITLE
doc: Add link to needs-release-notes label

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -74,7 +74,9 @@ Release Process
 #### Before final release
 
 - Merge the release notes from [the wiki](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/) into the branch.
-- Ensure the "Needs release note" label is removed from all relevant pull requests and issues.
+- Ensure the "Needs release note" label is removed from all relevant pull
+  requests and issues:
+  https://github.com/bitcoin/bitcoin/issues?q=label%3A%22Needs+release+note%22
 
 #### Tagging a release (candidate)
 


### PR DESCRIPTION
This makes it easier to spot and not forget. C.f. https://github.com/bitcoin/bitcoin/pull/28597#issuecomment-1845299642