### PR TITLE
doc: Wrap flags with code in developer-notes.md

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -358,7 +358,7 @@ produce better debugging builds.
 ### Show sources in debugging
 
 If you have ccache enabled, absolute paths are stripped from debug information
-with the -fdebug-prefix-map and -fmacro-prefix-map options (if supported by the
+with the `-fdebug-prefix-map` and `-fmacro-prefix-map` options (if supported by the
 compiler). This might break source file detection in case you move binaries
 after compilation, debug from the directory other than the project root or use
 an IDE that only supports absolute paths for debugging.


### PR DESCRIPTION
Before wrap code block
<img width="1077" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/93f39960-311d-411d-acaf-dce69ad36ca0">


After wrap code block
<img width="1073" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/fe6a5cd2-e981-45b1-a150-5a55fab81ae6">
