### PR TITLE
refactor: Remove nChainTx from consensus

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -303,7 +303,7 @@ public:
     std::string ToString() const;
 
     //! Check whether this block index entry is valid up to the passed validity level.
-    bool IsValid(enum BlockStatus nUpTo = BLOCK_VALID_TRANSACTIONS) const
+    bool IsValid(BlockStatus nUpTo) const
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
@@ -323,7 +323,7 @@ public:
 
     //! Raise the validity level of this block index entry.
     //! Returns true if the validity was changed.
-    bool RaiseValidity(enum BlockStatus nUpTo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    bool RaiseValidity(BlockStatus nUpTo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
         assert(!(nUpTo & ~BLOCK_VALID_MASK)); // Only validity flags allowed.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1478,7 +1478,7 @@ void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, c
                 return;
             }
             if (pindex->nStatus & BLOCK_HAVE_DATA || (activeChain && activeChain->Contains(pindex))) {
-                if (activeChain && pindex->HaveNumChainTxs())
+                if (activeChain && pindex->IsValidTransactionsTree())
                     state->pindexLastCommonBlock = pindex;
             } else if (!IsBlockRequested(pindex->GetBlockHash())) {
                 // The block is not already downloaded, and not yet in flight.
@@ -2279,8 +2279,8 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         LOCK(cs_main);
         const CBlockIndex* pindex = m_chainman.m_blockman.LookupBlockIndex(inv.hash);
         if (pindex) {
-            if (pindex->HaveNumChainTxs() && !pindex->IsValid(BLOCK_VALID_SCRIPTS) &&
-                    pindex->IsValid(BLOCK_VALID_TREE)) {
+            if (!pindex->IsValid(BLOCK_VALID_SCRIPTS) &&
+                    pindex->IsValidTransactionsTree()) {
                 // If we have the block and all of its parents, but have not yet validated it,
                 // we might be in the middle of connecting it (ie in the unlock of cs_main
                 // before ActivateBestChain but after AcceptBlock).

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -30,7 +30,7 @@ FUZZ_TARGET(chain)
         (void)disk_block_index->GetMedianTimePast();
         (void)disk_block_index->GetUndoPos();
         (void)disk_block_index->HaveNumChainTxs();
-        (void)disk_block_index->IsValid();
+        (void)disk_block_index->IsValid(BLOCK_VALID_TRANSACTIONS);
     }
 
     const CBlockHeader block_header = disk_block_index->GetBlockHeader();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3535,7 +3535,7 @@ void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex) {
 
     // Remove the invalidity flag from this block and all its descendants.
     for (auto& [_, block_index] : m_blockman.m_block_index) {
-        if (!block_index.IsValid() && block_index.GetAncestor(nHeight) == pindex) {
+        if (!block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.GetAncestor(nHeight) == pindex) {
             block_index.nStatus &= ~BLOCK_FAILED_MASK;
             m_blockman.m_dirty_blockindex.insert(&block_index);
             if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.HaveNumChainTxs() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), &block_index)) {


### PR DESCRIPTION
`nChainTx` is returned by RPCs and is used to estimate (sync and rescan) progress.

However, it is also used for consensus and P2P logic to denote that a block and all its parents have `BLOCK_VALID_TRANSACTIONS` set.

This is confusing, because:

* It would be clearer to use the `BlockStatus` enum for this as well.
* It requires AssumeUtxo to fake the `nChainTx` values.
* It makes it harder to remove `nChainTx` completely, or limit it to code that needs it (estimate sync and scan progress and report it on RPC).

Fix it by introducing a new `BLOCK_VALID_TRANSACTIONS_TREE` level and use it where possible.