### PR TITLE
ci: add print of powershell version to win64 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
           $env:CI_QT_URL | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_url"
           $env:CI_QT_CONF | Out-File -FilePath "$env:GITHUB_WORKSPACE\qt_conf"
           py -3 --version
+          Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
 
       - name: Restore static Qt cache
         id: static-qt-cache


### PR DESCRIPTION
Extraction of just printing powershell version from closed PR: https://github.com/bitcoin/bitcoin/pull/29581

See https://github.com/bitcoin/bitcoin/pull/29581#issuecomment-1984212990 for the cause of a CI failure which was a powershell update.

This PR will make it easier to notice in the future that PS has changed.