### PR TITLE
log, refactor: Allow log macros to accept context arguments

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -792,8 +792,7 @@ While `LogInfo`, `LogWarning` and `LogError` messages should be rare,
 in case there are circumstances where they are not, those messages
 are automatically rate-limited to prevent potential disk-filling
 attacks. For the cases where this protection is undesirable,
-rate-limiting can be avoided with the `util::log::NO_RATE_LIMIT` tag, eg
-`LogInfo(util::log::NO_RATE_LIMIT, "UpdateTip: new best=%s ...",...)`.
+rate-limiting can be avoided with the `ratelimit = false` log option.
 
 ## General C++
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -75,10 +75,9 @@ bool BCLog::Logger::StartLogging()
     // dump buffered messages from before we opened the log
     m_buffering = false;
     if (m_buffer_lines_discarded > 0) {
-        LogPrint_({
+        LogPrint_({.level = Level::Info, .ratelimit = false}, {
             .category = BCLog::ALL,
             .level = Level::Info,
-            .should_ratelimit = false,
             .source_loc = SourceLocation{__func__},
             .message = strprintf("Early logging buffer overflowed, %d log lines discarded.", m_buffer_lines_discarded),
         });
@@ -430,14 +429,14 @@ std::string BCLog::Logger::Format(const util::log::Entry& entry) const
     return result;
 }
 
-void BCLog::Logger::LogPrint(util::log::Entry entry)
+void BCLog::Logger::LogPrint(const util::log::Options& options, util::log::Entry entry)
 {
     STDLOCK(m_cs);
-    return LogPrint_(std::move(entry));
+    return LogPrint_(options, std::move(entry));
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void BCLog::Logger::LogPrint_(util::log::Entry entry)
+void BCLog::Logger::LogPrint_(const util::log::Options& options, util::log::Entry entry)
 {
     if (m_buffering) {
         {
@@ -460,14 +459,14 @@ void BCLog::Logger::LogPrint_(util::log::Entry entry)
 
     std::string str_prefixed{Format(entry)};
     bool ratelimit{false};
-    if (entry.should_ratelimit && m_limiter) {
+    if (options.ratelimit && m_limiter) {
         auto status{m_limiter->Consume(entry.source_loc, str_prefixed)};
         if (status == LogRateLimiter::Status::NEWLY_SUPPRESSED) {
             // NOLINTNEXTLINE(misc-no-recursion)
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, // with ratelimit=false, this cannot lead to infinite recursion
+            {
                 .category = LogFlags::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = false, // with should_ratelimit=false, this cannot lead to infinite recursion
                 .source_loc = SourceLocation{__func__},
                 .message = strprintf(
                     "Excessive logging detected from %s:%d (%s): >%d bytes logged during "
@@ -540,10 +539,9 @@ void BCLog::Logger::ShrinkDebugFile()
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
             // LogWarning, except with m_cs held
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, {
                 .category = BCLog::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = true,
                 .source_loc = SourceLocation{__func__},
                 .message = "Failed to shrink debug log file: fseek(...) failed",
             });
@@ -620,8 +618,8 @@ bool util::log::hooks::ShouldLog(Category category, Level level)
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(Entry entry)
+void util::log::hooks::Log(const Options& options, Entry entry)
 {
     BCLog::Logger& logger{LogInstance()};
-    logger.LogPrint(std::move(entry));
+    logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -612,14 +612,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::hooks::ShouldLog(Category category, Level level)
+bool util::log::hooks::ShouldLog(Logger* log, Category category, Level level)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(const Options& options, Entry entry)
+void util::log::hooks::Log(Logger* log, const Options& options, Entry entry)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -574,7 +574,7 @@ void BCLog::LogRateLimiter::Reset()
     }
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
-        LogWarning(util::log::NO_RATE_LIMIT,
+        LOG_EMIT((.level = Level::Warning, .ratelimit = false),
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));
@@ -614,20 +614,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::ShouldDebugLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Debug);
-}
-
-bool util::log::ShouldTraceLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Trace);
-}
-
-void util::log::Log(util::log::Entry entry)
+bool util::log::hooks::ShouldLog(Category category, Level level)
 {
     BCLog::Logger& logger{LogInstance()};
-    if (logger.Enabled()) {
-        logger.LogPrint(std::move(entry));
-    }
+    return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+}
+
+void util::log::hooks::Log(Entry entry)
+{
+    BCLog::Logger& logger{LogInstance()};
+    logger.LogPrint(std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -349,7 +349,9 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 {
     if (category == LogFlags::NONE) category = LogFlags::ALL;
 
-    const bool has_category{m_always_print_category_level || category != LogFlags::ALL};
+    // Only log categories at debug level and below so users cannot use category
+    // filters at higher levels and miss important messages.
+    const bool has_category{level <= Level::Debug && (m_always_print_category_level || category != LogFlags::ALL)};
 
     // If there is no category, Info is implied
     if (!has_category && level == Level::Info) return {};

--- a/src/logging.h
+++ b/src/logging.h
@@ -160,7 +160,7 @@ namespace BCLog {
         std::list<std::function<void(const std::string&)>> m_print_callbacks GUARDED_BY(m_cs){};
 
         /** Send an entry to the log output (internal) */
-        void LogPrint_(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+        void LogPrint_(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
 
         std::string GetLogPrefix(LogFlags category, Level level) const;
 
@@ -178,7 +178,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send an entry to the log output */
-        void LogPrint(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+        void LogPrint(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs)

--- a/src/logging.h
+++ b/src/logging.h
@@ -127,7 +127,7 @@ namespace BCLog {
         bool SuppressionsActive() const { return m_suppression_active; }
     };
 
-    class Logger
+    class Logger : public util::log::Logger
     {
     private:
         mutable StdMutex m_cs; // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -228,6 +228,43 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 
+//! Example of a custom log context that includes a counter value in logged
+//! messages. Custom log contexts allow different areas of the codebase to
+//! attach information to log messages (like request ids or filenames) while
+//! still using standard logging macros.
+struct CountingLogContext {
+    static constexpr bool log_context{true};
+    util::log::Category category{BCLog::VALIDATION};
+    util::log::Logger* logger{nullptr};
+    int counter{0};
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+    {
+        return tfm::format("Custom #%d %s", ++counter, tfm::format(fmt, args...));
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(logging_CustomContext, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Debug);
+    CountingLogContext log;
+    LogTrace(log, "foo0: %s", "bar0"); // not logged
+    LogDebug(log, "foo1: %s", "bar1");
+    LogInfo(log, "foo2: %s", "bar2");
+    LogWarning(log, "foo3: %s", "bar3");
+    LogError(log, "foo4: %s", "bar4");
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[validation] Custom #1 foo1: bar1",
+        "Custom #2 foo2: bar2",
+        "[warning] Custom #3 foo3: bar3",
+        "[error] Custom #4 foo4: bar4",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -105,6 +105,35 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test logging to local logger.
+BOOST_AUTO_TEST_CASE(logging_local_logger)
+{
+    BCLog::Logger logger;
+    logger.m_log_timestamps = false;
+    logger.EnableCategory(BCLog::LogFlags::ALL);
+    logger.SetLogLevel(BCLog::Level::Trace);
+    BOOST_REQUIRE(logger.StartLogging());
+
+    std::vector<std::string> messages;
+    logger.PushBackCallback([&](const std::string& s) { messages.push_back(s); });
+
+    util::log::Context log{BCLog::NET, &logger};
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
+    constexpr auto expected{std::to_array({
+        "[error] error arg\n",
+        "[warning] warning arg\n",
+        "info arg\n",
+        "[net] debug arg\n",
+        "[net:trace] trace arg\n",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(messages.begin(), messages.end(), expected.begin(), expected.end());
+}
+
 //! Test calls to log macros with all possible types of arguments: with and
 //! without categories and with and without format arguments to make sure
 //! varargs are handled correctly.
@@ -150,6 +179,19 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
 
+    // Test logging with context object.
+    util::log::Context log{BCLog::TOR, &LogInstance()};
+    LogError(log, "error");
+    LogWarning(log, "warning");
+    LogInfo(log, "info");
+    LogDebug(log, "debug");
+    LogTrace(log, "trace");
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -170,6 +212,18 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
         "options info arg",
         "[net] options debug",
         "[net] options debug arg",
+
+        "[error] error",
+        "[warning] warning",
+        "info",
+        "[tor] debug",
+        "[tor:trace] trace",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+        "[tor] debug arg",
+        "[tor:trace] trace arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
 
     std::vector<Case> cases = {
         {"foo1: bar1", BCLog::NET, BCLog::Level::Debug, "[net] ", SourceLocation{__func__}},
-        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "[net:info] ", SourceLocation{__func__}},
+        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo3: bar3", BCLog::ALL, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},
         {"foo4: bar4", BCLog::ALL, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo5: bar5", BCLog::NONE, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using util::log::Level;
 using util::SplitString;
 using util::TrimString;
 
@@ -139,6 +140,16 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LogDebug(BCLog::NET, "debug %s", "arg");
     LogTrace(BCLog::NET, "trace %s", "arg");
 
+    LOG_EMIT((.level = Level::Info), "options info");
+    LOG_EMIT((.level = Level::Info), "options info %s", "arg");
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info"); // Not allowed because category is forbidden!
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info %s", "arg"); // Not allowed because category is forbidden!
+
+    // LOG_EMIT((.level = Level::Debug), "options debug"); // Not allowed because category is required!
+    // LOG_EMIT((.level = Level::Debug), "options debug %s", "arg"); // Not allowed because category is required!
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -154,6 +165,11 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
 
         "[net] debug arg",
         "[net:trace] trace arg",
+
+        "options info",
+        "options info arg",
+        "[net] options debug",
+        "[net] options debug arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -419,7 +435,7 @@ void LogFromLocation(Location location, const std::string& message) {
         LogDebug(BCLog::LogFlags::HTTP, "%s\n", message);
         return;
     case Location::INFO_NOLIMIT:
-        LogInfo(util::log::NO_RATE_LIMIT, "%s\n", message);
+        LOG_EMIT((.level = Level::Info, .ratelimit = false), "%s\n", message);
         return;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -463,4 +463,30 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
+{
+    for (bool enable_logger : {true, false}) {
+        LogInstance().DisconnectTestLogger();
+        if (enable_logger) {
+            BOOST_REQUIRE(LogInstance().StartLogging());
+        } else {
+            LogInstance().DisableLogging();
+        }
+        BOOST_REQUIRE_EQUAL(enable_logger, LogInstance().Enabled());
+
+        // Info or higher should always evaluate the arguments.
+        int counter = 0;
+        LogError("error (%s)", ++counter);
+        LogWarning("warning (%s)", ++counter);
+        LogInfo("info (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 3);
+
+        // Debug/Trace should skip argument evaluation when category is disabled.
+        counter = 0;
+        LogDebug(BCLog::NET, "debug (%s)", ++counter);
+        LogTrace(BCLog::NET, "trace (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -14,6 +14,7 @@
 #include <util/fs_helpers.h>
 #include <util/string.h>
 
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -103,6 +104,60 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test calls to log macros with all possible types of arguments: with and
+//! without categories and with and without format arguments to make sure
+//! varargs are handled correctly.
+//! Include commented out calls for combinations of macro arguments which are
+//! prohibited, for easy manual testing to confirm these calls produce readable
+//! compile errors.
+BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Trace);
+
+    // Test logging with no context.
+    LogError("error");
+    LogWarning("warning");
+    LogInfo("info");
+    // LogDebug("debug"); // Not allowed because category is required!
+    // LogTrace("trace"); // Not allowed because category is required!
+    LogError("error %s", "arg");
+    LogWarning("warning %s", "arg");
+    LogInfo("info %s", "arg");
+    // LogDebug("debug %s", "arg"); // Not allowed because category is required!
+    // LogTrace("trace %s", "arg"); // Not allowed because category is required!
+
+    // Test logging with category constant arguments.
+    // LogError(BCLog::NET, "error"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug");
+    LogTrace(BCLog::NET, "trace");
+    // LogError(BCLog::NET, "error %s", "arg"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning %s", "arg"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info %s", "arg"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug %s", "arg");
+    LogTrace(BCLog::NET, "trace %s", "arg");
+
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[error] error",
+        "[warning] warning",
+        "info",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+
+        "[net] debug",
+        "[net:trace] trace",
+
+        "[net] debug arg",
+        "[net:trace] trace arg",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
@@ -137,24 +192,6 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
         LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
-    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
-}
-
-BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
-{
-    LogInstance().EnableCategory(BCLog::NET);
-    LogTrace(BCLog::NET, "foo6: %s", "bar6"); // not logged
-    LogDebug(BCLog::NET, "foo7: %s", "bar7");
-    LogInfo("foo8: %s", "bar8");
-    LogWarning("foo9: %s", "bar9");
-    LogError("foo10: %s", "bar10");
-    std::vector<std::string> log_lines{ReadDebugLogLines()};
-    std::vector<std::string> expected = {
-        "[net] foo7: bar7",
-        "foo8: bar8",
-        "[warning] foo9: bar9",
-        "[error] foo10: bar10",
-    };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -489,4 +489,20 @@ BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(log_accept_category, LogSetup)
+{
+    using namespace util::log;
+    BCLog::Logger& logger{LogInstance()};
+
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::ALL, Level::Info));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::NET, Level::Warning));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::VALIDATION, Level::Error));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::LEVELDB, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::ALL, Level::Trace));
+
+    logger.EnableCategory(BCLog::TXPACKAGES);
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Trace));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -205,7 +205,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
         expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
-        LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
+        LogInstance().LogPrint({.level = level}, {.category = category, .level = level, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -88,7 +88,6 @@ enum class Level {
 struct Entry {
     Category category;
     Level level;
-    bool should_ratelimit{false}; //!< Hint for consumers if this entry should be ratelimited
     SystemClock::time_point timestamp{SystemClock::now()};
     std::chrono::seconds mocktime{GetMockTime()};
     std::string thread_name{util::ThreadGetInternalName()};
@@ -140,7 +139,7 @@ namespace hooks {
 bool ShouldLog(Category category, Level level);
 
 /// Send message to be logged.
-void Log(Entry entry);
+void Log(const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
@@ -179,10 +178,9 @@ Context GetContext(Category category)
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(Entry{
+    hooks::Log(options, Entry{
         .category = context.category,
         .level = options.level,
-        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
         .message = context.Format(fmt, args...)});
 }

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -7,6 +7,7 @@
 
 // This header works in tandem with `logging/categories.h`
 // to expose the complete logging interface.
+#include <attributes.h>
 #include <logging/categories.h> // IWYU pragma: export
 #include <tinyformat.h>
 #include <util/check.h>
@@ -17,6 +18,39 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <type_traits>
+
+/// Logging macros which output log messages at the specified levels. They
+/// accept printf-style format strings and arguments. The debug and trace macros
+/// also require an initial BCLog::LogFlags category argument.
+/// See the "Logging" section of /doc/developer-notes.md for more details.
+#define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
+#define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
+#define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
+#define LogDebug(...) LOG_EMIT((.level = util::log::Level::Debug), __VA_ARGS__)
+#define LogTrace(...) LOG_EMIT((.level = util::log::Level::Trace), __VA_ARGS__)
+
+/// Low-level logging macro called with an initial options argument. Meant to be
+/// called internally, and in special cases to override default behaviors.
+// NOLINTBEGIN(bugprone-lambda-function-name)
+// Allow __func__ to be used in any context without warnings:
+#define LOG_EMIT(options, ...)                                                                     \
+    do {                                                                                           \
+        constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
+        auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
+        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+            util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
+        } else if constexpr (_options.evaluate_when_disabled) {                                    \
+            [](auto&&...) {}(__VA_ARGS__);                                                         \
+        }                                                                                          \
+    } while (0)
+// NOLINTEND(bugprone-lambda-function-name)
+
+/// Return the first argument from a variadic macro argument list.
+#define PP_FIRST_ARG(arg, ...) arg
+
+/// Expand parenthesized macro arguments `(a, b)` into `a, b`.
+#define PP_EXPAND_ARGS(...) __VA_ARGS__
 
 /// Like std::source_location, but allowing to override the function name.
 class SourceLocation
@@ -43,12 +77,6 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
-//! Structure and constant for tagging not to rate limit.
-struct NoRateLimitTag {
-    explicit NoRateLimitTag() = default;
-};
-inline constexpr NoRateLimitTag NO_RATE_LIMIT{};
-
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -68,45 +96,120 @@ struct Entry {
     std::string message;
 };
 
-/// Return whether messages with specified category should be debug logged.
-/// Applications using the logging library need to provide this.
-bool ShouldDebugLog(Category category);
+/// Options that can be passed to log macros using designated initializers (e.g.
+/// `.ratelimit = true`). Add new options here when introducing new logging
+/// behaviors.
+struct Options {
+    Level level;
 
-/// Return whether messages with specified category should be trace logged.
-/// Applications using the logging library need to provide this.
-bool ShouldTraceLog(Category category);
+    // Info and higher log messages are logged by default, so ratelimit them.
+    // Users enabling logging at Debug and lower levels are assumed to be
+    // developers or power users who are aware that -debug may cause excessive
+    // disk usage due to logging.
+    bool ratelimit{level >= Level::Info};
 
-/** Send message to be logged. Applications using the logging library need to provide this. */
-void Log(Entry entry);
+    // Always evaluate format arguments at Info and higher levels because logs
+    // at these levels are rarely disabled, so it's safer to evaluate unused
+    // arguments than risk unintended side effects when logging is disabled.
+    bool evaluate_when_disabled{level >= Level::Info};
+};
 
-template <typename... Args>
-inline void LogPrintFormatInternal_(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    std::string log_msg;
-    try {
-        log_msg = tfm::format(fmt, args...);
-    } catch (tinyformat::format_error& fmterr) {
-        log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+/// Object representing context of log messages. Holds a logging category and
+/// implements log formatting.
+struct Context {
+    Category category;
+
+    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
+    {
+        std::string log_msg;
+        try {
+            log_msg = tfm::format(fmt, args...);
+        } catch (tinyformat::format_error& fmterr) {
+            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+        }
+        return log_msg;
     }
-    util::log::Log(util::log::Entry{
-        .category = flag,
-        .level = level,
-        .should_ratelimit = should_ratelimit,
+};
+
+/// External hooks that logging backends need to implement.
+namespace hooks {
+/// Return whether messages with specified category and level should be logged.
+bool ShouldLog(Category category, Level level);
+
+/// Send message to be logged.
+void Log(Entry entry);
+} // namespace hooks
+
+/// Internal functions used to help implement logging macros.
+namespace detail {
+/// Internal helper to get Context from the first macro argument. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <Options options>
+Context GetContext(std::string_view fmt)
+{
+    // Trigger compile error if caller does not pass a category constant as the
+    // first argument to a logging call, unless the level is Info or higher.
+    // There is no technical reason category arguments must be required, but
+    // categories are useful for finding and filtering relevant messages when
+    // debugging, so we want to encourage them.
+    static_assert(options.level >= Level::Info, "Missing required category argument for Debug/Trace logging call. Category can only be omitted for Info/Warning/Error calls.");
+    return Context{};
+}
+template <Options options>
+Context GetContext(Category category)
+{
+    // Trigger compile error if caller tries to pass a category constant as a
+    // first argument to a logging call at Info level or higher. There is no
+    // technical reason why all logging calls could not accept category
+    // arguments, but for various reasons, such as (1) not wanting to allow
+    // users to filter by category at high priority levels, and (2) wanting to
+    // incentivize developers to use lower log levels to avoid log spam, passing
+    // category constants at higher levels is forbidden.
+    static_assert(options.level < Level::Info, "Cannot pass category argument to Info/Warning/Error logging call. Please switch to Debug/Trace call, or drop the category argument!");
+    return Context{category};
+}
+
+/// Internal helper to construct log entry and emit log message. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <typename Context, typename... Args>
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    hooks::Log(Entry{
+        .category = context.category,
+        .level = options.level,
+        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
-        .message = std::move(log_msg)});
+        .message = context.Format(fmt, args...)});
+}
+template <typename Context, typename ContextArg, typename... Args>
+requires (!std::is_convertible_v<ContextArg, std::string_view>)
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ContextArg&&, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    Emit(std::move(options), std::move(source_loc), context, fmt, args...);
 }
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+template<Level level>
+bool ShouldLog(Category category)
 {
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/true, fmt, args...);
+    constexpr util::log::Options options{level};
+    static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
+    return util::log::hooks::ShouldLog(category, options.level);
 }
+} // namespace detail
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::log::NoRateLimitTag, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/false, fmt, args...);
-}
+/// Functions to detect when logging is enabled. Note: functions for detecting
+/// if logging is enabled at info/warning/error levels are intentionally not
+/// provided, because these logs are rarely disabled, so allowing code to
+/// condition on them could lead to bugs when they are disabled.
+///@{
+inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
+inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+///@}
 } // namespace util::log
 
 namespace BCLog {
@@ -114,33 +217,5 @@ namespace BCLog {
 using Level = util::log::Level;
 } // namespace BCLog
 
-// Allow __func__ to be used in any context without warnings:
-// NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define detail_LogWithSrcLoc(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
-
-// Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
-// Be conservative when using functions that unconditionally log to debug.log!
-// It should not be the case that an inbound peer can fill up a user's storage
-// with debug.log entries.
-#define LogInfo(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
-#define LogWarning(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
-#define LogError(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
-
-// Use a macro instead of a function for conditional logging to prevent
-// evaluating arguments when logging for the category is not enabled.
-
-// Log by prefixing the output with the passed category name and severity level. This logs conditionally if
-// the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
-// developers or power users who are aware that -debug may cause excessive disk usage due to logging.
-#define detail_LogIfCategoryAndLevelEnabled(category, shouldlog, level, ...)                  \
-    do {                                                                                      \
-        if (shouldlog(category)) {                                                            \
-            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__); \
-        }                                                                                     \
-    } while (0)
-
-// Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldDebugLog, util::log::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldTraceLog, util::log::Level::Trace, __VA_ARGS__)
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -25,7 +25,38 @@
 /// printf-style format string and arguments. For Debug and Trace macros,
 /// if a context parameter is not provided, a BCLog::LogFlags category argument
 /// must be provided instead.
-/// See the "Logging" section of /doc/developer-notes.md for more details.
+///
+/// - LogError(), LogWarning(), and LogInfo() are all enabled by default, so
+///   they should be called infrequently, in cases where they will not spam the
+///   log and take up disk space.
+///
+/// - LogDebug() is enabled when debug logging is enabled, and should be used to
+///   show messages that can help users troubleshoot issues.
+///
+/// - LogTrace() is enabled when both debug logging AND tracing are enabled, and
+///   should be used for fine-grained traces that will be helpful to developers.
+///
+/// For more information about log levels, see the -debug and -loglevel
+/// documentation, or the "Logging" section of /doc/developer-notes.md.
+///
+/// `LogDebug` and `LogTrace` macros require an initial category argument unless
+/// given a log source (which provides it). That enables Debug and Trace
+/// messages to be filtered by category. Higher levels do not take a category
+/// (but may be passed a log source):
+///
+///   LogDebug(BCLog::TXRECONCILIATION, "Forget txreconciliation state of peer=%d", peer_id);
+///   LogInfo("Important information, no category.");
+///
+/// Context arguments can also be passed to control log output (see class definition).
+///
+///   const util::log::Context m_log{BCLog::TXRECONCILIATION};
+///   ...
+///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
+///
+/// If severity level is Info or higher, rate limiting is applied to mitigate
+/// disk filling attacks. Users enabling logging at Debug and lower levels are
+/// assumed to be developers or power users who are aware that -debug may cause
+/// excessive disk usage due to logging.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
 #define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
@@ -82,6 +113,10 @@ using Category = uint64_t;
 /** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
 class Logger{};
 
+/// Log level constants. Most code will not need to use these directly and can
+/// use LogTrace, LogDebug, LogInfo, LogWarning, and LogError macros defined
+/// below. See macro definitions below or "Logging" section in
+/// developer-notes.md for more detailed information.
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -53,6 +53,10 @@
 ///   ...
 ///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
 ///
+/// Using context objects also provides the flexibility to add extra information
+/// and custom formatting to log messages, or to divert log messages to a local
+/// logger instead of the global logging instance.
+///
 /// If severity level is Info or higher, rate limiting is applied to mitigate
 /// disk filling attacks. Users enabling logging at Debug and lower levels are
 /// assumed to be developers or power users who are aware that -debug may cause
@@ -157,6 +161,7 @@ struct Options {
 /// optional log pointer which can be used by the application's log handler to
 /// determine where to log to, and a Format hook to control message formatting.
 struct Context {
+    static constexpr bool log_context{true};
     Category category;
     Logger* logger;
 
@@ -189,7 +194,8 @@ namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
 /// detect case where first macro argument is a string literal and context has
 /// been omitted.
-template <Options options>
+template <Options options, typename Context>
+requires (Context::log_context)
 Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -20,9 +20,11 @@
 #include <string_view>
 #include <type_traits>
 
-/// Logging macros which output log messages at the specified levels. They
-/// accept printf-style format strings and arguments. The debug and trace macros
-/// also require an initial BCLog::LogFlags category argument.
+/// Logging macros which output log messages at the specified levels. The
+/// macros accept an optional log context parameter followed by a
+/// printf-style format string and arguments. For Debug and Trace macros,
+/// if a context parameter is not provided, a BCLog::LogFlags category argument
+/// must be provided instead.
 /// See the "Logging" section of /doc/developer-notes.md for more details.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
@@ -38,7 +40,7 @@
     do {                                                                                           \
         constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
         auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
-        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+        if (util::log::hooks::ShouldLog(_context.logger, _context.category, _options.level)) {     \
             util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
         } else if constexpr (_options.evaluate_when_disabled) {                                    \
             [](auto&&...) {}(__VA_ARGS__);                                                         \
@@ -77,6 +79,9 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
+/** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
+class Logger{};
+
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -113,12 +118,14 @@ struct Options {
     bool evaluate_when_disabled{level >= Level::Info};
 };
 
-/// Object representing context of log messages. Holds a logging category and
-/// implements log formatting.
+/// Object representing context of log messages. Holds a logging category, an
+/// optional log pointer which can be used by the application's log handler to
+/// determine where to log to, and a Format hook to control message formatting.
 struct Context {
     Category category;
+    Logger* logger;
 
-    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+    explicit Context(Category category = BCLog::LogFlags::ALL, Logger* logger = nullptr) : category{category}, logger{logger} {}
 
     template <typename... Args>
     std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
@@ -136,17 +143,19 @@ struct Context {
 /// External hooks that logging backends need to implement.
 namespace hooks {
 /// Return whether messages with specified category and level should be logged.
-bool ShouldLog(Category category, Level level);
+bool ShouldLog(Logger* logger, Category category, Level level);
 
 /// Send message to be logged.
-void Log(const Options& options, Entry entry);
+void Log(Logger* logger, const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
 namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
+template <Options options>
+Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)
 {
@@ -173,12 +182,12 @@ Context GetContext(Category category)
 }
 
 /// Internal helper to construct log entry and emit log message. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(options, Entry{
+    hooks::Log(context.logger, options, Entry{
         .category = context.category,
         .level = options.level,
         .source_loc = std::move(source_loc),
@@ -192,11 +201,11 @@ void Emit(Options options, SourceLocation&& source_loc, Context&& context, Conte
 }
 
 template<Level level>
-bool ShouldLog(Category category)
+bool ShouldLog(const Context& context)
 {
     constexpr util::log::Options options{level};
     static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
-    return util::log::hooks::ShouldLog(category, options.level);
+    return util::log::hooks::ShouldLog(context.logger, context.category, options.level);
 }
 } // namespace detail
 
@@ -205,8 +214,8 @@ bool ShouldLog(Category category)
 /// provided, because these logs are rarely disabled, so allowing code to
 /// condition on them could lead to bugs when they are disabled.
 ///@{
-inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
-inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+inline bool ShouldDebugLog(const auto&... args) { return detail::ShouldLog<Level::Debug>(Context{args...}); }
+inline bool ShouldTraceLog(const auto&... args) { return detail::ShouldLog<Level::Trace>(Context{args...}); }
 ///@}
 } // namespace util::log
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2865,8 +2865,9 @@ static void UpdateTipLog(
 
     AssertLockHeld(::cs_main);
 
-    // Disable rate limiting as this may log frequently during IBD.
-    LogInfo(util::log::NO_RATE_LIMIT, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Disable rate limiting so this source location may log during IBD.
+    LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
+                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,


### PR DESCRIPTION
Allow `LogTrace()`, `LogDebug()`, `LogInfo()`, `LogWarning()`, and `LogError()` macros to accept context arguments to provide more information in log messages and more control over logging to callers.

For example, with this change wallet code can log with (in #30343):

```diff
-        WalletLogPrintf("Error: cannot erase address book entry data\n");
+        LogError(m_log, "Error: cannot erase address book entry data\n");
```

And kernel code can log with (in #30342):

```diff
-        LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
+        LogDebug(log, "Block mutated: %s\n", state.ToString());
```

where `m_log` / `log` types can vary and be defined by the subsystem. This allows subsystems to attach extra context to log messages like wallet names, or request ids. It also allows more than a single log stream to exist, and for messages to be logged to specified streams. Having a single global log stream works very well for `bitcoind` and will not change. But it limits functionality of libbitcoinkernel, forcing all potential users of the library, including applications written in different languages and running in different environments (like jupyter notebooks) to use shared global state and not be able to do things like get an isolated log trace from one operation.

The change is fully backwards compatible and does not require any updates to code that wants to continue using the macros as they are. The implementation of the macros is also improved. They now provide improved error messages when called with the wrong arguments. And they only call underlying `ShouldLog` `Log` and `Format` hooks as needed to avoid unnecessary work. The PR also adds more test coverage and documentation.

---

Note: Originally this PR also removed some restrictions around passing category constants to log macros to try to make them more consistent, but these changes were too controversial and have been dropped.

---

<!-- begin based-on -->
**This is based on #34778.** The non-base commits are:

- [`aa37de26b0f` log refactor: Allow log macros to accept context arguments](https://github.com/bitcoin/bitcoin/pull/29256/commits/aa37de26b0f31d1d731fc3a3fe20ca9d99f69062)
- [`1eedcb9db51` doc: Add documentation about log levels and macros](https://github.com/bitcoin/bitcoin/pull/29256/commits/1eedcb9db5156d36916ce4ccac49096a61d9c186)
- [`b5d3925d274` log refactor: Add support for custom log contexts](https://github.com/bitcoin/bitcoin/pull/29256/commits/b5d3925d27468ff4d5d2e6be7e9ec0c7f8c3a05e)<!-- end -->