### PR TITLE
serialization: c++20 endian/byteswap/clz modernization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -975,7 +975,7 @@ if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([-Wl,-fixup_chains], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-fixup_chains"], [], [$LDFLAG_WERROR])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,
     [#include <sys/types.h>
@@ -995,11 +995,6 @@ AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, b
                  #include <endian.h>
                  #elif HAVE_SYS_ENDIAN_H
                  #include <sys/endian.h>
-                 #endif])
-
-AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
-    [#if HAVE_BYTESWAP_H
-                 #include <byteswap.h>
                  #endif])
 
 AC_MSG_CHECKING([for __builtin_clzl])

--- a/configure.ac
+++ b/configure.ac
@@ -975,7 +975,7 @@ if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([-Wl,-fixup_chains], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-fixup_chains"], [], [$LDFLAG_WERROR])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
+AC_CHECK_HEADERS([sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,
     [#include <sys/types.h>
@@ -989,13 +989,6 @@ AC_CHECK_DECLS([setsid])
 AC_CHECK_DECLS([pipe2])
 
 AC_CHECK_FUNCS([timingsafe_bcmp])
-
-AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
-    [#if HAVE_ENDIAN_H
-                 #include <endian.h>
-                 #elif HAVE_SYS_ENDIAN_H
-                 #include <sys/endian.h>
-                 #endif])
 
 AC_MSG_CHECKING([for __builtin_clzl])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -5,44 +5,66 @@
 #ifndef BITCOIN_COMPAT_BYTESWAP_H
 #define BITCOIN_COMPAT_BYTESWAP_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
 #include <cstdint>
-
-#if defined(HAVE_BYTESWAP_H)
-#include <byteswap.h>
+#ifdef _MSC_VER
+#include <cstdlib>
 #endif
 
-#if defined(MAC_OSX)
 
-#include <libkern/OSByteOrder.h>
-#define bswap_16(x) OSSwapInt16(x)
-#define bswap_32(x) OSSwapInt32(x)
-#define bswap_64(x) OSSwapInt64(x)
+// All internal_bswap_* functions can be replaced with std::byteswap once we
+// require c++23. Both libstdc++ and libc++ implement std::byteswap via these
+// builtins.
 
+#ifndef DISABLE_BUILTIN_BSWAPS
+#  if defined __has_builtin
+#    if __has_builtin(__builtin_bswap16)
+#      define bitcoin_builtin_bswap16(x) __builtin_bswap16(x)
+#    endif
+#    if __has_builtin(__builtin_bswap32)
+#      define bitcoin_builtin_bswap32(x) __builtin_bswap32(x)
+#    endif
+#    if __has_builtin(__builtin_bswap64)
+#      define bitcoin_builtin_bswap64(x) __builtin_bswap64(x)
+#    endif
+#  elif defined(_MSC_VER)
+#      define bitcoin_builtin_bswap16(x) _byteswap_ushort(x)
+#      define bitcoin_builtin_bswap32(x) _byteswap_ulong(x)
+#      define bitcoin_builtin_bswap64(x) _byteswap_uint64(x)
+#  endif
+#endif
+
+// MSVC's _byteswap_* functions are not constexpr
+
+#ifndef _MSC_VER
+#define BSWAP_CONSTEXPR constexpr
 #else
-// Non-MacOS / non-Darwin
+#define BSWAP_CONSTEXPR
+#endif
 
-#if HAVE_DECL_BSWAP_16 == 0
-inline uint16_t bswap_16(uint16_t x)
+inline BSWAP_CONSTEXPR uint16_t internal_bswap_16(uint16_t x)
 {
+#ifdef bitcoin_builtin_bswap16
+    return bitcoin_builtin_bswap16(x);
+#else
     return (x >> 8) | (x << 8);
+#endif
 }
-#endif // HAVE_DECL_BSWAP16 == 0
 
-#if HAVE_DECL_BSWAP_32 == 0
-inline uint32_t bswap_32(uint32_t x)
+inline BSWAP_CONSTEXPR uint32_t internal_bswap_32(uint32_t x)
 {
+#ifdef bitcoin_builtin_bswap32
+    return bitcoin_builtin_bswap32(x);
+#else
     return (((x & 0xff000000U) >> 24) | ((x & 0x00ff0000U) >>  8) |
             ((x & 0x0000ff00U) <<  8) | ((x & 0x000000ffU) << 24));
+#endif
 }
-#endif // HAVE_DECL_BSWAP32 == 0
 
-#if HAVE_DECL_BSWAP_64 == 0
-inline uint64_t bswap_64(uint64_t x)
+inline BSWAP_CONSTEXPR uint64_t internal_bswap_64(uint64_t x)
 {
+#ifdef bitcoin_builtin_bswap64
+    return bitcoin_builtin_bswap64(x);
+#else
      return (((x & 0xff00000000000000ull) >> 56)
           | ((x & 0x00ff000000000000ull) >> 40)
           | ((x & 0x0000ff0000000000ull) >> 24)
@@ -51,9 +73,7 @@ inline uint64_t bswap_64(uint64_t x)
           | ((x & 0x0000000000ff0000ull) << 24)
           | ((x & 0x000000000000ff00ull) << 40)
           | ((x & 0x00000000000000ffull) << 56));
+#endif
 }
-#endif // HAVE_DECL_BSWAP64 == 0
-
-#endif // defined(MAC_OSX)
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -5,237 +5,70 @@
 #ifndef BITCOIN_COMPAT_ENDIAN_H
 #define BITCOIN_COMPAT_ENDIAN_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
 #include <compat/byteswap.h>
 
+#include <bit>
 #include <cstdint>
 
-#if defined(HAVE_ENDIAN_H)
-#include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
-#include <sys/endian.h>
-#endif
-
-#ifndef HAVE_CONFIG_H
-// While not technically a supported configuration, defaulting to defining these
-// DECLs when we were compiled without autotools makes it easier for other build
-// systems to build things like libbitcoinconsensus for strange targets.
-#ifdef htobe16
-#define HAVE_DECL_HTOBE16 1
-#endif
-#ifdef htole16
-#define HAVE_DECL_HTOLE16 1
-#endif
-#ifdef be16toh
-#define HAVE_DECL_BE16TOH 1
-#endif
-#ifdef le16toh
-#define HAVE_DECL_LE16TOH 1
-#endif
-
-#ifdef htobe32
-#define HAVE_DECL_HTOBE32 1
-#endif
-#ifdef htole32
-#define HAVE_DECL_HTOLE32 1
-#endif
-#ifdef be32toh
-#define HAVE_DECL_BE32TOH 1
-#endif
-#ifdef le32toh
-#define HAVE_DECL_LE32TOH 1
-#endif
-
-#ifdef htobe64
-#define HAVE_DECL_HTOBE64 1
-#endif
-#ifdef htole64
-#define HAVE_DECL_HTOLE64 1
-#endif
-#ifdef be64toh
-#define HAVE_DECL_BE64TOH 1
-#endif
-#ifdef le64toh
-#define HAVE_DECL_LE64TOH 1
-#endif
-
-#endif // HAVE_CONFIG_H
-
-#if defined(WORDS_BIGENDIAN)
-
-#if HAVE_DECL_HTOBE16 == 0
-inline uint16_t htobe16(uint16_t host_16bits)
+inline BSWAP_CONSTEXPR uint16_t htobe16_internal(uint16_t host_16bits)
 {
-    return host_16bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_16(host_16bits);
+        else return host_16bits;
 }
-#endif // HAVE_DECL_HTOBE16
-
-#if HAVE_DECL_HTOLE16 == 0
-inline uint16_t htole16(uint16_t host_16bits)
+inline BSWAP_CONSTEXPR uint16_t htole16_internal(uint16_t host_16bits)
 {
-    return internal_bswap_16(host_16bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_16(host_16bits);
+        else return host_16bits;
 }
-#endif // HAVE_DECL_HTOLE16
-
-#if HAVE_DECL_BE16TOH == 0
-inline uint16_t be16toh(uint16_t big_endian_16bits)
+inline BSWAP_CONSTEXPR uint16_t be16toh_internal(uint16_t big_endian_16bits)
 {
-    return big_endian_16bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_16(big_endian_16bits);
+        else return big_endian_16bits;
 }
-#endif // HAVE_DECL_BE16TOH
-
-#if HAVE_DECL_LE16TOH == 0
-inline uint16_t le16toh(uint16_t little_endian_16bits)
+inline BSWAP_CONSTEXPR uint16_t le16toh_internal(uint16_t little_endian_16bits)
 {
-    return internal_bswap_16(little_endian_16bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_16(little_endian_16bits);
+        else return little_endian_16bits;
 }
-#endif // HAVE_DECL_LE16TOH
-
-#if HAVE_DECL_HTOBE32 == 0
-inline uint32_t htobe32(uint32_t host_32bits)
+inline BSWAP_CONSTEXPR uint32_t htobe32_internal(uint32_t host_32bits)
 {
-    return host_32bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_32(host_32bits);
+        else return host_32bits;
 }
-#endif // HAVE_DECL_HTOBE32
-
-#if HAVE_DECL_HTOLE32 == 0
-inline uint32_t htole32(uint32_t host_32bits)
+inline BSWAP_CONSTEXPR uint32_t htole32_internal(uint32_t host_32bits)
 {
-    return internal_bswap_32(host_32bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_32(host_32bits);
+        else return host_32bits;
 }
-#endif // HAVE_DECL_HTOLE32
-
-#if HAVE_DECL_BE32TOH == 0
-inline uint32_t be32toh(uint32_t big_endian_32bits)
+inline BSWAP_CONSTEXPR uint32_t be32toh_internal(uint32_t big_endian_32bits)
 {
-    return big_endian_32bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_32(big_endian_32bits);
+        else return big_endian_32bits;
 }
-#endif // HAVE_DECL_BE32TOH
-
-#if HAVE_DECL_LE32TOH == 0
-inline uint32_t le32toh(uint32_t little_endian_32bits)
+inline BSWAP_CONSTEXPR uint32_t le32toh_internal(uint32_t little_endian_32bits)
 {
-    return internal_bswap_32(little_endian_32bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_32(little_endian_32bits);
+        else return little_endian_32bits;
 }
-#endif // HAVE_DECL_LE32TOH
-
-#if HAVE_DECL_HTOBE64 == 0
-inline uint64_t htobe64(uint64_t host_64bits)
+inline BSWAP_CONSTEXPR uint64_t htobe64_internal(uint64_t host_64bits)
 {
-    return host_64bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_64(host_64bits);
+        else return host_64bits;
 }
-#endif // HAVE_DECL_HTOBE64
-
-#if HAVE_DECL_HTOLE64 == 0
-inline uint64_t htole64(uint64_t host_64bits)
+inline BSWAP_CONSTEXPR uint64_t htole64_internal(uint64_t host_64bits)
 {
-    return internal_bswap_64(host_64bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_64(host_64bits);
+        else return host_64bits;
 }
-#endif // HAVE_DECL_HTOLE64
-
-#if HAVE_DECL_BE64TOH == 0
-inline uint64_t be64toh(uint64_t big_endian_64bits)
+inline BSWAP_CONSTEXPR uint64_t be64toh_internal(uint64_t big_endian_64bits)
 {
-    return big_endian_64bits;
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_64(big_endian_64bits);
+        else return big_endian_64bits;
 }
-#endif // HAVE_DECL_BE64TOH
-
-#if HAVE_DECL_LE64TOH == 0
-inline uint64_t le64toh(uint64_t little_endian_64bits)
+inline BSWAP_CONSTEXPR uint64_t le64toh_internal(uint64_t little_endian_64bits)
 {
-    return internal_bswap_64(little_endian_64bits);
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_64(little_endian_64bits);
+        else return little_endian_64bits;
 }
-#endif // HAVE_DECL_LE64TOH
-
-#else // WORDS_BIGENDIAN
-
-#if HAVE_DECL_HTOBE16 == 0
-inline uint16_t htobe16(uint16_t host_16bits)
-{
-    return internal_bswap_16(host_16bits);
-}
-#endif // HAVE_DECL_HTOBE16
-
-#if HAVE_DECL_HTOLE16 == 0
-inline uint16_t htole16(uint16_t host_16bits)
-{
-    return host_16bits;
-}
-#endif // HAVE_DECL_HTOLE16
-
-#if HAVE_DECL_BE16TOH == 0
-inline uint16_t be16toh(uint16_t big_endian_16bits)
-{
-    return internal_bswap_16(big_endian_16bits);
-}
-#endif // HAVE_DECL_BE16TOH
-
-#if HAVE_DECL_LE16TOH == 0
-inline uint16_t le16toh(uint16_t little_endian_16bits)
-{
-    return little_endian_16bits;
-}
-#endif // HAVE_DECL_LE16TOH
-
-#if HAVE_DECL_HTOBE32 == 0
-inline uint32_t htobe32(uint32_t host_32bits)
-{
-    return internal_bswap_32(host_32bits);
-}
-#endif // HAVE_DECL_HTOBE32
-
-#if HAVE_DECL_HTOLE32 == 0
-inline uint32_t htole32(uint32_t host_32bits)
-{
-    return host_32bits;
-}
-#endif // HAVE_DECL_HTOLE32
-
-#if HAVE_DECL_BE32TOH == 0
-inline uint32_t be32toh(uint32_t big_endian_32bits)
-{
-    return internal_bswap_32(big_endian_32bits);
-}
-#endif // HAVE_DECL_BE32TOH
-
-#if HAVE_DECL_LE32TOH == 0
-inline uint32_t le32toh(uint32_t little_endian_32bits)
-{
-    return little_endian_32bits;
-}
-#endif // HAVE_DECL_LE32TOH
-
-#if HAVE_DECL_HTOBE64 == 0
-inline uint64_t htobe64(uint64_t host_64bits)
-{
-    return internal_bswap_64(host_64bits);
-}
-#endif // HAVE_DECL_HTOBE64
-
-#if HAVE_DECL_HTOLE64 == 0
-inline uint64_t htole64(uint64_t host_64bits)
-{
-    return host_64bits;
-}
-#endif // HAVE_DECL_HTOLE64
-
-#if HAVE_DECL_BE64TOH == 0
-inline uint64_t be64toh(uint64_t big_endian_64bits)
-{
-    return internal_bswap_64(big_endian_64bits);
-}
-#endif // HAVE_DECL_BE64TOH
-
-#if HAVE_DECL_LE64TOH == 0
-inline uint64_t le64toh(uint64_t little_endian_64bits)
-{
-    return little_endian_64bits;
-}
-#endif // HAVE_DECL_LE64TOH
-
-#endif // WORDS_BIGENDIAN
 
 #endif // BITCOIN_COMPAT_ENDIAN_H

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -76,7 +76,7 @@ inline uint16_t htobe16(uint16_t host_16bits)
 #if HAVE_DECL_HTOLE16 == 0
 inline uint16_t htole16(uint16_t host_16bits)
 {
-    return bswap_16(host_16bits);
+    return internal_bswap_16(host_16bits);
 }
 #endif // HAVE_DECL_HTOLE16
 
@@ -90,7 +90,7 @@ inline uint16_t be16toh(uint16_t big_endian_16bits)
 #if HAVE_DECL_LE16TOH == 0
 inline uint16_t le16toh(uint16_t little_endian_16bits)
 {
-    return bswap_16(little_endian_16bits);
+    return internal_bswap_16(little_endian_16bits);
 }
 #endif // HAVE_DECL_LE16TOH
 
@@ -104,7 +104,7 @@ inline uint32_t htobe32(uint32_t host_32bits)
 #if HAVE_DECL_HTOLE32 == 0
 inline uint32_t htole32(uint32_t host_32bits)
 {
-    return bswap_32(host_32bits);
+    return internal_bswap_32(host_32bits);
 }
 #endif // HAVE_DECL_HTOLE32
 
@@ -118,7 +118,7 @@ inline uint32_t be32toh(uint32_t big_endian_32bits)
 #if HAVE_DECL_LE32TOH == 0
 inline uint32_t le32toh(uint32_t little_endian_32bits)
 {
-    return bswap_32(little_endian_32bits);
+    return internal_bswap_32(little_endian_32bits);
 }
 #endif // HAVE_DECL_LE32TOH
 
@@ -132,7 +132,7 @@ inline uint64_t htobe64(uint64_t host_64bits)
 #if HAVE_DECL_HTOLE64 == 0
 inline uint64_t htole64(uint64_t host_64bits)
 {
-    return bswap_64(host_64bits);
+    return internal_bswap_64(host_64bits);
 }
 #endif // HAVE_DECL_HTOLE64
 
@@ -146,7 +146,7 @@ inline uint64_t be64toh(uint64_t big_endian_64bits)
 #if HAVE_DECL_LE64TOH == 0
 inline uint64_t le64toh(uint64_t little_endian_64bits)
 {
-    return bswap_64(little_endian_64bits);
+    return internal_bswap_64(little_endian_64bits);
 }
 #endif // HAVE_DECL_LE64TOH
 
@@ -155,7 +155,7 @@ inline uint64_t le64toh(uint64_t little_endian_64bits)
 #if HAVE_DECL_HTOBE16 == 0
 inline uint16_t htobe16(uint16_t host_16bits)
 {
-    return bswap_16(host_16bits);
+    return internal_bswap_16(host_16bits);
 }
 #endif // HAVE_DECL_HTOBE16
 
@@ -169,7 +169,7 @@ inline uint16_t htole16(uint16_t host_16bits)
 #if HAVE_DECL_BE16TOH == 0
 inline uint16_t be16toh(uint16_t big_endian_16bits)
 {
-    return bswap_16(big_endian_16bits);
+    return internal_bswap_16(big_endian_16bits);
 }
 #endif // HAVE_DECL_BE16TOH
 
@@ -183,7 +183,7 @@ inline uint16_t le16toh(uint16_t little_endian_16bits)
 #if HAVE_DECL_HTOBE32 == 0
 inline uint32_t htobe32(uint32_t host_32bits)
 {
-    return bswap_32(host_32bits);
+    return internal_bswap_32(host_32bits);
 }
 #endif // HAVE_DECL_HTOBE32
 
@@ -197,7 +197,7 @@ inline uint32_t htole32(uint32_t host_32bits)
 #if HAVE_DECL_BE32TOH == 0
 inline uint32_t be32toh(uint32_t big_endian_32bits)
 {
-    return bswap_32(big_endian_32bits);
+    return internal_bswap_32(big_endian_32bits);
 }
 #endif // HAVE_DECL_BE32TOH
 
@@ -211,7 +211,7 @@ inline uint32_t le32toh(uint32_t little_endian_32bits)
 #if HAVE_DECL_HTOBE64 == 0
 inline uint64_t htobe64(uint64_t host_64bits)
 {
-    return bswap_64(host_64bits);
+    return internal_bswap_64(host_64bits);
 }
 #endif // HAVE_DECL_HTOBE64
 
@@ -225,7 +225,7 @@ inline uint64_t htole64(uint64_t host_64bits)
 #if HAVE_DECL_BE64TOH == 0
 inline uint64_t be64toh(uint64_t big_endian_64bits)
 {
-    return bswap_64(big_endian_64bits);
+    return internal_bswap_64(big_endian_64bits);
 }
 #endif // HAVE_DECL_BE64TOH
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -7,7 +7,6 @@
 
 #include <compat/endian.h>
 
-#include <bit>
 #include <cstdint>
 #include <cstring>
 
@@ -81,12 +80,6 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
     memcpy(ptr, &v, 8);
-}
-
-/** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
-uint64_t static inline CountBits(uint64_t x)
-{
-    return std::bit_width(x);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -14,38 +14,38 @@ uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
-    return le16toh(x);
+    return le16toh_internal(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
-    return le32toh(x);
+    return le32toh_internal(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
-    return le64toh(x);
+    return le64toh_internal(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
-    uint16_t v = htole16(x);
+    uint16_t v = htole16_internal(x);
     memcpy(ptr, &v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
-    uint32_t v = htole32(x);
+    uint32_t v = htole32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
-    uint64_t v = htole64(x);
+    uint64_t v = htole64_internal(x);
     memcpy(ptr, &v, 8);
 }
 
@@ -53,32 +53,32 @@ uint16_t static inline ReadBE16(const unsigned char* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
-    return be16toh(x);
+    return be16toh_internal(x);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
-    return be32toh(x);
+    return be32toh_internal(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
-    return be64toh(x);
+    return be64toh_internal(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
-    uint32_t v = htobe32(x);
+    uint32_t v = htobe32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
-    uint64_t v = htobe64(x);
+    uint64_t v = htobe64_internal(x);
     memcpy(ptr, &v, 8);
 }
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -5,14 +5,11 @@
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
-#include <stdint.h>
-#include <string.h>
-
 #include <compat/endian.h>
+
+#include <bit>
+#include <cstdint>
+#include <cstring>
 
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
@@ -89,22 +86,7 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
 uint64_t static inline CountBits(uint64_t x)
 {
-#if HAVE_BUILTIN_CLZL
-    if (sizeof(unsigned long) >= sizeof(uint64_t)) {
-        return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
-    }
-#endif
-#if HAVE_BUILTIN_CLZLL
-    if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
-        return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
-    }
-#endif
-    int ret = 0;
-    while (x) {
-        x >>= 1;
-        ++ret;
-    }
-    return ret;
+    return std::bit_width(x);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -392,7 +392,7 @@ Binary Session::MyDestination() const
     }
 
     memcpy(&cert_len, &m_private_key.at(CERT_LEN_POS), sizeof(cert_len));
-    cert_len = be16toh(cert_len);
+    cert_len = be16toh_internal(cert_len);
 
     const size_t dest_len = DEST_LEN_BASE + cert_len;
 

--- a/src/random.h
+++ b/src/random.h
@@ -11,6 +11,7 @@
 #include <span.h>
 #include <uint256.h>
 
+#include <bit>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -203,7 +204,7 @@ public:
     {
         assert(range);
         --range;
-        int bits = CountBits(range);
+        int bits = std::bit_width(range);
         while (true) {
             uint64_t ret = randbits(bits);
             if (ret <= range) return ret;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -60,27 +60,27 @@ template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
 }
 template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
 {
-    obj = htole16(obj);
+    obj = htole16_internal(obj);
     s.write(AsBytes(Span{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata16be(Stream &s, uint16_t obj)
 {
-    obj = htobe16(obj);
+    obj = htobe16_internal(obj);
     s.write(AsBytes(Span{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
-    obj = htole32(obj);
+    obj = htole32_internal(obj);
     s.write(AsBytes(Span{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
 {
-    obj = htobe32(obj);
+    obj = htobe32_internal(obj);
     s.write(AsBytes(Span{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
-    obj = htole64(obj);
+    obj = htole64_internal(obj);
     s.write(AsBytes(Span{&obj, 1}));
 }
 template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
@@ -93,31 +93,31 @@ template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
     s.read(AsWritableBytes(Span{&obj, 1}));
-    return le16toh(obj);
+    return le16toh_internal(obj);
 }
 template<typename Stream> inline uint16_t ser_readdata16be(Stream &s)
 {
     uint16_t obj;
     s.read(AsWritableBytes(Span{&obj, 1}));
-    return be16toh(obj);
+    return be16toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
     s.read(AsWritableBytes(Span{&obj, 1}));
-    return le32toh(obj);
+    return le32toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
     s.read(AsWritableBytes(Span{&obj, 1}));
-    return be32toh(obj);
+    return be32toh_internal(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
     s.read(AsWritableBytes(Span{&obj, 1}));
-    return le64toh(obj);
+    return le64toh_internal(obj);
 }
 
 
@@ -548,10 +548,10 @@ struct CustomUintFormatter
     {
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
         if (BigEndian) {
-            uint64_t raw = htobe64(v);
+            uint64_t raw = htobe64_internal(v);
             s.write(AsBytes(Span{&raw, 1}).last(Bytes));
         } else {
-            uint64_t raw = htole64(v);
+            uint64_t raw = htole64_internal(v);
             s.write(AsBytes(Span{&raw, 1}).first(Bytes));
         }
     }
@@ -563,10 +563,10 @@ struct CustomUintFormatter
         uint64_t raw = 0;
         if (BigEndian) {
             s.read(AsWritableBytes(Span{&raw, 1}).last(Bytes));
-            v = static_cast<I>(be64toh(raw));
+            v = static_cast<I>(be64toh_internal(raw));
         } else {
             s.read(AsWritableBytes(Span{&raw, 1}).first(Bytes));
-            v = static_cast<I>(le64toh(raw));
+            v = static_cast<I>(le64toh_internal(raw));
         }
     }
 };

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -16,9 +16,9 @@ BOOST_AUTO_TEST_CASE(bswap_tests)
     uint16_t e1 = 0x3412;
     uint32_t e2 = 0xbc9a7856;
     uint64_t e3 = 0xbc9a78563412f0de;
-    BOOST_CHECK(bswap_16(u1) == e1);
-    BOOST_CHECK(bswap_32(u2) == e2);
-    BOOST_CHECK(bswap_64(u3) == e3);
+    BOOST_CHECK(internal_bswap_16(u1) == e1);
+    BOOST_CHECK(internal_bswap_32(u2) == e2);
+    BOOST_CHECK(internal_bswap_64(u3) == e3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -1060,28 +1060,6 @@ BOOST_AUTO_TEST_CASE(hkdf_hmac_sha256_l32_tests)
                 "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d");
 }
 
-BOOST_AUTO_TEST_CASE(countbits_tests)
-{
-    FastRandomContext ctx;
-    for (unsigned int i = 0; i <= 64; ++i) {
-        if (i == 0) {
-            // Check handling of zero.
-            BOOST_CHECK_EQUAL(CountBits(0), 0U);
-        } else if (i < 10) {
-            for (uint64_t j = uint64_t{1} << (i - 1); (j >> i) == 0; ++j) {
-                // Exhaustively test up to 10 bits
-                BOOST_CHECK_EQUAL(CountBits(j), i);
-            }
-        } else {
-            for (int k = 0; k < 1000; k++) {
-                // Randomly test 1000 samples of each length above 10 bits.
-                uint64_t j = (uint64_t{1}) << (i - 1) | ctx.randbits(i - 1);
-                BOOST_CHECK_EQUAL(CountBits(j), i);
-            }
-        }
-    }
-}
-
 BOOST_AUTO_TEST_CASE(sha256d64)
 {
     for (int i = 0; i <= 32; ++i) {

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -80,7 +80,6 @@ FUZZ_TARGET(integer, .init = initialize_integer)
     static const uint256 u256_max(uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
     const std::vector<uint256> v256{u256, u256_min, u256_max};
     (void)ComputeMerkleRoot(v256);
-    (void)CountBits(u64);
     (void)DecompressAmount(u64);
     {
         if (std::optional<CAmount> parsed = ParseMoney(FormatMoney(i64))) {

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -5,13 +5,13 @@
 #include <util/asmap.h>
 
 #include <clientversion.h>
-#include <crypto/common.h>
 #include <logging.h>
 #include <serialize.h>
 #include <streams.h>
 #include <util/fs.h>
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cstdio>
 #include <utility>
@@ -111,7 +111,7 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
         } else if (opcode == Instruction::MATCH) {
             match = DecodeMatch(pos, endpos);
             if (match == INVALID) break; // Match bits straddle EOF
-            matchlen = CountBits(match) - 1;
+            matchlen = std::bit_width(match) - 1;
             if (bits < matchlen) break; // Not enough input bits
             for (uint32_t bit = 0; bit < matchlen; bit++) {
                 if ((ip[ip.size() - bits]) != ((match >> (matchlen - 1 - bit)) & 1)) {
@@ -175,7 +175,7 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
         } else if (opcode == Instruction::MATCH) {
             uint32_t match = DecodeMatch(pos, endpos);
             if (match == INVALID) return false; // Match bits straddle EOF
-            int matchlen = CountBits(match) - 1;
+            int matchlen = std::bit_width(match) - 1;
             if (prevopcode != Instruction::MATCH) had_incomplete_match = false;
             if (matchlen < 8 && had_incomplete_match) return false; // Within a sequence of matches only at most one should be incomplete
             had_incomplete_match = (matchlen < 8);


### PR DESCRIPTION
This replaces #28674, #29036, and #29057. Now ready for testing and review.

Replaces platform-specific endian and byteswap functions. This is especially useful for kernel, as it means that our deep serialization code no longer requires bitcoin-config.h.

I apologize for the size of the last commit, but it's hard to avoid making those changes at once.

All platforms now use our internal functions rather than libc or platform-specific ones, with the exception of MSVC.

Sadly, benchmarking showed that not all compilers are capable of detecting and optimizing byteswap functions, so compiler builtins are instead used where possible. However, they're now detected via macros rather than autoconf checks.

This[ matches how libc++ implements std::byteswap for c++23](https://github.com/llvm/llvm-project/blob/main/libcxx/include/__bit/byteswap.h#L26).

I suggest we move/rename `compat/endian.h`, but I left that out of this PR to avoid bikeshedding.

#29057 pointed out some irregularities in benchmarks. After messing with various compilers and configs for a few weeks with these changes, I'm of the opinion that we can't win on every platform every time, so we should take the code that makes sense going forward. That said, if any real-world slowdowns are caused here, we should obviously investigate.