### PR TITLE
wallet: move lock to the top of ReleaseWallet

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -493,7 +493,9 @@ static RPCHelpMan unloadwallet()
         }
     }
 
-    UnloadWallet(std::move(wallet));
+    if (!UnloadWallet(std::move(wallet))) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet already marked for unloading");
+    }
 
     UniValue result(UniValue::VOBJ);
     PushWarnings(warnings, result);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -86,7 +86,7 @@ struct WalletContext;
 //! wallet pointer owners release the wallet.
 //! Note that, when blocking is not required, the wallet is implicitly unloaded
 //! by the shared pointer deleter.
-void UnloadWallet(std::shared_ptr<CWallet>&& wallet);
+bool UnloadWallet(std::shared_ptr<CWallet>&& wallet);
 
 bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/29073
Calling `unloadwallet` first marks that wallet for unloading and then unloads it. If the unloading does not finish in time and `unloadwallet` is called again for the same wallet an assertion error is thrown `wallet/wallet.cpp:246: void wallet::UnloadWallet(std::shared_ptr<CWallet> &&): Assertion it.second` which is not descriptive. The test in issue https://github.com/bitcoin/bitcoin/issues/29073 is sometimes failing due to that assertion. This pull request fixes that by changing the error returned from RPC to `Wallet already marked for unloading` and takes that into account for the test. Maybe it even makes sense to do nothing if the case above happens which will not require changes to the test since no error is returned.