### PR TITLE
RFC: Deprecate libconsensus

### DIFF
--- a/doc/release-notes-29189.md
+++ b/doc/release-notes-29189.md
@@ -1,0 +1,15 @@
+libbitcoinconsensus
+========================
+
+This library is deprecated and will be removed for v28.
+
+It has existed for nearly 10 years with very little known uptake or impact. It
+has become a maintenance burden.
+
+The underlying functionality does not change between versions, so any users of
+the library can continue to use the final release indefinitely, with the
+understanding that Taproot is its final consensus update.
+
+In the future, libbitcoinkernel will provide a much more useful API that is
+aware of the UTXO set, and therefore be able to fully validate transactions and
+blocks.

--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -2,6 +2,7 @@ Shared Libraries
 ================
 
 ## bitcoinconsensus
+***This library is deprecated and will be removed in v28***
 
 The purpose of this library is to make the verification functionality that is critical to Bitcoin's consensus available to other applications, e.g. to language bindings.
 


### PR DESCRIPTION
This library has existed for nearly 10 years with very little known uptake or impact. It has become a maintenance burden. In several cases it dictates our code/library structure (for example necessitating LIBBITCOIN_CRYPTO_BASE), as well as build-system procedures (building multiple copies of object files especially for the lib).

Several discussions have arisen wrt migrating it to CMake and it has become difficult to justify adding more complexity for a library that is virtually unused anyway.

See for example the discussions:
https://github.com/hebasto/bitcoin/pull/41
https://github.com/bitcoin/bitcoin/pull/29123

And here: https://github.com/bitcoin/bitcoin/pull/29180
Where it is pointed out that the libbitcoinconsensus functions are slower than those the internal bitcoind equivalents due to the missing sha2 implementations.

Instead, we (fanquake, hebasto, TheCharlatan, and I) propose simply not migrating it to CMake and letting it end with v27. Any remaining use-cases could be handled in the future by libbitcoinkernel.

If there are any users currently using libbitcoinconsensus, please chime in with your use-case!

Edit: Corrected final release to be v27.