### PR TITLE
fix: avoid calling `GetCoin` and `SignTransaction()` inside of `assert(...)` in tests

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -381,16 +381,14 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
     for (const auto& outpoint_to_spend : inputs) {
         // - Use GetCoin to properly populate utxo_to_spend,
         Coin utxo_to_spend;
-        bool has_utxo = coins_cache.GetCoin(outpoint_to_spend, utxo_to_spend);
-        assert(has_utxo);
+        Assert(coins_cache.GetCoin(outpoint_to_spend, utxo_to_spend));
         input_coins.insert({outpoint_to_spend, utxo_to_spend});
         inputs_amount += utxo_to_spend.out.nValue;
     }
     // - Default signature hashing type
     int nHashType = SIGHASH_ALL;
     std::map<int, bilingual_str> input_errors;
-    bool complete = SignTransaction(mempool_txn, &keystore, input_coins, nHashType, input_errors);
-    assert(complete);
+    Assert(SignTransaction(mempool_txn, &keystore, input_coins, nHashType, input_errors));
     CAmount current_fee = inputs_amount - std::accumulate(outputs.begin(), outputs.end(), CAmount(0),
         [](const CAmount& acc, const CTxOut& out) {
         return acc + out.nValue;
@@ -407,8 +405,7 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
             mempool_txn.vout[fee_output.value()].nValue -= deduction;
             // Re-sign since an output has changed
             input_errors.clear();
-            complete = SignTransaction(mempool_txn, &keystore, input_coins, nHashType, input_errors);
-            assert(complete);
+            Assert(SignTransaction(mempool_txn, &keystore, input_coins, nHashType, input_errors));
             current_fee = target_fee;
         }
     }


### PR DESCRIPTION
Technically, it's not possible to compile without assertions at the moment because of [this check](https://github.com/bitcoin/bitcoin/blob/master/src/util/check.h#L34-L36). However, if it would be removed one day then `txpackage_tests` will start to fail for such builds.

Running `txpackage_tests` compiled with the check removed and `CPPFLAGS="-DNDEBUG"`:
master: `*** 21 failures are detected in the test module "Bitcoin Core Test Suite"`
this PR: `*** No errors detected`