### PR TITLE
Bugfix: GUI: Help messages already have a trailing newline, so don't add an extra one

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -124,7 +124,7 @@ HelpMessageDialog::~HelpMessageDialog()
 void HelpMessageDialog::printToConsole()
 {
     // On other operating systems, the expected action is to print the message to the console.
-    tfm::format(std::cout, "%s\n", qPrintable(text));
+    tfm::format(std::cout, "%s", qPrintable(text));
 }
 
 void HelpMessageDialog::showOrPrint()


### PR DESCRIPTION
Reviewing #29585, I noticed that `bitcoin-qt` adds an extra newline for `-help` and `-version` beyond the other binaries'.