### PR TITLE
wallet: Set descriptors flag after migrating blank wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4257,6 +4257,9 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
         success = local_wallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET);
         if (!success) {
             success = DoMigration(*local_wallet, context, error, res);
+        } else {
+            // Make sure that descriptors flag is actually set
+            local_wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         }
     }
 

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -881,7 +881,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         assert_equal(wallet.getwalletinfo()["blank"], True)
         wallet.migratewallet()
         assert_equal(wallet.getwalletinfo()["blank"], True)
-
+        assert_equal(wallet.getwalletinfo()["descriptors"], True)
 
     def test_avoidreuse(self):
         self.log.info("Test that avoidreuse persists after migration")


### PR DESCRIPTION
While rebasing #28710 after #28976 was merged, I realized that although blank wallets were being moved to sqlite, `WALLET_FLAG_DESCRIPTORS` was not being set so those blank wallets would still continue to be treated as legacy wallets.

To fix that, just set the descriptor flags for blank wallets. Also added a test to catch this.