### PR TITLE
doc: update `BroadcastTransaction` comment

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -32,7 +32,7 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
 
 TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
-    // BroadcastTransaction can be called by either sendrawtransaction RPC or the wallet.
+    // BroadcastTransaction can be called by RPC or by the wallet.
     // chainman, mempool and peerman are initialized before the RPC server and wallet are started
     // and reset after the RPC sever and wallet are stopped.
     assert(node.chainman);


### PR DESCRIPTION
`BroadcastTransaction` is also called by `submitpackage` RPC.

All transactions that are accepted into the mempool post package processing are broadcasted to peers individually here
https://github.com/bitcoin/bitcoin/blob/ea4ddd8652d9dd1e7698e2a6f84c606cf24a2e3e/src/rpc/mempool.cpp#L926


It's not maintainable to list all the callers of a function.

 



