### PR TITLE
refactor: Remove pre-C++20 code, fs::path cleanup

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1406,7 +1406,7 @@ A few guidelines for introducing and reviewing new RPC interfaces:
 
   - *Rationale*: User-facing consistency.
 
-- Use `fs::path::u8string()` and `fs::u8path()` functions when converting path
+- Use `fs::path::u8string()`/`fs::path::utf8string()` and `fs::u8path()` functions when converting path
   to JSON strings, not `fs::PathToString` and `fs::PathFromString`
 
   - *Rationale*: JSON strings are Unicode strings, not byte strings, and

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -34,7 +34,7 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
 
     fs::path wallet_path = test_setup->m_path_root / strprintf("test_wallet_%d", random.rand32()).c_str();
     bench.run([&] {
-        auto wallet = CreateWallet(context, wallet_path.u8string(), /*load_on_start=*/std::nullopt, options, status, error_string, warnings);
+        auto wallet = CreateWallet(context, wallet_path.utf8string(), /*load_on_start=*/std::nullopt, options, status, error_string, warnings);
         assert(status == DatabaseStatus::SUCCESS);
         assert(wallet != nullptr);
 

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -277,7 +277,7 @@ fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value)
     return result.has_filename() ? result : result.parent_path();
 }
 
-const fs::path& ArgsManager::GetBlocksDirPath() const
+fs::path ArgsManager::GetBlocksDirPath() const
 {
     LOCK(cs_args);
     fs::path& path = m_cached_blocks_path;
@@ -302,7 +302,7 @@ const fs::path& ArgsManager::GetBlocksDirPath() const
     return path;
 }
 
-const fs::path& ArgsManager::GetDataDir(bool net_specific) const
+fs::path ArgsManager::GetDataDir(bool net_specific) const
 {
     LOCK(cs_args);
     fs::path& path = net_specific ? m_cached_network_datadir_path : m_cached_datadir_path;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -215,21 +215,21 @@ protected:
      *
      * @return Blocks path which is network specific
      */
-    const fs::path& GetBlocksDirPath() const;
+    fs::path GetBlocksDirPath() const;
 
     /**
      * Get data directory path
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
      */
-    const fs::path& GetDataDirBase() const { return GetDataDir(false); }
+    fs::path GetDataDirBase() const { return GetDataDir(false); }
 
     /**
      * Get data directory path with appended network identifier
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
      */
-    const fs::path& GetDataDirNet() const { return GetDataDir(true); }
+    fs::path GetDataDirNet() const { return GetDataDir(true); }
 
     /**
      * Clear cached directory paths
@@ -420,7 +420,7 @@ private:
      * @param net_specific Append network identifier to the returned path
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
      */
-    const fs::path& GetDataDir(bool net_specific) const;
+    fs::path GetDataDir(bool net_specific) const;
 
     /**
      * Return -regtest/-signet/-testnet/-chain= setting as a ChainType enum if a

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -723,8 +723,7 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
 
 QString formatDurationStr(std::chrono::seconds dur)
 {
-    using days = std::chrono::duration<int, std::ratio<86400>>; // can remove this line after C++20
-    const auto d{std::chrono::duration_cast<days>(dur)};
+    const auto d{std::chrono::duration_cast<std::chrono::days>(dur)};
     const auto h{std::chrono::duration_cast<std::chrono::hours>(dur - d)};
     const auto m{std::chrono::duration_cast<std::chrono::minutes>(dur - d - h)};
     const auto s{std::chrono::duration_cast<std::chrono::seconds>(dur - d - h - m)};

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -669,7 +669,7 @@ fs::path QStringToPath(const QString &path)
 
 QString PathToQString(const fs::path &path)
 {
-    return QString::fromStdString(path.u8string());
+    return QString::fromStdString(path.utf8string());
 }
 
 QString NetworkToQString(Network net)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2603,7 +2603,7 @@ static RPCHelpMan dumptxoutset()
     if (fs::exists(path)) {
         throw JSONRPCError(
             RPC_INVALID_PARAMETER,
-            path.u8string() + " already exists. If you are sure this is what you want, "
+            path.utf8string() + " already exists. If you are sure this is what you want, "
             "move it out of the way first");
     }
 
@@ -2612,7 +2612,7 @@ static RPCHelpMan dumptxoutset()
     if (afile.IsNull()) {
         throw JSONRPCError(
             RPC_INVALID_PARAMETER,
-            "Couldn't open file " + temppath.u8string() + " for writing.");
+            "Couldn't open file " + temppath.utf8string() + " for writing.");
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
@@ -2620,7 +2620,7 @@ static RPCHelpMan dumptxoutset()
         node, node.chainman->ActiveChainstate(), afile, path, temppath);
     fs::rename(temppath, path);
 
-    result.pushKV("path", path.u8string());
+    result.pushKV("path", path.utf8string());
     return result;
 },
     };
@@ -2692,7 +2692,7 @@ UniValue CreateUTXOSnapshot(
     result.pushKV("coins_written", maybe_stats->coins_count);
     result.pushKV("base_hash", tip->GetBlockHash().ToString());
     result.pushKV("base_height", tip->nHeight);
-    result.pushKV("path", path.u8string());
+    result.pushKV("path", path.utf8string());
     result.pushKV("txoutset_hash", maybe_stats->hashSerialized.ToString());
     result.pushKV("nchaintx", tip->nChainTx);
     return result;
@@ -2745,7 +2745,7 @@ static RPCHelpMan loadtxoutset()
     if (afile.IsNull()) {
         throw JSONRPCError(
             RPC_INVALID_PARAMETER,
-            "Couldn't open file " + path.u8string() + " for reading.");
+            "Couldn't open file " + path.utf8string() + " for reading.");
     }
 
     SnapshotMetadata metadata;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -806,7 +806,7 @@ static RPCHelpMan savemempool()
     }
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("filename", dump_path.u8string());
+    ret.pushKV("filename", dump_path.utf8string());
 
     return ret;
 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -243,7 +243,7 @@ static RPCHelpMan getrpcinfo()
     UniValue result(UniValue::VOBJ);
     result.pushKV("active_commands", active_commands);
 
-    const std::string path = LogInstance().m_file_path.u8string();
+    const std::string path = LogInstance().m_file_path.utf8string();
     UniValue log_path(UniValue::VSTR, path);
     result.pushKV("logpath", log_path);
 

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -20,9 +20,10 @@ BOOST_AUTO_TEST_CASE(fsbridge_pathtostring)
     std::string u8_str = "fs_tests_₿_🏃";
     std::u8string str8{u8"fs_tests_₿_🏃"};
     BOOST_CHECK_EQUAL(fs::PathToString(fs::PathFromString(u8_str)), u8_str);
-    BOOST_CHECK_EQUAL(fs::u8path(u8_str).u8string(), u8_str);
-    BOOST_CHECK_EQUAL(fs::path(str8).u8string(), u8_str);
-    BOOST_CHECK_EQUAL(fs::PathFromString(u8_str).u8string(), u8_str);
+    BOOST_CHECK_EQUAL(fs::u8path(u8_str).utf8string(), u8_str);
+    BOOST_CHECK_EQUAL(fs::path(str8).utf8string(), u8_str);
+    BOOST_CHECK(fs::path(str8).u8string() == str8);
+    BOOST_CHECK_EQUAL(fs::PathFromString(u8_str).utf8string(), u8_str);
     BOOST_CHECK_EQUAL(fs::PathToString(fs::u8path(u8_str)), u8_str);
 #ifndef WIN32
     // On non-windows systems, verify that arbitrary byte strings containing

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -18,8 +18,10 @@ BOOST_FIXTURE_TEST_SUITE(fs_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(fsbridge_pathtostring)
 {
     std::string u8_str = "fs_tests_₿_🏃";
+    std::u8string str8{u8"fs_tests_₿_🏃"};
     BOOST_CHECK_EQUAL(fs::PathToString(fs::PathFromString(u8_str)), u8_str);
     BOOST_CHECK_EQUAL(fs::u8path(u8_str).u8string(), u8_str);
+    BOOST_CHECK_EQUAL(fs::path(str8).u8string(), u8_str);
     BOOST_CHECK_EQUAL(fs::PathFromString(u8_str).u8string(), u8_str);
     BOOST_CHECK_EQUAL(fs::PathToString(fs::u8path(u8_str)), u8_str);
 #ifndef WIN32
@@ -47,7 +49,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
     fs::path tmpfolder = m_args.GetDataDirBase();
     // tmpfile1 should be the same as tmpfile2
     fs::path tmpfile1 = tmpfolder / fs::u8path("fs_tests_₿_🏃");
-    fs::path tmpfile2 = tmpfolder / fs::u8path("fs_tests_₿_🏃");
+    fs::path tmpfile2 = tmpfolder / fs::path(u8"fs_tests_₿_🏃");
     {
         std::ofstream file{tmpfile1};
         file << "bitcoin";

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,6 +18,7 @@
 #endif
 
 #include <cassert>
+#include <cerrno>
 #include <string>
 
 namespace fsbridge {
@@ -130,4 +131,4 @@ std::string get_filesystem_error_message(const fs::filesystem_error& e)
 #endif
 }
 
-} // fsbridge
+} // namespace fsbridge

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,6 +14,8 @@
 #include <ios>
 #include <ostream>
 #include <string>
+#include <system_error>
+#include <type_traits>
 #include <utility>
 
 /** Filesystem operations and types */

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -35,7 +35,7 @@ public:
     // Allow path objects arguments for compatibility.
     path(std::filesystem::path path) : std::filesystem::path::path(std::move(path)) {}
     path& operator=(std::filesystem::path path) { std::filesystem::path::operator=(std::move(path)); return *this; }
-    path& operator/=(std::filesystem::path path) { std::filesystem::path::operator/=(path); return *this; }
+    path& operator/=(const std::filesystem::path& path) { std::filesystem::path::operator/=(path); return *this; }
 
     // Allow literal string arguments, which are safe as long as the literals are ASCII.
     path(const char* c) : std::filesystem::path(c) {}
@@ -97,9 +97,9 @@ static inline auto quoted(const std::string& s)
 }
 
 // Allow safe path append operations.
-static inline path operator/(path p1, path p2)
+static inline path operator/(path p1, const path& p2)
 {
-    p1 /= std::move(p2);
+    p1 /= p2;
     return p1;
 }
 static inline path operator/(path p1, const char* p2)

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -56,10 +56,8 @@ public:
 
     std::string u8string() const
     {
-        const auto& utf8_str{std::filesystem::path::u8string()};
-        // utf8_str might either be std::string (C++17) or std::u8string
-        // (C++20). Convert both to std::string. This method can be removed
-        // after switching to C++20.
+        const std::u8string& utf8_str{std::filesystem::path::u8string()};
+        // Convert to std::string as a convenience for use in RPC code.
         return std::string{utf8_str.begin(), utf8_str.end()};
     }
 
@@ -71,11 +69,7 @@ public:
 
 static inline path u8path(const std::string& utf8_str)
 {
-#if __cplusplus < 202002L
-    return std::filesystem::u8path(utf8_str);
-#else
     return std::filesystem::path(std::u8string{utf8_str.begin(), utf8_str.end()});
-#endif
 }
 
 // Disallow implicit std::string conversion for absolute to avoid

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -734,7 +734,7 @@ RPCHelpMan dumpwallet()
      * It may also avoid other security issues.
      */
     if (fs::exists(filepath)) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.u8string() + " already exists. If you are sure this is what you want, move it out of the way first");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.utf8string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 
     std::ofstream file;
@@ -828,7 +828,7 @@ RPCHelpMan dumpwallet()
     file.close();
 
     UniValue reply(UniValue::VOBJ);
-    reply.pushKV("filename", filepath.u8string());
+    reply.pushKV("filename", filepath.utf8string());
 
     return reply;
 },

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -165,7 +165,7 @@ static RPCHelpMan listwalletdir()
     UniValue wallets(UniValue::VARR);
     for (const auto& path : ListDatabases(GetWalletDir())) {
         UniValue wallet(UniValue::VOBJ);
-        wallet.pushKV("name", path.u8string());
+        wallet.pushKV("name", path.utf8string());
         wallets.push_back(wallet);
     }
 
@@ -802,7 +802,7 @@ static RPCHelpMan migratewallet()
             if (res->solvables_wallet) {
                 r.pushKV("solvables_name", res->solvables_wallet->GetName());
             }
-            r.pushKV("backup_path", res->backup_path.u8string());
+            r.pushKV("backup_path", res->backup_path.utf8string());
 
             return r;
         },


### PR DESCRIPTION
This:

* Removes dead code.
* Avoids unused copies in some places.
* Adds copies in other places for safety.