### PR TITLE
test: Check object hashes in wait_for_getheaders

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1410,7 +1410,7 @@ class FullBlockTest(BitcoinTestFramework):
         # an INV for the next block and receive two getheaders - one for the
         # IBD and one for the INV. We'd respond to both and could get
         # unexpectedly disconnected if the DoS score for that error is 50.
-        self.helper_peer.wait_for_getheaders(timeout=timeout)
+        self.helper_peer.wait_for_getheaders(hash_stop=0, timeout=timeout)
 
     def reconnect_p2p(self, timeout=60):
         """Tear down and bootstrap the P2P connection to the node.

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -308,7 +308,7 @@ class MiningTest(BitcoinTestFramework):
 
         # Should ask for the block from a p2p node, if they announce the header as well:
         peer = node.add_p2p_connection(P2PDataStore())
-        peer.wait_for_getheaders(timeout=5)  # Drop the first getheaders
+        peer.wait_for_getheaders(hash_stop=0, timeout=5)  # Drop the first getheaders
         peer.send_blocks_and_test(blocks=[block], node=node)
         # Must be active now:
         assert chain_tip(block.hash, status='active', branchlen=0) in node.getchaintips()

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -40,7 +40,7 @@ class HeadersSyncTest(BitcoinTestFramework):
         peer1 = self.nodes[0].add_p2p_connection(P2PInterface())
 
         # Wait for peer1 to receive a getheaders
-        peer1.wait_for_getheaders()
+        peer1.wait_for_getheaders(hash_stop=0)
         # An empty reply will clear the outstanding getheaders request,
         # allowing additional getheaders requests to be sent to this peer in
         # the future.
@@ -67,7 +67,7 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.announce_random_block(all_peers)
 
         self.log.info("Check that peer1 receives a getheaders in response")
-        peer1.wait_for_getheaders()
+        peer1.wait_for_getheaders(hash_stop=0)
         peer1.send_message(msg_headers()) # Send empty response, see above
         with p2p_lock:
             peer1.last_message.pop("getheaders", None)
@@ -89,14 +89,14 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.announce_random_block(all_peers)
 
         self.log.info("Check that peer1 receives a getheaders in response")
-        peer1.wait_for_getheaders()
+        peer1.wait_for_getheaders(hash_stop=0)
 
         self.log.info("Check that the remaining peer received a getheaders as well")
         expected_peer = peer2
         if peer2 == peer_receiving_getheaders:
             expected_peer = peer3
 
-        expected_peer.wait_for_getheaders()
+        expected_peer.wait_for_getheaders(hash_stop=0)
 
         self.log.info("Success!")
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -198,7 +198,7 @@ class TestP2PConn(P2PInterface):
             self.send_message(msg)
         else:
             self.send_message(msg_inv(inv=[CInv(MSG_BLOCK, block.sha256)]))
-            self.wait_for_getheaders()
+            self.wait_for_getheaders(hash_stop=0)
             self.send_message(msg)
         self.wait_for_getdata([block.sha256])
 

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -334,7 +334,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
-                    test_node.wait_for_getheaders()
+                    test_node.wait_for_getheaders(hash_stop=0)
                     # Should have received a getheaders now
                     test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
@@ -536,7 +536,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with p2p_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[1]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(hash_stop=0)
             test_node.send_header_for_blocks(blocks)
             test_node.wait_for_getdata([x.sha256 for x in blocks])
             [test_node.send_message(msg_block(x)) for x in blocks]
@@ -559,7 +559,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with p2p_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(hash_stop=0)
 
         # Next header will connect, should re-set our count:
         test_node.send_header_for_blocks([blocks[0]])
@@ -574,7 +574,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with p2p_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i % len(blocks)]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(hash_stop=0)
 
         # Eventually this stops working.
         test_node.send_header_for_blocks([blocks[-1]])

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -524,15 +524,15 @@ class P2PInterface(P2PConnection):
 
         self.wait_until(test_function, timeout=timeout)
 
-    def wait_for_getheaders(self, timeout=60):
+    def wait_for_getheaders(self, hash_stop, timeout=60):
         """Waits for a getheaders message.
 
-        Receiving any getheaders message will satisfy the predicate. the last_message["getheaders"]
-        value must be explicitly cleared before calling this method, or this will return
-        immediately with success. TODO: change this method to take a hash value and only
-        return true if the correct block header has been requested."""
+        The object hashes in the hashstop  must match the provided hash_stop."""
         def test_function():
-            return self.last_message.get("getheaders")
+            last_headers = self.last_message.get("getheaders")
+            if not last_headers:
+                return False
+            return last_headers.hashstop == hash_stop
 
         self.wait_until(test_function, timeout=timeout)
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/18614

Previously, wait_for_getheaders only looked for the presence of a recent "getheaders" message. Additionally checking the hashstop inside the message should make tests involving wait_for_getheaders more robust.

This PR is progress towards closing issue: https://github.com/bitcoin/bitcoin/issues/18614  after PR: https://github.com/bitcoin/bitcoin/pull/18690 (merged) which introduced this check for wait_for_getdata 