### PR TITLE
ci: print python version on win64 native job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,15 @@ jobs:
         with:
           arch: x64
 
-      - name: Check MSBuild and Qt
+      - name: Get tool information
         run: |
           msbuild -version | Out-File -FilePath "$env:GITHUB_WORKSPACE\msbuild_version"
           Get-Content -Path "$env:GITHUB_WORKSPACE\msbuild_version"
           $env:VCToolsVersion | Out-File -FilePath "$env:GITHUB_WORKSPACE\toolset_version"
-          Get-Content -Path "$env:GITHUB_WORKSPACE\toolset_version"
+          Write-Host "VCToolsVersion $(Get-Content -Path "$env:GITHUB_WORKSPACE\toolset_version")"
           $env:CI_QT_URL | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_url"
           $env:CI_QT_CONF | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_conf"
+          py -3 --version
 
       - name: Restore static Qt cache
         id: static-qt-cache


### PR DESCRIPTION
Adds python version output to the Win64 Native CI job on Github Actions. Also clarifies that one of the versions already printed is the VCToolsVersion.

Before:

![Screenshot 2024-02-28 at 13 47 50](https://github.com/bitcoin/bitcoin/assets/1204616/e01bbba8-e2ad-419f-95d1-925d54b3e87a)

After:

![Screenshot 2024-02-28 at 13 54 22](https://github.com/bitcoin/bitcoin/assets/1204616/e8917376-c8ca-443e-91c7-a73064bd787b)

Should the individual python test runners print the python version instead or also?