### PR TITLE
Add missing byteswap functions for MSVC

### DIFF
--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -22,8 +22,14 @@
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
+#elif defined(_MSC_VER)
+#include <cstdlib>
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
 #else
-// Non-MacOS / non-Darwin
+// Non-MacOS / non-Darwin / non-Windows
 
 #if HAVE_DECL_BSWAP_16 == 0
 inline uint16_t bswap_16(uint16_t x)


### PR DESCRIPTION
This should give a speedup across the board for MSVC builds.

While working on modernizing our byteswapping code for c++20, we noticed that MSVC uses our hand-written byteswap functions, as opposed to using libc/compiler versions like almost all other platforms.

aureleoules did some great benchmarks in #28674 which show that these hand-written byteswaps often compile down to a slow mess.
hebasto confirmed that we're indeed hitting these paths for MSVC.

Quick tests with godbolt show that MSVC's provided `_byteswap_*` indeed speed things up.