### PR TITLE
assumeutxo: Add mainnet chainparams for block 830000

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -173,7 +173,12 @@ public:
         };
 
         m_assumeutxo_data = {
-            // TODO to be specified in a future patch.
+            {
+                .height = 830'000,
+                .hash_serialized = AssumeutxoHash{uint256S("0x626992d06b9651ae80865886896adbdde58a180f7d77a85543b0474aa2a4213a")},
+                .nChainTx = 964608352,
+                .blockhash = uint256S("0x000000000000000000011d55599ed27d7efca05f5849b755319c89eb2cffbc1f"),
+            }
         };
 
         chainTxData = ChainTxData{


### PR DESCRIPTION
This seems to have fallen a bit by the wayside (or I missed the conversation) but I don't see a blocker to not have them. I will share a link to the file shortly txoutsetfile.