### PR TITLE
doc: Assert that assumed-valid blocks are not fully valid in CheckBlockIndex()

### DIFF
--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -93,11 +93,15 @@ CreateAndActivateUTXOSnapshot(
             while (pindex && pindex != chain.m_chain.Tip()) {
                 pindex->nStatus &= ~BLOCK_HAVE_DATA;
                 pindex->nStatus &= ~BLOCK_HAVE_UNDO;
-                // We have to set the ASSUMED_VALID flag, because otherwise it
+                // Set the ASSUMED_VALID flag, because otherwise it
                 // would not be possible to have a block index entry without HAVE_DATA
                 // and with nTx > 0 (since we aren't setting the pruned flag);
+                // Also, downgrade from BLOCK_VALID_SCRIPTS, because
+                // assumed-valid can not be set for fully-valid blocks.
                 // see CheckBlockIndex().
                 pindex->nStatus |= BLOCK_ASSUMED_VALID;
+                pindex->nStatus &= ~BLOCK_VALID_SCRIPTS;
+                pindex->RaiseValidity(BLOCK_VALID_TREE);
                 pindex = pindex->pprev;
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4925,6 +4925,8 @@ void ChainstateManager::CheckBlockIndex()
             assert(pindex->nTx > 0);
             // Assumed-valid blocks should connect to the main chain.
             assert((pindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_TREE);
+            // Assumed-valid blocks should not be fully valid.
+            assert((pindex->nStatus & BLOCK_VALID_MASK) < BLOCK_VALID_SCRIPTS);
         } else {
             // Otherwise there should only be an nTx value if we have
             // actually seen a block's transactions.


### PR DESCRIPTION
It does not make sense for a block to be fully-valid and assumed-valid at the same time.

Check it in `CheckBlockIndex()` and fix the tests that violate this assumption.