### PR TITLE
addrman: delete addresses that don't belong to the supported networks

### DIFF
--- a/doc/release-notes-29330.md
+++ b/doc/release-notes-29330.md
@@ -1,0 +1,7 @@
+New settings
+============
+
+New flag `-cleanupaddrman` has been added
+to control whether addresses that do not
+belong to the supported networks should be
+deleted during initialization.

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -200,6 +200,9 @@ public:
     //! Update an entry's service bits.
     void SetServices(const CService& addr, ServiceFlags nServices);
 
+    //! Delete addresses from addrman that are not from the specified networks
+    void DeleteAddresses(const std::set<Network>& networks);
+
     /** Test-only function
      * Find the address record in AddrMan and return information about its
      * position.

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -141,6 +141,9 @@ public:
     void SetServices(const CService& addr, ServiceFlags nServices)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
+    void DeleteAddresses(const std::set<Network>& networks)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
     std::optional<AddressPosition> FindAddressEntry(const CAddress& addr)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
@@ -268,6 +271,8 @@ private:
     void Connected_(const CService& addr, NodeSeconds time) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     void SetServices_(const CService& addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    void DeleteAddresses_(const std::set<Network>& addresses) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     void ResolveCollisions_() EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -131,6 +131,25 @@ static void AddrManSelectByNetwork(benchmark::Bench& bench)
     });
 }
 
+static void AddrManDeleteAddresses(benchmark::Bench& bench)
+{
+    AddrMan addrman{EMPTY_NETGROUPMAN, /*deterministic=*/false, ADDRMAN_CONSISTENCY_CHECK_RATIO};
+
+    // add single I2P address to new table
+    CService i2p_service;
+    i2p_service.SetSpecial("udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p");
+    CAddress i2p_address(i2p_service, NODE_NONE);
+    i2p_address.nTime = Now<NodeSeconds>();
+    const CNetAddr source{LookupHost("252.2.2.2", false).value()};
+    addrman.Add({i2p_address}, source);
+
+    FillAddrMan(addrman);
+    const std::set<Network> network = {NET_I2P};
+    bench.run([&] {
+        (void)addrman.DeleteAddresses(network);
+    });
+}
+
 static void AddrManGetAddr(benchmark::Bench& bench)
 {
     AddrMan addrman{EMPTY_NETGROUPMAN, /*deterministic=*/false, ADDRMAN_CONSISTENCY_CHECK_RATIO};
@@ -170,6 +189,7 @@ static void AddrManAddThenGood(benchmark::Bench& bench)
 }
 
 BENCHMARK(AddrManAdd, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AddrManDeleteAddresses, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManSelect, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManSelectFromAlmostEmpty, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManSelectByNetwork, benchmark::PriorityLevel::HIGH);

--- a/src/net.h
+++ b/src/net.h
@@ -99,6 +99,8 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
 static constexpr bool DEFAULT_V2_TRANSPORT{false};
 
+static constexpr bool DEFAULT_CLEANUP_ADDRMAN{false};
+
 typedef int64_t NodeId;
 
 struct AddedNodeParams {

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -165,6 +165,24 @@ class AddrmanTest(BitcoinTestFramework):
             self.start_node(0)
         assert_equal(self.nodes[0].getnodeaddresses(), [])
 
+        self.log.info("Check -cleanupaddrman cleans up undesired addresses")
+        addresses = [
+            "1.65.195.98",
+            "2001:41f0::62:6974:636f:696e",
+            "2bqghnldu6mcug4pikzprwhtjjnsyederctvci6klcwzepnjd46ikjyd.onion",
+            "255fhcp6ajvftnyo7bwz3an3t4a4brhopm3bamyh2iu5r3gnr2rq.b32.i2p"
+        ]
+
+        for addr in addresses:
+            assert_equal(self.nodes[0].addpeeraddress(address=addr, port=8333), {"success": True})
+
+        self.restart_node(0, ["-cleanupaddrman", "-onlynet=ipv6"])
+        addrman_info = self.nodes[0].getaddrmaninfo()
+        for network, values in addrman_info.items():
+            if network not in ["ipv6", "all_networks"]:
+                assert_equal(values['total'], 0)
+            else:
+                assert_equal(values['total'], 1)
 
 if __name__ == "__main__":
     AddrmanTest().main()


### PR DESCRIPTION
This PR adds a new flag `-cleanupaddrman`. When initializing a node with this flag, it will delete addresses from addrman (both new and tried tables) that do not belong to the supported networks (e.g. `-onlynet`). Deleting addresses that do not belong to the supported networks can avoid a lot of unnecessary addrman `Select` calls (especially when turning from clearnet + Tor/I2P/CJDNS to Tor/I2P/CJDNS).

1. This flag is not enabled by default, if user intends to go back to the previous network, just do not set it.
2. Addresses from non-supported networks will naturely be replaced in addrman since we only store addresses from networks we support (cleaning up them on init is a way to avoid spending resources on it).
3. Avoiding these addresses in addrman can avoid exceeding the maximum number of tries in `ThreadOpenConnections`.
```cpp
// If we didn't find an appropriate destination after trying 100 addresses fetched from addrman,
// stop this loop, and let the outer loop run again (which sleeps, adds seed nodes, recalculates
// already-connected network ranges, ...) before trying new addrman addresses.
nTries++;
if (nTries > 100)
    break;
```  
4. Specially turning from clearnet + Tor/I2P/CJDNS to Tor/I2P/CJDNS, this feature it will ensure we will relay more addresses from these networks to other peers.

