### PR TITLE
test: p2p: check disconnect due to lack of desirable service flags

### DIFF
--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test P2P behaviour during the handshake phase (VERSION, VERACK messages).
+"""
+import itertools
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.messages import (
+    NODE_NETWORK,
+    NODE_NONE,
+    NODE_P2P_V2,
+    NODE_WITNESS,
+)
+from test_framework.p2p import P2PInterface
+
+
+# usual desirable service flags for outbound non-pruned peers
+DESIRABLE_SERVICE_FLAGS = NODE_NETWORK | NODE_WITNESS
+
+
+class P2PHandshakeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def add_outbound_connection(self, node, connection_type, services, wait_for_disconnect):
+        peer = node.add_outbound_p2p_connection(
+            P2PInterface(), p2p_idx=0, wait_for_disconnect=wait_for_disconnect,
+            connection_type=connection_type, services=services,
+            supports_v2_p2p=self.options.v2transport, advertise_v2_p2p=self.options.v2transport)
+        if not wait_for_disconnect:
+            # check that connection is alive past the version handshake and disconnect manually
+            peer.sync_with_ping()
+            peer.peer_disconnect()
+            peer.wait_for_disconnect()
+
+    def test_desirable_service_flags(self, node, service_flag_tests, expect_disconnect):
+        """Check that connecting to a peer either fails or succeeds depending on its offered
+           service flags in the VERSION message. The test is exercised for all relevant
+           outbound connection types where the desirable service flags check is done."""
+        CONNECTION_TYPES = ["outbound-full-relay", "block-relay-only", "addr-fetch"]
+        for conn_type, services in itertools.product(CONNECTION_TYPES, service_flag_tests):
+            if self.options.v2transport:
+                services |= NODE_P2P_V2
+            expected_result = "disconnect" if expect_disconnect else "connect"
+            self.log.info(f'    - services 0x{services:08x}, type "{conn_type}" [{expected_result}]')
+            if expect_disconnect:
+                expected_debug_log = f'does not offer the expected services ' \
+                        f'({services:08x} offered, {DESIRABLE_SERVICE_FLAGS:08x} expected)'
+                with node.assert_debug_log([expected_debug_log]):
+                    self.add_outbound_connection(node, conn_type, services, wait_for_disconnect=True)
+            else:
+                self.add_outbound_connection(node, conn_type, services, wait_for_disconnect=False)
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.log.info("Check that lacking desired service flags leads to disconnect (non-pruned peers)")
+        self.test_desirable_service_flags(node, [NODE_NONE, NODE_NETWORK, NODE_WITNESS], expect_disconnect=True)
+        self.test_desirable_service_flags(node, [NODE_NETWORK | NODE_WITNESS], expect_disconnect=False)
+
+        self.log.info("Check that feeler connections get disconnected immediately")
+        with node.assert_debug_log([f"feeler connection completed"]):
+            self.add_outbound_connection(node, "feeler", NODE_NONE, wait_for_disconnect=True)
+
+
+if __name__ == '__main__':
+    P2PHandshakeTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -46,6 +46,7 @@ MAX_PROTOCOL_MESSAGE_LENGTH = 4000000  # Maximum length of incoming protocol mes
 MAX_HEADERS_RESULTS = 2000  # Number of headers sent in one getheaders result
 MAX_INV_SIZE = 50000  # Maximum number of entries in an 'inv' protocol message
 
+NODE_NONE = 0
 NODE_NETWORK = (1 << 0)
 NODE_BLOOM = (1 << 2)
 NODE_WITNESS = (1 << 3)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -726,7 +726,7 @@ class TestNode():
 
         return p2p_conn
 
-    def add_outbound_p2p_connection(self, p2p_conn, *, wait_for_verack=True, p2p_idx, connection_type="outbound-full-relay", supports_v2_p2p=None, advertise_v2_p2p=None, **kwargs):
+    def add_outbound_p2p_connection(self, p2p_conn, *, wait_for_verack=True, wait_for_disconnect=False, p2p_idx, connection_type="outbound-full-relay", supports_v2_p2p=None, advertise_v2_p2p=None, **kwargs):
         """Add an outbound p2p connection from node. Must be an
         "outbound-full-relay", "block-relay-only", "addr-fetch" or "feeler" connection.
 
@@ -773,7 +773,7 @@ class TestNode():
         if reconnect:
             p2p_conn.wait_for_reconnect()
 
-        if connection_type == "feeler":
+        if connection_type == "feeler" or wait_for_disconnect:
             # feeler connections are closed as soon as the node receives a `version` message
             p2p_conn.wait_until(lambda: p2p_conn.message_count["version"] == 1, check_connected=False)
             p2p_conn.wait_until(lambda: not p2p_conn.is_connected, check_connected=False)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -395,6 +395,8 @@ BASE_SCRIPTS = [
     'rpc_getdescriptorinfo.py',
     'rpc_mempool_info.py',
     'rpc_help.py',
+    'p2p_handshake.py',
+    'p2p_handshake.py --v2transport',
     'feature_dirsymlinks.py',
     'feature_help.py',
     'feature_shutdown.py',


### PR DESCRIPTION
This PR adds missing test coverage for disconnecting peers which don't offer the desirable service flags in their VERSION message:
https://github.com/bitcoin/bitcoin/blob/5f3a0574c45477288bc678b15f24940486084576/src/net_processing.cpp#L3384-L3389
This check is relevant for the connection types "outbound-full-relay", "block-relay-only" and "addr-fetch" (see `CNode::ExpectServicesFromConn(...)`). Feeler connections always disconnect, which is also tested here.

In lack of finding a proper file where this test would fit in, I created a new one. Happy to take suggestions there.