### PR TITLE
Add `SigVersion` parameter to `IsOpSuccess()`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -661,6 +661,7 @@ libbitcoin_consensus_a_SOURCES = \
   script/script.h \
   script/script_error.cpp \
   script/script_error.h \
+  script/sigversion.h \
   serialize.h \
   span.h \
   tinyformat.h \

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <script/script.h>
 #include <script/interpreter.h>
+#include <script/sigversion.h>
 #include <streams.h>
 #include <test/util/transaction_utils.h>
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -15,6 +15,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/sigversion.h>
 #include <script/solver.h>
 #include <serialize.h>
 #include <span.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -30,6 +30,7 @@
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <script/solver.h>
 #include <uint256.h>
 #include <undo.h>
@@ -565,7 +566,7 @@ static RPCHelpMan decodescript()
         for (CScript::const_iterator it{script.begin()}; it != script.end();) {
             opcodetype op;
             CHECK_NONFATAL(script.GetOp(it, op));
-            if (op == OP_CHECKSIGADD || IsOpSuccess(op)) {
+            if (op == OP_CHECKSIGADD || IsOpSuccess(op, SigVersion::TAPSCRIPT)) {
                 return false;
             }
         }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -10,6 +10,7 @@
 #include <crypto/sha256.h>
 #include <pubkey.h>
 #include <script/script.h>
+#include <script/sigversion.h>
 #include <uint256.h>
 
 typedef std::vector<unsigned char> valtype;
@@ -1799,7 +1800,7 @@ static bool ExecuteWitnessScript(const Span<const valtype>& stack_span, const CS
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
             }
             // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
-            if (IsOpSuccess(opcode)) {
+            if (IsOpSuccess(opcode, sigversion)) {
                 if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
                     return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
                 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -187,14 +187,6 @@ struct PrecomputedTransactionData
     explicit PrecomputedTransactionData(const T& tx);
 };
 
-enum class SigVersion
-{
-    BASE = 0,        //!< Bare scripts and BIP16 P2SH-wrapped redeemscripts
-    WITNESS_V0 = 1,  //!< Witness v0 (P2WPKH and P2WSH); see BIP 141
-    TAPROOT = 2,     //!< Witness v1 with 32-byte program, not BIP16 P2SH-wrapped, key path spending; see BIP 341
-    TAPSCRIPT = 3,   //!< Witness v1 with 32-byte program, not BIP16 P2SH-wrapped, script path spending, leaf version 0xc0; see BIP 342
-};
-
 struct ScriptExecutionData
 {
     //! Whether m_tapleaf_hash is initialized.

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -7,6 +7,7 @@
 
 #include <crypto/common.h>
 #include <hash.h>
+#include <script/sigversion.h>
 #include <uint256.h>
 #include <util/hash_type.h>
 #include <util/strencodings.h>
@@ -338,12 +339,23 @@ bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator en
     return true;
 }
 
-bool IsOpSuccess(const opcodetype& opcode)
+bool IsOpSuccess(const opcodetype& opcode, SigVersion sigversion)
 {
-    return opcode == 80 || opcode == 98 || (opcode >= 126 && opcode <= 129) ||
+    switch (sigversion)
+    {
+    case SigVersion::TAPSCRIPT:
+        return opcode == 80 || opcode == 98 || (opcode >= 126 && opcode <= 129) ||
            (opcode >= 131 && opcode <= 134) || (opcode >= 137 && opcode <= 138) ||
            (opcode >= 141 && opcode <= 142) || (opcode >= 149 && opcode <= 153) ||
            (opcode >= 187 && opcode <= 254);
+        break;
+    case SigVersion::BASE:
+    case SigVersion::WITNESS_V0:
+    case SigVersion::TAPROOT:
+        //impossible to have OP_SUCCESSx in old sig versions
+        break;
+    }
+    assert(false);
 }
 
 bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode) {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+enum class SigVersion;
+
 // Maximum number of bytes pushable to the stack
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520;
 
@@ -588,7 +590,7 @@ public:
 };
 
 /** Test for OP_SUCCESSx opcodes as defined by BIP342. */
-bool IsOpSuccess(const opcodetype& opcode);
+bool IsOpSuccess(const opcodetype& opcode, SigVersion sigVersion);
 
 bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode);
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -12,6 +12,7 @@
 #include <script/keyorigin.h>
 #include <script/miniscript.h>
 #include <script/script.h>
+#include <script/sigversion.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <uint256.h>

--- a/src/script/sigversion.h
+++ b/src/script/sigversion.h
@@ -1,0 +1,10 @@
+#ifndef BITCOIN_SCRIPT_SIGVERSION_H
+#define BITCOIN_SCRIPT_SIGVERSION_H
+enum class SigVersion
+{
+    BASE = 0,        //!< Bare scripts and BIP16 P2SH-wrapped redeemscripts
+    WITNESS_V0 = 1,  //!< Witness v0 (P2WPKH and P2WSH); see BIP 141
+    TAPROOT = 2,     //!< Witness v1 with 32-byte program, not BIP16 P2SH-wrapped, key path spending; see BIP 341
+    TAPSCRIPT = 3,   //!< Witness v1 with 32-byte program, not BIP16 P2SH-wrapped, script path spending, leaf version 0xc0; see BIP 342
+};
+#endif // BITCOIN_SCRIPT_SIGVERSION_H

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -4,6 +4,7 @@
 
 #include <pubkey.h>
 #include <script/interpreter.h>
+#include <script/sigversion.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -4,6 +4,7 @@
 
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
+#include <script/sigversion.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -9,6 +9,7 @@
 #include <script/keyorigin.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -4,6 +4,7 @@
 
 #include <pubkey.h>
 #include <script/interpreter.h>
+#include <script/sigversion.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <uint256.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -14,6 +14,7 @@
 #include <script/sigcache.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <script/solver.h>
 #include <streams.h>
 #include <test/util/json.h>
@@ -22,6 +23,7 @@
 #include <test/util/transaction_utils.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
+
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -8,6 +8,7 @@
 #include <hash.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/sigversion.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/data/sighash.json.h>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -19,6 +19,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <script/solver.h>
 #include <streams.h>
 #include <test/util/json.h>

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -7,6 +7,7 @@
 #include <random.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/sigversion.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
 #include <util/chaintype.h>

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -7,6 +7,7 @@
 
 #include <consensus/consensus.h>
 #include <script/interpreter.h>
+#include <script/sigversion.h>
 #include <primitives/transaction.h>
 
 class uint256;

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1140,7 +1140,7 @@ def spenders_taproot_active():
     hashtype = lambda _: random.choice(VALID_SIGHASHES_TAPROOT)
     for opval in range(76, 0x100):
         opcode = CScriptOp(opval)
-        if not is_op_success(opcode):
+        if not is_op_success(opcode, LEAF_VERSION_TAPSCRIPT):
             continue
         scripts = [
             ("bare_success", CScript([opcode])),
@@ -1171,7 +1171,7 @@ def spenders_taproot_active():
     # Non-OP_SUCCESSx (verify that those aren't accidentally treated as OP_SUCCESSx)
     for opval in range(0, 0x100):
         opcode = CScriptOp(opval)
-        if is_op_success(opcode):
+        if is_op_success(opcode, LEAF_VERSION_TAPSCRIPT):
             continue
         scripts = [
             ("normal", CScript([OP_RETURN, opcode] + [OP_NOP] * 75)),

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -923,5 +923,8 @@ def taproot_construct(pubkey, scripts=None, treat_internal_as_infinity=False):
     leaves = dict((name, TaprootLeafInfo(script, version, merklebranch, leaf)) for name, version, script, merklebranch, leaf in ret)
     return TaprootInfo(CScript([OP_1, tweaked]), pubkey, negated + 0, tweak, leaves, h, tweaked)
 
-def is_op_success(o):
-    return o == 0x50 or o == 0x62 or o == 0x89 or o == 0x8a or o == 0x8d or o == 0x8e or (o >= 0x7e and o <= 0x81) or (o >= 0x83 and o <= 0x86) or (o >= 0x95 and o <= 0x99) or (o >= 0xbb and o <= 0xfe)
+def is_op_success(o, sig_version):
+    if (sig_version == LEAF_VERSION_TAPSCRIPT):
+        return o == 0x50 or o == 0x62 or o == 0x89 or o == 0x8a or o == 0x8d or o == 0x8e or (o >= 0x7e and o <= 0x81) or (o >= 0x83 and o <= 0x86) or (o >= 0x95 and o <= 0x99) or (o >= 0xbb and o <= 0xfe)
+    else:
+        assert False


### PR DESCRIPTION
This PR adds a `SigVersion` parameter to `IsOpSuccess()`. This is needed to make continued progress on #29221 . 

### Problem
As per [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki#rationale)
>Given that OP_SUCCESSx even causes potentially unparseable scripts to pass, it can be used to introduce multi-byte opcodes, or even a completely new scripting language when prefixed with a specific OP_SUCCESSx opcode.

This is occurring on #29221, in [script_assets_test.json](https://github.com/bitcoin-core/qa-assets/blob/main/unit_test_data/script_assets_test.json) there exists a witness redeemScript `de4c`. In #29221 this translates to `OP_GREATHERTHAN64 OP_PUSHDATA1`.

When looking at parsing logic for [`GetScriptOp`](https://github.com/bitcoin/bitcoin/blob/3d52cedb497e0ec029ba3cef95b00169c157d8ae/src/script/script.cpp#L310) we see that `OP_PUSHDATA1` requires a data element following it to specify the push size. Since this is not available, the script fails to parse and thus fails the entire script.

### Solution

Make `IsOpSuccess()` dependent on `SigVersion`. Now for `SigVersion::TAPSCRIPT` leaf versions, we retain the `OP_SUCCESSx` semantics, thus trivially parsing and passing the witness redeemScript `de4c`

If you want to see how this works with #29221, please see this commit that shows this logic working in tandem with the new op codes proposed in the 64 bit arithmetic BIP:

- https://github.com/bitcoin/bips/pull/1538
- https://github.com/Christewart/bitcoin/commits/64bit-arith-script-asset-debug/
