### PR TITLE
p2p: When close to the tip, download blocks in parallel from additional peers to prevent stalling

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -113,6 +113,8 @@ static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 static constexpr auto BLOCK_STALLING_TIMEOUT_DEFAULT{2s};
 /** Maximum timeout for stalling block download. */
 static constexpr auto BLOCK_STALLING_TIMEOUT_MAX{64s};
+/** Timeout for stalling when close to the tip, after which we may add additional peers to download from */
+static constexpr auto BLOCK_NEARTIP_TIMEOUT_MAX{30s};
 /** Maximum depth of blocks we're willing to serve as compact blocks to peers
  *  when requested. For older blocks, a regular BLOCK response will be sent. */
 static const int MAX_CMPCTBLOCK_DEPTH = 5;
@@ -787,7 +789,10 @@ private:
     std::atomic<int> m_best_height{-1};
     /** The time of the best chain tip block */
     std::atomic<std::chrono::seconds> m_best_block_time{0s};
-
+    /** The last time we requested a block from any peer */
+    std::atomic<std::chrono::seconds> m_last_block_requested{0s};
+    /** The last time we received a block from any peer */
+    std::atomic<std::chrono::seconds> m_last_block_received{0s};
     /** Next time to check for stale tip */
     std::chrono::seconds m_stale_tip_check_time GUARDED_BY(cs_main){0s};
 
@@ -1375,6 +1380,7 @@ bool PeerManagerImpl::BlockRequested(NodeId nodeid, const CBlockIndex& block, st
     if (pit) {
         *pit = &itInFlight->second.second;
     }
+    m_last_block_requested = GetTime<std::chrono::seconds>();
     return true;
 }
 
@@ -1623,6 +1629,30 @@ void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, c
                 if (waitingfor == -1) {
                     // This is the first already-in-flight block.
                     waitingfor = mapBlocksInFlight.lower_bound(pindex->GetBlockHash())->second.first;
+
+                    // Decide whether to request this block from additional peers in parallel.
+                    // This is done if we are close (<=1024 blocks) from the tip, so that the usual
+                    // stalling mechanism doesn't work. To reduce excessive waste of bandwith, do this only
+                    // 30 seconds (BLOCK_NEARTIP_TIMEOUT_MAX) after a block was requested or received from any peer,
+                    // and only with up to 3 peers in parallel.
+                    bool already_requested_from_peer{false};
+                    auto range{mapBlocksInFlight.equal_range(pindex->GetBlockHash())};
+                    while (range.first != range.second) {
+                        if (range.first->second.first == peer.m_id) {
+                            already_requested_from_peer = true;
+                            break;
+                        }
+                        range.first++;
+                    }
+                    if (nMaxHeight <= nWindowEnd && // we have 1024 or less blocks left to download
+                        m_last_block_requested.load() > 0s  &&
+                        GetTime<std::chrono::microseconds>() > m_last_block_requested.load() + BLOCK_NEARTIP_TIMEOUT_MAX &&
+                        GetTime<std::chrono::microseconds>() > m_last_block_received.load() + BLOCK_NEARTIP_TIMEOUT_MAX &&
+                        !already_requested_from_peer &&
+                        mapBlocksInFlight.count(pindex->GetBlockHash()) <= 2) {
+                        LogDebug(BCLog::NET, "Possible stalling close to tip: Requesting block %s additionally from peer %d\n", pindex->GetBlockHash().ToString(), peer.m_id);
+                        vBlocks.push_back(pindex);
+                    }
                 }
                 continue;
             }
@@ -3608,6 +3638,7 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
     m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block);
     if (new_block) {
         node.m_last_block_time = GetTime<std::chrono::seconds>();
+        m_last_block_received = GetTime<std::chrono::seconds>();
         // In case this block came from a different peer than we requested
         // from, we can erase the block request now anyway (as we just stored
         // this block to disk).

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -154,33 +154,63 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
     def near_tip_stalling(self):
         node = self.nodes[1]
-        peers = []
-        stall_block = self.blocks[0].sha256
-        self.log.info("Part 2: Test stalling close to the tip")
-        # only send 1024 headers, so that the window can't overshoot and the ibd stalling mechanism isn't triggered
-        headers_message = msg_headers()
-        headers_message.headers = [CBlockHeader(b) for b in self.blocks[:self.NUM_BLOCKS-1]]
-        self.log.info("Add two stalling peers")
-        for id in range(2):
-            peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
-            peers[-1].block_store = self.block_dict
-            peers[-1].send_message(headers_message)
+        self.log.info("Part 3: Test stalling close to the tip")
+        # only send <= 1024 headers, so that the window can't overshoot and the ibd stalling mechanism isn't triggered
+        # make sure it works at different lengths
+        for header_length in [1, 10, 1024]:
+            peers = []
+            stall_block = self.blocks[0].sha256
+            headers_message = msg_headers()
+            headers_message.headers = [CBlockHeader(b) for b in self.blocks[:self.NUM_BLOCKS-1][:header_length]]
 
-        self.wait_until(lambda: sum(len(peer['inflight']) for peer in node.getpeerinfo()) == 1)
-        self.all_sync_send_with_ping(peers)
-        assert peers[0].stall_block_requested
-        assert not peers[1].stall_block_requested
+            self.mocktime = int(time.time())
+            node.setmocktime(self.mocktime)
 
-        self.log.info("Check that after 9 minutes, nothing is done against the stalling")
-        self.mocktime = int(time.time()) + 9 * 60
-        node.setmocktime(self.mocktime)
-        self.all_sync_send_with_ping(peers)
+            self.log.info(f"Add three stalling peers, sending {header_length} headers")
+            for id in range(4):
+                peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
+                peers[-1].block_store = self.block_dict
+                peers[-1].send_message(headers_message)
 
-        self.log.info("Check that after more than 10 minutes, the stalling peer is disconnected")
-        self.mocktime += 2 * 60
-        node.setmocktime(self.mocktime)
-        peers[0].wait_for_disconnect()
-        self.wait_until(lambda: peers[1].stall_block_requested)
+            self.wait_until(lambda: sum(len(peer['inflight']) for peer in node.getpeerinfo()) == 1)
+            self.all_sync_send_with_ping(peers)
+            assert_equal(sum(peer.stall_block_requested for peer in peers),  1)
+
+            self.log.info("Check that after 30 seconds we request the block from a second peer")
+            self.mocktime += 31
+            node.setmocktime(self.mocktime)
+            self.wait_until(lambda: sum(peer.stall_block_requested for peer in peers) == 2)
+
+            self.log.info("Check that after another 30 seconds we request the block from a third peer")
+            self.mocktime += 31
+            node.setmocktime(self.mocktime)
+            self.wait_until(lambda: sum(peer.stall_block_requested for peer in peers) == 3)
+
+            self.log.info("Check that after another 30 seconds we aren't requesting it from a fourth peer yet")
+            self.mocktime += 31
+            node.setmocktime(self.mocktime)
+            self.all_sync_send_with_ping(peers)
+            self.wait_until(lambda: sum(peer.stall_block_requested for peer in peers) == 3)
+
+            self.log.info("Check that after another 20 minutes, first three stalling peers are disconnected")
+            # 10 minutes BLOCK_DOWNLOAD_TIMEOUT_BASE + 2*5 minutes BLOCK_DOWNLOAD_TIMEOUT_PER_PEER
+            self.mocktime += 20 * 60
+            node.setmocktime(self.mocktime)
+            # all peers have been requested
+            self.wait_until(lambda: sum(peer.stall_block_requested for peer in peers) == 4)
+
+            self.log.info("Check that after another 20 minutes, last stalling peer is disconnected")
+            # 10 minutes BLOCK_DOWNLOAD_TIMEOUT_BASE + 2*5 minutes BLOCK_DOWNLOAD_TIMEOUT_PER_PEER
+            self.mocktime += 20 * 60
+            node.setmocktime(self.mocktime)
+            for peer in peers:
+                peer.wait_for_disconnect()
+
+        self.log.info("Provide missing block and check that the sync succeeds")
+        peer = node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=0, connection_type="outbound-full-relay")
+        peer.send_message(msg_block(self.block_dict[stall_block]))
+        self.wait_until(lambda: node.getblockcount() == self.NUM_BLOCKS - 1)
+        node.disconnect_p2ps()
 
     def all_sync_send_with_ping(self, peers):
         for p in peers:

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -49,41 +49,42 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def run_test(self):
-        NUM_BLOCKS = 1025
-        NUM_PEERS = 4
+    def prepare_blocks(self):
+        self.log.info("Prepare blocks without sending them to any node")
+        self.NUM_BLOCKS = 1025
+        self.block_dict = {}
+        self.blocks = []
+
         node = self.nodes[0]
         tip = int(node.getbestblockhash(), 16)
-        blocks = []
         height = 1
         block_time = node.getblock(node.getbestblockhash())['time'] + 1
-        self.log.info("Prepare blocks without sending them to the node")
-        block_dict = {}
-        for _ in range(NUM_BLOCKS):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
-            blocks[-1].solve()
-            tip = blocks[-1].sha256
+        for _ in range(self.NUM_BLOCKS):
+            self.blocks.append(create_block(tip, create_coinbase(height), block_time))
+            self.blocks[-1].solve()
+            tip = self.blocks[-1].sha256
             block_time += 1
             height += 1
-            block_dict[blocks[-1].sha256] = blocks[-1]
-        stall_block = blocks[0].sha256
+            self.block_dict[self.blocks[-1].sha256] = self.blocks[-1]
+
+    def ibd_stalling(self):
+        NUM_PEERS = 4
+        stall_block = self.blocks[0].sha256
+        node = self.nodes[0]
 
         headers_message = msg_headers()
-        headers_message.headers = [CBlockHeader(b) for b in blocks[:NUM_BLOCKS-1]]
+        headers_message.headers = [CBlockHeader(b) for b in self.blocks[:self.NUM_BLOCKS-1]]
         peers = []
 
         self.log.info("Check that a staller does not get disconnected if the 1024 block lookahead buffer is filled")
         self.mocktime = int(time.time()) + 1
         for id in range(NUM_PEERS):
             peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
-            peers[-1].block_store = block_dict
+            peers[-1].block_store = self.block_dict
             peers[-1].send_message(headers_message)
 
-        # Need to wait until 1023 blocks are received - the magic total bytes number is a workaround in lack of an rpc
-        # returning the number of downloaded (but not connected) blocks.
-        bytes_recv = 172761 if not self.options.v2transport else 169692
-        self.wait_until(lambda: self.total_bytes_recv_for_blocks() == bytes_recv)
-
+        # Wait until all blocks are received (except for stall_block), so that no other blocks are in flight.
+        self.wait_until(lambda: sum(len(peer['inflight']) for peer in node.getpeerinfo()) == 1)
         self.all_sync_send_with_ping(peers)
         # If there was a peer marked for stalling, it would get disconnected
         self.mocktime += 3
@@ -92,7 +93,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         assert_equal(node.num_test_p2p_connections(), NUM_PEERS)
 
         self.log.info("Check that increasing the window beyond 1024 blocks triggers stalling logic")
-        headers_message.headers = [CBlockHeader(b) for b in blocks]
+        headers_message.headers = [CBlockHeader(b) for b in self.blocks]
         with node.assert_debug_log(expected_msgs=['Stall started']):
             for p in peers:
                 p.send_message(headers_message)
@@ -138,17 +139,10 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         with node.assert_debug_log(expected_msgs=['Decreased stalling timeout to 2 seconds']):
             for p in peers:
                 if p.is_connected and (stall_block in p.getdata_requests):
-                    p.send_message(msg_block(block_dict[stall_block]))
+                    p.send_message(msg_block(self.block_dict[stall_block]))
 
         self.log.info("Check that all outstanding blocks get connected")
-        self.wait_until(lambda: node.getblockcount() == NUM_BLOCKS)
-
-    def total_bytes_recv_for_blocks(self):
-        total = 0
-        for info in self.nodes[0].getpeerinfo():
-            if ("block" in info["bytesrecv_per_msg"].keys()):
-                total += info["bytesrecv_per_msg"]["block"]
-        return total
+        self.wait_until(lambda: node.getblockcount() == self.NUM_BLOCKS)
 
     def all_sync_send_with_ping(self, peers):
         for p in peers:
@@ -160,6 +154,10 @@ class P2PIBDStallingTest(BitcoinTestFramework):
             if p.is_connected and (hash in p.getdata_requests):
                 return True
         return False
+
+    def run_test(self):
+        self.prepare_blocks()
+        self.ibd_stalling()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem:**
For stalling at the tip, we have a parallel download mechanism for compact blocks that was added in #27626.
For stalling during IBD, we have a lookahead window of 1024 blocks, and if that is exceeded, we disconnect the stalling peer.
However, if we are close to but not at the tip (<=1024 blocks), neither of these mechanisms apply. We can't do compact blocks yet, and the stalling mechanism doesn't work because the 1024 window cannot be exceeded.

As a result, we have to resort to `BLOCK_DOWNLOAD_TIMEOUT_BASE` which only disconnects a peer after 10 minutes (plus 5 minutes more for each additional peers we currently have blocks in flight). This is too long in my opinion, especially since peers get assigned up to 16 blocks (`MAX_BLOCKS_IN_TRANSIT_PER_PEER`) and could repeat this process to stall us even longer if they send us a block after 10 minutes.
This issue was observed in #29281 and https://github.com/bitcoin/bitcoin/issues/12291#issuecomment-1898517930 with broken peers that didn't send us blocks.

**Proposed solution:**
If we are 1024 or less blocks away from the tip and haven't requested or received a block from any peer for 30 seconds, add another peer to download the critical block from that would help us advance our tip. Add up to two additional peers this way.

**Other thoughts**
* I also considered the alternative of extending the existing stalling mechanism that disconnects instead of introducing parallel downloads. This could be potentially less wasteful, but we might be over-eager to disconnect peers when really close to the tip, plus this might lead to cycling through lots of peers in extreme situations where we have a very slow internet connection.
* The chosen timeout of 30 seconds could lead to inefficiencies / bandwidth waste when we have a really slow internet connection. Maybe it could make sense to track the last successful download times from existing peers and use a dynamic timeout according to that statistics, instead of setting it to a fixed value. 
* I will leave this PR in draft until I have tested it a bit more in the wild.

Fixes #29281