### PR TITLE
test: fix intermittent error in rpc_net.py (#29030)

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -110,7 +110,7 @@ class NetTest(BitcoinTestFramework):
         no_version_peer_id = 2
         no_version_peer_conntime = int(time.time())
         self.nodes[0].setmocktime(no_version_peer_conntime)
-        with self.nodes[0].assert_debug_log([f"Added connection peer={no_version_peer_id}"]):
+        with self.nodes[0].wait_for_new_peer():
             no_version_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         self.nodes[0].setmocktime(0)
         peer_info = self.nodes[0].getpeerinfo()[no_version_peer_id]


### PR DESCRIPTION
Asserting for the debug log message "Added connection peer=" is insufficient for ensuring that this new connection will show up in a following getpeerinfo() call, as the debug message is written in the CNode ctor, which means it hasn't necessarily been added to CConnman.m_nodes at this point.

Solve this by using the recently introduced `wait_for_new_peer` helper (see #29006,  commit 00e0658e77f66103ebdeb29def99dc9f937c049d), which is more robust.

Fixes #29030.