### PR TITLE
optimization: Speed up Base58 encoding/decoding by 400%/200% via preliminary byte packing

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -84,7 +84,6 @@ static constexpr int64_t log256_58Ratio = 1366LL; // Approximation of log(256)/l
         psz++;
     if (*psz != 0)
         return false;
-    // Skip leading zeroes in b256.
     std::vector<unsigned char>::iterator it = b256.begin() + (size - length);
     // Copy result into output vector.
     vch.reserve(zeroes + (b256.end() - it));
@@ -120,12 +119,9 @@ std::string EncodeBase58(Span<const unsigned char> input)
         length = i;
         input = input.subspan(1);
     }
-    // Skip leading zeroes in base58 result.
-    std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
-    while (it != b58.end() && *it == 0)
-        it++;
     // Translate the result into a string.
     std::string str;
+    std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
     str.reserve(zeroes + (b58.end() - it));
     str.assign(zeroes, '1');
     while (it != b58.end())

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -43,11 +43,13 @@ static constexpr int8_t mapBase58[256] = {
 
 static constexpr int base{58};
 static constexpr int64_t baseScale{1000LL};
-static constexpr int64_t log58_256Ratio =  733LL;  // Approximation of log(base)/log(256), scaled by baseScale.
+static constexpr int64_t log58_256Ratio =  733LL; // Approximation of log(base)/log(256), scaled by baseScale.
 static constexpr int64_t log256_58Ratio = 1366LL; // Approximation of log(256)/log(base), scaled by baseScale.
 
 // Defines the size of groups that fit into 64 bit batches, processed together for encoding and decoding efficiency.
 static constexpr int encodingBatch = 7;
+static constexpr int decodingBatch = 9;
+static constexpr int64_t decodingPowerOf58 = static_cast<int64_t>(base)*base*base*base*base*base*base*base*base; // pow(base, decodingBatch)
 
 [[nodiscard]] static bool DecodeBase58(const char* input, std::vector<unsigned char>& result, const int max_ret_len)
 {
@@ -66,12 +68,14 @@ static constexpr int encodingBatch = 7;
     result.reserve(leading + size);
     result.assign(leading, 0x00);
 
-    std::vector<uint8_t> inputBatched;
-    inputBatched.reserve(effectiveLength);
-    for (; *input && !IsSpace(*input); ++input) {
+    // Convert the Base58 string to a 64 bit representation for faster manipulation.
+    std::vector<int64_t> inputBatched((effectiveLength + decodingBatch - 1) / decodingBatch, 0);
+    const size_t groupOffset = (decodingBatch - (effectiveLength % decodingBatch)) % decodingBatch;
+    for (size_t i{0}; *input && !IsSpace(*input); ++input, ++i) {
         const int8_t digit = mapBase58[static_cast<uint8_t>(*input)];
-        if (digit == -1) [[unlikely]]  return false;
-        inputBatched.push_back(digit);
+        if (digit == -1) [[unlikely]] return false;
+        const size_t index = (groupOffset + i) / decodingBatch;
+        inputBatched[index] = (inputBatched[index] * base) + digit;
     }
     for (; *input; ++input)
         if (!IsSpace(*input)) [[unlikely]] return false; // Ensure no non-space characters after processing.
@@ -80,7 +84,7 @@ static constexpr int encodingBatch = 7;
     for (size_t i{0}; i < inputBatched.size(); ++resultLength) {
         int64_t remainder = 0;
         for (size_t j{i}; j < inputBatched.size(); ++j) { // Calculate next digit, dividing inputBatched
-            const int64_t accumulator = (remainder * base) + inputBatched[j];
+            const int64_t accumulator = (remainder * decodingPowerOf58) + inputBatched[j];
             inputBatched[j] = accumulator / 256;
             remainder = accumulator % 256;
         }


### PR DESCRIPTION
To mitigate the quadratic complexity inherent in the sequential byte division of the Base58 encoding process, this update aggregates characters into groups of 7 and 9, fitting them into 64-bit long integers.
This refinement utilizes the inherent efficiency of native division and modulo operations on 64-bit architectures, significantly optimizing computational overhead.
The benchmarks indicate a ~4.4x speedup for `Base58Encode`:

> make && ./src/bench/bench_bitcoin --filter=Base58Encode --min-time=1000

before:
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               61.00 |       16,393,083.32 |    0.2% |      1.07 | `Base58Encode`

after:
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               13.79 |       72,502,616.20 |    0.1% |      1.10 | `Base58Encode`

------

The same was applied to decoding, resulting in a ~2x speedup:

> make && ./src/bench/bench_bitcoin --filter=Base58Decode --min-time=1000

before:
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               17.41 |       57,429,723.99 |    0.1% |      1.10 | `Base58Decode`

after:
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                8.80 |      113,590,754.53 |    0.1% |      1.11 | `Base58Decode`

-----

This also speed up [listunspent](https://github.com/bitcoin/bitcoin/pull/29473#issuecomment-2200977622) by >50%.

-----

See https://github.com/bitcoin/bitcoin/pull/29473#issuecomment-2200977622 for additional benchmarks and https://github.com/bitcoin/bitcoin/pull/30035 for additional tests.
I've also tested with with the following temp test (comparing the exact previous impl with the new one for random inputs: https://gist.github.com/paplorinc/96d8e355f6fef10ac79f62d89a6d9f19#file-base58_tests-cpp-L211-L249)