### PR TITLE
wallet: Avoid potentially writing incorrect best block locator

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -137,13 +137,6 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
-    //! Get locator for the current chain tip.
-    virtual CBlockLocator getTipLocator() = 0;
-
-    //! Return a locator that refers to a block in the active chain.
-    //! If specified block is not in the active chain, return locator for the latest ancestor that is in the chain.
-    virtual CBlockLocator getActiveChainLocator(const uint256& block_hash) = 0;
-
     //! Return height of the highest block on chain in common with the locator,
     //! which will either be the original block used to create the locator,
     //! or one of its ancestors.
@@ -315,7 +308,7 @@ public:
         virtual void blockConnected(ChainstateRole role, const BlockInfo& block) {}
         virtual void blockDisconnected(const BlockInfo& block) {}
         virtual void updatedBlockTip() {}
-        virtual void chainStateFlushed(ChainstateRole role, const CBlockLocator& locator) {}
+        virtual void chainStateFlushed(ChainstateRole role) {}
     };
 
     //! Register handler for notifications.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -452,7 +452,7 @@ public:
         m_notifications->updatedBlockTip();
     }
     void ChainStateFlushed(ChainstateRole role, const CBlockLocator& locator) override {
-        m_notifications->chainStateFlushed(role, locator);
+        m_notifications->chainStateFlushed(role);
     }
     std::shared_ptr<Chain::Notifications> m_notifications;
 };
@@ -535,17 +535,6 @@ public:
         LOCK(::cs_main);
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
-    }
-    CBlockLocator getTipLocator() override
-    {
-        LOCK(::cs_main);
-        return chainman().ActiveChain().GetLocator();
-    }
-    CBlockLocator getActiveChainLocator(const uint256& block_hash) override
-    {
-        LOCK(::cs_main);
-        const CBlockIndex* index = chainman().m_blockman.LookupBlockIndex(block_hash);
-        return GetLocator(index);
     }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -627,15 +627,19 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
-void CWallet::chainStateFlushed(ChainstateRole role, const CBlockLocator& loc)
+void CWallet::chainStateFlushed(ChainstateRole role)
 {
     // Don't update the best block until the chain is attached so that in case of a shutdown,
     // the rescan will be restarted at next startup.
     if (m_attaching_chain || role == ChainstateRole::BACKGROUND) {
         return;
     }
-    WalletBatch batch(GetDatabase());
-    batch.WriteBestBlock(loc);
+    CBlockLocator loc;
+    WITH_LOCK(cs_wallet, chain().findBlock(m_last_block_processed, FoundBlock().locator(loc)));
+    if (!loc.IsNull()) {
+        WalletBatch batch(GetDatabase());
+        batch.WriteBestBlock(loc);
+    }
 }
 
 void CWallet::SetMinVersion(enum WalletFeature nVersion, WalletBatch* batch_in)
@@ -1913,8 +1917,8 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                 result.last_scanned_height = block_height;
 
                 if (save_progress && next_interval) {
-                    CBlockLocator loc = m_chain->getActiveChainLocator(block_hash);
-
+                    CBlockLocator loc;
+                    chain().findBlock(block_hash, FoundBlock().locator(loc));
                     if (!loc.IsNull()) {
                         WalletLogPrintf("Saving scan progress %d.\n", block_height);
                         WalletBatch batch(GetDatabase());
@@ -3003,7 +3007,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         }
 
         if (chain) {
-            walletInstance->chainStateFlushed(ChainstateRole::NORMAL, chain->getTipLocator());
+            walletInstance->chainStateFlushed(ChainstateRole::NORMAL);
         }
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
@@ -3290,7 +3294,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             }
         }
         walletInstance->m_attaching_chain = false;
-        walletInstance->chainStateFlushed(ChainstateRole::NORMAL, chain.getTipLocator());
+        walletInstance->chainStateFlushed(ChainstateRole::NORMAL);
         walletInstance->GetDatabase().IncrementUpdateCounter();
     }
     walletInstance->m_attaching_chain = false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -790,7 +790,7 @@ public:
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
-    void chainStateFlushed(ChainstateRole role, const CBlockLocator& loc) override;
+    void chainStateFlushed(ChainstateRole role) override;
 
     DBErrors LoadWallet();
 


### PR DESCRIPTION
This PR updates the `CWallet::chainStateFlushed` method to write the `m_last_block_processed` locator to the database as the wallet's best block instead of the chain tip locator.

Saving the last block processed locator as the best block is less fragile than saving `chainStateFlushed` locator as best block.

Right now wallet code relies on `blockConnected` notifications being sent before `chainStateFlushed` notifications, and on the `chainStateFlushed` locator pointing to the last connected block. But this is a fragile assumption that can be easily broken by `ActivateBestChain`/`ConnectTrace` changes, and in fact is currently broken (since d96c59cc5cd2f73f1f55c133c52208671fe75ef3 from #25740) when the assumeutxo snapshot block is validated. In that case the background validation `chainStateFlushed` notification is sent _before_ the `blockConnected` notification so writing the locator as the best block would record a best block that was never processed. This specific change does not cause a problem for the wallet, because the wallet ignores events from the background validation chainstate. But nothing prevents similar out-of-order `chainStateFlushed` notifications from being sent in the future, so it is safer for the wallet to not rely on the chain tip sent in `chainStateFlushed` notifications.

A good followup to this change would probably be to drop the `ChainStateFlushed` locator argument entirely so it is not misused in the future. Indexing code already stopped using this locator argument a long time ago for identifying the best block (in 4368384f1d267b011e03a805f934f5c47e2ca1b2 from #14121), though it is currently using the locator argument to log diagnostic warnings.