### PR TITLE
build: Require libc++-16 or later

### DIFF
--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -8,8 +8,8 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
 export CI_IMAGE_NAME_TAG="docker.io/ubuntu:22.04"
-# Use minimum supported python3.9 (or best-effort 3.10) and clang-15, see doc/dependencies.md
-export PACKAGES="python3-zmq clang-15 llvm-15 libc++abi-15-dev libc++-15-dev"
-export DEP_OPTS="NO_WALLET=1 CC=clang-15 CXX='clang++-15 -stdlib=libc++'"
+# Use minimum supported python3.9 (or best-effort 3.10) and clang-15 with libstdc++-11, see doc/dependencies.md
+export PACKAGES="python3-zmq clang-15 llvm-15"
+export DEP_OPTS="NO_WALLET=1 CC=clang-15 CXX='clang++-15 -stdlib=libstdc++'"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-reduce-exports --enable-experimental-util-chainstate --with-experimental-kernel-lib --enable-shared"

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -8,7 +8,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 | --- | --- |
 | [Autoconf](https://www.gnu.org/software/autoconf/) | [2.69](https://github.com/bitcoin/bitcoin/pull/17769) |
 | [Automake](https://www.gnu.org/software/automake/) | [1.13](https://github.com/bitcoin/bitcoin/pull/18290) |
-| [Clang](https://clang.llvm.org) | [15.0](https://github.com/bitcoin/bitcoin/pull/29165) |
+| [Clang](https://clang.llvm.org) | [15.0](https://github.com/bitcoin/bitcoin/pull/29165) (with at least [libc++ 16.0](https://github.com/bitcoin/bitcoin/pull/29077), libstdc++ requires at least clang-16)|
 | [GCC](https://gcc.gnu.org) | [11.1](https://github.com/bitcoin/bitcoin/pull/29091) |
 | [Python](https://www.python.org) (scripts, tests) | [3.9](https://github.com/bitcoin/bitcoin/pull/28211) |
 | [systemtap](https://sourceware.org/systemtap/) ([tracing](tracing.md))| N/A |


### PR DESCRIPTION
I am not familiar with macOS, but given that https://github.com/bitcoin/bitcoin/pull/28622 prescribes a minimum of libc++-16 for macOS, doing the same on Linux could make sense?

This is needed for stuff:

* `std::ranges::equal`, see https://github.com/bitcoin/bitcoin/pull/29071
* `std::source_location`, see https://github.com/bitcoin/bitcoin/pull/28999#issuecomment-1851949647

I don't think anyone is using `-stdlib=libc++` on Linux, except for the CI and OSS-Fuzz?

The minimum required clang version remains at `clang++-15`.