### PR TITLE
consensus: Consistently encode and decode `OP_1NEGATE` similar to other small ints in Script

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -518,14 +518,18 @@ public:
     {
         if (opcode == OP_0)
             return 0;
+        if (opcode == OP_1NEGATE)
+            return -1;
         assert(opcode >= OP_1 && opcode <= OP_16);
         return (int)opcode - (int)(OP_1 - 1);
     }
     static opcodetype EncodeOP_N(int n)
     {
-        assert(n >= 0 && n <= 16);
+        assert(n >= -1 && n <= 16);
         if (n == 0)
             return OP_0;
+        if (n == -1)
+            return OP_1NEGATE;
         return (opcodetype)(OP_1+n-1);
     }
 

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -55,10 +55,10 @@ static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
     return false;
 }
 
-/** Test for "small positive integer" script opcodes - OP_1 through OP_16. */
+/** Test for "small positive integer" script opcodes - OP_0 through OP_16 and OP_1NEGATE. */
 static constexpr bool IsSmallInteger(opcodetype opcode)
 {
-    return opcode >= OP_1 && opcode <= OP_16;
+    return opcode == OP_0 || (opcode >= OP_1 && opcode <= OP_16) || opcode == OP_1NEGATE;
 }
 
 /** Retrieve a minimally-encoded number in range [min,max] from an (opcode, data) pair,


### PR DESCRIPTION
This PR fixes inconsistent behavior for encoding/decoding small integers in Script discovered when working on #29221. 

`OP_1NEGATE` is the minimally encoded version of the number `-1` in Script. All other minimally encoded small integers (`OP_0`, `OP_1`,...,`OP_16`) are handled correctly by `DecodeOP_N()` and `EncodeOP_N()`.

This PR extends this functionality to handling `OP_1NEGATE` in the same way we treat other small integers in Script.

We treat all small integers [consistently in `EvalScript()`](https://github.com/bitcoin/bitcoin/blob/03cff2c1421e5db59963eba1a845ef5dd318c275/src/script/interpreter.cpp#L483) - so we should treat their encoding and decoding helper functions consistently as well. It doesn't make sense to handle `OP_1NEGATE` separately imo.

This is useful for future extensions of the Script language - such as [64bit arithmetic](https://delvingbitcoin.org/t/64-bit-arithmetic-soft-fork/397). If this change isn't accepted, we need to adhoc handle `OP_1NEGATE` separately from other small integers when encoding/decoding `OP_1NEGATE`.