### PR TITLE
ci: switch back to executing functional tests with powershell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
           $env:CI_QT_URL | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_url"
           $env:CI_QT_CONF | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_conf"
           py -3 --version
+          Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
 
       - name: Restore static Qt cache
         id: static-qt-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,5 +290,6 @@ jobs:
       - name: Run functional tests
         env:
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
-        shell: cmd
-        run: py -3 test\functional\test_runner.py --jobs %NUMBER_OF_PROCESSORS% --ci --quiet --tmpdirprefix=%RUNNER_TEMP% --combinedlogslen=99999999 --timeout-factor=%TEST_RUNNER_TIMEOUT_FACTOR% %TEST_RUNNER_EXTRA%
+        run: |
+          $command = "py -3 test\functional\test_runner.py --jobs $($env:NUMBER_OF_PROCESSORS) --ci --quiet --tmpdirprefix=$($env:RUNNER_TEMP) --combinedlogslen=99999999 --timeout-factor=$($env:TEST_RUNNER_TIMEOUT_FACTOR) $($env:TEST_RUNNER_EXTRA)"
+          Invoke-Expression $command


### PR DESCRIPTION
In this PR: https://github.com/bitcoin/bitcoin/pull/29535 it was noticed that the functional test runner was skipping running the tests with the message of `Test '' not found in full test list`

I believe that this was caused by Powershell passing a blank `TEST_RUNNER_EXTRA` environment variable as an empty flag to the `test_runner.py` script which then tries to find a test to run with a blank name.

This PR switches the functional tests back to using Powershell but instead of passing an empty argument, constructs a command string and then executes that command. It also prints the powershell version to help diagnose any issues in the future (not that this issue was related to powershell version).

I believe it's best to switch back to powershell rather than stick with cmd, even though it currently works, as this is what I would expect the majority of users and windows developers would use.

---

Some extra notes:

- Run with `--extended takes` ~ 28 minutes
- Run without `--extended takes` ~ 15 minutes
- The mac job appears to never run with `--extended`