### PR TITLE
RBF: Require unconfirmed inputs to come from a single conflicting transaction

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -87,28 +87,57 @@ std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx,
                                                const CTxMemPool::setEntries& iters_conflicting)
 {
     AssertLockHeld(pool.cs);
-    std::set<uint256> parents_of_conflicts;
-    for (const auto& mi : iters_conflicting) {
-        for (const CTxIn& txin : mi->GetTx().vin) {
-            parents_of_conflicts.insert(txin.prevout.hash);
+
+    // Rule #2: We don't want to accept replacements that require low feerate junk to be
+    // mined first.  Ideally we'd keep track of the ancestor feerates and make the decision
+    // based on that, but for now requiring all new inputs to be confirmed works.
+    //
+    // Furthermore, to avoid replacing an existing transaction with a worse
+    // transaction, we also require all unconfirmed inputs to come from a
+    // *single* replaced transaction. Otherwise you could replace a desirable
+    // transaction, and an undesirable transaction, with a single undesirable
+    // transaction.
+    //
+    // Note that if you relax this to make RBF a little more useful, this may break the
+    // CalculateMempoolAncestors RBF relaxation which subtracts the conflict count/size from the
+    // descendant limit.
+
+    // First, identify all unconfirmed inputs that the replacement transaction
+    // has.
+    std::set<COutPoint> unconfirmed_prevouts;
+    for (unsigned int j = 0; j < tx.vin.size(); j++) {
+        // Rather than check the UTXO set - potentially expensive - it's cheaper to just check
+        // if the new input refers to a tx that's in the mempool.
+        if (pool.exists(GenTxid::Txid(tx.vin[j].prevout.hash))) {
+            unconfirmed_prevouts.insert(tx.vin[j].prevout);
         }
     }
 
-    for (unsigned int j = 0; j < tx.vin.size(); j++) {
-        // Rule #2: We don't want to accept replacements that require low feerate junk to be
-        // mined first.  Ideally we'd keep track of the ancestor feerates and make the decision
-        // based on that, but for now requiring all new inputs to be confirmed works.
-        //
-        // Note that if you relax this to make RBF a little more useful, this may break the
-        // CalculateMempoolAncestors RBF relaxation which subtracts the conflict count/size from the
-        // descendant limit.
-        if (!parents_of_conflicts.count(tx.vin[j].prevout.hash)) {
-            // Rather than check the UTXO set - potentially expensive - it's cheaper to just check
-            // if the new input refers to a tx that's in the mempool.
-            if (pool.exists(GenTxid::Txid(tx.vin[j].prevout.hash))) {
-                return strprintf("replacement %s adds unconfirmed input, idx %d",
-                                 tx.GetHash().ToString(), j);
+    if (!unconfirmed_prevouts.empty()) {
+        // The replacement has unconfirmed inputs. Check if they all came from
+        // a single replaced transaction.
+        for (const auto& mi : iters_conflicting) {
+            bool found_unconfirmed_prevout = false;
+            for (const CTxIn& txin : mi->GetTx().vin) {
+                if (unconfirmed_prevouts.erase(txin.prevout)) {
+                    found_unconfirmed_prevout = true;
+                }
             }
+
+            // We've fully processed *a* replaced transaction that had
+            // unconfirmed prevouts. We can quit now, as any further
+            // unconfirmed outputs are either from another replaced
+            // transaction - not allowed - or entirely new.
+            if (found_unconfirmed_prevout) {
+                break;
+            }
+        }
+
+        // By putting this check here, we handle the case where
+        // iters_conflicting is empty.
+        if (!unconfirmed_prevouts.empty()) {
+            return strprintf("replacement %s adds unconfirmed input(s)",
+                             tx.GetHash().ToString());
         }
     }
     return std::nullopt;

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -63,7 +63,8 @@ std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx, CTxMem
     EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 
 /** The replacement transaction may only include an unconfirmed input if that input was included in
- * one of the original transactions.
+ * one of the original transactions, and only one of the original transactions
+ * may have unconfirmed inputs.
  * @returns error message if tx spends unconfirmed inputs not also spent by iters_conflicting,
  * otherwise std::nullopt. */
 std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx, const CTxMemPool& pool,


### PR DESCRIPTION
Extends BIP-125 Rule #2 slightly. Rational: if we allow unconfirmed inputs to come from multiple conflicts, we could allow a desirable transaction, and an undesirable transaction, to be replaced by a single undesirable transaction.

This solves the same problem that https://github.com/bitcoin/bitcoin/pull/26451 was intended to solve, in a simpler way.

May not actually be worth adding to Bitcoin Core, as other solutions are coming. But I wrote the code for my [replace-by-fee-rate work](https://petertodd.org/2024/one-shot-replace-by-fee-rate), where it fixes the infinite replacement cycle issue @murchandamus outlines [here](https://stacker.news/items/393182), so I figured I might as well open a pull-req.