### PR TITLE
fuzz: avoid underflow in `coins_view` target

### DIFF
--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -157,6 +157,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
     }
 
     if (!good_data) return;
+    coins_view_cache.SanityCheck();
 
     {
         const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);


### PR DESCRIPTION
Catching the exception in `AddCoin` and continuing will lead to the calculated memory usage of the cache to be out of sync (lower by the size of the existing coin). If we later remove more coins, this can lead to an underflow and the sanitizer will trip on a later overflow when we add back to `cachedCoinsUsage`. See https://github.com/bitcoin/bitcoin/pull/28216#issuecomment-1872991949.

I found this while rebasing #28216 but another way of exposing this mistake is to simply run the cache sanity check after the `LIMITED_WHILE` loop. This PR fixes the underflow by not continuing when hitting this exception and adds the sanity check.

The crash can be reproduced with the following seed:
```
q6urNzc3NzfHx8fHx8fHx8fHx8cBpwAAAAD//wD/////7/+CAAAAAAAAAAGCgv9Z/////////8dDbwBcXW+XbyEhL01BTklGRVNULTAwMCEhBQUFBQUFBQX///////8hISMjIyP/ISHd//9rQ0P/AQAAISEhISMjIyP/ISHd//9rQ0MhISEFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQAFBf8BAAAhISEhIyMjI/8hISEhISMjIyP/ISHd//9rQ0P/AQAAISEhISMjIyP/ISHd//9rQ0MhIUM/ISEhIf//////AH//////AQAAISEhISMjIyP/ISHd//9rQ0P/AQAAISEhISMjIyP/ISEhISEjIyMj/yEh3f//a0ND/wEAACEhISEjIyMj/yEh3f//a0NDISEhBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUABQUFBQUFx/9rQ0P/AQAAISEhISMjIyP/ISHd//9rQ0MhISEFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQAFBQUFBQXHx8fHx8fHx8fHx8fHxzc3Nzc3NzfHx8fHx8cFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFIf//ISEhISMjIyP/ISHd//////////////8x////////////ISHd//////////////8y/////+//////////////////f2vHx0ND/8fHxzc3Nzc3Nzc=
```