### PR TITLE
NOMERGE UFG Default permitbaremultisig=0

### DIFF
--- a/doc/release-notes-28217.md
+++ b/doc/release-notes-28217.md
@@ -1,0 +1,4 @@
+P2P and network changes
+-----------------------
+
+- Changing the default setting of -permitbaremultisig to false. Non-P2SH multisig transactions will no longer be relayed by default. (#28217)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -36,7 +36,7 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 /** Default for -bytespersigop */
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -permitbaremultisig */
-static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
+static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{false};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */


### PR DESCRIPTION
Cherry-picks patches from #28217 on top of #29088 so that CI can verify 29088 does what it says on the box