### PR TITLE
Add missed `config/bitcoin-config.h` header

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -5,6 +5,10 @@
 
 #include <wallet/walletdb.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <common/system.h>
 #include <key_io.h>
 #include <protocol.h>


### PR DESCRIPTION
The `config/bitcoin-config.h` header is required to provide definitions for the `USE_BDB` and `USE_SQLITE` macros.

While this header might be included indirectly elsewhere, including it explicitly makes the build process more robust.