### PR TITLE
validation: Use witness maleation flag for non-segwit blocks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3744,9 +3744,9 @@ static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
  * first transaction needs to have at least one input. */
 static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_commitment, BlockValidationState& state)
 {
-    if (expect_witness_commitment) {
-        if (block.m_checked_witness_commitment) return true;
+    if (block.m_checked_witness_commitment) return true;
 
+    if (expect_witness_commitment) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != NO_WITNESS_COMMITMENT) {
             assert(!block.vtx.empty() && !block.vtx[0]->vin.empty());
@@ -3787,6 +3787,7 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
         }
     }
 
+    block.m_checked_witness_commitment = true;
     return true;
 }
 


### PR DESCRIPTION
~~Depends on #29524~~

This is an alternative to #29539 since the race condition documented there should be fixed by #29524. The race condition was [discussed here](https://github.com/bitcoin/bitcoin/pull/29412#discussion_r1503345647). If the race is not possible we can cache this check for non-segwit blocks (= no expected witness) as well.