### PR TITLE
build: make BITCOIN_QT_PATH_PROGS always check $PATH before failure

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -37,6 +37,9 @@ AC_DEFUN([BITCOIN_QT_PATH_PROGS],[
   BITCOIN_QT_CHECK([
     if test "$3" != ""; then
       AC_PATH_PROGS([$1], [$2], [], [$3])
+      if test "$$1" = ""; then
+        AC_PATH_PROGS([$1], [$2])
+      fi
     else
       AC_PATH_PROGS([$1], [$2])
     fi


### PR DESCRIPTION
`BITCOIN_QT_PATH_PROGS` should conform to it's documentation for parameter `$3`:
> dnl Inputs: $3: Look for $2 here before $PATH

Prior to the change, when `$3` was specified, the function would *not* check `$PATH`. Fixing this resolves the case where the `lrelease`, `lupdate` and `lconvert` binaries live in a different directory than the other QT Base binaries, hindering `./configure` from detecting them. The issue was observed on Nix(OS) which has different binary folders for `nixpkgs.qt5.qtbase` and `nixpkgs.qt5.qttools`, causing `./configure` to not allow building `bitcoin-qt`.

(This issue is GUI-related but involves the build system).

## Testing

1. Install NixOS or the `nix` package manager (<https://nixos.org/download/>).
2. Clone the Bitcoin Core repo.
3. Copy `shell.nix` from https://gist.github.com/cbergqvist/7d9ce7663414214bb991007ab8138725 into the repo directory
4. Run `nix-shell` from the CLI inside the repo directory.
5. Run `make clean && ./configure` and observe change in output depending on whether this change is applied to the repo or not.

### Expected output from `./configure` *without* the change
```
checking for Qt5Core >= 5.11.3... yes
checking for Qt5Gui >= 5.11.3... yes
checking for Qt5Widgets >= 5.11.3... yes
checking for Qt5Network >= 5.11.3... yes
checking for Qt5Test >= 5.11.3... yes
checking for Qt5DBus >= 5.11.3... yes
checking for static Qt... no
checking whether -fPIE can be used with this Qt config... no
checking for moc-qt5... no
checking for moc5... no
checking for moc... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/moc
checking for uic-qt5... no
checking for uic5... no
checking for uic... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/uic
checking for rcc-qt5... no
checking for rcc5... no
checking for rcc... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/rcc
checking for lrelease-qt5... no
checking for lrelease5... no
checking for lrelease... no
configure: WARNING: LRELEASE not found; bitcoin-qt frontend will not be built
checking whether to build Bitcoin Core GUI... no
```

### Expected output from `./configure` *with* the change
```
checking for Qt5Core >= 5.11.3... yes
checking for Qt5Gui >= 5.11.3... yes
checking for Qt5Widgets >= 5.11.3... yes
checking for Qt5Network >= 5.11.3... yes
checking for Qt5Test >= 5.11.3... yes
checking for Qt5DBus >= 5.11.3... yes
checking for static Qt... no
checking whether -fPIE can be used with this Qt config... no
checking for moc-qt5... no
checking for moc5... no
checking for moc... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/moc
checking for uic-qt5... no
checking for uic5... no
checking for uic... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/uic
checking for rcc-qt5... no
checking for rcc5... no
checking for rcc... /nix/store/78yxzzk2fb6am5v4dihalw9hrrj0rg8l-qtbase-5.15.12-dev/bin/rcc
checking for lrelease-qt5... no
checking for lrelease5... no
checking for lrelease... no
checking for lrelease-qt5... no
checking for lrelease5... no
checking for lrelease... /nix/store/4dc19x6k1ma72s13i4gs75amgsxz5jmy-qttools-5.15.12-dev/bin/lrelease
checking for lupdate-qt5... no
checking for lupdate5... no
checking for lupdate... no
checking for lupdate-qt5... no
checking for lupdate5... no
checking for lupdate... /nix/store/4dc19x6k1ma72s13i4gs75amgsxz5jmy-qttools-5.15.12-dev/bin/lupdate
checking for lconvert-qt5... no
checking for lconvert5... no
checking for lconvert... no
checking for lconvert-qt5... no
checking for lconvert5... no
checking for lconvert... /nix/store/4dc19x6k1ma72s13i4gs75amgsxz5jmy-qttools-5.15.12-dev/bin/lconvert
checking whether to build Bitcoin Core GUI... yes (Qt5)
```
