### PR TITLE
p2p: Don't consider blocks mutated if they don't connect to known prev block

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4721,7 +4721,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         const CBlockIndex* prev_block{WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock))};
 
-        if (IsBlockMutated(/*block=*/*pblock,
+        // Check for possible mutation if it connects to something we know so we can check for DEPLOYMENT_SEGWIT being active
+        if (prev_block && IsBlockMutated(/*block=*/*pblock,
                            /*check_witness_root=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
             LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", peer->m_id);
             Misbehaving(*peer, 100, "mutated block");


### PR DESCRIPTION
Followup to https://github.com/bitcoin/bitcoin/pull/29412 to revert some of the behavior change that was likely unintentional.

Based on comments from https://github.com/bitcoin/bitcoin/pull/29412#discussion_r1507499192