### PR TITLE
rpc: method removeprunedfunds should take an array of txids

### DIFF
--- a/doc/release-notes-29468.md
+++ b/doc/release-notes-29468.md
@@ -1,0 +1,4 @@
+# RPC `removeprunedfunds` update
+
+- The `removeprunedfunds` RPC method has been enhanced to accept an array of transaction IDs (`txids`).
+- This update allows for the batch removal of transactions, facilitating more efficient management of pruned wallets.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -304,6 +304,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "stop", 0, "wait" },
     { "addnode", 2, "v2transport" },
     { "addconnection", 2, "v2transport" },
+    { "removeprunedfunds", 0, "txids" },
 };
 // clang-format on
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -378,15 +378,19 @@ RPCHelpMan importprunedfunds()
 RPCHelpMan removeprunedfunds()
 {
     return RPCHelpMan{"removeprunedfunds",
-                "\nDeletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n",
+                "\nDeletes the specified transactions from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n",
                 {
-                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded id of the transaction you are deleting"},
+                    {"txids", RPCArg::Type::ARR, RPCArg::Optional::NO, "The hex-encoded ids of the transactions you are deleting",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The hex-encoded id of a transaction you are deleting"},
+                        },
+                    },
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
-                    HelpExampleCli("removeprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"") +
+                    HelpExampleCli("removeprunedfunds", "'[\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\", \"9414f1681fb1255bd168a806254321a837008dd4480c02226063183deb100204\"]'") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("removeprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"")
+            + HelpExampleRpc("removeprunedfunds", "'[\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\", \"9414f1681fb1255bd168a806254321a837008dd4480c02226063183deb100204\"]'")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -395,10 +399,13 @@ RPCHelpMan removeprunedfunds()
 
     LOCK(pwallet->cs_wallet);
 
-    uint256 hash(ParseHashV(request.params[0], "txid"));
-    std::vector<uint256> vHash;
-    vHash.push_back(hash);
-    if (auto res = pwallet->RemoveTxs(vHash); !res) {
+    std::vector<uint256> vHashes;
+    for (const UniValue& txidVal : request.params[0].get_array().getValues()) {
+        uint256 hash(ParseHashV(txidVal, "txid"));
+        vHashes.push_back(hash);
+    }
+
+    if (auto res = pwallet->RemoveTxs(vHashes); !res) {
         throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(res).original);
     }
 

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -116,7 +116,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
             # send/bumpfee and re-adds it to the wallet (undoing the next
             # removeprunedfunds). So empty the scheduler queue:
             node.syncwithvalidationinterfacequeue()
-            node.removeprunedfunds(child_txid)
+            node.removeprunedfunds([child_txid])
             child_txid = bumped_txid
         entry_time = node.getmempoolentry(child_txid)["time"]
 


### PR DESCRIPTION
This PR addresses issue [#29466](https://github.com/bitcoin/bitcoin/issues/29466) by updating the `removeprunedfunds` RPC method to accept an array of transaction IDs (txids). This enhancement allows for batch removal of transactions, improving usability for pruned wallets. The change includes updates to the RPC method signature and the corresponding functional test adjustments to align with the new input format. This feature simplifies wallet management by enabling more efficient transaction handling.