### PR TITLE
test: unbreak: exclude windows from wallet_assumeutxo

### DIFF
--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -25,6 +25,9 @@ FINAL_HEIGHT = 399
 class AssumeutxoTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        # Disable this test for Windows currently because it doesn't allow two
+        # bitcoind processes simultaneously trying to read the same wallet file.
+        self.skip_if_platform_not_posix()
 
     def add_options(self, parser):
         self.add_wallet_options(parser, legacy=False)


### PR DESCRIPTION
Basic fix for the CI failure introduced in #28838 until something better can be devised.

Apparently Windows doesn't allow two processes to read the same wallet file. Note that this failure is unique to the tests and not something an end user would see (unless they were running two bitcoind instances...).