### PR TITLE
[doc]: add doxygen comment describing  what `CheckPackageLimits` returns

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -605,6 +605,7 @@ public:
      *                                          to mempool. The transactions need not be direct
      *                                          ancestors/descendants of each other.
      * @param[in]       total_vsize             Sum of virtual sizes for all transactions in package.
+     * @returns {} or the error reason if a limit is hit.
      */
     util::Result<void> CheckPackageLimits(const Package& package,
                                           int64_t total_vsize) const EXCLUSIVE_LOCKS_REQUIRED(cs);


### PR DESCRIPTION
This PR adds a  doxygen comment on `CheckPackageLimits` describing what the method returns.

Fixes https://github.com/bitcoin/bitcoin/pull/28863#discussion_r1429805433