### PR TITLE
test: Refactor subtree exclusion in lint tests

### DIFF
--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -87,3 +87,7 @@ To do so, add the upstream repository as remote:
 ```
 git remote add --fetch secp256k1 https://github.com/bitcoin-core/secp256k1.git
 ```
+
+lint_ignore_dirs.py
+===================
+Add list of common directories to ignore when running tests

--- a/test/lint/lint-include-guards.py
+++ b/test/lint/lint-include-guards.py
@@ -12,19 +12,17 @@ import re
 import sys
 from subprocess import check_output
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
+
 
 HEADER_ID_PREFIX = 'BITCOIN_'
 HEADER_ID_SUFFIX = '_H'
 
 EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/bitcoin-tidy',
                              'src/crypto/ctaes',
-                             'src/leveldb',
-                             'src/crc32c',
-                             'src/secp256k1',
-                             'src/minisketch',
                              'src/tinyformat.h',
                              'src/bench/nanobench.h',
-                             'src/test/fuzz/FuzzedDataProvider.h']
+                             'src/test/fuzz/FuzzedDataProvider.h'] + SHARED_EXCLUDED_SUBTREES
 
 
 def _get_header_file_lst() -> list[str]:

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -14,13 +14,11 @@ import sys
 
 from subprocess import check_output, CalledProcessError
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
+
 
 EXCLUDED_DIRS = ["contrib/devtools/bitcoin-tidy/",
-                 "src/leveldb/",
-                 "src/crc32c/",
-                 "src/secp256k1/",
-                 "src/minisketch/",
-                ]
+                ] + SHARED_EXCLUDED_SUBTREES
 
 EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",
                            "boost/multi_index/detail/hash_index_iterator.hpp",

--- a/test/lint/lint-spelling.py
+++ b/test/lint/lint-spelling.py
@@ -11,8 +11,11 @@ Note: Will exit successfully regardless of spelling errors.
 
 from subprocess import check_output, STDOUT, CalledProcessError
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
+
 IGNORE_WORDS_FILE = 'test/lint/spelling.ignore-words.txt'
-FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/leveldb/", ":(exclude)src/crc32c/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)src/secp256k1/", ":(exclude)src/minisketch/", ":(exclude)contrib/guix/patches"]
+FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/guix/patches"]
+FILES_ARGS += [f":(exclude){dir}" for dir in SHARED_EXCLUDED_SUBTREES]
 
 
 def check_codespell_install():

--- a/test/lint/lint_ignore_dirs.py
+++ b/test/lint/lint_ignore_dirs.py
@@ -1,0 +1,5 @@
+SHARED_EXCLUDED_SUBTREES = ["src/leveldb/",
+                 "src/crc32c/",
+                 "src/secp256k1/",
+                 "src/minisketch/",
+                ]


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/17413

Refactor subtree exclusion in lint tests to one place

Second attempt after PR: https://github.com/bitcoin/bitcoin/pull/24435