### PR TITLE
contrib: list other binaries in manpage output

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -62,6 +62,10 @@ with tempfile.NamedTemporaryFile('w', suffix='.h2m') as footer:
     # Copyright is the same for all binaries, so just use the first.
     footer.write('[COPYRIGHT]\n')
     footer.write('\n'.join(versions[0][2]).strip())
+    # Create SEE ALSO section
+    footer.write('\n[SEE ALSO]\n')
+    footer.write(', '.join(s.rpartition('/')[2] + '(1)' for s in BINARIES))
+    footer.write('\n')
     footer.flush()
 
     # Call the binaries through help2man to produce a manual page for each of them.


### PR DESCRIPTION
Add a `SEE ALSO` section to the manpages.

Master:
![master](https://github.com/bitcoin/bitcoin/assets/863730/da6f0151-e43a-4578-983d-4f2def80a8eb)

This PR:
![pr](https://github.com/bitcoin/bitcoin/assets/863730/d57a1c9a-50c7-4f1a-834e-0f8af8520921)


Should be enough to close #29558.