### PR TITLE
rpc: Fix race in loadtxoutset

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2785,12 +2785,11 @@ static RPCHelpMan loadtxoutset()
     if (!chainman.ActivateSnapshot(afile, metadata, false)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to load UTXO snapshot " + fs::PathToString(path));
     }
-    CBlockIndex* new_tip{WITH_LOCK(::cs_main, return chainman.ActiveTip())};
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("coins_loaded", metadata.m_coins_count);
-    result.pushKV("tip_hash", new_tip->GetBlockHash().ToString());
-    result.pushKV("base_height", new_tip->nHeight);
+    result.pushKV("tip_hash", snapshot_start_block->GetBlockHash().ToString());
+    result.pushKV("base_height", snapshot_start_block->nHeight);
     result.pushKV("path", fs::PathToString(path));
     return result;
 },

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1021,5 +1021,4 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         return self.config["components"].getboolean("USE_BDB")
 
     def has_blockfile(self, node, filenum: str):
-        blocksdir = node.datadir_path / self.chain / 'blocks'
-        return (blocksdir / f"blk{filenum}.dat").is_file()
+        return (node.blocks_path/ f"blk{filenum}.dat").is_file()


### PR DESCRIPTION
The tip may have advanced, also if it did not, there is no reason to
have two variables point to the same block.

Fixes https://github.com/bitcoin/bitcoin/pull/27596#discussion_r1344694600