### PR TITLE
test: Remove struct.pack from almost all places

### DIFF
--- a/contrib/seeds/generate-seeds.py
+++ b/contrib/seeds/generate-seeds.py
@@ -115,7 +115,7 @@ def parse_spec(s):
 def ser_compact_size(l):
     r = b""
     if l < 253:
-        r = struct.pack("B", l)
+        r = l.to_bytes(1, "little")
     elif l < 0x10000:
         r = struct.pack("<BH", 253, l)
     elif l < 0x100000000:
@@ -129,10 +129,10 @@ def bip155_serialize(spec):
     Serialize (networkID, addr, port) tuple to BIP155 binary format.
     '''
     r = b""
-    r += struct.pack('B', spec[0].value)
+    r += spec[0].value.to_bytes(1, "little")
     r += ser_compact_size(len(spec[1]))
     r += spec[1]
-    r += struct.pack('>H', spec[2])
+    r += spec[2].to_bytes(2, "big")
     return r
 
 def process_nodes(g, f, structname):

--- a/contrib/seeds/generate-seeds.py
+++ b/contrib/seeds/generate-seeds.py
@@ -29,7 +29,6 @@ These should be pasted into `src/chainparamsseeds.h`.
 
 from base64 import b32decode
 from enum import Enum
-import struct
 import sys
 import os
 import re
@@ -117,11 +116,11 @@ def ser_compact_size(l):
     if l < 253:
         r = l.to_bytes(1, "little")
     elif l < 0x10000:
-        r = struct.pack("<BH", 253, l)
+        r = (253).to_bytes(1, "little") + l.to_bytes(2, "little")
     elif l < 0x100000000:
-        r = struct.pack("<BI", 254, l)
+        r = (254).to_bytes(1, "little") + l.to_bytes(4, "little")
     else:
-        r = struct.pack("<BQ", 255, l)
+        r = (255).to_bytes(1, "little") + l.to_bytes(8, "little")
     return r
 
 def bip155_serialize(spec):

--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -52,10 +52,10 @@ def signet_txs(block, challenge):
     mroot = block.get_merkle_root(hashes)
 
     sd = b""
-    sd += struct.pack("<i", block.nVersion)
+    sd += block.nVersion.to_bytes(4, "little", signed=True)
     sd += ser_uint256(block.hashPrevBlock)
     sd += ser_uint256(mroot)
-    sd += struct.pack("<I", block.nTime)
+    sd += block.nTime.to_bytes(4, "little")
 
     to_spend = CTransaction()
     to_spend.nVersion = 0

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -28,15 +28,15 @@ def serialize_addrman(
     tried = []
     INCOMPATIBILITY_BASE = 32
     r = MAGIC_BYTES[net_magic]
-    r += struct.pack("B", format)
-    r += struct.pack("B", (INCOMPATIBILITY_BASE + lowest_compatible))
+    r += format.to_bytes(1, "little")
+    r += (INCOMPATIBILITY_BASE + lowest_compatible).to_bytes(1, "little")
     r += ser_uint256(bucket_key)
-    r += struct.pack("<i", (len_new or len(new)))
-    r += struct.pack("<i", (len_tried or len(tried)))
+    r += (len_new or len(new)).to_bytes(4, "little", signed=True)
+    r += (len_tried or len(tried)).to_bytes(4, "little", signed=True)
     ADDRMAN_NEW_BUCKET_COUNT = 1 << 10
-    r += struct.pack("<i", (ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30)))
+    r += (ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30)).to_bytes(4, "little", signed=True)
     for _ in range(ADDRMAN_NEW_BUCKET_COUNT):
-        r += struct.pack("<i", (0))
+        r += (0).to_bytes(4, "little", signed=True)
     checksum = hash256(r)
     r += mock_checksum or checksum
     return r

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -6,7 +6,6 @@
 
 import os
 import re
-import struct
 
 from test_framework.messages import ser_uint256, hash256, MAGIC_BYTES
 from test_framework.netutil import ADDRMAN_NEW_BUCKET_COUNT, ADDRMAN_TRIED_BUCKET_COUNT, ADDRMAN_BUCKET_SIZE

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -29,14 +29,14 @@ def serialize_addrman(
     INCOMPATIBILITY_BASE = 32
     r = MAGIC_BYTES[net_magic]
     r += struct.pack("B", format)
-    r += struct.pack("B", INCOMPATIBILITY_BASE + lowest_compatible)
+    r += struct.pack("B", (INCOMPATIBILITY_BASE + lowest_compatible))
     r += ser_uint256(bucket_key)
-    r += struct.pack("<i", len_new or len(new))
-    r += struct.pack("<i", len_tried or len(tried))
+    r += struct.pack("<i", (len_new or len(new)))
+    r += struct.pack("<i", (len_tried or len(tried)))
     ADDRMAN_NEW_BUCKET_COUNT = 1 << 10
-    r += struct.pack("<i", ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30))
+    r += struct.pack("<i", (ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30)))
     for _ in range(ADDRMAN_NEW_BUCKET_COUNT):
-        r += struct.pack("<i", 0)
+        r += struct.pack("<i", (0))
     checksum = hash256(r)
     r += mock_checksum or checksum
     return r

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test block processing."""
 import copy
-import struct
 import time
 
 from test_framework.blocktools import (
@@ -67,7 +66,7 @@ class CBrokenBlock(CBlock):
     def serialize(self, with_witness=False):
         r = b""
         r += super(CBlock, self).serialize()
-        r += struct.pack("<BQ", 255, len(self.vtx))
+        r += (255).to_bytes(1, "little") + len(self.vtx).to_bytes(8, "little")
         for tx in self.vtx:
             if with_witness:
                 r += tx.serialize_with_witness()

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -5,7 +5,6 @@
 """Test node responses to invalid network messages."""
 
 import random
-import struct
 import time
 
 from test_framework.messages import (
@@ -233,7 +232,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
                 '208d'))     # port
 
     def test_addrv2_unrecognized_network(self):
-        now_hex = struct.pack('<I', int(time.time())).hex()
+        now_hex = int(time.time()).to_bytes(4, "little").hex()
         self.test_addrv2('unrecognized network',
             [
                 'received: addrv2 (25 bytes)',

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -5,7 +5,6 @@
 """Test segwit transactions and blocks on P2P network."""
 from decimal import Decimal
 import random
-import struct
 import time
 
 from test_framework.blocktools import (

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -1165,16 +1165,16 @@ class SegWitTest(BitcoinTestFramework):
                 if not self.wit.is_null():
                     flags |= 1
                 r = b""
-                r += struct.pack("<i", self.nVersion)
+                r += self.nVersion.to_bytes(4, "little", signed=True)
                 if flags:
                     dummy = []
                     r += ser_vector(dummy)
-                    r += struct.pack("<B", flags)
+                    r += flags.to_bytes(1, "little")
                 r += ser_vector(self.vin)
                 r += ser_vector(self.vout)
                 if flags & 1:
                     r += self.wit.serialize()
-                r += struct.pack("<I", self.nLockTime)
+                r += self.nLockTime.to_bytes(4, "little")
                 return r
 
         tx2 = BrokenCTransaction()
@@ -1976,11 +1976,11 @@ class SegWitTest(BitcoinTestFramework):
         def serialize_with_bogus_witness(tx):
             flags = 3
             r = b""
-            r += struct.pack("<i", tx.nVersion)
+            r += tx.nVersion.to_bytes(4, "little", signed=True)
             if flags:
                 dummy = []
                 r += ser_vector(dummy)
-                r += struct.pack("<B", flags)
+                r += flags.to_bytes(1, "little")
             r += ser_vector(tx.vin)
             r += ser_vector(tx.vout)
             if flags & 1:
@@ -1990,7 +1990,7 @@ class SegWitTest(BitcoinTestFramework):
                     for _ in range(len(tx.wit.vtxinwit), len(tx.vin)):
                         tx.wit.vtxinwit.append(CTxInWitness())
                 r += tx.wit.serialize()
-            r += struct.pack("<I", tx.nLockTime)
+            r += tx.nLockTime.to_bytes(4, "little")
             return r
 
         class msg_bogus_tx(msg_tx):

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -411,7 +411,7 @@ class P2PConnection(asyncio.Protocol):
             tmsg = self.magic_bytes
             tmsg += msgtype
             tmsg += b"\x00" * (12 - len(msgtype))
-            tmsg += struct.pack("<I", len(data))
+            tmsg += len(data).to_bytes(4, "little")
             th = sha256(data)
             h = sha256(th)
             tmsg += h[:4]

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -8,7 +8,6 @@ This file is modified from python-bitcoinlib.
 """
 
 from collections import namedtuple
-import struct
 import unittest
 
 from .key import TaggedHash, tweak_add_pubkey, compute_xonly_pubkey

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -800,13 +800,13 @@ def BIP341_sha_prevouts(txTo):
     return sha256(b"".join(i.prevout.serialize() for i in txTo.vin))
 
 def BIP341_sha_amounts(spent_utxos):
-    return sha256(b"".join(struct.pack("<q", u.nValue) for u in spent_utxos))
+    return sha256(b"".join(u.nValue.to_bytes(8, "little", signed=True) for u in spent_utxos))
 
 def BIP341_sha_scriptpubkeys(spent_utxos):
     return sha256(b"".join(ser_string(u.scriptPubKey) for u in spent_utxos))
 
 def BIP341_sha_sequences(txTo):
-    return sha256(b"".join(struct.pack("<I", i.nSequence) for i in txTo.vin))
+    return sha256(b"".join(i.nSequence.to_bytes(4, "little") for i in txTo.vin))
 
 def BIP341_sha_outputs(txTo):
     return sha256(b"".join(o.serialize() for o in txTo.vout))

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -58,9 +58,9 @@ class CScriptOp(int):
         elif len(d) <= 0xff:
             return b'\x4c' + bytes([len(d)]) + d  # OP_PUSHDATA1
         elif len(d) <= 0xffff:
-            return b'\x4d' + struct.pack(b'<H', len(d)) + d  # OP_PUSHDATA2
+            return b'\x4d' + struct.pack('<H', len(d)) + d  # OP_PUSHDATA2
         elif len(d) <= 0xffffffff:
-            return b'\x4e' + struct.pack(b'<I', len(d)) + d  # OP_PUSHDATA4
+            return b'\x4e' + struct.pack('<I', len(d)) + d  # OP_PUSHDATA4
         else:
             raise ValueError("Data too long to encode in a PUSHDATA op")
 
@@ -670,7 +670,7 @@ def LegacySignatureMsg(script, txTo, inIdx, hashtype):
         txtmp.vin.append(tmp)
 
     s = txtmp.serialize_without_witness()
-    s += struct.pack(b"<I", hashtype)
+    s += struct.pack("<I", hashtype)
 
     return (s, None)
 

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet balance RPC methods."""
 from decimal import Decimal
-import struct
 
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE as ADDRESS_WATCHONLY
 from test_framework.blocktools import COINBASE_MATURITY
@@ -266,8 +265,8 @@ class WalletTest(BitcoinTestFramework):
         tx_orig = self.nodes[0].gettransaction(txid)['hex']
         # Increase fee by 1 coin
         tx_replace = tx_orig.replace(
-            struct.pack("<q", 99 * 10**8).hex(),
-            struct.pack("<q", 98 * 10**8).hex(),
+            (99 * 10**8).to_bytes(8, "little", signed=True).hex(),
+            (98 * 10**8).to_bytes(8, "little", signed=True).hex(),
         )
         tx_replace = self.nodes[0].signrawtransactionwithwallet(tx_replace)['hex']
         # Total balance is given by the sum of outputs of the tx


### PR DESCRIPTION
`struct.pack` has many issues:

* The format string consists of characters that may be confusing and may need to be looked up in the documentation, as opposed to using easy to understand self-documenting code.

This lead to many test bugs, which weren't hit, which is fine, but still confusing. Ref: https://github.com/bitcoin/bitcoin/pull/29400, https://github.com/bitcoin/bitcoin/pull/29399, https://github.com/bitcoin/bitcoin/pull/29363, fa3886b7c69cbbe564478f30bb2c35e9e6b1cffa, ...

Fix all issues by using the built-in `int` helpers `to_bytes` via a scripted diff.

Review notes:

* For `struct.pack` and `int.to_bytes` the error behavior is the same, although the error messages are not identical.
* Two `struct.pack` remain. One for float serialization in a C++ code comment, and one for native serialization.

