### PR TITLE
lint: Misc improvements for lint runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ win32-build
 test/config.ini
 test/cache/*
 test/.mypy_cache/
+test/lint/test_runner/target/
 
 !src/leveldb*/Makefile
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -338,7 +338,7 @@ clean-docs:
 clean-local: clean-docs
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ fuzz.coverage/ test/tmp/ cache/ $(OSX_APP)
 	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache share/rpcauth/__pycache__
-	rm -rf osx_volname dist/
+	rm -rf osx_volname dist/ test/lint/test_runner/target/ test/lint/__pycache__
 
 test-security-check:
 if TARGET_DARWIN

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -16,7 +16,11 @@ result is cached and it prevents issues when the image changes.
 test runner
 ===========
 
-To run all the lint checks in the test runner outside the docker, use:
+To run all the lint checks in the test runner outside the docker you first need
+to install the rust toolchain using your package manager of choice or
+[rustup](https://www.rust-lang.org/tools/install).
+
+Then you can use:
 
 ```sh
 ( cd ./test/lint/test_runner/ && cargo fmt && cargo clippy && RUST_BACKTRACE=1 cargo run )


### PR DESCRIPTION
1. Document the dependency to rust being installed locally
2. Add the build output directory to gitignore
3. Clean up the build output directory when running `make clean`