### PR TITLE
test: fixes flaky wallet_import_rescan functional test

### DIFF
--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -147,6 +147,7 @@ AMOUNT_DUST = 0.00000546
 
 def get_rand_amount():
     r = random.uniform(AMOUNT_DUST, 1)
+    r = AMOUNT_DUST
     return Decimal(str(round(r, 8)))
 
 
@@ -273,7 +274,7 @@ class ImportRescanTest(BitcoinTestFramework):
             variant.key = self.nodes[1].dumpprivkey(variant.address["address"])
             # Ensure output is large enough to pay for fees: conservatively assuming txsize of
             # 500 vbytes and feerate of 20 sats/vbytes
-            variant.initial_amount = max(get_rand_amount(), (500 * 20 / COIN) + AMOUNT_DUST)
+            variant.initial_amount = max(get_rand_amount(), round((500 * 20 / COIN) + AMOUNT_DUST), 8)
             variant.initial_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.initial_amount)
             variant.confirmation_height = 0
             variant.timestamp = timestamp


### PR DESCRIPTION
wallet_import_rescan is, potentially, not rounding values used for `sendtoaddress` in one of the test cases. Under normal conditions, the value is randomly picked and rounded to 8 decimal positions, however, for this specific case the value is limited to a maximum value that is not properly rounded. If that value happens to be picked, the test will fail.

I noticed this in a completely unrelated PR where the test failed: https://cirrus-ci.com/task/5467779164274688?logs=ci#L2684

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
