### PR TITLE
Remove `dnsseed.bitcoin.dashjr.org` temporarily

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -133,7 +133,6 @@ public:
         // release ASAP to avoid it where possible.
         vSeeds.emplace_back("seed.bitcoin.sipa.be."); // Pieter Wuille, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("dnsseed.bluematt.me."); // Matt Corallo, only supports x9
-        vSeeds.emplace_back("dnsseed.bitcoin.dashjr.org."); // Luke Dashjr
         vSeeds.emplace_back("seed.bitcoinstats.com."); // Christian Decker, supports x1 - xf
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch."); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.net."); // Peter Todd, only supports x1, x5, x9, and xd


### PR DESCRIPTION
Rationale: 

- Only this seeder is giving different results that include older versions: https://github.com/bitcoin/bitcoin/pull/29145#pullrequestreview-1797445282

- Warnings on **luke.dashjr.org** reduces the confidence to use this as DNS seed in bitcoin core: https://pastebin.com/raw/Cwk2a1xr

- He is not following [DNS seed policy](https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md) rule 0 and 1