### PR TITLE
kernel: Handle fatal errors through return values

### DIFF
--- a/contrib/devtools/bitcoin-tidy/CMakeLists.txt
+++ b/contrib/devtools/bitcoin-tidy/CMakeLists.txt
@@ -25,7 +25,7 @@ find_program(CLANG_TIDY_EXE NAMES "clang-tidy-${LLVM_VERSION_MAJOR}" "clang-tidy
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
 
-add_library(bitcoin-tidy MODULE bitcoin-tidy.cpp logprintf.cpp)
+add_library(bitcoin-tidy MODULE bitcoin-tidy.cpp logprintf.cpp fatal_error.cpp)
 target_include_directories(bitcoin-tidy SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
 
 # Disable RTTI and exceptions as necessary
@@ -58,8 +58,9 @@ else()
 endif()
 
 # Create a dummy library that runs clang-tidy tests as a side-effect of building
-add_library(bitcoin-tidy-tests OBJECT EXCLUDE_FROM_ALL example_logprintf.cpp)
+add_library(bitcoin-tidy-tests OBJECT EXCLUDE_FROM_ALL example_logprintf.cpp example_fatal_error.cpp)
 add_dependencies(bitcoin-tidy-tests bitcoin-tidy)
+target_include_directories(bitcoin-tidy-tests PRIVATE "${PROJECT_SOURCE_DIR}/../../../src")
 
 set_target_properties(bitcoin-tidy-tests PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 

--- a/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
+++ b/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "fatal_error.h"
 #include "logprintf.h"
 
 #include <clang-tidy/ClangTidyModule.h>
@@ -13,6 +14,7 @@ public:
     void addCheckFactories(clang::tidy::ClangTidyCheckFactories& CheckFactories) override
     {
         CheckFactories.registerCheck<bitcoin::LogPrintfCheck>("bitcoin-unterminated-logprintf");
+        CheckFactories.registerCheck<bitcoin::FatalErrorCheck>("bitcoin-fatal-error");
     }
 };
 

--- a/contrib/devtools/bitcoin-tidy/example_fatal_error.cpp
+++ b/contrib/devtools/bitcoin-tidy/example_fatal_error.cpp
@@ -1,0 +1,237 @@
+// Copyright (c) 2024-present Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "util/result.h"
+
+#include <functional>
+#include <string>
+#include <thread>
+
+// Test for bitcoin-fatal-error
+
+using util::Result;
+
+enum class FatalError
+{
+    Fatal
+};
+
+enum class ChainstateLoadError
+{
+    Error
+};
+
+Result<void, FatalError> void_fatal_func()
+{
+    return {};
+}
+
+Result<bool, FatalError> bool_fatal_func()
+{
+    return true;
+}
+
+Result<int, FatalError> int_fatal_func()
+{
+    return 1;
+}
+
+class Test {
+public:
+    Result<void, FatalError> fatal_func() {
+        return void_fatal_func();
+    }
+};
+
+template<typename T>
+void CheckFatalBad(Result<T, FatalError> fatal, int i, int j) {
+    return;
+}
+
+template<typename T>
+void CheckFatal(Result<T, FatalError> fatal, int i, int j) {
+    return;
+}
+
+void TraceThread(std::string name, std::function<void()> thread_func) {
+    thread_func();
+}
+
+Result<void, FatalError> good_fatal_func_1()
+{
+    auto lambda_1 = ([&]() {
+        return void_fatal_func();
+    });
+
+    auto lambda_2 = ([&]() {
+        Result<void, FatalError> result{};
+        result.Set(void_fatal_func());
+    });
+
+    auto lambda_3 = ([&]() {
+        Result<void, FatalError> result{};
+        result.MoveMessages(void_fatal_func());
+    });
+
+    auto lambda_4 = ([&]() {
+        Result<void, FatalError> result{};
+        auto res{void_fatal_func()};
+        result.MoveMessages(res);
+    });
+    return {};
+}
+
+Result<void, FatalError> good_fatal_func_2()
+{
+    Result<void, FatalError> result{};
+    auto res{void_fatal_func()};
+    result.MoveMessages(res);
+    return result;
+}
+
+Result<void, FatalError> good_fatal_func_3()
+{
+    auto res{void_fatal_func()};
+    return res;
+}
+
+Result<void, FatalError> good_fatal_func_4()
+{
+    Result<void, FatalError> result{};
+    result.Set(void_fatal_func());
+    result.MoveMessages(void_fatal_func());
+    if (result)
+    {
+        return void_fatal_func();
+    }
+    return result;
+}
+
+Result<void, FatalError> good_fatal_func_5()
+{
+    Result<void, FatalError> result{};
+    if (auto res{void_fatal_func()}; !res)
+    {
+        result.MoveMessages(res);
+        return result;
+    }
+    return {};
+}
+
+Result<int, FatalError> good_fatal_func_6()
+{
+    Test testy{};
+    auto res{testy.fatal_func()};
+    Result<void, FatalError> result{};
+    result.MoveMessages(res);
+    return 0;
+}
+
+Result<int, FatalError> good_fatal_func_7()
+{
+    Result<int, FatalError> result{1};
+    result.Set([&]()
+    {
+        return int_fatal_func();
+    }());
+    return int_fatal_func();
+}
+
+Result<void, FatalError> good_fatal_func_8()
+{
+    Result<void, FatalError> result{};
+    result.Set(void_fatal_func());
+    auto res{void_fatal_func()};
+    if (!res) {
+        result.Set(std::move(res));
+    } else {
+        result.MoveMessages(res);
+    }
+    return result;
+}
+
+void good_fatal_func_9()
+{
+    CheckFatal(bool_fatal_func(), 0, 0);
+}
+
+void good_fatal_func_10()
+{
+    [&]()
+    {
+        CheckFatal(void_fatal_func(), 0, 0);
+    }();
+}
+
+int good_fatal_func_11()
+{
+    int i = 0;
+    if (1) {
+        i += 1;
+    }
+    auto handle = std::thread(&TraceThread, "", [] {
+        CheckFatal(void_fatal_func(), 0, 0);
+    });
+    return i;
+}
+
+Result<int, ChainstateLoadError> good_fatal_func_12()
+{
+    bool_fatal_func();
+    return {0};
+}
+
+void bad_fatal_func_1()
+{
+    void_fatal_func();
+    auto testy{void_fatal_func()};
+}
+
+void bad_fatal_func_2()
+{
+    Test testy{};
+    testy.fatal_func();
+}
+
+void bad_fatal_func_3()
+{
+    [&]()
+    {
+        void_fatal_func();
+    }();
+}
+
+void bad_fatal_func_4()
+{
+    CheckFatalBad(void_fatal_func(), 0, 0);
+}
+
+void bad_fatal_func_5()
+{
+    CheckFatal(void_fatal_func(), 0, 0);
+    void_fatal_func();
+}
+
+void bad_fatal_func_6()
+{
+    int zero{0};
+    void_fatal_func();
+    CheckFatal(void_fatal_func(), 0, 0);
+}
+
+Result<int, FatalError> bad_fatal_func_7()
+{
+    [&]()
+    {
+        return void_fatal_func();
+    }();
+    return {0};
+}
+
+Result<int, FatalError> bad_fatal_func_8()
+{
+    auto res{void_fatal_func()};
+    if (!res) return {util::Error{}, util::MoveMessages(res), res.GetFailure()};
+    return 0;
+}

--- a/contrib/devtools/bitcoin-tidy/fatal_error.cpp
+++ b/contrib/devtools/bitcoin-tidy/fatal_error.cpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2024-present Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "fatal_error.h"
+
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+#include <string>
+
+using namespace clang::ast_matchers;
+
+namespace bitcoin {
+
+/**
+ * @class VisitHandledFatal
+ *
+ * Visits call expressions inside a given function to check if a specific call
+ * expression is used as an argument by a certain list of "valid" functions.
+ */
+class VisitHandledFatal : public clang::RecursiveASTVisitor<VisitHandledFatal> {
+private:
+    const clang::CallExpr* m_fatal_call_expr;
+    bool m_handled_fatal{false};
+    const std::set<std::string> m_valid_function_names;
+
+public:
+    explicit VisitHandledFatal(const clang::CallExpr* fatal_call_expr,
+                               const std::set<std::string> valid_function_names)
+        : m_fatal_call_expr{fatal_call_expr},
+          m_valid_function_names{valid_function_names} {}
+
+    bool VisitCallExpr(const clang::CallExpr* call_expr) {
+        // Find functions handling fatal errors
+        if (const clang::FunctionDecl* callee{call_expr->getDirectCallee()}) {
+            const auto name{callee->getNameAsString()};
+            if (m_valid_function_names.contains(name)) {
+                // Inspect the found function's argument
+                if (call_expr->getNumArgs() > 0) {
+                    const clang::Expr* check_fatal_argument{call_expr->getArg(0)->IgnoreImpCasts()};
+
+                    // The call expression might be moved, so retrieve the relevant
+                    // temporaries first
+                    if (const auto* temp_expr{clang::dyn_cast<clang::MaterializeTemporaryExpr>(check_fatal_argument)}) {
+                        if (const auto* bound_temp_expr{clang::dyn_cast<clang::CXXBindTemporaryExpr>(temp_expr->getSubExpr()->IgnoreImpCasts())}) {
+                            if (const auto* argument{clang::dyn_cast<clang::CallExpr>(bound_temp_expr->getSubExpr()->IgnoreImpCasts())}) {
+                                check_fatal_argument = argument;
+                            }
+                        }
+                    }
+
+                    // The call expression is usually held in a temporary, so retrieve the
+                    // temporary first
+                    if (const auto* temp_expr{clang::dyn_cast<clang::CXXBindTemporaryExpr>(check_fatal_argument)}) {
+                        if (const auto* argument{clang::dyn_cast<clang::CallExpr>(temp_expr->getSubExpr()->IgnoreImpCasts())}) {
+                            check_fatal_argument = argument;
+                        }
+                    }
+
+                    // Do a direct pointer comparison here, since we expect them to be the
+                    // same AST node
+                    if (check_fatal_argument == m_fatal_call_expr) {
+                        m_handled_fatal = true;
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    bool HandledFatal() { return m_handled_fatal; }
+};
+
+/**
+ * @class VisitConsumedFatal
+ *
+ * Visits call expressions and return statements inside a given function to
+ * check if a specific variable is either used by a specific "valid" function,
+ * or used by a return statement.
+ */
+class VisitConsumedFatal
+    : public clang::RecursiveASTVisitor<VisitConsumedFatal> {
+private:
+    const clang::VarDecl* m_fatal_var;
+    bool m_consumed_fatal{false};
+
+public:
+    explicit VisitConsumedFatal(const clang::VarDecl* fatal_var)
+        : m_fatal_var{fatal_var} {}
+
+    bool VisitCXXMemberCallExpr(const clang::CXXMemberCallExpr* expr) {
+        // Find method calls of interest
+        if (const auto* member_expr{dyn_cast<clang::MemberExpr>(expr->getCallee())}) {
+            if (member_expr->getMemberDecl()->getNameAsString() == "MoveMessages") {
+                // Retrieve the first argument of the method call
+                if (const auto* decl_ref{dyn_cast<clang::DeclRefExpr>(expr->getArg(0)->IgnoreImpCasts())}) {
+                    // Once found, check if the arguments declaration matches the variable
+                    // of interest.
+                    if (decl_ref->getDecl() == m_fatal_var) {
+                        m_consumed_fatal = true;
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    bool VisitReturnStmt(const clang::ReturnStmt* returnStmt) {
+        // Retrieve the value returned by a return statement
+        if (const clang::Expr* ret_expr{returnStmt->getRetValue()}) {
+            // The Result type has a complicated move constructor, so retrieve the
+            // actual value from behind the constructor
+            if (const auto* construct_expr{dyn_cast<clang::CXXConstructExpr>(ret_expr)}) {
+                if (construct_expr->getNumArgs() > 0) {
+                    if (const auto* decl_ref_expr{dyn_cast<clang::DeclRefExpr>(construct_expr->getArg(0)->IgnoreImpCasts())}) {
+                        // If the value could be retrieved, check if its declaration matches
+                        // the variable of interest
+                        if (decl_ref_expr->getDecl() == m_fatal_var) {
+                            m_consumed_fatal = true;
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    bool ConsumedFatalVar() { return m_consumed_fatal; }
+};
+
+void FatalErrorCheck::registerMatchers(clang::ast_matchers::MatchFinder* finder) {
+    auto fatal_error_type_matcher = callExpr(
+        hasType(
+            classTemplateSpecializationDecl(
+                hasTemplateArgument(
+                    1,
+                    refersToType(
+                        hasDeclaration(
+                            enumDecl(
+                                matchesName("FatalError")
+                            )
+                        )
+                    )
+                )
+            )
+        ),
+        // Add an exception for fatal error results produced by calls to the
+        // Result's Set method
+        unless(
+            callee(
+                cxxMethodDecl(
+                    hasName("Set"),
+                    ofClass(
+                        hasName("Result")
+                    )
+                )
+            )
+        )
+    );
+
+    finder->addMatcher(
+        fatal_error_type_matcher.bind("call-to-fatal-error"),
+        this);
+}
+
+void FatalErrorCheck::check(const clang::ast_matchers::MatchFinder::MatchResult &result) {
+    const auto* fatal_call_expr{result.Nodes.getNodeAs<clang::CallExpr>("call-to-fatal-error")};
+    if (!fatal_call_expr) return;
+
+    const clang::FunctionDecl* fatal_enclosing_func{nullptr};
+
+    // Traverse up the AST to find the function declaration enclosing the
+    // FatalError call.
+    auto parents{result.Context->getParents(*fatal_call_expr)};
+    while (!parents.empty()) {
+        auto current_node{parents[0]};
+        parents = result.Context->getParents(current_node);
+
+        if (const auto* func_decl{current_node.get<clang::FunctionDecl>()}) {
+            // Ensure that func_decl is not a lambda.
+            if (const auto* method_decl{clang::dyn_cast<clang::CXXMethodDecl>(func_decl)}) {
+                if (method_decl->getParent()->isLambda()) {
+                    continue;
+                }
+            }
+            fatal_enclosing_func = func_decl;
+            break;
+        }
+    }
+
+    if (!fatal_enclosing_func) return;
+
+    // Make an exception for functions returning ChainstateLoadError.
+    if (fatal_enclosing_func->getReturnType().getAsString().find("ChainstateLoadError") != std::string::npos) {
+        return;
+    }
+
+    // Check that the enclosing function also returns a FatalError.
+    if (fatal_enclosing_func->getReturnType().getAsString().find("FatalError") == std::string::npos) {
+        // Make an exception for functions that handle the FatalError.
+        const std::set<std::string> function_names{
+            "CheckFatal", "HandleFatalError", "UnwrapFatalError", "CheckFatalFailure"
+        };
+        VisitHandledFatal visitor{fatal_call_expr, function_names};
+        visitor.TraverseStmt(fatal_enclosing_func->getBody());
+        if (visitor.HandledFatal()) return;
+
+        const clang::FunctionDecl* fatal_func{fatal_call_expr->getDirectCallee()};
+        const std::string fatal_call_name = fatal_func ? fatal_func->getNameAsString() : "a function";
+
+        const auto &source_manager{result.Context->getSourceManager()};
+        const std::string message =
+            fatal_enclosing_func->getNameAsString() +
+            " does not return or handle a FatalError, but calls " +
+            fatal_call_name + " on line " +
+            std::to_string(source_manager.getSpellingLineNumber( fatal_call_expr->getBeginLoc())) +
+            " which does return a FatalError.\n"
+            "To fix this, either return a FatalError in this function, "
+            "or handle the FatalError with one of `CheckFatal`, "
+            "`HandleFatalError`, `UnwrapFatalError`, or `CheckFatalFailure`";
+
+        // If the enclosing function was expanded from a macro, just report on the
+        // line reporting the fatal call expression.
+        const auto loc{fatal_enclosing_func->getBeginLoc()};
+        if (loc.isMacroID()) {
+            diag(fatal_call_expr->getBeginLoc(), message);
+        } else {
+            diag(loc, message);
+        }
+        return;
+    }
+
+    // Track whether the identified FatalError results returned from function
+    // calls are consumed properly, meaning
+    // 1. Check if they are returned immediately
+    // 2. Check if they are assigned to an existing result with .MoveMessages or
+    // .Set
+    // 3. Check if they are eventually used as an arugment by a .MoveMessages call
+
+    // Check if the result is immediately returned or get the variable it is
+    // assigned to
+    const clang::VarDecl* fatal_var_decl{nullptr};
+    parents = result.Context->getParents(*fatal_call_expr);
+    while (!parents.empty()) {
+        // Move up the AST until a FunctionDecl is reached - in which case no
+        // consuming return statement or variable declaration was found.
+        if (parents[0].get<clang::FunctionDecl>()) {
+            break;
+        }
+        if (parents[0].get<clang::ReturnStmt>()) {
+            // If the value is returned immediately, the check is done.
+            return;
+        }
+        if (const auto* var_decl{parents[0].get<clang::VarDecl>()}) {
+            fatal_var_decl = var_decl;
+            break;
+        }
+        parents = result.Context->getParents(parents[0]);
+    }
+
+    // Check if the result is immediately consumed by the .MoveMessages() or
+    // .Set() methods.
+    const std::set<std::string> function_names{"Set", "MoveMessages"};
+    VisitHandledFatal visitor{fatal_call_expr, function_names};
+    visitor.TraverseStmt(fatal_enclosing_func->getBody());
+    // If the value is consumed immediately, the check is done.
+    if (visitor.HandledFatal()) return;
+
+    // If the declaration was found, ensure that it is either returned, or used by
+    // a call to .MoveMessages.
+    if (fatal_var_decl) {
+      VisitConsumedFatal visitor{fatal_var_decl};
+      visitor.TraverseStmt(fatal_enclosing_func->getBody());
+      // If the value is eventually consumed, the check is done.
+      if (visitor.ConsumedFatalVar()) return;
+    }
+
+    diag(fatal_call_expr->getBeginLoc(),
+         "Call to function returning a FatalError result not properly consumed.\n"
+         "It can either be immediately returned or directly consumed by "
+         ".MoveMessages or .Set, "
+         "or assigned to a variable which in turn has to be passed to "
+         ".MoveMessages or be returned eventually.");
+}
+
+} // namespace bitcoin

--- a/contrib/devtools/bitcoin-tidy/fatal_error.h
+++ b/contrib/devtools/bitcoin-tidy/fatal_error.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2024-present Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FATAL_ERROR_CHECK_H
+#define FATAL_ERROR_CHECK_H
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace bitcoin {
+
+/**
+ * @class FatalErrorCheck
+ *
+ * Warn about incorrect usage of util::Result<T, FatalError>. The check enforces
+ * the following rules:
+ *
+ * 1. If a function calls another function with a util::Result<T, FatalCondition>
+ * return type, its return type has to be util::Result<T, FatalCondition> too,
+ * or it has to handle the value returned by the function with one of
+ * "CheckFatal", "HandleFatalError", "UnwrapFatalError", "CheckFatalFailure".
+ *
+ * 2. In functions returning a util::Result<T, FatalCondition> a call to a
+ * function returning a util::Result<T, FatalCondition> needs to propagate the
+ * value by either:
+ *  a) Returning it immediately
+ *  b) Assigning it immediately to an existing result with .MoveMessages() or
+ *     .Set()
+ *  c) Eventually passing it as an arugment to a .MoveMessages() call
+ */
+class FatalErrorCheck final : public clang::tidy::ClangTidyCheck {
+public:
+  FatalErrorCheck(clang::StringRef Name, clang::tidy::ClangTidyContext *Context)
+      : clang::tidy::ClangTidyCheck(Name, Context) {}
+
+  bool isLanguageVersionSupported(
+      const clang::LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void registerMatchers(clang::ast_matchers::MatchFinder *Finder) override;
+  void
+  check(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bitcoin
+
+#endif // FATAL_ERROR_CHECK_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -188,6 +188,7 @@ BITCOIN_CORE_H = \
   kernel/context.h \
   kernel/cs_main.h \
   kernel/disconnected_transactions.h \
+  kernel/fatal_error.h \
   kernel/mempool_entry.h \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -753,6 +753,7 @@ libbitcoin_util_a_SOURCES = \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/readwritefile.cpp \
+  util/result.cpp \
   util/signalinterrupt.cpp \
   util/thread.cpp \
   util/threadinterrupt.cpp \
@@ -991,6 +992,7 @@ libbitcoinkernel_la_SOURCES = \
   util/hasher.cpp \
   util/moneystr.cpp \
   util/rbf.cpp \
+  util/result.cpp \
   util/serfloat.cpp \
   util/signalinterrupt.cpp \
   util/strencodings.cpp \

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
+#include <kernel/fatal_error.h>
 #include <node/miner.h>
 #include <random.h>
 #include <test/util/mining.h>
@@ -38,7 +39,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(txr);
+            const MempoolAcceptResult res = UnwrapFatalError(test_setup->m_node.chainman->ProcessTransaction(txr));
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
         }
     }

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -6,6 +6,7 @@
 #include <bench/data.h>
 #include <chainparams.h>
 #include <clientversion.h>
+#include <kernel/fatal_error.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
 #include <validation.h>
@@ -56,7 +57,7 @@ static void LoadExternalBlockFile(benchmark::Bench& bench)
         // "rb" is "binary, O_RDONLY", positioned to the start of the file.
         // The file will be closed by LoadExternalBlockFile().
         AutoFile file{fsbridge::fopen(blkfile, "rb")};
-        testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
+        UnwrapFatalError(testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent));
     });
     fs::remove(blkfile);
 }

--- a/src/bench/readblock.cpp
+++ b/src/bench/readblock.cpp
@@ -6,6 +6,7 @@
 #include <bench/data.h>
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <node/blockstorage.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
@@ -18,7 +19,7 @@ static FlatFilePos WriteBlockToDisk(ChainstateManager& chainman)
     CBlock block;
     stream >> TX_WITH_WITNESS(block);
 
-    return chainman.m_blockman.SaveBlockToDisk(block, 0, nullptr);
+    return UnwrapFatalError(chainman.m_blockman.SaveBlockToDisk(block, 0, nullptr));
 }
 
 static void ReadBlockFromDiskTest(benchmark::Bench& bench)

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -122,13 +122,13 @@ int main(int argc, char* argv[])
     cache_sizes.coins_db = 2 << 22;
     cache_sizes.coins = (450 << 20) - (2 << 20) - (2 << 22);
     node::ChainstateLoadOptions options;
-    auto [status, error] = node::LoadChainstate(chainman, cache_sizes, options);
-    if (status != node::ChainstateLoadStatus::SUCCESS) {
+    auto result = node::LoadChainstate(chainman, cache_sizes, options);
+    if (!result) {
         std::cerr << "Failed to load Chain state from your datadir." << std::endl;
         goto epilogue;
     } else {
-        std::tie(status, error) = node::VerifyLoadedChainstate(chainman, options);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
+        result = node::VerifyLoadedChainstate(chainman, options);
+        if (!result) {
             std::cerr << "Failed to verify loaded Chain state from your datadir." << std::endl;
             goto epilogue;
         }

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -285,7 +285,7 @@ epilogue:
         LOCK(cs_main);
         for (Chainstate* chainstate : chainman.GetAll()) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                UnwrapFatalError(chainstate->ForceFlushStateToDisk());
                 chainstate->ResetCoinsViews();
             }
         }

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
 
     for (Chainstate* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
         BlockValidationState state;
-        if (!chainstate->ActivateBestChain(state, nullptr)) {
+        if (!UnwrapFatalError(chainstate->ActivateBestChain(state, nullptr))) {
             std::cerr << "Failed to connect best block (" << state.ToString() << ")" << std::endl;
             goto epilogue;
         }

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -90,14 +90,6 @@ int main(int argc, char* argv[])
         {
             std::cout << "Warning: " << warning.original << std::endl;
         }
-        void flushError(const bilingual_str& message) override
-        {
-            std::cerr << "Error flushing block data to disk: " << message.original << std::endl;
-        }
-        void fatalError(const bilingual_str& message) override
-        {
-            std::cerr << "Error: " << message.original << std::endl;
-        }
     };
     auto notifications = std::make_unique<KernelNotifications>();
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -15,6 +15,7 @@
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/checks.h>
 #include <kernel/context.h>
+#include <kernel/fatal_error.h>
 #include <kernel/validation_cache_sizes.h>
 
 #include <consensus/validation.h>
@@ -226,7 +227,7 @@ int main(int argc, char* argv[])
         bool new_block;
         auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
         validation_signals.RegisterSharedValidationInterface(sc);
-        bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+        bool accepted = UnwrapFatalError(chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block));
         validation_signals.UnregisterSharedValidationInterface(sc);
         if (!new_block && accepted) {
             std::cerr << "duplicate" << std::endl;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1576,33 +1576,36 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
         uiInterface.InitMessage(_("Loading block index…").translated);
         const auto load_block_index_start_time{SteadyClock::now()};
-        auto catch_exceptions = [](auto&& f) {
+        auto catch_exceptions = [](auto&& f) -> util::Result<void, node::ChainstateLoadError> {
             try {
                 return f();
             } catch (const std::exception& e) {
                 LogPrintf("%s\n", e.what());
-                return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error opening block database"));
+                return {util::Error{_("Error opening block database")}, node::ChainstateLoadError::FAILURE};
             }
         };
-        auto [status, error] = catch_exceptions([&]{ return LoadChainstate(chainman, cache_sizes, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        auto result = catch_exceptions([&]{ return LoadChainstate(chainman, cache_sizes, options); });
+        if (result) {
             uiInterface.InitMessage(_("Verifying blocks…").translated);
             if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
                 LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                                   MIN_BLOCKS_TO_KEEP);
             }
-            std::tie(status, error) = catch_exceptions([&]{ return VerifyLoadedChainstate(chainman, options);});
-            if (status == node::ChainstateLoadStatus::SUCCESS) {
+            result = catch_exceptions([&]{ return VerifyLoadedChainstate(chainman, options);});
+            if (result) {
                 fLoaded = true;
                 LogPrintf(" block index %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - load_block_index_start_time));
             }
         }
 
-        if (status == node::ChainstateLoadStatus::FAILURE_FATAL || status == node::ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB || status == node::ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE) {
-            return InitError(error);
+        if (!result && (result.GetFailure() == node::ChainstateLoadError::FAILURE_FATAL ||
+                        result.GetFailure() == node::ChainstateLoadError::FAILURE_INCOMPATIBLE_DB ||
+                        result.GetFailure() == node::ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE)) {
+            return InitError(util::ErrorString(result));
         }
 
         if (!fLoaded && !ShutdownRequested(node)) {
+            bilingual_str error = util::ErrorString(result);
             // first suggest a reindex
             if (!options.reindex) {
                 bool fRet = uiInterface.ThreadSafeQuestion(

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -119,6 +119,7 @@ using kernel::DumpMempool;
 using kernel::LoadMempool;
 using kernel::ValidationCacheSizes;
 
+using node::AbortNode;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CacheSizes;
@@ -1762,7 +1763,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         // Start indexes initial sync
         if (!StartIndexBackgroundSync(node)) {
             bilingual_str err_str = _("Failed to start indexes, shutting down..");
-            chainman.GetNotifications().fatalError(err_str);
+            AbortNode(node.shutdown, node.exit_status, err_str);
             return;
         }
         // Load mempool from disk

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -326,7 +326,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (Chainstate* chainstate : node.chainman->GetAll()) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)CheckFatal(chainstate->ForceFlushStateToDisk(), node.shutdown, node.exit_status);
             }
         }
     }
@@ -352,7 +352,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (Chainstate* chainstate : node.chainman->GetAll()) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)CheckFatal(chainstate->ForceFlushStateToDisk(), node.shutdown, node.exit_status);
                 chainstate->ResetCoinsViews();
             }
         }
@@ -1683,7 +1683,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LOCK(cs_main);
             for (Chainstate* chainstate : chainman.GetAll()) {
                 uiInterface.InitMessage(_("Pruning blockstore…").translated);
-                chainstate->PruneAndFlush();
+                (void)CheckFatal(chainstate->PruneAndFlush(), node.shutdown, node.exit_status);
             }
         }
     } else {
@@ -1769,7 +1769,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         // Load mempool from disk
         if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
-            LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
+            (void)CheckFatal(LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {}), node.shutdown, node.exit_status);
             pool->SetLoadTried(!chainman.m_interrupt);
         }
     });

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -998,7 +998,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // ********************************************************* Step 3: parameter-to-internal-flags
     auto result = init::SetLoggingCategories(args);
     if (!result) return InitError(util::ErrorString(result));
-    result = init::SetLoggingLevel(args);
+    result.Set(init::SetLoggingLevel(args));
     if (!result) return InitError(util::ErrorString(result));
 
     nConnectTimeout = args.GetIntArg("-timeout", DEFAULT_CONNECT_TIMEOUT);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1643,6 +1643,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,
                                      node.banman.get(), chainman,
+                                     node.shutdown, node.exit_status,
                                      *node.mempool, peerman_opts);
     validation_signals.RegisterValidationInterface(node.peerman.get());
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -41,6 +41,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/abort.h>
 #include <node/blockmanager_args.h>
 #include <node/blockstorage.h>
 #include <node/caches.h>
@@ -122,16 +123,17 @@ using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CacheSizes;
 using node::CalculateCacheSizes;
+using node::CheckFatal;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINTPRIORITY;
 using node::DEFAULT_STOPATHEIGHT;
 using node::fReindex;
+using node::ImportBlocks;
 using node::KernelNotifications;
 using node::LoadChainstate;
 using node::MempoolPath;
 using node::NodeContext;
 using node::ShouldPersistMempool;
-using node::ImportBlocks;
 using node::VerifyLoadedChainstate;
 
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
@@ -1748,7 +1750,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     chainman.m_thread_load = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &node] {
         // Import blocks
-        ImportBlocks(chainman, vImportFiles);
+        CheckFatal(ImportBlocks(chainman, vImportFiles), node.shutdown, node.exit_status);
         if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
             LogPrintf("Stopping after block import\n");
             if (!(*Assert(node.shutdown))()) {

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -11,7 +11,10 @@ namespace kernel {
 
 enum class FatalError {
     BlockFileImportFailed,
+    ChainstateRenameFailed,
     ConnectBestBlockFailed,
+    NoChainstatePaths,
+    SnapshotAlreadyValidated,
     SnapshotChainstateDirRemovalFailed,
 };
 

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -12,8 +12,12 @@ namespace kernel {
 enum class FatalError {
     AcceptBlockFailed,
     BlockFileImportFailed,
+    BlockIndexWriteFailed,
     ChainstateRenameFailed,
+    CoinDatabaseWriteFailed,
+    DiskSpaceTooLow,
     DisconnectBlockFailed,
+    FlushStateToDiskFailed,
     NoChainstatePaths,
     ReadBlockFailed,
     SnapshotAlreadyValidated,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -15,6 +15,7 @@ enum class FatalError {
     BlockIndexWriteFailed,
     ChainstateRenameFailed,
     CoinDatabaseWriteFailed,
+    CorruptBlock,
     DiskSpaceTooLow,
     DisconnectBlockFailed,
     FlushStateToDiskFailed,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -29,6 +29,7 @@ enum class FatalError {
     SnapshotHashMismatch,
     SnapshotMissingChainparams,
     SnapshotStatsFailed,
+    WriteUndoDataFailed,
 };
 
 template <typename T>

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_FATAL_ERROR_H
+#define BITCOIN_KERNEL_FATAL_ERROR_H
+
+#include <util/result.h>
+
+namespace kernel {
+
+enum class FatalError {
+    ConnectBestBlockFailed,
+};
+
+template <typename T>
+[[nodiscard]] bool IsFatal(const util::Result<T, FatalError>& result)
+{
+    return !result || !result.GetErrors().empty();
+}
+
+template <typename T>
+[[nodiscard]] T UnwrapFatalError(const util::Result<T, FatalError> result)
+{
+    assert(!IsFatal(result));
+    if constexpr (std::is_void<T>::value) {
+        return;
+    } else {
+        return result.value();
+    }
+}
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_FATAL_ERROR_H

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -15,6 +15,7 @@ enum class FatalError {
     ChainstateRenameFailed,
     DisconnectBlockFailed,
     NoChainstatePaths,
+    ReadBlockFailed,
     SnapshotAlreadyValidated,
     SnapshotBaseBlockhashMismatch,
     SnapshotChainstateDirRemovalFailed,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -19,6 +19,7 @@ enum class FatalError {
     CorruptBlock,
     DiskSpaceTooLow,
     DisconnectBlockFailed,
+    FlushBlockFileFailed,
     FlushStateToDiskFailed,
     NoChainstatePaths,
     ReadBlockFailed,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -13,6 +13,7 @@ enum class FatalError {
     AcceptBlockFailed,
     BlockFileImportFailed,
     BlockIndexWriteFailed,
+    BlockWriteFailed,
     ChainstateRenameFailed,
     CoinDatabaseWriteFailed,
     CorruptBlock,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -10,6 +10,7 @@
 namespace kernel {
 
 enum class FatalError {
+    BlockFileImportFailed,
     ConnectBestBlockFailed,
 };
 

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -13,7 +13,7 @@ enum class FatalError {
     AcceptBlockFailed,
     BlockFileImportFailed,
     ChainstateRenameFailed,
-    ConnectBestBlockFailed,
+    DisconnectBlockFailed,
     NoChainstatePaths,
     SnapshotAlreadyValidated,
     SnapshotBaseBlockhashMismatch,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -21,6 +21,7 @@ enum class FatalError {
     DisconnectBlockFailed,
     FlushBlockFileFailed,
     FlushStateToDiskFailed,
+    FlushUndoFileFailed,
     NoChainstatePaths,
     ReadBlockFailed,
     SnapshotAlreadyValidated,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -11,6 +11,7 @@ namespace kernel {
 
 enum class FatalError {
     AcceptBlockFailed,
+    AssumeUtxoDataNotFound,
     BlockFileImportFailed,
     BlockIndexWriteFailed,
     BlockWriteFailed,

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -15,7 +15,11 @@ enum class FatalError {
     ConnectBestBlockFailed,
     NoChainstatePaths,
     SnapshotAlreadyValidated,
+    SnapshotBaseBlockhashMismatch,
     SnapshotChainstateDirRemovalFailed,
+    SnapshotHashMismatch,
+    SnapshotMissingChainparams,
+    SnapshotStatsFailed,
 };
 
 template <typename T>
@@ -33,6 +37,12 @@ template <typename T>
     } else {
         return result.value();
     }
+}
+
+template <typename T>
+[[nodiscard]] bool CheckFatalFailure(const util::Result<T, kernel::FatalError> result, const kernel::FatalError expected_failure)
+{
+    return !result && result.GetFailure() == expected_failure;
 }
 
 } // namespace kernel

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -12,6 +12,7 @@ namespace kernel {
 enum class FatalError {
     BlockFileImportFailed,
     ConnectBestBlockFailed,
+    SnapshotChainstateDirRemovalFailed,
 };
 
 template <typename T>

--- a/src/kernel/fatal_error.h
+++ b/src/kernel/fatal_error.h
@@ -10,6 +10,7 @@
 namespace kernel {
 
 enum class FatalError {
+    AcceptBlockFailed,
     BlockFileImportFailed,
     ChainstateRenameFailed,
     ConnectBestBlockFailed,

--- a/src/kernel/mempool_persist.h
+++ b/src/kernel/mempool_persist.h
@@ -5,7 +5,9 @@
 #ifndef BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 #define BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 
+#include <kernel/fatal_error.h>
 #include <util/fs.h>
+#include <util/result.h>
 
 class Chainstate;
 class CTxMemPool;
@@ -23,8 +25,9 @@ struct ImportMempoolOptions {
     bool apply_fee_delta_priority{true};
     bool apply_unbroadcast_set{true};
 };
+
 /** Import the file and attempt to add its contents to the mempool. */
-bool LoadMempool(CTxMemPool& pool, const fs::path& load_path,
+[[nodiscard]] util::Result<bool, FatalError> LoadMempool(CTxMemPool& pool, const fs::path& load_path,
                  Chainstate& active_chainstate,
                  ImportMempoolOptions&& opts);
 

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -39,23 +39,6 @@ public:
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
     virtual void warning(const bilingual_str& warning) {}
-
-    //! The flush error notification is sent to notify the user that an error
-    //! occurred while flushing block data to disk. Kernel code may ignore flush
-    //! errors that don't affect the immediate operation it is trying to
-    //! perform. Applications can choose to handle the flush error notification
-    //! by logging the error, or notifying the user, or triggering an early
-    //! shutdown as a precaution against causing more errors.
-    virtual void flushError(const bilingual_str& message) {}
-
-    //! The fatal error notification is sent to notify the user when an error
-    //! occurs in kernel code that can't be recovered from. After this
-    //! notification is sent, whatever function triggered the error should also
-    //! return an error code or raise an exception. Applications can choose to
-    //! handle the fatal error notification by logging the error, or notifying
-    //! the user, or triggering an early shutdown as a precaution against
-    //! causing more errors.
-    virtual void fatalError(const bilingual_str& message) {}
 };
 } // namespace kernel
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2341,7 +2341,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     } // release cs_main before calling ActivateBestChain
     if (need_activate_chain) {
         BlockValidationState state;
-        if (!m_chainman.ActiveChainstate().ActivateBestChain(state, a_recent_block)) {
+        if (!CheckFatal(m_chainman.ActiveChainstate().ActivateBestChain(state, a_recent_block), m_shutdown, m_exit_status)) {
             LogPrint(BCLog::NET, "failed to activate chain (%s)\n", state.ToString());
         }
     }
@@ -4118,7 +4118,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 a_recent_block = m_most_recent_block;
             }
             BlockValidationState state;
-            if (!m_chainman.ActiveChainstate().ActivateBestChain(state, a_recent_block)) {
+            if (!CheckFatal(m_chainman.ActiveChainstate().ActivateBestChain(state, a_recent_block), m_shutdown, m_exit_status)) {
                 LogPrint(BCLog::NET, "failed to activate chain (%s)\n", state.ToString());
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -22,6 +22,7 @@
 #include <merkleblock.h>
 #include <netbase.h>
 #include <netmessagemaker.h>
+#include <node/abort.h>
 #include <node/blockstorage.h>
 #include <node/txreconciliation.h>
 #include <policy/fees.h>
@@ -52,6 +53,8 @@
 #include <optional>
 #include <typeinfo>
 #include <utility>
+
+using node::CheckFatal;
 
 /** Headers download timeout.
  *  Timeout = base + per_header * (expected number of headers) */
@@ -484,6 +487,8 @@ class PeerManagerImpl final : public PeerManager
 public:
     PeerManagerImpl(CConnman& connman, AddrMan& addrman,
                     BanMan* banman, ChainstateManager& chainman,
+                    util::SignalInterrupt* shutdown,
+                    std::atomic<int>& exit_status,
                     CTxMemPool& pool, Options opts);
 
     /** Overridden from CValidationInterface. */
@@ -737,6 +742,8 @@ private:
     /** Pointer to this node's banman. May be nullptr - check existence before dereferencing. */
     BanMan* const m_banman;
     ChainstateManager& m_chainman;
+    util::SignalInterrupt* m_shutdown;
+    std::atomic<int>& m_exit_status;
     CTxMemPool& m_mempool;
     TxRequestTracker m_txrequest GUARDED_BY(::cs_main);
     std::unique_ptr<TxReconciliationTracker> m_txreconciliation;
@@ -1957,13 +1964,17 @@ std::optional<std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBl
 
 std::unique_ptr<PeerManager> PeerManager::make(CConnman& connman, AddrMan& addrman,
                                                BanMan* banman, ChainstateManager& chainman,
+                                               util::SignalInterrupt* shutdown,
+                                               std::atomic<int>& exit_status,
                                                CTxMemPool& pool, Options opts)
 {
-    return std::make_unique<PeerManagerImpl>(connman, addrman, banman, chainman, pool, opts);
+    return std::make_unique<PeerManagerImpl>(connman, addrman, banman, chainman, shutdown, exit_status, pool, opts);
 }
 
 PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
                                  BanMan* banman, ChainstateManager& chainman,
+                                 util::SignalInterrupt* shutdown,
+                                 std::atomic<int>& exit_status,
                                  CTxMemPool& pool, Options opts)
     : m_rng{opts.deterministic_rng},
       m_fee_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}, m_rng},
@@ -1972,6 +1983,8 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
       m_addrman(addrman),
       m_banman(banman),
       m_chainman(chainman),
+      m_shutdown(shutdown),
+      m_exit_status(exit_status),
       m_mempool(pool),
       m_opts{opts}
 {
@@ -3357,7 +3370,7 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked)
 {
     bool new_block{false};
-    m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block);
+    (void)CheckFatal(m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block), m_shutdown, m_exit_status);
     if (new_block) {
         node.m_last_block_time = GetTime<std::chrono::seconds>();
         // In case this block came from a different peer than we requested

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -13,6 +13,9 @@ class AddrMan;
 class CChainParams;
 class CTxMemPool;
 class ChainstateManager;
+namespace util {
+class SignalInterrupt;
+}
 
 /** Whether transaction reconciliation protocol should be enabled by default. */
 static constexpr bool DEFAULT_TXRECONCILIATION_ENABLE{false};
@@ -65,6 +68,8 @@ public:
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
+                                             util::SignalInterrupt* shutdown,
+                                             std::atomic<int>& exit_status,
                                              CTxMemPool& pool, Options opts);
     virtual ~PeerManager() { }
 

--- a/src/node/abort.h
+++ b/src/node/abort.h
@@ -7,10 +7,12 @@
 
 #include <kernel/fatal_error.h>
 #include <util/result.h>
+#include <util/translation.h>
+#include <validation.h>
 
 #include <atomic>
-
-struct bilingual_str;
+#include <optional>
+#include <string>
 
 namespace util {
 class SignalInterrupt;
@@ -18,6 +20,16 @@ class SignalInterrupt;
 
 namespace node {
 void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& user_message);
+
+template <typename T>
+std::optional<T> HandleFatalError(const util::Result<T, kernel::FatalError> result, util::SignalInterrupt* shutdown, std::atomic<int>& exit_status)
+{
+    if (!result.GetErrors().empty() || !result) {
+        AbortNode(shutdown, exit_status, ErrorString(result));
+    }
+    if (!result) return std::nullopt;
+    return result.value();
+}
 
 template <typename T>
 [[nodiscard]] T CheckFatal(const util::Result<T, kernel::FatalError> result, util::SignalInterrupt* shutdown, std::atomic<int>& exit_status)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1198,7 +1198,7 @@ util::Result<void, kernel::FatalError> ImportBlocks(ChainstateManager& chainman,
                     break; // This error is logged in OpenBlockFile
                 }
                 LogPrintf("Reindexing block file blk%05u.dat...\n", (unsigned int)nFile);
-                chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
+                result.Set(chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent));
                 if (chainman.m_interrupt || IsFatal(result)) {
                     LogPrintf("Interrupt requested. Exit %s\n", __func__);
                     return result;
@@ -1217,7 +1217,7 @@ util::Result<void, kernel::FatalError> ImportBlocks(ChainstateManager& chainman,
             AutoFile file{fsbridge::fopen(path, "rb")};
             if (!file.IsNull()) {
                 LogPrintf("Importing blocks file %s...\n", fs::PathToString(path));
-                chainman.LoadExternalBlockFile(file);
+                result.Set(chainman.LoadExternalBlockFile(file));
                 if (chainman.m_interrupt || IsFatal(result)) {
                     LogPrintf("Interrupt requested. Exit %s\n", __func__);
                     return result;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -997,7 +997,7 @@ bool BlockManager::WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const
     return true;
 }
 
-bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+util::Result<bool, kernel::FatalError> BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
 {
     AssertLockHeld(::cs_main);
     const BlockfileType type = BlockfileTypeForHeight(block.nHeight);
@@ -1011,7 +1011,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
             return false;
         }
         if (!UndoWriteToDisk(blockundo, _pos, block.pprev->GetBlockHash())) {
-            return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
+            return ValidationFatalError(state, _("Failed to write undo data"), kernel::FatalError::WriteUndoDataFailed);
         }
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
         // we want to flush the rev (undo) file once we've written the last block, which is indicated by the last height

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -40,6 +40,8 @@
 #include <map>
 #include <unordered_map>
 
+using kernel::FatalError;
+
 namespace kernel {
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
 static constexpr uint8_t DB_BLOCK_INDEX{'b'};
@@ -395,7 +397,7 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     return pindex;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+util::Result<bool, FatalError> BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
 {
     if (!m_block_tree_db->LoadBlockIndexGuts(
             GetConsensus(), [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, m_interrupt)) {
@@ -405,7 +407,7 @@ util::Result<bool, kernel::FatalError> BlockManager::LoadBlockIndex(const std::o
     if (snapshot_blockhash) {
         const std::optional<AssumeutxoData> maybe_au_data = GetParams().AssumeutxoForBlockhash(*snapshot_blockhash);
         if (!maybe_au_data) {
-            return {util::Error{strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString())}, kernel::FatalError::AssumeUtxoDataNotFound};
+            return {util::Error{strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString())}, FatalError::AssumeUtxoDataNotFound};
         }
         const AssumeutxoData& au_data = *Assert(maybe_au_data);
         m_snapshot_height = au_data.height;
@@ -495,7 +497,7 @@ bool BlockManager::WriteBlockIndexDB()
     return true;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+util::Result<bool, FatalError> BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
 {
     auto result{LoadBlockIndex(snapshot_blockhash)};
     if (!result || !result.value()) {
@@ -739,18 +741,18 @@ bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex& in
     return true;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::FlushUndoFile(int block_file, bool finalize)
+util::Result<bool, FatalError> BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
     if (!UndoFileSeq().Flush(undo_pos_old, finalize)) {
-        return {util::Error{_("Flushing undo file to disk failed. This is likely the result of an I/O error.")}, kernel::FatalError::FlushUndoFileFailed};
+        return {util::Error{_("Flushing undo file to disk failed. This is likely the result of an I/O error.")}, FatalError::FlushUndoFileFailed};
     }
     return true;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
+util::Result<bool, FatalError> BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
 {
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     LOCK(cs_LastBlockFile);
 
     if (m_blockfile_info.size() < 1) {
@@ -765,7 +767,7 @@ util::Result<bool, kernel::FatalError> BlockManager::FlushBlockFile(int blockfil
     FlatFilePos block_pos_old(blockfile_num, m_blockfile_info[blockfile_num].nSize);
     if (!BlockFileSeq().Flush(block_pos_old, fFinalize)) {
         LogError("%s: Failed to flush block file\n", __func__);
-        result.Set({util::Error{_("Flushing block file to disk failed. This is likely the result of an I/O error.")}, kernel::FatalError::FlushBlockFileFailed});
+        result.Set({util::Error{_("Flushing block file to disk failed. This is likely the result of an I/O error.")}, FatalError::FlushBlockFileFailed});
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
     // e.g. during IBD or a sync after a node going offline
@@ -788,7 +790,7 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
     return (height >= *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::FlushChainstateBlockFile(int tip_height)
+util::Result<bool, FatalError> BlockManager::FlushChainstateBlockFile(int tip_height)
 {
     LOCK(cs_LastBlockFile);
     auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
@@ -852,11 +854,11 @@ fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos) const
     return BlockFileSeq().FileName(pos);
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown)
+util::Result<bool, FatalError> BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown)
 {
     LOCK(cs_LastBlockFile);
 
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     const BlockfileType chain_type = BlockfileTypeForHeight(nHeight);
 
@@ -941,7 +943,7 @@ util::Result<bool, kernel::FatalError> BlockManager::FindBlockPos(FlatFilePos& p
         bool out_of_space;
         size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
         if (out_of_space) {
-            result.Set({util::Error{_("Disk space is too low!")}, kernel::FatalError::DiskSpaceTooLow});
+            result.Set({util::Error{_("Disk space is too low!")}, FatalError::DiskSpaceTooLow});
             return result;
         }
         if (bytes_allocated != 0 && IsPruneMode()) {
@@ -953,7 +955,7 @@ util::Result<bool, kernel::FatalError> BlockManager::FindBlockPos(FlatFilePos& p
     return result;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
+util::Result<bool, FatalError> BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
 {
     pos.nFile = nFile;
 
@@ -966,7 +968,7 @@ util::Result<bool, kernel::FatalError> BlockManager::FindUndoPos(BlockValidation
     bool out_of_space;
     size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return ValidationFatalError(state, _("Disk space is too low!"), kernel::FatalError::DiskSpaceTooLow);
+        return ValidationFatalError(state, _("Disk space is too low!"), FatalError::DiskSpaceTooLow);
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
@@ -1000,12 +1002,12 @@ bool BlockManager::WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const
     return true;
 }
 
-util::Result<bool, kernel::FatalError> BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+util::Result<bool, FatalError> BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
 {
     AssertLockHeld(::cs_main);
     const BlockfileType type = BlockfileTypeForHeight(block.nHeight);
     auto& cursor = *Assert(WITH_LOCK(cs_LastBlockFile, return m_blockfile_cursors[type]));
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     // Write undo information to disk
     if (block.GetUndoPos().IsNull()) {
@@ -1016,7 +1018,7 @@ util::Result<bool, kernel::FatalError> BlockManager::WriteUndoDataForBlock(const
             return result;
         }
         if (!UndoWriteToDisk(blockundo, _pos, block.pprev->GetBlockHash())) {
-            return ValidationFatalError(state, _("Failed to write undo data"), kernel::FatalError::WriteUndoDataFailed);
+            return ValidationFatalError(state, _("Failed to write undo data"), FatalError::WriteUndoDataFailed);
         }
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
         // we want to flush the rev (undo) file once we've written the last block, which is indicated by the last height
@@ -1140,10 +1142,10 @@ bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatF
     return true;
 }
 
-util::Result<FlatFilePos, kernel::FatalError> BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight, const FlatFilePos* dbp)
+util::Result<FlatFilePos, FatalError> BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight, const FlatFilePos* dbp)
 {
     unsigned int nBlockSize = ::GetSerializeSize(TX_WITH_WITNESS(block));
-    util::Result<FlatFilePos, kernel::FatalError> result{FlatFilePos{}};
+    util::Result<FlatFilePos, FatalError> result{FlatFilePos{}};
     FlatFilePos blockPos;
     const auto position_known {dbp != nullptr};
     if (position_known) {
@@ -1161,7 +1163,7 @@ util::Result<FlatFilePos, kernel::FatalError> BlockManager::SaveBlockToDisk(cons
     }
     if (!position_known) {
         if (!WriteBlockToDisk(block, blockPos)) {
-            result.Set({util::Error{_("Failed to write block")}, kernel::FatalError::BlockWriteFailed});
+            result.Set({util::Error{_("Failed to write block")}, FatalError::BlockWriteFailed});
             return result;
         }
     }
@@ -1186,10 +1188,10 @@ public:
     }
 };
 
-util::Result<void, kernel::FatalError> ImportBlocks(ChainstateManager& chainman, std::vector<fs::path> vImportFiles)
+util::Result<void, FatalError> ImportBlocks(ChainstateManager& chainman, std::vector<fs::path> vImportFiles)
 {
     ScheduleBatchPriority();
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
 
     {
         ImportingNow imp{chainman.m_blockman.m_importing};

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -159,7 +159,7 @@ private:
     /** Return false if undo file flushing fails. */
     [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
 
-    [[nodiscard]] bool FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown);
     [[nodiscard]] bool FlushChainstateBlockFile(int tip_height);
     bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -19,6 +19,7 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/result.h>
 
 #include <array>
 #include <atomic>
@@ -38,6 +39,9 @@ class BlockValidationState;
 class CBlockUndo;
 class Chainstate;
 class ChainstateManager;
+namespace kernel {
+enum class FatalError;
+}
 namespace Consensus {
 struct Params;
 }
@@ -370,7 +374,7 @@ public:
     void CleanupBlockRevFiles() const;
 };
 
-void ImportBlocks(ChainstateManager& chainman, std::vector<fs::path> vImportFiles);
+[[nodiscard]] util::Result<void, kernel::FatalError> ImportBlocks(ChainstateManager& chainman, std::vector<fs::path> vImportFiles);
 } // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -161,7 +161,7 @@ private:
 
     [[nodiscard]] util::Result<bool, kernel::FatalError> FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown);
     [[nodiscard]] util::Result<bool, kernel::FatalError> FlushChainstateBlockFile(int tip_height);
-    bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 
     FlatFileSeq BlockFileSeq() const;
     FlatFileSeq UndoFileSeq() const;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -154,13 +154,13 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return false if block file or undo file flushing fails. */
-    [[nodiscard]] bool FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo);
 
     /** Return false if undo file flushing fails. */
     [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
 
     [[nodiscard]] util::Result<bool, kernel::FatalError> FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown);
-    [[nodiscard]] bool FlushChainstateBlockFile(int tip_height);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> FlushChainstateBlockFile(int tip_height);
     bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 
     FlatFileSeq BlockFileSeq() const;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -317,7 +317,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk. If dbp is not nullptr, then it provides the known position of the block within a block file on disk. */
-    FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const FlatFilePos* dbp);
+    [[nodiscard]] util::Result<FlatFilePos, kernel::FatalError> SaveBlockToDisk(const CBlock& block, int nHeight, const FlatFilePos* dbp);
 
     /** Whether running in -prune mode. */
     [[nodiscard]] bool IsPruneMode() const { return m_prune_mode; }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -313,7 +313,7 @@ public:
     /** Get block file info entry for one block file */
     CBlockFileInfo* GetBlockFileInfo(size_t n);
 
-    bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+    [[nodiscard]] util::Result<bool, kernel::FatalError> WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk. If dbp is not nullptr, then it provides the known position of the block within a block file on disk. */

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -157,7 +157,7 @@ private:
     [[nodiscard]] util::Result<bool, kernel::FatalError> FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo);
 
     /** Return false if undo file flushing fails. */
-    [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> FlushUndoFile(int block_file, bool finalize = false);
 
     [[nodiscard]] util::Result<bool, kernel::FatalError> FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown);
     [[nodiscard]] util::Result<bool, kernel::FatalError> FlushChainstateBlockFile(int tip_height);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -150,7 +150,7 @@ private:
      * per index entry (nStatus, nChainWork, nTimeMax, etc.) as well as peripheral
      * collections like m_dirty_blockindex.
      */
-    bool LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+    [[nodiscard]] util::Result<bool, kernel::FatalError> LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return false if block file or undo file flushing fails. */
@@ -290,7 +290,7 @@ public:
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 
     bool WriteBlockIndexDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+    [[nodiscard]] util::Result<bool, kernel::FatalError> LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -269,10 +269,14 @@ util::Result<void, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager
                         ChainstateLoadError::FAILURE};
             }
 
-            VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
+            auto res = CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
                 options.check_blocks);
+            if (IsFatal(res)) {
+                return {util::Error{}, util::MoveMessages(res), ChainstateLoadError::FAILURE_FATAL};
+            }
+            VerifyDBResult result = res.value();
             switch (result) {
             case VerifyDBResult::SUCCESS:
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <coins.h>
 #include <consensus/params.h>
+#include <kernel/fatal_error.h>
 #include <logging.h>
 #include <node/blockstorage.h>
 #include <node/caches.h>
@@ -215,8 +216,8 @@ util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainm
         // do nothing; expected case
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogPrintf("[snapshot] cleaning up unneeded background chainstate, then reinitializing\n");
-        if (!chainman.ValidatedSnapshotCleanup()) {
-            return {util::Error{Untranslated("Background chainstate cleanup failed unexpectedly.")}, ChainstateLoadError::FAILURE_FATAL};
+        if (auto res{chainman.ValidatedSnapshotCleanup()}; IsFatal(res)) {
+            return {util::Error{}, util::MoveMessages(res), ChainstateLoadError::FAILURE_FATAL};
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -156,9 +156,10 @@ static util::Result<void, ChainstateLoadError> CompleteChainstateInitialization(
     // Now that chainstates are loaded and we're able to flush to
     // disk, rebalance the coins caches to desired levels based
     // on the condition of each chainstate.
-    chainman.MaybeRebalanceCaches();
+    util::Result<void, ChainstateLoadError> result{};
+    result.MoveMessages(chainman.MaybeRebalanceCaches());
 
-    return {};
+    return result;
 }
 
 util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -63,9 +63,10 @@ static util::Result<void, ChainstateLoadError> CompleteChainstateInitialization(
     // block file from disk.
     // Note that it also sets fReindex global based on the disk flag!
     // From here on, fReindex and options.reindex values may be different!
-    if (!chainman.LoadBlockIndex()) {
+    auto res{chainman.LoadBlockIndex()};
+    if (IsFatal(res) || !res.value()) {
         if (chainman.m_interrupt) return {util::Error{}, ChainstateLoadError::INTERRUPTED};
-        return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
+        return {util::Error{_("Failed loading block database.")}, util::MoveMessages(res), ChainstateLoadError::FAILURE_FATAL};
     }
 
     if (!chainman.BlockIndex().empty() &&

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -32,7 +32,7 @@
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
 // to ChainstateManager::InitializeChainstate().
-static ChainstateLoadResult CompleteChainstateInitialization(
+static util::Result<void, ChainstateLoadError> CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const CacheSizes& cache_sizes,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
@@ -56,28 +56,28 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         }
     }
 
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return {util::Error{}, ChainstateLoadError::INTERRUPTED};
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets fReindex global based on the disk flag!
     // From here on, fReindex and options.reindex values may be different!
     if (!chainman.LoadBlockIndex()) {
-        if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
-        return {ChainstateLoadStatus::FAILURE, _("Error loading block database")};
+        if (chainman.m_interrupt) return {util::Error{}, ChainstateLoadError::INTERRUPTED};
+        return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
     }
 
     if (!chainman.BlockIndex().empty() &&
             !chainman.m_blockman.LookupBlockIndex(chainman.GetConsensus().hashGenesisBlock)) {
         // If the loaded chain has a wrong genesis, bail out immediately
         // (we're likely using a testnet datadir, or the other way around).
-        return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Incorrect or no genesis block found. Wrong datadir for network?")};
+        return {util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
     }
 
     // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
     // in the past, but is now trying to run unpruned.
     if (chainman.m_blockman.m_have_pruned && !options.prune) {
-        return {ChainstateLoadStatus::FAILURE, _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")};
+        return {util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE};
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -85,7 +85,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // (otherwise we use the one already on disk).
     // This is called again in ImportBlocks after the reindex completes.
     if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
-        return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+        return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
     }
 
     auto is_coinsview_empty = [&](Chainstate* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -119,14 +119,15 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {
-            return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Unsupported chainstate database format found. "
-                                                                     "Please restart with -reindex-chainstate. This will "
-                                                                     "rebuild the chainstate database.")};
+            return {util::Error{ _("Unsupported chainstate database format found. "
+                                   "Please restart with -reindex-chainstate. This will "
+                                   "rebuild the chainstate database.")},
+                    ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
         }
 
         // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (!chainstate->ReplayBlocks()) {
-            return {ChainstateLoadStatus::FAILURE, _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")};
+            return {util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE};
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
@@ -136,7 +137,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         if (!is_coinsview_empty(chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block
             if (!chainstate->LoadChainTip()) {
-                return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+                return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
             }
             assert(chainstate->m_chain.Tip() != nullptr);
         }
@@ -146,8 +147,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         auto chainstates{chainman.GetAll()};
         if (std::any_of(chainstates.begin(), chainstates.end(),
                         [](const Chainstate* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-            return {ChainstateLoadStatus::FAILURE, strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                                             chainman.GetConsensus().SegwitHeight)};
+            return {util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                          chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE};
         };
     }
 
@@ -156,11 +157,11 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // on the condition of each chainstate.
     chainman.MaybeRebalanceCaches();
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options)
+util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                       const ChainstateLoadOptions& options)
 {
     if (!chainman.AssumedValidBlock().IsNull()) {
         LogPrintf("Assuming ancestors of block %s have valid signatures.\n", chainman.AssumedValidBlock().GetHex());
@@ -191,13 +192,13 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     if (has_snapshot && (options.reindex || options.reindex_chainstate)) {
         LogPrintf("[snapshot] deleting snapshot chainstate due to reindexing\n");
         if (!chainman.DeleteSnapshotChainstate()) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
+            return {util::Error{Untranslated("Couldn't remove snapshot chainstate.")}, ChainstateLoadError::FAILURE_FATAL};
         }
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, options);
-    if (init_status != ChainstateLoadStatus::SUCCESS) {
-        return {init_status, init_error};
+    auto result{CompleteChainstateInitialization(chainman, cache_sizes, options)};
+    if (!result) {
+        return result;
     }
 
     // If a snapshot chainstate was fully validated by a background chainstate during
@@ -215,7 +216,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogPrintf("[snapshot] cleaning up unneeded background chainstate, then reinitializing\n");
         if (!chainman.ValidatedSnapshotCleanup()) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Background chainstate cleanup failed unexpectedly.")};
+            return {util::Error{Untranslated("Background chainstate cleanup failed unexpectedly.")}, ChainstateLoadError::FAILURE_FATAL};
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with
@@ -231,20 +232,21 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, options);
-        if (init_status != ChainstateLoadStatus::SUCCESS) {
-            return {init_status, init_error};
+        auto result{CompleteChainstateInitialization(chainman, cache_sizes, options)};
+        if (!result) {
+            return result;
         }
     } else {
-        return {ChainstateLoadStatus::FAILURE, _(
+        return {util::Error{_(
            "UTXO snapshot failed to validate. "
-           "Restart to resume normal initial block download, or try loading a different snapshot.")};
+           "Restart to resume normal initial block download, or try loading a different snapshot.")},
+           ChainstateLoadError::FAILURE};
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
+util::Result<void, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](Chainstate* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.reindex || options.reindex_chainstate || chainstate->CoinsTip().GetBestBlock().IsNull();
@@ -256,9 +258,10 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
         if (!is_coinsview_empty(chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
             if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
-                                                         "This may be due to your computer's date and time being set incorrectly. "
-                                                         "Only rebuild the block database if you are sure that your computer's date and time are correct")};
+                return {util::Error{_("The block database contains a block which appears to be from the future. "
+                                      "This may be due to your computer's date and time being set incorrectly. "
+                                      "Only rebuild the block database if you are sure that your computer's date and time are correct")},
+                        ChainstateLoadError::FAILURE};
             }
 
             VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
@@ -270,18 +273,18 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:
                 break;
             case VerifyDBResult::INTERRUPTED:
-                return {ChainstateLoadStatus::INTERRUPTED, _("Block verification was interrupted")};
+                return {util::Error{_("Block verification was interrupted")}, ChainstateLoadError::INTERRUPTED};
             case VerifyDBResult::CORRUPTED_BLOCK_DB:
-                return {ChainstateLoadStatus::FAILURE, _("Corrupted block database detected")};
+                return {util::Error{_("Corrupted block database detected")}, ChainstateLoadError::FAILURE};
             case VerifyDBResult::SKIPPED_L3_CHECKS:
                 if (options.require_full_verification) {
-                    return {ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE, _("Insufficient dbcache for block verification")};
+                    return {util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE};
                 }
                 break;
             } // no default case, so the compiler can warn about missing cases
         }
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 } // namespace node

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
+#include <util/result.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -35,12 +36,11 @@ struct ChainstateLoadOptions {
     std::function<void()> coins_error_cb;
 };
 
-//! Chainstate load status. Simple applications can just check for the success
-//! case, and treat other cases as errors. More complex applications may want to
-//! try reindexing in the generic failure case, and pass an interrupt callback
-//! and exit cleanly in the interrupted case.
-enum class ChainstateLoadStatus {
-    SUCCESS,
+//! Chainstate load errors. Simple applications can just treat all errors as
+//! failures. More complex applications may want to try reindexing in the
+//! generic error case, and pass an interrupt callback and exit cleanly in the
+//! interrupted case.
+enum class ChainstateLoadError {
     FAILURE, //!< Generic failure which reindexing may fix
     FAILURE_FATAL, //!< Fatal error which should not prompt to reindex
     FAILURE_INCOMPATIBLE_DB,
@@ -48,25 +48,9 @@ enum class ChainstateLoadStatus {
     INTERRUPTED,
 };
 
-//! Chainstate load status code and optional error string.
-using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
-
-/** This sequence can have 4 types of outcomes:
- *
- *  1. Success
- *  2. Shutdown requested
- *    - nothing failed but a shutdown was triggered in the middle of the
- *      sequence
- *  3. Soft failure
- *    - a failure that might be recovered from with a reindex
- *  4. Hard failure
- *    - a failure that definitively cannot be recovered from with a reindex
- *
- *  LoadChainstate returns a (status code, error string) tuple.
- */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options);
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
+util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                       const ChainstateLoadOptions& options);
+util::Result<void, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -48,7 +48,7 @@ enum class ChainstateLoadError {
     INTERRUPTED,
 };
 
-util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+[[nodiscard]] util::Result<void, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
                                                        const ChainstateLoadOptions& options);
 util::Result<void, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -75,7 +75,7 @@ struct NodeContext {
     std::unique_ptr<KernelNotifications> notifications;
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
-    std::atomic<int> exit_status{EXIT_SUCCESS};
+    mutable std::atomic<int> exit_status{EXIT_SUCCESS};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -84,17 +84,6 @@ void KernelNotifications::warning(const bilingual_str& warning)
     DoWarning(warning);
 }
 
-void KernelNotifications::flushError(const bilingual_str& message)
-{
-    AbortNode(&m_shutdown, m_exit_status, message);
-}
-
-void KernelNotifications::fatalError(const bilingual_str& message)
-{
-    node::AbortNode(m_shutdown_on_fatal_error ? &m_shutdown : nullptr,
-                    m_exit_status, message);
-}
-
 void ReadNotificationArgs(const ArgsManager& args, KernelNotifications& notifications)
 {
     if (auto value{args.GetIntArg("-stopatheight")}) notifications.m_stop_at_height = *value;

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -36,10 +36,6 @@ public:
 
     void warning(const bilingual_str& warning) override;
 
-    void flushError(const bilingual_str& message) override;
-
-    void fatalError(const bilingual_str& message) override;
-
     //! Block height after which blockTip notification will return Interrupted{}, if >0.
     int m_stop_at_height{DEFAULT_STOPATHEIGHT};
     //! Useful for tests, can be set to false to avoid shutdown on fatal error.

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -29,6 +29,8 @@ class ChainstateManager;
 
 namespace Consensus { struct Params; };
 
+namespace util { class SignalInterrupt; };
+
 namespace node {
 static const bool DEFAULT_PRINTPRIORITY = false;
 
@@ -152,6 +154,9 @@ private:
     const CTxMemPool* const m_mempool;
     Chainstate& m_chainstate;
 
+    util::SignalInterrupt* m_shutdown;
+    std::atomic<int>& m_exit_status;
+
 public:
     struct Options {
         // Configuration parameters for the block size
@@ -161,8 +166,8 @@ public:
         bool test_block_validity{true};
     };
 
-    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool);
-    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options);
+    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, util::SignalInterrupt* shutdown, std::atomic<int>& exit_status);
+    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options, util::SignalInterrupt* shutdown, std::atomic<int>& exit_status);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -7,12 +7,13 @@
 #include <index/txindex.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/abort.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <node/transaction.h>
 #include <txmempool.h>
 #include <validation.h>
 #include <validationinterface.h>
-#include <node/transaction.h>
 
 #include <future>
 
@@ -71,17 +72,19 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             if (max_tx_fee > 0) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ true);
-                if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
-                    return HandleATMPError(result.m_state, err_string);
-                } else if (result.m_base_fees.value() > max_tx_fee) {
+                const auto result{HandleFatalError(node.chainman->ProcessTransaction(tx, /*test_accept=*/true), node.shutdown, node.exit_status)};
+                if (!result) return TransactionError::MEMPOOL_ERROR;
+                if (result.value().m_result_type != MempoolAcceptResult::ResultType::VALID) {
+                    return HandleATMPError(result.value().m_state, err_string);
+                } else if (result.value().m_base_fees.value() > max_tx_fee) {
                     return TransactionError::MAX_FEE_EXCEEDED;
                 }
             }
             // Try to submit the transaction to the mempool.
-            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ false);
-            if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
-                return HandleATMPError(result.m_state, err_string);
+            const auto result{HandleFatalError(node.chainman->ProcessTransaction(tx, /*test_accept=*/ false), node.shutdown, node.exit_status)};
+            if (!result) return TransactionError::MEMPOOL_ERROR;
+            if (result.value().m_result_type != MempoolAcceptResult::ResultType::VALID) {
+                return HandleATMPError(result.value().m_state, err_string);
             }
 
             // Transaction was accepted to the mempool.

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -377,7 +377,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
                 editStatus = WALLET_UNLOCK_FAILURE;
                 return QString();
             }
-            op_dest = walletModel->wallet().getNewDestination(address_type, strLabel);
+            op_dest.Set(walletModel->wallet().getNewDestination(address_type, strLabel));
             if (!op_dest) {
                 editStatus = KEY_GENERATION_FAILURE;
                 return QString();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1521,6 +1521,7 @@ static RPCHelpMan preciousblock()
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
     CBlockIndex* pblockindex;
 
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     {
         LOCK(cs_main);
@@ -1531,7 +1532,7 @@ static RPCHelpMan preciousblock()
     }
 
     BlockValidationState state;
-    chainman.ActiveChainstate().PreciousBlock(state, pblockindex);
+    (void)CheckFatal(chainman.ActiveChainstate().PreciousBlock(state, pblockindex), node.shutdown, node.exit_status);
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());
@@ -1559,6 +1560,7 @@ static RPCHelpMan invalidateblock()
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
     BlockValidationState state;
 
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     CBlockIndex* pblockindex;
     {
@@ -1571,7 +1573,7 @@ static RPCHelpMan invalidateblock()
     chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
 
     if (state.IsValid()) {
-        chainman.ActiveChainstate().ActivateBestChain(state);
+        (void)CheckFatal(chainman.ActiveChainstate().ActivateBestChain(state), node.shutdown, node.exit_status);
     }
 
     if (!state.IsValid()) {
@@ -1598,6 +1600,7 @@ static RPCHelpMan reconsiderblock()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
@@ -1612,7 +1615,7 @@ static RPCHelpMan reconsiderblock()
     }
 
     BlockValidationState state;
-    chainman.ActiveChainstate().ActivateBestChain(state);
+    (void)CheckFatal(chainman.ActiveChainstate().ActivateBestChain(state), node.shutdown, node.exit_status);
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -25,6 +25,7 @@
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/abort.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
@@ -59,6 +60,7 @@ using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 
 using node::BlockManager;
+using node::CheckFatal;
 using node::NodeContext;
 using node::SnapshotMetadata;
 
@@ -2787,7 +2789,7 @@ static RPCHelpMan loadtxoutset()
             strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call this RPC again.",
                       base_blockhash.ToString()));
     }
-    if (!chainman.ActivateSnapshot(afile, metadata, false)) {
+    if (!CheckFatal(chainman.ActivateSnapshot(afile, metadata, false), node.shutdown, node.exit_status)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to load UTXO snapshot " + fs::PathToString(path));
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -799,6 +799,7 @@ static RPCHelpMan pruneblockchain()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     if (!chainman.m_blockman.IsPruneMode()) {
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
@@ -835,7 +836,7 @@ static RPCHelpMan pruneblockchain()
         height = chainHeight - MIN_BLOCKS_TO_KEEP;
     }
 
-    PruneBlockFilesManual(active_chainstate, height);
+    (void)CheckFatal(PruneBlockFilesManual(active_chainstate, height), node.shutdown, node.exit_status);
     const CBlockIndex& block{*CHECK_NONFATAL(active_chain.Tip())};
     return block.nStatus & BLOCK_HAVE_DATA ? active_chainstate.m_blockman.GetFirstStoredBlock(block)->nHeight - 1 : block.nHeight;
 },
@@ -949,7 +950,7 @@ static RPCHelpMan gettxoutsetinfo()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    active_chainstate.ForceFlushStateToDisk();
+    (void)CheckFatal(active_chainstate.ForceFlushStateToDisk(), node.shutdown, node.exit_status);
 
     CCoinsView* coins_view;
     BlockManager* blockman;
@@ -1570,7 +1571,7 @@ static RPCHelpMan invalidateblock()
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         }
     }
-    chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
+    (void)CheckFatal(chainman.ActiveChainstate().InvalidateBlock(state, pblockindex), node.shutdown, node.exit_status);
 
     if (state.IsValid()) {
         (void)CheckFatal(chainman.ActiveChainstate().ActivateBestChain(state), node.shutdown, node.exit_status);
@@ -2234,7 +2235,7 @@ static RPCHelpMan scantxoutset()
             ChainstateManager& chainman = EnsureChainman(node);
             LOCK(cs_main);
             Chainstate& active_chainstate = chainman.ActiveChainstate();
-            active_chainstate.ForceFlushStateToDisk();
+            (void)CheckFatal(active_chainstate.ForceFlushStateToDisk(), node.shutdown, node.exit_status);
             pcursor = CHECK_NONFATAL(active_chainstate.CoinsDB().Cursor());
             tip = CHECK_NONFATAL(active_chainstate.m_chain.Tip());
         }
@@ -2679,7 +2680,7 @@ UniValue CreateUTXOSnapshot(
         //
         LOCK(::cs_main);
 
-        chainstate.ForceFlushStateToDisk();
+        (void)CheckFatal(chainstate.ForceFlushStateToDisk(), node.shutdown, node.exit_status);
 
         maybe_stats = GetUTXOStats(&chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, node.rpc_interruption_point);
         if (!maybe_stats) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include <deploymentstatus.h>
 #include <key_io.h>
 #include <net.h>
+#include <node/abort.h>
 #include <node/context.h>
 #include <node/miner.h>
 #include <pow.h>
@@ -46,6 +47,7 @@
 
 using node::BlockAssembler;
 using node::CBlockTemplate;
+using node::CheckFatal;
 using node::NodeContext;
 using node::RegenerateCommitments;
 using node::UpdateTime;
@@ -127,7 +129,7 @@ static RPCHelpMan getnetworkhashps()
     };
 }
 
-static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block)
+static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block, NodeContext& node)
 {
     block_out.reset();
     block.hashMerkleRoot = BlockMerkleRoot(block);
@@ -147,14 +149,14 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 
     if (!process_new_block) return true;
 
-    if (!chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr)) {
+    if (!CheckFatal(chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr), node.shutdown, node.exit_status)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
     }
 
     return true;
 }
 
-static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& mempool, const CScript& coinbase_script, int nGenerate, uint64_t nMaxTries)
+static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& mempool, const CScript& coinbase_script, int nGenerate, uint64_t nMaxTries, NodeContext& node)
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
@@ -163,7 +165,7 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
 
         std::shared_ptr<const CBlock> block_out;
-        if (!GenerateBlock(chainman, pblocktemplate->block, nMaxTries, block_out, /*process_new_block=*/true)) {
+        if (!GenerateBlock(chainman, pblocktemplate->block, nMaxTries, block_out, /*process_new_block=*/true, node)) {
             break;
         }
 
@@ -242,7 +244,7 @@ static RPCHelpMan generatetodescriptor()
     const CTxMemPool& mempool = EnsureMemPool(node);
     ChainstateManager& chainman = EnsureChainman(node);
 
-    return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries);
+    return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries, node);
 },
     };
 }
@@ -290,7 +292,7 @@ static RPCHelpMan generatetoaddress()
 
     CScript coinbase_script = GetScriptForDestination(destination);
 
-    return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries);
+    return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries, node);
 },
     };
 }
@@ -395,7 +397,7 @@ static RPCHelpMan generateblock()
     std::shared_ptr<const CBlock> block_out;
     uint64_t max_tries{DEFAULT_MAX_TRIES};
 
-    if (!GenerateBlock(chainman, block, max_tries, block_out, process_new_block) || !block_out) {
+    if (!GenerateBlock(chainman, block, max_tries, block_out, process_new_block, node) || !block_out) {
         throw JSONRPCError(RPC_MISC_ERROR, "Failed to make block.");
     }
 
@@ -1017,6 +1019,7 @@ static RPCHelpMan submitblock()
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a coinbase");
     }
 
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     uint256 hash = block.GetHash();
     {
@@ -1043,7 +1046,7 @@ static RPCHelpMan submitblock()
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    bool accepted = CheckFatal(chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block), node.shutdown, node.exit_status);
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -68,7 +68,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), m_node.shutdown, m_node.exit_status}.CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <index/blockfilterindex.h>
 #include <interfaces/chain.h>
+#include <kernel/fatal_error.h>
 #include <node/miner.h>
 #include <pow.h>
 #include <test/util/blockfilter.h>
@@ -174,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        BOOST_REQUIRE(UnwrapFatalError(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr)));
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -192,7 +193,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        BOOST_REQUIRE(UnwrapFatalError(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr)));
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -223,7 +224,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     // Reorg back to chain A.
      for (size_t i = 2; i < 4; i++) {
          const auto& block = chainA[i];
-         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+         BOOST_REQUIRE(UnwrapFatalError(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr)));
      }
 
      // Check that chain A and B blocks can be retrieved.

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -4,11 +4,12 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <kernel/fatal_error.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>
-#include <script/solver.h>
 #include <primitives/block.h>
+#include <script/solver.h>
 #include <util/chaintype.h>
 #include <validation.h>
 
@@ -35,20 +36,20 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     };
     BlockManager blockman{*Assert(m_node.shutdown), blockman_opts};
     // simulate adding a genesis block normally
-    BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    BOOST_CHECK_EQUAL(UnwrapFatalError(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, nullptr)).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
     // simulate what happens during reindex
     // simulate a well-formed genesis block being found at offset 8 in the blk00000.dat file
     // the block is found at offset 8 because there is an 8 byte serialization header
     // consisting of 4 magic bytes + 4 length bytes before each block in a well-formed blk file.
     FlatFilePos pos{0, BLOCK_SERIALIZATION_HEADER_SIZE};
-    BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, &pos).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    BOOST_CHECK_EQUAL(UnwrapFatalError(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, &pos)).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
     // now simulate what happens after reindex for the first new block processed
     // the actual block contents don't matter, just that it's a block.
     // verify that the write position is at offset 0x12d.
     // this is a check to make sure that https://github.com/bitcoin/bitcoin/issues/21379 does not recur
     // 8 bytes (for serialization header) + 285 (for serialized genesis block) = 293
     // add another 8 bytes for the second block's serialization header and we get 293 + 8 = 301
-    FlatFilePos actual{blockman.SaveBlockToDisk(params->GenesisBlock(), 1, nullptr)};
+    FlatFilePos actual{UnwrapFatalError(blockman.SaveBlockToDisk(params->GenesisBlock(), 1, nullptr))};
     BOOST_CHECK_EQUAL(actual.nPos, BLOCK_SERIALIZATION_HEADER_SIZE + ::GetSerializeSize(TX_WITH_WITNESS(params->GenesisBlock())) + BLOCK_SERIALIZATION_HEADER_SIZE);
 }
 
@@ -158,10 +159,10 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
 
     // Write the first block; dbp=nullptr means this block doesn't already have a disk
     // location, so allocate a free location and write it there.
-    FlatFilePos pos1{blockman.SaveBlockToDisk(block1, /*nHeight=*/1, /*dbp=*/nullptr)};
+    FlatFilePos pos1{UnwrapFatalError(blockman.SaveBlockToDisk(block1, /*nHeight=*/1, /*dbp=*/nullptr))};
 
     // Write second block
-    FlatFilePos pos2{blockman.SaveBlockToDisk(block2, /*nHeight=*/2, /*dbp=*/nullptr)};
+    FlatFilePos pos2{UnwrapFatalError(blockman.SaveBlockToDisk(block2, /*nHeight=*/2, /*dbp=*/nullptr))};
 
     // Two blocks in the file
     BOOST_CHECK_EQUAL(blockman.CalculateCurrentUsage(), (TEST_BLOCK_SIZE + BLOCK_SERIALIZATION_HEADER_SIZE) * 2);
@@ -189,7 +190,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
     // to block 2 location.
     CBlockFileInfo* block_data = blockman.GetBlockFileInfo(0);
     BOOST_CHECK_EQUAL(block_data->nBlocks, 2);
-    BOOST_CHECK(blockman.SaveBlockToDisk(block3, /*nHeight=*/3, /*dbp=*/&pos2) == pos2);
+    BOOST_CHECK(UnwrapFatalError(blockman.SaveBlockToDisk(block3, /*nHeight=*/3, /*dbp=*/&pos2)) == pos2);
     // Metadata is updated...
     BOOST_CHECK_EQUAL(block_data->nBlocks, 3);
     // ...but there are still only two blocks in the file

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -6,6 +6,7 @@
 #include <index/coinstatsindex.h>
 #include <interfaces/chain.h>
 #include <kernel/coinstats.h>
+#include <kernel/fatal_error.h>
 #include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
@@ -98,7 +99,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             LOCK(cs_main);
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
-            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
+            BOOST_CHECK(UnwrapFatalError(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true)));
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
             BOOST_CHECK(UnwrapFatalError(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true)));
             CCoinsViewCache view(&chainstate.CoinsTip());
-            BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
+            BOOST_CHECK(UnwrapFatalError(chainstate.ConnectBlock(block, state, new_block_index, view)));
         }
         // Send block connected notification, then stop the index without
         // sending a chainstate flushed notification. Prior to #24138, this

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 {
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
 {
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
 
     constexpr int max_outbound_block_relay{MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     constexpr int64_t MINIMUM_CONNECT_TIME{30};
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <flatfile.h>
+#include <kernel/fatal_error.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -36,9 +37,9 @@ FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_fil
         // Corresponds to the -reindex case (track orphan blocks across files).
         FlatFilePos flat_file_pos;
         std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
-        g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent);
+        UnwrapFatalError(g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent));
     } else {
         // Corresponds to the -loadblock= case (orphan blocks aren't tracked across files).
-        g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file);
+        UnwrapFatalError(g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file));
     }
 }

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -169,7 +169,7 @@ FUZZ_TARGET(mini_miner_selection, .init = initialize_miner)
     miner_options.nBlockMaxWeight = DEFAULT_BLOCK_MAX_WEIGHT;
     miner_options.test_block_validity = false;
 
-    node::BlockAssembler miner{g_setup->m_node.chainman->ActiveChainstate(), &pool, miner_options};
+    node::BlockAssembler miner{g_setup->m_node.chainman->ActiveChainstate(), &pool, miner_options, g_setup->m_node.shutdown, g_setup->m_node.exit_status};
     node::MiniMiner mini_miner{pool, outpoints};
     assert(mini_miner.IsReadyToCalculate());
 

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
@@ -277,12 +278,12 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
         auto single_submit = txs.size() == 1 && fuzzed_data_provider.ConsumeBool();
 
         const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}));
+                                    return UnwrapFatalError(ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{})));
 
         // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
         // can be a source of divergence.
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
-                                   /*bypass_limits=*/false, /*test_accept=*/!single_submit));
+        const auto res = WITH_LOCK(::cs_main, return UnwrapFatalError(AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+                                   /*bypass_limits=*/false, /*test_accept=*/!single_submit)));
         const bool passed = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
 
         node.validation_signals->SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
@@ -291,7 +292,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
         // Make sure ProcessNewPackage on one transaction works.
         // The result is not guaranteed to be the same as what is returned by ATMP.
         const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{}));
+                                    return UnwrapFatalError(ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{})));
         // If something went wrong due to a package-specific policy, it might not return a
         // validation result for the transaction.
         if (result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {
@@ -301,7 +302,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return UnwrapFatalError(AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false)));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
@@ -403,7 +404,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
 
         const auto tx = MakeTransactionRef(mut_tx);
         const bool bypass_limits = fuzzed_data_provider.ConsumeBool();
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return UnwrapFatalError(AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false)));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <node/utxo_snapshot.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -53,7 +54,7 @@ FUZZ_TARGET(utxo_snapshot, .init = initialize_chain)
         } catch (const std::ios_base::failure&) {
             return false;
         }
-        return chainman.ActivateSnapshot(infile, metadata, /*in_memory=*/true);
+        return UnwrapFatalError(chainman.ActivateSnapshot(infile, metadata, /*in_memory=*/true));
     }};
 
     if (fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -6,6 +6,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <kernel/coinstats.h>
+#include <kernel/fatal_error.h>
 #include <node/miner.h>
 #include <script/interpreter.h>
 #include <streams.h>
@@ -79,7 +80,7 @@ FUZZ_TARGET(utxo_total_supply)
     };
     const auto UpdateUtxoStats = [&]() {
         LOCK(chainman.GetMutex());
-        chainman.ActiveChainstate().ForceFlushStateToDisk();
+        UnwrapFatalError(chainman.ActiveChainstate().ForceFlushStateToDisk());
         utxo_stats = std::move(
             *Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::NONE, &chainman.ActiveChainstate().CoinsDB(), chainman.m_blockman, {})));
         // Check that miner can't print more money than they are allowed to

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -48,10 +48,10 @@ FUZZ_TARGET(validation_load_mempool, .init = initialize_validation_load_mempool)
     auto fuzzed_fopen = [&](const fs::path&, const char*) {
         return fuzzed_file_provider.open();
     };
-    (void)LoadMempool(pool, MempoolPath(g_setup->m_args), chainstate,
+    (void)UnwrapFatalError(LoadMempool(pool, MempoolPath(g_setup->m_args), chainstate,
                       {
                           .mockable_fopen_function = fuzzed_fopen,
-                      });
+                      }));
     pool.SetLoadTried(true);
     (void)DumpMempool(pool, MempoolPath(g_setup->m_args), fuzzed_fopen, true);
 }

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -5,8 +5,9 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
-#include <test/util/setup_common.h>
+#include <kernel/fatal_error.h>
 #include <script/solver.h>
+#include <test/util/setup_common.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -102,7 +103,7 @@ BOOST_AUTO_TEST_CASE(findCommonAncestor)
     auto* orig_tip = active.Tip();
     for (int i = 0; i < 10; ++i) {
         BlockValidationState state;
-        m_node.chainman->ActiveChainstate().InvalidateBlock(state, active.Tip());
+        (void)UnwrapFatalError(m_node.chainman->ActiveChainstate().InvalidateBlock(state, active.Tip()));
     }
     BOOST_CHECK_EQUAL(active.Height(), orig_tip->nHeight - 10);
     coinbaseKey.MakeNewKey(true);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx10.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx10.vout[0].nValue = 10 * COIN;
 
-    ancestors_calculated = pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(NodeSeconds{4s}).FromTx(tx10), CTxMemPool::Limits::NoLimits());
+    ancestors_calculated.Set(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(NodeSeconds{4s}).FromTx(tx10), CTxMemPool::Limits::NoLimits()));
     BOOST_REQUIRE(ancestors_calculated);
     BOOST_CHECK(*ancestors_calculated == setAncestors);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -64,7 +64,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(CTxMemPool& tx_mempool)
 
     options.nBlockMaxWeight = MAX_BLOCK_WEIGHT;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler{m_node.chainman->ActiveChainstate(), &tx_mempool, options};
+    return BlockAssembler{m_node.chainman->ActiveChainstate(), &tx_mempool, options, m_node.shutdown, m_node.exit_status};
 }
 
 constexpr static struct {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -8,6 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
+#include <kernel/fatal_error.h>
 #include <node/miner.h>
 #include <policy/policy.h>
 #include <test/util/random.h>
@@ -635,7 +636,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = bi.nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr));
+        BOOST_CHECK(UnwrapFatalError(Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr)));
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -84,7 +84,7 @@ static void AddPeer(NodeId& id, std::vector<CNode*>& nodes, PeerManager& peerman
 BOOST_AUTO_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection)
 {
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
     NodeId id{0};
     std::vector<CNode*> nodes;
 

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -17,11 +17,11 @@ BOOST_FIXTURE_TEST_SUITE(peerman_tests, RegTestingSetup)
 /** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
 static constexpr int64_t NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 144;
 
-static void mineBlock(const node::NodeContext& node, std::chrono::seconds block_time)
+static void mineBlock(node::NodeContext& node, std::chrono::seconds block_time)
 {
     auto curr_time = GetTime<std::chrono::seconds>();
     SetMockTime(block_time); // update time so the block is created with it
-    CBlock block = node::BlockAssembler{node.chainman->ActiveChainstate(), nullptr}.CreateNewBlock(CScript() << OP_TRUE)->block;
+    CBlock block = node::BlockAssembler{node.chainman->ActiveChainstate(), nullptr, node.shutdown, node.exit_status}.CreateNewBlock(CScript() << OP_TRUE)->block;
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     SetMockTime(curr_time); // process block at current time

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -3,8 +3,9 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <node/miner.h>
+#include <kernel/fatal_error.h>
 #include <net_processing.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
@@ -24,14 +25,14 @@ static void mineBlock(const node::NodeContext& node, std::chrono::seconds block_
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     SetMockTime(curr_time); // process block at current time
-    Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+    Assert(UnwrapFatalError(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr)));
     node.validation_signals->SyncWithValidationInterfaceQueue(); // drain events queue
 }
 
 // Verifying when network-limited peer connections are desirable based on the node's proximity to the tip
 BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
 {
-    std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, m_node.shutdown, m_node.exit_status, *m_node.mempool, {});
     auto consensus = m_node.chainman->GetParams().GetConsensus();
 
     // Check we start connecting to full nodes

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <util/result.h>
 
 #include <boost/test/unit_test.hpp>
@@ -33,6 +34,34 @@ std::ostream& operator<<(std::ostream& os, const NoCopy& o)
     return os << "NoCopy(" << *o.m_n << ")";
 }
 
+struct NoCopyNoMove {
+    NoCopyNoMove(int n) : m_n{n} {}
+    NoCopyNoMove(const NoCopyNoMove&) = delete;
+    NoCopyNoMove(NoCopyNoMove&&) = delete;
+    int m_n;
+};
+
+bool operator==(const NoCopyNoMove& a, const NoCopyNoMove& b)
+{
+    return a.m_n == b.m_n;
+}
+
+std::ostream& operator<<(std::ostream& os, const NoCopyNoMove& o)
+{
+    os << "NoCopyNoMove(" << o.m_n << ")";
+    return os;
+}
+
+util::Result<void> VoidSuccessFn()
+{
+    return {};
+}
+
+util::Result<void> VoidFailFn()
+{
+    return util::Error{Untranslated("void fail.")};
+}
+
 util::Result<int> IntFn(int i, bool success)
 {
     if (success) return i;
@@ -45,21 +74,46 @@ util::Result<bilingual_str> StrFn(bilingual_str s, bool success)
     return util::Error{strprintf(Untranslated("str %s error."), s.original)};
 }
 
-util::Result<NoCopy> NoCopyFn(int i, bool success)
+util::Result<NoCopy, NoCopy> NoCopyFn(int i, bool success)
 {
     if (success) return {i};
-    return util::Error{Untranslated(strprintf("nocopy %i error.", i))};
+    return {util::Error{Untranslated(strprintf("nocopy %i error.", i))}, i};
 }
 
-template <typename T>
-void ExpectResult(const util::Result<T>& result, bool success, const bilingual_str& str)
+util::Result<NoCopyNoMove, NoCopyNoMove> NoCopyNoMoveFn(int i, bool success)
+{
+    if (success) return {i};
+    return {util::Error{Untranslated(strprintf("nocopynomove %i error.", i))}, i};
+}
+
+enum FnError { ERR1, ERR2 };
+
+util::Result<int, FnError> IntFailFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("int %i error.", i))}, i % 2 ? ERR1 : ERR2};
+}
+
+util::Result<NoCopyNoMove, FnError> EnumFailFn(FnError ret)
+{
+    return {util::Error{Untranslated("enum fail.")}, ret};
+}
+
+util::Result<int, int> TruthyFalsyFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("failure value %i.", i))}, i};
+}
+
+template <typename T, typename F>
+void ExpectResult(const util::Result<T, F>& result, bool success, const bilingual_str& str)
 {
     BOOST_CHECK_EQUAL(bool(result), success);
     BOOST_CHECK_EQUAL(util::ErrorString(result), str);
 }
 
-template <typename T, typename... Args>
-void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args&&... args)
+template <typename T, typename F, typename... Args>
+void ExpectSuccess(const util::Result<T, F>& result, const bilingual_str& str, Args&&... args)
 {
     ExpectResult(result, true, str);
     BOOST_CHECK_EQUAL(result.has_value(), true);
@@ -67,40 +121,61 @@ void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args
     BOOST_CHECK_EQUAL(&result.value(), &*result);
 }
 
-template <typename T, typename... Args>
-void ExpectFail(const util::Result<T>& result, const bilingual_str& str)
+template <typename T, typename F, typename... Args>
+void ExpectFail(const util::Result<T, F>& result, bilingual_str str, Args&&... args)
 {
     ExpectResult(result, false, str);
+    BOOST_CHECK_EQUAL(result.GetFailure(), F{std::forward<Args>(args)...});
 }
 
 BOOST_AUTO_TEST_CASE(check_returned)
 {
+    ExpectResult(VoidSuccessFn(), true, {});
+    ExpectResult(VoidFailFn(), false, Untranslated("void fail."));
     ExpectSuccess(IntFn(5, true), {}, 5);
-    ExpectFail(IntFn(5, false), Untranslated("int 5 error."));
+    ExpectResult(IntFn(5, false), false, Untranslated("int 5 error."));
     ExpectSuccess(NoCopyFn(5, true), {}, 5);
-    ExpectFail(NoCopyFn(5, false), Untranslated("nocopy 5 error."));
+    ExpectFail(NoCopyFn(5, false), Untranslated("nocopy 5 error."), 5);
+    ExpectSuccess(NoCopyNoMoveFn(5, true), {}, 5);
+    ExpectFail(NoCopyNoMoveFn(5, false), Untranslated("nocopynomove 5 error."), 5);
     ExpectSuccess(StrFn(Untranslated("S"), true), {}, Untranslated("S"));
-    ExpectFail(StrFn(Untranslated("S"), false), Untranslated("str S error."));
+    ExpectResult(StrFn(Untranslated("S"), false), false, Untranslated("str S error."));
+    ExpectFail(EnumFailFn(ERR2), Untranslated("enum fail."), ERR2);
+    ExpectSuccess(TruthyFalsyFn(0, true), {}, 0);
+    ExpectFail(TruthyFalsyFn(0, false), Untranslated("failure value 0."), 0);
+    ExpectSuccess(TruthyFalsyFn(1, true), {}, 1);
+    ExpectFail(TruthyFalsyFn(1, false), Untranslated("failure value 1."), 1);
 }
 
 BOOST_AUTO_TEST_CASE(check_set)
 {
     // Test using Set method to change a result value from success -> failure,
     // and failure->success.
-    util::Result<int> result{0};
+    util::Result<int, FnError> result;
     ExpectSuccess(result, {}, 0);
-    result.Set({util::Error{Untranslated("error")}});
-    ExpectFail(result, Untranslated("error"));
+    result.Set({util::Error{Untranslated("error")}, ERR1});
+    ExpectFail(result, Untranslated("error"), ERR1);
     result.Set(2);
     ExpectSuccess(result, Untranslated(""), 2);
 
     // Test the same thing but with non-copyable success and failure types.
-    util::Result<NoCopy> result2{0};
+    util::Result<NoCopy, NoCopy> result2{0};
     ExpectSuccess(result2, {}, 0);
-    result2.Set({util::Error{Untranslated("error")}});
-    ExpectFail(result2, Untranslated("error"));
-    result2.Set(util::Result<NoCopy>{4});
+    result2.Set({util::Error{Untranslated("error")}, 3});
+    ExpectFail(result2, Untranslated("error"), 3);
+    result2.Set(4);
     ExpectSuccess(result2, Untranslated(""), 4);
+}
+
+BOOST_AUTO_TEST_CASE(check_dereference_operators)
+{
+    util::Result<std::pair<int, std::string>> mutable_result;
+    const auto& const_result{mutable_result};
+    mutable_result.value() = {1, "23"};
+    BOOST_CHECK_EQUAL(mutable_result->first, 1);
+    BOOST_CHECK_EQUAL(const_result->second, "23");
+    (*mutable_result).first = 5;
+    BOOST_CHECK_EQUAL((*const_result).first, 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_value_or)
@@ -111,6 +186,20 @@ BOOST_AUTO_TEST_CASE(check_value_or)
     BOOST_CHECK_EQUAL(NoCopyFn(10, false).value_or(20), 20);
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), true).value_or(Untranslated("B")), Untranslated("A"));
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), false).value_or(Untranslated("B")), Untranslated("B"));
+}
+
+struct Derived : NoCopyNoMove {
+    using NoCopyNoMove::NoCopyNoMove;
+};
+
+util::Result<std::unique_ptr<NoCopyNoMove>> DerivedToBaseFn(util::Result<std::unique_ptr<Derived>> derived)
+{
+    return derived;
+}
+
+BOOST_AUTO_TEST_CASE(derived_to_base)
+{
+    BOOST_CHECK_EQUAL(*Assert(*Assert(DerivedToBaseFn(std::make_unique<Derived>(5)))), 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -172,6 +172,12 @@ void ExpectFail(const util::Result<T, F>& result, bilingual_str str, Args&&... a
     BOOST_CHECK_EQUAL(result.GetFailure(), F{std::forward<Args>(args)...});
 }
 
+BOOST_AUTO_TEST_CASE(check_sizes)
+{
+    static_assert(sizeof(util::Result<int>) == sizeof(void*)*2);
+    static_assert(sizeof(util::Result<void>) == sizeof(void*));
+}
+
 BOOST_AUTO_TEST_CASE(check_returned)
 {
     ExpectResult(VoidSuccessFn(), true, {});

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -2,10 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <tinyformat.h>
 #include <util/check.h>
 #include <util/result.h>
+#include <util/translation.h>
 
+#include <algorithm>
 #include <boost/test/unit_test.hpp>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
 
 inline bool operator==(const bilingual_str& a, const bilingual_str& b)
 {
@@ -90,13 +97,50 @@ enum FnError { ERR1, ERR2 };
 
 util::Result<int, FnError> IntFailFn(int i, bool success)
 {
-    if (success) return i;
+    if (success) return {util::Warning{Untranslated(strprintf("int %i warn.", i))}, i};
     return {util::Error{Untranslated(strprintf("int %i error.", i))}, i % 2 ? ERR1 : ERR2};
+}
+
+util::Result<std::string, FnError> StrFailFn(int i, bool success)
+{
+    auto result = IntFailFn(i, success);
+    if (!success) return {util::MoveMessages(result), util::Error{Untranslated("str error")}, result.GetFailure()};
+    return {util::MoveMessages(result), strprintf("%i", *result)};
 }
 
 util::Result<NoCopyNoMove, FnError> EnumFailFn(FnError ret)
 {
     return {util::Error{Untranslated("enum fail.")}, ret};
+}
+
+util::Result<void> WarnFn()
+{
+    return {util::Warning{Untranslated("warn.")}};
+}
+
+util::Result<int> MultiWarnFn(int ret)
+{
+    util::Result<void> result;
+    for (int i = 0; i < ret; ++i) {
+        result.AddWarning(strprintf(Untranslated("warn %i."), i));
+    }
+    return {util::MoveMessages(result), ret};
+}
+
+util::Result<void, int> ChainedFailFn(FnError arg, int ret)
+{
+    return {util::Error{Untranslated("chained fail.")}, util::MoveMessages(EnumFailFn(arg)), util::MoveMessages(WarnFn()), ret};
+}
+
+util::Result<int, FnError> AccumulateFn(bool success)
+{
+    util::Result<int, FnError> result;
+    util::Result<int> x = MultiWarnFn(1) >> result;
+    BOOST_REQUIRE(x);
+    util::Result<int> y = MultiWarnFn(2) >> result;
+    BOOST_REQUIRE(y);
+    result.Set(IntFailFn(*x + *y, success));
+    return result;
 }
 
 util::Result<int, int> TruthyFalsyFn(int i, bool success)
@@ -140,7 +184,13 @@ BOOST_AUTO_TEST_CASE(check_returned)
     ExpectFail(NoCopyNoMoveFn(5, false), Untranslated("nocopynomove 5 error."), 5);
     ExpectSuccess(StrFn(Untranslated("S"), true), {}, Untranslated("S"));
     ExpectResult(StrFn(Untranslated("S"), false), false, Untranslated("str S error."));
+    ExpectSuccess(StrFailFn(1, true), Untranslated("int 1 warn."), "1");
+    ExpectFail(StrFailFn(2, false), Untranslated("int 2 error. str error"), ERR2);
     ExpectFail(EnumFailFn(ERR2), Untranslated("enum fail."), ERR2);
+    ExpectFail(ChainedFailFn(ERR1, 5), Untranslated("chained fail. enum fail. warn."), 5);
+    ExpectSuccess(MultiWarnFn(3), Untranslated("warn 0. warn 1. warn 2."), 3);
+    ExpectSuccess(AccumulateFn(true), Untranslated("warn 0. warn 0. warn 1. int 3 warn."), 3);
+    ExpectFail(AccumulateFn(false), Untranslated("int 3 error. warn 0. warn 0. warn 1."), ERR1);
     ExpectSuccess(TruthyFalsyFn(0, true), {}, 0);
     ExpectFail(TruthyFalsyFn(0, false), Untranslated("failure value 0."), 0);
     ExpectSuccess(TruthyFalsyFn(1, true), {}, 1);
@@ -156,7 +206,7 @@ BOOST_AUTO_TEST_CASE(check_set)
     result.Set({util::Error{Untranslated("error")}, ERR1});
     ExpectFail(result, Untranslated("error"), ERR1);
     result.Set(2);
-    ExpectSuccess(result, Untranslated(""), 2);
+    ExpectSuccess(result, Untranslated("error"), 2);
 
     // Test the same thing but with non-copyable success and failure types.
     util::Result<NoCopy, NoCopy> result2{0};
@@ -164,7 +214,7 @@ BOOST_AUTO_TEST_CASE(check_set)
     result2.Set({util::Error{Untranslated("error")}, 3});
     ExpectFail(result2, Untranslated("error"), 3);
     result2.Set(4);
-    ExpectSuccess(result2, Untranslated(""), 4);
+    ExpectSuccess(result2, Untranslated("error"), 4);
 }
 
 BOOST_AUTO_TEST_CASE(check_dereference_operators)
@@ -186,6 +236,16 @@ BOOST_AUTO_TEST_CASE(check_value_or)
     BOOST_CHECK_EQUAL(NoCopyFn(10, false).value_or(20), 20);
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), true).value_or(Untranslated("B")), Untranslated("A"));
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), false).value_or(Untranslated("B")), Untranslated("B"));
+}
+
+BOOST_AUTO_TEST_CASE(check_message_accessors)
+{
+    util::Result<void> result{util::Error{Untranslated("Error.")}, util::Warning{Untranslated("Warning.")}};
+    BOOST_CHECK_EQUAL(result.GetErrors().size(), 1);
+    BOOST_CHECK_EQUAL(result.GetErrors()[0], Untranslated("Error."));
+    BOOST_CHECK_EQUAL(result.GetWarnings().size(), 1);
+    BOOST_CHECK_EQUAL(result.GetWarnings()[0], Untranslated("Warning."));
+    BOOST_CHECK_EQUAL(util::ErrorString(result), Untranslated("Error. Warning."));
 }
 
 struct Derived : NoCopyNoMove {

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -83,6 +83,26 @@ BOOST_AUTO_TEST_CASE(check_returned)
     ExpectFail(StrFn(Untranslated("S"), false), Untranslated("str S error."));
 }
 
+BOOST_AUTO_TEST_CASE(check_set)
+{
+    // Test using Set method to change a result value from success -> failure,
+    // and failure->success.
+    util::Result<int> result{0};
+    ExpectSuccess(result, {}, 0);
+    result.Set({util::Error{Untranslated("error")}});
+    ExpectFail(result, Untranslated("error"));
+    result.Set(2);
+    ExpectSuccess(result, Untranslated(""), 2);
+
+    // Test the same thing but with non-copyable success and failure types.
+    util::Result<NoCopy> result2{0};
+    ExpectSuccess(result2, {}, 0);
+    result2.Set({util::Error{Untranslated("error")}});
+    ExpectFail(result2, Untranslated("error"));
+    result2.Set(util::Result<NoCopy>{4});
+    ExpectSuccess(result2, Untranslated(""), 4);
+}
+
 BOOST_AUTO_TEST_CASE(check_value_or)
 {
     BOOST_CHECK_EQUAL(IntFn(10, true).value_or(20), 10);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <key_io.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
@@ -132,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
                                                    /*output_amount=*/CAmount(48 * COIN), /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
     Package package_parent_child{tx_parent, tx_child};
-    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    const auto result_parent_child = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{}));
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_parent_child, result_parent_child, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -151,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
     CTransactionRef giant_ptx = create_placeholder_tx(999, 999);
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * 1000);
     Package package_single_giant{giant_ptx};
-    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    auto result_single_large = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{}));
     if (auto err_single_large{CheckPackageMempoolAcceptResult(package_single_giant, result_single_large, /*expect_valid=*/false, nullptr)}) {
         BOOST_ERROR(err_single_large.value());
     } else {
@@ -274,8 +275,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
                                                  /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
         package_unrelated.emplace_back(MakeTransactionRef(mtx));
     }
-    auto result_unrelated_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto result_unrelated_submit = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{}));
     // We don't expect m_tx_results for each transaction when basic sanity checks haven't passed.
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
@@ -314,8 +315,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // 3 Generations is not allowed.
     {
-        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto result_3gen_submit = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         BOOST_CHECK(result_3gen_submit.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -331,8 +332,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         mtx_parent_invalid.vin[0].scriptWitness = bad_witness;
         CTransactionRef tx_parent_invalid = MakeTransactionRef(mtx_parent_invalid);
         Package package_invalid_parent{tx_parent_invalid, tx_child};
-        auto result_quit_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto result_quit_early = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{}));
         if (auto err_parent_invalid{CheckPackageMempoolAcceptResult(package_invalid_parent, result_quit_early, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent_invalid.value());
         } else {
@@ -352,8 +353,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
     package_missing_parent.push_back(tx_parent);
     package_missing_parent.push_back(MakeTransactionRef(mtx_child));
     {
-        const auto result_missing_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto result_missing_parent = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         BOOST_CHECK(result_missing_parent.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetRejectReason(), "package-not-child-with-unconfirmed-parents");
@@ -362,8 +363,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // Submit package with parent + child.
     {
-        const auto submit_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_parent_child = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_parent_child.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_parent_child.m_state.GetRejectReason());
@@ -384,8 +385,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // Already-in-mempool transactions should be detected and de-duplicated.
     {
-        const auto submit_deduped = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_deduped = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_deduped{CheckPackageMempoolAcceptResult(package_parent_child, submit_deduped, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_deduped.value());
         } else {
@@ -455,16 +456,16 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // same-txid-different-witness.
     {
         Package package_parent_child1{ptx_parent, ptx_child1};
-        const auto submit_witness1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_witness1 = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_witness1{CheckPackageMempoolAcceptResult(package_parent_child1, submit_witness1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness1.value());
         }
 
         // Child2 would have been validated individually.
         Package package_parent_child2{ptx_parent, ptx_child2};
-        const auto submit_witness2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_witness2 = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_witness2{CheckPackageMempoolAcceptResult(package_parent_child2, submit_witness2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness2.value());
         } else {
@@ -477,8 +478,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 
         // Deduplication should work when wtxid != txid. Submit package with the already-in-mempool
         // transactions again, which should not fail.
-        const auto submit_segwit_dedup = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_segwit_dedup = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_segwit_dedup{CheckPackageMempoolAcceptResult(package_parent_child1, submit_segwit_dedup, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_segwit_dedup.value());
         } else {
@@ -507,8 +508,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // We already submitted child1 above.
     {
         Package package_child2_grandchild{ptx_child2, ptx_grandchild};
-        const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_spend_ignored = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_spend_ignored{CheckPackageMempoolAcceptResult(package_child2_grandchild, submit_spend_ignored, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_spend_ignored.value());
         } else {
@@ -571,7 +572,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    const MempoolAcceptResult parent2_v2_result = UnwrapFatalError(m_node.chainman->ProcessTransaction(ptx_parent2_v2));
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 
@@ -606,7 +607,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // parent3 should be accepted
     // child should be accepted
     {
-        const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{});
+        const auto mixed_result = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{}));
         if (auto err_mixed{CheckPackageMempoolAcceptResult(package_mixed, mixed_result, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_mixed.value());
         } else {
@@ -669,8 +670,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), child_value - coinbase_value);
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        const auto submit_cpfp_deprio = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{}));
         if (auto err_cpfp_deprio{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp_deprio, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp_deprio.value());
         } else {
@@ -691,8 +692,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // child pays enough for the package feerate to meet the threshold.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        const auto submit_cpfp = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{}));
         if (auto err_cpfp{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp.value());
         } else {
@@ -743,8 +744,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
 
     // Cheap package should fail for being too low fee.
     {
-        const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_package_too_low = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_package_too_low{CheckPackageMempoolAcceptResult(package_still_too_low, submit_package_too_low, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_package_too_low.value());
         } else {
@@ -769,8 +770,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     m_node.mempool->PrioritiseTransaction(tx_child_cheap->GetHash(), 1 * COIN);
     // Now that the child's fees have "increased" by 1 BTC, the cheap package should succeed.
     {
-        const auto submit_prioritised_package = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_prioritised_package = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_prioritised{CheckPackageMempoolAcceptResult(package_still_too_low, submit_prioritised_package, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_prioritised.value());
         } else {
@@ -817,8 +818,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // Parent pays 1 BTC and child pays none. The parent should be accepted without the child.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_rich_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        const auto submit_rich_parent = UnwrapFatalError(ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{}));
         if (auto err_rich_parent{CheckPackageMempoolAcceptResult(package_rich_parent, submit_rich_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_rich_parent.value());
         } else {

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -3,10 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <key_io.h>
-#include <policy/v3_policy.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
+#include <policy/v3_policy.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <script/script.h>
@@ -39,7 +40,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx));
+    const MempoolAcceptResult result = UnwrapFatalError(m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx)));
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <key.h>
 #include <random.h>
 #include <script/sign.h>
@@ -37,7 +38,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(tx));
+        const MempoolAcceptResult result = UnwrapFatalError(m_node.chainman->ProcessTransaction(MakeTransactionRef(tx)));
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -84,7 +84,7 @@ CreateAndActivateUTXOSnapshot(
             chain.CoinsTip().SetBestBlock(gen_hash);
             chain.setBlockIndexCandidates.insert(node.chainman->m_blockman.LookupBlockIndex(gen_hash));
             chain.LoadChainTip();
-            node.chainman->MaybeRebalanceCaches();
+            UnwrapFatalError(node.chainman->MaybeRebalanceCaches());
 
             // Reset the HAVE_DATA flags below the snapshot height, simulating
             // never-having-downloaded them in the first place.

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -77,7 +77,7 @@ CreateAndActivateUTXOSnapshot(
             node.chainman->ResetChainstates();
             node.chainman->InitializeChainstate(node.mempool.get());
             Chainstate& chain = node.chainman->ActiveChainstate();
-            Assert(chain.LoadGenesisBlock());
+            Assert(UnwrapFatalError(chain.LoadGenesisBlock()));
             // These cache values will be corrected shortly in `MaybeRebalanceCaches`.
             chain.InitCoinsDB(1 << 20, true, false, "");
             chain.InitCoinsCache(1 << 20);

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -6,6 +6,7 @@
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
 #include <clientversion.h>
+#include <kernel/fatal_error.h>
 #include <logging.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
@@ -124,7 +125,7 @@ CreateAndActivateUTXOSnapshot(
         new_active.m_chain.SetTip(*(tip->pprev));
     }
 
-    bool res = node.chainman->ActivateSnapshot(auto_infile, metadata, in_memory_chainstate);
+    bool res = UnwrapFatalError(node.chainman->ActivateSnapshot(auto_infile, metadata, in_memory_chainstate));
 
     // Restore the old tip.
     new_active.m_chain.SetTip(*tip);

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -106,7 +106,7 @@ CreateAndActivateUTXOSnapshot(
             }
         }
         BlockValidationState state;
-        if (!node.chainman->ActiveChainstate().ActivateBestChain(state)) {
+        if (!UnwrapFatalError(node.chainman->ActiveChainstate().ActivateBestChain(state))) {
             throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
         }
         Assert(

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -7,6 +7,7 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <key_io.h>
 #include <node/context.h>
 #include <pow.h>
@@ -96,7 +97,7 @@ COutPoint MineBlock(const NodeContext& node, std::shared_ptr<CBlock>& block)
     bool new_block;
     BlockValidationStateCatcher bvsc{block->GetHash()};
     node.validation_signals->RegisterValidationInterface(&bvsc);
-    const bool processed{chainman.ProcessNewBlock(block, true, true, &new_block)};
+    const bool processed{UnwrapFatalError(chainman.ProcessNewBlock(block, true, true, &new_block))};
     const bool duplicate{!new_block && processed};
     assert(!duplicate);
     node.validation_signals->UnregisterValidationInterface(&bvsc);

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
                                      const BlockAssembler::Options& assembler_options)
 {
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{Assert(node.chainman)->ActiveChainstate(), Assert(node.mempool.get()), assembler_options}
+        BlockAssembler{Assert(node.chainman)->ActiveChainstate(), Assert(node.mempool.get()), assembler_options, node.shutdown, node.exit_status}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -372,7 +372,7 @@ CBlock TestChain100Setup::CreateBlock(
     const CScript& scriptPubKey,
     Chainstate& chainstate)
 {
-    CBlock block = BlockAssembler{chainstate, nullptr}.CreateNewBlock(scriptPubKey)->block;
+    CBlock block = BlockAssembler{chainstate, nullptr, m_node.shutdown, m_node.exit_status}.CreateNewBlock(scriptPubKey)->block;
 
     Assert(block.vtx.size() == 1);
     for (const CMutableTransaction& tx : txns) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -477,7 +477,7 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn));
+        const MempoolAcceptResult result = UnwrapFatalError(m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn)));
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     }
     return mempool_txn;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -284,11 +284,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto result = LoadChainstate(chainman, m_cache_sizes, options);
+    assert(result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    result = VerifyLoadedChainstate(chainman, options);
+    assert(result);
 
     BlockValidationState state;
     if (!chainman.ActiveChainstate().ActivateBestChain(state)) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -292,7 +292,7 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     assert(result);
 
     BlockValidationState state;
-    if (!chainman.ActiveChainstate().ActivateBestChain(state)) {
+    if (!UnwrapFatalError(chainman.ActiveChainstate().ActivateBestChain(state))) {
         throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
     }
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -22,6 +22,7 @@
 #include <init.h>
 #include <init/common.h>
 #include <interfaces/chain.h>
+#include <kernel/fatal_error.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
 #include <net.h>
@@ -322,6 +323,7 @@ TestingSetup::TestingSetup(
     peerman_opts.deterministic_rng = true;
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
+                                       m_node.shutdown, m_node.exit_status,
                                        *m_node.mempool, peerman_opts);
 
     {
@@ -394,7 +396,7 @@ CBlock TestChain100Setup::CreateAndProcessBlock(
 
     CBlock block = this->CreateBlock(txns, scriptPubKey, *chainstate);
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr);
+    (void)UnwrapFatalError(Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr));
 
     return block;
 }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx);
+                const MempoolAcceptResult result = UnwrapFatalError(m_node.chainman->ProcessTransaction(tx));
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             }
         }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     static int i = 0;
     static uint64_t time = Params().GenesisBlock().nTime;
 
-    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(CScript{} << i++ << OP_TRUE);
+    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), m_node.shutdown, m_node.exit_status}.CreateNewBlock(CScript{} << i++ << OP_TRUE);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(witness_commitment_index)
     LOCK(Assert(m_node.chainman)->GetMutex());
     CScript pubKey;
     pubKey << 1 << OP_TRUE;
-    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), m_node.shutdown, m_node.exit_status}.CreateNewBlock(pubKey);
     CBlock pblock = ptemplate->block;
 
     CTxOut witness;

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -130,7 +130,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     }
 
     // UpdateTip is called here
-    bool block_added = background_cs.ActivateBestChain(state, pblockone);
+    bool block_added = UnwrapFatalError(background_cs.ActivateBestChain(state, pblockone));
 
     // Ensure tip is as expected
     BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), pblockone->GetHash());

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -4,6 +4,7 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <kernel/fatal_error.h>
 #include <random.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
@@ -123,8 +124,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
         LOCK(::cs_main);
         bool checked = CheckBlock(*pblockone, state, chainparams.GetConsensus());
         BOOST_CHECK(checked);
-        bool accepted = chainman.AcceptBlock(
-            pblockone, state, &pindex, true, nullptr, &newblock, true);
+        bool accepted = UnwrapFatalError(chainman.AcceptBlock(
+            pblockone, state, &pindex, true, nullptr, &newblock, true));
         BOOST_CHECK(accepted);
     }
 

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
     c1.InitCoinsDB(
         /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));
-    BOOST_REQUIRE(c1.LoadGenesisBlock()); // Need at least one block loaded to be able to flush caches
+    BOOST_REQUIRE(UnwrapFatalError(c1.LoadGenesisBlock())); // Need at least one block loaded to be able to flush caches
 
     // Add a coin to the in-memory cache, upsize once, then downsize.
     {

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -44,18 +44,18 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
 
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
+        (void)UnwrapFatalError(c1.ResizeCoinsCaches(
             1 << 24,  // upsizing the coinsview cache
             1 << 22  // downsizing the coinsdb cache
-        );
+        ));
 
         // View should still have the coin cached, since we haven't destructed the cache on upsize.
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
+        (void)UnwrapFatalError(c1.ResizeCoinsCaches(
             1 << 22,  // downsizing the coinsview cache
             1 << 23  // upsizing the coinsdb cache
-        );
+        ));
 
         // The view cache should be empty since we had to destruct to downsize.
         BOOST_CHECK(!c1.CoinsTip().HaveCoinInCache(outpoint));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager, TestChain100Setup)
         c2.LoadChainTip();
     }
     BlockValidationState _;
-    BOOST_CHECK(c2.ActivateBestChain(_, nullptr));
+    BOOST_CHECK(UnwrapFatalError(c2.ActivateBestChain(_, nullptr)));
 
     BOOST_CHECK_EQUAL(manager.SnapshotBlockhash().value(), snapshot_blockhash);
     BOOST_CHECK(manager.IsSnapshotActive());

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -126,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c1.InitCoinsCache(1 << 23);
-        manager.MaybeRebalanceCaches();
+        UnwrapFatalError(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_EQUAL(c1.m_coinstip_cache_size_bytes, max_cache);
@@ -152,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c2.InitCoinsCache(1 << 23);
-        manager.MaybeRebalanceCaches();
+        UnwrapFatalError(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_CLOSE(c1.m_coinstip_cache_size_bytes, max_cache * 0.05, 1);
@@ -371,7 +371,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             for (Chainstate* cs : chainman.GetAll()) {
                 LOCK(::cs_main);
-                cs->ForceFlushStateToDisk();
+                UnwrapFatalError(cs->ForceFlushStateToDisk());
             }
             // Process all callbacks referring to the old manager before wiping it.
             m_node.validation_signals->SyncWithValidationInterfaceQueue();
@@ -576,7 +576,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_init, SnapshotTestSetup)
     BlockValidationState unused_state;
     {
         LOCK2(::cs_main, bg_chainstate.MempoolMutex());
-        BOOST_CHECK(bg_chainstate.DisconnectTip(unused_state, &unused_pool));
+        BOOST_CHECK(UnwrapFatalError(bg_chainstate.DisconnectTip(unused_state, &unused_pool)));
         unused_pool.clear();  // to avoid queuedTx assertion errors on teardown
     }
     BOOST_CHECK_EQUAL(bg_chainstate.m_chain.Height(), 109);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>
+#include <kernel/fatal_error.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
@@ -25,6 +26,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using kernel::CheckFatalFailure;
+using kernel::FatalError;
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
@@ -635,7 +638,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     const uint256 snapshot_tip_hash = WITH_LOCK(chainman.GetMutex(),
         return chainman.ActiveTip()->GetBlockHash());
 
-    res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+    res = WITH_LOCK(::cs_main, return UnwrapFatalError(chainman.MaybeCompleteSnapshotValidation()));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SUCCESS);
 
     WITH_LOCK(::cs_main, BOOST_CHECK(chainman.IsSnapshotValidated()));
@@ -651,7 +654,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     BOOST_CHECK_EQUAL(all_chainstates[0], &active_cs);
 
     // Trying completion again should return false.
-    res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+    res = WITH_LOCK(::cs_main, return UnwrapFatalError(chainman.MaybeCompleteSnapshotValidation()));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SKIPPED);
 
     // The invalid snapshot path should not have been used.
@@ -703,7 +706,6 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, Sna
     auto chainstates = this->SetupSnapshot();
     Chainstate& validation_chainstate = *std::get<0>(chainstates);
     ChainstateManager& chainman = *Assert(m_node.chainman);
-    SnapshotCompletionResult res;
     m_node.notifications->m_shutdown_on_fatal_error = false;
 
     // Test tampering with the IBD UTXO set with an extra coin to ensure it causes
@@ -722,8 +724,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, Sna
 
     {
         ASSERT_DEBUG_LOG("failed to validate the -assumeutxo snapshot state");
-        res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
-        BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+        BOOST_CHECK(WITH_LOCK(::cs_main, return CheckFatalFailure(chainman.MaybeCompleteSnapshotValidation(), FatalError::SnapshotHashMismatch)));
     }
 
     auto all_chainstates = chainman.GetAll();

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -447,7 +447,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
             BOOST_CHECK(cs->setBlockIndexCandidates.empty());
         }
 
-        WITH_LOCK(::cs_main, chainman.LoadBlockIndex());
+        WITH_LOCK(::cs_main, (void)UnwrapFatalError(chainman.LoadBlockIndex()));
     };
 
     // Ensure that without any assumed-valid BlockIndex entries, only the current tip is

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <util/result.h>
+
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+#include <util/translation.h>
+
+namespace util {
+namespace detail {
+bilingual_str JoinMessages(const std::vector<bilingual_str>& errors, const std::vector<bilingual_str>& warnings)
+{
+    bilingual_str result;
+    for (const auto& messages : {errors, warnings}) {
+        for (const auto& message : messages) {
+            if (!result.empty()) result += Untranslated(" ");
+            result += message;
+        }
+    }
+    return result;
+}
+
+void MoveMessages(std::vector<bilingual_str>& src, std::vector<bilingual_str>& dest)
+{
+    dest.insert(dest.end(), std::make_move_iterator(src.begin()), std::make_move_iterator(src.end()));
+    src.clear();
+}
+} // namespace detail
+} // namespace util

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -39,6 +39,13 @@ private:
 
     std::variant<bilingual_str, T> m_variant;
 
+    //! Disallow operator= and require explicit Result::Set() calls to avoid
+    //! confusion in the future when the Result class gains support for richer
+    //! error reporting, and callers should have ability to set a new result
+    //! value without clearing existing error messages.
+    Result& operator=(const Result&) = default;
+    Result& operator=(Result&&) = default;
+
     template <typename FT>
     friend bilingual_str ErrorString(const Result<FT>& result);
 
@@ -46,6 +53,9 @@ public:
     Result() : m_variant{std::in_place_index_t<1>{}, std::monostate{}} {}  // constructor for void
     Result(T obj) : m_variant{std::in_place_index_t<1>{}, std::move(obj)} {}
     Result(Error error) : m_variant{std::in_place_index_t<0>{}, std::move(error.message)} {}
+    Result(const Result&) = default;
+    Result(Result&&) = default;
+    ~Result() = default;
 
     //! std::optional methods, so functions returning optional<T> can change to
     //! return Result<T> with minimal changes to existing code, and vice versa.
@@ -75,6 +85,9 @@ public:
     const T& operator*() const LIFETIMEBOUND { return value(); }
     T* operator->() LIFETIMEBOUND { return &value(); }
     T& operator*() LIFETIMEBOUND { return value(); }
+
+    //! Assign success or failure value from another result object.
+    Result& Set(Result&& other) LIFETIMEBOUND { return *this = std::move(other); }
 };
 
 template <typename T>

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -8,68 +8,188 @@
 #include <attributes.h>
 #include <util/translation.h>
 
-#include <variant>
+#include <cassert>
+#include <memory>
+#include <new>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace util {
 
+//! The `Result` class provides a standard way for functions to return an error
+//! string in addition to optional result values.
+//!
+//! The easiest way to understand `Result<T>` is to think of it as a substitute
+//! for `std::optional<T>`, that just contains an error string in
+//! addition to the optional return value. For example:
+//!
+//!    util::Result<int> AddNumbers(int a, int b)
+//!    {
+//!        if (b == 0) return util::Error{_("Not adding 0, that's dumb.")};
+//!        return a + b;
+//!    }
+//!
+//!    void TryAddNumbers(int a, int b)
+//!    {
+//!        if (auto result = AddNumbers(a, b)) {
+//!            LogPrintf("%i + %i = %i\n", a, b, *result);
+//!        } else {
+//!            LogPrintf("Error: %s\n", util::ErrorString(result).translated);
+//!        }
+//!    }
+//!
+//! The `Result` class is intended to be used for high-level functions that need
+//! to report error messages to end users. Low-level functions that don't need
+//! error-reporting and only need error-handling should avoid `Result` and
+//! instead use standard classes like `std::optional`, `std::variant`,
+//! `std::expected`, and `std::tuple`, or custom structs and enum types to
+//! return function results.
+//!
+//! Usage examples can be found in \example ../test/result_tests.cpp, but in
+//! general code using `Result<T>` return values is similar to code using
+//! `std::optional<T>` return values. Existing functions returning
+//! `std::optional<T>` can be updated to return `Result<T>` usually just
+//! replacing `return std::nullopt;` with `return util::Error{error_string};`.
+//!
+//! An optional failure type `F` can be passed as a `Result<T, F>` template
+//! argument. The default type `F = void` is sufficient for most code that just
+//! needs an error description without more complicated error handling. But code
+//! that does need more fine-grained failure information can set custom error
+//! values of type `F` and retrieve them with the `GetFailure()` method.
+template <typename T, typename F = void>
+class Result;
+
+//! Wrapper type to pass error strings to Result constructors.
 struct Error {
     bilingual_str message;
 };
 
-//! The util::Result class provides a standard way for functions to return
-//! either error messages or result values.
-//!
-//! It is intended for high-level functions that need to report error strings to
-//! end users. Lower-level functions that don't need this error-reporting and
-//! only need error-handling should avoid util::Result and instead use standard
-//! classes like std::optional, std::variant, and std::tuple, or custom structs
-//! and enum types to return function results.
-//!
-//! Usage examples can be found in \example ../test/result_tests.cpp, but in
-//! general code returning `util::Result<T>` values is very similar to code
-//! returning `std::optional<T>` values. Existing functions returning
-//! `std::optional<T>` can be updated to return `util::Result<T>` and return
-//! error strings usually just replacing `return std::nullopt;` with `return
-//! util::Error{error_string};`.
-template <class M>
-class Result
-{
-private:
-    using T = std::conditional_t<std::is_same_v<M, void>, std::monostate, M>;
+namespace detail {
+//! Substitute for std::monostate that doesn't depend on std::variant.
+struct MonoState{};
 
-    std::variant<bilingual_str, T> m_variant;
+//! Error information only allocated on failure.
+template <typename F>
+struct ErrorInfo {
+    std::conditional_t<std::is_same_v<F, void>, MonoState, F> failure;
+    bilingual_str error;
+};
+
+//! Result base class which is inherited by Result<T, F>.
+//! T is the type of the success return value, or void if there is none.
+//! F is the type of the failure return value, or void if there is none.
+template <typename T, typename F>
+class ResultBase;
+
+//! Result base specialization for empty (T=void) value type. Holds error
+//! information and provides accessor methods.
+template <typename F>
+class ResultBase<void, F>
+{
+protected:
+    std::unique_ptr<ErrorInfo<F>> m_info;
+
+    //! Value setter methods which do nothing because this ResultBase class is
+    //! specialized for type T=void, so there is no result value for it to hold.
+    //! The other ResultBase specialization below for non-void T overrides these
+    //! methods to manage the result value it contains.
+    void ConstructValue() {}
+    template <typename O>
+    void MoveValue(O&& other) {}
+    void DestroyValue() {}
+
+    //! Helper function to construct a new Result success value or failure value
+    //! using the arguments provided.
+    template <bool Failure, typename Result, typename... Args>
+    static void ConstructResult(Result& result, Args&&... args)
+    {
+        if constexpr (Failure) {
+            static_assert(sizeof...(args) > 0 || !std::is_scalar_v<F>,
+                "Refusing to default-construct failure value with int, float, enum, or pointer type, please specify an explicit failure value.");
+            result.m_info.reset(new detail::ErrorInfo<F>{.failure{std::forward<Args>(args)...}, .error{}});
+        } else {
+            result.ConstructValue(std::forward<Args>(args)...);
+        }
+    }
+
+    //! ConstructResult() overload peeling off a util::Error constructor argument.
+    template <bool Failure, typename Result, typename... Args>
+    static void ConstructResult(Result& result, util::Error error, Args&&... args)
+    {
+        ConstructResult</*Failure=*/true>(result, std::forward<Args>(args)...);
+        result.m_info->error = std::move(error.message);
+    }
+
+    //! Helper function to move success or failure values and any error
+    //! message from one result object to another. The two result
+    //! objects must have compatible success and failure types.
+    template <bool Constructed, typename DstResult, typename SrcResult>
+    static void MoveResult(DstResult& dst, SrcResult&& src)
+    {
+        if constexpr (Constructed) {
+            if (dst) {
+                dst.DestroyValue();
+            } else {
+                dst.m_info.reset();
+            }
+        }
+        if (src) {
+            dst.MoveValue(std::move(src));
+        } else {
+            dst.m_info.reset(new detail::ErrorInfo<F>{std::move(*src.m_info)});
+        }
+    }
 
     //! Disallow operator= and require explicit Result::Set() calls to avoid
     //! confusion in the future when the Result class gains support for richer
     //! error reporting, and callers should have ability to set a new result
     //! value without clearing existing error messages.
-    Result& operator=(const Result&) = default;
-    Result& operator=(Result&&) = default;
+    template <typename Result>
+    ResultBase& operator=(Result&&) = delete;
 
-    template <typename FT>
-    friend bilingual_str ErrorString(const Result<FT>& result);
+    template <typename, typename>
+    friend class ResultBase;
 
 public:
-    Result() : m_variant{std::in_place_index_t<1>{}, std::monostate{}} {}  // constructor for void
-    Result(T obj) : m_variant{std::in_place_index_t<1>{}, std::move(obj)} {}
-    Result(Error error) : m_variant{std::in_place_index_t<0>{}, std::move(error.message)} {}
-    Result(const Result&) = default;
-    Result(Result&&) = default;
-    ~Result() = default;
+    //! Success check.
+    explicit operator bool() const { return !m_info; }
 
+    //! Error retrieval.
+    const auto& GetFailure() const LIFETIMEBOUND { assert(!*this); return m_info->failure; }
+
+    static constexpr bool is_result{true};
+};
+
+//! Result base class for T value type. Holds value and provides accessor methods.
+template <typename T, typename F>
+class ResultBase : public ResultBase<void, F>
+{
+protected:
+    //! Result success value. Uses anonymous union so success value is never
+    //! constructed in failure case.
+    union { T m_value; };
+
+    template <typename... Args>
+    void ConstructValue(Args&&... args) { new (&m_value) T{std::forward<Args>(args)...}; }
+    template <typename O>
+    void MoveValue(O&& other) { new (&m_value) T{std::move(other.m_value)}; }
+    void DestroyValue() { m_value.~T(); }
+
+    //! Empty constructor that needs to be declared because the class contains a union.
+    ResultBase() {}
+    ~ResultBase() { if (*this) DestroyValue(); }
+
+    template <typename, typename>
+    friend class ResultBase;
+
+public:
     //! std::optional methods, so functions returning optional<T> can change to
     //! return Result<T> with minimal changes to existing code, and vice versa.
-    bool has_value() const noexcept { return m_variant.index() == 1; }
-    const T& value() const LIFETIMEBOUND
-    {
-        assert(has_value());
-        return std::get<1>(m_variant);
-    }
-    T& value() LIFETIMEBOUND
-    {
-        assert(has_value());
-        return std::get<1>(m_variant);
-    }
+    bool has_value() const { return bool{*this}; }
+    const T& value() const LIFETIMEBOUND { assert(has_value()); return m_value; }
+    T& value() LIFETIMEBOUND { assert(has_value()); return m_value; }
     template <class U>
     T value_or(U&& default_value) const&
     {
@@ -80,21 +200,57 @@ public:
     {
         return has_value() ? std::move(value()) : std::forward<U>(default_value);
     }
-    explicit operator bool() const noexcept { return has_value(); }
     const T* operator->() const LIFETIMEBOUND { return &value(); }
     const T& operator*() const LIFETIMEBOUND { return value(); }
     T* operator->() LIFETIMEBOUND { return &value(); }
     T& operator*() LIFETIMEBOUND { return value(); }
+};
+} // namespace detail
 
-    //! Assign success or failure value from another result object.
-    Result& Set(Result&& other) LIFETIMEBOUND { return *this = std::move(other); }
+template <typename T, typename F>
+class Result : public detail::ResultBase<T, F>
+{
+protected:
+    using Base = detail::ResultBase<T, F>;
+
+public:
+    //! Construct a Result object setting a success or failure value. An
+    //! optional util::Error argument is processed first to set an error
+    //! message. Then, any remaining arguments are passed to the type `T`
+    //! constructor and used to construct a success value in the success case.
+    //! In the failure case, any remaining arguments are passed to the type `F`
+    //! constructor and used to construct a failure value.
+    template <typename... Args>
+    Result(Args&&... args)
+    {
+        Base::template ConstructResult</*Failure=*/false>(*this, std::forward<Args>(args)...);
+    }
+
+    //! Move-construct a Result object from another Result object, moving the
+    //! success or failure value and any error message.
+    template <typename O>
+    requires (std::decay_t<O>::is_result)
+    Result(O&& other)
+    {
+        Base::template MoveResult</*Constructed=*/false>(*this, std::move(other));
+    }
+
+    //! Move success or failure values and any error message from another Result
+    //! object to this object.
+    Result& Set(Result&& other) LIFETIMEBOUND
+    {
+        Base::template MoveResult</*Constructed=*/true>(*this, std::move(other));
+        return *this;
+    }
+
+    inline friend bilingual_str _ErrorString(const Result& result)
+    {
+        return result ? bilingual_str{} : result.m_info->error;
+    }
 };
 
-template <typename T>
-bilingual_str ErrorString(const Result<T>& result)
-{
-    return result ? bilingual_str{} : std::get<0>(result.m_variant);
-}
+template <typename T, typename F>
+bilingual_str ErrorString(const Result<T, F>& result) { return _ErrorString(result); }
 } // namespace util
 
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -18,11 +18,11 @@
 
 namespace util {
 
-//! The `Result` class provides a standard way for functions to return an error
-//! string in addition to optional result values.
+//! The `Result` class provides a standard way for functions to return error and
+//! warning strings in addition to optional result values.
 //!
 //! The easiest way to understand `Result<T>` is to think of it as a substitute
-//! for `std::optional<T>`, that just contains an error string in
+//! for `std::optional<T>`, that just contains error and warning strings in
 //! addition to the optional return value. For example:
 //!
 //!    util::Result<int> AddNumbers(int a, int b)
@@ -61,20 +61,44 @@ namespace util {
 template <typename T, typename F = void>
 class Result;
 
-//! Wrapper type to pass error strings to Result constructors.
+//! Wrapper types to pass error and warning strings to Result constructors.
 struct Error {
     bilingual_str message;
 };
+struct Warning {
+    bilingual_str message;
+};
+
+//! Wrapper type to move error and warning strings from an existing Result object to a new Result constructor.
+template <typename Result>
+struct MoveMessages {
+    MoveMessages(Result&& result) : m_result(result) {}
+    Result& m_result;
+};
+
+//! Template deduction guide for MoveMessages class.
+template <class Result>
+MoveMessages(Result&& result) -> MoveMessages<Result>;
 
 namespace detail {
+//! Empty string list
+const std::vector<bilingual_str> EMPTY_LIST{};
+
+//! Helper function to join messages in space separated string.
+bilingual_str JoinMessages(const std::vector<bilingual_str>& errors, const std::vector<bilingual_str>& warnings);
+
+//! Helper function to move messages from one vector to another.
+void MoveMessages(std::vector<bilingual_str>& src, std::vector<bilingual_str>& dest);
+
 //! Substitute for std::monostate that doesn't depend on std::variant.
 struct MonoState{};
 
-//! Error information only allocated on failure.
+//! Error information only allocated if there are errors or warnings.
 template <typename F>
 struct ErrorInfo {
-    std::conditional_t<std::is_same_v<F, void>, MonoState, F> failure;
-    bilingual_str error;
+    std::optional<std::conditional_t<std::is_same_v<F, void>, MonoState, F>> failure{};
+    std::vector<bilingual_str> errors{};
+    std::vector<bilingual_str> warnings{};
 };
 
 //! Result base class which is inherited by Result<T, F>.
@@ -90,6 +114,12 @@ class ResultBase<void, F>
 {
 protected:
     std::unique_ptr<ErrorInfo<F>> m_info;
+
+    ErrorInfo<F>& Info() LIFETIMEBOUND
+    {
+        if (!m_info) m_info = std::make_unique<ErrorInfo<F>>();
+        return *m_info;
+    }
 
     //! Value setter methods which do nothing because this ResultBase class is
     //! specialized for type T=void, so there is no result value for it to hold.
@@ -108,7 +138,7 @@ protected:
         if constexpr (Failure) {
             static_assert(sizeof...(args) > 0 || !std::is_scalar_v<F>,
                 "Refusing to default-construct failure value with int, float, enum, or pointer type, please specify an explicit failure value.");
-            result.m_info.reset(new detail::ErrorInfo<F>{.failure{std::forward<Args>(args)...}, .error{}});
+            result.Info().failure.emplace(std::forward<Args>(args)...);
         } else {
             result.ConstructValue(std::forward<Args>(args)...);
         }
@@ -118,12 +148,28 @@ protected:
     template <bool Failure, typename Result, typename... Args>
     static void ConstructResult(Result& result, util::Error error, Args&&... args)
     {
+        result.AddError(std::move(error.message));
         ConstructResult</*Failure=*/true>(result, std::forward<Args>(args)...);
-        result.m_info->error = std::move(error.message);
     }
 
-    //! Helper function to move success or failure values and any error
-    //! message from one result object to another. The two result
+    //! ConstructResult() overload peeling off a util::Warning constructor argument.
+    template <bool Failure, typename Result, typename... Args>
+    static void ConstructResult(Result& result, util::Warning warning, Args&&... args)
+    {
+        result.AddWarning(std::move(warning.message));
+        ConstructResult<Failure>(result, std::forward<Args>(args)...);
+    }
+
+    //! ConstructResult() overload peeling off a util::MoveMessages constructor argument.
+    template <bool Failure, typename Result, typename R, typename... Args>
+    static void ConstructResult(Result& result, util::MoveMessages<R> messages, Args&&... args)
+    {
+        result.MoveMessages(std::move(messages.m_result));
+        ConstructResult<Failure>(result, std::forward<Args>(args)...);
+    }
+
+    //! Helper function to move success or failure values and any error and
+    //! warning messages from one result object to another. The two result
     //! objects must have compatible success and failure types.
     template <bool Constructed, typename DstResult, typename SrcResult>
     static void MoveResult(DstResult& dst, SrcResult&& src)
@@ -132,20 +178,21 @@ protected:
             if (dst) {
                 dst.DestroyValue();
             } else {
-                dst.m_info.reset();
+                dst.m_info->failure.reset();
             }
         }
+        dst.MoveMessages(src);
         if (src) {
             dst.MoveValue(std::move(src));
         } else {
-            dst.m_info.reset(new detail::ErrorInfo<F>{std::move(*src.m_info)});
+            dst.Info().failure = std::move(src.m_info->failure);
         }
     }
 
-    //! Disallow operator= and require explicit Result::Set() calls to avoid
-    //! confusion in the future when the Result class gains support for richer
-    //! error reporting, and callers should have ability to set a new result
-    //! value without clearing existing error messages.
+    //! Disallow potentially dangerous assignment operators which might erase
+    //! error and warning messages. The Result::Set() method can be used instead
+    //! of operator= to assign result values while keeping any existing errors
+    //! and warnings.
     template <typename Result>
     ResultBase& operator=(Result&&) = delete;
 
@@ -154,10 +201,35 @@ protected:
 
 public:
     //! Success check.
-    explicit operator bool() const { return !m_info; }
+    explicit operator bool() const { return !m_info || !m_info->failure; }
 
     //! Error retrieval.
-    const auto& GetFailure() const LIFETIMEBOUND { assert(!*this); return m_info->failure; }
+    const auto& GetFailure() const LIFETIMEBOUND { assert(!*this); return *m_info->failure; }
+    const std::vector<bilingual_str>& GetErrors() const LIFETIMEBOUND { return m_info ? m_info->errors : EMPTY_LIST; }
+    const std::vector<bilingual_str>& GetWarnings() const LIFETIMEBOUND { return m_info ? m_info->warnings : EMPTY_LIST; }
+
+    //! Add error and warning messages.
+    void AddError(bilingual_str error)
+    {
+        if (!error.empty()) this->Info().errors.emplace_back(std::move(error));
+    }
+    void AddWarning(bilingual_str warning)
+    {
+        if (!warning.empty()) this->Info().warnings.emplace_back(std::move(warning));
+    }
+
+    //! Move error and warning messages from another result to this one.
+    template <typename Result>
+    void MoveMessages(Result&& other)
+    {
+        if (other.m_info) {
+            // Check that errors and warnings are empty before calling
+            // MoveMessages to avoid allocating memory in this->Info() in the
+            // typical case when there are no errors or warnings.
+            if (!other.m_info->errors.empty()) detail::MoveMessages(other.m_info->errors, this->Info().errors);
+            if (!other.m_info->warnings.empty()) detail::MoveMessages(other.m_info->warnings, this->Info().warnings);
+        }
+    }
 
     static constexpr bool is_result{true};
 };
@@ -214,9 +286,10 @@ protected:
     using Base = detail::ResultBase<T, F>;
 
 public:
-    //! Construct a Result object setting a success or failure value. An
-    //! optional util::Error argument is processed first to set an error
-    //! message. Then, any remaining arguments are passed to the type `T`
+    //! Construct a Result object setting a success or failure value and
+    //! optional warning and error messages. Initial util::Error, util::Warning,
+    //! and util::MoveMessages arguments are processed first to add warning and
+    //! error messages. Then, any remaining arguments are passed to the type `T`
     //! constructor and used to construct a success value in the success case.
     //! In the failure case, any remaining arguments are passed to the type `F`
     //! constructor and used to construct a failure value.
@@ -227,7 +300,7 @@ public:
     }
 
     //! Move-construct a Result object from another Result object, moving the
-    //! success or failure value and any error message.
+    //! success or failure value and any error or warning messages.
     template <typename O>
     requires (std::decay_t<O>::is_result)
     Result(O&& other)
@@ -235,22 +308,47 @@ public:
         Base::template MoveResult</*Constructed=*/false>(*this, std::move(other));
     }
 
-    //! Move success or failure values and any error message from another Result
-    //! object to this object.
+    //! Move success or failure values from another Result object to this
+    //! object. Also move any error and warning messages from the other Result
+    //! object to this one. If this Result object has an existing success or
+    //! failure value, it is cleared and replaced by the other value. If this
+    //! Result object has any error or warning messages, they are kept and
+    //! appended to.
     Result& Set(Result&& other) LIFETIMEBOUND
     {
         Base::template MoveResult</*Constructed=*/true>(*this, std::move(other));
         return *this;
     }
-
-    inline friend bilingual_str _ErrorString(const Result& result)
-    {
-        return result ? bilingual_str{} : result.m_info->error;
-    }
 };
 
+//! Operator moving warning and error messages from a source result object
+//! to a destination result object. Only moves message strings, does not
+//! change success or failure values of either Result object.
+//!
+//! This is useful for combining error and warning messages from multiple
+//! result objects into a single object, e.g.:
+//!
+//!    util::Result<void> result;
+//!    auto r1 = DoSomething() >> result;
+//!    auto r2 = DoSomethingElse() >> result;
+//!    ...
+//!    return result;
+//!
+template <typename S, typename D>
+requires (std::decay_t<S>::is_result)
+S&& operator>>(S&& src LIFETIMEBOUND, D&& dst)
+{
+    dst.MoveMessages(src);
+    return std::move(src);
+}
+
+//! Join error and warning messages in a space separated string. This is
+//! intended for simple applications where there's probably only one error or
+//! warning message to report, but multiple messages should not be lost if they
+//! are present. More complicated applications should use GetErrors() and
+//! GetWarning() methods directly.
 template <typename T, typename F>
-bilingual_str ErrorString(const Result<T, F>& result) { return _ErrorString(result); }
+bilingual_str ErrorString(const Result<T, F>& result) { return detail::JoinMessages(result.GetErrors(), result.GetWarnings()); }
 } // namespace util
 
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2643,6 +2643,7 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
     assert(this->CanFlushToDisk());
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
+    util::Result<bool, kernel::FatalError> result{true};
 
     const size_t coins_count = CoinsTip().GetCacheSize();
     const size_t coins_mem_usage = CoinsTip().DynamicMemoryUsage();
@@ -2723,9 +2724,11 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
-                // TODO: Handle return error, or add detailed comment why it is
+                // TODO (fatal error): Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
+                auto res{m_blockman.FlushChainstateBlockFile(m_chain.Height())};
+                result.MoveMessages(res);
+                if (!res || !res.value()) {
                     LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Warning, "%s: Failed to flush block file.\n", __func__);
                 }
             }
@@ -2780,7 +2783,7 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
     } catch (const std::runtime_error& e) {
         return ValidationFatalError(state, strprintf(_("Fatal error while flushing: %s"), e.what()), kernel::FatalError::FlushStateToDiskFailed);
     }
-    return true;
+    return result;
 }
 
 util::Result<void, kernel::FatalError> Chainstate::ForceFlushStateToDisk()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -294,11 +294,12 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     return true;
 }
 
-void Chainstate::MaybeUpdateMempoolForReorg(
+util::Result<void, kernel::FatalError> Chainstate::MaybeUpdateMempoolForReorg(
     DisconnectedBlockTransactions& disconnectpool,
     bool fAddToMempool)
 {
-    if (!m_mempool) return;
+    util::Result<void, kernel::FatalError> result{};
+    if (!m_mempool) return result;
 
     AssertLockHeld(cs_main);
     AssertLockHeld(m_mempool->cs);
@@ -314,9 +315,11 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
             if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
-                    /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
-                        MempoolAcceptResult::ResultType::VALID) {
+                ([&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs) {
+                    const auto res{AcceptToMemoryPool(*this, *it, GetTime(), /*bypass_limits=*/true, /*test_accept=*/false)};
+                    result.MoveMessages(res);
+                    return res && res.value().m_result_type != MempoolAcceptResult::ResultType::VALID;
+                })()) {
                 // If the transaction doesn't make it in to the mempool, remove any
                 // transactions that depend on it (which would now be orphans).
                 m_mempool->removeRecursive(**it, MemPoolRemovalReason::REORG);
@@ -388,6 +391,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
     m_mempool->removeForReorg(m_chain, filter_final_and_mature);
     // Re-limit mempool size, in case we added any transactions
     LimitMempoolSize(*m_mempool, this->CoinsTip());
+    return result;
 }
 
 /**
@@ -1685,7 +1689,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
 } // anon namespace
 
-MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+util::Result<MempoolAcceptResult, kernel::FatalError> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
@@ -1712,11 +1716,13 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
-    return result;
+    util::Result<MempoolAcceptResult, kernel::FatalError> ret{result};
+    // Do not return early on fatal flush errors.
+    ret.MoveMessages(active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
+    return ret;
 }
 
-PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
+util::Result<PackageMempoolAcceptResult, kernel::FatalError> ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
                                                    const Package& package, bool test_accept, const std::optional<CFeeRate>& client_maxfeerate)
 {
     AssertLockHeld(cs_main);
@@ -1744,8 +1750,10 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     }
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
-    return result;
+    util::Result<PackageMempoolAcceptResult, kernel::FatalError> ret{result};
+    // Do not return early on fatal flush errors.
+    ret.MoveMessages(active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
+    return ret;
 }
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
@@ -2626,7 +2634,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
-bool Chainstate::FlushStateToDisk(
+util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
     BlockValidationState &state,
     FlushStateMode mode,
     int nManualPruneHeight)
@@ -2709,7 +2717,7 @@ bool Chainstate::FlushStateToDisk(
         if (fDoFullFlush || fPeriodicWrite) {
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                return ValidationFatalError(state, _("Disk space is too low!"), kernel::FatalError::DiskSpaceTooLow);
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2727,7 +2735,7 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block index to disk", BCLog::BENCH);
 
                 if (!m_blockman.WriteBlockIndexDB()) {
-                    return FatalError(m_chainman.GetNotifications(), state, _("Failed to write to block index database."));
+                    return ValidationFatalError(state, _("Failed to write to block index database"), kernel::FatalError::BlockIndexWriteFailed);
                 }
             }
             // Finally remove any pruned files
@@ -2749,11 +2757,12 @@ bool Chainstate::FlushStateToDisk(
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
             if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
-                return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                return ValidationFatalError(state, _("Disk space is too low!"), kernel::FatalError::DiskSpaceTooLow);
             }
             // Flush the chainstate (which may refer to block index entries).
-            if (!CoinsTip().Flush())
-                return FatalError(m_chainman.GetNotifications(), state, _("Failed to write to coin database."));
+            if (!CoinsTip().Flush()) {
+                return ValidationFatalError(state, _("Failed to write coin database"), kernel::FatalError::CoinDatabaseWriteFailed);
+            }
             m_last_flush = nNow;
             full_flush_completed = true;
             TRACE5(utxocache, flush,
@@ -2769,26 +2778,36 @@ bool Chainstate::FlushStateToDisk(
         m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), m_chain.GetLocator());
     }
     } catch (const std::runtime_error& e) {
-        return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));
+        return ValidationFatalError(state, strprintf(_("Fatal error while flushing: %s"), e.what()), kernel::FatalError::FlushStateToDiskFailed);
     }
     return true;
 }
 
-void Chainstate::ForceFlushStateToDisk()
+util::Result<void, kernel::FatalError> Chainstate::ForceFlushStateToDisk()
 {
     BlockValidationState state;
-    if (!this->FlushStateToDisk(state, FlushStateMode::ALWAYS)) {
+    util::Result<void, kernel::FatalError> result{};
+    // Do not return early on fatal flush errors.
+    auto res{this->FlushStateToDisk(state, FlushStateMode::ALWAYS)};
+    result.MoveMessages(res);
+    if (!res || !res.value()) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
+    return result;
 }
 
-void Chainstate::PruneAndFlush()
+util::Result<void, kernel::FatalError> Chainstate::PruneAndFlush()
 {
     BlockValidationState state;
+    util::Result<void, kernel::FatalError> result{};
     m_blockman.m_check_for_pruning = true;
-    if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
+    // Do not return early on fatal flush errors.
+    auto res{this->FlushStateToDisk(state, FlushStateMode::NONE)};
+    result.MoveMessages(res);
+    if (!res || !res.value()) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
+    return result;
 }
 
 /** Private helper function that concatenates warning messages. */
@@ -2877,10 +2896,12 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
   * disconnectpool (note that the caller is responsible for mempool consistency
   * in any case).
   */
-bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
+util::Result<bool, kernel::FatalError> Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
+
+    util::Result<bool, kernel::FatalError> result{true};
 
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
@@ -2890,7 +2911,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlockFromDisk(block, *pindexDelete)) {
         LogError("DisconnectTip(): Failed to read block\n");
-        return false;
+        result.Set(false);
+        return result;
     }
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
@@ -2899,7 +2921,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
-            return false;
+            result.Set(false);
+            return result;
         }
         bool flushed = view.Flush();
         assert(flushed);
@@ -2919,9 +2942,9 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     }
 
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
-        return false;
-    }
+    // TODO (fatal error): Add rationale for returning early on a fatal flush error here.
+    result.Set(FlushStateToDisk(state, FlushStateMode::IF_NEEDED));
+    if (!result || !result.value()) return result;
 
     if (disconnectpool && m_mempool) {
         // Save transactions to re-add to mempool at end of reorg. If any entries are evicted for
@@ -2939,7 +2962,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     if (m_chainman.m_options.signals) {
         m_chainman.m_options.signals->BlockDisconnected(pblock, pindexDelete);
     }
-    return true;
+    return result;
 }
 
 static SteadyClock::duration time_connect_total{};
@@ -3051,9 +3074,9 @@ util::Result<bool, kernel::FatalError> Chainstate::ConnectTip(BlockValidationSta
              Ticks<SecondsDouble>(time_flush),
              Ticks<MillisecondsDouble>(time_flush) / num_blocks_total);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
-        return false;
-    }
+    // TODO (fatal error): Add rationale for returning early on a fatal flush error here.
+    result.Set(FlushStateToDisk(state, FlushStateMode::IF_NEEDED));
+    if (!result || !result.value()) return result;
     const auto time_5{SteadyClock::now()};
     time_chainstate += time_5 - time_4;
     LogPrint(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n",
@@ -3190,15 +3213,18 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChainStep(BlockVa
     bool fBlocksDisconnected = false;
     DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
     while (m_chain.Tip() && m_chain.Tip() != pindexFork) {
-        if (!DisconnectTip(state, &disconnectpool)) {
+        result.Set(DisconnectTip(state, &disconnectpool));
+        if (!result || !result.value()) {
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
-            MaybeUpdateMempoolForReorg(disconnectpool, false);
+            result.MoveMessages(MaybeUpdateMempoolForReorg(disconnectpool, false));
 
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
-            result.Set(ValidationFatalError(state, _("Failed to disconnect block."), kernel::FatalError::DisconnectBlockFailed));
+            if (result) {
+                result.Set(ValidationFatalError(state, _("Failed to disconnect block."), kernel::FatalError::DisconnectBlockFailed));
+            }
             return result;
         }
         fBlocksDisconnected = true;
@@ -3239,7 +3265,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChainStep(BlockVa
                     // A system error occurred (disk space, database error, ...).
                     // Make the mempool consistent with the current tip, just in case
                     // any observers try to use it before shutdown.
-                    MaybeUpdateMempoolForReorg(disconnectpool, false);
+                    result.MoveMessages(MaybeUpdateMempoolForReorg(disconnectpool, false));
                     if (!res) return res;
                     result.Set(false);
                     return result;
@@ -3258,7 +3284,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChainStep(BlockVa
     if (fBlocksDisconnected) {
         // If any blocks were disconnected, disconnectpool may be non empty.  Add
         // any disconnected transactions back to the mempool.
-        MaybeUpdateMempoolForReorg(disconnectpool, true);
+        result.MoveMessages(MaybeUpdateMempoolForReorg(disconnectpool, true));
     }
     if (m_mempool) m_mempool->check(this->CoinsTip(), this->m_chain.Height() + 1);
 
@@ -3430,7 +3456,8 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChain(BlockValida
             // If a background chainstate is in use, we may need to rebalance our
             // allocation of caches once a chainstate exits initial block download.
             LOCK(::cs_main);
-            m_chainman.MaybeRebalanceCaches();
+            // TODO (fatal error): Add rationale for not returning early on a fatal error here.
+            result.MoveMessages(m_chainman.MaybeRebalanceCaches());
         }
 
         if (WITH_LOCK(::cs_main, return m_disabled)) {
@@ -3458,11 +3485,8 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChain(BlockValida
     m_chainman.CheckBlockIndex();
 
     // Write changes periodically to disk, after relay.
-    if (!FlushStateToDisk(state, FlushStateMode::PERIODIC)) {
-        result.Set(false);
-        return result;
-    }
-
+    // TODO (fatal error): Add rationale for propagating a fatal flush error here.
+    result.Set(FlushStateToDisk(state, FlushStateMode::PERIODIC));
     return result;
 }
 
@@ -3497,14 +3521,16 @@ util::Result<bool, kernel::FatalError> Chainstate::PreciousBlock(BlockValidation
     return ActivateBestChain(state, std::shared_ptr<const CBlock>());
 }
 
-bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
+util::Result<bool, kernel::FatalError> Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
 
+    util::Result<bool, kernel::FatalError> result{false};
+
     // Genesis block can't be invalidated
     assert(pindex);
-    if (pindex->nHeight == 0) return false;
+    if (pindex->nHeight == 0) return result;
 
     CBlockIndex* to_mark_failed = pindex;
     bool pindex_was_in_chain = false;
@@ -3544,7 +3570,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
 
     // Disconnect (descendants of) pindex, and mark them invalid.
     while (true) {
-        if (m_chainman.m_interrupt) break;
+        if (m_chainman.m_interrupt || IsFatal(result)) break;
 
         // Make sure the queue of validation callbacks doesn't grow unboundedly.
         if (m_chainman.m_options.signals) LimitValidationInterfaceQueue(*m_chainman.m_options.signals);
@@ -3560,14 +3586,15 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         // ActivateBestChain considers blocks already in m_chain
         // unconditionally valid already, so force disconnect away from it.
         DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
-        bool ret = DisconnectTip(state, &disconnectpool);
+        result.Set(DisconnectTip(state, &disconnectpool));
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding
         // transactions back to the mempool if disconnecting was successful,
         // and we're not doing a very deep invalidation (in which case
         // keeping the mempool up to date is probably futile anyway).
-        MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret);
-        if (!ret) return false;
+        result.MoveMessages(MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && result && result.value()));
+        if (!result || !result.value()) return result;
+
         assert(invalid_walk_tip->pprev == m_chain.Tip());
 
         // We immediately mark the disconnected blocks as invalid.
@@ -3608,7 +3635,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         LOCK(cs_main);
         if (m_chain.Contains(to_mark_failed)) {
             // If the to-be-marked invalid block is in the active chain, something is interfering and we can't proceed.
-            return false;
+            return result;
         }
 
         // Mark pindex (or the last disconnected block) as invalid, even when it never was in the main chain
@@ -3644,7 +3671,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         // changes.
         (void)m_chainman.GetNotifications().blockTip(GetSynchronizationState(m_chainman.IsInitialBlockDownload()), *to_mark_failed->pprev);
     }
-    return true;
+    result.Set(true);
+    return result;
 }
 
 void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex) {
@@ -4293,6 +4321,7 @@ void ChainstateManager::ReportHeadersPresync(const arith_uint256& work, int64_t 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
+    util::Result<bool, kernel::FatalError> result{true};
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4304,8 +4333,10 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
     bool accepted_header{AcceptBlockHeader(block, state, &pindex, min_pow_checked)};
     CheckBlockIndex();
 
-    if (!accepted_header)
-        return false;
+    if (!accepted_header) {
+        result.Set(false);
+        return result;
+    }
 
     // Check all requested blocks that we do not already have for validity and
     // save them to disk. Skip processing of unrequested blocks as an anti-DoS
@@ -4328,17 +4359,17 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
 
     // TODO: deal better with return value and error conditions for duplicate
     // and unrequested blocks.
-    if (fAlreadyHave) return true;
+    if (fAlreadyHave) return result;
     if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
-        if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
-        if (fTooFarAhead) return true;        // Block height is too high
+        if (pindex->nTx != 0) return result;    // This is a previously-processed block that was pruned
+        if (!fHasMoreOrSameWork) return result; // Don't process less-work chains
+        if (fTooFarAhead) return result;        // Block height is too high
 
         // Protect against DoS attacks from low-work chains.
         // If our tip is behind, a peer could try to send us
         // low-work blocks on a fake chain that we would never
         // request; don't process these.
-        if (pindex->nChainWork < MinimumChainWork()) return true;
+        if (pindex->nChainWork < MinimumChainWork()) return result;
     }
 
     const CChainParams& params{GetParams()};
@@ -4364,14 +4395,16 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
     try {
         FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, pindex->nHeight, dbp)};
         if (blockPos.IsNull()) {
-            state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
-            return false;
+            result.Set(state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__)));
+            return result;
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return ValidationFatalError(state, strprintf(_("System error while saving block to disk: %s"), e.what()), kernel::FatalError::AcceptBlockFailed);
+        result.Set(ValidationFatalError(state, strprintf(_("System error while saving block to disk: %s"), e.what()), kernel::FatalError::AcceptBlockFailed));
+        return result;
     }
 
+    // Do not return early on fatal flush errors.
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate
     // data, so we should move this to ChainstateManager so that we can be more
     // intelligent about how we flush.
@@ -4379,11 +4412,11 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
     // the block files may be pruned, so we can just call this on one
     // chainstate (particularly if we haven't implemented pruning with
     // background validation yet).
-    ActiveChainstate().FlushStateToDisk(state, FlushStateMode::NONE);
+    result.MoveMessages(ActiveChainstate().FlushStateToDisk(state, FlushStateMode::NONE));
 
     CheckBlockIndex();
 
-    return true;
+    return result;
 }
 
 util::Result<bool, kernel::FatalError> ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
@@ -4445,7 +4478,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ProcessNewBlock(const 
      return result;
 }
 
-MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+util::Result<MempoolAcceptResult, kernel::FatalError> ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
 {
     AssertLockHeld(cs_main);
     Chainstate& active_chainstate = ActiveChainstate();
@@ -4454,7 +4487,8 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
+    // TODO: Add rationale for not returning flush error early.
+    auto result{AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept)};
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }
@@ -4498,13 +4532,17 @@ bool TestBlockValidity(BlockValidationState& state,
 }
 
 /* This function is called from the RPC code for pruneblockchain */
-void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
+util::Result<void, kernel::FatalError> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
     BlockValidationState state;
-    if (!active_chainstate.FlushStateToDisk(
-            state, FlushStateMode::NONE, nManualPruneHeight)) {
+    util::Result<void, kernel::FatalError> result{};
+    // Do not return early on fatal flush errors.
+    const auto res{active_chainstate.FlushStateToDisk(state, FlushStateMode::NONE, nManualPruneHeight)};
+    if (!res || !res.value()) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
+    result.MoveMessages(res);
+    return result;
 }
 
 bool Chainstate::LoadChainTip()
@@ -5376,7 +5414,7 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+util::Result<bool, kernel::FatalError> Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
 {
     AssertLockHeld(::cs_main);
     if (coinstip_size == m_coinstip_cache_size_bytes &&
@@ -5395,16 +5433,13 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
         this->ToString(), coinstip_size * (1.0 / 1024 / 1024));
 
     BlockValidationState state;
-    bool ret;
 
     if (coinstip_size > old_coinstip_size) {
         // Likely no need to flush if cache sizes have grown.
-        ret = FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
-    } else {
-        // Otherwise, flush state to disk and deallocate the in-memory coins map.
-        ret = FlushStateToDisk(state, FlushStateMode::ALWAYS);
+        return FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
     }
-    return ret;
+    // Otherwise, flush state to disk and deallocate the in-memory coins map.
+    return FlushStateToDisk(state, FlushStateMode::ALWAYS);
 }
 
 //! Guess how far we are in the verification process at the given block index
@@ -5511,6 +5546,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
         bool in_memory)
 {
     uint256 base_blockhash = metadata.m_base_blockhash;
+    util::Result<bool, kernel::FatalError> result{true};
 
     if (this->SnapshotBlockhash()) {
         LogPrintf("[snapshot] can't activate a snapshot-based chainstate more than once\n");
@@ -5552,9 +5588,10 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
 
         // Temporarily resize the active coins cache to make room for the newly-created
         // snapshot chain.
-        this->ActiveChainstate().ResizeCoinsCaches(
+        // Do not return early if the resize returns a fatal error.
+        result.MoveMessages(this->ActiveChainstate().ResizeCoinsCaches(
             static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC),
-            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC));
+            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC)));
     }
 
     auto snapshot_chainstate = WITH_LOCK(::cs_main,
@@ -5572,7 +5609,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
 
     auto cleanup_bad_snapshot = [&](const char* reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> util::Result<bool, kernel::FatalError> {
         LogPrintf("[snapshot] activation failed - %s\n", reason);
-        this->MaybeRebalanceCaches();
+        result.MoveMessages(this->MaybeRebalanceCaches());
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
         // has been created, so only attempt removal if we got that far.
@@ -5591,7 +5628,8 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
                     kernel::FatalError::SnapshotChainstateDirRemovalFailed};
             }
         }
-        return false;
+        result.Set(false);
+        return result;
     };
 
     if (!this->PopulateAndValidateSnapshot(*snapshot_chainstate, coins_file, metadata)) {
@@ -5633,8 +5671,8 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
     LogPrintf("[snapshot] (%.2f MB)\n",
         m_snapshot_chainstate->CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
-    this->MaybeRebalanceCaches();
-    return true;
+    result.MoveMessages(this->MaybeRebalanceCaches());
+    return result;
 }
 
 static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_loaded)
@@ -5895,6 +5933,8 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         return SnapshotCompletionResult::SKIPPED;
     }
 
+    util::Result<SnapshotCompletionResult, kernel::FatalError> result{SnapshotCompletionResult::SUCCESS};
+
     assert(SnapshotBlockhash());
     uint256 snapshot_blockhash = *Assert(SnapshotBlockhash());
 
@@ -5944,7 +5984,8 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
     assert(this->GetAll().size() == 2);
 
     CCoinsViewDB& ibd_coins_db = m_ibd_chainstate->CoinsDB();
-    m_ibd_chainstate->ForceFlushStateToDisk();
+    // Do not return early on fatal flush errors.
+    result.MoveMessages(m_ibd_chainstate->ForceFlushStateToDisk());
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(curr_height);
     if (!maybe_au_data) {
@@ -5994,7 +6035,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         snapshot_blockhash.ToString());
 
     m_ibd_chainstate->m_disabled = true;
-    this->MaybeRebalanceCaches();
+    result.MoveMessages(this->MaybeRebalanceCaches());
 
     return SnapshotCompletionResult::SUCCESS;
 }
@@ -6012,8 +6053,9 @@ bool ChainstateManager::IsSnapshotActive() const
     return m_snapshot_chainstate && m_active_chainstate == m_snapshot_chainstate.get();
 }
 
-void ChainstateManager::MaybeRebalanceCaches()
+util::Result<void, kernel::FatalError> ChainstateManager::MaybeRebalanceCaches()
 {
+    util::Result<void, kernel::FatalError> result;
     AssertLockHeld(::cs_main);
     bool ibd_usable = this->IsUsable(m_ibd_chainstate.get());
     bool snapshot_usable = this->IsUsable(m_snapshot_chainstate.get());
@@ -6022,30 +6064,31 @@ void ChainstateManager::MaybeRebalanceCaches()
     if (ibd_usable && !snapshot_usable) {
         // Allocate everything to the IBD chainstate. This will always happen
         // when we are not using a snapshot.
-        m_ibd_chainstate->ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        result.MoveMessages(m_ibd_chainstate->ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache));
     }
     else if (snapshot_usable && !ibd_usable) {
         // If background validation has completed and snapshot is our active chain...
         LogPrintf("[snapshot] allocating all cache to the snapshot chainstate\n");
         // Allocate everything to the snapshot chainstate.
-        m_snapshot_chainstate->ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        result.MoveMessages(m_snapshot_chainstate->ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache));
     }
     else if (ibd_usable && snapshot_usable) {
         // If both chainstates exist, determine who needs more cache based on IBD status.
         //
         // Note: shrink caches first so that we don't inadvertently overwhelm available memory.
         if (IsInitialBlockDownload()) {
-            m_ibd_chainstate->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            m_snapshot_chainstate->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
+            result.MoveMessages(m_ibd_chainstate->ResizeCoinsCaches(
+                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05));
+            result.MoveMessages(m_snapshot_chainstate->ResizeCoinsCaches(
+                    m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95));
         } else {
-            m_snapshot_chainstate->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            m_ibd_chainstate->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
+            result.MoveMessages(m_snapshot_chainstate->ResizeCoinsCaches(
+                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05));
+            result.MoveMessages(m_ibd_chainstate->ResizeCoinsCaches(
+                    m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95));
         }
     }
+    return result;
 }
 
 void ChainstateManager::ResetChainstates()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -970,7 +970,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
         }
-        ancestors = m_pool.CalculateMemPoolAncestors(*entry, cpfp_carve_out_limits);
+        ancestors.Set(m_pool.CalculateMemPoolAncestors(*entry, cpfp_carve_out_limits));
         if (!ancestors) return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4869,14 +4869,15 @@ void Chainstate::ClearBlockIndexCandidates()
     setBlockIndexCandidates.clear();
 }
 
-bool ChainstateManager::LoadBlockIndex()
+util::Result<bool, kernel::FatalError> ChainstateManager::LoadBlockIndex()
 {
     AssertLockHeld(cs_main);
+    util::Result<bool, kernel::FatalError> result{true};
     // Load block index from databases
     bool needs_init = fReindex;
     if (!fReindex) {
-        bool ret{m_blockman.LoadBlockIndexDB(SnapshotBlockhash())};
-        if (!ret) return false;
+        result.Set(m_blockman.LoadBlockIndexDB(SnapshotBlockhash()));
+        if (!result || !result.value()) return result;
 
         m_blockman.ScanAndUnlinkAlreadyPrunedFiles();
 
@@ -4885,7 +4886,10 @@ bool ChainstateManager::LoadBlockIndex()
                   CBlockIndexHeightOnlyComparator());
 
         for (CBlockIndex* pindex : vSortedByHeight) {
-            if (m_interrupt) return false;
+            if (m_interrupt || IsFatal(result)) {
+                result.Set(false);
+                return result;
+            }
             // If we have an assumeutxo-based chainstate, then the snapshot
             // block will be a candidate for the tip, but it may not be
             // VALID_TRANSACTIONS (eg if we haven't yet downloaded the block),
@@ -4918,7 +4922,7 @@ bool ChainstateManager::LoadBlockIndex()
 
         LogPrintf("Initializing databases...\n");
     }
-    return true;
+    return result;
 }
 
 util::Result<bool, kernel::FatalError> Chainstate::LoadGenesisBlock()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2564,9 +2564,10 @@ util::Result<bool, kernel::FatalError> Chainstate::ConnectBlock(const CBlock& bl
     if (fJustCheck)
         return true;
 
-    if (!m_blockman.WriteUndoDataForBlock(blockundo, state, *pindex)) {
-        return false;
-    }
+    util::Result<bool, kernel::FatalError> result{true};
+
+    result.Set(m_blockman.WriteUndoDataForBlock(blockundo, state, *pindex));
+    if (!result || !result.value()) return result;
 
     const auto time_5{SteadyClock::now()};
     time_undo += time_5 - time_4;
@@ -2599,7 +2600,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ConnectBlock(const CBlock& bl
         time_5 - time_start // in microseconds (µs)
     );
 
-    return true;
+    return result;
 }
 
 CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -79,6 +79,7 @@
 using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
+using kernel::FatalError;
 using kernel::Notifications;
 
 using fsbridge::FopenFn;
@@ -294,11 +295,11 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     return true;
 }
 
-util::Result<void, kernel::FatalError> Chainstate::MaybeUpdateMempoolForReorg(
+util::Result<void, FatalError> Chainstate::MaybeUpdateMempoolForReorg(
     DisconnectedBlockTransactions& disconnectpool,
     bool fAddToMempool)
 {
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
     if (!m_mempool) return result;
 
     AssertLockHeld(cs_main);
@@ -1689,7 +1690,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
 } // anon namespace
 
-util::Result<MempoolAcceptResult, kernel::FatalError> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+util::Result<MempoolAcceptResult, FatalError> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
@@ -1716,7 +1717,7 @@ util::Result<MempoolAcceptResult, kernel::FatalError> AcceptToMemoryPool(Chainst
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
-    util::Result<MempoolAcceptResult, kernel::FatalError> ret{result};
+    util::Result<MempoolAcceptResult, FatalError> ret{result};
     // Do not return early on fatal flush errors.
     ret.MoveMessages(active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
     return ret;
@@ -1750,7 +1751,7 @@ util::Result<PackageMempoolAcceptResult, kernel::FatalError> ProcessNewPackage(C
     }
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
-    util::Result<PackageMempoolAcceptResult, kernel::FatalError> ret{result};
+    util::Result<PackageMempoolAcceptResult, FatalError> ret{result};
     // Do not return early on fatal flush errors.
     ret.MoveMessages(active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
     return ret;
@@ -2060,12 +2061,6 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     return true;
 }
 
-bool FatalError(Notifications& notifications, BlockValidationState& state, const bilingual_str& message)
-{
-    notifications.fatalError(message);
-    return state.Error(message.original);
-}
-
 util::Result<bool, kernel::FatalError> ValidationFatalError(BlockValidationState& state, const bilingual_str& message, kernel::FatalError result)
 {
     state.Error(message.original);
@@ -2260,7 +2255,7 @@ static int64_t num_blocks_total = 0;
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-util::Result<bool, kernel::FatalError> Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+util::Result<bool, FatalError> Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                                CCoinsViewCache& view, bool fJustCheck)
 {
     AssertLockHeld(cs_main);
@@ -2291,7 +2286,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ConnectBlock(const CBlock& bl
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
             // problems.
-            return ValidationFatalError(state, _("Corrupt block found indicating potential hardware failure."), kernel::FatalError::CorruptBlock);
+            return ValidationFatalError(state, _("Corrupt block found indicating potential hardware failure."), FatalError::CorruptBlock);
         }
         LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
@@ -2635,7 +2630,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
+util::Result<bool, FatalError> Chainstate::FlushStateToDisk(
     BlockValidationState &state,
     FlushStateMode mode,
     int nManualPruneHeight)
@@ -2644,7 +2639,7 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
     assert(this->CanFlushToDisk());
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     const size_t coins_count = CoinsTip().GetCacheSize();
     const size_t coins_mem_usage = CoinsTip().DynamicMemoryUsage();
@@ -2719,7 +2714,7 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
         if (fDoFullFlush || fPeriodicWrite) {
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                return ValidationFatalError(state, _("Disk space is too low!"), kernel::FatalError::DiskSpaceTooLow);
+                return ValidationFatalError(state, _("Disk space is too low!"), FatalError::DiskSpaceTooLow);
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2739,7 +2734,7 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block index to disk", BCLog::BENCH);
 
                 if (!m_blockman.WriteBlockIndexDB()) {
-                    return ValidationFatalError(state, _("Failed to write to block index database"), kernel::FatalError::BlockIndexWriteFailed);
+                    return ValidationFatalError(state, _("Failed to write to block index database"), FatalError::BlockIndexWriteFailed);
                 }
             }
             // Finally remove any pruned files
@@ -2761,11 +2756,11 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
             if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
-                return ValidationFatalError(state, _("Disk space is too low!"), kernel::FatalError::DiskSpaceTooLow);
+                return ValidationFatalError(state, _("Disk space is too low!"), FatalError::DiskSpaceTooLow);
             }
             // Flush the chainstate (which may refer to block index entries).
             if (!CoinsTip().Flush()) {
-                return ValidationFatalError(state, _("Failed to write coin database"), kernel::FatalError::CoinDatabaseWriteFailed);
+                return ValidationFatalError(state, _("Failed to write coin database"), FatalError::CoinDatabaseWriteFailed);
             }
             m_last_flush = nNow;
             full_flush_completed = true;
@@ -2782,15 +2777,15 @@ util::Result<bool, kernel::FatalError> Chainstate::FlushStateToDisk(
         m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), m_chain.GetLocator());
     }
     } catch (const std::runtime_error& e) {
-        return ValidationFatalError(state, strprintf(_("Fatal error while flushing: %s"), e.what()), kernel::FatalError::FlushStateToDiskFailed);
+        return ValidationFatalError(state, strprintf(_("Fatal error while flushing: %s"), e.what()), FatalError::FlushStateToDiskFailed);
     }
     return result;
 }
 
-util::Result<void, kernel::FatalError> Chainstate::ForceFlushStateToDisk()
+util::Result<void, FatalError> Chainstate::ForceFlushStateToDisk()
 {
     BlockValidationState state;
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
     // Do not return early on fatal flush errors.
     auto res{this->FlushStateToDisk(state, FlushStateMode::ALWAYS)};
     result.MoveMessages(res);
@@ -2800,10 +2795,10 @@ util::Result<void, kernel::FatalError> Chainstate::ForceFlushStateToDisk()
     return result;
 }
 
-util::Result<void, kernel::FatalError> Chainstate::PruneAndFlush()
+util::Result<void, FatalError> Chainstate::PruneAndFlush()
 {
     BlockValidationState state;
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
     m_blockman.m_check_for_pruning = true;
     // Do not return early on fatal flush errors.
     auto res{this->FlushStateToDisk(state, FlushStateMode::NONE)};
@@ -2900,12 +2895,12 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
   * disconnectpool (note that the caller is responsible for mempool consistency
   * in any case).
   */
-util::Result<bool, kernel::FatalError> Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
+util::Result<bool, FatalError> Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
@@ -3020,12 +3015,12 @@ public:
  *
  * The block is added to connectTrace if connection succeeds.
  */
-util::Result<bool, kernel::FatalError> Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool)
+util::Result<bool, FatalError> Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     assert(pindexNew->pprev == m_chain.Tip());
     // Read block from disk.
@@ -3034,7 +3029,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ConnectTip(BlockValidationSta
     if (!pblock) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
         if (!m_blockman.ReadBlockFromDisk(*pblockNew, *pindexNew)) {
-            return ValidationFatalError(state, _("Failed to read block"), kernel::FatalError::ReadBlockFailed);
+            return ValidationFatalError(state, _("Failed to read block"), FatalError::ReadBlockFailed);
         }
         pthisBlock = pblockNew;
     } else {
@@ -3204,12 +3199,12 @@ void Chainstate::PruneBlockIndexCandidates() {
  *
  * @returns true unless a system error occurred
  */
-util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace)
+util::Result<bool, FatalError> Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(pindexMostWork);
 
@@ -3227,7 +3222,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChainStep(BlockVa
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
             if (result) {
-                result.Set(ValidationFatalError(state, _("Failed to disconnect block."), kernel::FatalError::DisconnectBlockFailed));
+                result.Set(ValidationFatalError(state, _("Failed to disconnect block."), FatalError::DisconnectBlockFailed));
             }
             return result;
         }
@@ -3335,7 +3330,7 @@ static void LimitValidationInterfaceQueue(ValidationSignals& signals) LOCKS_EXCL
     }
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
+util::Result<bool, FatalError> Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
 {
     AssertLockNotHeld(m_chainstate_mutex);
 
@@ -3359,7 +3354,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChain(BlockValida
         return false;
     }
 
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     CBlockIndex *pindexMostWork = nullptr;
     CBlockIndex *pindexNewTip = nullptr;
     bool exited_ibd{false};
@@ -3494,7 +3489,7 @@ util::Result<bool, kernel::FatalError> Chainstate::ActivateBestChain(BlockValida
     return result;
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+util::Result<bool, FatalError> Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
@@ -3525,12 +3520,12 @@ util::Result<bool, kernel::FatalError> Chainstate::PreciousBlock(BlockValidation
     return ActivateBestChain(state, std::shared_ptr<const CBlock>());
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
+util::Result<bool, FatalError> Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
 
-    util::Result<bool, kernel::FatalError> result{false};
+    util::Result<bool, FatalError> result{false};
 
     // Genesis block can't be invalidated
     assert(pindex);
@@ -4323,9 +4318,9 @@ void ChainstateManager::ReportHeadersPresync(const arith_uint256& work, int64_t 
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
+util::Result<bool, FatalError> ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4407,7 +4402,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
         }
         ReceivedBlockTransactions(block, pindex, blockPos.value());
     } catch (const std::runtime_error& e) {
-        result.Set(ValidationFatalError(state, strprintf(_("System error while saving block to disk: %s"), e.what()), kernel::FatalError::AcceptBlockFailed));
+        result.Set(ValidationFatalError(state, strprintf(_("System error while saving block to disk: %s"), e.what()), FatalError::AcceptBlockFailed));
         return result;
     }
 
@@ -4426,9 +4421,9 @@ util::Result<bool, kernel::FatalError> ChainstateManager::AcceptBlock(const std:
     return result;
 }
 
-util::Result<bool, kernel::FatalError> ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
+util::Result<bool, FatalError> ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
 {
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     AssertLockNotHeld(cs_main);
 
     {
@@ -4485,7 +4480,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ProcessNewBlock(const 
      return result;
 }
 
-util::Result<MempoolAcceptResult, kernel::FatalError> ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+util::Result<MempoolAcceptResult, FatalError> ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
 {
     AssertLockHeld(cs_main);
     Chainstate& active_chainstate = ActiveChainstate();
@@ -4500,7 +4495,7 @@ util::Result<MempoolAcceptResult, kernel::FatalError> ChainstateManager::Process
     return result;
 }
 
-util::Result<bool, kernel::FatalError> TestBlockValidity(BlockValidationState& state,
+util::Result<bool, FatalError> TestBlockValidity(BlockValidationState& state,
                        const CChainParams& chainparams,
                        Chainstate& chainstate,
                        const CBlock& block,
@@ -4538,10 +4533,10 @@ util::Result<bool, kernel::FatalError> TestBlockValidity(BlockValidationState& s
 }
 
 /* This function is called from the RPC code for pruneblockchain */
-util::Result<void, kernel::FatalError> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
+util::Result<void, FatalError> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
     BlockValidationState state;
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
     // Do not return early on fatal flush errors.
     const auto res{active_chainstate.FlushStateToDisk(state, FlushStateMode::NONE, nManualPruneHeight)};
     if (!res || !res.value()) {
@@ -4590,14 +4585,14 @@ CVerifyDB::~CVerifyDB()
     m_notifications.progress(bilingual_str{}, 100, false);
 }
 
-util::Result<VerifyDBResult, kernel::FatalError> CVerifyDB::VerifyDB(
+util::Result<VerifyDBResult, FatalError> CVerifyDB::VerifyDB(
     Chainstate& chainstate,
     const Consensus::Params& consensus_params,
     CCoinsView& coinsview,
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
-    util::Result<VerifyDBResult, kernel::FatalError> result{VerifyDBResult::SUCCESS};
+    util::Result<VerifyDBResult, FatalError> result{VerifyDBResult::SUCCESS};
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
         return result;
@@ -4869,10 +4864,10 @@ void Chainstate::ClearBlockIndexCandidates()
     setBlockIndexCandidates.clear();
 }
 
-util::Result<bool, kernel::FatalError> ChainstateManager::LoadBlockIndex()
+util::Result<bool, FatalError> ChainstateManager::LoadBlockIndex()
 {
     AssertLockHeld(cs_main);
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
     // Load block index from databases
     bool needs_init = fReindex;
     if (!fReindex) {
@@ -4925,10 +4920,10 @@ util::Result<bool, kernel::FatalError> ChainstateManager::LoadBlockIndex()
     return result;
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::LoadGenesisBlock()
+util::Result<bool, FatalError> Chainstate::LoadGenesisBlock()
 {
     LOCK(cs_main);
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     const CChainParams& params{m_chainman.GetParams()};
 
@@ -4960,7 +4955,7 @@ util::Result<bool, kernel::FatalError> Chainstate::LoadGenesisBlock()
     return result;
 }
 
-util::Result<void, kernel::FatalError> ChainstateManager::LoadExternalBlockFile(
+util::Result<void, FatalError> ChainstateManager::LoadExternalBlockFile(
     AutoFile& file_in,
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
@@ -4970,7 +4965,7 @@ util::Result<void, kernel::FatalError> ChainstateManager::LoadExternalBlockFile(
 
     const auto start{SteadyClock::now()};
     const CChainParams& params{GetParams()};
-    util::Result<void, kernel::FatalError> result{};
+    util::Result<void, FatalError> result{};
 
     int nLoaded = 0;
     try {
@@ -5143,7 +5138,7 @@ util::Result<void, kernel::FatalError> ChainstateManager::LoadExternalBlockFile(
             }
         }
     } catch (const std::runtime_error& e) {
-        result.Set({util::Error{strprintf(_("Fatal error: %s"), e.what())}, kernel::FatalError::BlockFileImportFailed});
+        result.Set({util::Error{strprintf(_("Fatal error: %s"), e.what())}, FatalError::BlockFileImportFailed});
     }
     LogPrintf("Loaded %i blocks from external file in %dms\n", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
     return result;
@@ -5447,7 +5442,7 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-util::Result<bool, kernel::FatalError> Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+util::Result<bool, FatalError> Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
 {
     AssertLockHeld(::cs_main);
     if (coinstip_size == m_coinstip_cache_size_bytes &&
@@ -5573,13 +5568,13 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return destroyed && !fs::exists(db_path);
 }
 
-util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
+util::Result<bool, FatalError> ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
     uint256 base_blockhash = metadata.m_base_blockhash;
-    util::Result<bool, kernel::FatalError> result{true};
+    util::Result<bool, FatalError> result{true};
 
     if (this->SnapshotBlockhash()) {
         LogPrintf("[snapshot] can't activate a snapshot-based chainstate more than once\n");
@@ -5640,7 +5635,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
             static_cast<size_t>(current_coinstip_cache_size * SNAPSHOT_CACHE_PERC));
     }
 
-    auto cleanup_bad_snapshot = [&](const char* reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> util::Result<bool, kernel::FatalError> {
+    auto cleanup_bad_snapshot = [&](const char* reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> util::Result<bool, FatalError> {
         LogPrintf("[snapshot] activation failed - %s\n", reason);
         result.MoveMessages(this->MaybeRebalanceCaches());
 
@@ -5658,7 +5653,7 @@ util::Result<bool, kernel::FatalError> ChainstateManager::ActivateSnapshot(
                         "Failed to remove snapshot chainstate dir (%s). "
                         "Manually remove it before restarting.\n"),
                         fs::PathToString(*snapshot_datadir))},
-                    kernel::FatalError::SnapshotChainstateDirRemovalFailed};
+                    FatalError::SnapshotChainstateDirRemovalFailed};
             }
         }
         result.Set(false);
@@ -5946,7 +5941,7 @@ bool ChainstateManager::PopulateAndValidateSnapshot(
 //      through IsUsable() checks, or
 //
 //  (ii) giving each chainstate its own lock instead of using cs_main for everything.
-util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::MaybeCompleteSnapshotValidation()
+util::Result<SnapshotCompletionResult, FatalError> ChainstateManager::MaybeCompleteSnapshotValidation()
 {
     AssertLockHeld(cs_main);
     if (m_ibd_chainstate.get() == &this->ActiveChainstate() ||
@@ -5966,12 +5961,12 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         return SnapshotCompletionResult::SKIPPED;
     }
 
-    util::Result<SnapshotCompletionResult, kernel::FatalError> result{SnapshotCompletionResult::SUCCESS};
+    util::Result<SnapshotCompletionResult, FatalError> result{SnapshotCompletionResult::SUCCESS};
 
     assert(SnapshotBlockhash());
     uint256 snapshot_blockhash = *Assert(SnapshotBlockhash());
 
-    auto handle_invalid_snapshot = [&](kernel::FatalError fatal) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> util::Result<SnapshotCompletionResult, kernel::FatalError> {
+    auto handle_invalid_snapshot = [&](FatalError fatal) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> util::Result<SnapshotCompletionResult, FatalError> {
         bilingual_str user_error = strprintf(_(
             "%s failed to validate the -assumeutxo snapshot state. "
             "This indicates a hardware problem, or a bug in the software, or a "
@@ -5995,7 +5990,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         assert(!this->IsUsable(m_snapshot_chainstate.get()));
         assert(this->IsUsable(m_ibd_chainstate.get()));
 
-        util::Result<SnapshotCompletionResult, kernel::FatalError> result{util::Error{user_error}, fatal};
+        util::Result<SnapshotCompletionResult, FatalError> result{util::Error{user_error}, fatal};
         result.MoveMessages(m_snapshot_chainstate->InvalidateCoinsDBOnDisk());
         return result;
     };
@@ -6004,7 +5999,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         LogPrintf("[snapshot] supposed base block %s does not match the "
           "snapshot base block %s (height %d). Snapshot is not valid.\n",
           index_new.ToString(), snapshot_blockhash.ToString(), snapshot_base_height);
-        return handle_invalid_snapshot(kernel::FatalError::SnapshotBaseBlockhashMismatch);
+        return handle_invalid_snapshot(FatalError::SnapshotBaseBlockhashMismatch);
     }
 
     assert(index_new.nHeight == snapshot_base_height);
@@ -6024,7 +6019,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
     if (!maybe_au_data) {
         LogPrintf("[snapshot] assumeutxo data not found for height "
             "(%d) - refusing to validate snapshot\n", curr_height);
-        return handle_invalid_snapshot(kernel::FatalError::SnapshotMissingChainparams);
+        return handle_invalid_snapshot(FatalError::SnapshotMissingChainparams);
     }
 
     const AssumeutxoData& au_data = *maybe_au_data;
@@ -6047,7 +6042,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         // While this isn't a problem with the snapshot per se, this condition
         // prevents us from validating the snapshot, so we should shut down and let the
         // user handle the issue manually.
-        return handle_invalid_snapshot(kernel::FatalError::SnapshotStatsFailed);
+        return handle_invalid_snapshot(FatalError::SnapshotStatsFailed);
     }
     const auto& ibd_stats = *maybe_ibd_stats;
 
@@ -6061,7 +6056,7 @@ util::Result<SnapshotCompletionResult, kernel::FatalError> ChainstateManager::Ma
         LogPrintf("[snapshot] hash mismatch: actual=%s, expected=%s\n",
             ibd_stats.hashSerialized.ToString(),
             au_data.hash_serialized.ToString());
-        return handle_invalid_snapshot(kernel::FatalError::SnapshotHashMismatch);
+        return handle_invalid_snapshot(FatalError::SnapshotHashMismatch);
     }
 
     LogPrintf("[snapshot] snapshot beginning at %s has been fully validated\n",
@@ -6086,9 +6081,9 @@ bool ChainstateManager::IsSnapshotActive() const
     return m_snapshot_chainstate && m_active_chainstate == m_snapshot_chainstate.get();
 }
 
-util::Result<void, kernel::FatalError> ChainstateManager::MaybeRebalanceCaches()
+util::Result<void, FatalError> ChainstateManager::MaybeRebalanceCaches()
 {
-    util::Result<void, kernel::FatalError> result;
+    util::Result<void, FatalError> result;
     AssertLockHeld(::cs_main);
     bool ibd_usable = this->IsUsable(m_ibd_chainstate.get());
     bool snapshot_usable = this->IsUsable(m_snapshot_chainstate.get());
@@ -6216,7 +6211,7 @@ static fs::path GetSnapshotCoinsDBPath(Chainstate& cs) EXCLUSIVE_LOCKS_REQUIRED(
     return *storage_path_maybe;
 }
 
-util::Result<void, kernel::FatalError> Chainstate::InvalidateCoinsDBOnDisk()
+util::Result<void, FatalError> Chainstate::InvalidateCoinsDBOnDisk()
 {
     fs::path snapshot_datadir = GetSnapshotCoinsDBPath(*this);
 
@@ -6245,7 +6240,7 @@ util::Result<void, kernel::FatalError> Chainstate::InvalidateCoinsDBOnDisk()
             "snapshot directory %s, otherwise you will encounter the same error again "
             "on the next startup."),
             src_str, dest_str, src_str)},
-            kernel::FatalError::ChainstateRenameFailed};
+            FatalError::ChainstateRenameFailed};
     }
     return {};
 }
@@ -6288,7 +6283,7 @@ std::optional<int> ChainstateManager::GetSnapshotBaseHeight() const
     return base ? std::make_optional(base->nHeight) : std::nullopt;
 }
 
-util::Result<void, kernel::FatalError> ChainstateManager::ValidatedSnapshotCleanup()
+util::Result<void, FatalError> ChainstateManager::ValidatedSnapshotCleanup()
 {
     AssertLockHeld(::cs_main);
     auto get_storage_path = [](auto& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> std::optional<fs::path> {
@@ -6304,7 +6299,7 @@ util::Result<void, kernel::FatalError> ChainstateManager::ValidatedSnapshotClean
         // No need to clean up.
         return {
             util::Error{Untranslated("Validated snapshot cleanup stopped, nothing to clean up")},
-            kernel::FatalError::SnapshotAlreadyValidated};
+            FatalError::SnapshotAlreadyValidated};
     }
     // If either path doesn't exist, that means at least one of the chainstates
     // is in-memory, in which case we can't do on-disk cleanup. You'd better be
@@ -6312,7 +6307,7 @@ util::Result<void, kernel::FatalError> ChainstateManager::ValidatedSnapshotClean
     if (!ibd_chainstate_path_maybe || !snapshot_chainstate_path_maybe) {
         LogPrintf("[snapshot] snapshot chainstate cleanup cannot happen with "
                   "in-memory chainstates. You are testing, right?\n");
-        return {util::Error{_("Cannot cleanup chainstate snapshot with in-memory chainstates.")}, kernel::FatalError::NoChainstatePaths};
+        return {util::Error{_("Cannot cleanup chainstate snapshot with in-memory chainstates.")}, FatalError::NoChainstatePaths};
     }
 
     const auto& snapshot_chainstate_path = *snapshot_chainstate_path_maybe;
@@ -6337,13 +6332,13 @@ util::Result<void, kernel::FatalError> ChainstateManager::ValidatedSnapshotClean
     auto rename_failed_abort = [](
                                    fs::path p_old,
                                    fs::path p_new,
-                                   const fs::filesystem_error& err) -> util::Result<void, kernel::FatalError> {
+                                   const fs::filesystem_error& err) -> util::Result<void, FatalError> {
         LogPrintf("Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
         return {util::Error{strprintf(_(
             "Rename of '%s' -> '%s' failed. "
             "Cannot clean up the background chainstate leveldb directory."),
-            fs::PathToString(p_old), fs::PathToString(p_new))}, kernel::FatalError::ChainstateRenameFailed};
+            fs::PathToString(p_old), fs::PathToString(p_new))}, FatalError::ChainstateRenameFailed};
     };
 
     try {

--- a/src/validation.h
+++ b/src/validation.h
@@ -759,7 +759,7 @@ public:
 
 private:
     [[nodiscard]] util::Result<bool, kernel::FatalError> ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
-    bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     void InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* FindMostWorkChain() EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -688,7 +688,7 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool ActivateBestChain(
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ActivateBestChain(
         BlockValidationState& state,
         std::shared_ptr<const CBlock> pblock = nullptr)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
@@ -708,7 +708,7 @@ public:
      *
      * May not be called in a validationinterface callback.
      */
-    bool PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+    [[nodiscard]] util::Result<bool, kernel::FatalError> PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -758,7 +758,7 @@ public:
     }
 
 private:
-    bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     void InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -1253,7 +1253,7 @@ public:
     //! directories are moved or deleted.
     //!
     //! @sa node/chainstate:LoadChainstate()
-    bool ValidatedSnapshotCleanup() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<void, kernel::FatalError> ValidatedSnapshotCleanup() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! @returns the chainstate that indexes should consult when ensuring that an
     //!   index is synced with a chain where we can expect block index entries to have

--- a/src/validation.h
+++ b/src/validation.h
@@ -1052,7 +1052,7 @@ public:
     //!   faking nTx* block index data along the way.
     //! - Move the new chainstate to `m_snapshot_chainstate` and make it our
     //!   ChainstateActive().
-    [[nodiscard]] bool ActivateSnapshot(
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ActivateSnapshot(
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! Once the background validation chainstate has reached the height which

--- a/src/validation.h
+++ b/src/validation.h
@@ -1062,7 +1062,8 @@ public:
     //! If the coins match (expected), then mark the validation chainstate for
     //! deletion and continue using the snapshot chainstate as active.
     //! Otherwise, revert to using the ibd chainstate and shutdown.
-    SnapshotCompletionResult MaybeCompleteSnapshotValidation() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<SnapshotCompletionResult, kernel::FatalError> MaybeCompleteSnapshotValidation()
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Returns nullptr if no snapshot has been loaded.
     const CBlockIndex* GetSnapshotBaseBlock() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -98,6 +98,8 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);
 
+[[nodiscard]] util::Result<bool, kernel::FatalError> ValidationFatalError(BlockValidationState& state, const bilingual_str& message, kernel::FatalError result);
+
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex);
 
@@ -795,7 +797,7 @@ private:
      * In case of an invalid snapshot, rename the coins leveldb directory so
      * that it can be examined for issue diagnosis.
      */
-    [[nodiscard]] util::Result<void> InvalidateCoinsDBOnDisk() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<void, kernel::FatalError> InvalidateCoinsDBOnDisk() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     friend ChainstateManager;
 };
@@ -1165,7 +1167,7 @@ public:
      * @param[out]  new_block A boolean which is set to indicate if the block was first received via this call
      * @returns     If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block) LOCKS_EXCLUDED(cs_main);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Process incoming block headers.
@@ -1199,7 +1201,7 @@ public:
      *
      * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -726,7 +726,7 @@ public:
     /** Whether the chain state needs to be redownloaded due to lack of witness data */
     [[nodiscard]] bool NeedsRedownload() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
-    bool LoadGenesisBlock();
+    [[nodiscard]] util::Result<bool, kernel::FatalError> LoadGenesisBlock();
 
     void TryAddBlockIndexCandidate(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -375,7 +375,7 @@ static_assert(std::is_nothrow_destructible_v<CScriptCheck>);
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
-bool TestBlockValidity(BlockValidationState& state,
+[[nodiscard]] util::Result<bool, kernel::FatalError> TestBlockValidity(BlockValidationState& state,
                        const CChainParams& chainparams,
                        Chainstate& chainstate,
                        const CBlock& block,
@@ -409,7 +409,7 @@ private:
 public:
     explicit CVerifyDB(kernel::Notifications& notifications);
     ~CVerifyDB();
-    [[nodiscard]] VerifyDBResult VerifyDB(
+    [[nodiscard]] util::Result<VerifyDBResult, kernel::FatalError> VerifyDB(
         Chainstate& chainstate,
         const Consensus::Params& consensus_params,
         CCoinsView& coinsview,
@@ -697,7 +697,7 @@ public:
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+    [[nodiscard]] util::Result<bool, kernel::FatalError> ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Apply the effects of a block disconnection on the UTXO set.

--- a/src/validation.h
+++ b/src/validation.h
@@ -96,8 +96,6 @@ extern const std::vector<std::string> CHECKLEVEL_DOC;
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
-bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);
-
 [[nodiscard]] util::Result<bool, kernel::FatalError> ValidationFatalError(BlockValidationState& state, const bilingual_str& message, kernel::FatalError result);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */

--- a/src/validation.h
+++ b/src/validation.h
@@ -52,6 +52,9 @@ class DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
 struct LockPoints;
 struct AssumeutxoData;
+namespace kernel {
+enum class FatalError;
+} // namespace kernel
 namespace node {
 class SnapshotMetadata;
 } // namespace node
@@ -1132,7 +1135,7 @@ public:
      *                                              unknown parent, key is parent block hash
      *                                              (only used for reindex)
      * */
-    void LoadExternalBlockFile(
+    [[nodiscard]] util::Result<void, kernel::FatalError> LoadExternalBlockFile(
         AutoFile& file_in,
         FlatFilePos* dbp = nullptr,
         std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);

--- a/src/validation.h
+++ b/src/validation.h
@@ -1215,7 +1215,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex
-    bool LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] util::Result<bool, kernel::FatalError> LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -683,11 +683,11 @@ util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, co
     // Vector of results. We will choose the best one based on waste.
     std::vector<SelectionResult> results;
     std::vector<util::Result<SelectionResult>> errors;
-    auto append_error = [&] (const util::Result<SelectionResult>& result) {
+    auto append_error = [&] (util::Result<SelectionResult>&& result) {
         // If any specific error message appears here, then something different from a simple "no selection found" happened.
         // Let's save it, so it can be retrieved to the user if no other selection algorithm succeeded.
         if (HasErrorMsg(result)) {
-            errors.emplace_back(result);
+            errors.emplace_back(std::move(result));
         }
     };
 
@@ -698,7 +698,7 @@ util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, co
     if (!coin_selection_params.m_subtract_fee_outputs) {
         if (auto bnb_result{SelectCoinsBnB(groups.positive_group, nTargetValue, coin_selection_params.m_cost_of_change, max_inputs_weight)}) {
             results.push_back(*bnb_result);
-        } else append_error(bnb_result);
+        } else append_error(std::move(bnb_result));
     }
 
     // As Knapsack and SRD can create change, also deduce change weight.
@@ -707,25 +707,25 @@ util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, co
     // The knapsack solver has some legacy behavior where it will spend dust outputs. We retain this behavior, so don't filter for positive only here.
     if (auto knapsack_result{KnapsackSolver(groups.mixed_group, nTargetValue, coin_selection_params.m_min_change_target, coin_selection_params.rng_fast, max_inputs_weight)}) {
         results.push_back(*knapsack_result);
-    } else append_error(knapsack_result);
+    } else append_error(std::move(knapsack_result));
 
     if (coin_selection_params.m_effective_feerate > CFeeRate{3 * coin_selection_params.m_long_term_feerate}) { // Minimize input set for feerates of at least 3×LTFRE (default: 30 ṩ/vB+)
         if (auto cg_result{CoinGrinder(groups.positive_group, nTargetValue, coin_selection_params.m_min_change_target, max_inputs_weight)}) {
             cg_result->ComputeAndSetWaste(coin_selection_params.min_viable_change, coin_selection_params.m_cost_of_change, coin_selection_params.m_change_fee);
             results.push_back(*cg_result);
         } else {
-            append_error(cg_result);
+            append_error(std::move(cg_result));
         }
     }
 
     if (auto srd_result{SelectCoinsSRD(groups.positive_group, nTargetValue, coin_selection_params.m_change_fee, coin_selection_params.rng_fast, max_inputs_weight)}) {
         results.push_back(*srd_result);
-    } else append_error(srd_result);
+    } else append_error(std::move(srd_result));
 
     if (results.empty()) {
         // No solution found, retrieve the first explicit error (if any).
         // future: add 'severity level' to errors so the worst one can be retrieved instead of the first one.
-        return errors.empty() ? util::Error() : errors.front();
+        return errors.empty() ? util::Error() : std::move(errors.front());
     }
 
     // If the chosen input set has unconfirmed inputs, check for synergies from overlapping ancestry

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -291,7 +291,10 @@ FUZZ_TARGET(coinselection)
     }
 
     std::vector<COutput> utxos;
-    std::vector<util::Result<SelectionResult>> results{result_srd, result_knapsack, result_bnb};
+    std::vector<util::Result<SelectionResult>> results;
+    results.emplace_back(std::move(result_srd));
+    results.emplace_back(std::move(result_knapsack));
+    results.emplace_back(std::move(result_bnb));
     CAmount new_total_balance{CreateCoins(fuzzed_data_provider, utxos, coin_params, next_locktime)};
     if (new_total_balance > 0) {
         std::set<std::shared_ptr<COutput>> new_utxo_pool;

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -108,9 +108,9 @@ struct FuzzedWallet {
         auto type{fuzzed_data_provider.PickValueInArray(OUTPUT_TYPES)};
         util::Result<CTxDestination> op_dest{util::Error{}};
         if (fuzzed_data_provider.ConsumeBool()) {
-            op_dest = wallet->GetNewDestination(type, "");
+            op_dest.Set(wallet->GetNewDestination(type, ""));
         } else {
-            op_dest = wallet->GetNewChangeDestination(type);
+            op_dest.Set(wallet->GetNewChangeDestination(type));
         }
         return *Assert(op_dest);
     }

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -102,7 +102,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
 
     // Second case, don't use 'subtract_fee_from_outputs'.
     recipients[0].fSubtractFeeFromAmount = false;
-    res_tx = CreateTransaction(*wallet, recipients, /*change_pos=*/std::nullopt, coin_control);
+    res_tx.Set(CreateTransaction(*wallet, recipients, /*change_pos=*/std::nullopt, coin_control));
     BOOST_CHECK(!res_tx.has_value());
 }
 

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -134,7 +134,7 @@ class AssumeutxoTest(BitcoinTestFramework):
             with self.nodes[0].assert_debug_log([log_msg]):
                 self.nodes[0].assert_start_raises_init_error(expected_msg=error_msg)
 
-        expected_error_msg = f"Error: A fatal internal error occurred, see debug.log for details: Assumeutxo data not found for the given blockhash '7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a'."
+        expected_error_msg = f"Error: Failed loading block database. Assumeutxo data not found for the given blockhash '7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a'."
         error_details = f"Assumeutxo data not found for the given blockhash"
         expected_error(log_msg=error_details, error_msg=expected_error_msg)
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -98,11 +98,11 @@ class InitStressTest(BitcoinTestFramework):
         files_to_delete = {
             'blocks/index/*.ldb': 'Error opening block database.',
             'chainstate/*.ldb': 'Error opening block database.',
-            'blocks/blk*.dat': 'Error loading block database.',
+            'blocks/blk*.dat': 'Failed loading block database.',
         }
 
         files_to_perturb = {
-            'blocks/index/*.ldb': 'Error loading block database.',
+            'blocks/index/*.ldb': 'Failed loading block database.',
             'chainstate/*.ldb': 'Error opening block database.',
             'blocks/blk*.dat': 'Corrupted block database detected.',
         }

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -47,6 +47,7 @@ KNOWN_VIOLATIONS = [
     "src/test/util_tests.cpp:.*strtoll",
     "src/wallet/bdb.cpp:.*DbEnv::strerror",  # False positive
     "src/util/syserror.cpp:.*strerror",      # Outside this function use `SysErrorString`
+    "contrib/devtools/bitcoin-tidy/fatal_error.cpp:.*std::to_string*",
 ]
 
 REGEXP_EXTERNAL_DEPENDENCIES_EXCLUSIONS = [

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -17,6 +17,7 @@ lief
 mor
 nd
 nin
+ot
 requestor
 ser
 siz


### PR DESCRIPTION
Based on #25665.

Currently functions issuing fatal errors call the `fatalError` notification method to issue a shutdown procedure. This makes it hard for higher level functions to figure out if an error deeper in the call stack occurred. For users of the kernel it might also be difficult to assert which function call issued a fatal error if they are being run concurrently. If the kernel would eventually be used by external users, getting fatal error information through a callback instead of function return values would also be cumbersome and limiting. Unit, bench, and fuzz tests currently don't have a way to effectively test against fatal errors.

This patch set is an attempt to make fatal error handling in the kernel code more transparent. Fatal errors are now passed up the call stack through `util::Result<T, FatalError>` failure values. A previous attempt at this by theuni always immediately returned failure values if a function call returned a failure. However, this is not always desirable (see discussion [here](https://github.com/bitcoin/bitcoin/pull/27866#discussion_r1256378064)). Sometimes, further operations can still be completed even if a fatal error was issued. The solution to this is that these "ignored" errors are still moved through `util::Result`'s error string values with its `.MoveMessages` method, even while a failure value in the result is not present.

Next to some smaller behavior changes, the most significant change is that the issuing of a shutdown procedure is delayed until a potential fatal error is handled as opposed to immediately when it is first encountered. Another effect is that potential fatal errors are now asserted in the bench, fuzz and unit tests. Some of the currently not immediately returned fatal errors need some further scrutiny. These are marked with a `TODO (fatal error)` comment and could be tackled in a later PR.

To validate this approach a new clang-tidy check is introduced. It implements the following checks:

1. If a function calls another function with a `util::Result<T, FatalCondition>` return type, its return type has to be `util::Result<T, FatalCondition>` too, or it has to handle the value returned by the function with one of `CheckFatal`, `HandleFatalError`,
`UnwrapFatalError`, or `CheckFatalFailure`.
2. In functions returning a `util::Result<T, FatalCondition>` a call to a function returning a `util::Result<T, FatalCondition>` needs to propagate the value by either:
   - Returning it immediately
   - Assigning it immediately to an existing result with `.MoveMessages()` or `.Set()`
   - Eventually passing it as an argument to a `.MoveMessages()`

---

This PR is part of the [libbitcoinkernel project](https://github.com/bitcoin/bitcoin/issues/27587) and is a step towards stage 2, creating a more refined kernel API.