### PR TITLE
fuzz: restrict fopencookie usage to Linux & FreeBSD

### DIFF
--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -272,7 +272,7 @@ FILE* FuzzedFileProvider::open()
         [&] {
             mode = "a+";
         });
-#if defined _GNU_SOURCE && !defined __ANDROID__
+#if defined _GNU_SOURCE && (defined(__linux__) || defined(__FreeBSD__))
     const cookie_io_functions_t io_hooks = {
         FuzzedFileProvider::read,
         FuzzedFileProvider::write,


### PR DESCRIPTION
Should fix the GCC compilation portion of https://github.com/bitcoin/bitcoin/issues/29517#issuecomment-1973573314.

See also: https://www.gnu.org/software/gnulib/manual/html_node/fopencookie.html.