### PR TITLE
test: fix intermittent failure in `rpc_setban.py --v2transport`, run it in CI

### DIFF
--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the setban rpc call."""
 
+from contextlib import ExitStack
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     p2p_port,
@@ -29,7 +30,13 @@ class SetBanTests(BitcoinTestFramework):
         self.nodes[1].setban("127.0.0.1", "add")
 
         # Node 0 should not be able to reconnect
-        with self.nodes[1].assert_debug_log(expected_msgs=['dropped (banned)\n'], timeout=50):
+        context = ExitStack()
+        context.enter_context(self.nodes[1].assert_debug_log(expected_msgs=['dropped (banned)\n'], timeout=50))
+        # When disconnected right after connecting, a v2 node will attempt to reconnect with v1.
+        # Wait for that to happen so that it cannot mess with later tests.
+        if self.options.v2transport:
+            context.enter_context(self.nodes[0].assert_debug_log(expected_msgs=['trying v1 connection'], timeout=50))
+        with context:
             self.restart_node(1, [])
             self.nodes[0].addnode("127.0.0.1:" + str(p2p_port(1)), "onetry")
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -254,6 +254,7 @@ BASE_SCRIPTS = [
     'p2p_nobloomfilter_messages.py',
     'p2p_filter.py',
     'rpc_setban.py',
+    'rpc_setban.py --v2transport',
     'p2p_blocksonly.py',
     'mining_prioritisetransaction.py',
     'p2p_invalid_locator.py',


### PR DESCRIPTION
This test failed for me on master locally:
The reason is that when initiating a v2 connection and being immediately disconnected, a node cannot know if the disconnect happens because the peer only supports v1, or because it has banned you, so it schedules to reconnect with v1. If the test doesn't wait for that, the reconnect can happen at a bad time, resulting in failure in a later `connect_nodes` call.
Also add the test with `--v2transport` to the test runner because banning with v2 seems like a useful thing to have test coverage for.