### PR TITLE
refactor: Allow CScript construction from any std::input_iterator

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_PREVECTOR_H
 #define BITCOIN_PREVECTOR_H
 
-#include <assert.h>
-#include <cstdlib>
-#include <stdint.h>
-#include <string.h>
-
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
 #include <type_traits>
 #include <utility>
 
@@ -210,7 +210,7 @@ private:
         std::fill_n(dst, count, value);
     }
 
-    template<typename InputIterator>
+    template <std::input_iterator InputIterator>
     void fill(T* dst, InputIterator first, InputIterator last) {
         while (first != last) {
             new(static_cast<void*>(dst)) T(*first);
@@ -229,7 +229,7 @@ public:
         fill(item_ptr(0), n, val);
     }
 
-    template<typename InputIterator>
+    template <std::input_iterator InputIterator>
     void assign(InputIterator first, InputIterator last) {
         size_type n = last - first;
         clear();
@@ -252,7 +252,7 @@ public:
         fill(item_ptr(0), n, val);
     }
 
-    template<typename InputIterator>
+    template <std::input_iterator InputIterator>
     prevector(InputIterator first, InputIterator last) {
         size_type n = last - first;
         change_capacity(n);
@@ -381,7 +381,7 @@ public:
         fill(item_ptr(p), count, value);
     }
 
-    template<typename InputIterator>
+    template <std::input_iterator InputIterator>
     void insert(iterator pos, InputIterator first, InputIterator last) {
         size_type p = pos - begin();
         difference_type count = last - first;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -50,7 +50,6 @@ public:
         T* ptr{};
     public:
         typedef Diff difference_type;
-        typedef T value_type;
         typedef T* pointer;
         typedef T& reference;
         using element_type = T;
@@ -102,7 +101,6 @@ public:
         const T* ptr{};
     public:
         typedef Diff difference_type;
-        typedef const T value_type;
         typedef const T* pointer;
         typedef const T& reference;
         using element_type = const T;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -429,11 +429,11 @@ protected:
         }
         return *this;
     }
+
 public:
     CScript() = default;
-    CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
-    CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
-    CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
+    template <std::input_iterator InputIterator>
+    CScript(InputIterator first, InputIterator last) : CScriptBase{first, last} { }
 
     SERIALIZE_METHODS(CScript, obj) { READWRITE(AsBase<CScriptBase>(obj)); }
 


### PR DESCRIPTION
Currently only (pre)vector iterators and raw pointers are accepted. However, this makes it harder to construct from input iterators provided by other classes, such as `std::span`.

Fix that.