### PR TITLE
addrman: improve performance of `GetAddr` when specifying network

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -810,6 +810,12 @@ std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct
     AssertLockHeld(cs);
 
     size_t nNodes = vRandom.size();
+    if (network) {
+        auto it = m_network_counts.find(*network);
+        if (it == m_network_counts.end()) return {};
+        const auto counts{it->second};
+        nNodes = counts.n_new + counts.n_tried;
+    }
     if (max_pct != 0) {
         nNodes = max_pct * nNodes / 100;
     }

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -826,6 +826,7 @@ std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct
     // gather a list of random nodes, skipping those of low quality
     const auto now{Now<NodeSeconds>()};
     std::vector<CAddress> addresses;
+    addresses.reserve(nNodes);
     for (unsigned int n = 0; n < vRandom.size(); n++) {
         if (addresses.size() >= nNodes)
             break;

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -143,6 +143,26 @@ static void AddrManGetAddr(benchmark::Bench& bench)
     });
 }
 
+static void AddrManGetAddrByNetwork(benchmark::Bench& bench)
+{
+    AddrMan addrman{EMPTY_NETGROUPMAN, /*deterministic=*/false, ADDRMAN_CONSISTENCY_CHECK_RATIO};
+
+    // add single I2P address to new table
+    CService i2p_service;
+    i2p_service.SetSpecial("udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p");
+    CAddress i2p_address(i2p_service, NODE_NONE);
+    i2p_address.nTime = Now<NodeSeconds>();
+    const CNetAddr source{LookupHost("252.2.2.2", false).value()};
+    addrman.Add({i2p_address}, source);
+
+    FillAddrMan(addrman);
+
+    bench.run([&] {
+        const auto& addresses = addrman.GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/NET_I2P);
+        assert(addresses.size() > 0);
+    });
+}
+
 static void AddrManAddThenGood(benchmark::Bench& bench)
 {
     auto markSomeAsGood = [](AddrMan& addrman) {
@@ -174,4 +194,5 @@ BENCHMARK(AddrManSelect, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManSelectFromAlmostEmpty, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManSelectByNetwork, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManGetAddr, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AddrManGetAddrByNetwork, benchmark::PriorityLevel::HIGH);
 BENCHMARK(AddrManAddThenGood, benchmark::PriorityLevel::HIGH);


### PR DESCRIPTION
`GetAddr` returns all or many randomly selected addresses, it uses `vRandom` (randomly-ordered vector of all `nIds`) to get the addresses. However, if a network is specified, we could check the number of entries in `vRandom` from that network using `m_network_counts` since it contains the number of entries in addrman per network. This way we could avoid unnecessary searchs in `vRandom`. So...

This PR improve the performance of addrman's `GetAddr` by checking `m_network_counts` when specifying a network. 

------------------
`AddrManGetAddrByNetwork` bench:

master:
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          797,416.00 |            1,254.05 |    0.2% |      0.01 | `AddrManGetAddrByNetwork`
```

this PR:
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          462,875.00 |            2,160.41 |    5.6% |      0.01 | :wavy_dash: `AddrManGetAddrByNetwork` (Unstable with ~2.2 iters. Increase `minEpochIterations` to e.g. 22)
```