### PR TITLE
doc: update signet faucet link in offline-signing-tutorial.md

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -114,7 +114,7 @@ At this point, it's important to understand that both the `offline_wallet` and o
 tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 ```
 
-2. Visit a faucet like https://signet.bc-2.jp and enter your address from the previous command to receive a small amount of signet coins to this address.
+2. Visit a faucet like https://signetfaucet.com and enter your address from the previous command to receive a small amount of signet coins to this address.
 
 3. Confirm that coins were received using the online `watch_only_wallet`. Note that the transaction may take a few moments before being received on your local node, depending on its connectivity. Just re-run the command periodically until the transaction is received.
 


### PR DESCRIPTION
https://signet.bc-2.jp is broken and https://signetfaucet.com is the same as before.

https://signet.bc-2.jp from archive.org
<img width="1258" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/36817aa6-95ea-427d-8d1d-93e21af86dce">

https://signetfaucet.com
<img width="1242" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/e3248fb0-8a6d-45b3-9268-d883d2385c8f">

reference: https://en.bitcoin.it/wiki/Signet#Faucets
