### PR TITLE
log: Remove error() reference

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -215,7 +215,7 @@ static inline bool LogAcceptCategory(BCLog::LogFlags category, BCLog::Level leve
 /** Return true if str parses as a log category and set the flag */
 bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 
-// Be conservative when using LogPrintf/error or other things which
+// Be conservative when using functions that
 // unconditionally log to debug.log! It should not be the case that an inbound
 // peer can fill up a user's disk with debug.log entries.
 


### PR DESCRIPTION
Mini-followup to #29236 that was just merged. Removes a reference to `error()` that was missed in a comment.