### PR TITLE
Add multiplication operator to CFeeRate

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -71,6 +71,8 @@ public:
     friend bool operator!=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK != b.nSatoshisPerK; }
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
     std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::BTC_KVB) const;
+    friend CFeeRate operator*(const CFeeRate& f, int a) { return CFeeRate(a * f.nSatoshisPerK); }
+    friend CFeeRate operator*(int a, const CFeeRate& f) { return CFeeRate(a * f.nSatoshisPerK); }
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -87,10 +87,30 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     CFeeRate(MAX_MONEY, std::numeric_limits<uint32_t>::max()).GetFeePerK();
 
     // check multiplication operator
+    // check multiplying by zero
     feeRate = CFeeRate(1000);
     BOOST_CHECK(0 * feeRate == CFeeRate(0));
+    BOOST_CHECK(feeRate * 0 == CFeeRate(0));
+    // check multiplying by a positive integer
     BOOST_CHECK(3 * feeRate == CFeeRate(3000));
+    BOOST_CHECK(feeRate * 3 == CFeeRate(3000));
+    // check multiplying by a negative integer
     BOOST_CHECK(-3 * feeRate == CFeeRate(-3000));
+    BOOST_CHECK(feeRate * -3 == CFeeRate(-3000));
+    // check commutativity
+    BOOST_CHECK(2 * feeRate == feeRate * 2);
+    // check with large numbers
+    int largeNumber = 1000000;
+    BOOST_CHECK(largeNumber * feeRate == feeRate * largeNumber);
+    // check boundary values
+    int maxInt = std::numeric_limits<int>::max();
+    feeRate = CFeeRate(maxInt);
+    BOOST_CHECK(feeRate * 2 == CFeeRate(static_cast<int64_t>(maxInt) * 2));
+    BOOST_CHECK(2 * feeRate == CFeeRate(static_cast<int64_t>(maxInt) * 2));
+    // check with zero fee rate
+    feeRate = CFeeRate(0);
+    BOOST_CHECK(feeRate * 5 == CFeeRate(0));
+    BOOST_CHECK(5 * feeRate == CFeeRate(0));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -85,6 +85,12 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<uint32_t>::max()).GetFeePerK();
+
+    // check multiplication operator
+    feeRate = CFeeRate(1000);
+    BOOST_CHECK(0 * feeRate == CFeeRate(0));
+    BOOST_CHECK(3 * feeRate == CFeeRate(3000));
+    BOOST_CHECK(-3 * feeRate == CFeeRate(-3000));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)


### PR DESCRIPTION
Allows us to use 
`coin_selection_params.m_long_term_feerate * 3`
or
`3 * coin_selection_params.m_long_term_feerate`
instead of  
`CFeeRate{coin_selection_params.m_long_term_feerate.GetFee(3000)}`

inspired by https://github.com/bitcoin/bitcoin/pull/27877#discussion_r1414455724