### PR TITLE
wallet: Fix use-after-free in WalletBatch::EraseRecords

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1401,13 +1401,13 @@ bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)
         }
 
         // Make a copy of key to avoid data being deleted by the following read of the type
-        Span key_data{key};
+        const SerializeData key_data{key.begin(), key.end()};
 
         std::string type;
         key >> type;
 
         if (types.count(type) > 0) {
-            if (!m_batch->Erase(key_data)) {
+            if (!m_batch->Erase(Span{key_data})) {
                 cursor.reset(nullptr);
                 m_batch->TxnAbort();
                 return false; // erase failed


### PR DESCRIPTION
Creating a copy of the pointer to the underlying data of the stream is not enough to copy the data.

Currently this happens to work sometimes, because the stream may not immediately free unused memory. However, there is no guarantee by the stream interface to always behave this way. Also, if `vector::clear` is called on the underlying memory, any pointers to it are invalid.

Fix this, by creating a full copy of all bytes.