### PR TITLE
refactor: use push_back in TaprootBuilder::Add(), rm NOLINTNEXTLINE and comment

### DIFF
--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -368,9 +368,7 @@ TaprootBuilder& TaprootBuilder::Add(int depth, Span<const unsigned char> script,
     /* Construct NodeInfo object with leaf hash and (if track is true) also leaf information. */
     NodeInfo node;
     node.hash = ComputeTapleafHash(leaf_version, script);
-    // due to bug in clang-tidy-17:
-    // NOLINTNEXTLINE(modernize-use-emplace)
-    if (track) node.leaves.emplace_back(LeafInfo{std::vector<unsigned char>(script.begin(), script.end()), leaf_version, {}});
+    if (track) node.leaves.push_back(LeafInfo{std::vector<unsigned char>(script.begin(), script.end()), leaf_version, /*merkle_branch=*/{}});
     /* Insert into the branch. */
     Insert(std::move(node), depth);
     return *this;


### PR DESCRIPTION
Using `emplace_back` and disabling the `modernize-use-emplace` Tidy CI check seems pointless here, as IIUC it doesn't avoid a temporary object compared to just using `push_back`. See https://github.com/bitcoin/bitcoin/pull/28583 for more context.