### PR TITLE
build: Fix check whether `-latomic` needed

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -4,7 +4,7 @@ dnl permitted in any medium without royalty provided the copyright notice
 dnl and this notice are preserved. This file is offered as-is, without any
 dnl warranty.
 
-# Clang prior to version 15, when building for 32-bit,
+# Clang, when building for 32-bit,
 # and linking against libstdc++, requires linking with
 # -latomic if using the C++ atomic library.
 # Can be tested with: clang++ test.cpp -m32
@@ -24,6 +24,8 @@ m4_define([_CHECK_ATOMIC_testbody], [[
 
     std::atomic<std::chrono::seconds> t{0s};
     t.store(2s);
+    auto t1 = t.load();
+    t.compare_exchange_strong(t1, 3s);
 
     std::atomic<int64_t> a{};
 


### PR DESCRIPTION
Clang >=15 still might need linking against `libatomic`.

We use `std::atomic<std::chrono::seconds>::compare_exchange_strong` in `net_processing.cpp`.

Addresses the https://github.com/bitcoin/bitcoin/pull/29165#discussion_r1440293694.