### PR TITLE
wallet: clarify FundTransaction signature

### DIFF
--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -224,7 +224,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const 
  * Insert additional inputs into the transaction by
  * calling CreateTransaction();
  */
-util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CMutableTransaction& tx, const std::vector<CRecipient>& recipients, std::optional<unsigned int> change_pos, bool lockUnspents, CCoinControl);
+util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const std::vector<CTxIn>& inputs, const std::vector<CRecipient>& recipients, std::optional<unsigned int> change_pos, bool lockUnspents, CCoinControl);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_SPEND_H

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -166,7 +166,7 @@ struct FuzzedWallet {
         // Clear tx.vout since it is not meant to be used now that we are passing outputs directly.
         // This sets us up for a future PR to completely remove tx from the function signature in favor of passing inputs directly
         tx.vout.clear();
-        (void)FundTransaction(*wallet, tx, recipients, change_position, /*lockUnspents=*/false, coin_control);
+        (void)FundTransaction(*wallet, tx.vin, recipients, change_position, /*lockUnspents=*/false, coin_control);
     }
 };
 


### PR DESCRIPTION
Follow up for #28560 ([comment](https://github.com/bitcoin/bitcoin/pull/28560#discussion_r1432869408))

Pass `vector<CTxIn>` instead of `CMutableTransaction` through parameters. Pass `locktime` and `nVersion` as part of `CoinControl` object.