### PR TITLE
test: Fix SegwitV0SignatureMsg nLockTime signedness

### DIFF
--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -747,7 +747,7 @@ def SegwitV0SignatureMsg(script, txTo, inIdx, hashtype, amount):
     ss += struct.pack("<q", amount)
     ss += struct.pack("<I", txTo.vin[inIdx].nSequence)
     ss += ser_uint256(hashOutputs)
-    ss += struct.pack("<i", txTo.nLockTime)
+    ss += txTo.nLockTime.to_bytes(4, "little")
     ss += struct.pack("<I", hashtype)
     return ss
 


### PR DESCRIPTION
It is unsigned in Bitcoin Core, so the tests should match it:

https://github.com/bitcoin/bitcoin/blob/5b8990a1f3c49b0b02b7383c69e95320acbda13e/src/script/interpreter.cpp#L1611

The bug was introduced when the code was written in 330b0f31ee5719d94f9e52dfc83c5d82168241f9.

(Lowercase `i` means signed, see https://docs.python.org/3/library/struct.html#format-characters)