### PR TITLE
Revert "ci: Only run functional tests on windows in master"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,10 +282,6 @@ jobs:
         run: py -3 test\util\rpcauth-test.py
 
       - name: Run functional tests
-        # Don't run functional tests for pull requests.
-        # The test suit regularly fails to complete in windows native github
-        # actions as a child process stops making progress. The root cause has
-        # not yet been determined.
-        # Discussed in https://github.com/bitcoin/bitcoin/pull/28509
-        if: github.event_name != 'pull_request'
-        run: py -3 test\functional\test_runner.py --jobs $env:NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix=$env:RUNNER_TEMP --combinedlogslen=99999999 --timeout-factor=$env:TEST_RUNNER_TIMEOUT_FACTOR --extended
+        env:
+          TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
+        run: py -3 test\functional\test_runner.py --jobs $env:NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix=$env:RUNNER_TEMP --combinedlogslen=99999999 --timeout-factor=$env:TEST_RUNNER_TIMEOUT_FACTOR $env:TEST_RUNNER_EXTRA


### PR DESCRIPTION
This PR reverts commit aba4a5887b44bf7cbee9ea0a8e02bb92c1b4147b from https://github.com/bitcoin/bitcoin/pull/28567.

The Windows-specific code received [quality](https://github.com/bitcoin/bitcoin/pull/28486) and [performance](https://github.com/bitcoin/bitcoin/pull/29045) improvements recently. So there are no reasons to skip functional tests in PRs anymore.

In my own repo, I've run the GHA Windows job more than 100 times with no failure.