### PR TITLE
bitcoin-cli help detail to show full help for all RPCs

### DIFF
--- a/doc/release-notes-29163.md
+++ b/doc/release-notes-29163.md
@@ -1,0 +1,9 @@
+Tools and Utilities
+---
+
+A new argument, `helpdetail` has been added to `bitcoin-cli` that
+displays the full help text for all RPC methods on standard output.
+Typical usage:
+```
+bitcoin-cli helpdetail | less
+```

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -136,6 +136,7 @@ private:
 public:
     CRPCTable();
     std::string help(const std::string& name, const JSONRPCRequest& helpreq) const;
+    std::string helpdetail(const JSONRPCRequest& helpreq) const;
 
     /**
      * Execute a method.

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -150,6 +150,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "gettxoutsetinfo",
     "gettxspendingprevout",
     "help",
+    "helpdetail",
     "invalidateblock",
     "joinpsbts",
     "listbanned",

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -125,6 +125,18 @@ class HelpRpcTest(BitcoinTestFramework):
                 # Make sure the node can generate the help at runtime without crashing
                 f.write(self.nodes[0].help(call))
 
+        help_detail = self.nodes[0].helpdetail()
+
+        # the test-only (hidden) RPCs should not appear in the result
+        assert "This RPC is for testing only" not in help_detail
+
+        # These strings should only appear in the full text
+        # (and not in the one-line summary "bitcoin-cli help")
+        assert "Arguments:" in help_detail
+        assert "Result" in help_detail
+        assert "The block size excluding witness data" in help_detail
+
+
     def wallet_help(self):
         assert 'getnewaddress ( "label" "address_type" )' in self.nodes[0].help('getnewaddress')
         self.restart_node(0, extra_args=['-nowallet=1'])


### PR DESCRIPTION
Prints to stdout a concatenation of full help text as if you had run `bitcoin-cli help` on every RPC. This allows you to search help text when you can't remember the name of an RPC.

For example, suppose you remember there is an RPC that shows you orphaned chain branches but can't remember its name. This PR allows you to run:
```
bitcoin-cli helpdetail | less
```
and then search for "orphan", you'd immediately find `getchaintips`. It shows the category before each RPC's help text, which also helps visually separate the individual RPC helps.