### PR TITLE
test: handle wallet_reorgrestore.py failed

### DIFF
--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -72,6 +72,8 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[2]])
         conflicted = self.nodes[0].gettransaction(conflicted_txid)
         conflicting = self.nodes[0].gettransaction(conflicting_txid)
+        self.nodes[0].syncwithvalidationinterfacequeue()
+        self.nodes[2].syncwithvalidationinterfacequeue()
         assert_equal(conflicted["confirmations"], -9)
         assert_equal(conflicted["walletconflicts"][0], conflicting["txid"])
 


### PR DESCRIPTION
This PR fixes test issue mentioned in https://github.com/bitcoin/bitcoin/issues/29392.