### PR TITLE
wallet: Add `createwalletdescriptor` and `gethdkeys` RPCs for adding new automatically generated descriptors

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -223,6 +223,12 @@ struct CExtKey {
             a.key == b.key;
     }
 
+    CExtKey() = default;
+    CExtKey(const CExtPubKey& xpub, const CKey& key_in) : nDepth(xpub.nDepth), nChild(xpub.nChild), chaincode(xpub.chaincode), key(key_in)
+    {
+        std::copy(xpub.vchFingerprint, xpub.vchFingerprint + sizeof(xpub.vchFingerprint), vchFingerprint);
+    }
+
     void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     [[nodiscard]] bool Derive(CExtKey& out, unsigned int nChild) const;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -278,6 +278,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "gethdkeys", 0, "active_only" },
     { "gethdkeys", 0, "options" },
     { "gethdkeys", 0, "private" },
+    { "createwalletdescriptor", 1, "options" },
+    { "createwalletdescriptor", 1, "internal" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -275,6 +275,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
     { "upgradewallet", 0, "version" },
+    { "gethdkeys", 0, "active_only" },
+    { "gethdkeys", 0, "options" },
+    { "gethdkeys", 0, "private" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -158,6 +158,13 @@ struct Descriptor {
 
     /** Get the maximum size number of stack elements for satisfying this descriptor. */
     virtual std::optional<int64_t> MaxSatisfactionElems() const = 0;
+
+    /** Return all (extended) public keys for this descriptor, including any from subdescriptors.
+     *
+     * @param[out] pubkeys Any public keys
+     * @param[out] ext_pubs Any extended public keys
+     */
+    virtual void GetPubKeys(std::set<CPubKey>& pubkeys, std::set<CExtPubKey>& ext_pubs) const = 0;
 };
 
 /** Parse a `descriptor` string. Included private keys are put in `out`.

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2327,55 +2327,7 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, co
         return false;
     }
 
-    int64_t creation_time = GetTime();
-
-    std::string xpub = EncodeExtPubKey(master_key.Neuter());
-
-    // Build descriptor string
-    std::string desc_prefix;
-    std::string desc_suffix = "/*)";
-    switch (addr_type) {
-    case OutputType::LEGACY: {
-        desc_prefix = "pkh(" + xpub + "/44h";
-        break;
-    }
-    case OutputType::P2SH_SEGWIT: {
-        desc_prefix = "sh(wpkh(" + xpub + "/49h";
-        desc_suffix += ")";
-        break;
-    }
-    case OutputType::BECH32: {
-        desc_prefix = "wpkh(" + xpub + "/84h";
-        break;
-    }
-    case OutputType::BECH32M: {
-        desc_prefix = "tr(" + xpub + "/86h";
-        break;
-    }
-    case OutputType::UNKNOWN: {
-        // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN OutputType,
-        // so if we get to this point something is wrong
-        assert(false);
-    }
-    } // no default case, so the compiler can warn about missing cases
-    assert(!desc_prefix.empty());
-
-    // Mainnet derives at 0', testnet and regtest derive at 1'
-    if (Params().IsTestChain()) {
-        desc_prefix += "/1h";
-    } else {
-        desc_prefix += "/0h";
-    }
-
-    std::string internal_path = internal ? "/1" : "/0";
-    std::string desc_str = desc_prefix + "/0h" + internal_path + desc_suffix;
-
-    // Make the descriptor
-    FlatSigningProvider keys;
-    std::string error;
-    std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false);
-    WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
-    m_wallet_descriptor = w_desc;
+    m_wallet_descriptor = GenerateWalletDescriptor(master_key.Neuter(), addr_type, internal);
 
     // Store the master private key, and descriptor
     if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -633,6 +633,9 @@ public:
     bool SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal);
 
     bool HavePrivateKeys() const override;
+    bool HasPrivKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    //! Retrieve the particular key if it is available. Returns nullopt if the key is not in the wallet, or if the wallet is locked.
+    std::optional<CKey> GetKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     std::optional<int64_t> GetOldestKeyPoolTime() const override;
     unsigned int GetKeyPoolSize() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -672,7 +672,7 @@ public:
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;
     int32_t GetEndRange() const;
 
-    bool GetDescriptorString(std::string& out, const bool priv) const;
+    [[nodiscard]] bool GetDescriptorString(std::string& out, const bool priv) const;
 
     void UpgradeDescriptorCache();
 };

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -34,6 +34,7 @@ public:
     std::optional<int64_t> ScriptSize() const override { return {}; }
     std::optional<int64_t> MaxSatisfactionWeight(bool) const override { return {}; }
     std::optional<int64_t> MaxSatisfactionElems() const override { return {}; }
+    void GetPubKeys(std::set<CPubKey>& pubkeys, std::set<CExtPubKey>& ext_pubs) const override {}
 };
 
 BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3463,6 +3463,17 @@ std::set<ScriptPubKeyMan*> CWallet::GetActiveScriptPubKeyMans() const
     return spk_mans;
 }
 
+bool CWallet::IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const
+{
+    for (const auto& [_, ext_spkm] : m_external_spk_managers) {
+        if (ext_spkm == &spkm) return true;
+    }
+    for (const auto& [_, int_spkm] : m_internal_spk_managers) {
+        if (int_spkm == &spkm) return true;
+    }
+    return false;
+}
+
 std::set<ScriptPubKeyMan*> CWallet::GetAllScriptPubKeyMans() const
 {
     std::set<ScriptPubKeyMan*> spk_mans;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4507,4 +4507,19 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
     }
     return active_xpubs;
 }
+
+std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const
+{
+    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+
+    for (const auto& spkm : GetAllScriptPubKeyMans()) {
+        const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
+        assert(desc_spkm);
+        LOCK(desc_spkm->cs_desc_man);
+        if (std::optional<CKey> key = desc_spkm->GetKey(keyid)) {
+            return key;
+        }
+    }
+    return std::nullopt;
+}
 } // namespace wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1018,6 +1018,8 @@ public:
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
     void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
 
+    //! Create new DescriptorScriptPubKeyMan and add it to the wallet
+    DescriptorScriptPubKeyMan& SetupDescriptorScriptPubKeyMan(WalletBatch& batch, const CExtKey& master_key, const OutputType& output_type, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
     void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void SetupDescriptorScriptPubKeyMans() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1056,6 +1056,9 @@ public:
     void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm);
 
     void TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) override;
+
+    //! Retrieve the xpubs in use by the active descriptors
+    std::set<CExtPubKey> GetActiveHDPubKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1059,6 +1059,10 @@ public:
 
     //! Retrieve the xpubs in use by the active descriptors
     std::set<CExtPubKey> GetActiveHDPubKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    //! Find the private key for the given key id from the wallet's descriptors, if available
+    //! Returns nullopt when no descriptor has the key or if the wallet is locked.
+    std::optional<CKey> GetKey(const CKeyID& keyid) const;
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -942,6 +942,7 @@ public:
 
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;
+    bool IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const;
 
     //! Returns all unique ScriptPubKeyMans
     std::set<ScriptPubKeyMan*> GetAllScriptPubKeyMans() const;

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -4,7 +4,9 @@
 
 #include <wallet/walletutil.h>
 
+#include <chainparams.h>
 #include <common/args.h>
+#include <key_io.h>
 #include <logging.h>
 
 namespace wallet {
@@ -43,4 +45,58 @@ WalletFeature GetClosestWalletFeature(int version)
     }
     return static_cast<WalletFeature>(0);
 }
+
+WalletDescriptor GenerateWalletDescriptor(const CExtPubKey& master_key, const OutputType& addr_type, bool internal)
+{
+    int64_t creation_time = GetTime();
+
+    std::string xpub = EncodeExtPubKey(master_key);
+
+    // Build descriptor string
+    std::string desc_prefix;
+    std::string desc_suffix = "/*)";
+    switch (addr_type) {
+    case OutputType::LEGACY: {
+        desc_prefix = "pkh(" + xpub + "/44h";
+        break;
+    }
+    case OutputType::P2SH_SEGWIT: {
+        desc_prefix = "sh(wpkh(" + xpub + "/49h";
+        desc_suffix += ")";
+        break;
+    }
+    case OutputType::BECH32: {
+        desc_prefix = "wpkh(" + xpub + "/84h";
+        break;
+    }
+    case OutputType::BECH32M: {
+        desc_prefix = "tr(" + xpub + "/86h";
+        break;
+    }
+    case OutputType::UNKNOWN: {
+        // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN OutputType,
+        // so if we get to this point something is wrong
+        assert(false);
+    }
+    } // no default case, so the compiler can warn about missing cases
+    assert(!desc_prefix.empty());
+
+    // Mainnet derives at 0', testnet and regtest derive at 1'
+    if (Params().IsTestChain()) {
+        desc_prefix += "/1h";
+    } else {
+        desc_prefix += "/0h";
+    }
+
+    std::string internal_path = internal ? "/1" : "/0";
+    std::string desc_str = desc_prefix + "/0h" + internal_path + desc_suffix;
+
+    // Make the descriptor
+    FlatSigningProvider keys;
+    std::string error;
+    std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false);
+    WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+    return w_desc;
+}
+
 } // namespace wallet

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -114,6 +114,8 @@ public:
     WalletDescriptor() {}
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), id(DescriptorID(*descriptor)), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) { }
 };
+
+WalletDescriptor GenerateWalletDescriptor(const CExtPubKey& master_key, const OutputType& output_type, bool internal);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETUTIL_H

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -182,6 +182,7 @@ BASE_SCRIPTS = [
     'wallet_keypool_topup.py --descriptors',
     'wallet_fast_rescan.py --descriptors',
     'wallet_gethdkeys.py --descriptors',
+    'wallet_createwalletdescriptor.py --descriptors',
     'interface_zmq.py',
     'rpc_invalid_address_message.py',
     'rpc_validateaddress.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -181,6 +181,7 @@ BASE_SCRIPTS = [
     'wallet_keypool_topup.py --legacy-wallet',
     'wallet_keypool_topup.py --descriptors',
     'wallet_fast_rescan.py --descriptors',
+    'wallet_gethdkeys.py --descriptors',
     'interface_zmq.py',
     'rpc_invalid_address_message.py',
     'rpc_validateaddress.py',

--- a/test/functional/wallet_createwalletdescriptor.py
+++ b/test/functional/wallet_createwalletdescriptor.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet createwalletdescriptor RPC."""
+
+from test_framework.descriptors import descsum_create
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet_util import WalletUnlock
+
+
+class WalletCreateDescriptorTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.test_basic()
+        self.test_imported_other_keys()
+        self.test_encrypted()
+
+    def test_basic(self):
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("blank", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("blank")
+
+        xpub_info = def_wallet.gethdkeys(private=True)
+        xpub = xpub_info[0]["xpub"]
+        xprv = xpub_info[0]["xprv"]
+        expected_descs = []
+        for desc in def_wallet.listdescriptors()["descriptors"]:
+            if desc["desc"].startswith("wpkh("):
+                expected_descs.append(desc["desc"])
+
+        assert_raises_rpc_error(-5, "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'", wallet.createwalletdescriptor, "bech32")
+        assert_raises_rpc_error(-5, f"Private key for {xpub} is not known", wallet.createwalletdescriptor, type="bech32", hdkey=xpub)
+
+        self.log.info("Test createwalletdescriptor after importing active descriptor to blank wallet")
+        # Import one active descriptor
+        assert_equal(wallet.importdescriptors([{"desc": descsum_create(f"pkh({xprv}/44h/2h/0h/0/0/*)"), "timestamp": "now", "active": True}])[0]["success"], True)
+        assert_equal(len(wallet.listdescriptors()["descriptors"]), 1)
+        assert_equal(len(wallet.gethdkeys()), 1)
+
+        new_descs = wallet.createwalletdescriptor("bech32")["descs"]
+        assert_equal(len(new_descs), 2)
+        assert_equal(len(wallet.gethdkeys()), 1)
+        assert_equal(new_descs, expected_descs)
+
+        self.log.info("Test descriptor creation options")
+        old_descs = set([(d["desc"], d["active"], d["internal"]) for d in wallet.listdescriptors(private=True)["descriptors"]])
+        wallet.createwalletdescriptor(type="bech32m", internal=False)
+        curr_descs = set([(d["desc"], d["active"], d["internal"]) for d in wallet.listdescriptors(private=True)["descriptors"]])
+        new_descs = list(curr_descs - old_descs)
+        assert_equal(len(new_descs), 1)
+        assert_equal(len(wallet.gethdkeys()), 1)
+        assert_equal(new_descs[0][0], descsum_create(f"tr({xprv}/86h/1h/0h/0/*)"))
+        assert_equal(new_descs[0][1], True)
+        assert_equal(new_descs[0][2], False)
+
+        old_descs = curr_descs
+        wallet.createwalletdescriptor(type="bech32m", internal=True)
+        curr_descs = set([(d["desc"], d["active"], d["internal"]) for d in wallet.listdescriptors(private=True)["descriptors"]])
+        new_descs = list(curr_descs - old_descs)
+        assert_equal(len(new_descs), 1)
+        assert_equal(len(wallet.gethdkeys()), 1)
+        assert_equal(new_descs[0][0], descsum_create(f"tr({xprv}/86h/1h/0h/1/*)"))
+        assert_equal(new_descs[0][1], True)
+        assert_equal(new_descs[0][2], True)
+
+    def test_imported_other_keys(self):
+        self.log.info("Test createwalletdescriptor with multiple keys in active descriptors")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("multiple_keys")
+        wallet = self.nodes[0].get_wallet_rpc("multiple_keys")
+
+        wallet_xpub = wallet.gethdkeys()[0]["xpub"]
+
+        xpub_info = def_wallet.gethdkeys(private=True)
+        xpub = xpub_info[0]["xpub"]
+        xprv = xpub_info[0]["xprv"]
+
+        assert_equal(wallet.importdescriptors([{"desc": descsum_create(f"wpkh({xprv}/0/0/*)"), "timestamp": "now", "active": True}])[0]["success"], True)
+        assert_equal(len(wallet.gethdkeys()), 2)
+
+        assert_raises_rpc_error(-5, "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'", wallet.createwalletdescriptor, "bech32")
+        assert_raises_rpc_error(-4, "Descriptor already exists", wallet.createwalletdescriptor, type="bech32m", hdkey=wallet_xpub)
+        assert_raises_rpc_error(-5, "Unable to parse HD key. Please provide a valid xpub", wallet.createwalletdescriptor, type="bech32m", hdkey=xprv)
+
+        # Able to replace tr() descriptor with other hd key
+        wallet.createwalletdescriptor(type="bech32m", hdkey=xpub)
+
+    def test_encrypted(self):
+        self.log.info("Test createwalletdescriptor with encrypted wallets")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("encrypted", blank=True, passphrase="pass")
+        wallet = self.nodes[0].get_wallet_rpc("encrypted")
+
+        xpub_info = def_wallet.gethdkeys(private=True)
+        xprv = xpub_info[0]["xprv"]
+
+        with WalletUnlock(wallet, "pass"):
+            assert_equal(wallet.importdescriptors([{"desc": descsum_create(f"wpkh({xprv}/0/0/*)"), "timestamp": "now", "active": True}])[0]["success"], True)
+        assert_equal(len(wallet.gethdkeys()), 1)
+
+        assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", wallet.createwalletdescriptor, type="bech32m")
+
+        with WalletUnlock(wallet, "pass"):
+            wallet.createwalletdescriptor(type="bech32m")
+
+
+
+if __name__ == '__main__':
+    WalletCreateDescriptorTest().main()

--- a/test/functional/wallet_gethdkeys.py
+++ b/test/functional/wallet_gethdkeys.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet gethdkeys RPC."""
+
+from test_framework.descriptors import descsum_create
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet_util import WalletUnlock
+
+
+class WalletGetHDKeyTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.test_basic_gethdkeys()
+        self.test_ranged_imports()
+        self.test_lone_key_imports()
+        self.test_ranged_multisig()
+        self.test_mixed_multisig()
+
+    def test_basic_gethdkeys(self):
+        self.log.info("Test gethdkeys basics")
+        self.nodes[0].createwallet("basic")
+        wallet = self.nodes[0].get_wallet_rpc("basic")
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 1)
+        assert_equal(xpub_info[0]["has_private"], True)
+
+        assert "xprv" not in xpub_info[0]
+        xpub = xpub_info[0]["xpub"]
+
+        xpub_info = wallet.gethdkeys(private=True)
+        xprv = xpub_info[0]["xprv"]
+        assert_equal(xpub_info[0]["xpub"], xpub)
+        assert_equal(xpub_info[0]["has_private"], True)
+
+        descs = wallet.listdescriptors(True)
+        for desc in descs["descriptors"]:
+            assert xprv in desc["desc"]
+
+        self.log.info("HD pubkey can be retrieved from encrypted wallets")
+        prev_xprv = xprv
+        wallet.encryptwallet("pass")
+        # HD key is rotated on encryption, there should now be 2 HD keys
+        assert_equal(len(wallet.gethdkeys()), 2)
+        # New key is active, should be able to get only that one and its descriptors
+        xpub_info = wallet.gethdkeys(active_only=True)
+        assert_equal(len(xpub_info), 1)
+        assert xpub_info[0]["xpub"] != xpub
+        assert "xprv" not in xpub_info[0]
+        assert_equal(xpub_info[0]["has_private"], True)
+
+        self.log.info("HD privkey can be retrieved from encrypted wallets")
+        assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first", wallet.gethdkeys, private=True)
+        with WalletUnlock(wallet, "pass"):
+            xpub_info = wallet.gethdkeys(active_only=True, private=True)[0]
+            assert xpub_info["xprv"] != xprv
+            for desc in wallet.listdescriptors(True)["descriptors"]:
+                if desc["active"]:
+                    # After encrypting, HD key was rotated and should appear in all active descriptors
+                    assert xpub_info["xprv"] in desc["desc"]
+                else:
+                    # Inactive descriptors should have the previous HD key
+                    assert prev_xprv in desc["desc"]
+
+    def test_ranged_imports(self):
+        self.log.info("Keys of imported ranged descriptors appear in gethdkeys")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("imports")
+        wallet = self.nodes[0].get_wallet_rpc("imports")
+
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 1)
+        active_xpub = xpub_info[0]["xpub"]
+
+        import_xpub = def_wallet.gethdkeys(active_only=True)[0]["xpub"]
+        desc_import = def_wallet.listdescriptors(True)["descriptors"]
+        for desc in desc_import:
+            desc["active"] = False
+        wallet.importdescriptors(desc_import)
+        assert_equal(wallet.gethdkeys(active_only=True), xpub_info)
+
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 2)
+        for x in xpub_info:
+            if x["xpub"] == active_xpub:
+                for desc in x["descriptors"]:
+                    assert_equal(desc["active"], True)
+            elif x["xpub"] == import_xpub:
+                for desc in x["descriptors"]:
+                    assert_equal(desc["active"], False)
+            else:
+                assert False
+
+
+    def test_lone_key_imports(self):
+        self.log.info("Non-HD keys do not appear in gethdkeys")
+        self.nodes[0].createwallet("lonekey", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("lonekey")
+
+        assert_equal(wallet.gethdkeys(), [])
+        wallet.importdescriptors([{"desc": descsum_create("wpkh(cTe1f5rdT8A8DFgVWTjyPwACsDPJM9ff4QngFxUixCSvvbg1x6sh)"), "timestamp": "now"}])
+        assert_equal(wallet.gethdkeys(), [])
+
+        self.log.info("HD keys of non-ranged descriptors should appear in gethdkeys")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        xpub_info = def_wallet.gethdkeys(private=True)
+        xpub = xpub_info[0]["xpub"]
+        xprv = xpub_info[0]["xprv"]
+        prv_desc = descsum_create(f"wpkh({xprv})")
+        pub_desc = descsum_create(f"wpkh({xpub})")
+        assert_equal(wallet.importdescriptors([{"desc": prv_desc, "timestamp": "now"}])[0]["success"], True)
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 1)
+        assert_equal(xpub_info[0]["xpub"], xpub)
+        assert_equal(len(xpub_info[0]["descriptors"]), 1)
+        assert_equal(xpub_info[0]["descriptors"][0]["desc"], pub_desc)
+        assert_equal(xpub_info[0]["descriptors"][0]["active"], False)
+
+    def test_ranged_multisig(self):
+        self.log.info("HD keys of a multisig appear in gethdkeys")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("ranged_multisig")
+        wallet = self.nodes[0].get_wallet_rpc("ranged_multisig")
+
+        xpub1 = wallet.gethdkeys()[0]["xpub"]
+        xprv1 = wallet.gethdkeys(private=True)[0]["xprv"]
+        xpub2 = def_wallet.gethdkeys()[0]["xpub"]
+
+        prv_multi_desc = descsum_create(f"wsh(multi(2,{xprv1}/*,{xpub2}/*))")
+        pub_multi_desc = descsum_create(f"wsh(multi(2,{xpub1}/*,{xpub2}/*))")
+        assert_equal(wallet.importdescriptors([{"desc": prv_multi_desc, "timestamp": "now"}])[0]["success"], True)
+
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 2)
+        for x in xpub_info:
+            if x["xpub"] == xpub1:
+                found_desc = next((d for d in xpub_info[0]["descriptors"] if d["desc"] == pub_multi_desc), None)
+                assert found_desc is not None
+                assert_equal(found_desc["active"], False)
+            elif x["xpub"] == xpub2:
+                assert_equal(len(x["descriptors"]), 1)
+                assert_equal(x["descriptors"][0]["desc"], pub_multi_desc)
+                assert_equal(x["descriptors"][0]["active"], False)
+            else:
+                assert False
+
+    def test_mixed_multisig(self):
+        self.log.info("Non-HD keys of a multisig do not appear in gethdkeys")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("single_multisig")
+        wallet = self.nodes[0].get_wallet_rpc("single_multisig")
+
+        xpub = wallet.gethdkeys()[0]["xpub"]
+        xprv = wallet.gethdkeys(private=True)[0]["xprv"]
+        pub = def_wallet.getaddressinfo(def_wallet.getnewaddress())["pubkey"]
+
+        prv_multi_desc = descsum_create(f"wsh(multi(2,{xprv},{pub}))")
+        pub_multi_desc = descsum_create(f"wsh(multi(2,{xpub},{pub}))")
+        import_res = wallet.importdescriptors([{"desc": prv_multi_desc, "timestamp": "now"}])
+        assert_equal(import_res[0]["success"], True)
+
+        xpub_info = wallet.gethdkeys()
+        assert_equal(len(xpub_info), 1)
+        assert_equal(xpub_info[0]["xpub"], xpub)
+        found_desc = next((d for d in xpub_info[0]["descriptors"] if d["desc"] == pub_multi_desc), None)
+        assert found_desc is not None
+        assert_equal(found_desc["active"], False)
+
+
+if __name__ == '__main__':
+    WalletGetHDKeyTest().main()


### PR DESCRIPTION
This PR adds a `createwalletdescriptor` RPC which allows users to add new automatically generated descriptors to their wallet, e.g. to upgrade a 0.21.x wallet to contain a taproot descriptor. This RPC takes 3 arguments: the output type to create a descriptor for, whether the descriptor will be internal or external, and the HD key to use if the user wishes to use a specific key. The HD key is an optional parameter. If it is not specified, the wallet will use the key shared by the active descriptors, if they are all single key. For most users in the expected upgrade scenario, this should be sufficient. In more advanced cases, the user must specify the HD key to use.

Currently, specified HD keys must already exist in the wallet. To make it easier for the user to know, `gethdkeys` is also added to list out the HD keys in use by all of the descriptors in the wallet. This will include all HD keys, whether we have the private key, for it, which descriptors use it and their activeness, and optionally the extended private key. In this way, users with more complex wallets will be still be able to get HD keys from their wallet for use in other scenarios, and if they want to use `createwalletdescriptor`, they can easily get the keys that they can specify to it.

See also https://github.com/bitcoin/bitcoin/pull/26728#issuecomment-1866961865