### PR TITLE
build, msvc: Do not compile redundant sources

### DIFF
--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -9,19 +9,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\init\bitcoin-qt.cpp" />
-    <ClCompile Include="..\..\src\test\util\setup_common.cpp" />
-    <ClCompile Include="..\..\src\wallet\test\util.cpp">
-      <ObjectFileName>$(IntDir)wallet_test_util.obj</ObjectFileName>
-    </ClCompile>
     <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
     <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
     <ClCompile Include="..\..\src\qt\test\optiontests.cpp" />
     <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
     <ClCompile Include="..\..\src\qt\test\test_main.cpp" />
     <ClCompile Include="..\..\src\qt\test\uritests.cpp" />
-    <ClCompile Include="..\..\src\qt\test\util.cpp">
-      <ObjectFileName>$(IntDir)qt_test_util.obj</ObjectFileName>
-    </ClCompile>
+    <ClCompile Include="..\..\src\qt\test\util.cpp" />
     <ClCompile Include="..\..\src\qt\test\wallettests.cpp" />
     <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />


### PR DESCRIPTION
The `test\util\setup_common.cpp` and `wallet\test\util.cpp` sources are already compiled and included in the `libtest_util` library, which is linked to the `test_bitcoin-qt.exe` binary. This PR follows the same logic as `Makefile.qttest.include`.

Useful for comparing project files across the master branch and the developing [cmake-staging](https://github.com/hebasto/bitcoin/tree/cmake-staging) branch.