### PR TITLE
build: Drop `ALLOW_HOST_PACKAGES` support in depends

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -9,8 +9,8 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_qt5
 export CI_IMAGE_NAME_TAG="docker.io/debian:bullseye"
 # Use minimum supported python3.9 and gcc-10, see doc/dependencies.md
-export PACKAGES="gcc-10 g++-10 python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
-export DEP_OPTS="NO_QT=1 NO_UPNP=1 NO_NATPMP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1 CC=gcc-10 CXX=g++-10"
+export PACKAGES="gcc-10 g++-10 python3-zmq"
+export DEP_OPTS="NO_UPNP=1 NO_NATPMP=1 DEBUG=1 CC=gcc-10 CXX=g++-10"
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -242,7 +242,6 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \
             -e 's|@CPPFLAGS@|$(strip $(host_CPPFLAGS) $(host_$(release_type)_CPPFLAGS))|' \
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
-            -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
             -e 's|@no_qr@|$(NO_QR)|' \
             -e 's|@no_zmq@|$(NO_ZMQ)|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -110,9 +110,6 @@ The following can be set when running make: `make FOO=bar`
 - `NO_UPNP`: Don't download/build/cache packages needed for enabling UPnP
 - `NO_NATPMP`: Don't download/build/cache packages needed for enabling NAT-PMP
 - `NO_USDT`: Don't download/build/cache packages needed for enabling USDT tracepoints
-- `ALLOW_HOST_PACKAGES`: Packages that are missed in dependencies (due to `NO_*` option or
-  build script logic) are searched for among the host system packages using
-  `pkg-config`. It allows building with packages of other (newer) versions
 - `MULTIPROCESS`: Build libmultiprocess (experimental, requires CMake)
 - `DEBUG`: Disable some optimizations and enable more runtime checking
 - `HOST_ID_SALT`: Optional salt to use when generating host package ids

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -89,9 +89,7 @@ fi
 PKG_CONFIG="$(which pkg-config) --static"
 
 PKG_CONFIG_PATH="${depends_prefix}/share/pkgconfig:${depends_prefix}/lib/pkgconfig"
-if test -z "@allow_host_packages@"; then
-  PKG_CONFIG_LIBDIR="${depends_prefix}/lib/pkgconfig"
-fi
+PKG_CONFIG_LIBDIR="${depends_prefix}/lib/pkgconfig"
 
 CPPFLAGS="-I${depends_prefix}/include/ ${CPPFLAGS}"
 LDFLAGS="-L${depends_prefix}/lib ${LDFLAGS}"


### PR DESCRIPTION
The `ALLOW_HOST_PACKAGES` variable was introduced in bitcoin#10508 "to speed up build and avoid timeout".

It is no longer the case for our CI infrastructure, which uses self- hosted persistent workers and depends caching.

In the current circumstances, it does not seem worth porting this feature to the upcoming [CMake-based](https://github.com/bitcoin/bitcoin/issues/28607) build system.