### PR TITLE
refactor: improve readability of numeric literals in consensus parameters and network settings

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -113,6 +113,8 @@ code.
     between integer types, use functional casts such as `int(x)` or `int{x}`
     instead of `(int) x`. When casting between more complex types, use `static_cast`.
     Use `reinterpret_cast` and `const_cast` as appropriate.
+  - Enhance readability of numeric literals, especially for amounts, sizes, or bitmasks, by using the C++14 digit separator (`'`).
+    This aids in visual clarity for large numbers by grouping digits in threes from the right, e.g. `CAmount COIN = 100'000'000`.
 
 For function calls a namespace should be specified explicitly, unless such functions have been declared within it.
 Otherwise, [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl), also known as ADL, could be

--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -12,7 +12,7 @@
 typedef int64_t CAmount;
 
 /** The amount of satoshis in one BTC. */
-static constexpr CAmount COIN = 100000000;
+static constexpr CAmount COIN = 100'000'000;
 
 /** No amount larger than this (in satoshi) is valid.
  *
@@ -23,7 +23,7 @@ static constexpr CAmount COIN = 100000000;
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static constexpr CAmount MAX_MONEY = 21000000 * COIN;
+static constexpr CAmount MAX_MONEY = 21'000'000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif // BITCOIN_CONSENSUS_AMOUNT_H

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -10,11 +10,11 @@
 #include <stdint.h>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
-static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
+static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4'000'000;
 /** The maximum allowed weight for a block, see BIP 141 (network rule) */
-static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
+static const unsigned int MAX_BLOCK_WEIGHT = 4'000'000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
-static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
+static const int64_t MAX_BLOCK_SIGOPS_COST = 80'000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -74,7 +74,7 @@ public:
         m_chain_type = ChainType::MAIN;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 210'000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"), SCRIPT_VERIFY_NONE);
         consensus.script_flag_exceptions.emplace( // Taproot exception
@@ -194,7 +194,7 @@ public:
         m_chain_type = ChainType::TESTNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 210'000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256S("0x00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"), SCRIPT_VERIFY_NONE);
         consensus.BIP34Height = 21111;
@@ -333,7 +333,7 @@ public:
         m_chain_type = ChainType::SIGNET;
         consensus.signet_blocks = true;
         consensus.signet_challenge.assign(bin.begin(), bin.end());
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 210'000;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;

--- a/src/net.h
+++ b/src/net.h
@@ -65,7 +65,7 @@ static constexpr auto FEELER_INTERVAL = 2min;
 /** Run the extra block-relay-only connection loop once every 5 minutes. **/
 static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
 /** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4'000'000;
 /** Maximum length of the user agent string in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes over which we'll relay everything (blocks, tx, addrs, etc) */
@@ -94,8 +94,8 @@ static constexpr std::chrono::hours ASMAP_HEALTH_CHECK_INTERVAL{24};
 static constexpr bool DEFAULT_FORCEDNSSEED{false};
 static constexpr bool DEFAULT_DNSSEED{true};
 static constexpr bool DEFAULT_FIXEDSEEDS{true};
-static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
-static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
+static const size_t DEFAULT_MAXRECEIVEBUFFER = 5'000;
+static const size_t DEFAULT_MAXSENDBUFFER    = 1'000;
 
 static constexpr bool DEFAULT_V2_TRANSPORT{true};
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -43,7 +43,7 @@ static const int MAX_STACK_SIZE = 1000;
 
 // Threshold for nLockTime: below this value it is interpreted as block number,
 // otherwise as UNIX timestamp.
-static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
+static const unsigned int LOCKTIME_THRESHOLD = 500'000'000; // Tue Nov  5 00:53:20 1985 UTC
 
 // Maximum nLockTime. Since a lock time indicates the last invalid timestamp, a
 // transaction with this lock time will never be valid unless lock time


### PR DESCRIPTION
This commit enhances the readability of large numeric literals across various parts of the Bitcoin Core codebase by introducing thousands separators ('), leveraging the C++14 digit separator feature.

This readability enhancement follows the precedent set in various places within the Bitcoin Core codebase and aligns with ongoing efforts to improve code quality and developer experience: delimiters were already [used](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/mempool_limits.h#L26) [in](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/mempool_options.h#L40) [a](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/mempool_limits.h#L22) [few](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/chainparams.cpp#L380) [places](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/chainparams.cpp#L271), even in comments:
<img alt="image" src="https://github.com/bitcoin/bitcoin/assets/1841944/997032db-3595-4f32-a17e-62ec9d3ded82">
