### PR TITLE
policy: bump TX_MAX_STANDARD_VERSION to 3

### DIFF
--- a/doc/bips.md
+++ b/doc/bips.md
@@ -69,3 +69,4 @@ BIPs that are implemented by Bitcoin Core:
   [`385`](https://github.com/bitcoin/bips/blob/master/bip-0385.mediawiki):
   Output Script Descriptors, and most of Script Expressions are implemented as of **v0.17.0** ([PR 13697](https://github.com/bitcoin/bitcoin/pull/13697)).
 * [`BIP 386`](https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki): tr() Output Script Descriptors are implemented as of **v22.0** ([PR 22051](https://github.com/bitcoin/bitcoin/pull/22051)).
+* [`BIP 431`](https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki): transactions with nVersion=3 are standard and treated as Topologically Restricted Until Confirmation as of **v28.0** ([PR 29496](https://github.com/bitcoin/bitcoin/pull/29496)).

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -131,7 +131,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
 // allowing the new transaction version in the wallet/RPC.
-static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{2};
+static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{3};
 
 /**
 * Check for standard transaction types

--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -15,8 +15,9 @@
 #include <set>
 #include <string>
 
-// This module enforces rules for transactions with nVersion=3 ("v3 transactions") which help make
+// This module enforces rules for BIP 431 TRUC transactions (with nVersion=3) which help make
 // RBF abilities more robust.
+static constexpr decltype(CTransaction::nVersion) TRUC_VERSION{3};
 
 // v3 only allows 1 parent and 1 child when unconfirmed.
 /** Maximum number of transactions including an unconfirmed tx and its descendants. */

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -173,7 +173,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
             // Create transaction to add to the mempool
             const CTransactionRef tx = [&] {
                 CMutableTransaction tx_mut;
-                tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ? 3 : CTransaction::CURRENT_VERSION;
+                tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ? TRUC_VERSION : CTransaction::CURRENT_VERSION;
                 tx_mut.nLockTime = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<uint32_t>();
                 // Last tx will sweep all outpoints in package
                 const auto num_in = last_tx ? package_outpoints.size()  : fuzzed_data_provider.ConsumeIntegralInRange<int>(1, mempool_outpoints.size());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -226,7 +226,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
         // Create transaction to add to the mempool
         const CTransactionRef tx = [&] {
             CMutableTransaction tx_mut;
-            tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ? 3 : CTransaction::CURRENT_VERSION;
+            tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ? TRUC_VERSION : CTransaction::CURRENT_VERSION;
             tx_mut.nLockTime = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<uint32_t>();
             const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<int>(1, outpoints_rbf.size());
             const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<int>(1, outpoints_rbf.size() * 2);

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -286,7 +286,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
     script_multisig << OP_2 << OP_CHECKMULTISIG;
     {
         CMutableTransaction mtx_many_sigops = CMutableTransaction{};
-        mtx_many_sigops.nVersion = 3;
+        mtx_many_sigops.nVersion = TRUC_VERSION;
         for (const auto& outpoint : multisig_outpoints) {
             mtx_many_sigops.vin.emplace_back(outpoint);
             mtx_many_sigops.vin.back().scriptWitness.stack.emplace_back(script_multisig.begin(), script_multisig.end());

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -118,7 +118,7 @@ void CheckMempoolV3Invariants(const CTxMemPool& tx_pool)
     LOCK(tx_pool.cs);
     for (const auto& tx_info : tx_pool.infoAll()) {
         const auto& entry = *Assert(tx_pool.GetEntry(tx_info.tx->GetHash()));
-        if (tx_info.tx->nVersion == 3) {
+        if (tx_info.tx->nVersion == TRUC_VERSION) {
             // Check that special maximum virtual size is respected
             Assert(entry.GetTxSize() <= V3_MAX_VSIZE);
 
@@ -133,12 +133,12 @@ void CheckMempoolV3Invariants(const CTxMemPool& tx_pool)
                 Assert(entry.GetTxSize() <= V3_CHILD_MAX_VSIZE);
                 // All v3 transactions must only have v3 unconfirmed parents.
                 const auto& parents = entry.GetMemPoolParentsConst();
-                Assert(parents.begin()->get().GetSharedTx()->nVersion == 3);
+                Assert(parents.begin()->get().GetSharedTx()->nVersion == TRUC_VERSION);
             }
         } else if (entry.GetCountWithAncestors() > 1) {
             // All non-v3 transactions must only have non-v3 unconfirmed parents.
             for (const auto& parent : entry.GetMemPoolParentsConst()) {
-                Assert(parent.get().GetSharedTx()->nVersion != 3);
+                Assert(parent.get().GetSharedTx()->nVersion != TRUC_VERSION);
             }
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -831,7 +831,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 //
                 // Replaceability signaling of the original transactions may be
                 // ignored due to node setting.
-                const bool allow_rbf{m_pool.m_opts.full_rbf || SignalsOptInRBF(*ptxConflicting) || ptxConflicting->nVersion == 3};
+                const bool allow_rbf{m_pool.m_opts.full_rbf || SignalsOptInRBF(*ptxConflicting) || ptxConflicting->nVersion == TRUC_VERSION};
                 if (!allow_rbf) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
@@ -935,7 +935,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // method of ensuring the tx remains bumped. For example, the fee-bumping child could disappear
     // due to a replacement.
     // The only exception is v3 transactions.
-    if (!bypass_limits && ws.m_ptx->nVersion != 3 && ws.m_modified_fees < m_pool.m_opts.min_relay_feerate.GetFee(ws.m_vsize)) {
+    if (!bypass_limits && ws.m_ptx->nVersion != TRUC_VERSION && ws.m_modified_fees < m_pool.m_opts.min_relay_feerate.GetFee(ws.m_vsize)) {
         // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
         // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
@@ -1017,7 +1017,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             .descendant_count = maybe_rbf_limits.descendant_count + 1,
             .descendant_size_vbytes = maybe_rbf_limits.descendant_size_vbytes + EXTRA_DESCENDANT_TX_SIZE_LIMIT,
         };
-        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT || ws.m_ptx->nVersion == 3) {
+        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT || ws.m_ptx->nVersion == TRUC_VERSION) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
         }
         if (auto ancestors_retry{m_pool.CalculateMemPoolAncestors(*entry, cpfp_carve_out_limits)}) {

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -287,7 +287,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         self.log.info('Some nonstandard transactions')
         tx = tx_from_hex(raw_tx_reference)
-        tx.nVersion = 3  # A version currently non-standard
+        tx.nVersion = 4  # A version currently non-standard
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'version'}],
             rawtxs=[tx.serialize().hex()],

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -3,6 +3,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+from test_framework.messages import (
+    tx_from_hex,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -33,6 +36,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.test_anti_fee_sniping()
         self.test_tx_size_too_large()
         self.test_create_too_long_mempool_chain()
+        self.test_version3()
 
     def test_anti_fee_sniping(self):
         self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
@@ -105,6 +109,23 @@ class CreateTxWalletTest(BitcoinTestFramework):
                                 test_wallet.send, outputs=[{test_wallet.getnewaddress(): 0.3}], options=options)
 
         test_wallet.unloadwallet()
+
+    def test_version3(self):
+        self.log.info('Check wallet does not create transactions with nVersion=3 yet')
+        wallet_rpc = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        self.nodes[0].createwallet("v3")
+        wallet_v3 = self.nodes[0].get_wallet_rpc("v3")
+
+        tx_data = wallet_rpc.send(outputs=[{wallet_v3.getnewaddress(): 25}], options={"change_position": 0})
+        wallet_tx_data = wallet_rpc.gettransaction(tx_data["txid"])
+        tx_current_version = tx_from_hex(wallet_tx_data["hex"])
+
+        # While v3 transactions are standard, the CURRENT_VERSION is 2.
+        # This test can be removed if CURRENT_VERSION is changed, and replaced with tests that the
+        # wallet handles v3 rules properly.
+        assert_equal(tx_current_version.nVersion, 2)
+        wallet_v3.unloadwallet()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make `nVersion=3` (which is currently nonstandard on mainnet) standard.

Note that we will treat these transactions as Topologically Restricted Until Confirmation (TRUC). Spec is in BIP 431 and implementation is in #28948, #29306, and #29873

See #27463 for overall project tracking, and #29319 for information about relevance to cluster mempool.