### PR TITLE
Add a note to msvc readme re building Qt for Bitcoin Core.

### DIFF
--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -34,6 +34,8 @@ To build Bitcoin Core with the GUI, a static build of Qt is required.
 
 1. Download a single ZIP archive of Qt source code from https://download.qt.io/official_releases/qt/ (e.g., [`qt-everywhere-opensource-src-5.15.11.zip`](https://download.qt.io/official_releases/qt/5.15/5.15.11/single/qt-everywhere-opensource-src-5.15.11.zip)), and expand it into a dedicated folder. The following instructions assume that this folder is `C:\dev\qt-source`.
 
+> 💡 **Tip:** If you use the default path with "Extract All" for the Qt source code zip file, and end up with something like `C:\dev\qt-everywhere-opensource-src-5.15.11\qt-everywhere-src-5.15.11`, you are likely to encounter a "path too long" error when building. To fix the problem move the source files to a shorter path such as the recommended `C:\dev\qt-source`.
+
 2. Open "x64 Native Tools Command Prompt for VS 2022", and input the following commands:
 ```cmd
 cd C:\dev\qt-source


### PR DESCRIPTION
Updated the msvc readme with a note about avoiding path too long errors when building Qt with Bitcoin Core.

Would have saved me half an hour if I'd remembered this from the last time I did the build.
