### PR TITLE
refactor: Reserve memory for ToLower/ToUpper conversions

### DIFF
--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -444,6 +444,7 @@ bool ParseFixedPoint(std::string_view val, int decimals, int64_t *amount_out)
 std::string ToLower(std::string_view str)
 {
     std::string r;
+    r.reserve(str.size());
     for (auto ch : str) r += ToLower(ch);
     return r;
 }
@@ -451,6 +452,7 @@ std::string ToLower(std::string_view str)
 std::string ToUpper(std::string_view str)
 {
     std::string r;
+    r.reserve(str.size());
     for (auto ch : str) r += ToUpper(ch);
     return r;
 }


### PR DESCRIPTION
Similarly to https://github.com/bitcoin/bitcoin/pull/29458, we're preallocating the result string based on the input string's length.
The methods were already [covered by tests](https://github.com/bitcoin/bitcoin/blob/master/src/test/util_tests.cpp#L1250-L1276).