### PR TITLE
doc: Update OpenBSD build docs for 7.4

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 # OpenBSD Build Guide
 
-**Updated for OpenBSD [7.3](https://www.openbsd.org/73.html)**
+**Updated for OpenBSD [7.4](https://www.openbsd.org/74.html)**
 
 This guide describes how to build bitcoind, command-line utilities, and GUI on OpenBSD.
 
@@ -42,6 +42,8 @@ BerkeleyDB is only required to support legacy wallets.
 
 It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
 from ports. However you can build it yourself, [using depends](/depends).
+
+Refer to [depends/README.md](/depends/README.md) for detailed instructions.
 
 ```bash
 gmake -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1


### PR DESCRIPTION
Updated OpenBSD Build doc for 7.4 after testing all build options. No issues on my end. 

Also added a note about referring to depends/README.md for detailed instructions on required dependencies.
This was added in reference to a conversation in #29443

