### PR TITLE
refactor: Reduce memory copying operations in bech32 encoding

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -393,6 +393,7 @@ DecodeResult Decode(const std::string& str, CharLimit limit) {
         values[i] = rev;
     }
     std::string hrp;
+    hrp.reserve(pos);
     for (size_t i = 0; i < pos; ++i) {
         hrp += LowerCase(str[i]);
     }
@@ -425,6 +426,7 @@ std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, Ch
     }
 
     std::string hrp;
+    hrp.reserve(pos);
     for (size_t i = 0; i < pos; ++i) {
         hrp += LowerCase(str[i]);
     }

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -363,13 +363,13 @@ std::string Encode(Encoding encoding, const std::string& hrp, const data& values
     // to return a lowercase Bech32/Bech32m string, but if given an uppercase HRP, the
     // result will always be invalid.
     for (const char& c : hrp) assert(c < 'A' || c > 'Z');
-    data checksum = CreateChecksum(encoding, hrp, values);
-    data combined = Cat(values, checksum);
-    std::string ret = hrp + '1';
-    ret.reserve(ret.size() + combined.size());
-    for (const auto c : combined) {
-        ret += CHARSET[c];
-    }
+
+    std::string ret;
+    ret.reserve(hrp.size() + 1 + values.size() + CHECKSUM_SIZE);
+    ret += hrp;
+    ret += '1';
+    for (const uint8_t& i : values) ret += CHARSET[i];
+    for (const uint8_t& i : CreateChecksum(encoding, hrp, values)) ret += CHARSET[i];
     return ret;
 }
 


### PR DESCRIPTION
Started optimizing the base conversions in [TryParseHex](https://github.com/bitcoin/bitcoin/pull/29458), [Base58](https://github.com/bitcoin/bitcoin/pull/29473) and [IsSpace](https://github.com/bitcoin/bitcoin/pull/29602) - this is the next step.

Part of this change was already merged in https://github.com/bitcoin/bitcoin/pull/30047, which made decoding `~26%` faster.

Here I've reduced the memory reallocations and copying operations in bech32 encode, making it `~15%` faster.

>  make && ./src/bench/bench_bitcoin --filter='Bech32Encode' --min-time=1000

Before:
```
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               19.97 |       50,074,562.72 |    0.1% |      1.06 | `Bech32Encode`
```

After:
```
|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               17.33 |       57,687,668.20 |    0.1% |      1.10 | `Bech32Encode`
```