### PR TITLE
test: removes unnecessary check from validation_tests

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -233,7 +233,6 @@ BOOST_AUTO_TEST_CASE(block_malleation)
         // Block with two transactions is mutated if any node is duplicate.
         {
             block.vtx[1] = block.vtx[0];
-            BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
             HashWriter hasher;
             hasher.write(block.vtx[0]->GetHash());
             hasher.write(block.vtx[1]->GetHash());


### PR DESCRIPTION
An unnecessary check was added to the block mutation tests in #29412 where IsBlockMutated is returning true for the invalid reasons: we try to check mutation via transaction duplication, but the merkle root is not updated before the check, therefore the check fails because the provided root and the computed root differ, but not because the block contains the same transaction twice.

Notice that a proper check to test the duplication case is added a few lines later, so this check is just meaningless and can be removed. Check https://github.com/bitcoin/bitcoin/pull/29412#discussion_r1506490281 for context.