### PR TITLE
Update functional test runner to return error code when no tests are found to run

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -473,7 +473,7 @@ def main():
     if not enable_bitcoind:
         print("No functional tests to run.")
         print("Rerun ./configure with --with-daemon and then make")
-        sys.exit(0)
+        sys.exit(1)
 
     # Build list of tests
     test_list = []
@@ -522,7 +522,7 @@ def main():
     if not test_list:
         print("No valid test scripts specified. Check that your test is in one "
               "of the test lists in test_runner.py, or run test_runner.py with no arguments to run all tests")
-        sys.exit(0)
+        sys.exit(1)
 
     if args.help:
         # Print help for test_runner.py, then print help of the first script (with args removed) and exit.


### PR DESCRIPTION
As discussed in the following PR comment: https://github.com/bitcoin/bitcoin/pull/29535#issuecomment-1979259786

Prevents the test_runner from exiting silently with code 0 when no tests were found which has recently happened after a GHA runner update such as in this run: https://github.com/bitcoin/bitcoin/actions/runs/8131828989/job/22239779585#step:27:63