### PR TITLE
rpc: provide per message stats for global traffic via new RPC 'getnetmsgstats'

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -665,7 +665,7 @@ void CNode::CopyStats(CNodeStats& stats)
 }
 #undef X
 
-bool CNode::ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete)
+bool CNode::ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete, NetStats& net_stats)
 {
     complete = false;
     const auto time{NodeClock::now()};
@@ -687,6 +687,12 @@ bool CNode::ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete)
                 // Message deserialization failed. Drop the message but don't disconnect the peer.
                 // store the size of the corrupt message
                 mapRecvBytesPerMsgType.at(NET_MESSAGE_TYPE_OTHER) += msg.m_raw_message_size;
+                net_stats.Record(NetStats::RECV,
+                                 ConnectedThroughNetwork(),
+                                 m_conn_type,
+                                 NET_MESSAGE_TYPE_OTHER,
+                                 /*num_messages=*/1,
+                                 msg.m_raw_message_size);
                 continue;
             }
 
@@ -698,6 +704,12 @@ bool CNode::ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete)
             }
             assert(i != mapRecvBytesPerMsgType.end());
             i->second += msg.m_raw_message_size;
+            net_stats.Record(NetStats::RECV,
+                             ConnectedThroughNetwork(),
+                             m_conn_type,
+                             /*msg_type=*/i->first,
+                             /*num_messages=*/1,
+                             msg.m_raw_message_size);
 
             // push the message to the process queue,
             vRecvMsg.push_back(std::move(msg));
@@ -1604,7 +1616,7 @@ Transport::Info V2Transport::GetInfo() const noexcept
     return info;
 }
 
-std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
+std::pair<size_t, bool> CConnman::SocketSendData(CNode& node)
 {
     auto it = node.vSendMsg.begin();
     size_t nSentSize = 0;
@@ -1617,9 +1629,19 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
             // there is an existing message still being sent, or (for v2 transports) when the
             // handshake has not yet completed.
             size_t memusage = it->GetMemoryUsage();
+            const auto msg_type = it->m_type;
             if (node.m_transport->SetMessageToSend(*it)) {
                 // Update memory usage of send buffer (as *it will be deleted).
+                // We record a message when it is pushed to the transport,
+                // and we record bytes later, incrementally, when they are
+                // actually written to the socket.
                 node.m_send_memusage -= memusage;
+                m_net_stats.Record(NetStats::SENT,
+                                   node.ConnectedThroughNetwork(),
+                                   node.m_conn_type,
+                                   msg_type,
+                                   /*num_messages=*/1,
+                                   /*num_bytes=*/0);
                 ++it;
             }
         }
@@ -1655,6 +1677,12 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
             // Update statistics per message type.
             if (!msg_type.empty()) { // don't report v2 handshake bytes for now
                 node.AccountForSentBytes(msg_type, nBytes);
+                m_net_stats.Record(NetStats::SENT,
+                                   node.ConnectedThroughNetwork(),
+                                   node.m_conn_type,
+                                   msg_type,
+                                   /*num_messages=*/0,
+                                   nBytes);
             }
             nSentSize += nBytes;
             if ((size_t)nBytes != data.size()) {
@@ -2207,7 +2235,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
             if (nBytes > 0)
             {
                 bool notify = false;
-                if (!pnode->ReceiveMsgBytes({pchBuf, (size_t)nBytes}, notify)) {
+                if (!pnode->ReceiveMsgBytes({pchBuf, (size_t)nBytes}, notify, m_net_stats)) {
                     LogDebug(BCLog::NET,
                         "receiving message bytes failed, %s",
                         pnode->DisconnectMsg()
@@ -3953,6 +3981,152 @@ void CConnman::RecordBytesSent(uint64_t bytes)
     }
 
     nMaxOutboundTotalBytesSentInCycle += bytes;
+}
+
+NetStats::NetStats()
+    : m_msg_type_to_index{[]() {
+          MsgTypeToIndex m;
+          size_t i{0};
+          for (const auto& msg_type : ALL_NET_MESSAGE_TYPES) {
+              m[msg_type] = i++;
+          }
+          return m;
+      }()}
+{
+}
+
+void NetStats::Record(Direction direction,
+                      Network net,
+                      ConnectionType conn_type,
+                      const std::string& msg_type,
+                      size_t num_messages,
+                      size_t num_bytes)
+{
+    auto& d = m_data.at(DirectionToIndex(direction))
+                  .at(NetworkToIndex(net))
+                  .at(ConnectionTypeToIndex(conn_type))
+                  .at(MessageTypeToIndex(msg_type));
+    d.count += num_messages;
+    d.bytes += num_bytes;
+}
+
+void NetStats::ForEach(std::function<void(NetStats::Direction dir,
+                                          Network net,
+                                          ConnectionType con,
+                                          const std::string& msg,
+                                          const BytesAndCount& data)> func) const
+{
+    for (size_t dir_i = 0; dir_i < m_data.size(); ++dir_i) {
+        for (size_t net_i = 0; net_i < m_data[dir_i].size(); ++net_i) {
+            for (size_t con_i = 0; con_i < m_data[dir_i][net_i].size(); ++con_i) {
+                for (size_t msg_i = 0; msg_i < m_data[dir_i][net_i][con_i].size(); ++msg_i) {
+                    func(DirectionFromIndex(dir_i),
+                         NetworkFromIndex(net_i),
+                         ConnectionTypeFromIndex(con_i),
+                         MessageTypeFromIndex(msg_i),
+                         m_data[dir_i][net_i][con_i][msg_i]);
+                }
+            }
+        }
+    }
+}
+
+constexpr size_t NetStats::DirectionToIndex(Direction direction)
+{
+    switch (direction) {
+    case SENT: return 0;
+    case RECV: return 1;
+    }
+    assert(false);
+}
+
+constexpr NetStats::Direction NetStats::DirectionFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return SENT;
+    case 1: return RECV;
+    }
+    assert(false);
+}
+
+constexpr size_t NetStats::NetworkToIndex(Network net)
+{
+    switch (net) {
+    case NET_UNROUTABLE: return 0;
+    case NET_IPV4: return 1;
+    case NET_IPV6: return 2;
+    case NET_ONION: return 3;
+    case NET_I2P: return 4;
+    case NET_CJDNS: return 5;
+    case NET_INTERNAL: return 6;
+    case NET_MAX: assert(false);
+    }
+    assert(false);
+}
+
+constexpr Network NetStats::NetworkFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return NET_UNROUTABLE;
+    case 1: return NET_IPV4;
+    case 2: return NET_IPV6;
+    case 3: return NET_ONION;
+    case 4: return NET_I2P;
+    case 5: return NET_CJDNS;
+    case 6: return NET_INTERNAL;
+    }
+    assert(false);
+}
+
+constexpr size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
+{
+    switch (conn_type) {
+    case ConnectionType::INBOUND: return 0;
+    case ConnectionType::OUTBOUND_FULL_RELAY: return 1;
+    case ConnectionType::MANUAL: return 2;
+    case ConnectionType::FEELER: return 3;
+    case ConnectionType::BLOCK_RELAY: return 4;
+    case ConnectionType::ADDR_FETCH: return 5;
+    case ConnectionType::PRIVATE_BROADCAST: return 6;
+    }
+    assert(false);
+}
+
+constexpr ConnectionType NetStats::ConnectionTypeFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return ConnectionType::INBOUND;
+    case 1: return ConnectionType::OUTBOUND_FULL_RELAY;
+    case 2: return ConnectionType::MANUAL;
+    case 3: return ConnectionType::FEELER;
+    case 4: return ConnectionType::BLOCK_RELAY;
+    case 5: return ConnectionType::ADDR_FETCH;
+    case 6: return ConnectionType::PRIVATE_BROADCAST;
+    }
+    assert(false);
+}
+
+size_t NetStats::MessageTypeToIndex(const std::string& msg_type) const
+{
+    auto it = m_msg_type_to_index.find(msg_type);
+    if (it != m_msg_type_to_index.end()) {
+        return it->second;
+    }
+    // Unknown message (NET_MESSAGE_TYPE_OTHER), use the last entry in the array.
+    return ALL_NET_MESSAGE_TYPES.size();
+}
+
+std::string NetStats::MessageTypeFromIndex(size_t index)
+{
+    if (index == ALL_NET_MESSAGE_TYPES.size()) {
+        return NET_MESSAGE_TYPE_OTHER;
+    }
+    return ALL_NET_MESSAGE_TYPES.at(index);
+}
+
+const NetStats& CConnman::GetNetStats() const
+{
+    return m_net_stats;
 }
 
 uint64_t CConnman::GetMaxOutboundTarget() const

--- a/src/net.h
+++ b/src/net.h
@@ -666,6 +666,84 @@ public:
     Info GetInfo() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex);
 };
 
+/**
+ * Network traffic (bytes and number of messages). Split by direction, network, connection type and message type.
+ */
+class NetStats
+{
+public:
+    /// Used to designate the direction of the recorded traffic.
+    enum Direction { SENT, RECV };
+
+    /// Number of elements in `Direction`.
+    static constexpr size_t NUM_DIRECTIONS{2};
+
+    struct BytesAndCount {
+        std::atomic_uint64_t bytes{0}; //!< Number of bytes transferred.
+        std::atomic_uint64_t count{0}; //!< Number of messages transferred.
+
+        BytesAndCount& operator+=(const BytesAndCount& toadd)
+        {
+            bytes += toadd.bytes;
+            count += toadd.count;
+            return *this;
+        }
+    };
+
+    NetStats();
+
+    /**
+     * Increment the number of messages transferred by `num_messages` and the number of bytes by `num_bytes`.
+     */
+    void Record(Direction direction,
+                Network net,
+                ConnectionType conn_type,
+                const std::string& msg_type,
+                size_t num_messages,
+                size_t num_bytes);
+
+    /**
+     * Call the provided function for each stat.
+     */
+    void ForEach(std::function<void(NetStats::Direction dir,
+                                    Network net,
+                                    ConnectionType con,
+                                    const std::string& msg,
+                                    const BytesAndCount& data)> func) const;
+
+private:
+    // The ...FromIndex() and ...ToIndex() methods below convert from/to
+    // indexes of `m_data[]` to the actual values they represent. For example,
+    // assuming MessageTypeToIndex("ping") == 15, then everything stored in
+    // m_data[i][j][k][15] is traffic from "ping" messages (for any i, j, k).
+
+    static constexpr size_t DirectionToIndex(Direction direction);
+    static constexpr Direction DirectionFromIndex(size_t index);
+
+    static constexpr size_t NetworkToIndex(Network net);
+    static constexpr Network NetworkFromIndex(size_t index);
+
+    static constexpr size_t ConnectionTypeToIndex(ConnectionType conn_type);
+    static constexpr ConnectionType ConnectionTypeFromIndex(size_t index);
+
+    size_t MessageTypeToIndex(const std::string& msg_type) const;
+    static std::string MessageTypeFromIndex(size_t index);
+
+    // Access like m_data[direction index][net index][conn type index][msg type index].bytes = 123;
+    // Arrays are used so that this can be accessed from multiple threads without a mutex protection.
+    std::array<std::array<std::array<std::array<BytesAndCount, ALL_NET_MESSAGE_TYPES.size() + 1>,
+                                     NUM_CONNECTION_TYPES>,
+                          NET_MAX>,
+               NUM_DIRECTIONS>
+        m_data;
+
+
+    using MsgTypeToIndex = std::unordered_map<std::string, size_t>;
+
+    /// Holds the index `i` in `m_data[][][][i]` of a given message type for quick lookup.
+    const MsgTypeToIndex m_msg_type_to_index;
+};
+
 struct CNodeOptions
 {
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
@@ -946,7 +1024,8 @@ public:
      * @return  True if the peer should stay connected,
      *          False if the peer should be disconnected from.
      */
-    bool ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete) EXCLUSIVE_LOCKS_REQUIRED(!cs_vRecv);
+    bool ReceiveMsgBytes(std::span<const uint8_t> msg_bytes, bool& complete, NetStats& net_stats)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_vRecv);
 
     void SetCommonVersion(int greatest_common_version)
     {
@@ -1415,6 +1494,8 @@ public:
 
     bool MultipleManualOrFullOutboundConns(Network net) const EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
 
+    const NetStats& GetNetStats() const;
+
 private:
     struct ListenSocket {
     public:
@@ -1568,7 +1649,7 @@ private:
     NodeId GetNewNodeId();
 
     /** (Try to) send data from node's vSendMsg. Returns (bytes_sent, data_left). */
-    std::pair<size_t, bool> SocketSendData(CNode& node) const EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
+    std::pair<size_t, bool> SocketSendData(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
 
     void DumpAddresses();
 
@@ -1609,6 +1690,8 @@ private:
     mutable Mutex m_total_bytes_sent_mutex;
     std::atomic<uint64_t> nTotalBytesRecv{0};
     uint64_t nTotalBytesSent GUARDED_BY(m_total_bytes_sent_mutex) {0};
+
+    NetStats m_net_stats;
 
     // outbound limit & stats
     uint64_t nMaxOutboundTotalBytesSentInCycle GUARDED_BY(m_total_bytes_sent_mutex) {0};

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -12,9 +12,11 @@
  * information we have available at the time of opening or accepting the
  * connection. Aside from INBOUND, all types are initiated by us.
  *
- * If adding or removing types, please update CONNECTION_TYPE_DOC in
- * src/rpc/net.cpp and src/qt/rpcconsole.cpp, as well as the descriptions in
- * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler. */
+ * If adding or removing types, please update:
+ * - CONNECTION_TYPE_DOC in src/rpc/net.cpp and src/qt/rpcconsole.cpp
+ * - the descriptions in src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler
+ * - NUM_CONNECTION_TYPES below.
+ */
 enum class ConnectionType {
     /**
      * Inbound connections are those initiated by a peer. This is the only
@@ -83,6 +85,9 @@ enum class ConnectionType {
      */
     PRIVATE_BROADCAST,
 };
+
+/** Number of entries in ConnectionType. */
+static constexpr size_t NUM_CONNECTION_TYPES{7};
 
 /** Convert ConnectionType enum to a string value */
 std::string ConnectionTypeAsString(ConnectionType conn_type);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -569,6 +569,124 @@ static RPCMethod getaddednodeinfo()
     };
 }
 
+namespace net_stats {
+
+UniValue CreateJSON(const RPCMethod&, const JSONRPCRequest& request)
+{
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    const CConnman& connman = EnsureConnman(node);
+
+    std::unordered_map<
+        std::string, // "sent" or "recv"
+        std::unordered_map<std::string, // "ipv4", "tor", ...
+                           std::unordered_map<std::string, // "outbound-full-relay", "feeler", ...
+                                              std::unordered_map<std::string, // "verack", "ping", ...
+                                                                 NetStats::BytesAndCount>>>>
+        result_map;
+
+    connman.GetNetStats().ForEach([&result_map](NetStats::Direction dir,
+                                                Network net,
+                                                ConnectionType con,
+                                                const std::string& msg,
+                                                const NetStats::BytesAndCount& data) {
+        const std::string dir_str{dir == NetStats::SENT ? "sent" : "recv"};
+        const std::string net_str{GetNetworkName(net)};
+        const std::string con_str{ConnectionTypeAsString(con)};
+
+        result_map[dir_str][net_str][con_str][msg] += data;
+    });
+
+    auto Add = [](UniValue& target, const std::string& key, const UniValue& val) {
+        if (val.empty()) {
+            return;
+        }
+        target.pushKV(key, val);
+    };
+
+    UniValue dir_json{UniValue::VOBJ};
+    for (const auto& [dir_key, dir_val] : result_map) {
+        UniValue net_json{UniValue::VOBJ};
+        for (const auto& [net_key, net_val] : dir_val) {
+            UniValue con_json{UniValue::VOBJ};
+            for (const auto& [con_key, con_val] : net_val) {
+                UniValue msg_json{UniValue::VOBJ};
+                for (const auto& [msg_key, stats] : con_val) {
+                    const auto bytes = stats.bytes.load();
+                    const auto count = stats.count.load();
+                    if (bytes == 0 || count == 0) {
+                        continue;
+                    }
+                    UniValue bytes_and_count_json{UniValue::VOBJ};
+                    bytes_and_count_json.pushKV("bytes", bytes);
+                    bytes_and_count_json.pushKV("count", count);
+
+                    Add(msg_json, msg_key, bytes_and_count_json);
+                }
+                Add(con_json, con_key, msg_json);
+            }
+            Add(net_json, net_key, con_json);
+        }
+        Add(dir_json, dir_key, net_json);
+    }
+
+    return dir_json;
+}
+}; // namespace net_stats
+
+static RPCMethod getnetmsgstats()
+{
+    return RPCMethod{
+        "getnetmsgstats",
+        "Returns the messages count and total number of bytes for network traffic.\n",
+        {},
+        {RPCResult{
+            RPCResult::Type::OBJ_DYN,
+            "",
+            /*optional=*/false,
+            "When a direction, network,\n"
+            "connection type or message type is not listed,\n"
+            "the statistics for that are 0.",
+            {RPCResult{
+                RPCResult::Type::OBJ_DYN,
+                "sent",
+                /*optional=*/true,
+                "The direction in which the traffic occurred.",
+                {RPCResult{
+                    RPCResult::Type::OBJ_DYN,
+                    "ipv4",
+                    /*optional=*/true,
+                    "The network over which the traffic occurred.",
+                    {RPCResult{
+                        RPCResult::Type::OBJ_DYN,
+                        "inbound",
+                        /*optional=*/true,
+                        "The connection type over which the traffic occurred.",
+                        {RPCResult{RPCResult::Type::OBJ,
+                                   "verack",
+                                   /*optional=*/true,
+                                   "Type of the messages transferred.",
+                                   {RPCResult{RPCResult::Type::NUM,
+                                              "bytes",
+                                              /*optional=*/false,
+                                              "Total number of bytes.",
+                                              {},
+                                              {.skip_type_check = true}},
+                                    RPCResult{RPCResult::Type::NUM,
+                                              "count",
+                                              /*optional=*/false,
+                                              "Total number of messages.",
+                                              {},
+                                              {.skip_type_check = true}}},
+                                   {.skip_type_check = true}}},
+                        {.skip_type_check = true}}},
+                    {.skip_type_check = true}}},
+                {.skip_type_check = true}}},
+            {.skip_type_check = true}}},
+        RPCExamples{HelpExampleCli("getnetmsgstats", "") +
+                    HelpExampleRpc("getnetmsgstats", "")},
+        net_stats::CreateJSON};
+}
+
 static RPCMethod getnettotals()
 {
     return RPCMethod{"getnettotals",
@@ -1267,6 +1385,7 @@ void RegisterNetRPCCommands(CRPCTable& t)
         {"network", &addnode},
         {"network", &disconnectnode},
         {"network", &getaddednodeinfo},
+        {"network", &getnetmsgstats},
         {"network", &getnettotals},
         {"network", &getnetworkinfo},
         {"network", &setban},

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -40,6 +40,7 @@ FUZZ_TARGET(net, .init = initialize_net)
     {
         node.SetAddrLocal(*service_opt);
     }
+    NetStats net_stats;
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
         CallOneOf(
             fuzzed_data_provider,
@@ -62,7 +63,7 @@ FUZZ_TARGET(net, .init = initialize_net)
             [&] {
                 const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
                 bool complete;
-                node.ReceiveMsgBytes(b, complete);
+                node.ReceiveMsgBytes(b, complete, net_stats);
             });
     }
 

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -143,6 +143,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getmempoolcluster",
     "getmempoolinfo",
     "getmininginfo",
+    "getnetmsgstats",
     "getnettotals",
     "getnetworkhashps",
     "getnetworkinfo",

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -88,9 +88,9 @@ void ConnmanTestMsg::Reset()
     m_private_broadcast.m_num_to_open.store(0);
 }
 
-void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete) const
+void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete)
 {
-    assert(node.ReceiveMsgBytes(msg_bytes, complete));
+    assert(node.ReceiveMsgBytes(msg_bytes, complete, m_net_stats));
     if (complete) {
         node.MarkReceivedMsgsForProcessing();
     }
@@ -108,7 +108,7 @@ void ConnmanTestMsg::FlushSendBuffer(CNode& node) const
     }
 }
 
-bool ConnmanTestMsg::ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg) const
+bool ConnmanTestMsg::ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg)
 {
     bool queued = node.m_transport->SetMessageToSend(ser_msg);
     assert(queued);

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -107,9 +107,9 @@ struct ConnmanTestMsg : public CConnman {
         return m_msgproc->ProcessMessages(node, flagInterruptMsgProc);
     }
 
-    void NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete) const;
+    void NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete);
 
-    bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg) const;
+    bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg);
     void FlushSendBuffer(CNode& node) const;
 
     bool AlreadyConnectedToAddressPublic(const CNetAddr& addr) { return AlreadyConnectedToAddress(addr); };

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -93,6 +93,7 @@ class NetTest(BitcoinTestFramework):
         self.test_sendmsgtopeer()
         self.test_getaddrmaninfo()
         self.test_getrawaddrman()
+        self.test_getnetmsgstats()
 
     def test_connection_count(self):
         self.log.info("Test getconnectioncount")
@@ -205,6 +206,148 @@ class NetTest(BitcoinTestFramework):
             peer_after = lambda: next(p for p in self.nodes[0].getpeerinfo() if p['id'] == peer_before['id'])
             self.wait_until(lambda: peer_after()['bytesrecv_per_msg'].get('pong', 0) >= peer_before['bytesrecv_per_msg'].get('pong', 0) + ping_size, timeout=1)
             self.wait_until(lambda: peer_after()['bytessent_per_msg'].get('ping', 0) >= peer_before['bytessent_per_msg'].get('ping', 0) + ping_size, timeout=1)
+
+    def test_getnetmsgstats(self):
+        self.log.info("Test getnetmsgstats")
+
+        self.restart_node(0)
+        node0 = self.nodes[0]
+        self.connect_nodes(0, 1) # Generate some traffic.
+        # Wait for the initial messages to be sent/received (don't disconnect too early). "sendheaders" is the last one.
+        self.wait_until(lambda: "sendheaders" in node0.getnetmsgstats()["recv"]["not_publicly_routable"]["manual"])
+        self.wait_until(lambda: "sendheaders" in node0.getnetmsgstats()["sent"]["not_publicly_routable"]["manual"])
+        self.disconnect_nodes(0, 1) # Avoid random/unpredictable packets (e.g. ping) messing with the tests below.
+        assert_equal(len(node0.getpeerinfo()), 0)
+
+        # In v2 getnettotals counts also bytes that are not accounted at any message (the v2 handshake).
+        # Also the v2 handshake's size could vary.
+        if not self.options.v2transport:
+            self.log.info("Test getnetmsgstats: compare byte count getnetmsgstats vs getnettotals")
+            nettotals = self.nodes[0].getnettotals()
+            netmsgstats = self.nodes[0].getnetmsgstats()
+            recv_bytes = 0
+            sent_bytes = 0
+            for network in netmsgstats["recv"].values():
+                for connection_type in network.values():
+                    for message_type in connection_type.values():
+                        recv_bytes += message_type["bytes"]
+            for network in netmsgstats["sent"].values():
+                for connection_type in network.values():
+                    for message_type in connection_type.values():
+                        sent_bytes += message_type["bytes"]
+            assert_equal(nettotals["totalbytessent"], sent_bytes)
+            assert_equal(nettotals["totalbytesrecv"], recv_bytes)
+
+        self.log.info("Test getnetmsgstats: full output is as expected")
+        stats_full = node0.getnetmsgstats()
+        if self.options.v2transport:
+            assert_equal(
+                stats_full,
+                {
+                    "recv": {
+                        "not_publicly_routable": {
+                            "manual": {
+                                "addrv2": {"bytes": 63, "count": 1},
+                                "feefilter": {"bytes": 29, "count": 1},
+                                "getheaders": {"bytes": 666, "count": 1},
+                                "headers": {"bytes": 103, "count": 1},
+                                "ping": {"bytes": 29, "count": 1},
+                                "pong": {"bytes": 29, "count": 1},
+                                "sendaddrv2": {"bytes": 33, "count": 1},
+                                "sendcmpct": {"bytes": 30, "count": 1},
+                                "sendheaders": {"bytes": 33, "count": 1},
+                                "verack": {"bytes": 33, "count": 1},
+                                "version": {"bytes": 147, "count": 1},
+                                "wtxidrelay": {"bytes": 33, "count": 1},
+                            }
+                        }
+                    },
+                    "sent": {
+                        "not_publicly_routable": {
+                            "manual": {
+                                "feefilter": {"bytes": 29, "count": 1},
+                                "getaddr": {"bytes": 33, "count": 1},
+                                "getheaders": {"bytes": 666, "count": 1},
+                                "headers": {"bytes": 103, "count": 1},
+                                "ping": {"bytes": 29, "count": 1},
+                                "pong": {"bytes": 29, "count": 1},
+                                "sendaddrv2": {"bytes": 33, "count": 1},
+                                "sendcmpct": {"bytes": 30, "count": 1},
+                                "sendheaders": {"bytes": 33, "count": 1},
+                                "verack": {"bytes": 33, "count": 1},
+                                "version": {"bytes": 147, "count": 1},
+                                "wtxidrelay": {"bytes": 33, "count": 1},
+                            }
+                        }
+                    }
+                }
+            )
+        else:
+            assert_equal(
+                stats_full,
+                {
+                    "recv": {
+                        "not_publicly_routable": {
+                            "manual": {
+                                "addrv2": {"bytes": 66, "count": 1},
+                                "feefilter": {"bytes": 32, "count": 1},
+                                "getheaders": {"bytes": 669, "count": 1},
+                                "headers": {"bytes": 106, "count": 1},
+                                "ping": {"bytes": 32, "count": 1},
+                                "pong": {"bytes": 32, "count": 1},
+                                "sendaddrv2": {"bytes": 24, "count": 1},
+                                "sendcmpct": {"bytes": 33, "count": 1},
+                                "sendheaders": {"bytes": 24, "count": 1},
+                                "verack": {"bytes": 24, "count": 1},
+                                "version": {"bytes": 138, "count": 1},
+                                "wtxidrelay": {"bytes": 24, "count": 1},
+                            }
+                        }
+                    },
+                    "sent": {
+                        "not_publicly_routable": {
+                            "manual": {
+                                "feefilter": {"bytes": 32, "count": 1},
+                                "getaddr": {"bytes": 24, "count": 1},
+                                "getheaders": {"bytes": 669, "count": 1},
+                                "headers": {"bytes": 106, "count": 1},
+                                "ping": {"bytes": 32, "count": 1},
+                                "pong": {"bytes": 32, "count": 1},
+                                "sendaddrv2": {"bytes": 24, "count": 1},
+                                "sendcmpct": {"bytes": 33, "count": 1},
+                                "sendheaders": {"bytes": 24, "count": 1},
+                                "verack": {"bytes": 24, "count": 1},
+                                "version": {"bytes": 138, "count": 1},
+                                "wtxidrelay": {"bytes": 24, "count": 1},
+                            }
+                        }
+                    }
+                }
+            )
+
+        self.log.info("Test getnetmsgstats: message count and total number of bytes increment when PING is sent")
+        assert "inbound" not in node0.getnetmsgstats()["sent"]["not_publicly_routable"]
+        node2 = node0.add_p2p_connection(P2PInterface())
+        assert_equal(len(node0.getpeerinfo()), 1)
+        # Wait for the initial PING (that is sent immediately after the connection is established) to go through.
+        self.wait_until(lambda: node0.getnetmsgstats()["sent"]["not_publicly_routable"]["inbound"]["ping"]["count"] >= 1)
+        stats_before_ping = node0.getnetmsgstats()
+        node0.ping()
+        self.wait_until(lambda: node0.getnetmsgstats()["sent"]["not_publicly_routable"]["inbound"]["ping"]["count"] > stats_before_ping["sent"]["not_publicly_routable"]["inbound"]["ping"]["count"])
+        self.wait_until(lambda: node0.getnetmsgstats()["sent"]["not_publicly_routable"]["inbound"]["ping"]["bytes"] > stats_before_ping["sent"]["not_publicly_routable"]["inbound"]["ping"]["bytes"])
+
+        self.log.info("Test getnetmsgstats: when a message is broken in two, the stats only update once the full message has been received")
+        ping_msg = node2.build_message(test_framework.messages.msg_ping(nonce=12345))
+        stats_before_ping = node0.getnetmsgstats()
+        # Send the message in two pieces.
+        cut_pos = 7 # Chosen at an arbitrary position within the header.
+        node2.send_raw_message(ping_msg[:cut_pos])
+        assert_equal(node0.getnetmsgstats()["recv"]["not_publicly_routable"]["inbound"]["ping"], stats_before_ping["recv"]["not_publicly_routable"]["inbound"]["ping"])
+        # Send the rest of the ping.
+        node2.send_raw_message(ping_msg[cut_pos:])
+        self.wait_until(lambda: node0.getnetmsgstats()["recv"]["not_publicly_routable"]["inbound"]["ping"]["count"] == stats_before_ping["recv"]["not_publicly_routable"]["inbound"]["ping"]["count"] + 1)
+
+        node2.peer_disconnect()
 
     def test_getnetworkinfo(self):
         self.log.info("Test getnetworkinfo")


### PR DESCRIPTION
Introduce a new RPC, `getnetmsgstats` to retrieve traffic bytes and count of messages possibly broken down by:
* direction (sent or received)
* network (ipv4, tor, etc)
* connection type (outbound-full-relay, block-relay-only, etc)
* message type (verack, ping, etc)

Implements: https://github.com/bitcoin/bitcoin/issues/26337 Add per message stats to getnettotals rpc

---

Examples:

<details>
<summary>bitcoin-cli getnetmsgstats '["direction", "network", "connection_type", "message_type"]'</summary>

```
{
  "bytes": 5392756,
  "count": 32683
}
```
</details>

<details>
<summary>bitcoin-cli getnetmsgstats '["direction", "network", "connection_type"]'</summary>

```
{
  "sendcmpct": {
    "bytes": 975,
    "count": 31
  },
  "sendaddrv2": {
    "bytes": 816,
    "count": 28
  },
  "headers": {
    "bytes": 1786,
    "count": 28
  },
  "feefilter": {
    "bytes": 816,
    "count": 27
  },
  "version": {
    "bytes": 4843,
    "count": 37
  },
  "ping": {
    "bytes": 1104,
    "count": 36
  },
  "getaddr": {
    "bytes": 384,
    "count": 13
  },
  "block": {
    "bytes": 5128467,
    "count": 20365
  },
  "getheaders": {
    "bytes": 29436,
    "count": 28
  },
  "pong": {
    "bytes": 1040,
    "count": 34
  },
  "getdata": {
    "bytes": 1218925,
    "count": 20008
  },
  "sendheaders": {
    "bytes": 447,
    "count": 16
  },
  "wtxidrelay": {
    "bytes": 816,
    "count": 28
  },
  "addrv2": {
    "bytes": 301161,
    "count": 25
  },
  "verack": {
    "bytes": 816,
    "count": 28
  }
}
```
</details>

<details>
<summary>bitcoin-cli getnetmsgstats '["direction", "connection_type", "message_type"]'</summary>

```
{
  "i2p": {
    "bytes": 1311861,
    "count": 8226
  },
  "onion": {
    "bytes": 3932760,
    "count": 24272
  },
  "ipv6": {
    "bytes": 631265,
    "count": 3362
  },
  "ipv4": {
    "bytes": 1300106,
    "count": 7773
  }
}
```
</details>

<details>
<summary>bitcoin-cli getnetmsgstats</summary>

```
{
  "recv": {
    "i2p": {
      "manual": {
        "sendcmpct": {
          "bytes": 90,
          "count": 3
        },
        "sendaddrv2": {
          "bytes": 99,
          "count": 3
        },
        "headers": {
          "bytes": 309,
          "count": 3
        },
        "feefilter": {
          "bytes": 87,
          "count": 3
        },
        "version": {
          "bytes": 408,
          "count": 3
        },
        "ping": {
          "bytes": 87,
          "count": 3
        },
        "block": {
          "bytes": 432950,
          "count": 1794
        },
        "getheaders": {
          "bytes": 3150,
          "count": 3
        },
        "pong": {
          "bytes": 87,
          "count": 3
        },
        "wtxidrelay": {
          "bytes": 99,
          "count": 3
        },
        "addrv2": {
          "bytes": 68508,
          "count": 3
        },
        "verack": {
          "bytes": 99,
          "count": 3
        }
      }
    },
    "onion": {
      "block-relay-only": {
        "sendcmpct": {
          "bytes": 66,
          "count": 2
        },
        "sendaddrv2": {
          "bytes": 24,
          "count": 1
        },
        "headers": {
          "bytes": 106,
          "count": 1
        },
        "feefilter": {
          "bytes": 32,
          "count": 1
        },
        "version": {
          "bytes": 126,
          "count": 1
        },
        "ping": {
          "bytes": 64,
          "count": 2
        },
        "block": {
          "bytes": 478479,
          "count": 1896
        },
        "getheaders": {
          "bytes": 1053,
          "count": 1
        },
        "pong": {
          "bytes": 64,
          "count": 2
        },
        "sendheaders": {
          "bytes": 24,
          "count": 1
        },
        "wtxidrelay": {
          "bytes": 24,
          "count": 1
        },
        "verack": {
          "bytes": 24,
          "count": 1
        }
      },
      "outbound-full-relay": {
        "sendcmpct": {
          "bytes": 195,
          "count": 6
        },
        "sendaddrv2": {
          "bytes": 129,
          "count": 5
        },
        "headers": {
          "bytes": 527,
          "count": 5
        },
        "feefilter": {
          "bytes": 157,
          "count": 5
        },
        "version": {
          "bytes": 639,
          "count": 5
        },
        "ping": {
          "bytes": 189,
          "count": 6
        },
        "block": {
          "bytes": 1465688,
          "count": 5957
        },
        "getheaders": {
          "bytes": 5262,
          "count": 5
        },
        "pong": {
          "bytes": 189,
          "count": 6
        },
        "sendheaders": {
          "bytes": 24,
          "count": 1
        },
        "wtxidrelay": {
          "bytes": 129,
          "count": 5
        },
        "addrv2": {
          "bytes": 120693,
          "count": 9
        },
        "verack": {
          "bytes": 129,
          "count": 5
        }
      }
    },
    "ipv6": {
      "manual": {
        "sendcmpct": {
          "bytes": 120,
          "count": 4
        },
        "sendaddrv2": {
          "bytes": 132,
          "count": 4
        },
        "headers": {
          "bytes": 412,
          "count": 4
        },
        "feefilter": {
          "bytes": 116,
          "count": 4
        },
        "version": {
          "bytes": 544,
          "count": 4
        },
        "ping": {
          "bytes": 116,
          "count": 4
        },
        "block": {
          "bytes": 138074,
          "count": 583
        },
        "getheaders": {
          "bytes": 4200,
          "count": 4
        },
        "pong": {
          "bytes": 116,
          "count": 4
        },
        "wtxidrelay": {
          "bytes": 132,
          "count": 4
        },
        "addrv2": {
          "bytes": 93436,
          "count": 4
        },
        "verack": {
          "bytes": 132,
          "count": 4
        }
      },
      "outbound-full-relay": {
        "version": {
          "bytes": 126,
          "count": 1
        }
      }
    },
    "ipv4": {
      "outbound-full-relay": {
        "sendcmpct": {
          "bytes": 66,
          "count": 2
        },
        "sendaddrv2": {
          "bytes": 24,
          "count": 1
        },
        "headers": {
          "bytes": 106,
          "count": 1
        },
        "feefilter": {
          "bytes": 32,
          "count": 1
        },
        "version": {
          "bytes": 252,
          "count": 2
        },
        "ping": {
          "bytes": 32,
          "count": 1
        },
        "block": {
          "bytes": 313988,
          "count": 1255
        },
        "getheaders": {
          "bytes": 1053,
          "count": 1
        },
        "pong": {
          "bytes": 32,
          "count": 1
        },
        "sendheaders": {
          "bytes": 24,
          "count": 1
        },
        "wtxidrelay": {
          "bytes": 24,
          "count": 1
        },
        "addrv2": {
          "bytes": 40,
          "count": 1
        },
        "verack": {
          "bytes": 24,
          "count": 1
        }
      }
    }
  },
  "sent": {
    "i2p": {
      "manual": {
        "sendcmpct": {
          "bytes": 90,
          "count": 3
        },
        "sendaddrv2": {
          "bytes": 99,
          "count": 3
        },
        "headers": {
          "bytes": 66,
          "count": 3
        },
        "feefilter": {
          "bytes": 87,
          "count": 3
        },
        "version": {
          "bytes": 544,
          "count": 4
        },
        "ping": {
          "bytes": 87,
          "count": 3
        },
        "getaddr": {
          "bytes": 99,
          "count": 3
        },
        "getheaders": {
          "bytes": 3150,
          "count": 3
        },
        "pong": {
          "bytes": 87,
          "count": 3
        },
        "getdata": {
          "bytes": 105382,
          "count": 1789
        },
        "sendheaders": {
          "bytes": 99,
          "count": 3
        },
        "wtxidrelay": {
          "bytes": 99,
          "count": 3
        },
        "verack": {
          "bytes": 99,
          "count": 3
        }
      }
    },
    "onion": {
      "block-relay-only": {
        "sendcmpct": {
          "bytes": 33,
          "count": 1
        },
        "sendaddrv2": {
          "bytes": 24,
          "count": 1
        },
        "headers": {
          "bytes": 25,
          "count": 1
        },
        "version": {
          "bytes": 127,
          "count": 1
        },
        "ping": {
          "bytes": 64,
          "count": 2
        },
        "getheaders": {
          "bytes": 1053,
          "count": 1
        },
        "pong": {
          "bytes": 64,
          "count": 2
        },
        "getdata": {
          "bytes": 115932,
          "count": 1884
        },
        "sendheaders": {
          "bytes": 24,
          "count": 1
        },
        "wtxidrelay": {
          "bytes": 24,
          "count": 1
        },
        "verack": {
          "bytes": 24,
          "count": 1
        }
      },
      "outbound-full-relay": {
        "sendcmpct": {
          "bytes": 162,
          "count": 5
        },
        "sendaddrv2": {
          "bytes": 129,
          "count": 5
        },
        "headers": {
          "bytes": 122,
          "count": 5
        },
        "feefilter": {
          "bytes": 157,
          "count": 5
        },
        "version": {
          "bytes": 771,
          "count": 6
        },
        "ping": {
          "bytes": 221,
          "count": 7
        },
        "getaddr": {
          "bytes": 129,
          "count": 5
        },
        "getheaders": {
          "bytes": 5262,
          "count": 5
        },
        "pong": {
          "bytes": 189,
          "count": 6
        },
        "getdata": {
          "bytes": 363478,
          "count": 5932
        },
        "sendheaders": {
          "bytes": 129,
          "count": 5
        },
        "wtxidrelay": {
          "bytes": 129,
          "count": 5
        },
        "addrv2": {
          "bytes": 231,
          "count": 4
        },
        "verack": {
          "bytes": 129,
          "count": 5
        }
      }
    },
    "ipv6": {
      "manual": {
        "sendcmpct": {
          "bytes": 120,
          "count": 4
        },
        "sendaddrv2": {
          "bytes": 132,
          "count": 4
        },
        "headers": {
          "bytes": 88,
          "count": 4
        },
        "feefilter": {
          "bytes": 116,
          "count": 4
        },
        "version": {
          "bytes": 544,
          "count": 4
        },
        "ping": {
          "bytes": 116,
          "count": 4
        },
        "getaddr": {
          "bytes": 132,
          "count": 4
        },
        "getheaders": {
          "bytes": 4200,
          "count": 4
        },
        "pong": {
          "bytes": 116,
          "count": 4
        },
        "getdata": {
          "bytes": 35492,
          "count": 584
        },
        "sendheaders": {
          "bytes": 99,
          "count": 3
        },
        "wtxidrelay": {
          "bytes": 132,
          "count": 4
        },
        "verack": {
          "bytes": 132,
          "count": 4
        }
      },
      "outbound-full-relay": {
        "version": {
          "bytes": 254,
          "count": 2
        }
      }
    },
    "ipv4": {
      "outbound-full-relay": {
        "sendcmpct": {
          "bytes": 33,
          "count": 1
        },
        "sendaddrv2": {
          "bytes": 24,
          "count": 1
        },
        "headers": {
          "bytes": 25,
          "count": 1
        },
        "feefilter": {
          "bytes": 32,
          "count": 1
        },
        "version": {
          "bytes": 508,
          "count": 4
        },
        "ping": {
          "bytes": 32,
          "count": 1
        },
        "getaddr": {
          "bytes": 24,
          "count": 1
        },
        "getheaders": {
          "bytes": 1053,
          "count": 1
        },
        "pong": {
          "bytes": 32,
          "count": 1
        },
        "getdata": {
          "bytes": 76531,
          "count": 1231
        },
        "sendheaders": {
          "bytes": 24,
          "count": 1
        },
        "wtxidrelay": {
          "bytes": 24,
          "count": 1
        },
        "verack": {
          "bytes": 24,
          "count": 1
        }
      }
    }
  }
}
```
</details>

---

Previous incarnations of this:
https://github.com/bitcoin/bitcoin/pull/27534 rpc: add 'getnetmsgstats', new rpc to view network message statistics (Thank you, @satsie!)
https://github.com/bitcoin/bitcoin/pull/28926 rpc: add 'getnetmsgstats' RPC (Thank you, @willcl-ark!)