### PR TITLE
Fix tiebreak when loading blocks from disk (and add tests for comparing chain ties)

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -191,7 +191,9 @@ public:
     uint32_t nNonce{0};
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
-    int32_t nSequenceId{0};
+    //! Initialized to 1 when loading blocks from disk, except for blocks belonging to the best chain
+    //! which overwrite it to 0.
+    int32_t nSequenceId{1};
 
     //! (memory only) Maximum nTime in the chain up to and including this block.
     unsigned int nTimeMax{0};

--- a/src/chain.h
+++ b/src/chain.h
@@ -35,6 +35,9 @@ static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
  * MAX_FUTURE_BLOCK_TIME.
  */
 static constexpr int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME;
+//! Init values for CBlockIndex nSequenceId when loaded from disk
+static constexpr int32_t SEQ_ID_BEST_CHAIN_FROM_DISK = 0;
+static constexpr int32_t SEQ_ID_INIT_FROM_DISK = 1;
 
 /**
  * Maximum gap between node time and block time used
@@ -191,9 +194,9 @@ public:
     uint32_t nNonce{0};
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
-    //! Initialized to 1 when loading blocks from disk, except for blocks belonging to the best chain
-    //! which overwrite it to 0.
-    int32_t nSequenceId{1};
+    //! Initialized to SEQ_ID_INIT_FROM_DISK{1} when loading blocks from disk, except for blocks
+    //! belonging to the best chain which overwrite it to SEQ_ID_BEST_CHAIN_FROM_DISK{0}.
+    int32_t nSequenceId{SEQ_ID_INIT_FROM_DISK};
 
     //! (memory only) Maximum nTime in the chain up to and including this block.
     unsigned int nTimeMax{0};

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -161,7 +161,7 @@ bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIn
     if (pa->nChainWork > pb->nChainWork) return false;
     if (pa->nChainWork < pb->nChainWork) return true;
 
-    // ... then by earliest time received, ...
+    // ... then by earliest activatable time, ...
     if (pa->nSequenceId < pb->nSequenceId) return false;
     if (pa->nSequenceId > pb->nSequenceId) return true;
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -218,7 +218,7 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     // We assign the sequence id to blocks only when the full data is available,
     // to avoid miners withholding blocks but broadcasting headers, to get a
     // competitive advantage.
-    pindexNew->nSequenceId = 1;
+    pindexNew->nSequenceId = SEQ_ID_INIT_FROM_DISK;
 
     pindexNew->phashBlock = &((*mi).first);
     BlockMap::iterator miPrev = m_block_index.find(block.hashPrevBlock);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -166,7 +166,8 @@ bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIn
     if (pa->nSequenceId > pb->nSequenceId) return true;
 
     // Use pointer address as tie breaker (should only happen with blocks
-    // loaded from disk, as those all have id 0).
+    // loaded from disk, as those share the same id: 0 for blocks on the
+    // best chain, 1 for all others).
     if (pa < pb) return false;
     if (pa > pb) return true;
 
@@ -217,7 +218,7 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     // We assign the sequence id to blocks only when the full data is available,
     // to avoid miners withholding blocks but broadcasting headers, to get a
     // competitive advantage.
-    pindexNew->nSequenceId = 0;
+    pindexNew->nSequenceId = 1;
 
     pindexNew->phashBlock = &((*mi).first);
     BlockMap::iterator miPrev = m_block_index.find(block.hashPrevBlock);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4698,7 +4698,7 @@ bool Chainstate::LoadChainTip()
     // to maintain a consistent best tip over reboots in case of a tie.
     auto target = tip;
     while (target) {
-        target->nSequenceId = 0;
+        target->nSequenceId = SEQ_ID_BEST_CHAIN_FROM_DISK;
         target = target->pprev;
     }
 
@@ -5357,7 +5357,9 @@ void ChainstateManager::CheckBlockIndex() const
                 }
             }
         }
-        if (!pindex->HaveNumChainTxs()) assert(pindex->nSequenceId <= 1); // nSequenceId can't be set higher than 1 for blocks that aren't linked (negative is used for preciousblock, 0 for active chain)
+        // nSequenceId can't be set higher than SEQ_ID_INIT_FROM_DISK{1} for blocks that aren't linked
+        // (negative is used for preciousblock, SEQ_ID_BEST_CHAIN_FROM_DISK{0} for active chain when loaded from disk)
+        if (!pindex->HaveNumChainTxs()) assert(pindex->nSequenceId <= SEQ_ID_INIT_FROM_DISK);
         // VALID_TRANSACTIONS is equivalent to nTx > 0 for all nodes (whether or not pruning has occurred).
         // HAVE_DATA is only equivalent to nTx > 0 (or VALID_TRANSACTIONS) if no pruning has occurred.
         if (!m_blockman.m_have_pruned) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -1034,8 +1034,9 @@ public:
      * Every received block is assigned a unique and increasing identifier, so we
      * know which one to give priority in case of a fork.
      */
-    /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
-    int32_t nBlockSequenceId GUARDED_BY(::cs_main) = 1;
+    /** Blocks loaded from disk are assigned id 1 (0 if they belong to the best
+     * chain loaded from disk), so start the counter at 2. **/
+    int32_t nBlockSequenceId GUARDED_BY(::cs_main) = 2;
     /** Decreasing counter (used by subsequent preciousblock calls). */
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
@@ -1046,7 +1047,7 @@ public:
     void ResetBlockSequenceCounters() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        nBlockSequenceId = 1;
+        nBlockSequenceId = 2;
         nBlockReverseSequenceId = -1;
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1034,9 +1034,10 @@ public:
      * Every received block is assigned a unique and increasing identifier, so we
      * know which one to give priority in case of a fork.
      */
-    /** Blocks loaded from disk are assigned id 1 (0 if they belong to the best
-     * chain loaded from disk), so start the counter at 2. **/
-    int32_t nBlockSequenceId GUARDED_BY(::cs_main) = 2;
+    /** Blocks loaded from disk are assigned id SEQ_ID_INIT_FROM_DISK{1}
+     * (SEQ_ID_BEST_CHAIN_FROM_DISK{0} if they belong to the best chain loaded from disk),
+     * so start the counter after that. **/
+    int32_t nBlockSequenceId GUARDED_BY(::cs_main) = SEQ_ID_INIT_FROM_DISK + 1;
     /** Decreasing counter (used by subsequent preciousblock calls). */
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
@@ -1047,7 +1048,7 @@ public:
     void ResetBlockSequenceCounters() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        nBlockSequenceId = 2;
+        nBlockSequenceId = SEQ_ID_INIT_FROM_DISK + 1;
         nBlockReverseSequenceId = -1;
     }
 

--- a/test/functional/feature_chain_tiebreaks.py
+++ b/test/functional/feature_chain_tiebreaks.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that the correct active block is chosen in complex reorgs."""
+
+from test_framework.blocktools import create_block
+from test_framework.messages import CBlockHeader
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class ChainTiebreaksTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    @staticmethod
+    def send_headers(node, blocks):
+        """Submit headers for blocks to node."""
+        for block in blocks:
+            # Use RPC rather than P2P, to prevent the message from being interpreted as a block
+            # announcement.
+            node.submitheader(hexdata=CBlockHeader(block).serialize().hex())
+
+    def run_test(self):
+        node = self.nodes[0]
+        # Add P2P connection to bitcoind
+        peer = node.add_p2p_connection(P2PDataStore())
+
+        self.log.info('Precomputing blocks')
+        #
+        #          /- B3 -- B7
+        #        B1      \- B8
+        #       /  \
+        #      /    \ B4 -- B9
+        #   B0           \- B10
+        #      \
+        #       \  /- B5
+        #        B2
+        #          \- B6
+        #
+        blocks = []
+
+        # Construct B0, building off genesis.
+        start_height = node.getblockcount()
+        blocks.append(create_block(
+            hashprev=int(node.getbestblockhash(), 16),
+            tmpl={"height": start_height + 1}
+        ))
+        blocks[-1].solve()
+
+        # Construct B1-B10.
+        for i in range(1, 11):
+            blocks.append(create_block(
+                hashprev=blocks[(i - 1) >> 1].hash_int,
+                tmpl={
+                    "height": start_height + (i + 1).bit_length(),
+                    # Make sure each block has a different hash.
+                    "curtime": blocks[-1].nTime + 1,
+                }
+            ))
+            blocks[-1].solve()
+
+        self.log.info('Make sure B0 is accepted normally')
+        peer.send_blocks_and_test([blocks[0]], node, success=True)
+        # B0 must be active chain now.
+        assert_equal(node.getbestblockhash(), blocks[0].hash_hex)
+
+        self.log.info('Send B1 and B2 headers, and then blocks in opposite order')
+        self.send_headers(node, blocks[1:3])
+        peer.send_blocks_and_test([blocks[2]], node, success=True)
+        peer.send_blocks_and_test([blocks[1]], node, success=False)
+        # B2 must be active chain now, as full data for B2 was received first.
+        assert_equal(node.getbestblockhash(), blocks[2].hash_hex)
+
+        self.log.info('Send all further headers in order')
+        self.send_headers(node, blocks[3:])
+        # B2 is still the active chain, headers don't change this.
+        assert_equal(node.getbestblockhash(), blocks[2].hash_hex)
+
+        self.log.info('Send blocks B7-B10')
+        peer.send_blocks_and_test([blocks[7]], node, success=False)
+        peer.send_blocks_and_test([blocks[8]], node, success=False)
+        peer.send_blocks_and_test([blocks[9]], node, success=False)
+        peer.send_blocks_and_test([blocks[10]], node, success=False)
+        # B2 is still the active chain, as B7-B10 have missing parents.
+        assert_equal(node.getbestblockhash(), blocks[2].hash_hex)
+
+        self.log.info('Send parents B3-B4 of B8-B10 in reverse order')
+        peer.send_blocks_and_test([blocks[4]], node, success=False, force_send=True)
+        peer.send_blocks_and_test([blocks[3]], node, success=False, force_send=True)
+        # B9 is now active. Despite B7 being received earlier, the missing parent.
+        assert_equal(node.getbestblockhash(), blocks[9].hash_hex)
+
+        self.log.info('Invalidate B9-B10')
+        node.invalidateblock(blocks[9].hash_hex)
+        node.invalidateblock(blocks[10].hash_hex)
+        # B7 is now active.
+        assert_equal(node.getbestblockhash(), blocks[7].hash_hex)
+
+if __name__ == '__main__':
+    ChainTiebreaksTest(__file__).main()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -866,8 +866,8 @@ class P2PDataStore(P2PInterface):
          - the on_getheaders handler will ensure that any getheaders are responded to
          - if force_send is False: wait for getdata for each of the blocks. The on_getdata handler will
            ensure that any getdata messages are responded to. Otherwise send the full block unsolicited.
-         - if success is True: assert that the node's tip advances to the most recent block
-         - if success is False: assert that the node's tip doesn't advance
+         - if success is True: assert that the node's tip is the last block in blocks at the end of the operation.
+         - if success is False: assert that the node's tip isn't the last block in blocks at the end of the operation
          - if reject_reason is set: assert that the correct reject message is logged"""
 
         with p2p_lock:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -320,6 +320,7 @@ BASE_SCRIPTS = [
     'feature_includeconf.py',
     'feature_addrman.py',
     'feature_asmap.py',
+    'feature_chain_tiebreaks.py',
     'feature_fastprune.py',
     'feature_framework_miniwallet.py',
     'mempool_unbroadcast.py',


### PR DESCRIPTION
This PR grabs some interesting bits from https://github.com/bitcoin/bitcoin/pull/29284 and fixes some edge cases in how block tiebreaks are dealt with.

## Regarding #29284

The main functionality from the PR was dropped given it was not an issue anymore, however, reviewers pointed out some comments were outdated https://github.com/bitcoin/bitcoin/pull/29284#discussion_r1522023578 (which to my understanding may have led to thinking that there was still an issue) it also added test coverage for the aforementioned case which was already passing on master and is useful to keep.

## New functionality

While reviewing the superseded PR, it was noticed that blocks that are loaded from disk may face a similar issue (check https://github.com/bitcoin/bitcoin/pull/29284#issuecomment-1994317785 for more context).

The issue comes from how tiebreaks for equal work blocks are handled: if two blocks have the same amount of work, the one that is activatable first wins, that is, the one for which we have all its data (and all of its ancestors'). The variable that keeps track of this, within `CBlockIndex` is `nSequenceId`, which is not persisted over restarts. This means that when a node is restarted, all blocks loaded from disk are defaulted the same `nSequenceId`: 0. 
Now, when trying to decide what chain is best on loading blocks from disk, the previous tiebreaker rule is not decisive anymore, so the `CBlockIndexWorkComparator` has to default to its last rule: whatever block is loaded first (has a smaller memory address). 

This means that if multiple same work tip candidates were available before restarting the node, it could be the case that the selected chain tip after restarting does not match the one before.

Therefore, the way `nSequenceId` is initialized is changed to:

- 0 for blocks that belong to the previously known best chain
- 1 to all other blocks loaded from disk