### PR TITLE
redeclare nChainTx to use uint64_t

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -177,13 +177,12 @@ public:
 
     //! (memory only) Number of transactions in the chain up to and including this block.
     //! This value will be non-zero only if and only if transactions for this block and all its parents are available.
-    //! Change to 64-bit type before 2024 (assuming worst case of 60 byte transactions).
     //!
     //! Note: this value is faked during use of a UTXO snapshot because we don't
     //! have the underlying block data available during snapshot load.
     //! @sa AssumeutxoData
     //! @sa ActivateSnapshot
-    unsigned int nChainTx{0};
+    uint64_t nChainTx{0};
 
     //! Verification status of this block. See enum BlockStatus
     //!

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -69,7 +69,7 @@ struct AssumeutxoData {
  */
 struct ChainTxData {
     int64_t nTime;    //!< UNIX timestamp of last known number of transactions
-    int64_t nTxCount; //!< total number of transactions between genesis and that timestamp
+    uint64_t nTxCount; //!< total number of transactions between genesis and that timestamp
     double dTxRate;   //!< estimated number of transactions per second after that timestamp
 };
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -72,7 +72,7 @@ FUZZ_TARGET(utxo_snapshot, .init = initialize_chain)
         Assert(*chainman.ActiveChainstate().m_from_snapshot_blockhash ==
                *chainman.SnapshotBlockhash());
         const auto& coinscache{chainman.ActiveChainstate().CoinsTip()};
-        int64_t chain_tx{};
+        uint64_t chain_tx{};
         for (const auto& block : *g_chain) {
             Assert(coinscache.HaveCoin(COutPoint{block->vtx.at(0)->GetHash(), 0}));
             const auto* index{chainman.m_blockman.LookupBlockIndex(block->GetHash())};


### PR DESCRIPTION
Following up on https://github.com/bitcoin/bitcoin/issues/29258 the type of ```nChainTx``` has now been changed to a ```uint64_t``` allowing for the counting of TXs well into the future. The note about changing the type in 2024 was also removed. This passes all extended tests.