### PR TITLE
Add issuer-selected opt-in txn / pckg policy checks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -243,6 +243,7 @@ BITCOIN_CORE_H = \
   noui.h \
   outputtype.h \
   policy/v3_policy.h \
+  policy/issuer_selected_policy.h \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
@@ -443,6 +444,7 @@ libbitcoin_node_a_SOURCES = \
   node/validation_cache_args.cpp \
   noui.cpp \
   policy/v3_policy.cpp \
+  policy/issuer_selected_policy.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
   policy/packages.cpp \
@@ -705,6 +707,7 @@ libbitcoin_common_a_SOURCES = \
   net_permissions.cpp \
   outputtype.cpp \
   policy/v3_policy.cpp \
+  policy/issuer_selected_policy.cpp \
   policy/feerate.cpp \
   policy/policy.cpp \
   protocol.cpp \
@@ -964,6 +967,7 @@ libbitcoinkernel_la_SOURCES = \
   node/chainstate.cpp \
   node/utxo_snapshot.cpp \
   policy/v3_policy.cpp \
+  policy/issuer_selected_policy.cpp \
   policy/feerate.cpp \
   policy/packages.cpp \
   policy/policy.cpp \

--- a/src/policy/issuer_selected_policy.cpp
+++ b/src/policy/issuer_selected_policy.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/issuer_selected_policy.h>
+
+#include <coins.h>
+#include <consensus/amount.h>
+#include <logging.h>
+#include <tinyformat.h>
+#include <util/check.h>
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+// If this flag is set, CTxIn::nSequence of V3 transaction is not interpreted as a relative lock-time.
+static const uint32_t SEQUENCE_ISSUER_SELECTED_LIMITS_DISABLE_FLAG = (1U << 30);
+
+// This mask is applied to extract ancestor limit from the sequence field.
+static const uint32_t SEQUENCE_ISSUER_SELECTED_ANCESTOR_MASK = 0x00ff0000;
+
+// This mask is applied to extract descendant limit from the sequence field.
+static const uint32_t SEQUENCE_ISSUER_SELECTED_DESCENDANT_MASK = 0x0000ff00;
+
+// This mask is applied to extract package-level vbytes limit from the sequence field.
+static const uint32_t SEQUENCE_ISSUER_SELECTED_WEIGHT_MASK = 0x000000ff;
+
+// Granularity-level: 1024 vbytes
+static const uint32_t SEQUENCE_ISSUER_SELECTED_WEIGHT_GRANULARITY = 10;
+
+struct IssuerSelectedLimits {
+    uint32_t m_ancestor_limit;
+    /** Wtxid used for debug string */
+    uint32_t m_descendant_limit;
+    /** nVersion used to check inheritance of v3 and non-v3 */
+    int64_t m_package_max_size;
+
+    IssuerSelectedLimits() = delete;
+    IssuerSelectedLimits(uint32_t ancestor_limit, uint32_t descendant_limit , int64_t package_max_size) :
+        m_ancestor_limit{ancestor_limit}, m_descendant_limit{descendant_limit}, m_package_max_size{package_max_size}
+    {}
+};
+
+std::optional<IssuerSelectedLimits> ParsePackageTopologicalLimits(const CTransactionRef& ptx)
+{
+    uint32_t sequence_field = ptx->vin[0].nSequence;
+ 
+    // Mark incompatibility between V3+ tagged input and relative-lock time (bip68) due to the 32-bits nSequence
+    // field constraints.This is not an issue for current deployed LN pre-signed transactions using relative-lock time,
+    // as only malleable second-stage transactions (`option_anchors_zero_fee_htlc_tx`) are encumbered by a CSV 1.
+    // LN transactions issuers can generate their second-stage transactions by placing a dummy input with the
+    // issuer-selected topological and size limits, without channel-type level upgrades.
+    // There are few "cold custody" / multi-sig use-cases relying on relative-locktime usage, however there is
+    // no ecosystem-level documentation informing on the exact uses of relative lock time, neither available 
+    // on-chain economic metrics as in the optimistic case there are never published.
+    if (sequence_field & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) {
+        return std::nullopt;
+    }
+
+    // Mark v3+ semantics as transaction / package issuer opt-in only.
+    if (sequence_field & SEQUENCE_ISSUER_SELECTED_LIMITS_DISABLE_FLAG) {
+        return std::nullopt;
+    }
+
+    const uint32_t ancestor_limit = sequence_field & SEQUENCE_ISSUER_SELECTED_ANCESTOR_MASK;
+    const uint32_t descendant_limit = sequence_field & SEQUENCE_ISSUER_SELECTED_DESCENDANT_MASK;
+    const uint32_t weight_limit = (uint32_t)(sequence_field & SEQUENCE_ISSUER_SELECTED_WEIGHT_MASK) << SEQUENCE_ISSUER_SELECTED_WEIGHT_GRANULARITY;
+
+    // This parsing logic can be adapted for forward-compatibility in matters of issuer-selected policy limits:
+    //      - encodes accumulated package SigOpCost
+    //      - commit to package-level dynamic DUST_RELAY_TX_FEE or DEFAULT_INCREMENTAL_RELAY_FEE
+    //      - opt-in if limits are strict (at the pckg-level) or composable (at the tx-level) to allow non-interactive composability among N chain of transaction issuers.
+
+    IssuerSelectedLimits tx_issuer_selected_limits(ancestor_limit, descendant_limit, weight_limit);
+
+    return tx_issuer_selected_limits;
+}
+
+std::optional<std::string> PackageIssuerSelectedChecks(const CTransactionRef& ptx, int64_t vsize,
+                                           const Package& package,
+                                           const CTxMemPool::setEntries& mempool_ancestors)
+{
+
+    // We fetch the issuer-selected from the reference_tx. Lack of issuer-selected opt-in by reference tx should be treated as an error.
+    std::optional<IssuerSelectedLimits> issuer_selected_limits_ret = ParsePackageTopologicalLimits(ptx);
+    if (!issuer_selected_limits_ret.has_value()) return std::nullopt;
+    uint32_t reference_tx_ancestor_limit = (*issuer_selected_limits_ret).m_ancestor_limit;
+    uint32_t reference_tx_descendant_limit = (*issuer_selected_limits_ret).m_descendant_limit;
+    int32_t reference_tx_package_max_size = (*issuer_selected_limits_ret).m_package_max_size;
+
+    // Check that "issuer selected" package limits are within mempool default limits.
+    if ((reference_tx_ancestor_limit < 1 || reference_tx_ancestor_limit > DEFAULT_ANCESTOR_LIMIT)
+        || (reference_tx_descendant_limit < 1 || reference_tx_descendant_limit > DEFAULT_DESCENDANT_LIMIT)
+        || (reference_tx_package_max_size < ((int32_t) MIN_STANDARD_TX_NONWITNESS_SIZE) || reference_tx_package_max_size > MAX_STANDARD_TX_WEIGHT)) {
+            return strprintf("issuer-selected policy: issuer-selected limits should be in bounds of hard tx-relay policy limits");
+    }
+
+    int32_t accumulated_package_weight = GetTransactionWeight(*ptx);
+
+    if (mempool_ancestors.size() > reference_tx_ancestor_limit) {
+            return strprintf("issuer-selected policy: issuer-selected limits should be in bounds of hard tx-relay policy limits");
+    }
+    
+    // We verify that all the transactions in the package have equivalent issuer-selected limits.
+    for (const auto& package_tx : package) {
+
+        // All issuer-selected policy packages txn must be nversion=3
+        if (package_tx->nVersion != 3) {
+            return strprintf("v3 tx %s (wtxid=%s) cannot spend from non-v3",
+                             package_tx->GetHash().ToString(), package_tx->GetWitnessHash().ToString());
+        }
+        std::optional<IssuerSelectedLimits> issuer_selected_limits_ret = ParsePackageTopologicalLimits(package_tx);
+        if (!issuer_selected_limits_ret.has_value()) return strprintf("strict issuer-selected policy: all txns should have opted-in in issuer-selected limits");
+        uint32_t check_tx_ancestor_limit = (*issuer_selected_limits_ret).m_ancestor_limit;
+        uint32_t check_tx_descendant_limit = (*issuer_selected_limits_ret).m_descendant_limit;
+        int32_t check_tx_package_max_size = (*issuer_selected_limits_ret).m_package_max_size;
+
+        // We enforce strict v3+ policy, all the issuer-selected limits should be equivalent
+        if ((reference_tx_ancestor_limit != check_tx_ancestor_limit)
+                || (reference_tx_descendant_limit != check_tx_descendant_limit)
+                || (reference_tx_package_max_size != check_tx_package_max_size)) {
+            return strprintf("strict issuer-selected policy: all txns should have equivalent issuer-selected limits");
+        }
+
+        accumulated_package_weight += GetTransactionWeight(*package_tx);
+    }
+
+    // Be more conservative than in-mempool ancestor / descendant accumulated size limit.
+    if (accumulated_package_weight > MAX_STANDARD_TX_WEIGHT) {
+            return strprintf("issuer-selected policy: issuer-selected limits should be in bounds of hard tx-relay policy limits");
+    }
+
+    // We start at 0 to account for the transaction itself.
+    uint32_t accumulated_descendant = 0;
+    for (const auto& mempool_ancestor: mempool_ancestors) {
+            // We subtract the child from any children of all of its mempool ancestor
+            const auto& children = mempool_ancestor->GetMemPoolChildrenConst();
+            accumulated_descendant += (children.size() - 1);
+    }
+
+    // We previously verified that issuer-selected descendant limit where equal to MAX_PACKAGE_COUNT
+    if ((accumulated_descendant > reference_tx_descendant_limit) || (package.size() > reference_tx_descendant_limit)) {
+        return strprintf("issuer-selected policy: issuer-selected limits should be in bounds of hard tx-relay policy limits");
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> SingleIssuerSelectedChecks(const CTransactionRef& ptx,
+                                          const CTxMemPool::setEntries& mempool_ancestors,
+                                          const std::set<Txid>& direct_conflicts,
+                                          int64_t vsize)
+{
+    // Check v3+ and non-v3+ inheritance.
+    for (const auto& entry : mempool_ancestors) {
+        if (ptx->nVersion != 3 && entry->GetTx().nVersion == 3) {
+            return strprintf("non-v3 tx %s (wtxid=%s) cannot spend from v3 tx %s (wtxid=%s)",
+                             ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString(),
+                             entry->GetSharedTx()->GetHash().ToString(), entry->GetSharedTx()->GetWitnessHash().ToString());
+        } else if (ptx->nVersion == 3 && entry->GetTx().nVersion != 3) {
+            return strprintf("v3 tx %s (wtxid=%s) cannot spend from non-v3 tx %s (wtxid=%s)",
+                             ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString(),
+                             entry->GetSharedTx()->GetHash().ToString(), entry->GetSharedTx()->GetWitnessHash().ToString());
+        }
+    }
+
+    // The rest of the rules only apply to transactions with nVersion=3.
+    if (ptx->nVersion != 3) return std::nullopt;
+
+    std::optional<IssuerSelectedLimits> issuer_selected_limits_ret = ParsePackageTopologicalLimits(ptx);
+    if (!issuer_selected_limits_ret.has_value()) return std::nullopt;
+    uint32_t tx_ancestor_limit = (*issuer_selected_limits_ret).m_ancestor_limit;
+    uint32_t tx_descendant_limit = (*issuer_selected_limits_ret).m_descendant_limit;
+    int32_t tx_package_max_size = (*issuer_selected_limits_ret).m_package_max_size;
+
+    // Check that "issuer selected" package limits are within mempool default limits.
+    if ((tx_ancestor_limit < 1 || tx_ancestor_limit > DEFAULT_ANCESTOR_LIMIT)
+        || (tx_descendant_limit < 1 || tx_descendant_limit > DEFAULT_DESCENDANT_LIMIT)
+        || (tx_package_max_size < ((int32_t) MIN_STANDARD_TX_NONWITNESS_SIZE) || tx_package_max_size > MAX_STANDARD_TX_WEIGHT)) {
+            return strprintf("issuer-selected policy: issuer-selected limits should be in bounds of hard tx-relay policy limits");
+    }
+
+    // Check that "transaction-issuer selected" package limits are respected.
+    if (mempool_ancestors.size() + 1 > tx_ancestor_limit) {
+        return strprintf("tx %s (wtxid=%s) would have too many ancestors",
+                         ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString());
+    }
+
+    // Check the descendant counts of in-mempool ancestors.
+    const auto& parent_entry = *mempool_ancestors.begin();
+
+    // We allow one more descendant if this single issuer-selected transaction replaces a subpackage.
+    if (parent_entry->GetCountWithDescendants() + 1 > tx_descendant_limit) {
+        return strprintf("tx %u (wtxid=%s) would exceed descendant count limit",
+                         parent_entry->GetSharedTx()->GetHash().ToString(),
+                         parent_entry->GetSharedTx()->GetWitnessHash().ToString());
+    }
+
+    return std::nullopt;
+}

--- a/src/policy/issuer_selected_policy.h
+++ b/src/policy/issuer_selected_policy.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_V3PLUS_POLICY_H
+#define BITCOIN_POLICY_V3PLUS_POLICY_H
+
+#include <consensus/amount.h>
+#include <consensus/validation.h>
+#include <policy/packages.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <txmempool.h>
+#include <util/result.h>
+
+#include <set>
+#include <string>
+
+std::optional<std::string> SingleIssuerSelectedChecks(const CTransactionRef& ptx,
+                                          const CTxMemPool::setEntries& mempool_ancestors,
+                                          const std::set<Txid>& direct_conflicts,
+                                          int64_t vsize);
+
+std::optional<std::string> PackageIssuerSelectedChecks(const CTransactionRef& ptx, int64_t vsize,
+                                           const Package& package,
+                                           const CTxMemPool::setEntries& mempool_ancestors);
+
+#endif //BITCOIN_POLICY_V3PLUS_POLICY_H

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -88,4 +88,8 @@ bool IsChildWithParents(const Package& package);
  * other (the package is a "tree").
  */
 bool IsChildWithParentsTree(const Package& package);
+
+// Common helpers use with issuer-selected transaction/package policy checks
+std::vector<size_t> FindInPackageParents(const Package& package, const CTransactionRef& ptx);
+
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/policy/v3_policy.cpp
+++ b/src/policy/v3_policy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2024 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,29 +13,6 @@
 #include <algorithm>
 #include <numeric>
 #include <vector>
-
-/** Helper for PackageV3Checks: Returns a vector containing the indices of transactions (within
- * package) that are direct parents of ptx. */
-std::vector<size_t> FindInPackageParents(const Package& package, const CTransactionRef& ptx)
-{
-    std::vector<size_t> in_package_parents;
-
-    std::set<Txid> possible_parents;
-    for (auto &input : ptx->vin) {
-        possible_parents.insert(input.prevout.hash);
-    }
-
-    for (size_t i{0}; i < package.size(); ++i) {
-        const auto& tx = package.at(i);
-        // We assume the package is sorted, so that we don't need to continue
-        // looking past the transaction itself.
-        if (&(*tx) == &(*ptx)) break;
-        if (possible_parents.count(tx->GetHash())) {
-            in_package_parents.push_back(i);
-        }
-    }
-    return in_package_parents;
-}
 
 /** Helper for PackageV3Checks, storing info for a mempool or package parent. */
 struct ParentInfo {


### PR DESCRIPTION
All the values selected by the transaction issuers are implemented to respect current hard policy limits as of 27.0
Bitcoin Core version (e.g `MAX_PACKAGE_COUNT` or `MAX_STANDARD_TX_WEIGHT`). As such introducing a new distinction in the Bitcoin ecosystem among tx-relay policy checks enforced by full-nodes hosts of a said full-node implementation/version and the the policy-check opt-ed by any transaction or second-layers use-cases. That way any significant on-chain economic  traffic can be still processed by low-performance full-nodes hosts, without altering the DoS profile risks.

E.g in the context of the Lightning Network, lightning nodes can adjust their pinning risk exposures affecting their channel funds safety differently in function of each lightning topological peers (- assuming the BOLT protocol upgrades its negotiation flow `open_channel` / `accept_channel`). As such lightning peers can enforce a trade-off between their off chain HTLC throughputs and their tx-relay jamming exposure (e.g pinning or RC attacks).

E.g in the context of collaborative custody management, distrusted stakeholders owning a set of pre-signed set of transactions can all commits to the same set of max tx size / max package limits, as such introducing more reliability on the worst amount of fee-bumping reserves that should be provisioned instead of hard limits like the current approach with v3.

_Wait ! I’m lost reading this OP ?! Already  too much information, what should I do ? Go to read Bitcoin Optech 10 articles series’s [“Waiting for confirmation: a series about mempool and relay policy”](https://bitcoinops.org/en/blog/waiting-for-confirmation/) as a starter and then come back to read or comment._

The opt-in mechanism uses a one bit flag in the nSequence field which is already a standard and consenus Bitcoin transaction field since the genesis block. The mechansim (`ParsePackageTopologicalLimits()`) check that bip68 is disabled to avoid conflicts of semantics, as the remaining nSequence field bits are interpreted as dynamic issuers-selected policy checks (currently implemented ancestor / descendant / max package limits size). The intrusive aspect of the mechanism is minimal and the interpreted field could be uplifted in other parts of standard transaction fields while conserving the same policy check enforcement semantics.

Here the code excerpt that deserves a `doc/policy/` , a BIP or a banana.
```
 (sequence_field & SEQUENCE_ISSUER_SELECTED_LIMITS_DISABLE_FLAG) {
        return std::nullopt;
    }

    const uint32_t ancestor_limit = sequence_field & SEQUENCE_ISSUER_SELECTED_ANCESTOR_MASK;
    const uint32_t descendant_limit = sequence_field & SEQUENCE_ISSUER_SELECTED_DESCENDANT_MASK;
    const uint32_t weight_limit = (uint32_t)(sequence_field & SEQUENCE_ISSUER_SELECTED_WEIGHT_MASK)
     << SEQUENCE_ISSUER_SELECTED_WEIGHT_GRANULARITY;

    // This parsing logic can be adapted for forward-compatibility in matters of issuer-selected
    // policy limits:
    //      - encodes accumulated package SigOpCost
    //      - commit to package-level dynamic DUST_RELAY_TX_FEE or DEFAULT_INCREMENTAL_RELAY_FEE
    //      - opt-in if limits are strict (at the pckg-level) or composable (at the tx-level)
    //        to allow non-interactive composability among N chain of transaction issuers.

    IssuerSelectedLimits tx_issuer_selected_limits(ancestor_limit, descendant_limit, weight_limit);
```

Issuer-selected fields getting economic popularity and not jeopardizing bitcoin security model and long-term decentralization equlibrium of the ecosystem of peer-to-peer full-nodes and solo mining operations could get a consensus enforcement, going through the traditional consensus design & development process (narrator note: no ones really knows or is sure there is  something as traditional consensus development process...). The nSequence consensus field due to its 32 bits limitation is space limited, even if a lot can be achieved with bit-wise operations.

From a technical philosophy perspective, I think this introduction of issuer-selected transaction / package policy limits checks should should reduce the amount of "bargaing-on-policy" we have seen recently with `mempoolfullrbf` (LN-vs-zero-conf-acceptance business) or do-digital-art-on-chain-and-the-posterity-will-say-if-it-is-bansky-or-crap-waste colored coins and tokens experimentations.

This patchset built on the v3 patchset and its followups (commit `37fdf5a4`), is already integrated in the package mempool
acceptance code flow. There is 1 logical conflict for now as the 1000 vbytes limit is enforced by default for v3 (which still
exposes a lot of loss of funds risk exposure for some time-sensitive flows like lightning considering "loophole" and NTA pinning scenario  - see #28948). In the future, this limit can just become a "tx issuer-selected policy check" limit.

In the future, such transaction / package “issuer-selected” can be used as a signaling mechanism, e.g for [replace-by-feerate](https://petertodd.org/2024/one-shot-replace-by-fee-rate) dynamic window enforced at the mempool-level, for the use-cases who wishing to ensure their chain of transactions are minimal by not using CPFP.

For more discussions on mempool policy technical philosophy design and trade-offs on downstream use-cases, see the old email  thread ["On mempool consistency"](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021116.html).

This patchset can be applied on top of any fork of bitcoin core 27.0 with the minimal of engineering effort by anyone wishing
to experiment with mempool policy for its use-case (I'll see if I have time to carry this patchset forward as I'm officially in
sabbatical from bitcoin core development taking the sun on the beach just yelling at them when the stuff is broken, we’re all btc investors).