### PR TITLE
refactor: Improve naming of CBlock::GetHash() -> GetHeaderHash()

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -29,7 +29,7 @@ struct TestBlockAndIndex {
 
         stream >> TX_WITH_WITNESS(block);
 
-        blockHash = block.GetHash();
+        blockHash = block.GetHeaderHash();
         blockindex.phashBlock = &blockHash;
         blockindex.nBits = 403014710;
     }

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -29,7 +29,7 @@ TipBlock getTip(const CChainParams& params, const node::NodeContext& context)
 {
     auto tip = WITH_LOCK(::cs_main, return context.chainman->ActiveTip());
     return (tip) ? TipBlock{tip->GetBlockHash(), tip->GetBlockTime(), tip->nHeight} :
-           TipBlock{params.GenesisBlock().GetHash(), params.GenesisBlock().GetBlockTime(), 0};
+           TipBlock{params.GenesisBlock().GetHeaderHash(), params.GenesisBlock().GetBlockTime(), 0};
 }
 
 void generateFakeBlock(const CChainParams& params,

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
             break;
         }
 
-        uint256 hash = block.GetHash();
+        uint256 hash = block.GetHeaderHash();
         {
             LOCK(cs_main);
             const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(hash);
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
         protected:
             void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override
             {
-                if (block.GetHash() != hash)
+                if (block.GetHeaderHash() != hash)
                     return;
                 found = true;
                 state = stateIn;
@@ -225,7 +225,7 @@ int main(int argc, char* argv[])
         };
 
         bool new_block;
-        auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
+        auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHeaderHash());
         validation_signals.RegisterSharedValidationInterface(sc);
         bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
         validation_signals.UnregisterSharedValidationInterface(sc);

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -216,7 +216,7 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const uint256& block_hash,
 }
 
 BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const CBlockUndo& block_undo)
-    : m_filter_type(filter_type), m_block_hash(block.GetHash())
+    : m_filter_type(filter_type), m_block_hash(block.GetHeaderHash())
 {
     GCSFilter::Params params;
     if (!BuildParams(params)) {

--- a/src/chain.h
+++ b/src/chain.h
@@ -426,7 +426,7 @@ public:
         READWRITE(obj.nNonce);
     }
 
-    uint256 ConstructBlockHash() const
+    uint256 ConstructHeaderHash() const
     {
         CBlockHeader block;
         block.nVersion = nVersion;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -122,7 +122,7 @@ public:
         m_assumed_chain_state_size = 10;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHeaderHash();
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -235,7 +235,7 @@ public:
         m_assumed_chain_state_size = 3;
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHeaderHash();
         assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -369,7 +369,7 @@ public:
         nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1598918400, 52613770, 0x1e0377ae, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHeaderHash();
         assert(consensus.hashGenesisBlock == uint256S("0x00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -474,7 +474,7 @@ public:
         }
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHeaderHash();
         assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -116,7 +116,7 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
             CDiskBlockIndex diskindex;
             if (pcursor->GetValue(diskindex)) {
                 // Construct block index object
-                CBlockIndex* pindexNew = insertBlockIndex(diskindex.ConstructBlockHash());
+                CBlockIndex* pindexNew = insertBlockIndex(diskindex.ConstructHeaderHash());
                 pindexNew->pprev          = insertBlockIndex(diskindex.hashPrev);
                 pindexNew->nHeight        = diskindex.nHeight;
                 pindexNew->nFile          = diskindex.nFile;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1056,7 +1056,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetHash(), block.nBits, GetConsensus())) {
+    if (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, GetConsensus())) {
         LogError("ReadBlockFromDisk: Errors in block header at %s\n", pos.ToString());
         return false;
     }
@@ -1077,7 +1077,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex& index) co
     if (!ReadBlockFromDisk(block, block_pos)) {
         return false;
     }
-    if (block.GetHash() != index.GetBlockHash()) {
+    if (block.GetHeaderHash() != index.GetBlockHash()) {
         LogError("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s\n",
                      index.ToString(), block_pos.ToString());
         return false;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -288,7 +288,7 @@ public:
     uint256 getBestBlockHash() override
     {
         const CBlockIndex* tip = WITH_LOCK(::cs_main, return chainman().ActiveChain().Tip());
-        return tip ? tip->GetBlockHash() : chainman().GetParams().GenesisBlock().GetHash();
+        return tip ? tip->GetBlockHash() : chainman().GetParams().GenesisBlock().GetHeaderHash();
     }
     int64_t getLastBlockTime() override
     {

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -17,7 +17,7 @@ std::string CBlock::ToString() const
 {
     std::stringstream s;
     s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
-        GetHash().ToString(),
+        GetBlockHeader().GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -114,6 +114,14 @@ public:
     }
 
     std::string ToString() const;
+
+    // Don't expose the inherited GetHash() method since it might be
+    // interpreted as representing the whole block while it only represents
+    // the header and doesn't check the block's transactions.
+    uint256 GetHash() = delete;
+    uint256 GetHeaderHash() const {
+        return GetBlockHeader().GetHash();
+    }
 };
 
 /** Describes a place in the block chain to another node such that if the

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -132,7 +132,7 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
     block_out.reset();
     block.hashMerkleRoot = BlockMerkleRoot(block);
 
-    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(block.GetHash(), block.nBits, chainman.GetConsensus()) && !chainman.m_interrupt) {
+    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(block.GetHeaderHash(), block.nBits, chainman.GetConsensus()) && !chainman.m_interrupt) {
         ++block.nNonce;
         --max_tries;
     }
@@ -169,7 +169,7 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
 
         if (block_out) {
             --nGenerate;
-            blockHashes.push_back(block_out->GetHash().GetHex());
+            blockHashes.push_back(block_out->GetHeaderHash().GetHex());
         }
     }
     return blockHashes;
@@ -400,7 +400,7 @@ static RPCHelpMan generateblock()
     }
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("hash", block_out->GetHash().GetHex());
+    obj.pushKV("hash", block_out->GetHeaderHash().GetHex());
     if (!process_new_block) {
         DataStream block_ser;
         block_ser << TX_WITH_WITNESS(*block_out);
@@ -686,7 +686,7 @@ static RPCHelpMan getblocktemplate()
             if (!DecodeHexBlk(block, dataval.get_str()))
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-            uint256 hash = block.GetHash();
+            uint256 hash = block.GetHeaderHash();
             const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(hash);
             if (pindex) {
                 if (pindex->IsValid(BLOCK_VALID_SCRIPTS))
@@ -980,7 +980,7 @@ public:
 
 protected:
     void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override {
-        if (block.GetHash() != hash)
+        if (block.GetHeaderHash() != hash)
             return;
         found = true;
         state = stateIn;
@@ -1018,7 +1018,7 @@ static RPCHelpMan submitblock()
     }
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    uint256 hash = block.GetHash();
+    uint256 hash = block.GetHeaderHash();
     {
         LOCK(cs_main);
         const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(hash);
@@ -1041,7 +1041,7 @@ static RPCHelpMan submitblock()
     }
 
     bool new_block;
-    auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
+    auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHeaderHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
     bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -123,7 +123,7 @@ std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& c
 // Signet block solution checker
 bool CheckSignetBlockSolution(const CBlock& block, const Consensus::Params& consensusParams)
 {
-    if (block.GetHash() == consensusParams.hashGenesisBlock) {
+    if (block.GetHeaderHash() == consensusParams.hashGenesisBlock) {
         // genesis block solution is always valid
         return true;
     }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -46,7 +46,7 @@ static CBlock BuildBlockTestCase() {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
     return block;
 }
 
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
 
         CBlock block3;
         BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[1]}) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.GetHeaderHash().ToString(), block3.GetHeaderHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
     }
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
         CBlock block3;
         PartiallyDownloadedBlock partialBlockCopy = partialBlock;
         BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[0]}) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.GetHeaderHash().ToString(), block3.GetHeaderHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
 
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
         CBlock block2;
         PartiallyDownloadedBlock partialBlockCopy = partialBlock;
         BOOST_CHECK(partialBlock.FillBlock(block2, {}) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.GetHeaderHash().ToString(), block2.GetHeaderHash().ToString());
         bool mutated;
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
         BOOST_CHECK(!mutated);
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
 
     // Test simple header round-trip with only coinbase
     {
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
         CBlock block2;
         std::vector<CTransactionRef> vtx_missing;
         BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.GetHeaderHash().ToString(), block2.GetHeaderHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
         BOOST_CHECK(!mutated);
     }

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -84,7 +84,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
         block.hashMerkleRoot = BlockMerkleRoot(block);
     }
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
 
     return block;
 }
@@ -181,7 +181,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const CBlockIndex* block_index;
         {
             LOCK(cs_main);
-            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHash());
+            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHeaderHash());
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const CBlockIndex* block_index;
         {
             LOCK(cs_main);
-            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHash());
+            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHeaderHash());
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const CBlockIndex* block_index;
         {
             LOCK(cs_main);
-            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHash());
+            block_index = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHeaderHash());
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
@@ -234,14 +234,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 
          {
              LOCK(cs_main);
-             block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainA[i]->GetHash());
+             block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainA[i]->GetHeaderHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
          CheckFilterLookups(filter_index, block_index, chainA_last_header, m_node.chainman->m_blockman);
 
          {
              LOCK(cs_main);
-             block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainB[i]->GetHash());
+             block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainB[i]->GetHeaderHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
          CheckFilterLookups(filter_index, block_index, chainB_last_header, m_node.chainman->m_blockman);

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     filter.insert(uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHash().GetHex());
+    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHeaderHash().GetHex());
 
     BOOST_CHECK_EQUAL(merkleBlock.vMatchedTxn.size(), 1U);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     // Also match the 8th transaction
     filter.insert(uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     filter.insert(ParseHex("044a656f065871a353f216ca26cef8dde2f03e8c16202d2e8ad769f02032cb86a5eb5e56842e92e19141d60a01928f8dd2c875a390f67c1f6c94cfc617c0ea45af"));
 
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 4);
 
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     filter.insert(ParseHex("044a656f065871a353f216ca26cef8dde2f03e8c16202d2e8ad769f02032cb86a5eb5e56842e92e19141d60a01928f8dd2c875a390f67c1f6c94cfc617c0ea45af"));
 
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 3);
 
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
     filter.insert(uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
 
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     filter.insert(uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     // Also match the 4th transaction
     filter.insert(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
     filter.insert(ParseHex("b6efd80d99179f4f4ff6f4dd0a007d018c385d21"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     // We should match the generation outpoint
     BOOST_CHECK(filter.contains(COutPoint(TxidFromString("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
     filter.insert(ParseHex("b6efd80d99179f4f4ff6f4dd0a007d018c385d21"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHeaderHash());
 
     // We shouldn't match any outpoints (UPDATE_NONE)
     BOOST_CHECK(!filter.contains(COutPoint(TxidFromString("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -50,7 +50,7 @@ FUZZ_TARGET(block, .init = initialize_block)
     } else if (valid_incl_merkle || valid_incl_pow) {
         assert(valid_incl_none);
     }
-    (void)block.GetHash();
+    (void)block.GetHeaderHash();
     (void)block.ToString();
     (void)BlockMerkleRoot(block);
     if (!block.vtx.empty()) {

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -23,7 +23,7 @@ FUZZ_TARGET(chain)
     disk_block_index->phashBlock = &zero;
     {
         LOCK(::cs_main);
-        (void)disk_block_index->ConstructBlockHash();
+        (void)disk_block_index->ConstructHeaderHash();
         (void)disk_block_index->GetBlockPos();
         (void)disk_block_index->GetBlockTime();
         (void)disk_block_index->GetBlockTimeMax();

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -130,7 +130,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
     case READ_STATUS_OK:
         assert(!skipped_missing);
         assert(!fail_check_block);
-        assert(block->GetHash() == reconstructed_block.GetHash());
+        assert(block->GetHeaderHash() == reconstructed_block.GetHeaderHash());
         break;
     case READ_STATUS_CHECKBLOCK_FAILED: [[fallthrough]];
     case READ_STATUS_FAILED:

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -61,7 +61,7 @@ FUZZ_TARGET(utxo_snapshot, .init = initialize_chain)
             BlockValidationState dummy;
             bool processed{chainman.ProcessNewBlockHeaders({*block}, true, dummy)};
             Assert(processed);
-            const auto* index{WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block->GetHash()))};
+            const auto* index{WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block->GetHeaderHash()))};
             Assert(index);
         }
     }
@@ -75,7 +75,7 @@ FUZZ_TARGET(utxo_snapshot, .init = initialize_chain)
         int64_t chain_tx{};
         for (const auto& block : *g_chain) {
             Assert(coinscache.HaveCoin(COutPoint{block->vtx.at(0)->GetHash(), 0}));
-            const auto* index{chainman.m_blockman.LookupBlockIndex(block->GetHash())};
+            const auto* index{chainman.m_blockman.LookupBlockIndex(block->GetHeaderHash())};
             const auto num_tx{Assert(index)->nTx};
             Assert(num_tx == 1);
             chain_tx += num_tx;

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -77,15 +77,15 @@ BOOST_AUTO_TEST_CASE(headers_sync_state)
 
     // Generate headers for two different chains (using differing merkle roots
     // to ensure the headers are different).
-    GenerateHeaders(first_chain, target_blocks-1, Params().GenesisBlock().GetHash(),
+    GenerateHeaders(first_chain, target_blocks-1, Params().GenesisBlock().GetHeaderHash(),
             Params().GenesisBlock().nVersion, Params().GenesisBlock().nTime,
             ArithToUint256(0), Params().GenesisBlock().nBits);
 
-    GenerateHeaders(second_chain, target_blocks-2, Params().GenesisBlock().GetHash(),
+    GenerateHeaders(second_chain, target_blocks-2, Params().GenesisBlock().GetHeaderHash(),
             Params().GenesisBlock().nVersion, Params().GenesisBlock().nTime,
             ArithToUint256(1), Params().GenesisBlock().nBits);
 
-    const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(Params().GenesisBlock().GetHash()));
+    const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(Params().GenesisBlock().GetHeaderHash()));
     std::vector<CBlockHeader> headers_batch;
 
     // Feed the first chain to HeadersSyncState, by delivering 1 header

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(findBlock)
 
     CBlock data;
     BOOST_CHECK(chain->findBlock(active[30]->GetBlockHash(), FoundBlock().data(data)));
-    BOOST_CHECK_EQUAL(data.GetHash(), active[30]->GetBlockHash());
+    BOOST_CHECK_EQUAL(data.GetHeaderHash(), active[30]->GetBlockHash());
 
     int64_t time = -1;
     BOOST_CHECK(chain->findBlock(active[40]->GetBlockHash(), FoundBlock().time(time)));

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(merkleblock_construct_from_txids_found)
 
     CMerkleBlock merkleBlock(block, txids);
 
-    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHash().GetHex());
+    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHeaderHash().GetHex());
 
     // vMatchedTxn is only used when bloom filter is specified.
     BOOST_CHECK_EQUAL(merkleBlock.vMatchedTxn.size(), 0U);
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(merkleblock_construct_from_txids_not_found)
     txids2.insert(TxidFromString("0xc0ffee00003bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
     CMerkleBlock merkleBlock(block, txids2);
 
-    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHash().GetHex());
+    BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHeaderHash().GetHex());
     BOOST_CHECK_EQUAL(merkleBlock.vMatchedTxn.size(), 0U);
 
     std::vector<uint256> vMatched;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr));
-        pblock->hashPrevBlock = pblock->GetHash();
+        pblock->hashPrevBlock = pblock->GetHeaderHash();
     }
 
     LOCK(cs_main);

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -21,7 +21,7 @@ static void mineBlock(const node::NodeContext& node, std::chrono::seconds block_
     auto curr_time = GetTime<std::chrono::seconds>();
     SetMockTime(block_time); // update time so the block is created with it
     CBlock block = node::BlockAssembler{node.chainman->ActiveChainstate(), nullptr}.CreateNewBlock(CScript() << OP_TRUE)->block;
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     SetMockTime(curr_time); // process block at current time
     Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -162,7 +162,7 @@ void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
     const auto consensus = chainParams->GetConsensus();
 
     // hash genesis is correct
-    BOOST_CHECK_EQUAL(consensus.hashGenesisBlock, chainParams->GenesisBlock().GetHash());
+    BOOST_CHECK_EQUAL(consensus.hashGenesisBlock, chainParams->GenesisBlock().GetHeaderHash());
 
     // target timespan is an even multiple of spacing
     BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan % consensus.nPowTargetSpacing, 0);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     block = CreateAndProcessBlock(spends, scriptPubKey);
     {
         LOCK(cs_main);
-        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHash());
+        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHeaderHash());
     }
 
     // Test 2: ... and should be rejected if spend1 is in the memory pool
@@ -76,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     block = CreateAndProcessBlock(spends, scriptPubKey);
     {
         LOCK(cs_main);
-        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHash());
+        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHeaderHash());
     }
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 1U);
     WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[0]}, MemPoolRemovalReason::CONFLICT));
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     block = CreateAndProcessBlock(spends, scriptPubKey);
     {
         LOCK(cs_main);
-        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHash());
+        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHeaderHash());
     }
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 1U);
     WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[1]}, MemPoolRemovalReason::CONFLICT));
@@ -100,7 +100,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     block = CreateAndProcessBlock(oneSpend, scriptPubKey);
     {
         LOCK(cs_main);
-        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() == block.GetHash());
+        BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() == block.GetHeaderHash());
     }
     // spends[1] should have been removed from the mempool when the
     // block with spends[0] is accepted:
@@ -236,8 +236,8 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
 
     block = CreateAndProcessBlock({spend_tx}, p2pk_scriptPubKey);
     LOCK(cs_main);
-    BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() == block.GetHash());
-    BOOST_CHECK(m_node.chainman->ActiveChainstate().CoinsTip().GetBestBlock() == block.GetHash());
+    BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() == block.GetHeaderHash());
+    BOOST_CHECK(m_node.chainman->ActiveChainstate().CoinsTip().GetBestBlock() == block.GetHeaderHash());
 
     // Test P2SH: construct a transaction that is valid without P2SH, and
     // then test validity with P2SH.

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -378,7 +378,7 @@ CBlock TestChain100Setup::CreateBlock(
     }
     RegenerateCommitments(block, *Assert(m_node.chainman));
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHeaderHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
 
     return block;
 }

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -132,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     bool block_added = background_cs.ActivateBestChain(state, pblockone);
 
     // Ensure tip is as expected
-    BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), pblockone->GetHash());
+    BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), pblockone->GetHeaderHash());
 
     // g_best_block should be unchanged after adding a block to the background
     // validation chain.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2195,7 +2195,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     AssertLockHeld(cs_main);
     assert(pindex);
 
-    uint256 block_hash{block.GetHash()};
+    uint256 block_hash{block.GetHeaderHash()};
     assert(*pindex->phashBlock == block_hash);
     const bool parallel_script_checks{m_chainman.GetCheckQueue().HasThreads()};
 
@@ -3291,7 +3291,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
                 bool fInvalidFound = false;
                 std::shared_ptr<const CBlock> nullBlockPtr;
-                if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace)) {
+                if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHeaderHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace)) {
                     // A system error occurred
                     return false;
                 }
@@ -4362,7 +4362,7 @@ bool TestBlockValidity(BlockValidationState& state,
     AssertLockHeld(cs_main);
     assert(pindexPrev && pindexPrev == chainstate.m_chain.Tip());
     CCoinsViewCache viewNew(&chainstate.CoinsTip());
-    uint256 block_hash(block.GetHash());
+    uint256 block_hash(block.GetHeaderHash());
     CBlockIndex indexDummy(block);
     indexDummy.pprev = pindexPrev;
     indexDummy.nHeight = pindexPrev->nHeight + 1;
@@ -4761,7 +4761,7 @@ bool Chainstate::LoadGenesisBlock()
     // m_blockman.m_block_index. Note that we can't use m_chain here, since it is
     // set based on the coins db, not the block index db, which is the only
     // thing loaded at this point.
-    if (m_blockman.m_block_index.count(params.GenesisBlock().GetHash()))
+    if (m_blockman.m_block_index.count(params.GenesisBlock().GetHeaderHash()))
         return true;
 
     try {
@@ -4924,13 +4924,13 @@ void ChainstateManager::LoadExternalBlockFile(
                         std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
                         if (m_blockman.ReadBlockFromDisk(*pblockrecursive, it->second)) {
-                            LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, pblockrecursive->GetHash().ToString(),
+                            LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, pblockrecursive->GetHeaderHash().ToString(),
                                     head.ToString());
                             LOCK(cs_main);
                             BlockValidationState dummy;
                             if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
                                 nLoaded++;
-                                queue.push_back(pblockrecursive->GetHash());
+                                queue.push_back(pblockrecursive->GetHeaderHash());
                             }
                         }
                         range.first++;
@@ -5160,7 +5160,7 @@ void ChainstateManager::CheckBlockIndex()
                 }
             }
         }
-        // assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHash()); // Perhaps too slow
+        // assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHeaderHash()); // Perhaps too slow
         // End: actual consistency checks.
 
         // Try descending into the first subnode.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -208,7 +208,7 @@ void ValidationSignals::BlockConnected(ChainstateRole role, const std::shared_pt
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockConnected(role, pblock, pindex); });
     };
     ENQUEUE_AND_LOG_EVENT(event, "%s: block hash=%s block height=%d", __func__,
-                          pblock->GetHash().ToString(),
+                          pblock->GetHeaderHash().ToString(),
                           pindex->nHeight);
 }
 
@@ -228,7 +228,7 @@ void ValidationSignals::BlockDisconnected(const std::shared_ptr<const CBlock>& p
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockDisconnected(pblock, pindex); });
     };
     ENQUEUE_AND_LOG_EVENT(event, "%s: block hash=%s block height=%d", __func__,
-                          pblock->GetHash().ToString(),
+                          pblock->GetHeaderHash().ToString(),
                           pindex->nHeight);
 }
 
@@ -242,11 +242,11 @@ void ValidationSignals::ChainStateFlushed(ChainstateRole role, const CBlockLocat
 
 void ValidationSignals::BlockChecked(const CBlock& block, const BlockValidationState& state) {
     LOG_EVENT("%s: block hash=%s state=%s", __func__,
-              block.GetHash().ToString(), state.ToString());
+              block.GetHeaderHash().ToString(), state.ToString());
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockChecked(block, state); });
 }
 
 void ValidationSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {
-    LOG_EVENT("%s: block hash=%s", __func__, block->GetHash().ToString());
+    LOG_EVENT("%s: block hash=%s", __func__, block->GetHeaderHash().ToString());
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NewPoWValidBlock(pindex, block); });
 }

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -236,7 +236,7 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
                     b.FundTx(fuzzed_data_provider, tx);
                 }
                 // Mine block
-                const uint256& hash = block.GetHash();
+                const uint256& hash = block.GetHeaderHash();
                 interfaces::BlockInfo info{hash};
                 info.prev_hash = &block.hashPrevBlock;
                 info.height = chain.size();
@@ -262,7 +262,7 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
                 auto& [coins, block]{chain.back()};
                 if (block.vtx.empty()) return; // Can only disconnect if the block was submitted first
                 // Disconnect block
-                const uint256& hash = block.GetHash();
+                const uint256& hash = block.GetHeaderHash();
                 interfaces::BlockInfo info{hash};
                 info.prev_hash = &block.hashPrevBlock;
                 info.height = chain.size() - 1;


### PR DESCRIPTION
dergoegge noted [here](https://github.com/bitcoin/bitcoin/pull/29412/commits/49257c0304828a185c273fcb99742c54bbef0c8e) that `CBlock::GetHash()` is a footgun since it only calculates the hash of the header and not the full block. I agree with that sentiment and think it would be beneficial to make this explicit by renaming the inherited function.

The same goes for `ConstructBlockHash()`.