### PR TITLE
refactor: Avoid unsigned integer overflow in `script/interpreter.cpp`

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -51,8 +51,8 @@ bool CastToBool(const valtype& vch)
  * Script is a stack machine (like Forth) that evaluates a predicate
  * returning a bool indicating valid or not.  There are no loops.
  */
-#define stacktop(i)  (stack.at(stack.size()+(i)))
-#define altstacktop(i)  (altstack.at(altstack.size()+(i)))
+#define stacktop(i) (stack.at(stack.size() - (-(i))))
+#define altstacktop(i) (altstack.at(altstack.size() - (-(i))))
 static inline void popstack(std::vector<valtype>& stack)
 {
     if (stack.empty())

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -55,7 +55,6 @@ unsigned-integer-overflow:MurmurHash3
 unsigned-integer-overflow:CBlockPolicyEstimator::processBlockTx
 unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
 unsigned-integer-overflow:prevector.h
-unsigned-integer-overflow:EvalScript
 unsigned-integer-overflow:xoroshiro128plusplus.h
 implicit-integer-sign-change:CBlockPolicyEstimator::processBlockTx
 implicit-integer-sign-change:SetStdinEcho


### PR DESCRIPTION
Although unsigned integer overflow is not undefined behavior, it's preferable to eliminate the need for an UBSan suppression for it.

~This is an alternative to https://github.com/bitcoin/bitcoin/pull/29541.~