### PR TITLE
test: create assert_not_equal util

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -35,6 +35,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
     assert_equal,
+    assert_not_equal,
     assert_raises_rpc_error,
     ensure_for,
     sha256sum_file,
@@ -475,7 +476,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         assert_equal(
             dump_output4['txoutset_hash'],
             "8a1db0d6e958ce0d7c963bc6fc91ead596c027129bacec68acc40351037b09d7")
-        assert sha256sum_file(dump_output['path']) != sha256sum_file(dump_output4['path'])
+        assert_not_equal(sha256sum_file(dump_output['path']), sha256sum_file(dump_output4['path']))
 
         # Use a hash instead of a height
         prev_snap_hash = n0.getblockhash(prev_snap_height)

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -7,7 +7,10 @@ Test that -discover does not add all interfaces' addresses if we listen on only 
 """
 
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_not_equal,
+)
 
 # We need to bind to a routable address for this test to exercise the relevant code
 # and also must have another routable address on another interface which must not
@@ -71,7 +74,7 @@ class BindPortDiscoverTest(BitcoinTestFramework):
             if local['address'] == ADDR1:
                 found_addr1 = True
                 assert_equal(local['port'], BIND_PORT)
-            assert local['address'] != ADDR2
+            assert_not_equal(local['address'], ADDR2)
         assert found_addr1
 
 if __name__ == '__main__':

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -27,6 +27,7 @@ from test_framework.script import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
 )
@@ -275,12 +276,12 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         res2 = index_node.gettxoutsetinfo(hash_type='muhash', hash_or_height=112)
         assert_equal(res["bestblock"], block)
         assert_equal(res["muhash"], res2["muhash"])
-        assert res["muhash"] != res_invalid["muhash"]
+        assert_not_equal(res["muhash"], res_invalid["muhash"])
 
         # Test that requesting reorged out block by hash is still returning correct results
         res_invalid2 = index_node.gettxoutsetinfo(hash_type='muhash', hash_or_height=reorg_block)
         assert_equal(res_invalid2["muhash"], res_invalid["muhash"])
-        assert res["muhash"] != res_invalid2["muhash"]
+        assert_not_equal(res["muhash"], res_invalid2["muhash"])
 
         # Add another block, so we don't depend on reconsiderblock remembering which
         # blocks were touched by invalidateblock

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -36,6 +36,7 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
 )
 from test_framework.wallet import (
@@ -274,7 +275,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         self.log.info(f"Restarted nodes: {self.restart_counts}; crashes on restart: {self.crashed_on_restart}")
 
         # If no nodes were restarted, we didn't test anything.
-        assert self.restart_counts != [0, 0, 0]
+        assert_not_equal(self.restart_counts, [0, 0, 0])
 
         # Make sure we tested the case of crash-during-recovery.
         assert self.crashed_on_restart > 0

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -14,6 +14,7 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
@@ -363,7 +364,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             self.nodes[0].mockscheduler(SECONDS_PER_HOUR)
 
         fee_dat_current_content = open(fee_dat, "rb").read()
-        assert fee_dat_current_content != fee_dat_initial_content
+        assert_not_equal(fee_dat_current_content, fee_dat_initial_content)
 
         fee_dat_initial_content = fee_dat_current_content
 
@@ -371,7 +372,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 5, sync_fun=self.no_op)
         self.restart_node(0)
         fee_dat_current_content = open(fee_dat, "rb").read()
-        assert fee_dat_current_content != fee_dat_initial_content
+        assert_not_equal(fee_dat_current_content, fee_dat_initial_content)
 
 
     def test_acceptstalefeeestimates_option(self):

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -22,6 +22,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     ensure_for,
+    assert_not_equal,
 )
 
 # 2 hashes required per regtest block (with no difficulty adjustment)
@@ -71,7 +72,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         ensure_for(duration=3, f=lambda: len(self.nodes[2].getchaintips()) == 1)
         assert_equal(self.nodes[2].getchaintips()[0]['height'], 0)
 
-        assert self.nodes[1].getbestblockhash() != self.nodes[0].getbestblockhash()
+        assert_not_equal(self.nodes[1].getbestblockhash(), self.nodes[0].getbestblockhash())
         assert_equal(self.nodes[2].getblockcount(), starting_blockcount)
 
         self.log.info("Check that getheaders requests to node2 are ignored")

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -93,6 +93,7 @@ from test_framework.script_util import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_raises_rpc_error,
     assert_equal,
 )
@@ -1570,20 +1571,20 @@ class TaprootTest(BitcoinTestFramework):
         # Require negated taps[0]
         assert taps[0].negflag
         # Require one negated and one non-negated in taps 1 and 2.
-        assert taps[1].negflag != taps[2].negflag
+        assert_not_equal(taps[1].negflag, taps[2].negflag)
         # Require one negated and one non-negated in taps 3 and 4.
-        assert taps[3].negflag != taps[4].negflag
+        assert_not_equal(taps[3].negflag, taps[4].negflag)
         # Require one negated and one non-negated in taps 5 and 6.
-        assert taps[5].negflag != taps[6].negflag
+        assert_not_equal(taps[5].negflag, taps[6].negflag)
 
         cblks = [{leaf: get({**DEFAULT_CONTEXT, 'tap': taps[i], 'leaf': leaf}, 'controlblock') for leaf in taps[i].leaves} for i in range(7)]
         # Require one swapped and one unswapped in taps 3 and 4.
-        assert (cblks[3]['0'][33:65] < cblks[3]['1'][33:65]) != (cblks[4]['0'][33:65] < cblks[4]['1'][33:65])
+        assert_not_equal((cblks[3]['0'][33:65] < cblks[3]['1'][33:65]), (cblks[4]['0'][33:65] < cblks[4]['1'][33:65]))
         # Require one swapped and one unswapped in taps 5 and 6, both at the top and child level.
-        assert (cblks[5]['0'][33:65] < cblks[5]['1'][65:]) != (cblks[6]['0'][33:65] < cblks[6]['1'][65:])
-        assert (cblks[5]['1'][33:65] < cblks[5]['2'][33:65]) != (cblks[6]['1'][33:65] < cblks[6]['2'][33:65])
+        assert_not_equal((cblks[5]['0'][33:65] < cblks[5]['1'][65:]), (cblks[6]['0'][33:65] < cblks[6]['1'][65:]))
+        assert_not_equal((cblks[5]['1'][33:65] < cblks[5]['2'][33:65]), (cblks[6]['1'][33:65] < cblks[6]['2'][33:65]))
         # Require within taps 5 (and thus also 6) that one level is swapped and the other is not.
-        assert (cblks[5]['0'][33:65] < cblks[5]['1'][65:]) != (cblks[5]['1'][33:65] < cblks[5]['2'][33:65])
+        assert_not_equal((cblks[5]['0'][33:65] < cblks[5]['1'][65:]), (cblks[5]['1'][33:65] < cblks[5]['2'][33:65]))
 
         # Compute a deterministic set of scriptPubKeys
         tap_spks = []

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -31,6 +31,7 @@ from test_framework.script import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
 )
 
@@ -86,7 +87,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
         child_two_txid = child_two.rehash()
 
         assert_equal(child_one_txid, child_two_txid)
-        assert child_one_wtxid != child_two_wtxid
+        assert_not_equal(child_one_wtxid, child_two_wtxid)
 
         self.log.info("Submit child_one to the mempool")
         txid_submitted = node.sendrawtransaction(child_one.serialize().hex())

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -15,6 +15,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
+    assert_not_equal,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -239,7 +240,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         # Spend works with dust spent
         sweep_tx_2 = self.wallet.create_self_transfer_multi(fee_per_output=2000, utxos_to_spend=dusty_tx["new_utxos"], version=3)
-        assert sweep_tx["hex"] != sweep_tx_2["hex"]
+        assert_not_equal(sweep_tx["hex"], sweep_tx_2["hex"])
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx_2["hex"]])
         assert_equal(res["package_msg"], "success")
 

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
@@ -479,7 +480,7 @@ class MempoolTRUC(BitcoinTestFramework):
         child_1_conflict = self.wallet.send_self_transfer(from_node=node, version=3, utxo_to_spend=ancestor_tx["new_utxos"][0], fee_rate=Decimal("0.01"))
 
         # Ensure child_1 and child_1_conflict are different transactions
-        assert (child_1_conflict["txid"] != child_1["txid"])
+        assert_not_equal(child_1_conflict["txid"], child_1["txid"])
         self.check_mempool([ancestor_tx["txid"], child_1_conflict["txid"], child_2["txid"]])
         assert_equal(node.getmempoolentry(ancestor_tx["txid"])["descendantcount"], 3)
 

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -13,6 +13,7 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
     create_lots_of_big_transactions,
@@ -302,7 +303,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(mock_time+10)
         new_template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
 
-        assert template != new_template
+        assert_not_equal(template, new_template)
 
 if __name__ == '__main__':
     PrioritiseTransactionTest(__file__).main()

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -21,6 +21,7 @@ from test_framework.messages import (
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
 )
 
@@ -69,11 +70,11 @@ class CompactFiltersTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 2000)
 
         # Check that nodes have signalled NODE_COMPACT_FILTERS correctly.
-        assert peer_0.nServices & NODE_COMPACT_FILTERS != 0
+        assert_not_equal(peer_0.nServices & NODE_COMPACT_FILTERS, 0)
         assert peer_1.nServices & NODE_COMPACT_FILTERS == 0
 
         # Check that the localservices is as expected.
-        assert int(self.nodes[0].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS != 0
+        assert_not_equal(int(self.nodes[0].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS, 0)
         assert int(self.nodes[1].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS == 0
 
         self.log.info("get cfcheckpt on chain to be re-orged out.")
@@ -93,7 +94,7 @@ class CompactFiltersTest(BitcoinTestFramework):
         self.nodes[0].syncwithvalidationinterfacequeue()
 
         main_block_hash = self.nodes[0].getblockhash(1000)
-        assert main_block_hash != stale_block_hash, "node 0 chain did not reorganize"
+        assert_not_equal(main_block_hash, stale_block_hash, error_message="node 0 chain did not reorganize")
 
         self.log.info("Check that peers can fetch cfcheckpt on active chain.")
         tip_hash = self.nodes[0].getbestblockhash()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -57,6 +57,7 @@ from test_framework.script import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     softfork_active,
 )
@@ -735,7 +736,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         test_node.send_and_ping(msg)
 
         # Check that the tip didn't advance
-        assert int(node.getbestblockhash(), 16) != block.sha256
+        assert_not_equal(int(node.getbestblockhash(), 16), block.sha256)
         test_node.sync_with_ping()
 
     # Helper for enabling cb announcements
@@ -788,7 +789,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         cmpct_block.use_witness = True
         delivery_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
-        assert int(node.getbestblockhash(), 16) != block.sha256
+        assert_not_equal(int(node.getbestblockhash(), 16), block.sha256)
 
         msg = msg_no_witness_blocktxn()
         msg.block_transactions.blockhash = block.sha256
@@ -865,19 +866,19 @@ class CompactBlocksTest(BitcoinTestFramework):
             with p2p_lock:
                 # The second peer to announce should still get a getblocktxn
                 assert "getblocktxn" in delivery_peer.last_message
-            assert int(node.getbestblockhash(), 16) != block.sha256
+            assert_not_equal(int(node.getbestblockhash(), 16), block.sha256)
 
             inbound_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
             with p2p_lock:
                 # The third inbound peer to announce should *not* get a getblocktxn
                 assert "getblocktxn" not in inbound_peer.last_message
-            assert int(node.getbestblockhash(), 16) != block.sha256
+            assert_not_equal(int(node.getbestblockhash(), 16), block.sha256)
 
             outbound_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
             with p2p_lock:
                 # The third peer to announce should get a getblocktxn if outbound
                 assert "getblocktxn" in outbound_peer.last_message
-            assert int(node.getbestblockhash(), 16) != block.sha256
+            assert_not_equal(int(node.getbestblockhash(), 16), block.sha256)
 
             # Second peer completes the compact block first
             msg = msg_blocktxn()

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -12,6 +12,7 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     p2p_port,
 )
@@ -82,9 +83,9 @@ class AddrTest(BitcoinTestFramework):
 
             if i > 0:
                 # Responses from different binds should be unique
-                assert last_response_on_local_bind != addr_receiver_onion1.get_received_addrs()
-                assert last_response_on_local_bind != addr_receiver_onion2.get_received_addrs()
-                assert last_response_on_onion_bind1 != addr_receiver_onion2.get_received_addrs()
+                assert_not_equal(last_response_on_local_bind, addr_receiver_onion1.get_received_addrs())
+                assert_not_equal(last_response_on_local_bind, addr_receiver_onion2.get_received_addrs())
+                assert_not_equal(last_response_on_onion_bind1, addr_receiver_onion2.get_received_addrs())
                 # Responses on from the same bind should be the same
                 assert_equal(last_response_on_local_bind, addr_receiver_local.get_received_addrs())
                 assert_equal(last_response_on_onion_bind1, addr_receiver_onion1.get_received_addrs())
@@ -113,9 +114,9 @@ class AddrTest(BitcoinTestFramework):
         addr_receiver_onion2.wait_until(addr_receiver_onion2.addr_received)
 
         # new response is different
-        assert set(last_response_on_local_bind) != set(addr_receiver_local.get_received_addrs())
-        assert set(last_response_on_onion_bind1) != set(addr_receiver_onion1.get_received_addrs())
-        assert set(last_response_on_onion_bind2) != set(addr_receiver_onion2.get_received_addrs())
+        assert_not_equal(set(last_response_on_local_bind), set(addr_receiver_local.get_received_addrs()))
+        assert_not_equal(set(last_response_on_onion_bind1), set(addr_receiver_onion1.get_received_addrs()))
+        assert_not_equal(set(last_response_on_onion_bind2), set(addr_receiver_onion2.get_received_addrs()))
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -9,6 +9,7 @@ import itertools
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_not_equal
 from test_framework.messages import (
     NODE_NETWORK,
     NODE_NETWORK_LIMITED,
@@ -55,7 +56,7 @@ class P2PHandshakeTest(BitcoinTestFramework):
             expected_result = "disconnect" if expect_disconnect else "connect"
             self.log.info(f'    - services 0x{services:08x}, type "{conn_type}" [{expected_result}]')
             if expect_disconnect:
-                assert (services & desirable_service_flags) != desirable_service_flags
+                assert_not_equal((services & desirable_service_flags), desirable_service_flags)
                 expected_debug_log = f'does not offer the expected services ' \
                         f'({services:08x} offered, {desirable_service_flags:08x} expected)'
                 with node.assert_debug_log([expected_debug_log]):

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -25,7 +25,10 @@ from test_framework.messages import COIN
 from test_framework.p2p import P2PDataStore
 from test_framework.script import OP_TRUE
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_not_equal,
+)
 
 
 class InvalidBlockRequestTest(BitcoinTestFramework):
@@ -81,7 +84,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         block2.vtx.append(tx2)
         assert_equal(block2.hashMerkleRoot, block2.calc_merkle_root())
         assert_equal(orig_hash, block2.rehash())
-        assert block2_orig.vtx != block2.vtx
+        assert_not_equal(block2_orig.vtx, block2.vtx)
 
         peer.send_blocks_and_test([block2], node, success=False, reject_reason='bad-txns-duplicate')
 

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -28,6 +28,7 @@ from test_framework.p2p import (
     TXID_RELAY_DELAY,
 )
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -116,7 +117,7 @@ class PeerTxRelayer(P2PTxInvStore):
         self.sync_with_ping()
         for getdata in self.getdata_received:
             for request in getdata.inv:
-                assert request.hash != txhash
+                assert_not_equal(request.hash, txhash)
 
 class OrphanHandlingTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -149,7 +150,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
         tx_bad_wit.wit.vtxinwit[0].scriptWitness.stack = [b'garbage']
 
         assert_equal(tx["txid"], tx_bad_wit.rehash())
-        assert tx["wtxid"] != tx_bad_wit.getwtxid()
+        assert_not_equal(tx["wtxid"], tx_bad_wit.getwtxid())
 
         return tx_bad_wit
 
@@ -410,8 +411,8 @@ class OrphanHandlingTest(BitcoinTestFramework):
         assert_equal(parent_low_fee_nonsegwit["txid"], parent_low_fee_nonsegwit["tx"].getwtxid())
         child = self.wallet.create_self_transfer(utxo_to_spend=parent_low_fee_nonsegwit["new_utxo"])
         grandchild = self.wallet.create_self_transfer(utxo_to_spend=child["new_utxo"])
-        assert child["txid"] != child["tx"].getwtxid()
-        assert grandchild["txid"] != grandchild["tx"].getwtxid()
+        assert_not_equal(child["txid"], child["tx"].getwtxid())
+        assert_not_equal(grandchild["txid"], grandchild["tx"].getwtxid())
 
         # Relay the parent. It should be rejected because it pays 0 fees.
         self.relay_transaction(peer1, parent_low_fee_nonsegwit["tx"])

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -10,7 +10,10 @@ import time
 from test_framework.messages import msg_pong
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_not_equal,
+)
 
 
 PING_INTERVAL = 2 * 60
@@ -52,7 +55,7 @@ class PingPongTest(BitcoinTestFramework):
         self.log.info('Check that ping is sent after connection is established')
         no_pong_node = self.nodes[0].add_p2p_connection(NodeNoPong())
         self.mock_forward(3)
-        assert no_pong_node.last_message.pop('ping').nonce != 0
+        assert_not_equal(no_pong_node.last_message.pop('ping').nonce, 0)
         self.check_peer_info(pingtime=None, minping=None, pingwait=3)
 
         self.log.info('Reply without nonce cancels ping')

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -81,6 +81,7 @@ from test_framework.script_util import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
     ensure_for,
@@ -250,7 +251,7 @@ class SegWitTest(BitcoinTestFramework):
         # self.std_wtx_node is for testing node1 with wtxid relay
         self.std_wtx_node = self.nodes[1].add_p2p_connection(TestP2PConn(wtxidrelay=True), services=P2P_SERVICES)
 
-        assert self.test_node.nServices & NODE_WITNESS != 0
+        assert_not_equal(self.test_node.nServices & NODE_WITNESS, 0)
 
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
@@ -336,7 +337,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Verify the hash with witness differs from the txid
         # (otherwise our testing framework must be broken!)
-        assert tx.rehash() != tx.getwtxid()
+        assert_not_equal(tx.rehash(), tx.getwtxid())
 
         # Construct a block that includes the transaction.
         block = self.build_next_block()
@@ -747,7 +748,7 @@ class SegWitTest(BitcoinTestFramework):
         block.solve()
 
         # Test the test -- witness serialization should be different
-        assert msg_block(block).serialize() != msg_no_witness_block(block).serialize()
+        assert_not_equal(msg_block(block).serialize(), msg_no_witness_block(block).serialize())
 
         # This empty block should be valid.
         test_witness_block(self.nodes[0], self.test_node, block, accepted=True)
@@ -758,7 +759,7 @@ class SegWitTest(BitcoinTestFramework):
         block_2.solve()
 
         # The commitment should have changed!
-        assert block_2.vtx[0].vout[-1] != block.vtx[0].vout[-1]
+        assert_not_equal(block_2.vtx[0].vout[-1], block.vtx[0].vout[-1])
 
         # This should also be valid.
         test_witness_block(self.nodes[0], self.test_node, block_2, accepted=True)
@@ -839,7 +840,7 @@ class SegWitTest(BitcoinTestFramework):
         # TODO: repeat this test with a block that can be relayed
         assert_equal('bad-witness-nonce-size', self.nodes[0].submitblock(block.serialize().hex()))
 
-        assert self.nodes[0].getbestblockhash() != block.hash
+        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.pop()
         assert block.get_weight() < MAX_BLOCK_WEIGHT
@@ -948,7 +949,7 @@ class SegWitTest(BitcoinTestFramework):
         block.vtx[0].wit = CTxWitness()  # drop the nonce
         block.solve()
         assert_equal('bad-witness-merkle-match', self.nodes[0].submitblock(block.serialize().hex()))
-        assert self.nodes[0].getbestblockhash() != block.hash
+        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         # Now redo commitment with the standard nonce, but let bitcoind fill it in.
         add_witness_commitment(block, nonce=0)
@@ -971,7 +972,7 @@ class SegWitTest(BitcoinTestFramework):
 
         assert_equal('bad-txnmrklroot', self.nodes[0].submitblock(block_2.serialize().hex()))
         # Tip should not advance!
-        assert self.nodes[0].getbestblockhash() != block_2.hash
+        assert_not_equal(self.nodes[0].getbestblockhash(), block_2.hash)
 
     @subtest
     def test_extra_witness_data(self):
@@ -1299,7 +1300,7 @@ class SegWitTest(BitcoinTestFramework):
         assert_equal(raw_tx["weight"], tx3.get_weight())
         assert_equal(len(raw_tx["vin"][0]["txinwitness"]), 1)
         assert_equal(raw_tx["vin"][0]["txinwitness"][0], witness_script.hex())
-        assert vsize != raw_tx["size"]
+        assert_not_equal(vsize, raw_tx["size"])
 
         # Cleanup: mine the transactions and update utxo for next test
         self.generate(self.nodes[0], 1)

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -19,7 +19,10 @@ from test_framework.p2p import (
     P2P_VERSION,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_not_equal,
+)
 
 class PeerNoVerack(P2PInterface):
     def __init__(self, wtxidrelay=True):
@@ -119,7 +122,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         no_txrelay_version_msg.relay = 0
         peer.send_without_ping(no_txrelay_version_msg)
         peer.wait_for_verack()
-        assert peer.nServices & NODE_BLOOM != 0
+        assert_not_equal(peer.nServices & NODE_BLOOM, 0)
         assert not peer.sendtxrcncl_msg_received
         self.nodes[0].disconnect_p2ps()
 

--- a/test/functional/p2p_v2_transport.py
+++ b/test/functional/p2p_v2_transport.py
@@ -10,6 +10,7 @@ import socket
 from test_framework.messages import MAGIC_BYTES, NODE_P2P_V2
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     p2p_port,
     assert_raises_rpc_error
@@ -70,7 +71,7 @@ class V2TransportTest(BitcoinTestFramework):
             self.connect_nodes(2, 3, peer_advertises_v2=False)
         self.generate(self.nodes[2], 8, sync_fun=lambda: self.sync_all(self.nodes[2:4]))
         assert_equal(self.nodes[3].getblockcount(), 8)
-        assert self.nodes[0].getbestblockhash() != self.nodes[2].getbestblockhash()
+        assert_not_equal(self.nodes[0].getbestblockhash(), self.nodes[2].getbestblockhash())
         # verify there is a v1 connection between node 2 and 3
         node_2_info = self.nodes[2].getpeerinfo()
         node_3_info = self.nodes[3].getpeerinfo()
@@ -89,7 +90,7 @@ class V2TransportTest(BitcoinTestFramework):
             self.connect_nodes(2, 1, peer_advertises_v2=False) # cannot enable v2 on v1 node
         self.sync_all(self.nodes[1:3])
         assert_equal(self.nodes[1].getblockcount(), 8)
-        assert self.nodes[0].getbestblockhash() != self.nodes[1].getbestblockhash()
+        assert_not_equal(self.nodes[0].getbestblockhash(), self.nodes[1].getbestblockhash())
         # verify there is a v1 connection between node 1 and 2
         node_1_info = self.nodes[1].getpeerinfo()
         node_2_info = self.nodes[2].getpeerinfo()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -49,6 +49,7 @@ from test_framework.p2p import P2PInterface
 from test_framework.script import hash256, OP_TRUE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
@@ -393,7 +394,7 @@ class BlockchainTest(BitcoinTestFramework):
         # hash_type muhash should return a different UTXO set hash.
         res6 = node.gettxoutsetinfo(hash_type='muhash')
         assert 'muhash' in res6
-        assert res['hash_serialized_3'] != res6['muhash']
+        assert_not_equal(res['hash_serialized_3'], res6['muhash'])
 
         # muhash should not be returned unless requested.
         for r in [res, res2, res3, res4, res5]:

--- a/test/functional/rpc_orphans.py
+++ b/test/functional/rpc_orphans.py
@@ -19,6 +19,7 @@ from test_framework.messages import (
 from test_framework.p2p import P2PInterface
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
     assert_raises_rpc_error,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -110,7 +111,7 @@ class OrphanRPCsTest(BitcoinTestFramework):
         assert tx_in_orphanage(node, tx_child_2["tx"])
 
         self.log.info("Check that orphan 1 and 2 were from different peers")
-        assert orphanage[0]["from"][0] != orphanage[1]["from"][0]
+        assert_not_equal(orphanage[0]["from"][0], orphanage[1]["from"][0])
         peer_ids = [orphanage[0]["from"][0], orphanage[1]["from"][0]]
 
         self.log.info("Unorphan child 2")

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -6,6 +6,7 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
 )
 
@@ -55,7 +56,7 @@ class PreciousTest(BitcoinTestFramework):
         self.log.info("Mine competing blocks E-F-G on Node 1")
         hashG = self.generate(self.nodes[1], 3, sync_fun=self.no_op)[-1]
         assert_equal(self.nodes[1].getblockcount(), 5)
-        assert hashC != hashG
+        assert_not_equal(hashC, hashG)
         self.log.info("Connect nodes and check no reorg occurs")
         # Submit competing blocks via RPC so any reorg should occur before we proceed (no way to wait on inaction for p2p sync)
         node_sync_via_rpc(self.nodes[0:2])

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -37,6 +37,7 @@ from test_framework.script import CScript, OP_TRUE
 from test_framework.script_util import MIN_STANDARD_TX_NONWITNESS_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_approx,
     assert_equal,
     assert_greater_than,
@@ -292,7 +293,7 @@ class PSBTTest(BitcoinTestFramework):
         processed_finalized_psbt = self.nodes[0].walletprocesspsbt(psbt=psbtx, finalize=True)
         finalized_psbt = processed_finalized_psbt['psbt']
         finalized_psbt_hex = processed_finalized_psbt['hex']
-        assert signed_psbt != finalized_psbt
+        assert_not_equal(signed_psbt, finalized_psbt)
         assert finalized_psbt_hex == finalized_hex
 
         # Manually selected inputs can be locked:

--- a/test/functional/test_framework/crypto/secp256k1.py
+++ b/test/functional/test_framework/crypto/secp256k1.py
@@ -17,6 +17,7 @@ Exports:
 
 import unittest
 from hashlib import sha256
+from test_framework.util import assert_not_equal
 
 class FE:
     """Objects of this class represent elements of the field GF(2**256 - 2**32 - 977).
@@ -40,7 +41,7 @@ class FE:
             num = (num * b._den) % FE.SIZE
         else:
             den = (den * b) % FE.SIZE
-        assert den != 0
+        assert_not_equal(den, 0)
         if num == 0:
             den = 1
         self._num = num

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -14,7 +14,7 @@ import random
 import unittest
 
 from test_framework.crypto import secp256k1
-from test_framework.util import random_bitflip
+from test_framework.util import assert_not_equal, random_bitflip
 
 # Point with no known discrete log.
 H_POINT = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
@@ -283,7 +283,7 @@ def sign_schnorr(key, msg, aux=None, flip_p=False, flip_r=False):
         sec = ORDER - sec
     t = (sec ^ int.from_bytes(TaggedHash("BIP0340/aux", aux), 'big')).to_bytes(32, 'big')
     kp = int.from_bytes(TaggedHash("BIP0340/nonce", t + P.to_bytes_xonly() + msg), 'big') % ORDER
-    assert kp != 0
+    assert_not_equal(kp, 0)
     R = kp * secp256k1.G
     k = kp if R.y.is_even() != flip_r else ORDER - kp
     e = int.from_bytes(TaggedHash("BIP0340/challenge", R.to_bytes_xonly() + P.to_bytes_xonly() + msg), 'big') % ORDER

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -77,6 +77,7 @@ from test_framework.messages import (
     sha256,
 )
 from test_framework.util import (
+    assert_not_equal,
     MAX_NODES,
     p2p_port,
     wait_until_helper_internal,
@@ -897,7 +898,7 @@ class P2PDataStore(P2PInterface):
             if success:
                 self.wait_until(lambda: node.getbestblockhash() == blocks[-1].hash, timeout=timeout)
             else:
-                assert node.getbestblockhash() != blocks[-1].hash
+                assert_not_equal(node.getbestblockhash(), blocks[-1].hash)
 
     def send_txs_and_test(self, txs, node, *, success=True, expect_disconnect=False, reject_reason=None):
         """Send txs to test node and test whether they're accepted to the mempool.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -33,6 +33,7 @@ from .p2p import P2P_SERVICES, P2P_SUBVERSION
 from .util import (
     MAX_NODES,
     assert_equal,
+    assert_not_equal,
     append_config,
     delete_cookie_file,
     get_auth_cookie,
@@ -668,7 +669,7 @@ class TestNode():
                 self.start(extra_args, stdout=log_stdout, stderr=log_stderr, *args, **kwargs)
                 ret = self.process.wait(timeout=self.rpc_timeout)
                 self.log.debug(self._node_msg(f'bitcoind exited with status {ret} during initialization'))
-                assert ret != 0  # Exit code must indicate failure
+                assert_not_equal(ret, 0) # Exit code must indicate failure
                 self.running = False
                 self.process = None
                 # Check stderr for expected message

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -76,6 +76,10 @@ def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
+def assert_not_equal(thing1, thing2, *, error_message=""):
+    if thing1 == thing2:
+        raise AssertionError(f"Both values are {thing1}{f', {error_message}' if error_message else ''}")
+
 
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -7,6 +7,7 @@
 from test_framework.address import address_to_scriptpubkey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_approx,
     assert_equal,
     assert_raises_rpc_error,
@@ -166,7 +167,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         # Make sure it's starting out as change as expected
         assert node.getaddressinfo(changeaddr)['ischange']
         for logical_tx in node.listtransactions():
-            assert logical_tx.get('address') != changeaddr
+            assert_not_equal(logical_tx.get('address'), changeaddr)
 
         # Spend it
         reset_balance(node, node.getnewaddress())
@@ -174,7 +175,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         # It should still be change
         assert node.getaddressinfo(changeaddr)['ischange']
         for logical_tx in node.listtransactions():
-            assert logical_tx.get('address') != changeaddr
+            assert_not_equal(logical_tx.get('address'), changeaddr)
 
     def test_sending_from_reused_address_without_avoid_reuse(self):
         '''

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -15,6 +15,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error
 )
@@ -169,7 +170,7 @@ class WalletDescriptorTest(BitcoinTestFramework):
         with WalletUnlock(send_wrpc, "pass"):
             addr = send_wrpc.getnewaddress()
             info2 = send_wrpc.getaddressinfo(addr)
-            assert info1['hdmasterfingerprint'] != info2['hdmasterfingerprint']
+            assert_not_equal(info1['hdmasterfingerprint'], info2['hdmasterfingerprint'])
         assert 'hdmasterfingerprint' in send_wrpc.getaddressinfo(send_wrpc.getnewaddress())
         info3 = send_wrpc.getaddressinfo(addr)
         assert_equal(info2['desc'], info3['desc'])

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -8,6 +8,7 @@ import time
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
 )
@@ -56,7 +57,7 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
                     assert hd_master_addr_old == addr
                 elif keytype == "hdseed=1":
                     # ensure we have generated a new hd master key
-                    assert hd_master_addr_old != addr
+                    assert_not_equal(hd_master_addr_old, addr)
                     hd_master_addr_ret = addr
                 elif keytype == "script=1":
                     # scripts don't have keypaths

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -18,6 +18,7 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_approx,
     assert_equal,
     assert_fee_amount,
@@ -660,7 +661,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         outputs = {self.nodes[0].getnewaddress():1.1}
         rawtx = wallet.createrawtransaction(inputs, outputs)
         fundedTx = wallet.fundrawtransaction(rawtx)
-        assert fundedTx["changepos"] != -1
+        assert_not_equal(fundedTx["changepos"], -1)
 
         # Now we need to unlock.
         with WalletUnlock(wallet, "test"):
@@ -903,10 +904,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         for out in res_dec['vout']:
             if out['value'] > 1.0:
                 changeaddress += out['scriptPubKey']['address']
-        assert changeaddress != ""
+        assert_not_equal(changeaddress, "")
         nextaddr = self.nodes[3].getnewaddress()
         # Now the change address key should be removed from the keypool.
-        assert changeaddress != nextaddr
+        assert_not_equal(changeaddress, nextaddr)
 
     def test_option_subtract_fee_from_outputs(self):
         self.log.info("Test fundrawtxn subtractFeeFromOutputs option")

--- a/test/functional/wallet_gethdkeys.py
+++ b/test/functional/wallet_gethdkeys.py
@@ -9,6 +9,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    assert_not_equal,
 )
 from test_framework.wallet_util import WalletUnlock
 
@@ -59,7 +60,7 @@ class WalletGetHDKeyTest(BitcoinTestFramework):
         # New key is active, should be able to get only that one and its descriptors
         xpub_info = wallet.gethdkeys(active_only=True)
         assert_equal(len(xpub_info), 1)
-        assert xpub_info[0]["xpub"] != xpub
+        assert_not_equal(xpub_info[0]["xpub"], xpub)
         assert "xprv" not in xpub_info[0]
         assert_equal(xpub_info[0]["has_private"], True)
 
@@ -67,7 +68,7 @@ class WalletGetHDKeyTest(BitcoinTestFramework):
         assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first", wallet.gethdkeys, private=True)
         with WalletUnlock(wallet, "pass"):
             xpub_info = wallet.gethdkeys(active_only=True, private=True)[0]
-            assert xpub_info["xprv"] != xprv
+            assert_not_equal(xpub_info["xprv"], xprv)
             for desc in wallet.listdescriptors(True)["descriptors"]:
                 if desc["active"]:
                     # After encrypting, HD key was rotated and should appear in all active descriptors

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -9,6 +9,7 @@ import shutil
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
 )
@@ -150,7 +151,7 @@ class WalletHDTest(BitcoinTestFramework):
             orig_masterkeyid = self.nodes[1].getwalletinfo()['hdseedid']
             self.nodes[1].sethdseed()
             new_masterkeyid = self.nodes[1].getwalletinfo()['hdseedid']
-            assert orig_masterkeyid != new_masterkeyid
+            assert_not_equal(orig_masterkeyid, new_masterkeyid)
             addr = self.nodes[1].getnewaddress()
             # Make sure the new address is the first from the keypool
             assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/0\'')
@@ -161,7 +162,7 @@ class WalletHDTest(BitcoinTestFramework):
             orig_masterkeyid = new_masterkeyid
             self.nodes[1].sethdseed(False, new_seed)
             new_masterkeyid = self.nodes[1].getwalletinfo()['hdseedid']
-            assert orig_masterkeyid != new_masterkeyid
+            assert_not_equal(orig_masterkeyid, new_masterkeyid)
             addr = self.nodes[1].getnewaddress()
             assert_equal(orig_masterkeyid, self.nodes[1].getaddressinfo(addr)['hdseedid'])
             # Make sure the new address continues previous keypool
@@ -173,7 +174,7 @@ class WalletHDTest(BitcoinTestFramework):
             assert_equal(new_masterkeyid, self.nodes[1].getaddressinfo(next_addr)['hdseedid'])
             # Make sure the new address is not from previous keypool
             assert_equal(self.nodes[1].getaddressinfo(next_addr)['hdkeypath'], 'm/0\'/0\'/0\'')
-            assert next_addr != addr
+            assert_not_equal(next_addr, addr)
 
             # Sethdseed parameter validity
             assert_raises_rpc_error(-1, 'sethdseed', self.nodes[0].sethdseed, False, new_seed, 0)

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -8,7 +8,11 @@ import time
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_not_equal,
+    assert_raises_rpc_error,
+)
 from test_framework.wallet_util import WalletUnlock
 
 class KeyPoolTest(BitcoinTestFramework):
@@ -80,7 +84,7 @@ class KeyPoolTest(BitcoinTestFramework):
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].getaddressinfo(addr)
         wallet_info = nodes[0].getwalletinfo()
-        assert addr_before_encrypting_data['hdmasterfingerprint'] != addr_data['hdmasterfingerprint']
+        assert_not_equal(addr_before_encrypting_data['hdmasterfingerprint'], addr_data['hdmasterfingerprint'])
         if not self.options.descriptors:
             assert addr_data['hdseedid'] == wallet_info['hdseedid']
         assert_raises_rpc_error(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -12,6 +12,7 @@ from test_framework.descriptors import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_raises_rpc_error,
 )
@@ -52,7 +53,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_equal(8, len([d for d in result['descriptors'] if d['active']]))
         assert_equal(4, len([d for d in result['descriptors'] if d['internal']]))
         for item in result['descriptors']:
-            assert item['desc'] != ''
+            assert_not_equal(item['desc'], '')
             assert item['next_index'] == 0
             assert item['range'] == [0, 0]
             assert item['timestamp'] is not None

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -14,6 +14,7 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_array_result,
     assert_equal,
     assert_raises_rpc_error,
@@ -307,7 +308,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         fee_join = self.nodes[0].getmempoolentry(txid_join)["fees"]["base"]
         # Fee should be correct: assert_equal(fee_join, self.nodes[0].gettransaction(txid_join)['fee'])
         # But it is not, see for example https://github.com/bitcoin/bitcoin/issues/14136:
-        assert fee_join != self.nodes[0].gettransaction(txid_join)["fee"]
+        assert_not_equal(fee_join, self.nodes[0].gettransaction(txid_join)["fee"])
 
     def run_invalid_parameters_test(self):
         self.log.info("Test listtransactions RPC parameter validity")

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -20,6 +20,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
         assert_equal,
         assert_greater_than,
+        assert_not_equal,
         assert_raises_rpc_error
 )
 
@@ -203,11 +204,11 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         tx_after_reorg = self.nodes[1].gettransaction(txid)
         # Check that normal confirmed tx is confirmed again but with different blockhash
         assert_equal(tx_after_reorg["confirmations"], 2)
-        assert tx_before_reorg["blockhash"] != tx_after_reorg["blockhash"]
+        assert_not_equal(tx_before_reorg["blockhash"], tx_after_reorg["blockhash"])
         conflicted_after_reorg = self.nodes[1].gettransaction(conflicted_txid)
         # Check that conflicted tx is confirmed again with blockhash different than previously conflicting tx
         assert_equal(conflicted_after_reorg["confirmations"], 1)
-        assert conflicting["blockhash"] != conflicted_after_reorg["blockhash"]
+        assert_not_equal(conflicting["blockhash"], conflicted_after_reorg["blockhash"])
 
         # Verify we mark coinbase txs, and their descendants, as abandoned during startup
         self.test_coinbase_automatic_abandon_during_startup()

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -11,6 +11,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_not_equal,
     assert_equal,
     assert_fee_amount,
     assert_greater_than,
@@ -46,7 +47,7 @@ class WalletSendTest(BitcoinTestFramework):
                   inputs=None, add_inputs=None, include_unsafe=None, change_address=None, change_position=None, change_type=None,
                   include_watching=None, locktime=None, lock_unspents=None, replaceable=None, subtract_fee_from_outputs=None,
                   expect_error=None, solving_data=None, minconf=None):
-        assert (amount is None) != (data is None)
+        assert_not_equal((amount is None), (data is None))
 
         from_balance_before = from_wallet.getbalances()["mine"]["trusted"]
         if include_unsafe:


### PR DESCRIPTION
In the functional tests there are lots of cases where we assert != which we now swap with assert_not_equal to be more readable

This is motivated/uses logic from this PR which was closed https://github.com/bitcoin/bitcoin/pull/28528
This partially helps https://github.com/bitcoin/bitcoin/issues/23119

I've broken it up to just `assert_not_equal` to keep the PR smaller as suggested in https://github.com/bitcoin/bitcoin/pull/28528#issuecomment-1959945805

I can create follow up PR's if this is wanted