### PR TITLE
depends: Ensure definitions are passed when building SQLite with `DEBUG=1`

### DIFF
--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -12,9 +12,9 @@ $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_config_opts_debug=--enable-debug
-$(package)_cflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
-$(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
-$(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
+$(package)_cppflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cppflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
+$(package)_cppflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
The SQLite build system overrides the `CFLAGS` when is configured with the `--enable-debug` option.

Amends https://github.com/bitcoin/bitcoin/pull/25987.

Otherwise, for example in OSS-Fuzz, the testing binaries diverge from the release ones.