### PR TITLE
rpc: Remove getblockheader

### DIFF
--- a/contrib/completions/bash/bitcoin-cli.bash
+++ b/contrib/completions/bash/bitcoin-cli.bash
@@ -72,7 +72,7 @@ _bitcoin_cli() {
                 COMPREPLY=( $( compgen -W "add remove" -- "$cur" ) )
                 return 0
                 ;;
-            fundrawtransaction|getblock|getblockheader|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listreceivedbyaddress|sendrawtransaction)
+            fundrawtransaction|getblock|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listreceivedbyaddress|sendrawtransaction)
                 COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
                 return 0
                 ;;

--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -323,7 +323,7 @@ def do_generate(args):
         bci = json.loads(args.bcli("getblockchaininfo"))
 
         if bestheader["hash"] != bci["bestblockhash"]:
-            bestheader = json.loads(args.bcli("getblockheader", bci["bestblockhash"]))
+            bestheader = json.loads(args.bcli("getblock", bci["bestblockhash"], "1"))
 
         if lastheader is None:
             lastheader = bestheader["hash"]

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -42,7 +42,7 @@ Release Process
     (and update the block height comment with that height), taking into account the following:
     - On mainnet, the selected value must not be orphaned, so it may be useful to set the height two blocks back from the tip.
     - Testnet should be set with a height some tens of thousands back from the tip, due to reorgs there.
-  - `nMinimumChainWork` with the "chainwork" value of RPC `getblockheader` using the same height as that selected for the previous step.
+  - `nMinimumChainWork` with the "chainwork" value of RPC `getblock` using the same height as that selected for the previous step.
 * Consider updating the headers synchronization tuning parameters to account for the chainparams updates.
   The optimal values change very slowly, so this isn't strictly necessary every release, but doing so doesn't hurt.
   - Update configuration variables in [`contrib/devtools/headerssync-params.py`](/contrib/devtools/headerssync-params.py):

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -109,7 +109,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent", 4, "include_immature_coinbase" },
     { "getblock", 1, "verbosity" },
     { "getblock", 1, "verbose" },
-    { "getblockheader", 1, "verbose" },
     { "getchaintxstats", 0, "nblocks" },
     { "gettransaction", 1, "include_watchonly" },
     { "gettransaction", 2, "verbose" },

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -119,7 +119,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getblockfilter",
     "getblockfrompeer", // when no peers are connected, no p2p message is sent
     "getblockhash",
-    "getblockheader",
     "getblockstats",
     "getblocktemplate",
     "getchaintips",

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -164,7 +164,7 @@ class AssumeutxoTest(BitcoinTestFramework):
 
         # Mock time for a deterministic chain
         for n in self.nodes:
-            n.setmocktime(n.getblockheader(n.getbestblockhash())['time'])
+            n.setmocktime(n.getblock(n.getbestblockhash(), 1)['time'])
 
         self.sync_blocks()
 

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -127,7 +127,7 @@ class BIP68Test(BitcoinTestFramework):
     # the current tip).
     def get_median_time_past(self, confirmations):
         block_hash = self.nodes[0].getblockhash(self.nodes[0].getblockcount()-confirmations)
-        return self.nodes[0].getblockheader(block_hash)["mediantime"]
+        return self.nodes[0].getblock(block_hash, 1)["mediantime"]
 
     # Test that sequence locks are respected for transactions spending confirmed inputs.
     def test_sequence_lock_confirmed_inputs(self):

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -122,7 +122,7 @@ class BIP65Test(BitcoinTestFramework):
             invalid_cltv_txs.append(spendtx)
 
         tip = self.nodes[0].getbestblockhash()
-        block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
+        block_time = self.nodes[0].getblock(tip, 1)['mediantime'] + 1
         block = create_block(int(tip, 16), create_coinbase(CLTV_HEIGHT - 1), block_time, version=3, txlist=invalid_cltv_txs)
         block.solve()
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -85,7 +85,7 @@ class BIP66Test(BitcoinTestFramework):
         spendtx.rehash()
 
         tip = self.nodes[0].getbestblockhash()
-        block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
+        block_time = self.nodes[0].getblock(tip, 1)['mediantime'] + 1
         block = create_block(int(tip, 16), create_coinbase(DERSIG_HEIGHT - 1), block_time, txlist=[spendtx])
         block.solve()
 

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -57,7 +57,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         self.log.info(f"Generating {num_blocks_to_generate} blocks on node0")
         hashes = self.generate(self.nodes[0], num_blocks_to_generate, sync_fun=self.no_op)
 
-        self.log.info(f"Node0 current chain work: {self.nodes[0].getblockheader(hashes[-1])['chainwork']}")
+        self.log.info(f"Node0 current chain work: {self.nodes[0].getblock(hashes[-1], 1)['chainwork']}")
 
         # Sleep a few seconds and verify that node2 didn't get any new blocks
         # or headers.  We sleep, rather than sync_blocks(node0, node1) because

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -281,7 +281,7 @@ class PruneTest(BitcoinTestFramework):
 
         def height(index):
             if use_timestamp:
-                return node.getblockheader(node.getblockhash(index))["time"] + TIMESTAMP_WINDOW
+                return node.getblock(node.getblockhash(index), 1)["time"] + TIMESTAMP_WINDOW
             else:
                 return index
 
@@ -311,7 +311,7 @@ class PruneTest(BitcoinTestFramework):
             assert_raises_rpc_error(-8, "Blockchain is shorter than the attempted prune height", node.pruneblockchain, future_parameter)
 
         # Pruned block should still know the number of transactions
-        assert_equal(node.getblockheader(node.getblockhash(1))["nTx"], block1_details["nTx"])
+        assert_equal(node.getblock(node.getblockhash(1), 1)["nTx"], block1_details["nTx"])
 
         # negative heights should raise an exception
         assert_raises_rpc_error(-8, "Negative block height", node.pruneblockchain, -10)

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -24,7 +24,7 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
         node = self.nodes[0]
         wallet = MiniWallet(node)
-        mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
+        mocktime = node.getblock(node.getblockhash(0), 1)['time'] + 1
         node.setmocktime(mocktime)
 
         # Generate 100 blocks and remove the first since we plan to spend its

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -41,7 +41,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         """Send numblocks blocks to peer with version set"""
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount()
-        block_time = self.nodes[0].getblockheader(tip)["time"] + 1
+        block_time = self.nodes[0].getblock(tip, 1)["time"] + 1
         tip = int(tip, 16)
 
         for _ in range(numblocks):

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -291,8 +291,8 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
                 if "coinbase" not in vin:
                     prevout_tx = self.nodes[0].getrawtransaction(
                         vin["txid"], True)
-                    prevout_tx_block = self.nodes[0].getblockheader(
-                        prevout_tx["blockhash"])
+                    prevout_tx_block = self.nodes[0].getblock(
+                        prevout_tx["blockhash"], 1)
                     spends_coinbase = "coinbase" in prevout_tx["vin"][0]
                     expected_utxocache_spents.append({
                         "txid": vin["txid"],

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -74,7 +74,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
         # Create longer chain starting 2 blocks before current tip
         height = len(block_hashes) - 2
         block_hash = block_hashes[height - 1]
-        block_time = self.nodes[0].getblockheader(block_hash)["mediantime"] + 1
+        block_time = self.nodes[0].getblock(block_hash, 1)["mediantime"] + 1
         new_blocks = self.build_chain(5, block_hash, height, block_time)
 
         # Force reorg to a longer chain

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -279,7 +279,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_invalid_pow_headers_msg(self):
         self.log.info("Test headers message with invalid proof-of-work is logged as misbehaving and disconnects peer")
         blockheader_tip_hash = self.nodes[0].getbestblockhash()
-        blockheader_tip = from_hex(CBlockHeader(), self.nodes[0].getblockheader(blockheader_tip_hash, False))
+        blockheader_tip = from_hex(CBlockHeader(), self.nodes[0].getblock(blockheader_tip_hash, 0))
 
         # send valid headers message first
         assert_equal(self.nodes[0].getblockchaininfo()['headers'], 0)
@@ -311,7 +311,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         block_hashes = self.generate(self.nodes[0], 10)
         block_headers = []
         for block_hash in block_hashes:
-            block_headers.append(from_hex(CBlockHeader(), self.nodes[0].getblockheader(block_hash, False)))
+            block_headers.append(from_hex(CBlockHeader(), self.nodes[0].getblock(block_hash, 0)))
 
         # continuous headers sequence should be fine
         MISBEHAVING_NONCONTINUOUS_HEADERS_MSGS = ['Misbehaving', 'non-continuous headers sequence']

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -148,7 +148,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         except Exception:
             pass
         # node2 must remain at height 0
-        assert_equal(self.nodes[2].getblockheader(self.nodes[2].getbestblockhash())['height'], 0)
+        assert_equal(self.nodes[2].getblock(self.nodes[2].getbestblockhash(), 1)['height'], 0)
 
         # now connect also to node 1 (non pruned)
         self.connect_nodes(1, 2)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -228,7 +228,7 @@ class SegWitTest(BitcoinTestFramework):
         """Build a block on top of node0's tip."""
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount() + 1
-        block_time = self.nodes[0].getblockheader(tip)["mediantime"] + 1
+        block_time = self.nodes[0].getblock(tip, 1)["mediantime"] + 1
         block = create_block(int(tip, 16), create_coinbase(height), block_time)
         block.rehash()
         return block

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -238,7 +238,7 @@ class SendHeadersTest(BitcoinTestFramework):
         self.test_nonnull_locators(test_node, inv_node)
 
     def test_null_locators(self, test_node, inv_node):
-        tip = self.nodes[0].getblockheader(self.generatetoaddress(self.nodes[0], 1, self.nodes[0].get_deterministic_priv_key().address)[0])
+        tip = self.nodes[0].getblock(self.generatetoaddress(self.nodes[0], 1, self.nodes[0].get_deterministic_priv_key().address)[0], 1)
         tip_hash = int(tip["hash"], 16)
 
         inv_node.check_last_inv_announcement(inv=[tip_hash])

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -172,7 +172,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # Now send the block at height 5 and check that it wasn't accepted (missing header)
         test_node.send_and_ping(msg_block(all_blocks[1]))
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblock, all_blocks[1].hash)
-        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, all_blocks[1].hash)
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblock, all_blocks[1].hash, 1)
 
         # The block at height 5 should be accepted if we provide the missing header, though
         headers_message = msg_headers()

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -22,7 +22,7 @@ class DumptxoutsetTest(BitcoinTestFramework):
     def run_test(self):
         """Test a trivial usage of the dumptxoutset RPC command."""
         node = self.nodes[0]
-        mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
+        mocktime = node.getblock(node.getblockhash(0), 1)['time'] + 1
         node.setmocktime(mocktime)
         self.generate(node, COINBASE_MATURITY)
 

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -18,7 +18,7 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
             break
         except Exception:
             blocks_to_copy.append(blockhash)
-            blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
+            blockhash = node_src.getblock(blockhash, 1)['previousblockhash']
     blocks_to_copy.reverse()
     for blockhash in blocks_to_copy:
         blockdata = node_src.getblock(blockhash, False)

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -42,7 +42,7 @@ class ScanblocksTest(BitcoinTestFramework):
 
         # mine a block and assure that the mined blockhash is in the filterresult
         blockhash = self.generate(node, 1)[0]
-        height = node.getblockheader(blockhash)['height']
+        height = node.getblock(blockhash, 1)['height']
         self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
 
         out = node.scanblocks("start", [f"addr({addr_1})"])
@@ -53,7 +53,7 @@ class ScanblocksTest(BitcoinTestFramework):
 
         # mine another block
         blockhash_new = self.generate(node, 1)[0]
-        height_new = node.getblockheader(blockhash_new)['height']
+        height_new = node.getblock(blockhash_new, 1)['height']
 
         # make sure the blockhash is not in the filter result if we set the start_height
         # to the just mined block (unlikely to hit a false positive)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -846,7 +846,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             cache_node.wait_for_rpc_connection()
 
             # Set a time in the past, so that blocks don't end up in the future
-            cache_node.setmocktime(cache_node.getblockheader(cache_node.getbestblockhash())['time'])
+            cache_node.setmocktime(cache_node.getblock(cache_node.getbestblockhash(), 1)['time'])
 
             # Create a 199-block-long chain; each of the 3 first nodes
             # gets 25 mature blocks and 25 immature.

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -60,7 +60,7 @@ class AssumeutxoTest(BitcoinTestFramework):
 
         # Mock time for a deterministic chain
         for n in self.nodes:
-            n.setmocktime(n.getblockheader(n.getbestblockhash())['time'])
+            n.setmocktime(n.getblock(n.getbestblockhash(), 1)['time'])
 
         self.sync_blocks()
 

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -192,7 +192,7 @@ class ImportRescanTest(BitcoinTestFramework):
             if i % 10 == 0:
                 blockhash = self.generate(self.nodes[0], 1)[0]
                 conf_height = self.nodes[0].getblockcount()
-                timestamp = self.nodes[0].getblockheader(blockhash)["time"]
+                timestamp = self.nodes[0].getblock(blockhash, 1)["time"]
                 for var in last_variants:
                     var.confirmation_height = conf_height
                     var.timestamp = timestamp
@@ -209,7 +209,7 @@ class ImportRescanTest(BitcoinTestFramework):
 
         blockhash = self.generate(self.nodes[0], 1)[0]
         conf_height = self.nodes[0].getblockcount()
-        timestamp = self.nodes[0].getblockheader(blockhash)["time"]
+        timestamp = self.nodes[0].getblock(blockhash, 1)["time"]
         for var in last_variants:
             var.confirmation_height = conf_height
             var.timestamp = timestamp
@@ -219,7 +219,7 @@ class ImportRescanTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getrawmempool(), [])
         set_node_times(
             self.nodes,
-            self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"] + TIMESTAMP_WINDOW + 1,
+            self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 1)["time"] + TIMESTAMP_WINDOW + 1,
         )
         self.generate(self.nodes[0], 1)
 
@@ -264,7 +264,7 @@ class ImportRescanTest(BitcoinTestFramework):
         # The late timestamp and pruned variants are not necessary when testing mempool rescan
         mempool_variants = [variant for variant in IMPORT_VARIANTS if variant.rescan != Rescan.late_timestamp and not variant.prune]
         # No further blocks are mined so the timestamp will stay the same
-        timestamp = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"]
+        timestamp = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 1)["time"]
 
         # Create one transaction on node 0 with a unique amount for
         # each possible type of wallet import RPC.

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -62,7 +62,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         })
 
         blockhash, = self.generate(self.nodes[2], 1)
-        blockheight = self.nodes[2].getblockheader(blockhash)['height']
+        blockheight = self.nodes[2].getblock(blockhash, 1)['height']
 
         txs = self.nodes[0].listtransactions()
         assert_array_result(txs, {"txid": txid}, {
@@ -106,7 +106,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         '''
         self.log.info("Test target_confirmations")
         blockhash, = self.generate(self.nodes[2], 1)
-        blockheight = self.nodes[2].getblockheader(blockhash)['height']
+        blockheight = self.nodes[2].getblock(blockhash, 1)['height']
 
         assert_equal(
             self.nodes[0].getblockhash(0),
@@ -165,7 +165,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         # and return the block height which listsinceblock now exposes since a5e7795.
         transactions = self.nodes[0].listsinceblock(nodes1_last_blockhash)['transactions']
         found = next(tx for tx in transactions if tx['txid'] == senttx)
-        assert_equal(found['blockheight'], self.nodes[0].getblockheader(nodes2_first_blockhash)['height'])
+        assert_equal(found['blockheight'], self.nodes[0].getblock(nodes2_first_blockhash, 1)['height'])
 
     def test_double_spend(self):
         '''
@@ -326,7 +326,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
 
         # gettransaction should work for txid1
         tx1 = self.nodes[0].gettransaction(txid1)
-        assert_equal(tx1['blockheight'], self.nodes[0].getblockheader(tx1['blockhash'])['height'])
+        assert_equal(tx1['blockheight'], self.nodes[0].getblock(tx1['blockhash'], 1)['height'])
 
         # listsinceblock(lastblockhash) should now include txid1 in transactions
         # as well as in removed

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -45,7 +45,7 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"category": "receive", "amount": Decimal("0.1"), "confirmations": 0, "trusted": False})
         self.log.info("Test confirmations change after mining a block")
         blockhash = self.generate(self.nodes[0], 1)[0]
-        blockheight = self.nodes[0].getblockheader(blockhash)['height']
+        blockheight = self.nodes[0].getblock(blockhash, 1)['height']
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
                             {"category": "send", "amount": Decimal("-0.1"), "confirmations": 1, "blockhash": blockhash, "blockheight": blockheight})

--- a/test/functional/wallet_pruning.py
+++ b/test/functional/wallet_pruning.py
@@ -38,7 +38,7 @@ class WalletPruningTest(BitcoinTestFramework):
 
     def mine_large_blocks(self, node, n):
         # Get the block parameters for the first block
-        best_block = node.getblockheader(node.getbestblockhash())
+        best_block = node.getblock(node.getbestblockhash(), 1)
         height = int(best_block["height"]) + 1
         self.nTime = max(self.nTime, int(best_block["time"])) + 1
         previousblockhash = int(best_block["hash"], 16)

--- a/test/functional/wallet_timelock.py
+++ b/test/functional/wallet_timelock.py
@@ -20,7 +20,7 @@ class WalletLocktimeTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
 
-        mtp_tip = node.getblockheader(node.getbestblockhash())["mediantime"]
+        mtp_tip = node.getblock(node.getbestblockhash(), 1)["mediantime"]
 
         self.log.info("Get new address with label")
         label = "timelock⌛🔓"


### PR DESCRIPTION
The `getblockheader` RPC with its true/false verbosity options returns the same content as `getblock` with verbosity 0/1. So this is an opportunity to remove some code very cleanly, as demonstrated here.

I looked for other issues or PRs that suggested this but wasn't successful, obviously let me know if I missed something.

Just looking for conceptual feedback for now. When that is positive I will first run `getblockheader` through a depecation cycle. If it is negative I will suggest some deduplication between the two RPCs instead. 