### PR TITLE
test: fix intermittent failures with test=addrman

### DIFF
--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -39,7 +39,8 @@ def expected_messages(filename):
 class AsmapTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-checkaddrman=1"]]  # Do addrman checks on all operations.
+        # Do addrman checks on all operations and use deterministic addrman
+        self.extra_args = [["-checkaddrman=1", "-test=addrman"]]
 
     def fill_addrman(self, node_id):
         """Add 2 tried addresses to the addrman, followed by 2 new addresses."""

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -319,7 +319,9 @@ class NetTest(BitcoinTestFramework):
 
     def test_addpeeraddress(self):
         self.log.info("Test addpeeraddress")
-        self.restart_node(1, ["-checkaddrman=1", "-test=addrman"])
+        # The node has an existing, non-deterministic addrman from a previous test.
+        # Clear it to have a deterministic addrman.
+        self.restart_node(1, ["-checkaddrman=1", "-test=addrman"], clear_addrman=True)
         node = self.nodes[1]
 
         self.log.debug("Test that addpeerinfo is a hidden RPC")


### PR DESCRIPTION
The `nKey` of the addrman is generated the first time the node is started with an empty `peers.dat`. Therefore, restarting a node or turning it off and on again won't make a previously non-deterministic addrman deterministic.
This could lead to intermittent failures in `feature_asmap.py` and `rpc_net.py`

Fixes #29634