### PR TITLE
test: Remove Windows-specific code from `system_tests/run_command`

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -29,23 +29,12 @@ BOOST_AUTO_TEST_CASE(dummy)
 
 BOOST_AUTO_TEST_CASE(run_command)
 {
-#ifdef WIN32
-    // https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html
-    auto hntdll = GetModuleHandleA("ntdll.dll");
-    assert(hntdll);
-    const bool wine_runtime = GetProcAddress(hntdll, "wine_get_version");
-#endif
-
     {
         const UniValue result = RunCommandParseJSON("");
         BOOST_CHECK(result.isNull());
     }
     {
-#ifdef WIN32
-        const UniValue result = RunCommandParseJSON("cmd.exe /c echo {\"success\": true}");
-#else
         const UniValue result = RunCommandParseJSON("echo \"{\"success\": true}\"");
-#endif
         BOOST_CHECK(result.isObject());
         const UniValue& success = result.find_value("success");
         BOOST_CHECK(!success.isNull());
@@ -53,11 +42,7 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // An invalid command is handled by Boost
-#ifdef WIN32
-        const int expected_error{wine_runtime ? 6 : 2};
-#else
         const int expected_error{2};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON("invalid_command"), boost::process::process_error, [&](const boost::process::process_error& e) {
             BOOST_CHECK(std::string(e.what()).find("RunCommandParseJSON error:") == std::string::npos);
             BOOST_CHECK_EQUAL(e.code().value(), expected_error);
@@ -66,11 +51,7 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, no output to stderr
-#ifdef WIN32
-        const std::string command{"cmd.exe /c exit 1"};
-#else
         const std::string command{"false"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             const std::string what{e.what()};
             BOOST_CHECK(what.find(strprintf("RunCommandParseJSON error: process(%s) returned 1: \n", command)) != std::string::npos);
@@ -79,13 +60,8 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, with error message for stderr
-#ifdef WIN32
-        const std::string command{"cmd.exe /c dir nosuchfile"};
-        const std::string expected{wine_runtime ? "File not found." : "File Not Found"};
-#else
         const std::string command{"ls nosuchfile"};
         const std::string expected{"No such file or directory"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             const std::string what(e.what());
             BOOST_CHECK(what.find(strprintf("RunCommandParseJSON error: process(%s) returned", command)) != std::string::npos);
@@ -95,15 +71,10 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Unable to parse JSON
-#ifdef WIN32
-        const std::string command{"cmd.exe /c echo {"};
-#else
         const std::string command{"echo {"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, HasReason("Unable to parse JSON: {"));
     }
-    // Test std::in, except for Windows
-#ifndef WIN32
+    // Test std::in
     {
         const UniValue result = RunCommandParseJSON("cat", "{\"success\": true}");
         BOOST_CHECK(result.isObject());
@@ -111,7 +82,6 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(!success.isNull());
         BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
-#endif
 }
 #endif // ENABLE_EXTERNAL_SIGNER
 


### PR DESCRIPTION
The removed code has been dead since https://github.com/bitcoin/bitcoin/pull/28967.

Required as a precondition for replacing Boost.Process with [cpp-subprocess](https://github.com/bitcoin/bitcoin/pull/28981) to make diff for this code meaningful and reviewable.

The plan is to reintroduce Windows-specific code in this test simultaneously with enabling Windows support in cpp-subprocess.