### PR TITLE
test: Fix utxo set hash serialisation signedness

### DIFF
--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test UTXO set hash value calculation in gettxoutsetinfo."""
 
-import struct
-
 from test_framework.messages import (
     CBlock,
     COutPoint,
@@ -58,7 +56,7 @@ class UTXOSetHashTest(BitcoinTestFramework):
                         continue
 
                     data = COutPoint(int(tx.rehash(), 16), n).serialize()
-                    data += struct.pack("<i", height * 2 + coinbase)
+                    data += (height * 2 + coinbase).to_bytes(4, "little")
                     data += tx_out.serialize()
 
                     muhash.insert(data)


### PR DESCRIPTION
It is unsigned in Bitcoin Core, so the tests should match it:

https://github.com/bitcoin/bitcoin/blob/5b8990a1f3c49b0b02b7383c69e95320acbda13e/src/kernel/coinstats.cpp#L54


Large positive values for the block height are too difficult to hit in tests, but it still seems fine to fix this.

The bug was introduced when the code was written in 6ccc8fc067bf516cda7bc5d7d721945be5ac2003.

(Lowercase `i` means signed, see https://docs.python.org/3/library/struct.html#format-characters)