### PR TITLE
doc: Clarify C++20 comments

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -71,7 +71,7 @@ auto& FuzzTargets()
 
 void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, FuzzTargetOptions opts)
 {
-    const auto it_ins{FuzzTargets().try_emplace(name, FuzzTarget /* temporary can be dropped in C++20 */ {std::move(target), std::move(opts)})};
+    const auto it_ins{FuzzTargets().try_emplace(name, FuzzTarget /* temporary can be dropped after clang-16 */ {std::move(target), std::move(opts)})};
     Assert(it_ins.second);
 }
 

--- a/src/util/overloaded.h
+++ b/src/util/overloaded.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,7 +15,7 @@ namespace util {
 //! https://en.cppreference.com/w/cpp/utility/variant/visit#Example
 template<class... Ts> struct Overloaded : Ts... { using Ts::operator()...; };
 
-//! Explicit deduction guide (not needed as of C++20)
+//! Explicit deduction guide (not needed after clang-17)
 template<class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 } // namespace util
 

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_UTIL_TYPES_H
 #define BITCOIN_UTIL_TYPES_H
 
+// Not needed after C++23 (DR, https://cplusplus.github.io/CWG/issues/2518.html)
 template <class>
 inline constexpr bool ALWAYS_FALSE{false};
 


### PR DESCRIPTION
Turns out "class template argument deduction for aggregates" is one of the few things implemented only in recent compilers, see https://en.cppreference.com/w/cpp/compiler_support/20

So clarify the comments.