### PR TITLE
depends: always configure with `--with-pic`

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -147,7 +147,7 @@ $(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"
 # config.guess, which is what we set it too here. This also quells autoconf
 # warnings, "If you wanted to set the --build type, don't use --host.",
 # when using versions older than 2.70.
-$(1)_autoconf=./configure --build=$(BUILD) --host=$($($(1)_type)_host) --prefix=$($($(1)_type)_prefix) $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
+$(1)_autoconf=./configure --build=$(BUILD) --host=$($($(1)_type)_host) --prefix=$($($(1)_type)_prefix) --with-pic $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
 ifneq ($($(1)_nm),)
 $(1)_autoconf += NM="$$($(1)_nm)"
 endif

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -162,6 +162,9 @@ From the [Gentoo Wiki entry](https://wiki.gentoo.org/wiki/Project:Quality_Assura
 >  creates. This leads to massive overlinking, which is toxic to the Gentoo
 >  ecosystem, as it leads to a massive number of unnecessary rebuilds.
 
+Where possible, packages are built with Position Independant Code. Either using
+the autotools `--with-pic` flag, or `DCMAKE_POSITION_INDEPENDENT_CODE` with CMake.
+
 ## Secondary dependencies:
 
 Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -9,11 +9,6 @@ $(package)_patches=clang_cxx_11.patch
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
 $(package)_config_opts_mingw32=--enable-mingw
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_freebsd=--with-pic
-$(package)_config_opts_netbsd=--with-pic
-$(package)_config_opts_openbsd=--with-pic
-$(package)_config_opts_android=--with-pic
 $(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security -Wno-error=implicit-int
 $(package)_cppflags_freebsd=-D_XOPEN_SOURCE=600 -D__BSD_VISIBLE=1
 $(package)_cppflags_netbsd=-D_XOPEN_SOURCE=600

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -11,7 +11,6 @@ define $(package)_set_vars
   $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts += --without-xmlwf
-  $(package)_config_opts_linux=--with-pic
   $(package)_cppflags += -D_DEFAULT_SOURCE
 endef
 

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -7,7 +7,6 @@ $(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts += --enable-option-checking --without-brotli
-  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -10,7 +10,6 @@ $(package)_dependencies=xproto
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -11,11 +11,6 @@ define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
-  $(package)_config_opts_linux=--with-pic
-  $(package)_config_opts_freebsd=--with-pic
-  $(package)_config_opts_netbsd=--with-pic
-  $(package)_config_opts_openbsd=--with-pic
-  $(package)_config_opts_android=--with-pic
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 
   ifeq ($(NO_HARDEN),)

--- a/depends/packages/libxcb_util.mk
+++ b/depends/packages/libxcb_util.mk
@@ -8,7 +8,6 @@ $(package)_dependencies=libxcb
 define $(package)_set_vars
 $(package)_config_opts = --disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-$(package)_config_opts += --with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -8,8 +8,6 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared --without-tools --without-tests --without-png
 $(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_android=--with-pic
 $(package)_cflags += -Wno-int-conversion -Wno-implicit-function-declaration
 endef
 

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -7,10 +7,6 @@ $(package)_sha256_hash=5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
 $(package)_config_opts+= --disable-rtree --disable-fts4 --disable-fts5
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_freebsd=--with-pic
-$(package)_config_opts_netbsd=--with-pic
-$(package)_config_opts_openbsd=--with-pic
 # We avoid using `--enable-debug` because it overrides CFLAGS, a behavior we want to prevent.
 $(package)_cflags_debug += -g
 $(package)_cppflags_debug += -DSQLITE_DEBUG

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -11,11 +11,6 @@ define $(package)_set_vars
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
   $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
   $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
-  $(package)_config_opts_linux=--with-pic
-  $(package)_config_opts_freebsd=--with-pic
-  $(package)_config_opts_netbsd=--with-pic
-  $(package)_config_opts_openbsd=--with-pic
-  $(package)_config_opts_android=--with-pic
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
We currently do this sporadically. Not only amongst packages, but across OS's, i.e sometimes it's done for BSDs/Android, and sometimes not.

Configure with `--with-pic` globally instead. I think this generally makes more sense, and should not have any downsides.

See related discussion in https://github.com/bitcoin/bitcoin/pull/28846#discussion_r1399123100.