### PR TITLE
Wallet: (Refactor) GetBalance to calculate used balance

### DIFF
--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -304,13 +304,20 @@ Balance GetBalance(const CWallet& wallet, const int min_depth, bool avoid_reuse)
             const int tx_depth{wallet.GetTxDepthInMainChain(wtx)};
             const CAmount tx_credit_mine{CachedTxGetAvailableCredit(wallet, wtx, ISMINE_SPENDABLE | reuse_filter)};
             const CAmount tx_credit_watchonly{CachedTxGetAvailableCredit(wallet, wtx, ISMINE_WATCH_ONLY | reuse_filter)};
+            const CAmount tx_credit_mine_used{CachedTxGetAvailableCredit(wallet, wtx, ISMINE_SPENDABLE | ISMINE_USED)};
+            if (is_trusted) { // min_depth == 0 when calculating used balance and tx_depth >= 0
+                ret.m_mine_used += tx_credit_mine_used;
+            }
             if (is_trusted && tx_depth >= min_depth) {
                 ret.m_mine_trusted += tx_credit_mine;
                 ret.m_watchonly_trusted += tx_credit_watchonly;
+                ret.m_mine_used -= tx_credit_mine; // remove overlap from used_balance
             }
             if (!is_trusted && tx_depth == 0 && wtx.InMempool()) {
                 ret.m_mine_untrusted_pending += tx_credit_mine;
                 ret.m_watchonly_untrusted_pending += tx_credit_watchonly;
+                ret.m_mine_used += tx_credit_mine_used;
+                ret.m_mine_used -= tx_credit_mine; // remove overlap from used_balance
             }
             ret.m_mine_immature += CachedTxGetImmatureCredit(wallet, wtx, ISMINE_SPENDABLE);
             ret.m_watchonly_immature += CachedTxGetImmatureCredit(wallet, wtx, ISMINE_WATCH_ONLY);

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -52,6 +52,7 @@ struct Balance {
     CAmount m_mine_trusted{0};           //!< Trusted, at depth=GetBalance.min_depth or more
     CAmount m_mine_untrusted_pending{0}; //!< Untrusted, but in mempool (pending)
     CAmount m_mine_immature{0};          //!< Immature coinbases in the main chain
+    CAmount m_mine_used{0};              //!< Used balance
     CAmount m_watchonly_trusted{0};
     CAmount m_watchonly_untrusted_pending{0};
     CAmount m_watchonly_immature{0};

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -475,10 +475,7 @@ RPCHelpMan getbalances()
         balances_mine.pushKV("untrusted_pending", ValueFromAmount(bal.m_mine_untrusted_pending));
         balances_mine.pushKV("immature", ValueFromAmount(bal.m_mine_immature));
         if (wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE)) {
-            // If the AVOID_REUSE flag is set, bal has been set to just the un-reused address balance. Get
-            // the total balance, and then subtract bal to get the reused address balance.
-            const auto full_bal = GetBalance(wallet, 0, false);
-            balances_mine.pushKV("used", ValueFromAmount(full_bal.m_mine_trusted + full_bal.m_mine_untrusted_pending - bal.m_mine_trusted - bal.m_mine_untrusted_pending));
+            balances_mine.pushKV("used", ValueFromAmount(bal.m_mine_used));
         }
         balances.pushKV("mine", balances_mine);
     }


### PR DESCRIPTION
Add `GetFullBalance()` to compute `used` balance in `getbalances RPC` and on GUI [GUI PR #775](https://github.com/bitcoin-core/gui/pull/775)

_Check https://github.com/bitcoin/bitcoin/pull/28776#discussion_r1407875236 by @achow101_

> However, I think it would be better to move all of this into `GetBalance` itself and just have it always compute the used balance for us rather than having the caller do this extra computation.

### Update:
- Compute `used` balance from `GetBalance(...)`