### PR TITLE
doc: document preference for list-initialization

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -113,6 +113,8 @@ code.
     between integer types, use functional casts such as `int(x)` or `int{x}`
     instead of `(int) x`. When casting between more complex types, use `static_cast`.
     Use `reinterpret_cast` and `const_cast` as appropriate.
+  - Prefer [`list initialization ({})`](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-list) where possible.
+    For example `int x{0};` instead of `int x = 0;` or `int x(0);`
 
 For function calls a namespace should be specified explicitly, unless such functions have been declared within it.
 Otherwise, [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl), also known as ADL, could be
@@ -138,7 +140,7 @@ int main()
 
 Block style example:
 ```c++
-int g_count = 0;
+int g_count{0};
 
 namespace foo {
 class Class
@@ -150,7 +152,7 @@ public:
     {
         // Comment summarising what this section of code does
         for (int i = 0; i < n; ++i) {
-            int total_sum = 0;
+            int total_sum{0};
             // When something fails, return early
             if (!Something()) return false;
             ...


### PR DESCRIPTION
Variable initialization is very complex in C++. There seems to be some consensus that when in doubt, use list-initialization. 

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-list
https://www.learncpp.com/cpp-tutorial/variable-assignment-and-initialization/
