### PR TITLE
refactor: Remove excess reserve() call for SecureString

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -83,14 +83,12 @@ void AskPassphraseDialog::setModel(WalletModel *_model)
 
 void AskPassphraseDialog::accept()
 {
-    SecureString oldpass, newpass1, newpass2;
     if (!model && mode != Encrypt)
         return;
 
-    oldpass.assign(std::string_view{ui->passEdit1->text().toStdString()});
-    newpass1.assign(std::string_view{ui->passEdit2->text().toStdString()});
-    newpass2.assign(std::string_view{ui->passEdit3->text().toStdString()});
-
+    const SecureString oldpass{ui->passEdit1->text().toStdString()};
+    const SecureString newpass1{ui->passEdit2->text().toStdString()};
+    const SecureString newpass2{ui->passEdit3->text().toStdString()};
     secureClearPassFields();
 
     switch(mode)

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -86,9 +86,6 @@ void AskPassphraseDialog::accept()
     SecureString oldpass, newpass1, newpass2;
     if (!model && mode != Encrypt)
         return;
-    oldpass.reserve(MAX_PASSPHRASE_SIZE);
-    newpass1.reserve(MAX_PASSPHRASE_SIZE);
-    newpass2.reserve(MAX_PASSPHRASE_SIZE);
 
     oldpass.assign(std::string_view{ui->passEdit1->text().toStdString()});
     newpass1.assign(std::string_view{ui->passEdit2->text().toStdString()});

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -213,7 +213,6 @@ void WalletControllerActivity::showProgressDialog(const QString& title_text, con
 CreateWalletActivity::CreateWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
     : WalletControllerActivity(wallet_controller, parent_widget)
 {
-    m_passphrase.reserve(MAX_PASSPHRASE_SIZE);
 }
 
 CreateWalletActivity::~CreateWalletActivity()

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -48,7 +48,6 @@ RPCHelpMan walletpassphrase()
 
         // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
         SecureString strWalletPass;
-        strWalletPass.reserve(100);
         strWalletPass = std::string_view{request.params[0].get_str()};
 
         // Get the timeout
@@ -141,11 +140,9 @@ RPCHelpMan walletpassphrasechange()
     LOCK2(pwallet->m_relock_mutex, pwallet->cs_wallet);
 
     SecureString strOldWalletPass;
-    strOldWalletPass.reserve(100);
     strOldWalletPass = std::string_view{request.params[0].get_str()};
 
     SecureString strNewWalletPass;
-    strNewWalletPass.reserve(100);
     strNewWalletPass = std::string_view{request.params[1].get_str()};
 
     if (strOldWalletPass.empty() || strNewWalletPass.empty()) {
@@ -261,7 +258,6 @@ RPCHelpMan encryptwallet()
     LOCK2(pwallet->m_relock_mutex, pwallet->cs_wallet);
 
     SecureString strWalletPass;
-    strWalletPass.reserve(100);
     strWalletPass = std::string_view{request.params[0].get_str()};
 
     if (strWalletPass.empty()) {

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -47,8 +47,7 @@ RPCHelpMan walletpassphrase()
         }
 
         // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
-        SecureString strWalletPass;
-        strWalletPass = std::string_view{request.params[0].get_str()};
+        const SecureString strWalletPass{request.params[0].get_str()};
 
         // Get the timeout
         nSleepTime = request.params[1].getInt<int64_t>();
@@ -139,11 +138,8 @@ RPCHelpMan walletpassphrasechange()
 
     LOCK2(pwallet->m_relock_mutex, pwallet->cs_wallet);
 
-    SecureString strOldWalletPass;
-    strOldWalletPass = std::string_view{request.params[0].get_str()};
-
-    SecureString strNewWalletPass;
-    strNewWalletPass = std::string_view{request.params[1].get_str()};
+    const SecureString strOldWalletPass{request.params[0].get_str()};
+    const SecureString strNewWalletPass{request.params[1].get_str()};
 
     if (strOldWalletPass.empty() || strNewWalletPass.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "passphrase cannot be empty");
@@ -257,8 +253,7 @@ RPCHelpMan encryptwallet()
 
     LOCK2(pwallet->m_relock_mutex, pwallet->cs_wallet);
 
-    SecureString strWalletPass;
-    strWalletPass = std::string_view{request.params[0].get_str()};
+    const SecureString strWalletPass{request.params[0].get_str()};
 
     if (strWalletPass.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "passphrase cannot be empty");

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -380,7 +380,6 @@ static RPCHelpMan createwallet()
         flags |= WALLET_FLAG_BLANK_WALLET;
     }
     SecureString passphrase;
-    passphrase.reserve(100);
     std::vector<bilingual_str> warnings;
     if (!request.params[3].isNull()) {
         passphrase = std::string_view{request.params[3].get_str()};
@@ -787,7 +786,6 @@ static RPCHelpMan migratewallet()
             }
 
             SecureString wallet_pass;
-            wallet_pass.reserve(100);
             if (!request.params[1].isNull()) {
                 wallet_pass = std::string_view{request.params[1].get_str()};
             }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -379,14 +379,11 @@ static RPCHelpMan createwallet()
     if (!request.params[2].isNull() && request.params[2].get_bool()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
     }
-    SecureString passphrase;
+    const SecureString passphrase{!request.params[3].isNull() ? request.params[3].get_str() : ""};
     std::vector<bilingual_str> warnings;
-    if (!request.params[3].isNull()) {
-        passphrase = std::string_view{request.params[3].get_str()};
-        if (passphrase.empty()) {
-            // Empty string means unencrypted
-            warnings.emplace_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
-        }
+    if (!request.params[3].isNull() && passphrase.empty()) {
+        // Empty string means unencrypted
+        warnings.emplace_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
     }
 
     if (!request.params[4].isNull() && request.params[4].get_bool()) {
@@ -785,10 +782,7 @@ static RPCHelpMan migratewallet()
                 wallet_name = request.params[0].get_str();
             }
 
-            SecureString wallet_pass;
-            if (!request.params[1].isNull()) {
-                wallet_pass = std::string_view{request.params[1].get_str()};
-            }
+            const SecureString wallet_pass{!request.params[1].isNull() ? request.params[1].get_str() : ""};
 
             WalletContext& context = EnsureWalletContext(request.context);
             util::Result<MigrationResult> res = MigrateLegacyToDescriptor(wallet_name, wallet_pass, context);


### PR DESCRIPTION
This PR removes excess `reserve()` call for `SecureString`

Call `reverse` was introduced when `std::string` was used. For `std::string`, this makes sense as it prevents re-allocation when the string's size increases to prevent a situation that memory will be re-allocated and "zeroing" will clean only the latest region, but not all of them.
However, with the use of a custom allocator, this call is no longer necessary; `secure_allocator` from `support/allocators/secure.h` ensures that all re-allocation would be safely re-written and secret passphrase won't stay in memory.