### PR TITLE
ci, iwyu: Drop backported mappings

### DIFF
--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,7 +1,4 @@
 # Fixups / upstreamed changes
 [
-  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
   { include: [ "<bits/chrono.h>", private, "<chrono>", public ] },
 ]


### PR DESCRIPTION
See https://github.com/include-what-you-use/include-what-you-use/pull/1026.

Split from https://github.com/bitcoin/bitcoin/pull/27710 as a non-controversial change.