### PR TITLE
test: speedup bip324_cipher.py unit test

### DIFF
--- a/test/functional/test_framework/crypto/bip324_cipher.py
+++ b/test/functional/test_framework/crypto/bip324_cipher.py
@@ -25,6 +25,8 @@ def pad16(x):
 
 def aead_chacha20_poly1305_encrypt(key, nonce, aad, plaintext):
     """Encrypt a plaintext using ChaCha20Poly1305."""
+    if plaintext is None:
+        return None
     ret = bytearray()
     msg_len = len(plaintext)
     for i in range((msg_len + 63) // 64):
@@ -42,7 +44,7 @@ def aead_chacha20_poly1305_encrypt(key, nonce, aad, plaintext):
 
 def aead_chacha20_poly1305_decrypt(key, nonce, aad, ciphertext):
     """Decrypt a ChaCha20Poly1305 ciphertext."""
-    if len(ciphertext) < 16:
+    if ciphertext is None or len(ciphertext) < 16:
         return None
     msg_len = len(ciphertext) - 16
     poly1305 = Poly1305(chacha20_block(key, nonce, 0)[:32])
@@ -191,11 +193,11 @@ class TestFrameworkAEAD(unittest.TestCase):
             dec_aead = FSChaCha20Poly1305(key)
 
             for _ in range(msg_idx):
-                enc_aead.encrypt(b"", b"")
+                enc_aead.encrypt(b"", None)
             ciphertext = enc_aead.encrypt(aad, plain)
             self.assertEqual(hex_cipher, ciphertext.hex())
 
             for _ in range(msg_idx):
-                dec_aead.decrypt(b"", bytes(16))
+                dec_aead.decrypt(b"", None)
             plaintext = dec_aead.decrypt(aad, ciphertext)
             self.assertEqual(plain, plaintext)


### PR DESCRIPTION
Executing the unit tests for the bip324_cipher.py module currently takes quite long (>60 seconds on my older notebook). Most time here is spent in empty plaintext/ciphertext encryption/decryption loops in `test_fschacha20poly1305aead`:

https://github.com/bitcoin/bitcoin/blob/9eeee7caa3f95ee17a645e12d330261f8e3c2dbf/test/functional/test_framework/crypto/bip324_cipher.py#L193-L194
https://github.com/bitcoin/bitcoin/blob/9eeee7caa3f95ee17a645e12d330261f8e3c2dbf/test/functional/test_framework/crypto/bip324_cipher.py#L198-L199

Their sole purpose is increasing the FSChaCha20Poly1305 packet counter in order to trigger rekeying, i.e. the actual encryption/decryption is not relevant, as the result is thrown away. This commit speeds up the tests by supporting to pass "None" as plaintext/ciphertext, indicating to the routines that no actual encryption/decryption should be done.

The approach here is a bit hacky, a cleaner alternative would probably be to introduce a special `seek`/`skip_packets` method and not touch the encrypt/decrypt routines, but that seemed overkill to me only for speeding up a unit test. Open for suggestions.

master branch:

```
$ python3 -m unittest ./test/functional/test_framework/crypto/bip324_cipher.py
..
----------------------------------------------------------------------
Ran 2 tests in 64.658s
```
PR branch:

```
$ python3 -m unittest ./test/functional/test_framework/crypto/bip324_cipher.py
..
---------------------------------------------------------------------- 
Ran 2 tests in 0.822s
```