### PR TITLE
Fix spelling errors

### DIFF
--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -211,7 +211,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
                     tx_mut.vin.push_back(tx_mut.vin.back());
                 }
 
-                // Refer to a non-existant input
+                // Refer to a non-existent input
                 if (fuzzed_data_provider.ConsumeBool()) {
                     tx_mut.vin.emplace_back();
                 }

--- a/src/test/span_tests.cpp
+++ b/src/test/span_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_SUITE(span_tests)
 // aren't compatible with Spans at compile time.
 //
 // Previously there was a bug where writing a SFINAE check for vector<bool> was
-// not possible, because in libstdc++ vector<bool> has a data() memeber
+// not possible, because in libstdc++ vector<bool> has a data() member
 // returning void*, and the Span template guide ignored the data() return value,
 // so the template substitution would succeed, but the constructor would fail,
 // resulting in a fatal compile error, rather than a SFINAE error that could be

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -7,6 +7,7 @@ cachable
 clen
 crypted
 debbugs
+falsy
 fo
 fpr
 hights


### PR DESCRIPTION
Found these when running lint tests locally.

```
src/rpc/util.h:405: falsy ==> falsely, false
src/rpc/util.h:408: falsy ==> falsely, false
src/test/fuzz/package_eval.cpp:214: non-existant ==> non-existent
src/test/span_tests.cpp:56: memeber ==> member
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/spelling.ignore-words.txt
```

Guess it's because I'm having different version of codespell?

In any case, these aren't false positives and should be fixed.