### PR TITLE
refactor: C++20: Use std::rotl

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -11,15 +11,14 @@
 #include <span.h>
 
 #include <algorithm>
+#include <bit>
 #include <string.h>
 
-constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
-
 #define QUARTERROUND(a,b,c,d) \
-  a += b; d = rotl32(d ^ a, 16); \
-  c += d; b = rotl32(b ^ c, 12); \
-  a += b; d = rotl32(d ^ a, 8); \
-  c += d; b = rotl32(b ^ c, 7);
+  a += b; d = std::rotl(d ^ a, 16); \
+  c += d; b = std::rotl(b ^ c, 12); \
+  a += b; d = std::rotl(d ^ a, 8); \
+  c += d; b = std::rotl(b ^ c, 7);
 
 #define REPEAT10(a) do { {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; } while(0)
 

--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -11,14 +11,9 @@
 
 #include <algorithm>
 #include <array> // For std::begin and std::end.
+#include <bit>
 
 #include <stdint.h>
-
-// Internal implementation code.
-namespace
-{
-uint64_t Rotl(uint64_t x, int n) { return (x << n) | (x >> (64 - n)); }
-} // namespace
 
 void KeccakF(uint64_t (&st)[25])
 {
@@ -41,38 +36,38 @@ void KeccakF(uint64_t (&st)[25])
         bc2 = st[2] ^ st[7] ^ st[12] ^ st[17] ^ st[22];
         bc3 = st[3] ^ st[8] ^ st[13] ^ st[18] ^ st[23];
         bc4 = st[4] ^ st[9] ^ st[14] ^ st[19] ^ st[24];
-        t = bc4 ^ Rotl(bc1, 1); st[0] ^= t; st[5] ^= t; st[10] ^= t; st[15] ^= t; st[20] ^= t;
-        t = bc0 ^ Rotl(bc2, 1); st[1] ^= t; st[6] ^= t; st[11] ^= t; st[16] ^= t; st[21] ^= t;
-        t = bc1 ^ Rotl(bc3, 1); st[2] ^= t; st[7] ^= t; st[12] ^= t; st[17] ^= t; st[22] ^= t;
-        t = bc2 ^ Rotl(bc4, 1); st[3] ^= t; st[8] ^= t; st[13] ^= t; st[18] ^= t; st[23] ^= t;
-        t = bc3 ^ Rotl(bc0, 1); st[4] ^= t; st[9] ^= t; st[14] ^= t; st[19] ^= t; st[24] ^= t;
+        t = bc4 ^ std::rotl(bc1, 1); st[0] ^= t; st[5] ^= t; st[10] ^= t; st[15] ^= t; st[20] ^= t;
+        t = bc0 ^ std::rotl(bc2, 1); st[1] ^= t; st[6] ^= t; st[11] ^= t; st[16] ^= t; st[21] ^= t;
+        t = bc1 ^ std::rotl(bc3, 1); st[2] ^= t; st[7] ^= t; st[12] ^= t; st[17] ^= t; st[22] ^= t;
+        t = bc2 ^ std::rotl(bc4, 1); st[3] ^= t; st[8] ^= t; st[13] ^= t; st[18] ^= t; st[23] ^= t;
+        t = bc3 ^ std::rotl(bc0, 1); st[4] ^= t; st[9] ^= t; st[14] ^= t; st[19] ^= t; st[24] ^= t;
 
         // Rho Pi
         t = st[1];
-        bc0 = st[10]; st[10] = Rotl(t, 1); t = bc0;
-        bc0 = st[7]; st[7] = Rotl(t, 3); t = bc0;
-        bc0 = st[11]; st[11] = Rotl(t, 6); t = bc0;
-        bc0 = st[17]; st[17] = Rotl(t, 10); t = bc0;
-        bc0 = st[18]; st[18] = Rotl(t, 15); t = bc0;
-        bc0 = st[3]; st[3] = Rotl(t, 21); t = bc0;
-        bc0 = st[5]; st[5] = Rotl(t, 28); t = bc0;
-        bc0 = st[16]; st[16] = Rotl(t, 36); t = bc0;
-        bc0 = st[8]; st[8] = Rotl(t, 45); t = bc0;
-        bc0 = st[21]; st[21] = Rotl(t, 55); t = bc0;
-        bc0 = st[24]; st[24] = Rotl(t, 2); t = bc0;
-        bc0 = st[4]; st[4] = Rotl(t, 14); t = bc0;
-        bc0 = st[15]; st[15] = Rotl(t, 27); t = bc0;
-        bc0 = st[23]; st[23] = Rotl(t, 41); t = bc0;
-        bc0 = st[19]; st[19] = Rotl(t, 56); t = bc0;
-        bc0 = st[13]; st[13] = Rotl(t, 8); t = bc0;
-        bc0 = st[12]; st[12] = Rotl(t, 25); t = bc0;
-        bc0 = st[2]; st[2] = Rotl(t, 43); t = bc0;
-        bc0 = st[20]; st[20] = Rotl(t, 62); t = bc0;
-        bc0 = st[14]; st[14] = Rotl(t, 18); t = bc0;
-        bc0 = st[22]; st[22] = Rotl(t, 39); t = bc0;
-        bc0 = st[9]; st[9] = Rotl(t, 61); t = bc0;
-        bc0 = st[6]; st[6] = Rotl(t, 20); t = bc0;
-        st[1] = Rotl(t, 44);
+        bc0 = st[10]; st[10] = std::rotl(t, 1); t = bc0;
+        bc0 = st[7]; st[7] = std::rotl(t, 3); t = bc0;
+        bc0 = st[11]; st[11] = std::rotl(t, 6); t = bc0;
+        bc0 = st[17]; st[17] = std::rotl(t, 10); t = bc0;
+        bc0 = st[18]; st[18] = std::rotl(t, 15); t = bc0;
+        bc0 = st[3]; st[3] = std::rotl(t, 21); t = bc0;
+        bc0 = st[5]; st[5] = std::rotl(t, 28); t = bc0;
+        bc0 = st[16]; st[16] = std::rotl(t, 36); t = bc0;
+        bc0 = st[8]; st[8] = std::rotl(t, 45); t = bc0;
+        bc0 = st[21]; st[21] = std::rotl(t, 55); t = bc0;
+        bc0 = st[24]; st[24] = std::rotl(t, 2); t = bc0;
+        bc0 = st[4]; st[4] = std::rotl(t, 14); t = bc0;
+        bc0 = st[15]; st[15] = std::rotl(t, 27); t = bc0;
+        bc0 = st[23]; st[23] = std::rotl(t, 41); t = bc0;
+        bc0 = st[19]; st[19] = std::rotl(t, 56); t = bc0;
+        bc0 = st[13]; st[13] = std::rotl(t, 8); t = bc0;
+        bc0 = st[12]; st[12] = std::rotl(t, 25); t = bc0;
+        bc0 = st[2]; st[2] = std::rotl(t, 43); t = bc0;
+        bc0 = st[20]; st[20] = std::rotl(t, 62); t = bc0;
+        bc0 = st[14]; st[14] = std::rotl(t, 18); t = bc0;
+        bc0 = st[22]; st[22] = std::rotl(t, 39); t = bc0;
+        bc0 = st[9]; st[9] = std::rotl(t, 61); t = bc0;
+        bc0 = st[6]; st[6] = std::rotl(t, 20); t = bc0;
+        st[1] = std::rotl(t, 44);
 
         // Chi Iota
         bc0 = st[0]; bc1 = st[1]; bc2 = st[2]; bc3 = st[3]; bc4 = st[4];

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -4,15 +4,15 @@
 
 #include <crypto/siphash.h>
 
-#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+#include <bit>
 
 #define SIPROUND do { \
-    v0 += v1; v1 = ROTL(v1, 13); v1 ^= v0; \
-    v0 = ROTL(v0, 32); \
-    v2 += v3; v3 = ROTL(v3, 16); v3 ^= v2; \
-    v0 += v3; v3 = ROTL(v3, 21); v3 ^= v0; \
-    v2 += v1; v1 = ROTL(v1, 17); v1 ^= v2; \
-    v2 = ROTL(v2, 32); \
+    v0 += v1; v1 = std::rotl(v1, 13); v1 ^= v0; \
+    v0 = std::rotl(v0, 32); \
+    v2 += v3; v3 = std::rotl(v3, 16); v3 ^= v2; \
+    v0 += v3; v3 = std::rotl(v3, 21); v3 ^= v0; \
+    v2 += v1; v1 = std::rotl(v1, 17); v1 ^= v2; \
+    v2 = std::rotl(v2, 32); \
 } while (0)
 
 CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -7,12 +7,8 @@
 #include <crypto/common.h>
 #include <crypto/hmac_sha512.h>
 
+#include <bit>
 #include <string>
-
-inline uint32_t ROTL32(uint32_t x, int8_t r)
-{
-    return (x << r) | (x >> (32 - r));
-}
 
 unsigned int MurmurHash3(unsigned int nHashSeed, Span<const unsigned char> vDataToHash)
 {
@@ -31,11 +27,11 @@ unsigned int MurmurHash3(unsigned int nHashSeed, Span<const unsigned char> vData
         uint32_t k1 = ReadLE32(blocks + i*4);
 
         k1 *= c1;
-        k1 = ROTL32(k1, 15);
+        k1 = std::rotl(k1, 15);
         k1 *= c2;
 
         h1 ^= k1;
-        h1 = ROTL32(h1, 13);
+        h1 = std::rotl(h1, 13);
         h1 = h1 * 5 + 0xe6546b64;
     }
 
@@ -55,7 +51,7 @@ unsigned int MurmurHash3(unsigned int nHashSeed, Span<const unsigned char> vData
         case 1:
             k1 ^= tail[0];
             k1 *= c1;
-            k1 = ROTL32(k1, 15);
+            k1 = std::rotl(k1, 15);
             k1 *= c2;
             h1 ^= k1;
     }

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -69,7 +69,6 @@ implicit-signed-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp
 shift-base:crypto/
-shift-base:ROTL32
 shift-base:streams.h
 shift-base:FormatHDKeypath
 shift-base:xoroshiro128plusplus.h


### PR DESCRIPTION
While exploring some C++20 changes and checking against our code I found this potential improvement:

1. We can replace our custom implementation of `rotl32` in crypto/chacha20 with `std::rotl` from the [new `bit` header](https://en.cppreference.com/w/cpp/header/bit).