### PR TITLE
fuzz: Exit and log stderr for parse_test_list errors

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -372,8 +372,8 @@ def parse_test_list(*, fuzz_bin):
             'PRINT_ALL_FUZZ_TARGETS_AND_ABORT': ''
         },
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
         text=True,
+        check=True,
     ).stdout.splitlines()
     return test_list_all
 


### PR DESCRIPTION
We should log all errors that occur when attempting to print the harness list in the fuzz test runner.