### PR TITLE
test: Fix CPartialMerkleTree.nTransactions signedness

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1063,7 +1063,7 @@ class CPartialMerkleTree:
         self.vBits = []
 
     def deserialize(self, f):
-        self.nTransactions = int.from_bytes(f.read(4), "little", signed=True)
+        self.nTransactions = int.from_bytes(f.read(4), "little")
         self.vHash = deser_uint256_vector(f)
         vBytes = deser_string(f)
         self.vBits = []
@@ -1072,7 +1072,7 @@ class CPartialMerkleTree:
 
     def serialize(self):
         r = b""
-        r += self.nTransactions.to_bytes(4, "little", signed=True)
+        r += self.nTransactions.to_bytes(4, "little")
         r += ser_uint256_vector(self.vHash)
         vBytesArray = bytearray([0x00] * ((len(self.vBits) + 7)//8))
         for i in range(len(self.vBits)):


### PR DESCRIPTION
It is unsigned in Bitcoin Core, so the tests should match it:

https://github.com/bitcoin/bitcoin/blob/aa9231fafe45513134ec8953a217cda07446fae8/src/merkleblock.h#L59


Large positive values, or "negative" values, are rejected anyway, but it still seems fine to fix this.

The bug was introduced when the code was written in d280617bf569f84457eaea546541dc74c67cd1e4.

(Lowercase `i` means signed, see https://docs.python.org/3/library/struct.html#format-characters)