### PR TITLE
Drop log category in `SeedStartup`

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -594,7 +594,7 @@ static void SeedStartup(CSHA512& hasher, RNGState& rng) noexcept
 
     // Static environment data
     RandAddStaticEnv(hasher);
-    LogPrint(BCLog::RAND, "Feeding %i bytes of environment data into RNG\n", hasher.Size() - old_size);
+    LogInfo("Feeding %i bytes of environment data into RNG\n", hasher.Size() - old_size);
 
     // Strengthen for 100 ms
     SeedStrengthen(hasher, rng, 100ms);


### PR DESCRIPTION
This `LogPrint(BCLog::RAND, ...)` is never logged because the `SeedStartup` function is called at a very early stage, such as during the instantiation of the static `CSignatureCache` object, before any log categories are added. This PR fixes this behavior.