### PR TITLE
build, depends: Fix `libmultiprocess` cross-compilation

### DIFF
--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -20,7 +20,7 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE)
+  $(MAKE) multiprocess
 endef
 
 define $(package)_stage_cmds


### PR DESCRIPTION
On the master branch @ 3b12fc7bcd94cf214984911f68612feb468d5404, the following command fails:
```
$ make -C depends libmultiprocess HOST=arm64-apple-darwin MULTIPROCESS=1
...
[100%] Linking CXX executable mpgen
...
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
...
```

This PR prevents building all default targets that include `mpgen`, which expectedly fails to link when cross-compiling.