### PR TITLE
fuzz: Improve fuzzing stability for minisketch harness

### DIFF
--- a/src/test/fuzz/minisketch.cpp
+++ b/src/test/fuzz/minisketch.cpp
@@ -12,14 +12,27 @@
 #include <map>
 #include <numeric>
 
-using node::MakeMinisketch32;
+namespace {
+
+Minisketch MakeFuzzMinisketch32(size_t capacity, uint32_t impl)
+{
+    return Assert(Minisketch(32, impl, capacity));
+}
+
+} // namespace
 
 FUZZ_TARGET(minisketch)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
     const auto capacity{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 200)};
-    Minisketch sketch_a{Assert(MakeMinisketch32(capacity))};
-    Minisketch sketch_b{Assert(MakeMinisketch32(capacity))};
+    const uint32_t impl{fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, Minisketch::MaxImplementation())};
+    if (!Minisketch::ImplementationSupported(32, impl)) return;
+
+    Minisketch sketch_a{MakeFuzzMinisketch32(capacity, impl)};
+    Minisketch sketch_b{MakeFuzzMinisketch32(capacity, impl)};
+    sketch_a.SetSeed(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+    sketch_b.SetSeed(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
 
     // Fill two sets and keep the difference in a map
     std::map<uint32_t, bool> diff;
@@ -47,8 +60,11 @@ FUZZ_TARGET(minisketch)
     }
     const auto num_diff{std::accumulate(diff.begin(), diff.end(), size_t{0}, [](auto n, const auto& e) { return n + e.second; })};
 
-    Minisketch sketch_ar{MakeMinisketch32(capacity)};
-    Minisketch sketch_br{MakeMinisketch32(capacity)};
+    Minisketch sketch_ar{MakeFuzzMinisketch32(capacity, impl)};
+    Minisketch sketch_br{MakeFuzzMinisketch32(capacity, impl)};
+    sketch_ar.SetSeed(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+    sketch_br.SetSeed(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+
     sketch_ar.Deserialize(sketch_a.Serialize());
     sketch_br.Deserialize(sketch_b.Serialize());
 


### PR DESCRIPTION
The `minisketch` harness has low stability due to:
* Rng internal to minisketch
* Benchmarkning for the best minisketch impl

Fix this by seeding the rng and letting the fuzzer choose the impl.

Also see #29018.