### PR TITLE
Replace non-standard CLZ builtins with c++20's bit_width

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -212,36 +212,6 @@ static void FastRandom_1bit(benchmark::Bench& bench)
     });
 }
 
-static void BitWidthCustom(benchmark::Bench& bench)
-{
-    uint64_t x = 0;
-    bench.run([&] {
-        x += CountBits(x);
-        x += CountBits(x + 1);
-        x += CountBits(x + 2);
-        x += CountBits(x + 3);
-        x += CountBits(x + 4);
-        x += CountBits(x + 5);
-        x += CountBits(x + 6);
-        x += CountBits(x + 7);
-    });
-}
-
-static void BitWidthStd(benchmark::Bench& bench)
-{
-    uint64_t x = 0;
-    bench.run([&] {
-        x += std::bit_width(x);
-        x += std::bit_width(x + 1);
-        x += std::bit_width(x + 2);
-        x += std::bit_width(x + 3);
-        x += std::bit_width(x + 4);
-        x += std::bit_width(x + 5);
-        x += std::bit_width(x + 6);
-        x += std::bit_width(x + 7);
-    });
-}
-
 static void MuHash(benchmark::Bench& bench)
 {
     MuHash3072 acc;
@@ -306,8 +276,6 @@ BENCHMARK(SHA256D64_1024_AVX2, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_SHANI, benchmark::PriorityLevel::HIGH);
 BENCHMARK(FastRandom_32bit, benchmark::PriorityLevel::HIGH);
 BENCHMARK(FastRandom_1bit, benchmark::PriorityLevel::HIGH);
-BENCHMARK(BitWidthStd, benchmark::PriorityLevel::HIGH);
-BENCHMARK(BitWidthCustom, benchmark::PriorityLevel::HIGH);
 
 BENCHMARK(MuHash, benchmark::PriorityLevel::HIGH);
 BENCHMARK(MuHashMul, benchmark::PriorityLevel::HIGH);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -212,6 +212,36 @@ static void FastRandom_1bit(benchmark::Bench& bench)
     });
 }
 
+static void BitWidthCustom(benchmark::Bench& bench)
+{
+    uint64_t x = 0;
+    bench.run([&] {
+        x += CountBits(x);
+        x += CountBits(x + 1);
+        x += CountBits(x + 2);
+        x += CountBits(x + 3);
+        x += CountBits(x + 4);
+        x += CountBits(x + 5);
+        x += CountBits(x + 6);
+        x += CountBits(x + 7);
+    });
+}
+
+static void BitWidthStd(benchmark::Bench& bench)
+{
+    uint64_t x = 0;
+    bench.run([&] {
+        x += std::bit_width(x);
+        x += std::bit_width(x + 1);
+        x += std::bit_width(x + 2);
+        x += std::bit_width(x + 3);
+        x += std::bit_width(x + 4);
+        x += std::bit_width(x + 5);
+        x += std::bit_width(x + 6);
+        x += std::bit_width(x + 7);
+    });
+}
+
 static void MuHash(benchmark::Bench& bench)
 {
     MuHash3072 acc;
@@ -276,6 +306,8 @@ BENCHMARK(SHA256D64_1024_AVX2, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_SHANI, benchmark::PriorityLevel::HIGH);
 BENCHMARK(FastRandom_32bit, benchmark::PriorityLevel::HIGH);
 BENCHMARK(FastRandom_1bit, benchmark::PriorityLevel::HIGH);
+BENCHMARK(BitWidthStd, benchmark::PriorityLevel::HIGH);
+BENCHMARK(BitWidthCustom, benchmark::PriorityLevel::HIGH);
 
 BENCHMARK(MuHash, benchmark::PriorityLevel::HIGH);
 BENCHMARK(MuHashMul, benchmark::PriorityLevel::HIGH);

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -9,6 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <bit>
 #include <stdint.h>
 #include <string.h>
 
@@ -89,22 +90,7 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
 uint64_t static inline CountBits(uint64_t x)
 {
-#if HAVE_BUILTIN_CLZL
-    if (sizeof(unsigned long) >= sizeof(uint64_t)) {
-        return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
-    }
-#endif
-#if HAVE_BUILTIN_CLZLL
-    if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
-        return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
-    }
-#endif
-    int ret = 0;
-    while (x) {
-        x >>= 1;
-        ++ret;
-    }
-    return ret;
+    return std::bit_width(x);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -9,7 +9,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <bit>
 #include <stdint.h>
 #include <string.h>
 
@@ -85,12 +84,6 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
     memcpy(ptr, &v, 8);
-}
-
-/** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
-uint64_t static inline CountBits(uint64_t x)
-{
-    return std::bit_width(x);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/random.h
+++ b/src/random.h
@@ -11,6 +11,7 @@
 #include <span.h>
 #include <uint256.h>
 
+#include <bit>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -203,7 +204,7 @@ public:
     {
         assert(range);
         --range;
-        int bits = CountBits(range);
+        int bits = std::bit_width(range);
         while (true) {
             uint64_t ret = randbits(bits);
             if (ret <= range) return ret;

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -1060,28 +1060,6 @@ BOOST_AUTO_TEST_CASE(hkdf_hmac_sha256_l32_tests)
                 "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d");
 }
 
-BOOST_AUTO_TEST_CASE(countbits_tests)
-{
-    FastRandomContext ctx;
-    for (unsigned int i = 0; i <= 64; ++i) {
-        if (i == 0) {
-            // Check handling of zero.
-            BOOST_CHECK_EQUAL(CountBits(0), 0U);
-        } else if (i < 10) {
-            for (uint64_t j = uint64_t{1} << (i - 1); (j >> i) == 0; ++j) {
-                // Exhaustively test up to 10 bits
-                BOOST_CHECK_EQUAL(CountBits(j), i);
-            }
-        } else {
-            for (int k = 0; k < 1000; k++) {
-                // Randomly test 1000 samples of each length above 10 bits.
-                uint64_t j = (uint64_t{1}) << (i - 1) | ctx.randbits(i - 1);
-                BOOST_CHECK_EQUAL(CountBits(j), i);
-            }
-        }
-    }
-}
-
 BOOST_AUTO_TEST_CASE(sha256d64)
 {
     for (int i = 0; i <= 32; ++i) {

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -80,7 +80,6 @@ FUZZ_TARGET(integer, .init = initialize_integer)
     static const uint256 u256_max(uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
     const std::vector<uint256> v256{u256, u256_min, u256_max};
     (void)ComputeMerkleRoot(v256);
-    (void)CountBits(u64);
     (void)DecompressAmount(u64);
     {
         if (std::optional<CAmount> parsed = ParseMoney(FormatMoney(i64))) {

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -5,13 +5,13 @@
 #include <util/asmap.h>
 
 #include <clientversion.h>
-#include <crypto/common.h>
 #include <logging.h>
 #include <serialize.h>
 #include <streams.h>
 #include <util/fs.h>
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cstdio>
 #include <utility>
@@ -111,7 +111,7 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
         } else if (opcode == Instruction::MATCH) {
             match = DecodeMatch(pos, endpos);
             if (match == INVALID) break; // Match bits straddle EOF
-            matchlen = CountBits(match) - 1;
+            matchlen = std::bit_width(match) - 1;
             if (bits < matchlen) break; // Not enough input bits
             for (uint32_t bit = 0; bit < matchlen; bit++) {
                 if ((ip[ip.size() - bits]) != ((match >> (matchlen - 1 - bit)) & 1)) {
@@ -175,7 +175,7 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
         } else if (opcode == Instruction::MATCH) {
             uint32_t match = DecodeMatch(pos, endpos);
             if (match == INVALID) return false; // Match bits straddle EOF
-            int matchlen = CountBits(match) - 1;
+            int matchlen = std::bit_width(match) - 1;
             if (prevopcode != Instruction::MATCH) had_incomplete_match = false;
             if (matchlen < 8 && had_incomplete_match) return false; // Within a sequence of matches only at most one should be incomplete
             had_incomplete_match = (matchlen < 8);


### PR DESCRIPTION
Split out of #28674

Note that we can't yet drop our configure checks because we pass the results on to minisketch. I've opened a PR for that upstream here: https://github.com/sipa/minisketch/pull/80

fanquake [suggested](https://github.com/bitcoin/bitcoin/pull/28674#discussion_r1422215535) that we simply replace our `CountBits` call-sites with uses of `std::bit_width` directly and just drop the tests and fuzzers. I agree with that, but I wanted to allow our tests/fuzzers to run with this change first to help convince reviewers that `std::bit_width` is a drop-in replacement for`CountBits`.

I can either add a commit on top of this PR to do the switch after the c-i has run or do it as a follow-up PR, I have no preference.

I was curious to see what would happen under the hood with this change. Fortunately libc++ (as an example) does exactly what one would expect, using the built-ins: https://github.com/llvm/llvm-project/blob/main/libcxx/include/__bit/countl.h#L56 