### PR TITLE
rpc: getdescriptorinfo also returns normalized descriptor

### DIFF
--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -181,6 +181,7 @@ static RPCHelpMan getdescriptorinfo()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR, "descriptor", "The descriptor in canonical form, without private keys"},
+                {RPCResult::Type::STR, "normalizeddescriptor", "The normalized descriptor, including the xpub at the last hardened step"},
                 {RPCResult::Type::STR, "checksum", "The checksum for the input descriptor"},
                 {RPCResult::Type::BOOL, "isrange", "Whether the descriptor is ranged"},
                 {RPCResult::Type::BOOL, "issolvable", "Whether the descriptor is solvable"},
@@ -201,8 +202,14 @@ static RPCHelpMan getdescriptorinfo()
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
             }
 
+            std::string normalizedDescriptor;
+            if (!desc->ToNormalizedString(provider, normalizedDescriptor)) {
+                normalizedDescriptor = desc->ToString();
+            }
+
             UniValue result(UniValue::VOBJ);
             result.pushKV("descriptor", desc->ToString());
+            result.pushKV("normalizeddescriptor", normalizedDescriptor);
             result.pushKV("checksum", GetDescriptorChecksum(request.params[0].get_str()));
             result.pushKV("isrange", desc->IsRange());
             result.pushKV("issolvable", desc->IsSolvable());

--- a/test/functional/rpc_getdescriptorinfo.py
+++ b/test/functional/rpc_getdescriptorinfo.py
@@ -20,9 +20,11 @@ class DescriptorTest(BitcoinTestFramework):
         self.wallet_names = []
 
     def test_desc(self, desc, isrange, issolvable, hasprivatekeys):
+        expected_normalized_desc_with_checksum = descsum_create(desc)
         info = self.nodes[0].getdescriptorinfo(desc)
         assert_equal(info, self.nodes[0].getdescriptorinfo(descsum_create(desc)))
         assert_equal(info['descriptor'], descsum_create(desc))
+        assert_equal(info['normalizeddescriptor'], expected_normalized_desc_with_checksum)
         assert_equal(info['isrange'], isrange)
         assert_equal(info['issolvable'], issolvable)
         assert_equal(info['hasprivatekeys'], hasprivatekeys)


### PR DESCRIPTION
This pull request introduces enhancements to the getdescriptorinfo RPC command, specifically by incorporating the functionality to return the `normalized_descriptor` alongside the original `descriptor` information. This improvement addresses the need for a standardized format that facilitates the use of descriptors in public key operations, especially important for scenarios requiring the derivation of addresses without access to private keys.

Related issue: https://github.com/bitcoin/bitcoin/issues/29320