### PR TITLE
depends: patch libool out of libnatpmp/miniupnpc

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -16,7 +16,6 @@ darwin_CXX:=$(shell xcrun -f clang++) -stdlib=libc++ -isysroot$(shell xcrun --sh
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)
-darwin_LIBTOOL:=$(shell xcrun -f libtool)
 darwin_OTOOL:=$(shell xcrun -f otool)
 darwin_NM:=$(shell xcrun -f nm)
 darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -6,7 +6,6 @@ $(1)_objc=$$($$($(1)_type)_OBJC)
 $(1)_objcxx=$$($$($(1)_type)_OBJCXX)
 $(1)_ar=$$($$($(1)_type)_AR)
 $(1)_ranlib=$$($$($(1)_type)_RANLIB)
-$(1)_libtool=$$($$($(1)_type)_LIBTOOL)
 $(1)_nm=$$($$($(1)_type)_NM)
 $(1)_cflags=$$($$($(1)_type)_CFLAGS) \
             $$($$($(1)_type)_$$(release_type)_CFLAGS)

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -39,7 +39,7 @@ llvm_config_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-config")
 llvm_lib_dir=$(shell $(llvm_config_prog) --libdir)
 endif
 
-cctools_TOOLS=AR RANLIB STRIP NM LIBTOOL OTOOL INSTALL_NAME_TOOL DSYMUTIL
+cctools_TOOLS=AR RANLIB STRIP NM OTOOL INSTALL_NAME_TOOL DSYMUTIL
 
 # Make-only lowercase function
 lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -7,7 +7,6 @@ default_host_CXX = $(host_toolchain)g++
 default_host_AR = $(host_toolchain)ar
 default_host_RANLIB = $(host_toolchain)ranlib
 default_host_STRIP = $(host_toolchain)strip
-default_host_LIBTOOL = $(host_toolchain)libtool
 default_host_NM = $(host_toolchain)nm
 default_host_OBJCOPY = $(host_toolchain)objcopy
 
@@ -39,5 +38,5 @@ host_$1 = $$($(host_arch)_$(host_os)_$1)
 host_$(release_type)_$1 = $$($(host_arch)_$(host_os)_$(release_type)_$1)
 endef
 
-$(foreach tool,CC CXX AR RANLIB STRIP LIBTOOL NM OBJCOPY OTOOL INSTALL_NAME_TOOL DSYMUTIL,$(eval $(call add_host_tool_func,$(tool))))
+$(foreach tool,CC CXX AR RANLIB STRIP NM OBJCOPY OTOOL INSTALL_NAME_TOOL DSYMUTIL,$(eval $(call add_host_tool_func,$(tool))))
 $(foreach flags,CFLAGS CXXFLAGS CPPFLAGS LDFLAGS, $(eval $(call add_host_flags_func,$(flags))))

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -74,7 +74,6 @@ These variables may be set to override or append their default values.
     $(package)_objcxx
     $(package)_ar
     $(package)_ranlib
-    $(package)_libtool
     $(package)_nm
     $(package)_cflags
     $(package)_cxxflags

--- a/depends/packages/libnatpmp.mk
+++ b/depends/packages/libnatpmp.mk
@@ -3,12 +3,16 @@ $(package)_version=07004b97cf691774efebe70404cf22201e4d330d
 $(package)_download_path=https://github.com/miniupnp/libnatpmp/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=9321953ceb39d07c25463e266e50d0ae7b64676bb3a986d932b18881ed94f1fb
+$(package)_patches=no_libtool.patch
 
 define $(package)_set_vars
   $(package)_build_opts=CC="$($(package)_cc)"
   $(package)_build_opts_mingw32=CPPFLAGS=-DNATPMP_STATICLIB
-  $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
   $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/no_libtool.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -3,20 +3,20 @@ $(package)_version=2.2.2
 $(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
-$(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch
+$(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch no_libtool.patch
 
 # Next time this package is updated, ensure that _WIN32_WINNT is still properly set.
 # See discussion in https://github.com/bitcoin/bitcoin/pull/25964.
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
-$(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
 $(package)_build_opts_mingw32=-f Makefile.mingw CFLAGS="$($(package)_cflags) -D_WIN32_WINNT=0x0601"
 $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
 endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch && \
-  patch -p1 < $($(package)_patch_dir)/respect_mingw_cflags.patch
+  patch -p1 < $($(package)_patch_dir)/respect_mingw_cflags.patch && \
+  patch -p1 < $($(package)_patch_dir)/no_libtool.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/libnatpmp/no_libtool.patch
+++ b/depends/patches/libnatpmp/no_libtool.patch
@@ -1,0 +1,15 @@
+diff -ruN libnatpmp-07004b97cf691774efebe70404cf22201e4d330d/Makefile libnatpmp-07004b97cf691774efebe70404cf22201e4d330d.new/Makefile
+--- libnatpmp-07004b97cf691774efebe70404cf22201e4d330d/Makefile	2022-07-05 07:49:50.000000000 +0000
++++ libnatpmp-07004b97cf691774efebe70404cf22201e4d330d.new/Makefile	2024-01-23 20:59:35.674821779 +0000
+@@ -197,11 +197,7 @@
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+ 
+ $(STATICLIB):	$(LIBOBJS)
+-ifneq (, $(findstring darwin, $(OS)))
+-	$(LIBTOOL) -static -o $@ $?
+-else
+ 	$(AR) crs $@ $?
+-endif
+ 
+ $(SHAREDLIB):	$(LIBOBJS)
+ ifneq (, $(findstring darwin, $(OS)))

--- a/depends/patches/miniupnpc/no_libtool.patch
+++ b/depends/patches/miniupnpc/no_libtool.patch
@@ -1,0 +1,15 @@
+diff -ruN miniupnpc-2.2.2/Makefile miniupnpc-2.2.2.new/Makefile
+--- miniupnpc-2.2.2/Makefile	2020-11-27 18:25:02.000000000 +0000
++++ miniupnpc-2.2.2.new/Makefile	2024-01-23 20:58:08.387188527 +0000
+@@ -298,11 +298,7 @@
+ 	makedepend -Y -- $(CFLAGS) -- $(SRCS) 2>/dev/null
+ 
+ $(LIBRARY):	$(LIBOBJS)
+-ifneq (, $(findstring darwin, $(OS)))
+-	$(LIBTOOL) -static -o $@ $?
+-else
+ 	$(AR) crs $@ $?
+-endif
+ 
+ $(SHAREDLIBRARY):	$(LIBOBJS)
+ ifneq (, $(findstring darwin, $(OS)))


### PR DESCRIPTION
An alternative to https://github.com/bitcoin/bitcoin/pull/29232

Rather than switching to the CMake builds which [proved problematic](https://github.com/bitcoin/bitcoin/pull/29232#issuecomment-1898513919), do the quick and dirty thing of just patching out libtool. Doesn't seem to introduce any new issues.

This should buy us time to upstream the necessary CMake fixes.