### PR TITLE
test: fix a race in rpc_net.py (wait for P2P handshake to complete)

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -113,6 +113,11 @@ class NetTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(no_version_peer_conntime)
         with self.nodes[0].wait_for_new_peer():
             no_version_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        # wait_for_new_peer() will return as soon as a new peer connects, before
+        # transport version has been established. Below we demand that
+        # "transport_protocol_type" is either v1 or v2, so wait for the handshake
+        # to complete.
+        self.wait_until(lambda: self.nodes[0].getpeerinfo()[no_version_peer_id]["transport_protocol_type"] in ["v1", "v2"])
         self.nodes[0].setmocktime(0)
         peer_info = self.nodes[0].getpeerinfo()[no_version_peer_id]
         peer_info.pop("addr")


### PR DESCRIPTION
We connect a new peer, wait for it using `self.nodes[0].wait_for_new_peer()` and then demand that "transport_protocol_type" is either "v1" or "v2". However `wait_for_new_peer()` may return too early - during the P2P handshake when "transport_protocol_type" is "detecting".

Fix this by waiting for the P2P handshake to complete and the protocol version to be established.

An example failure (equal fields removed for clarity):

```
AssertionError: not({
    ...
    'session_id': '',
    'transport_protocol_type': 'detecting',
} == {
    ...
    'session_id': '8fe5902166b892a57ac6849caadd02d2dff83d84f2e57ee50bf894f93cf2f62e',
    'transport_protocol_type': 'v2',
})
```

https://cirrus-ci.com/task/5839860502626304?logs=ci#L8326