### PR TITLE
refactor: Fix prevector iterator concept issues

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -47,13 +47,14 @@ public:
     typedef const value_type* const_pointer;
 
     class iterator {
-        T* ptr;
+        T* ptr{};
     public:
         typedef Diff difference_type;
         typedef T value_type;
         typedef T* pointer;
         typedef T& reference;
         typedef std::random_access_iterator_tag iterator_category;
+        iterator() = default;
         iterator(T* ptr_) : ptr(ptr_) {}
         T& operator*() const { return *ptr; }
         T* operator->() const { return ptr; }
@@ -77,13 +78,14 @@ public:
     };
 
     class reverse_iterator {
-        T* ptr;
+        T* ptr{};
     public:
         typedef Diff difference_type;
         typedef T value_type;
         typedef T* pointer;
         typedef T& reference;
         typedef std::bidirectional_iterator_tag iterator_category;
+        reverse_iterator() = default;
         reverse_iterator(T* ptr_) : ptr(ptr_) {}
         T& operator*() { return *ptr; }
         const T& operator*() const { return *ptr; }
@@ -98,13 +100,14 @@ public:
     };
 
     class const_iterator {
-        const T* ptr;
+        const T* ptr{};
     public:
         typedef Diff difference_type;
         typedef const T value_type;
         typedef const T* pointer;
         typedef const T& reference;
         typedef std::random_access_iterator_tag iterator_category;
+        const_iterator() = default;
         const_iterator(const T* ptr_) : ptr(ptr_) {}
         const_iterator(iterator x) : ptr(&(*x)) {}
         const T& operator*() const { return *ptr; }
@@ -128,13 +131,14 @@ public:
     };
 
     class const_reverse_iterator {
-        const T* ptr;
+        const T* ptr{};
     public:
         typedef Diff difference_type;
         typedef const T value_type;
         typedef const T* pointer;
         typedef const T& reference;
         typedef std::bidirectional_iterator_tag iterator_category;
+        const_reverse_iterator() = default;
         const_reverse_iterator(const T* ptr_) : ptr(ptr_) {}
         const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
         const T& operator*() const { return *ptr; }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -65,6 +65,7 @@ public:
         iterator operator--(int) { iterator copy(*this); --(*this); return copy; }
         difference_type friend operator-(iterator a, iterator b) { return (&(*a) - &(*b)); }
         iterator operator+(size_type n) const { return iterator(ptr + n); }
+        iterator friend operator+(size_type n, iterator x) { return x + n; }
         iterator& operator+=(size_type n) { ptr += n; return *this; }
         iterator operator-(size_type n) const { return iterator(ptr - n); }
         iterator& operator-=(size_type n) { ptr -= n; return *this; }
@@ -116,6 +117,7 @@ public:
         const_iterator operator--(int) { const_iterator copy(*this); --(*this); return copy; }
         difference_type friend operator-(const_iterator a, const_iterator b) { return (&(*a) - &(*b)); }
         const_iterator operator+(size_type n) const { return const_iterator(ptr + n); }
+        const_iterator friend operator+(size_type n, const_iterator x) { return x + n; }
         const_iterator& operator+=(size_type n) { ptr += n; return *this; }
         const_iterator operator-(size_type n) const { return const_iterator(ptr - n); }
         const_iterator& operator-=(size_type n) { ptr -= n; return *this; }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -58,16 +58,15 @@ public:
         iterator(T* ptr_) : ptr(ptr_) {}
         T& operator*() const { return *ptr; }
         T* operator->() const { return ptr; }
-        T& operator[](size_type pos) { return ptr[pos]; }
-        const T& operator[](size_type pos) const { return ptr[pos]; }
+        T& operator[](size_type pos) const { return ptr[pos]; }
         iterator& operator++() { ptr++; return *this; }
         iterator& operator--() { ptr--; return *this; }
         iterator operator++(int) { iterator copy(*this); ++(*this); return copy; }
         iterator operator--(int) { iterator copy(*this); --(*this); return copy; }
         difference_type friend operator-(iterator a, iterator b) { return (&(*a) - &(*b)); }
-        iterator operator+(size_type n) { return iterator(ptr + n); }
+        iterator operator+(size_type n) const { return iterator(ptr + n); }
         iterator& operator+=(size_type n) { ptr += n; return *this; }
-        iterator operator-(size_type n) { return iterator(ptr - n); }
+        iterator operator-(size_type n) const { return iterator(ptr - n); }
         iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(iterator x) const { return ptr == x.ptr; }
         bool operator!=(iterator x) const { return ptr != x.ptr; }
@@ -87,10 +86,8 @@ public:
         typedef std::bidirectional_iterator_tag iterator_category;
         reverse_iterator() = default;
         reverse_iterator(T* ptr_) : ptr(ptr_) {}
-        T& operator*() { return *ptr; }
-        const T& operator*() const { return *ptr; }
-        T* operator->() { return ptr; }
-        const T* operator->() const { return ptr; }
+        T& operator*() const { return *ptr; }
+        T* operator->() const { return ptr; }
         reverse_iterator& operator--() { ptr++; return *this; }
         reverse_iterator& operator++() { ptr--; return *this; }
         reverse_iterator operator++(int) { reverse_iterator copy(*this); ++(*this); return copy; }
@@ -118,9 +115,9 @@ public:
         const_iterator operator++(int) { const_iterator copy(*this); ++(*this); return copy; }
         const_iterator operator--(int) { const_iterator copy(*this); --(*this); return copy; }
         difference_type friend operator-(const_iterator a, const_iterator b) { return (&(*a) - &(*b)); }
-        const_iterator operator+(size_type n) { return const_iterator(ptr + n); }
+        const_iterator operator+(size_type n) const { return const_iterator(ptr + n); }
         const_iterator& operator+=(size_type n) { ptr += n; return *this; }
-        const_iterator operator-(size_type n) { return const_iterator(ptr - n); }
+        const_iterator operator-(size_type n) const { return const_iterator(ptr - n); }
         const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(const_iterator x) const { return ptr == x.ptr; }
         bool operator!=(const_iterator x) const { return ptr != x.ptr; }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -53,7 +53,8 @@ public:
         typedef T value_type;
         typedef T* pointer;
         typedef T& reference;
-        typedef std::random_access_iterator_tag iterator_category;
+        using element_type = T;
+        using iterator_category = std::contiguous_iterator_tag;
         iterator() = default;
         iterator(T* ptr_) : ptr(ptr_) {}
         T& operator*() const { return *ptr; }
@@ -104,7 +105,8 @@ public:
         typedef const T value_type;
         typedef const T* pointer;
         typedef const T& reference;
-        typedef std::random_access_iterator_tag iterator_category;
+        using element_type = const T;
+        using iterator_category = std::contiguous_iterator_tag;
         const_iterator() = default;
         const_iterator(const T* ptr_) : ptr(ptr_) {}
         const_iterator(iterator x) : ptr(&(*x)) {}


### PR DESCRIPTION
Currently prevector iterators have many issues:

* Forward iterators (and stronger) must be default constructible (https://eel.is/c++draft/forward.iterators#1.2). Otherwise, some functions can not be instantiated, like `std::minmax_element`.
* Various `const` issues with random access iterators. For example, a `const iterator` is different from a `const_iterator`, because the first one holds a mutable reference and must also return it without `const`. Also, `operator+` must be callable regardless of the iterator object's `const`-ness.
* When adding an offset to random access iterators, both `x+n` and `n+x` must be specified, see https://eel.is/c++draft/random.access.iterators#tab:randomaccessiterator

Fix all issues.

Also, upgrade the `std::random_access_iterator_tag` (C++17) to `std::contiguous_iterator_tag` (C++20)