### PR TITLE
Update build-unix.md - add boost library

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -44,7 +44,7 @@ Finally, clang (often less resource hungry) can be used instead of gcc, which is
 
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+    sudo apt-get install build-essential libboost-all-dev libtool autotools-dev automake pkg-config bsdmainutils python3
 
 Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 


### PR DESCRIPTION
`libboost-all-dev` is needed to compile on Debian stable (Bookworm).


