### PR TITLE
fuzz: set `m_fallback_fee` and `m_fee_mode` in `wallet_fees` target

### DIFF
--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -37,6 +37,10 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
     }
 
     if (fuzzed_data_provider.ConsumeBool()) {
+        wallet.m_fallback_fee = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+
+    if (fuzzed_data_provider.ConsumeBool()) {
         wallet.m_discard_rate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
     }
     (void)GetDiscardRate(wallet);
@@ -57,6 +61,9 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
     }
     if (fuzzed_data_provider.ConsumeBool()) {
         coin_control.m_confirm_target = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 999'000);
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        coin_control.m_fee_mode = fuzzed_data_provider.ConsumeBool() ? FeeEstimateMode::CONSERVATIVE : FeeEstimateMode::ECONOMICAL;
     }
 
     FeeCalculation fee_calculation;


### PR DESCRIPTION
`m_fallback_fee` and `m_fee_mode` are used in `GetMinimumFeeRate` but we're not setting any value for them in `wallet_fees` target. That's the reason fuzzing is never reaching the following code:

![Screenshot 2023-12-13 at 15 04 30](https://github.com/bitcoin/bitcoin/assets/19480819/454ddcaa-75ca-452f-ad13-5f142de0bdce)

This PR fixes it.


