### PR TITLE
doc: Clarify usage of checked witness commitment flag

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3698,6 +3698,13 @@ static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
 static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_commitment, BlockValidationState& state)
 {
     if (expect_witness_commitment) {
+        // The m_checked_witness_commitment flag is only used when a witness
+        // commitment is expected because segwit deployment is assumed disabled
+        // for blocks that are not attached to the chain since no previous
+        // block is available. Should the previous block arrive while the
+        // current block is still being processed (possible because cs_main is
+        // not held the whole time) it could happen that the check is skipped
+        // completely.
         if (block.m_checked_witness_commitment) return true;
 
         int commitpos = GetWitnessCommitmentIndex(block);


### PR DESCRIPTION
Follow-up to #29412

Adds a clarifying comment about the usage of `m_checked_witness_commitment ` based on the conversation in this thread: https://github.com/bitcoin/bitcoin/pull/29412#discussion_r1503345647