### PR TITLE
build: Remove HAVE_CONSENSUS_LIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1674,7 +1674,6 @@ AC_MSG_CHECKING([whether to build libraries])
 AM_CONDITIONAL([BUILD_BITCOIN_LIBS], [test $build_bitcoin_libs = "yes"])
 
 if test "$build_bitcoin_libs" = "yes"; then
-  AC_DEFINE([HAVE_CONSENSUS_LIB], [1], [Define this symbol if the consensus lib has been built])
   AC_CONFIG_FILES([libbitcoinconsensus.pc:libbitcoinconsensus.pc.in])
 fi
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -646,7 +646,6 @@ libbitcoin_consensus_a_SOURCES = \
   primitives/transaction.h \
   pubkey.cpp \
   pubkey.h \
-  script/bitcoinconsensus.cpp \
   script/interpreter.cpp \
   script/interpreter.h \
   script/script.cpp \
@@ -1013,7 +1012,7 @@ if BUILD_BITCOIN_LIBS
 lib_LTLIBRARIES += $(LIBBITCOINCONSENSUS)
 
 include_HEADERS = script/bitcoinconsensus.h
-libbitcoinconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
+libbitcoinconsensus_la_SOURCES = script/bitcoinconsensus.cpp support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -53,7 +53,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/strencodings.cpp \
   bench/util_time.cpp \
   bench/verify_script.cpp \
-  bench/xor.cpp
+  bench/xor.cpp \
+  script/bitcoinconsensus.cpp
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_BENCH_FILES)
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -33,6 +33,7 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 
 BITCOIN_TEST_SUITE = \
   test/main.cpp \
+  script/bitcoinconsensus.cpp \
   $(TEST_UTIL_H)
 
 FUZZ_SUITE_LD_COMMON = \
@@ -243,6 +244,7 @@ test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_fuzz_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) $(RUNTIME_LDFLAGS)
 test_fuzz_fuzz_SOURCES = \
  $(FUZZ_WALLET_SRC) \
+ script/bitcoinconsensus.cpp \
  test/fuzz/addition_overflow.cpp \
  test/fuzz/addrman.cpp \
  test/fuzz/asmap.cpp \

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -4,9 +4,7 @@
 
 #include <bench/bench.h>
 #include <key.h>
-#if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>
-#endif
 #include <script/script.h>
 #include <script/interpreter.h>
 #include <streams.h>
@@ -60,7 +58,6 @@ static void VerifyScriptBench(benchmark::Bench& bench)
         assert(err == SCRIPT_ERR_OK);
         assert(success);
 
-#if defined(HAVE_CONSENSUS_LIB)
         DataStream stream;
         stream << TX_WITH_WITNESS(txSpend);
         int csuccess = bitcoinconsensus_verify_script_with_amount(
@@ -69,7 +66,6 @@ static void VerifyScriptBench(benchmark::Bench& bench)
             txCredit.vout[0].nValue,
             (const unsigned char*)stream.data(), stream.size(), 0, flags, nullptr);
         assert(csuccess == 1);
-#endif
     });
     ECC_Stop();
 }


### PR DESCRIPTION
The `script/bitcoinconsensus` module defines the public interface for the `bitcoinconsensus` library. Even though this module is only required by the tests and the `bitcoinconsensus` library, it is currently compiled into the static internal `libbitcoin_consensus` library, and therefore used by a bunch of build targets that do not require it.

Since it is always part of the internal library, the `HAVE_CONSENSUS_LIB` define used by the tests is essentially
meaningless, since the module is always available. This can be verified on master by removing the `HAVE_CONSENSUS_LIB` checks in the tests, configuring with `--with-libs=no`, and running `make check`.

Improve all of this by including the `bitcoinconsensus` module only where it is required and removing the `HAVE_CONSENSUS_LIB` define.

An alternative to this patch was discussed in https://github.com/hebasto/bitcoin/pull/41: Actually linking the test binaries with the external consensus library if it is available. This has the disadvantage though that if the dynamic consensus library is built, it has to be available for the test binaries to load whenever and wherever they are being run.

