### PR TITLE
CKey: add Serialize and Unserialize

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -204,6 +204,7 @@ public:
     ECDHSecret ComputeBIP324ECDHSecret(const EllSwiftPubKey& their_ellswift,
                                        const EllSwiftPubKey& our_ellswift,
                                        bool initiating) const;
+
     /** Compute a KeyPair
      *
      *  Wraps a `secp256k1_keypair` type.
@@ -220,6 +221,31 @@ public:
      *                               Merkle root of the script tree).
      */
     KeyPair ComputeKeyPair(const uint256* merkle_root) const;
+
+    /** Straight-forward serialization of key bytes (and compressed flag).
+     *  Use GetPrivKey() for OpenSSL compatible DER encoding.
+     */
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        if (!IsValid()) {
+            throw std::ios_base::failure("invalid key");
+        }
+        s << fCompressed;
+        ::Serialize(s, Span{*this});
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> fCompressed;
+        MakeKeyData();
+        s >> Span{*keydata};
+        if (!Check(keydata->data())) {
+            ClearKeyData();
+            throw std::ios_base::failure("invalid key");
+        }
+    }
 };
 
 CKey GenerateRandomKey(bool compressed = true) noexcept;

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -386,4 +386,27 @@ BOOST_AUTO_TEST_CASE(key_schnorr_tweak_smoke_test)
     secp256k1_context_destroy(secp256k1_context_sign);
 }
 
+BOOST_AUTO_TEST_CASE(key_serialization)
+{
+    {
+        DataStream s{};
+        CKey key;
+        BOOST_CHECK_EXCEPTION(s << key, std::ios_base::failure,
+                              HasReason{"invalid key"});
+
+        s << MakeByteSpan(std::vector<std::byte>(33, std::byte(0)));
+        BOOST_CHECK_EXCEPTION(s >> key, std::ios_base::failure,
+                              HasReason{"invalid key"});
+    }
+
+    for (bool compressed : {true, false}) {
+        CKey key{GenerateRandomKey(/*compressed=*/compressed)};
+        DataStream s{};
+        s << key;
+        CKey key_copy;
+        s >> key_copy;
+        BOOST_CHECK(key == key_copy);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In #28983 I need to read and write two private keys to/from disk that are used by Stratum v2 peers to (optionally) authenticate us.

For the write part, I initially just put the key data into a `std::vector<unsigned char>` and then used a modified version of `WriteBinaryFile`. But @vasild pointed out in #29229 that:

> `CKey` stores sensitive data and takes care to wipe it from memory when freed. In #28983 `Read/WriteBinaryData()` is used in a way that defeats that - the sensitive data will be copied to a temporary variable (ordinary `std::vector`) for IO. Can we change `Read/WriteBinaryData()` to operate directly on `CKey` in such a way that data goes directly from `CKey` to the disk?

This PR tries a different approach that hopefully addresses that. See https://github.com/Sjors/bitcoin/pull/32 for how it's used (in `sv2_template_provider.cpp`).