### PR TITLE
BufferedFile: fclose at destruction

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -520,6 +520,10 @@ public:
             throw std::ios_base::failure("Rewind limit must be less than buffer size");
     }
 
+    ~BufferedFile() { fclose(); }
+
+    int fclose() { return m_src.fclose(); }
+
     //! check whether we're at the end of the source file
     bool eof() const {
         return m_read_pos == nSrcPos && m_src.feof();

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -65,4 +65,8 @@ FUZZ_TARGET(buffered_file)
         }
         opt_buffered_file->GetPos();
     }
+    if (opt_buffered_file) {
+        opt_buffered_file->fclose();
+        opt_buffered_file.reset();
+    }
 }


### PR DESCRIPTION
This is currently indirectly implied by src/bench/load_external.cpp:LoadExternalBlockFile
`The file will be closed by LoadExternalBlockFile().`

It reveals a subtle (but noop currently) bug in the BufferedFile fuzz tests: Because the BufferedFile is created before the CAutoFile, the CAutoFile gets cleaned up first, leaving the BufferedFile with pointers to a deleted CAutoFile. The simple fix for this is to use the newly-added `fclose` for BufferedFile, and both are trivial changes, so I've squashed them into a single commit.