### PR TITLE
wallet: Refactor DumpWallet function to accept -dumpfile path argument

### DIFF
--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -21,10 +21,9 @@ namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error)
+bool DumpWallet(const std::string& dump_filename, WalletDatabase& db, bilingual_str& error)
 {
     // Get the dumpfile
-    std::string dump_filename = args.GetArg("-dumpfile", "");
     if (dump_filename.empty()) {
         error = _("No dump file provided. To use dump, -dumpfile=<filename> must be provided.");
         return false;

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -16,7 +16,7 @@ class ArgsManager;
 namespace wallet {
 class WalletDatabase;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error);
+bool DumpWallet(const std::string& dump_filename, WalletDatabase& db, bilingual_str& error);
 bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
 } // namespace wallet
 

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -201,7 +201,8 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
             return false;
         }
 
-        bool ret = DumpWallet(args, *database, error);
+        const std::string dump_filename = args.GetArg("-dumpfile", "");
+        bool ret = DumpWallet(dump_filename, *database, error);
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
             return ret;


### PR DESCRIPTION
Quick follow-up to https://github.com/bitcoin/bitcoin/pull/29117, coming from _https://github.com/bitcoin/bitcoin/pull/29117#discussion_r1431999422_.

Refactor `DumpWallet(...)` to accept  the `-dumpfile` path arg instead of the entire `ArgsManager` 