### PR TITLE
lint: Fix COMMIT_RANGE issues

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -8,21 +8,24 @@ export LC_ALL=C
 
 set -ex
 
-if [ -n "$LOCAL_BRANCH" ]; then
-  # To faithfully recreate CI linting locally, specify all commits on the current
-  # branch.
-  COMMIT_RANGE="$(git merge-base HEAD master)..HEAD"
-elif [ -n "$CIRRUS_PR" ]; then
+if [ -n "$CIRRUS_PR" ]; then
   COMMIT_RANGE="HEAD~..HEAD"
-  echo
-  git log --no-merges --oneline "$COMMIT_RANGE"
-  echo
-  test/lint/commit-script-check.sh "$COMMIT_RANGE"
+  if [ "$(git rev-list -1 HEAD)" != "$(git rev-list -1 --merges HEAD)" ]; then
+    echo "Error: The top commit must be a merge commit, usually the remote 'pull/${PR_NUMBER}/merge' branch."
+    false
+  fi
 else
-  COMMIT_RANGE="SKIP_EMPTY_NOT_A_PR"
+  # Otherwise, assume that a merge commit exists. This merge commit is assumed
+  # to be the base, after which linting will be done. If the merge commit is
+  # HEAD, the range will be empty.
+  COMMIT_RANGE="$( git rev-list --max-count=1 --merges HEAD )..HEAD"
 fi
 export COMMIT_RANGE
 
+echo
+git log --no-merges --oneline "$COMMIT_RANGE"
+echo
+test/lint/commit-script-check.sh "$COMMIT_RANGE"
 RUST_BACKTRACE=1 "${LINT_RUNNER_PATH}/test_runner"
 
 if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; then

--- a/ci/lint/container-entrypoint.sh
+++ b/ci/lint/container-entrypoint.sh
@@ -14,7 +14,7 @@ export PATH="/python_build/bin:${PATH}"
 export LINT_RUNNER_PATH="/lint_test_runner"
 
 if [ -z "$1" ]; then
-  LOCAL_BRANCH=1 bash -ic "./ci/lint/06_script.sh"
+  bash -ic "./ci/lint/06_script.sh"
 else
   exec "$@"
 fi

--- a/test/lint/lint-git-commit-check.py
+++ b/test/lint/lint-git-commit-check.py
@@ -23,31 +23,18 @@ def parse_args():
         """,
         epilog=f"""
             You can manually set the commit-range with the COMMIT_RANGE
-            environment variable (e.g. "COMMIT_RANGE='47ba2c3...ee50c9e'
-            {sys.argv[0]}"). Defaults to current merge base when neither
-            prev-commits nor the environment variable is set.
+            environment variable (e.g. "COMMIT_RANGE='HEAD~n..HEAD'
+            {sys.argv[0]}") for the last 'n' commits.
         """)
-
-    parser.add_argument("--prev-commits", "-p", required=False, help="The previous n commits to check")
-
     return parser.parse_args()
 
 
 def main():
-    args = parse_args()
+    parse_args()
     exit_code = 0
 
-    if not os.getenv("COMMIT_RANGE"):
-        if args.prev_commits:
-            commit_range = "HEAD~" + args.prev_commits + "...HEAD"
-        else:
-            # This assumes that the target branch of the pull request will be master.
-            merge_base = check_output(["git", "merge-base", "HEAD", "master"], text=True, encoding="utf8").rstrip("\n")
-            commit_range = merge_base + "..HEAD"
-    else:
-        commit_range = os.getenv("COMMIT_RANGE")
-        if commit_range == "SKIP_EMPTY_NOT_A_PR":
-            sys.exit(0)
+    assert os.getenv("COMMIT_RANGE")  # E.g. COMMIT_RANGE='HEAD~n..HEAD'
+    commit_range = os.getenv("COMMIT_RANGE")
 
     commit_hashes = check_output(["git", "log", commit_range, "--format=%H"], text=True, encoding="utf8").splitlines()
 


### PR DESCRIPTION
`COMMIT_RANGE` has problems on forks or local branches:

* When `LOCAL_BRANCH` is set, it assumes the presence of a `master` branch, and that the `master` branch is up-to-date. Both of which may be false. (See also discussion in https://github.com/bitcoin/bitcoin/pull/29274#discussion_r1504226422)
* When `COMMIT_RANGE` isn't set in `lint-git-commit-check.py`, and `--prev-commits` isn't set either, it has the same (broken) assumptions.

Fix all issues by simply assuming a merge commit exists. This allows to drop `LOCAL_BRANCH`. It also allows to drop `SKIP_EMPTY_NOT_A_PR`, because scripts will already skip an empty range. Finally, it allows to drop `--prev-commits n`, because one can simply say `COMMIT_RANGE='HEAD~n..HEAD'` to achieve the same.