### PR TITLE
doc: refer to "Node relay options" in policy/README

### DIFF
--- a/doc/policy/README.md
+++ b/doc/policy/README.md
@@ -2,8 +2,8 @@
 
 **Policy** (Mempool or Transaction Relay Policy) is the node's set of validation rules, in addition
 to consensus, enforced for unconfirmed transactions before submitting them to the mempool. These
-rules are local to the node and configurable (e.g. `-minrelaytxfee`, `-limitancestorsize`,
-`-incrementalrelayfee`). Policy may include restrictions on the transaction itself, the transaction
+rules are local to the node and configurable, see "Node relay options" when running `-help`.
+Policy may include restrictions on the transaction itself, the transaction
 in relation to the current chain tip, and the transaction in relation to the node's mempool
 contents. Policy is *not* applied to transactions in blocks.
 


### PR DESCRIPTION
Fixed up #29095, to refer to `-help`, rather than listing every option.