### PR TITLE
Choose earliest-activatable as tie breaker between equal-work chains

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4041,7 +4041,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(const std::vector<CBlockHeader>& 
         if (IsInitialBlockDownload() && ppindex && *ppindex) {
             const CBlockIndex& last_accepted{**ppindex};
             const int64_t blocks_left{(GetTime() - last_accepted.GetBlockTime()) / GetConsensus().nPowTargetSpacing};
-            const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
+            const double progress{100.0 * (last_accepted.nHeight + 1) / (last_accepted.nHeight + 1 + blocks_left)};
             LogPrintf("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
         }
     }

--- a/test/functional/feature_chain_tiebreaks.py
+++ b/test/functional/feature_chain_tiebreaks.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that the correct active block is chosen in complex reorgs."""
+
+from test_framework.blocktools import create_block
+from test_framework.messages import CBlockHeader
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class ChainTiebreaksTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    @staticmethod
+    def send_headers(node, blocks):
+        """Submit headers for blocks to node."""
+        for block in blocks:
+            # Use RPC rather than P2P, to prevent the message from being interpreted as a block
+            # announcement.
+            node.submitheader(hexdata=CBlockHeader(block).serialize().hex())
+
+    def run_test(self):
+        node = self.nodes[0]
+        # Add P2P connection to bitcoind
+        peer = node.add_p2p_connection(P2PDataStore())
+
+        self.log.info('Precomputing blocks')
+        #
+        #          /- B3 -- B7
+        #        B1      \- B8
+        #       /  \
+        #      /    \ B4 -- B9
+        #   B0           \- B10
+        #      \
+        #       \  /- B5
+        #        B2
+        #          \- B6
+        #
+        blocks = []
+
+        # Construct B0, building off genesis.
+        start_height = node.getblockcount()
+        blocks.append(create_block(
+            hashprev=int(node.getbestblockhash(), 16),
+            tmpl={"height": start_height + 1}
+        ))
+        blocks[-1].solve()
+
+        # Construct B1-B10.
+        for i in range(1, 11):
+            blocks.append(create_block(
+                hashprev=int(blocks[(i - 1) >> 1].hash, 16),
+                tmpl={
+                    "height": start_height + (i + 1).bit_length(),
+                    # Make sure each block has a different hash.
+                    "curtime": blocks[-1].nTime + 1,
+                }
+            ))
+            blocks[-1].solve()
+
+        self.log.info('Make sure B0 is accepted normally')
+        peer.send_blocks_and_test([blocks[0]], node, success=True)
+        # B0 must be active chain now.
+        assert_equal(node.getbestblockhash(), blocks[0].hash)
+
+        self.log.info('Send B1 and B2 headers, and then blocks in opposite order')
+        self.send_headers(node, blocks[1:3])
+        peer.send_blocks_and_test([blocks[2]], node, success=True)
+        peer.send_blocks_and_test([blocks[1]], node, success=False)
+        # B2 must be active chain now, as full data for B2 was received first.
+        assert_equal(node.getbestblockhash(), blocks[2].hash)
+
+        self.log.info('Send all further headers in order')
+        self.send_headers(node, blocks[3:])
+        # B2 is still the active chain, headers don't change this.
+        assert_equal(node.getbestblockhash(), blocks[2].hash)
+
+        self.log.info('Send blocks B7-B10')
+        peer.send_blocks_and_test([blocks[7]], node, success=False)
+        peer.send_blocks_and_test([blocks[8]], node, success=False)
+        peer.send_blocks_and_test([blocks[9]], node, success=False)
+        peer.send_blocks_and_test([blocks[10]], node, success=False)
+        # B2 is still the active chain, as B7-B10 have missing parents.
+        assert_equal(node.getbestblockhash(), blocks[2].hash)
+
+        self.log.info('Send parents B3-B4 of B8-B10 in reverse order')
+        peer.send_blocks_and_test([blocks[4]], node, success=False, force_send=True)
+        peer.send_blocks_and_test([blocks[3]], node, success=False, force_send=True)
+        # B9 is now active. Despite B7 being received earlier, the missing parent.
+        assert_equal(node.getbestblockhash(), blocks[9].hash)
+
+        self.log.info('Invalidate B9-B10')
+        node.invalidateblock(blocks[9].hash)
+        node.invalidateblock(blocks[10].hash)
+        # B7 is now active.
+        assert_equal(node.getbestblockhash(), blocks[7].hash)
+
+if __name__ == '__main__':
+    ChainTiebreaksTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -354,6 +354,7 @@ BASE_SCRIPTS = [
     'feature_includeconf.py',
     'feature_addrman.py',
     'feature_asmap.py',
+    'feature_chain_tiebreaks.py',
     'feature_fastprune.py',
     'mempool_unbroadcast.py',
     'mempool_compatibility.py',


### PR DESCRIPTION
## UPDATE: the concern mentioned below doesn't exist, see comments below.

### Current logic

Since #3370, our logic for deciding which chain is active has been:
1. Among chains for which all transactions have been received, and are not known to contain invalid blocks...
2. Pick the one with the highest cumulative work.
3. If there are multiple such chaintips, pick the one for which the tip was received first (full block data, not just the header)

The reason for this last condition is protecting against block withholding. If an attacker manages to mine a block, quickly spread its header around the network but withhold the full block data, they can wait until a competing miner finds their block, at which point they broadcast the full block data. If rule (3) would use "earliest received header" as condition, they'd be able to retroactively make their block win.

### Remaining issue

It appears to me however that strictly speaking, the tie-breaker (3) doesn't fully solve this. It is still possible to play the same withholding game, but with an extra block depth:

```mermaid
graph RL
   a1["A"];
   b1["B"];
   c1["C"];
   b2["B'"];
   c2["C'"];
   c1 --> b1 --> a1;
   c2 --> b2 --> a1;
```

The attacker mines blocks B and C in secret, broadcasts the header of B, and the full block data of C. Other miners cannot build on top of this (except empty blocks). As soon as the rest of the network catches up (by mining B' and C'), the attacker broadcasts B. With the current logic, the attacker's A-B-C chain will become the active chain.

I consider this very hard to pull off, as it requires a full block advantage already, and headers do not propagate through the network on their own. Still, it deserves addressing.

### Solution

This pull requests replaces the tie-breaker (3) "earliest received tip" with "earliest activateable chain", as in: among the acceptable chains according to (2), pick the one for which the *entire* chain was received first.

Abstractly, the condition can be described as:
* Assign with each block a "timedata", the sorted high to low list of all timestamps at which all the blocks' ancestors were received.
* Among the (2) acceptable chaintips, pick the one which has the lowest timedata (comparing lexicographically after sorting).

In practice this is implemented by finding the maximum sequence value in each chain since the fork point between them, and then picking the one with the lowest maximum.