### PR TITLE
test: Drop `x` modifier in `fsbridge::fopen` call for MinGW builds

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -29,7 +29,14 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullpt"});
     }
     {
-        AutoFile xor_file{raw_file("wbx"), xor_pat};
+#ifdef __MINGW64__
+        // Our usage of mingw-w64 and the msvcrt runtime does not support
+        // the x modifier for the _wfopen().
+        const char* mode = "wb";
+#else
+        const char* mode = "wbx";
+#endif
+        AutoFile xor_file{raw_file(mode), xor_pat};
         xor_file << test1 << test2;
     }
     {


### PR DESCRIPTION
The MinGW-w64 toolchain links executables to the old msvcrt C Runtime Library that does not support the `x` modifier for the [`_wfopen()`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170) function.

Fixes https://github.com/bitcoin/bitcoin/issues/29014.