### PR TITLE
CAT in Tapscript (BIP-347)

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -128,7 +128,8 @@ static constexpr script_verify_flags STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRI
                                                              SCRIPT_VERIFY_CONST_SCRIPTCODE |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION |
                                                              SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS |
-                                                             SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE};
+                                                             SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE |
+                                                             SCRIPT_VERIFY_DISCOURAGE_OP_CAT};
 
 /** For convenience, standard but not mandatory verify flags. */
 static constexpr script_verify_flags STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -452,10 +452,16 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 if (opcode > OP_16 && ++nOpCount > MAX_OPS_PER_SCRIPT) {
                     return set_error(serror, SCRIPT_ERR_OP_COUNT);
                 }
+
+                // When OP_SUCCESS disabled opcodes (CVE-2010-5137) are
+                // redefined in tapscript, remove them from the if below
+                // and put them here
+                if (opcode == OP_CAT) {
+                    return set_error(serror, SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes (CVE-2010-5137).
+                }
             }
 
-            if (opcode == OP_CAT ||
-                opcode == OP_SUBSTR ||
+            if (opcode == OP_SUBSTR ||
                 opcode == OP_LEFT ||
                 opcode == OP_RIGHT ||
                 opcode == OP_INVERT ||
@@ -518,6 +524,19 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 //
                 case OP_NOP:
                     break;
+
+                case OP_CAT:
+                {
+                    if (stack.size() < 2)
+                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                    valtype& vch1 = stacktop(-2);
+                    valtype& vch2 = stacktop(-1);
+                    if (vch1.size() + vch2.size() > MAX_SCRIPT_ELEMENT_SIZE)
+                        return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
+                    vch1.insert(vch1.end(), vch2.begin(), vch2.end());
+                    stack.pop_back();
+                }
+                break;
 
                 case OP_CHECKLOCKTIMEVERIFY:
                 {
@@ -1844,10 +1863,19 @@ static bool ExecuteWitnessScript(const std::span<const valtype>& stack_span, con
             }
             // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
             if (IsOpSuccess(opcode)) {
-                if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
-                    return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
+                if (opcode == OP_CAT) {
+                    if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_CAT) {
+                        return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_CAT);
+                    } else if (!(flags & SCRIPT_VERIFY_OP_CAT)) {
+                        return set_success(serror);
+                    }
+                } else {
+                    // OP_SUCCESS behaviour
+                    if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
+                        return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
+                    }
+                    return set_success(serror);
                 }
-                return set_success(serror);
             }
         }
 
@@ -2190,6 +2218,9 @@ const std::map<std::string, script_verify_flag_name>& ScriptFlagNamesToEnum()
         FLAG_NAME(DISCOURAGE_UPGRADABLE_PUBKEYTYPE),
         FLAG_NAME(DISCOURAGE_OP_SUCCESS),
         FLAG_NAME(DISCOURAGE_UPGRADABLE_TAPROOT_VERSION),
+        FLAG_NAME(OP_CAT),
+        FLAG_NAME(DISCOURAGE_OP_CAT),
+
     };
 #undef FLAG_NAME
     return g_names_to_enum;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -145,6 +145,10 @@ enum class script_verify_flag_name : uint8_t {
     // Making unknown public key versions (in BIP 342 scripts) non-standard
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE,
 
+    // Support OP_CAT in tapscript
+    SCRIPT_VERIFY_OP_CAT,
+    SCRIPT_VERIFY_DISCOURAGE_OP_CAT,
+
     // Constants to point to the highest flag in use. Add new flags above this line.
     //
     SCRIPT_VERIFY_END_MARKER

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -76,6 +76,7 @@ std::string ScriptErrorString(const ScriptError serror)
         case SCRIPT_ERR_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION:
             return "Taproot version reserved for soft-fork upgrades";
         case SCRIPT_ERR_DISCOURAGE_OP_SUCCESS:
+        case SCRIPT_ERR_DISCOURAGE_OP_CAT:
             return "OP_SUCCESSx reserved for soft-fork upgrades";
         case SCRIPT_ERR_DISCOURAGE_UPGRADABLE_PUBKEYTYPE:
             return "Public key version reserved for soft-fork upgrades";

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -80,6 +80,9 @@ typedef enum ScriptError_t
     SCRIPT_ERR_TAPSCRIPT_MINIMALIF,
     SCRIPT_ERR_TAPSCRIPT_EMPTY_PUBKEY,
 
+    /* OP_CAT re-activation */
+    SCRIPT_ERR_DISCOURAGE_OP_CAT,
+
     /* Constant scriptCode */
     SCRIPT_ERR_OP_CODESEPARATOR,
     SCRIPT_ERR_SIG_FINDANDDELETE,

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -2576,6 +2576,420 @@
 ["0", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME", "CSV fails if stack top bit 1 << 31 is set and the tx version < 2"],
 ["0x050000000001", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME",
   "CSV fails if stack top bit 1 << 31 is not set, and tx version < 2"],
+["OP_CAT (and related) script verify flag tests"],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT",
+    "OK",
+    "TAPSCRIPT CAT test of OP_CAT flag by calling CAT on an empty stack. This does not error because no OP_CAT verify flag is set so CAT is OP_SUCCESS"
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT,OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is set however OP_CAT is not executed due to DISCOURAGE_OP_CAT."
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is not set and OP_CAT is not executed due to DISCOURAGE_OP_CAT."
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on a empty stack. Ordinarily this would be INVALID_STACK_OPERATION however due to DISCOURAGE_OP_CAT the script will throw before execution."
+],
+[
+    [
+        "#SCRIPT# 1",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "OK",
+    "TAPSCRIPT test of a valid script executed with DISCOURAGE_OP_CAT. This tests demonstrates that DISCOURAGE_OP_CAT has no affect when CAT is not used."
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT,DISCOURAGE_OP_SUCCESS",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of a invalid script (CAT called with empty stack) executed with DISCOURAGE_OP_CAT and DISCOURAGE_OP_SUCCESS flags enabled. This tests demonstrates that DISCOURAGE_OP_CAT will take priority over the OP_SUCCESS discourage flag and OP_CAT is never executed"
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT,DISCOURAGE_OP_SUCCESS",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT CAT on no stack elements with DISCOURAGE_OP_SUCCESS and OP_CAT script verify flags enabled. This test demonstrates that OP_CAT is no longer considered OP_SUCCESS when OP_CAT verify flag is set"
+],
+["OP_CAT functionality tests"],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT Test of OP_CAT flag by calling CAT on an empty stack. This throws an error because OP_CAT verify flag is set so CAT is executed"
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Test of OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is set so CAT is executed."
+],
+[
+    [
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUAL to stack element 78a11a1260c1101260"
+],
+[
+    [
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT",
+    "OK",
+    "TAPSCRIPT Test of OP_CAT flag, CATs 78a11a1260 and c1101260 together and checks it is EQUAL to stack element 78a11a1260c1101260. No OP_CAT verify flag set so CAT should be OP_SUCCESS."
+],
+[
+    [
+        "",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "EVAL_FALSE",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUAL to the empty stack element"
+],
+[
+    [
+        "51",
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUALVERIFY",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATS 78a11a1260 and c1101260 together and checks it is EQUALVERIFY to stack element 78a11a1260c1101260"
+],
+[
+    [
+        "51",
+        "c110126078a11a1260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUALVERIFY",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "EQUALVERIFY",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUALVERIFY to stack element c110126078a11a1260"
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT 0x4c 0x02 0xaabb EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs aa and bb together and checks EQUAL to aabb"
+],
+[
+    [
+        "eeffeeff",
+        "aa",
+        "bbff",
+        "#SCRIPT# CAT CAT DUP DROP 0x4c 0x07 0xeeffeeffaabbff EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs aa and bbcc and eeffeff together and checks EQUAL to eeffeeffaabbcc"
+],
+[
+    [
+        "c24f2c1e363e09a5dd56f0",
+        "89a0385490a11b6dc6740f3513",
+        "#SCRIPT# CAT 0x4c 0x18 0xc24f2c1e363e09a5dd56f089a0385490a11b6dc6740f3513 EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT on different sized random stack elements and compares the result."
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT on two hash outputs"
+],
+[
+    [
+        "51",
+        "bbbb",
+        "01",
+        "#SCRIPT# IF CAT ELSE DROP ENDIF",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT inside of an IF ELSE conditional (true IF)"
+],
+[
+    [
+        "51",
+        "",
+        "#SCRIPT# IF CAT ELSE DROP ENDIF",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "CLEANSTACK",
+    "TAPSCRIPT Tests CAT inside of an IF ELSE conditional (false IF)"
+],
+[
+    [
+        "1a1a",
+        "#SCRIPT# DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Runs DUP CAT seven times on 1a1a"
+],
+[
+    [
+        "1a1a1a1a1a1a1a",
+        "#SCRIPT# DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT Runs DUP CAT seven times on 1a1a1a1a1a1a1a triggering a stack size error as the result is larger than max stack element size"
+],
+[
+    [
+        "1ffe1234567890",
+        "00",
+        "#SCRIPT# HASH256 DUP SHA1 CAT DUP CAT TOALTSTACK HASH256 DUP CAT TOALTSTACK FROMALTSTACK",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT with a melange of other opcodes including FROMALTSTACK. "
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT ([], CAT) Tests CAT fails on empty stack"
+],
+[
+    [
+        "09ca7009ca7009ca7009ca7009ca70",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT ([09ca7009ca7009ca7009ca7009ca70], CAT) Tests CAT fails on a stack of only one element"
+],
+[
+    [
+        "",
+        "09ca7009ca7009ca7009ca7009ca70",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT (['', 09ca7009ca7009ca7009ca7009ca70], CAT) Tests CAT succeeds when one of the two values to concatenate is of size zero"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "0102030405060708",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT ([512 byte element, 09ca7009ca7009ca7009ca7009ca70], CAT) Tests edge case where concatenated value is exactly max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "01",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 01], CAT) Tests edge case where concatenated value is one byte larger than max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 520 byte element], CAT) Tests case where each element to concatenate is exactly max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93010203040506070809",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 521 byte element], CAT) Tests edge case where one of the elements to concatenate is one byte larger than max stack element size (520 bytes)"
+],
 
 ["MINIMALIF tests"],
 ["MINIMALIF is not applied to non-segwit scripts"],

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -94,7 +94,8 @@ static ScriptErrorDesc script_errors[]={
     {SCRIPT_ERR_TAPSCRIPT_EMPTY_PUBKEY, "TAPSCRIPT_EMPTY_PUBKEY"},
     {SCRIPT_ERR_OP_CODESEPARATOR, "OP_CODESEPARATOR"},
     {SCRIPT_ERR_SIG_FINDANDDELETE, "SIG_FINDANDDELETE"},
-    {SCRIPT_ERR_SCRIPTNUM, "SCRIPTNUM"}
+    {SCRIPT_ERR_SCRIPTNUM, "SCRIPTNUM"},
+    {SCRIPT_ERR_DISCOURAGE_OP_CAT, "DISCOURAGE_OP_CAT"}
 };
 
 static std::string FormatScriptFlags(script_verify_flags flags)
@@ -1730,6 +1731,83 @@ BOOST_AUTO_TEST_CASE(formatscriptflags)
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int(1u<<27)), "TAPROOT,0x08000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int((1u<<28) | (1ull<<58))), "TAPROOT,0x400000010000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(script_verify_flags::from_int(1u<<26)), "0x04000000");
+}
+
+std::tuple<CScript, CScriptWitness> ConstructWitnessForTaprootLeafSpend(std::vector<unsigned char> witVerifyScript, std::vector<std::vector<unsigned char>> witData) {
+    const KeyData keys;
+    TaprootBuilder builder;
+    builder.Add(/*depth=*/0, witVerifyScript, TAPROOT_LEAF_TAPSCRIPT, /*track=*/true);
+    builder.Finalize(XOnlyPubKey(keys.key0.GetPubKey()));
+
+    CScriptWitness witness;
+    witness.stack.insert(witness.stack.begin(), witData.begin(), witData.end());
+    witness.stack.push_back(witVerifyScript);
+    auto controlblock = *(builder.GetSpendData().scripts[{witVerifyScript, TAPROOT_LEAF_TAPSCRIPT}].begin());
+    witness.stack.push_back(controlblock);
+
+    CScript scriptPubKey = CScript() << OP_1 << ToByteVector(builder.GetOutput());
+    return std::make_tuple(scriptPubKey, witness);
+}
+
+BOOST_AUTO_TEST_CASE(cat_simple)
+{
+    std::vector<std::vector<unsigned char>> witData;
+    witData.emplace_back(ParseHex("aa"));
+    witData.emplace_back(ParseHex("bbbb"));
+
+    std::vector<unsigned char> witVerifyScript = {OP_CAT, OP_PUSHDATA1, 0x03, 0xaa, 0xbb, 0xbb, OP_EQUAL};
+    auto [scriptPubKey, wit] = ConstructWitnessForTaprootLeafSpend(witVerifyScript, witData);
+    CScript scriptSig = CScript(); // Script sig is always size 0 and empty in tapscript
+    script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
+    DoTest(scriptPubKey, scriptSig, wit, flags, "Simple CAT", SCRIPT_ERR_OK, /*nValue=*/1);
+}
+
+BOOST_AUTO_TEST_CASE(cat_empty_stack)
+{
+    // Ensures that OP_CAT successfully handles concatenating two empty stack elements
+    std::vector<std::vector<unsigned char>> witData;
+    witData.emplace_back();
+    witData.emplace_back();
+    std::vector<unsigned char> witVerifyScript = {OP_CAT, OP_PUSHDATA1, 0x00, OP_EQUAL};
+    auto [scriptPubKey, wit] = ConstructWitnessForTaprootLeafSpend(witVerifyScript, witData);
+    CScript scriptSig = CScript(); // Script sig is always size 0 and empty in tapscript
+    script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
+    DoTest(scriptPubKey, scriptSig, wit, flags, "CAT empty stack", SCRIPT_ERR_OK, /*nValue=*/1);
+}
+
+BOOST_AUTO_TEST_CASE(cat_dup_test)
+{
+    // CAT DUP exhaustion attacks using all element sizes from 1 to 522
+    // with CAT DUP repetitions up to 10. Ensures the correct error is thrown
+    // or not thrown, as appropriate.
+    unsigned int maxElementSize = 522;
+    unsigned int maxDupsToCheck = 10;
+
+    CScript scriptSig = CScript(); // Script sig is always size 0 and empty in tapscript
+    script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
+
+    std::vector<std::vector<unsigned char>> witData;
+    witData.emplace_back();
+    for (unsigned int elementSize = 1; elementSize <= maxElementSize; elementSize++) {
+        std::vector<unsigned char> witVerifyScript;
+        // increase the size of stack element by one byte
+        witData.at(0).emplace_back(0x1A);
+        for (unsigned int dups = 1; dups <= maxDupsToCheck; dups++) {
+            witVerifyScript.emplace_back(OP_DUP);
+            witVerifyScript.emplace_back(OP_CAT);
+            int expectedErr = SCRIPT_ERR_OK;
+            unsigned int catedStackElementSize = witData.at(0).size()<<dups;
+            if (catedStackElementSize > MAX_SCRIPT_ELEMENT_SIZE || elementSize > MAX_SCRIPT_ELEMENT_SIZE){
+                expectedErr = SCRIPT_ERR_PUSH_SIZE;
+                break;
+            }
+            auto [scriptPubKey, wit] = ConstructWitnessForTaprootLeafSpend(witVerifyScript, witData);
+            DoTest(scriptPubKey, scriptSig, wit, flags, "CAT DUP test", expectedErr, /*nValue=*/1);
+            // Once we hit the stack element size limit, break
+            if (expectedErr == SCRIPT_ERR_OK)
+                break;
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_opcat.py
+++ b/test/functional/feature_opcat.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test (OP_CAT)
+"""
+
+from test_framework.blocktools import (
+    create_coinbase,
+    create_block,
+    add_witness_commitment,
+)
+
+from test_framework.messages import (
+    CTransaction,
+    CTxOut,
+    CTxIn,
+    CTxInWitness,
+    COutPoint,
+    COIN,
+    sha256
+)
+from test_framework.address import (
+    hash160,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.script import (
+    CScript,
+    OP_CAT,
+    OP_HASH160,
+    OP_EQUAL,
+    taproot_construct,
+)
+from test_framework.script_util import script_to_p2sh_script
+from test_framework.key import ECKey, compute_xonly_pubkey
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet, MiniWalletMode
+from decimal import Decimal
+import random
+from io import BytesIO
+from test_framework.address import script_to_p2sh
+
+DISABLED_OP_CODE_MESSAGE = (
+    "Attempted to use a disabled opcode"
+)
+
+DISCOURAGED_CAT_ERROR = (
+    "OP_SUCCESSx reserved for soft-fork upgrades"
+)
+
+
+def random_bytes(n):
+    return bytes(random.getrandbits(8) for i in range(n))
+
+
+def random_p2sh():
+    return script_to_p2sh_script(random_bytes(20))
+
+
+def create_transaction_to_script(node, wallet, txid, script, *, amount_sats):
+    """Return signed transaction spending the first output of the
+    input txid. Note that the node must be able to sign for the
+    output that is being spent, and the node must not be running
+    multiple wallets.
+    """
+    random_address = script_to_p2sh(CScript())
+    output = wallet.get_utxo(txid=txid)
+    rawtx = node.createrawtransaction(
+        inputs=[{"txid": output["txid"], "vout": output["vout"]}],
+        outputs={random_address: Decimal(amount_sats) / COIN},
+    )
+    tx = CTransaction()
+    tx.deserialize(BytesIO(bytes.fromhex(rawtx)))
+    # Replace with our script
+    tx.vout[0].scriptPubKey = script
+    # Sign
+    wallet.sign_tx(tx)
+    return tx
+
+
+class CatTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [
+            ["-par=1"]
+        ]  # Use only one script thread to get the exact reject reason for testing
+        self.setup_clean_chain = True
+        self.rpc_timeout = 120
+
+    def get_block(self, txs):
+        self.tip = self.nodes[0].getbestblockhash()
+        self.height = self.nodes[0].getblockcount()
+        self.log.debug(self.height)
+        block = create_block(
+            int(self.tip, 16), create_coinbase(self.height + 1))
+        block.vtx.extend(txs)
+        add_witness_commitment(block)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        return block.serialize(True).hex(), block.hash_hex
+
+    def add_block(self, txs):
+        block, h = self.get_block(txs)
+        reason = self.nodes[0].submitblock(block)
+        if reason:
+            self.log.debug("Reject Reason: [%s]", reason)
+        assert_equal(self.nodes[0].getbestblockhash(), h)
+        return h
+
+    def run_test(self):
+        # The goal of this test suite is to test that OP_CAT is disabled by default in segwitv0, p2sh script
+        # and discouraged in tapscript.
+
+        wallet = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_P2PK)
+        self.nodes[0].add_p2p_connection(P2PInterface())
+
+        BLOCKS = 200
+        self.log.info("Mining %d blocks for mature coinbases", BLOCKS)
+        # Drop the last 100 as they're unspendable!
+        coinbase_txids = [
+            self.nodes[0].getblock(b)["tx"][0]
+            for b in self.generate(wallet, BLOCKS)[:-100]
+        ]
+        def get_coinbase(): return coinbase_txids.pop()
+        self.log.info("Creating setup transactions")
+
+        outputs = [CTxOut(i * 1000, random_p2sh()) for i in range(1, 11)]
+        # Add some fee
+        amount_sats = sum(out.nValue for out in outputs) + 200 * 500
+
+        private_key = ECKey()
+        # use simple deterministic private key (k=1)
+        private_key.set((1).to_bytes(32, "big"), False)
+        assert private_key.is_valid
+        public_key, _ = compute_xonly_pubkey(private_key.get_bytes())
+
+        op_cat_script = CScript([
+            # Calling CAT on an empty stack
+            # The content of the stack doesn't really matter for what we are testing
+            # The interpreter should never get to the point where its executing this OP_CAT instruction
+            OP_CAT,
+        ])
+
+        self.log.info("Creating a CAT tapscript funding tx")
+        taproot_op_cat = taproot_construct(
+            public_key, [("only-path", op_cat_script, 0xC0)])
+        taproot_op_cat_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            taproot_op_cat.scriptPubKey,
+            amount_sats=amount_sats,
+        )
+
+        self.log.info("Creating a CAT segwit funding tx")
+        segwit_cat_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            CScript([0, sha256(op_cat_script)]),
+            amount_sats=amount_sats,
+        )
+
+        self.log.info("Create p2sh OP_CAT funding tx")
+        p2sh_cat_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            CScript([OP_HASH160, hash160(op_cat_script), OP_EQUAL]),
+            amount_sats=amount_sats,
+        )
+
+        funding_txs = [
+            taproot_op_cat_funding_tx,
+            segwit_cat_funding_tx,
+            p2sh_cat_funding_tx
+        ]
+        (
+            taproot_op_cat_outpoint,
+            segwit_op_cat_outpoint,
+            bare_op_cat_outpoint,
+        ) = [COutPoint(tx.txid_int, 0) for tx in funding_txs]
+
+        self.log.info("Funding all outputs")
+        self.add_block(funding_txs)
+
+        self.log.info("Testing tapscript OP_CAT usage is discouraged")
+        taproot_op_cat_transaction = CTransaction()
+        taproot_op_cat_transaction.vin = [
+            CTxIn(taproot_op_cat_outpoint)]
+        taproot_op_cat_transaction.vout = outputs
+        taproot_op_cat_transaction.wit.vtxinwit += [
+            CTxInWitness()]
+        taproot_op_cat_transaction.wit.vtxinwit[0].scriptWitness.stack = [
+            op_cat_script,
+            bytes([0xC0 + taproot_op_cat.negflag]) +
+            taproot_op_cat.internal_pubkey,
+        ]
+
+        assert_raises_rpc_error(
+            -26,
+            DISCOURAGED_CAT_ERROR,
+            self.nodes[0].sendrawtransaction,
+            taproot_op_cat_transaction.serialize().hex(),
+        )
+        self.log.info(
+            "Tapscript OP_CAT spend not accepted by sendrawtransaction"
+        )
+
+        self.log.info("Testing Segwitv0 OP_CAT usage is disabled")
+        segwitv0_op_cat_transaction = CTransaction()
+        segwitv0_op_cat_transaction.vin = [
+            CTxIn(segwit_op_cat_outpoint)]
+        segwitv0_op_cat_transaction.vout = outputs
+        segwitv0_op_cat_transaction.wit.vtxinwit += [
+            CTxInWitness()]
+        segwitv0_op_cat_transaction.wit.vtxinwit[0].scriptWitness.stack = [
+            op_cat_script,
+        ]
+
+        assert_raises_rpc_error(
+            -26,
+            DISABLED_OP_CODE_MESSAGE,
+            self.nodes[0].sendrawtransaction,
+            segwitv0_op_cat_transaction.serialize().hex(),
+        )
+        self.log.info("Segwitv0 OP_CAT spend failed with expected error")
+
+        self.log.info("Testing p2sh script OP_CAT usage is disabled")
+        p2sh_op_cat_transaction = CTransaction()
+        p2sh_op_cat_transaction.vin = [
+            CTxIn(bare_op_cat_outpoint)]
+        p2sh_op_cat_transaction.vin[0].scriptSig = CScript(
+            [op_cat_script])
+        p2sh_op_cat_transaction.vout = outputs
+
+        assert_raises_rpc_error(
+            -26,
+            DISABLED_OP_CODE_MESSAGE,
+            self.nodes[0].sendrawtransaction,
+            p2sh_op_cat_transaction.serialize().hex(),
+        )
+        self.log.info("p2sh OP_CAT spend failed with expected error")
+
+
+if __name__ == "__main__":
+    CatTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -378,6 +378,7 @@ BASE_SCRIPTS = [
     'rpc_help.py',
     'feature_framework_testshell.py',
     'tool_rpcauth.py',
+    'feature_opcat.py',
     'p2p_handshake.py',
     'p2p_handshake.py --v2transport',
     'interface_ipc_cli.py',


### PR DESCRIPTION
# CAT in Tapscript

This PR provides the necessary code to enable the opcode OP\_CAT in Tapscript as specified in [BIP-347: OP\_CAT in Tapscript](https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki) and [BIN-2024-0001](https://github.com/bitcoin-inquisition/binana/blob/master/2024/BIN-2024-0001.md),

**Important:** This PR *does not* include miner activation functionality. This means that merging this PR into bitcoin-core will not make OP\_CAT functional in Bitcoin.
If this PR is merged it is *not* a signal of community consensus around activating CAT nor be read as a portent about the activation process or timeline.
The PR is not a stand-in for consensus around such decisions.

This PR includes:

- An implementation of the Tapscript opcode OP\_CAT along with the flags `SCRIPT_VERIFY_OP_CAT` and `SCRIPT_VERIFY_DISCOURAGE_OP_CAT`.
- Integration and unit tests which ensure that our CAT  implementation works as expected. This includes ensuring that CAT never uses more that 520 bytes of stack memory. A full description of what these tests cover is given below.
- An improvement to `src/test/script_tests.cpp` JSON script format enabling the rapid creation of new Tapscript unit tests.

## Activation on Bitcoin-inquisition (signet)

[Bitcoin-inquisition PR 37](https://github.com/bitcoin-inquisition/bitcoin/pull/39) which contained our implementation of OP\_CAT [was merged into bitcoin-inquisition (signet) on Apr 25 2024](https://github.com/bitcoin-inquisition/bitcoin/pull/39), released as [bitcoin-inquisition release 25.2 on Apr 26 2024.](https://github.com/bitcoin-inquisition/bitcoin/releases/tag/v25.2-inq) and activated in bitcoin-inquisition Apr 30 2024. The bitcoin-inquisition PR was reviewed in the PR review club [(transcript of discussion)](https://bitcoincore.reviews/bitcoin-inquisition-39). Since Apr 30 2024 there have been many OP\_CAT transactions created and spent on signet.

The code merged into bitcoin-inquisition differs from this PR, as we have removed the consensus logic which was used to activate it on signet.

## OP\_CAT Tapscript Implementation

We implement OP\_CAT as a new Tapscript op code by redefining the opcode OP\_SUCCESS126 (126 in decimal and 0x7e in hexadecimal). This is the same opcode value used by the original OP_CAT.

When evaluated, the OP\_CAT instruction:

1. Pops the top two values off the stack,
2. concatenates the popped values together in stack order,
3. and then pushes the concatenated value on the top of the stack.

OP\_CAT fails if there are fewer than two values on the stack or if a concatenated value would have a combined size greater than the maximum script element size of 520 bytes.

See [BIP 347](https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki) for a deeper description.

### Errors thrown

If evaluated OP\_CAT can throw the following errors:

- If at time of evaluation the stack has fewer than two elements we throw the error: `SCRIPT_ERR_INVALID_STACK_OPERATION`
- If at time of evaluation the top two stack elements have a combined size greater than `MAX_SCRIPT_ELEMENT_SIZE` (520 bytes) we throw the error: `SCRIPT_ERR_PUSH_SIZE`.

### Script verification flags

While this PR does not contain any miner signaling and activation logic and can not activate OP\_CAT, it does contain two flags which future activation logic could set to control activation of OP\_CAT.

- `SCRIPT_VERIFY_OP_CAT` IF a bitcoin node has this set to true, then it treat OP\_CAT enabled for Tapscript. That is, OP\_SUCCESS126 will be redefining to OP\_CAT in Tapscript. If this was set to true at the consensus level this would cause a soft fork.

`SCRIPT_VERIFY_DISCOURAGE_OP_CAT` When set to true, a node receiving any Tapscript transaction containing the opcode OP\_CAT or OP\_SUCCESS126 will reject the transaction throwing the error `SCRIPT_ERR_DISCOURAGE_OP_CAT` but not banning the node which relayed the transaction. This prevents nodes from relaying transactions with OP\_CAT. This  is equivalent to the behavior of `SCRIPT_ERR_DISCOURAGE_OP_CAT = true` when `SCRIPT_VERIFY_OP_CAT = false` as OP\_CAT is an OP\_SUCCESS (OP\_SUCCESS126).

This is how these two flags are intended to be used to ensure a smooth soft fork.

| Stage | `SCRIPT_VERIFY OP_CAT` | `SCRIPT_VERIFY DISCOURAGE_OP_CAT` | Status |
| --- | --- | --- | --- |
| **1.Default** | False | True | This does not represent any change in behavior of the bitcoin-core node. |
| **2.Upgrading** | True | True | OP\_CAT is activating. |
| **3.Upgraded** | True | False | It is clear that OP\_CAT has been activated and the network has been upgraded. |

The flag `SCRIPT_ERR_DISCOURAGE_OP_CAT` provides a window of time for the network to fully activate, before nodes will relay or accept transactions containing OP\_CAT in their mem pools.

## Tests

This PR contains a suite of script tests to ensure that OP\_CAT functions as expected. In the JSON script tests (`script_tests.json`), we test:

- That if OP\_CAT is not activated that there are no changes to bitcoin consensus.
- That regardless of the activation or non-activation of OP\_CAT in Tapscript, pre-Tapscript scripts, i.e. Bitcoin scripts, have no changes in behavior.
- That OP\_CAT when evaluated throws the expected error when there are less than two elements on the stack.
- That OP\_CAT when evaluated in a variety of circumstances and edge cases, successfully concatenates elements of the stack. This includes:
  - multiple calls to OP\_CAT in a row,
  - evaluating OP\_CAT inside of a IF conditional,
  - evaluating OP\_CAT on zero size stack elements, random and large stack elements,
  - evaluating OP\_CAT on values being moved to and from the alt stack,
  - and checking that when evaluated OP\_CAT concatenates the elements in the expected order.

All of these tests are designed to cover the happy path of OP\_CAT, the various errors which OP\_CAT can throw and all the corner cases between those two outcomes.

Additionally we include three tests outside of the JSON script tests.

- `cat_simple` and `cat_empty_stack` are designed to test OP\_CAT outside of the JSON serialization regime. Ensure that we catch bugs that we might miss in the JSON script tests due to a bug introduced at the JSON serialization layer.
- `cat_dup_test` enumerates all stack element sizes from 1 to 522 bytes and then enumerates up to 10 repetitions of `OP\_DUP OP\_CAT`. It then tests if the stack element would exceed 520 bytes and if so did OP\_CAT throw the error `SCRIPT_ERR_PUSH_SIZE`. This allows us to be certain that OP\_CAT will not introduce any `OP\_DUP OP\_CAT` memory exhaustion attacks.

### Better Tapscript tests in JSON script tests

While writing these JSON script tests (`script_tests.json`) we ran into the following problem. The JSON script tests are simple and easy to write for pre-Tapscript scripts, but adding or changing a Tapscript test requires substantial work per test.
Consider the following pre-tapscript test:

```json
["'aa' 'bb'", "CAT 0x4c 0x02 0xaabb EQUAL", "P2SH,STRICTENC", "DISABLED_OPCODE", "CAT disabled"]
```

whereas a Tapscript test for the same script (annotated with comments for better readability) would look like:

```json
[
    [
        "aa",
        "bb",
        "7e4c02aabb87", // output script
        "c0d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", // control block
        0.00000001
    ],
    "",
    "0x51 0x20 0x15048ed3a65748549c27b671936987093cf73a4c9cb18522a74fb9553060ca99", // Tapscript output
    "P2SH,WITNESS,TAPROOT",
    "OK",
    "TAPSCRIPT CATs aa and bb together and checks if EQUAL to aabb"
]
```

Computing the Tapscript output, such as `0x51 0x20 0x15048ed3a65748549c27b671936987093cf73a4c9cb18522a74fb9553060ca99`, requires writing custom code and running it for each test. The same is true for the Tapscript control block, such as `c0d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d`. If a test is changed or updated new outputs and control blocks must be computed. The complexity of doing this is likely the reason that no one has added any Tapscript tests to JSON script tests until this PR.

In this PR we address this issue by adding the following improvements to JSON script tests:

- Adding simple macros (`"#SCRIPT#` and `#CONTROLBLOCK#`) that allow the script test parser to automatically generate and inject a valid Tapscript output and control block to be computed automatically from the JSON script.
- Allowing Tapscript scripts to use the human readable strings like pre-script scripts by marking the location of the script in the witness stack using `#SCRIPT#`. This transforms the unreadable script `7e4c02aabb87` into `#SCRIPT# CAT 0x4c 0x02 0xaabb EQUAL`.

This results in the following JSON script test which is far easier to write and easier to read.

```json
[
    [
        "aa",
        "bb",
        "#SCRIPT# CAT",
        "#CONTROLBLOCK#",
        0.00000001
    ],
    "",
    "0x51 0x20 #TAPROOTOUTPUT#",
    "P2SH,WITNESS,TAPROOT,OP_CAT",
    "OK",
    "TAPSCRIPT Test of OP_CAT flag by calling CAT on two elements. TAPSCRIPT_OP_CAT flag is set so CAT is executed."
],
```
  
