### PR TITLE
Support self hosted Github workers on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   test-each-commit:
     name: 'test each commit'
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
+    if: github.repository_owner == 'bitcoin' && github.event_name == 'pull_request' && github.event.pull_request.commits != 1
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
     env:
       MAX_COUNT: 6
@@ -76,8 +76,7 @@ jobs:
     runs-on: macos-13
 
     # No need to run on the read-only mirror, unless it is a PR.
-    if: github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request'
-
+    if: github.repository_owner == 'bitcoin' && (github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request')
     timeout-minutes: 120
 
     env:
@@ -127,7 +126,7 @@ jobs:
     runs-on: windows-2022
 
     # No need to run on the read-only mirror, unless it is a PR.
-    if: github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'bitcoin' && (github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request')
 
     env:
       CCACHE_MAXSIZE: '200M'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,20 @@ concurrency:
   group: ${{ github.event_name != 'pull_request' && github.run_id || github.ref }}
   cancel-in-progress: true
 
-env:
-  DANGER_RUN_CI_ON_HOST: 1
-  CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
-  MAKEJOBS: '-j10'
-
 jobs:
+  # Jobs for GitHub-hosted runners.
+  # May use sudo and run outside of Docker container
+  # Disabled for forks due to high minute multipliers for Windows and macOS.
+
   test-each-commit:
     name: 'test each commit'
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'bitcoin' && github.event_name == 'pull_request' && github.event.pull_request.commits != 1
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
     env:
+      DANGER_RUN_CI_ON_HOST: 1
+      CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
+      MAKEJOBS: '-j10'
       MAX_COUNT: 6
     steps:
       - name: Determine fetch depth
@@ -80,6 +82,9 @@ jobs:
     timeout-minutes: 120
 
     env:
+      DANGER_RUN_CI_ON_HOST: 1
+      CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
+      MAKEJOBS: '-j10'
       FILE_ENV: './ci/test/00_setup_env_mac_native.sh'
       BASE_ROOT_DIR: ${{ github.workspace }}
 
@@ -129,6 +134,9 @@ jobs:
     if: github.repository_owner == 'bitcoin' && (github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request')
 
     env:
+      DANGER_RUN_CI_ON_HOST: 1
+      CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
+      MAKEJOBS: '-j10'
       CCACHE_MAXSIZE: '200M'
       CI_CCACHE_VERSION: '4.7.5'
       CI_QT_CONF: '-release -silent -opensource -confirm-license -opengl desktop -static -static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -nomake examples -nomake tests -nomake tools -no-angle -no-dbus -no-gif -no-gtk -no-ico -no-icu -no-libjpeg -no-libudev -no-sql-sqlite -no-sql-odbc -no-sqlite -no-vulkan -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip doc -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -no-openssl -no-feature-bearermanagement -no-feature-printdialog -no-feature-printer -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel -no-feature-textbrowser -no-feature-textmarkdownwriter -no-feature-textodfwriter -no-feature-xml'
@@ -288,3 +296,191 @@ jobs:
         env:
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
         run: py -3 test\functional\test_runner.py --jobs $env:NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix=$env:RUNNER_TEMP --combinedlogslen=99999999 --timeout-factor=$env:TEST_RUNNER_TIMEOUT_FACTOR $env:TEST_RUNNER_EXTRA
+
+  # Jobs for self-hosted runners
+  # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners
+  # May not use sudo and must run inside Docker container
+  linter:
+    name: 'Linter'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Docker image
+        run: |
+          docker build -t bitcoin-linter --file "./ci/lint_imagefile" ./
+
+      - name: Run linter
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/bitcoin -t bitcoin-linter
+
+  centos:
+    name: '32-bit CentOS, dash, gui'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  multiprocess:
+    name: 'multiprocess, i686, DEBUG'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_i686_multiprocess.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  mac_cross:
+    name: 'macOS-cross, gui, no tests'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_mac_cross.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  native_asan:
+    name: 'ASan + LSan + UBSan + integer, no depends, USDT'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_asan.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  native_fuzz:
+    name: 'fuzzer,address,undefined,integer, no depends'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
+      MAKEJOBS: '-j32'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  native_msan:
+    name: 'MSan, depends'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_msan.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  kernel:
+    name: 'no wallet, libbitcoinkernel'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  previous:
+    name: 'previous releases, depends DEBUG'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_previous_releases.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  tidy:
+    name: 'tidy'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_tidy.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  tsan:
+    name: 'TSan, depends, gui'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'
+
+  win64:
+    name: 'Win64, unit tests, no gui tests, no functional tests'
+    runs-on: [self-hosted, Linux, X64]
+    if: github.repository_owner != 'bitcoin' && github.event_name == 'pull_request'
+    env:
+      FILE_ENV: "./ci/test/00_setup_env_win64.sh"
+      MAKEJOBS: '-j4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run in Docker
+        run: |
+          docker stop $(docker ps -a -q) || true
+          env -i FILE_ENV="$FILE_ENV" MAKEJOBS="$MAKEJOBS" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DOCKER_HOST="$DOCKER_HOST" HOME="$HOME" PATH="$PATH" USER="$USER" bash -c './ci/test_run_all.sh'

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -11,7 +11,7 @@ set -ex
 if [ -n "$LOCAL_BRANCH" ]; then
   # To faithfully recreate CI linting locally, specify all commits on the current
   # branch.
-  COMMIT_RANGE="$(git merge-base HEAD master)..HEAD"
+  COMMIT_RANGE="$(git merge-base HEAD origin/master)..HEAD"
 elif [ -n "$CIRRUS_PR" ]; then
   COMMIT_RANGE="HEAD~..HEAD"
   echo

--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -12,9 +12,9 @@ set -ex
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   # Export all env vars to avoid missing some.
   # Though, exclude those with newlines to avoid parsing problems.
-  python3 -c 'import os; [print(f"{key}={value}") for key, value in os.environ.items() if "\n" not in value and "HOME" != key and "PATH" != key and "USER" != key]' | tee /tmp/env
+  python3 -c 'import os; [print(f"{key}={value}") for key, value in os.environ.items() if "\n" not in value and "HOME" != key and "PATH" != key and "USER" != key]' | tee "/tmp/env-$USER"
   # System-dependent env vars must be kept as is. So read them from the container.
-  docker run --rm "${CI_IMAGE_NAME_TAG}" bash -c "env | grep --extended-regexp '^(HOME|PATH|USER)='" | tee --append /tmp/env
+  docker run --rm "${CI_IMAGE_NAME_TAG}" bash -c "env | grep --extended-regexp '^(HOME|PATH|USER)='" | tee --append "/tmp/env-$USER"
   echo "Creating $CI_IMAGE_NAME_TAG container to run in"
   DOCKER_BUILDKIT=1 docker build \
       --file "${BASE_READ_ONLY_DIR}/ci/test_imagefile" \
@@ -52,7 +52,7 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
                   --mount "type=volume,src=${CONTAINER_NAME}_depends_sources,dst=$DEPENDS_DIR/sources" \
                   --mount "type=volume,src=${CONTAINER_NAME}_depends_SDKs_android,dst=$DEPENDS_DIR/SDKs/android" \
                   --mount "type=volume,src=${CONTAINER_NAME}_previous_releases,dst=$PREVIOUS_RELEASES_DIR" \
-                  --env-file /tmp/env \
+                  --env-file /tmp/env-$USER \
                   --name "$CONTAINER_NAME" \
                   "$CONTAINER_NAME")
   export CI_CONTAINER_ID


### PR DESCRIPTION
I find myself making pull requests against my fork (mostly on top of #28983), or asking others to do so. Since I don't want to splurge on a Cirrus account, and since Github free minutes are limited, I looked into how self hosted runners work on Github.

You can see this PR in action on this pull request to my fork: https://github.com/Sjors/bitcoin/actions/runs/7554260507

To test it yourself, spin up one or more [self hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) (each as its own user), install Docker (maybe in [single user mode](https://docs.docker.com/engine/security/rootless/)), and then make a pull request to your own fork, with this PR as the base branch.

Security wise: when dealing with code from strangers on the internet, review it first before running the CI.

This PR also disables Github Actions on forks in order to prevent forks from running out of free minutes (that their owners may need for other projects with much shorter CI runs). This could be made into a separate PR, or dropped altogether.

The first two commits could be split out as well.

TODO:
- [ ] deduplicate yaml (can't use anchors https://github.com/actions/runner/issues/1182)
- [ ] add macOS native worker
- [ ] add Windows native worker (I can't easily test this myself, so might leave it followup)
- [ ] prevent self hosted jobs from cluttering UI on the main 
- [ ] check behaviour against the gui repo
- [ ] make resource consumption configurable (some function of nproc? or configured locally on the workers?)
- [ ] documentation

Related: I wrote a [gist](https://gist.github.com/Sjors/cd55370fa67aa095df90c433ee9bd135) for how to run CI on Ubuntu desktop with one runner per window. The windows close if the run is successful so you can inspect the ones that fail. But I find using Github's CI web interface a bit more convenient, hence this PR.