### PR TITLE
docs: ci multi-arch requires qemu

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -14,10 +14,10 @@ testing compared to other parts of the codebase. If you want to keep the work tr
 system in a virtual machine with a Linux operating system of your choice.
 
 To allow for a wide range of tested environments, but also ensure reproducibility to some extent, the test stage
-requires `bash`, `docker`, and `python3` to be installed. To install all requirements on Ubuntu, run
+requires `bash`, `docker`, and `python3` to be installed. To run on different architectures than the host `qemu` is also required. To install all requirements on Ubuntu, run
 
 ```
-sudo apt install bash docker.io python3
+sudo apt install bash docker.io python3 qemu-user-static
 ```
 
 It is recommended to run the ci system in a clean env. To run the test stage


### PR DESCRIPTION
On a fresh Debian system qemu isn't installed and therefore the multi-architecture CI system doesn't run.

This documentation notes that qemu is required and how to install it.