### PR TITLE
depends: Update libmultiprocess library to fix C++20 macos build error

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=414542f81e0997354b45b8ade13ca144a3e35ff1
+$(package)_version=8da797c5f1644df1bffd84d10c1ae9836dc70d60
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=8542dbaf8c4fce8fd7af6929f5dc9b34dffa51c43e9ee360e93ee0f34b180bc2
+$(package)_sha256_hash=030f4d393d2ac9deba98d2e1973e22fc439ffc009d5f8ae3225c90639f86beb0
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds


### PR DESCRIPTION
Fixes #29248

The std::result_of type was removed in c++20, but was being referenced in some old, unused code in the library. The issue was fixed in:

- https://github.com/chaincodelabs/libmultiprocess/pull/91

This update also includes other recent libmultiprocess changes to improve C++20 support and fix build issues:

- https://github.com/chaincodelabs/libmultiprocess/pull/89
- https://github.com/chaincodelabs/libmultiprocess/pull/90
- https://github.com/chaincodelabs/libmultiprocess/pull/93
