### PR TITLE
test: fix `addnode` functional test failure on OpenBSD

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -9,6 +9,7 @@ Tests correspond to code in rpc/net.cpp.
 
 from decimal import Decimal
 from itertools import product
+import platform
 import time
 
 import test_framework.messages
@@ -220,8 +221,10 @@ class NetTest(BitcoinTestFramework):
         ip_port = "127.0.0.1:{}".format(p2p_port(2))
         self.nodes[0].addnode(node=ip_port, command='add')
         # try to add an equivalent ip
-        ip_port2 = "127.1:{}".format(p2p_port(2))
-        assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port2, command='add')
+        # (note that OpenBSD doesn't support the IPv4 shorthand notation with omitted zero-bytes)
+        if platform.system() != "OpenBSD":
+            ip_port2 = "127.1:{}".format(p2p_port(2))
+            assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port2, command='add')
         # check that the node has indeed been added
         added_nodes = self.nodes[0].getaddednodeinfo()
         assert_equal(len(added_nodes), 1)


### PR DESCRIPTION
This is the functional test counterpart of PR #28891 / commit 007d6f0e85bc329040bb405ef6016339518caa66 (unfortunately, I missed it back then and only ran the unit tests -- sorry for the noise).

master branch on OpenBSD 7.4:
```
$ ./test/functional/rpc_net.py 
2023-12-08T17:29:05.057000Z TestFramework (INFO): PRNG seed is: 6024296850131317403
2023-12-08T17:29:05.058000Z TestFramework (INFO): Initializing test directory /tmp/bitcoin_func_test_au3zchif
2023-12-08T17:29:05.618000Z TestFramework (INFO): Test getconnectioncount
2023-12-08T17:29:05.618000Z TestFramework (INFO): Test getpeerinfo
2023-12-08T17:29:06.643000Z TestFramework (INFO): Check getpeerinfo output before a version message was sent
2023-12-08T17:29:06.709000Z TestFramework (INFO): Test getnettotals
2023-12-08T17:29:06.773000Z TestFramework (INFO): Test getnetworkinfo
2023-12-08T17:29:06.978000Z TestFramework (INFO): Test addnode and getaddednodeinfo
2023-12-08T17:29:06.980000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 131, in main
    self.run_test()
  File "/home/thestack/bitcoin/./test/functional/rpc_net.py", line 65, in run_test
    self.test_addnode_getaddednodeinfo()
  File "/home/thestack/bitcoin/./test/functional/rpc_net.py", line 224, in test_addnode_getaddednodeinfo
    assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port2, command='add')
  File "/home/thestack/bitcoin/test/functional/test_framework/util.py", line 131, in assert_raises_rpc_error
    assert try_rpc(code, message, fun, *args, **kwds), "No exception raised"
AssertionError: No exception raised
```

On the PR branch, the same call succeeds.