### PR TITLE
depends: add -g to DEBUG=1 flags

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -105,7 +105,7 @@ endif
 darwin_release_CFLAGS=-O2
 darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 
-darwin_debug_CFLAGS=-O1
+darwin_debug_CFLAGS=-O1 -g
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_cmake_system=Darwin

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -10,7 +10,7 @@ endif
 linux_release_CFLAGS=-O2
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
-linux_debug_CFLAGS=-O1
+linux_debug_CFLAGS=-O1 -g
 linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_ENABLE_DEBUG_MODE=1

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -14,7 +14,7 @@ endif
 mingw32_release_CFLAGS=-O2
 mingw32_release_CXXFLAGS=$(mingw32_release_CFLAGS)
 
-mingw32_debug_CFLAGS=-O1
+mingw32_debug_CFLAGS=-O1 -g
 mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -8,7 +8,6 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
 $(package)_config_opts+= --disable-rtree --disable-fts4 --disable-fts5
 # We avoid using `--enable-debug` because it overrides CFLAGS, a behavior we want to prevent.
-$(package)_cflags_debug += -g
 $(package)_cppflags_debug += -DSQLITE_DEBUG
 $(package)_cppflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
 $(package)_cppflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS


### PR DESCRIPTION
Add `-g` to the base DEBUG=1 flags in depends.
Avoids the need to specify it per-package.
More alignment with `--enable-debug` behaviour in configure.

We also want to align the optimization flags, currently -O1 vs -O0, however that can be it's own PR.