### PR TITLE
test: assert rpc error for addnode v2transport not enabled

### DIFF
--- a/test/functional/p2p_v2_transport.py
+++ b/test/functional/p2p_v2_transport.py
@@ -12,6 +12,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     p2p_port,
+    assert_raises_rpc_error
 )
 
 
@@ -59,6 +60,11 @@ class V2TransportTest(BitcoinTestFramework):
         # V1 nodes can sync with each other
         assert_equal(self.nodes[2].getblockcount(), 0)
         assert_equal(self.nodes[3].getblockcount(), 0)
+
+        # addnode rpc error when v2transport requested but not enabled
+        ip_port = "127.0.0.1:{}".format(p2p_port(3))
+        assert_raises_rpc_error(-8, "Error: v2transport requested but not enabled (see -v2transport)", self.nodes[2].addnode, node=ip_port, command='add', v2transport=True)
+
         with self.nodes[2].assert_debug_log(expected_msgs=[],
                                             unexpected_msgs=[sending_handshake, downgrading_to_v1]):
             self.connect_nodes(2, 3, peer_advertises_v2=False)


### PR DESCRIPTION
Added coverage for the `addnode` rpc when v2transport is not enabled,
but is set as true when calling `addnode` rpc.

I ran the following to check if this rpc error message 
was covered in the functional tests.
`grep -nr "v2transport requested but not enabled" ./test/functional --binary-files=without-match`

Adds test coverage to this line.
https://github.com/bitcoin/bitcoin/blob/master/src/rpc/net.cpp#L339