### PR TITLE
log: Nuke error(...)

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -44,7 +44,7 @@ bool SerializeDB(Stream& stream, const Data& data)
         hashwriter << Params().MessageStart() << data;
         stream << hashwriter.GetHash();
     } catch (const std::exception& e) {
-        error("%s: Serialize or I/O error - %s", __func__, e.what());
+        LogError("%s: Serialize or I/O error - %s\n", __func__, e.what());
         return false;
     }
 
@@ -65,7 +65,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (fileout.IsNull()) {
         fileout.fclose();
         remove(pathTmp);
-        error("%s: Failed to open file %s", __func__, fs::PathToString(pathTmp));
+        LogError("%s: Failed to open file %s\n", __func__, fs::PathToString(pathTmp));
         return false;
     }
 
@@ -78,7 +78,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (!FileCommit(fileout.Get())) {
         fileout.fclose();
         remove(pathTmp);
-        error("%s: Failed to flush file %s", __func__, fs::PathToString(pathTmp));
+        LogError("%s: Failed to flush file %s\n", __func__, fs::PathToString(pathTmp));
         return false;
     }
     fileout.fclose();
@@ -86,7 +86,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     // replace existing file, if any, with new file
     if (!RenameOver(pathTmp, path)) {
         remove(pathTmp);
-        error("%s: Rename-into-place failed", __func__);
+        LogError("%s: Rename-into-place failed\n", __func__);
         return false;
     }
 
@@ -144,7 +144,7 @@ bool CBanDB::Write(const banmap_t& banSet)
     }
 
     for (const auto& err : errors) {
-        error("%s", err);
+        LogError("%s\n", err);
     }
     return false;
 }

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -44,7 +44,8 @@ bool SerializeDB(Stream& stream, const Data& data)
         hashwriter << Params().MessageStart() << data;
         stream << hashwriter.GetHash();
     } catch (const std::exception& e) {
-        return error("%s: Serialize or I/O error - %s", __func__, e.what());
+        error("%s: Serialize or I/O error - %s", __func__, e.what());
+        return false;
     }
 
     return true;
@@ -64,7 +65,8 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (fileout.IsNull()) {
         fileout.fclose();
         remove(pathTmp);
-        return error("%s: Failed to open file %s", __func__, fs::PathToString(pathTmp));
+        error("%s: Failed to open file %s", __func__, fs::PathToString(pathTmp));
+        return false;
     }
 
     // Serialize
@@ -76,14 +78,16 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (!FileCommit(fileout.Get())) {
         fileout.fclose();
         remove(pathTmp);
-        return error("%s: Failed to flush file %s", __func__, fs::PathToString(pathTmp));
+        error("%s: Failed to flush file %s", __func__, fs::PathToString(pathTmp));
+        return false;
     }
     fileout.fclose();
 
     // replace existing file, if any, with new file
     if (!RenameOver(pathTmp, path)) {
         remove(pathTmp);
-        return error("%s: Rename-into-place failed", __func__);
+        error("%s: Rename-into-place failed", __func__);
+        return false;
     }
 
     return true;

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -82,17 +82,17 @@ bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
 {
     FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
     if (!file) {
-        error("%s: failed to open file %d", __func__, pos.nFile);
+        LogError("%s: failed to open file %d\n", __func__, pos.nFile);
         return false;
     }
     if (finalize && !TruncateFile(file, pos.nPos)) {
         fclose(file);
-        error("%s: failed to truncate file %d", __func__, pos.nFile);
+        LogError("%s: failed to truncate file %d\n", __func__, pos.nFile);
         return false;
     }
     if (!FileCommit(file)) {
         fclose(file);
-        error("%s: failed to commit file %d", __func__, pos.nFile);
+        LogError("%s: failed to commit file %d\n", __func__, pos.nFile);
         return false;
     }
     DirectoryCommit(m_dir);

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -82,15 +82,18 @@ bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
 {
     FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
     if (!file) {
-        return error("%s: failed to open file %d", __func__, pos.nFile);
+        error("%s: failed to open file %d", __func__, pos.nFile);
+        return false;
     }
     if (finalize && !TruncateFile(file, pos.nPos)) {
         fclose(file);
-        return error("%s: failed to truncate file %d", __func__, pos.nFile);
+        error("%s: failed to truncate file %d", __func__, pos.nFile);
+        return false;
     }
     if (!FileCommit(file)) {
         fclose(file);
-        return error("%s: failed to commit file %d", __func__, pos.nFile);
+        error("%s: failed to commit file %d", __func__, pos.nFile);
+        return false;
     }
     DirectoryCommit(m_dir);
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -229,7 +229,8 @@ bool BaseIndex::Commit()
         }
     }
     if (!ok) {
-        return error("%s: Failed to commit latest %s state", __func__, GetName());
+        error("%s: Failed to commit latest %s state", __func__, GetName());
+        return false;
     }
     return true;
 }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -229,7 +229,7 @@ bool BaseIndex::Commit()
         }
     }
     if (!ok) {
-        error("%s: Failed to commit latest %s state", __func__, GetName());
+        LogError("%s: Failed to commit latest %s state\n", __func__, GetName());
         return false;
     }
     return true;

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -159,7 +159,9 @@ bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, const uint256&
     std::vector<uint8_t> encoded_filter;
     try {
         filein >> block_hash >> encoded_filter;
-        if (Hash(encoded_filter) != hash) return error("Checksum mismatch in filter decode.");
+        if (Hash(encoded_filter) != hash) {
+            return error("Checksum mismatch in filter decode.");
+        }
         filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter), /*skip_decode_check=*/true);
     }
     catch (const std::exception& e) {

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -138,7 +138,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                error("%s: previous block header not found; expected %s",
+                LogError("%s: previous block header not found; expected %s\n",
                              __func__, expected_block_hash.ToString());
                 return false;
             }
@@ -246,14 +246,14 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
     for (int height = start_height; height <= stop_height; ++height) {
         if (!db_it.GetKey(key) || key.height != height) {
-            error("%s: unexpected key in %s: expected (%c, %d)",
+            LogError("%s: unexpected key in %s: expected (%c, %d)\n",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
             return false;
         }
 
         std::pair<uint256, DBVal> value;
         if (!db_it.GetValue(value)) {
-            error("%s: unable to read value in %s at key (%c, %d)",
+            LogError("%s: unable to read value in %s at key (%c, %d)\n",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
             return false;
         }
@@ -288,7 +288,7 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
             CBlock block;
 
             if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, *iter_tip)) {
-                error("%s: Failed to read block %s from disk",
+                LogError("%s: Failed to read block %s from disk\n",
                              __func__, iter_tip->GetBlockHash().ToString());
                 return false;
             }
@@ -357,7 +357,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
         // exist. Any other errors indicate database corruption or a disk
         // failure, and starting the index would cause further corruption.
         if (m_db->Exists(DB_MUHASH)) {
-            error("%s: Cannot read current %s state; index may be corrupted",
+            LogError("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -366,7 +366,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
     if (block) {
         DBVal entry;
         if (!LookUpOne(*m_db, *block, entry)) {
-            error("%s: Cannot read current %s state; index may be corrupted",
+            LogError("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -374,7 +374,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
         uint256 out;
         m_muhash.Finalize(out);
         if (entry.muhash != out) {
-            error("%s: Cannot read current %s state; index may be corrupted",
+            LogError("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -429,7 +429,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                error("%s: previous block header not found; expected %s",
+                LogError("%s: previous block header not found; expected %s\n",
                              __func__, expected_block_hash.ToString());
                 return false;
             }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -138,8 +138,9 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                return error("%s: previous block header not found; expected %s",
+                error("%s: previous block header not found; expected %s",
                              __func__, expected_block_hash.ToString());
+                return false;
             }
         }
 
@@ -245,14 +246,16 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
     for (int height = start_height; height <= stop_height; ++height) {
         if (!db_it.GetKey(key) || key.height != height) {
-            return error("%s: unexpected key in %s: expected (%c, %d)",
+            error("%s: unexpected key in %s: expected (%c, %d)",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
+            return false;
         }
 
         std::pair<uint256, DBVal> value;
         if (!db_it.GetValue(value)) {
-            return error("%s: unable to read value in %s at key (%c, %d)",
+            error("%s: unable to read value in %s at key (%c, %d)",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
+            return false;
         }
 
         batch.Write(DBHashKey(value.first), std::move(value.second));
@@ -285,8 +288,9 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
             CBlock block;
 
             if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, *iter_tip)) {
-                return error("%s: Failed to read block %s from disk",
+                error("%s: Failed to read block %s from disk",
                              __func__, iter_tip->GetBlockHash().ToString());
+                return false;
             }
 
             if (!ReverseBlock(block, iter_tip)) {
@@ -353,23 +357,26 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
         // exist. Any other errors indicate database corruption or a disk
         // failure, and starting the index would cause further corruption.
         if (m_db->Exists(DB_MUHASH)) {
-            return error("%s: Cannot read current %s state; index may be corrupted",
+            error("%s: Cannot read current %s state; index may be corrupted",
                          __func__, GetName());
+            return false;
         }
     }
 
     if (block) {
         DBVal entry;
         if (!LookUpOne(*m_db, *block, entry)) {
-            return error("%s: Cannot read current %s state; index may be corrupted",
+            error("%s: Cannot read current %s state; index may be corrupted",
                          __func__, GetName());
+            return false;
         }
 
         uint256 out;
         m_muhash.Finalize(out);
         if (entry.muhash != out) {
-            return error("%s: Cannot read current %s state; index may be corrupted",
+            error("%s: Cannot read current %s state; index may be corrupted",
                          __func__, GetName());
+            return false;
         }
 
         m_transaction_output_count = entry.transaction_output_count;
@@ -422,8 +429,9 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                return error("%s: previous block header not found; expected %s",
+                error("%s: previous block header not found; expected %s",
                              __func__, expected_block_hash.ToString());
+                return false;
             }
         }
     }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -81,23 +81,23 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
 
     AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
-        error("%s: OpenBlockFile failed", __func__);
+        LogError("%s: OpenBlockFile failed\n", __func__);
         return false;
     }
     CBlockHeader header;
     try {
         file >> header;
         if (fseek(file.Get(), postx.nTxOffset, SEEK_CUR)) {
-            error("%s: fseek(...) failed", __func__);
+            LogError("%s: fseek(...) failed\n", __func__);
             return false;
         }
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
-        error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        LogError("%s: Deserialize or I/O error - %s\n", __func__, e.what());
         return false;
     }
     if (tx->GetHash() != tx_hash) {
-        error("%s: txid mismatch", __func__);
+        LogError("%s: txid mismatch\n", __func__);
         return false;
     }
     block_hash = header.GetHash();

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -81,20 +81,24 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
 
     AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
-        return error("%s: OpenBlockFile failed", __func__);
+        error("%s: OpenBlockFile failed", __func__);
+        return false;
     }
     CBlockHeader header;
     try {
         file >> header;
         if (fseek(file.Get(), postx.nTxOffset, SEEK_CUR)) {
-            return error("%s: fseek(...) failed", __func__);
+            error("%s: fseek(...) failed", __func__);
+            return false;
         }
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        return false;
     }
     if (tx->GetHash() != tx_hash) {
-        return error("%s: txid mismatch", __func__);
+        error("%s: txid mismatch", __func__);
+        return false;
     }
     block_hash = header.GetHash();
     return true;

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -134,7 +134,8 @@ static bool ComputeUTXOStats(CCoinsView* view, CCoinsStats& stats, T hash_obj, c
             outputs[key.n] = std::move(coin);
             stats.coins_count++;
         } else {
-            return error("%s: unable to read value", __func__);
+            error("%s: unable to read value", __func__);
+            return false;
         }
         pcursor->Next();
     }

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -134,7 +134,7 @@ static bool ComputeUTXOStats(CCoinsView* view, CCoinsStats& stats, T hash_obj, c
             outputs[key.n] = std::move(coin);
             stats.coins_count++;
         } else {
-            error("%s: unable to read value", __func__);
+            LogError("%s: unable to read value\n", __func__);
             return false;
         }
         pcursor->Next();

--- a/src/logging.h
+++ b/src/logging.h
@@ -264,10 +264,9 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
 #define LogPrint(category, ...)  LogDebug(category, __VA_ARGS__)
 
 template <typename... Args>
-bool error(const char* fmt, const Args&... args)
+void error(const char* fmt, const Args&... args)
 {
     LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
-    return false;
 }
 
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -263,10 +263,4 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
 // Deprecated conditional logging
 #define LogPrint(category, ...)  LogDebug(category, __VA_ARGS__)
 
-template <typename... Args>
-void error(const char* fmt, const Args&... args)
-{
-    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
-}
-
 #endif // BITCOIN_LOGGING_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -575,7 +575,7 @@ void CNode::SetAddrLocal(const CService& addrLocalIn) {
     AssertLockNotHeld(m_addr_local_mutex);
     LOCK(m_addr_local_mutex);
     if (addrLocal.IsValid()) {
-        error("Addr local already set for node: %i. Refusing to change from %s to %s", id, addrLocal.ToStringAddrPort(), addrLocalIn.ToStringAddrPort());
+        LogError("Addr local already set for node: %i. Refusing to change from %s to %s\n", id, addrLocal.ToStringAddrPort(), addrLocalIn.ToStringAddrPort());
     } else {
         addrLocal = addrLocalIn;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -364,8 +364,9 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             // Perform username/password authentication (as described in RFC1929)
             std::vector<uint8_t> vAuth;
             vAuth.push_back(0x01); // Current (and only) version of user/pass subnegotiation
-            if (auth->username.size() > 255 || auth->password.size() > 255)
+            if (auth->username.size() > 255 || auth->password.size() > 255) {
                 return error("Proxy username or password too long");
+            }
             vAuth.push_back(auth->username.size());
             vAuth.insert(vAuth.end(), auth->username.begin(), auth->username.end());
             vAuth.push_back(auth->password.size());
@@ -429,7 +430,9 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             recvr = InterruptibleRecv(pchRet3, nRecv, g_socks5_recv_timeout, sock);
             break;
         }
-        default: return error("Error: malformed proxy response");
+        default: {
+            return error("Error: malformed proxy response");
+        }
         }
         if (recvr != IntrRecvError::OK) {
             return error("Error reading from proxy");

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -338,7 +338,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
         IntrRecvError recvr;
         LogPrint(BCLog::NET, "SOCKS5 connecting %s\n", strDest);
         if (strDest.size() > 255) {
-            error("Hostname too long");
+            LogError("Hostname too long\n");
             return false;
         }
         // Construct the version identifier/method selection message
@@ -359,7 +359,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             return false;
         }
         if (pchRet1[0] != SOCKSVersion::SOCKS5) {
-            error("Proxy failed to initialize");
+            LogError("Proxy failed to initialize\n");
             return false;
         }
         if (pchRet1[1] == SOCKS5Method::USER_PASS && auth) {
@@ -367,7 +367,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             std::vector<uint8_t> vAuth;
             vAuth.push_back(0x01); // Current (and only) version of user/pass subnegotiation
             if (auth->username.size() > 255 || auth->password.size() > 255) {
-                error("Proxy username or password too long");
+                LogError("Proxy username or password too long\n");
                 return false;
             }
             vAuth.push_back(auth->username.size());
@@ -378,17 +378,17 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             LogPrint(BCLog::PROXY, "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
             uint8_t pchRetA[2];
             if (InterruptibleRecv(pchRetA, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
-                error("Error reading proxy authentication response");
+                LogError("Error reading proxy authentication response\n");
                 return false;
             }
             if (pchRetA[0] != 0x01 || pchRetA[1] != 0x00) {
-                error("Proxy authentication unsuccessful");
+                LogError("Proxy authentication unsuccessful\n");
                 return false;
             }
         } else if (pchRet1[1] == SOCKS5Method::NOAUTH) {
             // Perform no authentication
         } else {
-            error("Proxy requested wrong authentication method %02x", pchRet1[1]);
+            LogError("Proxy requested wrong authentication method %02x\n", pchRet1[1]);
             return false;
         }
         std::vector<uint8_t> vSocks5;
@@ -409,12 +409,12 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
                  * error message. */
                 return false;
             } else {
-                error("Error while reading proxy response");
+                LogError("Error while reading proxy response\n");
                 return false;
             }
         }
         if (pchRet2[0] != SOCKSVersion::SOCKS5) {
-            error("Proxy failed to accept request");
+            LogError("Proxy failed to accept request\n");
             return false;
         }
         if (pchRet2[1] != SOCKS5Reply::SUCCEEDED) {
@@ -423,7 +423,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             return false;
         }
         if (pchRet2[2] != 0x00) { // Reserved field must be 0
-            error("Error: malformed proxy response");
+            LogError("Error: malformed proxy response\n");
             return false;
         }
         uint8_t pchRet3[256];
@@ -433,7 +433,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
         case SOCKS5Atyp::DOMAINNAME: {
             recvr = InterruptibleRecv(pchRet3, 1, g_socks5_recv_timeout, sock);
             if (recvr != IntrRecvError::OK) {
-                error("Error reading from proxy");
+                LogError("Error reading from proxy\n");
                 return false;
             }
             int nRecv = pchRet3[0];
@@ -441,22 +441,22 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             break;
         }
         default: {
-            error("Error: malformed proxy response");
+            LogError("Error: malformed proxy response\n");
             return false;
         }
         }
         if (recvr != IntrRecvError::OK) {
-            error("Error reading from proxy");
+            LogError("Error reading from proxy\n");
             return false;
         }
         if (InterruptibleRecv(pchRet3, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
-            error("Error reading from proxy");
+            LogError("Error reading from proxy\n");
             return false;
         }
         LogPrint(BCLog::NET, "SOCKS5 connected %s\n", strDest);
         return true;
     } catch (const std::runtime_error& e) {
-        error("Error during SOCKS5 proxy handshake: %s", e.what());
+        LogError("Error during SOCKS5 proxy handshake: %s\n", e.what());
         return false;
     }
 }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1102,9 +1102,10 @@ bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatF
         filein >> blk_start >> blk_size;
 
         if (blk_start != GetParams().MessageStart()) {
-            return error("%s: Block magic mismatch for %s: %s versus expected %s", __func__, pos.ToString(),
+            error("%s: Block magic mismatch for %s: %s versus expected %s", __func__, pos.ToString(),
                          HexStr(blk_start),
                          HexStr(GetParams().MessageStart()));
+            return false;
         }
 
         if (blk_size > MAX_SIZE) {

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -158,7 +158,8 @@ bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
 bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
-        return error("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
+        error("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
+        return false;
     }
 
     LOCK(cs_KeyStore);

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -157,8 +157,9 @@ bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
 
 bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
 {
-    if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
+    if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
         return error("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
+    }
 
     LOCK(cs_KeyStore);
     mapScripts[CScriptID(redeemScript)] = redeemScript;

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -158,7 +158,7 @@ bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
 bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
-        error("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
+        LogError("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid\n", MAX_SCRIPT_ELEMENT_SIZE);
         return false;
     }
 

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -69,7 +69,7 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
     }
     auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
     if (!lock->TryLock()) {
-        error("Error while attempting to lock directory %s: %s", fs::PathToString(directory), lock->GetReason());
+        LogError("Error while attempting to lock directory %s: %s\n", fs::PathToString(directory), lock->GetReason());
         return LockResult::ErrorLock;
     }
     if (!probe_only) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2830,8 +2830,9 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     {
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
-        if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK)
+        if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
+        }
         bool flushed = view.Flush();
         assert(flushed);
     }
@@ -4358,12 +4359,15 @@ bool TestBlockValidity(BlockValidationState& state,
     indexDummy.phashBlock = &block_hash;
 
     // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_blockman, chainstate.m_chainman, pindexPrev))
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_blockman, chainstate.m_chainman, pindexPrev)) {
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, state.ToString());
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
+    }
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot)) {
         return error("%s: Consensus::CheckBlock: %s", __func__, state.ToString());
-    if (!ContextualCheckBlock(block, state, chainstate.m_chainman, pindexPrev))
+    }
+    if (!ContextualCheckBlock(block, state, chainstate.m_chainman, pindexPrev)) {
         return error("%s: Consensus::ContextualCheckBlock: %s", __func__, state.ToString());
+    }
     if (!chainstate.ConnectBlock(block, state, &indexDummy, viewNew, true)) {
         return false;
     }
@@ -4591,7 +4595,9 @@ bool Chainstate::ReplayBlocks()
 
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
     if (hashHeads.empty()) return true; // We're already in a consistent state.
-    if (hashHeads.size() != 2) return error("ReplayBlocks(): unknown inconsistent state");
+    if (hashHeads.size() != 2) {
+        return error("ReplayBlocks(): unknown inconsistent state");
+    }
 
     m_chainman.GetNotifications().progress(_("Replaying blocks…"), 0, false);
     LogPrintf("Replaying blocks\n");


### PR DESCRIPTION
`error(...)` has many issues:

* It is often used in the context of `return error(...)`, implying that it has a "fancy" type, creating confusion with `util::Result/Error`
* `-logsourcelocations` does not work with it, because it will pretend the error happened inside of `logging.h`
* The log line contains `ERROR: `, as opposed to `[error]`, like for other errors logged with `LogError`.

Fix all issues by removing it.