### PR TITLE
doc: Fix CI-detected codespell warnings

### DIFF
--- a/src/test/span_tests.cpp
+++ b/src/test/span_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_SUITE(span_tests)
 // aren't compatible with Spans at compile time.
 //
 // Previously there was a bug where writing a SFINAE check for vector<bool> was
-// not possible, because in libstdc++ vector<bool> has a data() memeber
+// not possible, because in libstdc++ vector<bool> has a data() member
 // returning void*, and the Span template guide ignored the data() return value,
 // so the template substitution would succeed, but the constructor would fail,
 // resulting in a fatal compile error, rather than a SFINAE error that could be

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -52,7 +52,7 @@ public:
     virtual bool WithEncryptionKey(std::function<bool (const CKeyingMaterial&)> cb) const = 0;
     virtual bool HasEncryptionKeys() const = 0;
     virtual bool IsLocked() const = 0;
-    //! Callback function for after TopUp completes containining any scripts that were added by a SPKMan
+    //! Callback function for after TopUp completes containing any scripts that were added by a SPKMan
     virtual void TopUpCallback(const std::set<CScript>&, ScriptPubKeyMan*) = 0;
 };
 


### PR DESCRIPTION
Split out the typo fixes encountered in https://github.com/bitcoin/bitcoin/pull/29458 to a separate PR.