### PR TITLE
guix: use GCC 11 in macOS build env

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -61,7 +61,6 @@ store_path() {
 # Set environment variables to point the NATIVE toolchain to the right
 # includes/libs
 NATIVE_GCC="$(store_path gcc-toolchain)"
-NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
 
 unset LIBRARY_PATH
 unset CPATH
@@ -70,11 +69,20 @@ unset CPLUS_INCLUDE_PATH
 unset OBJC_INCLUDE_PATH
 unset OBJCPLUS_INCLUDE_PATH
 
-export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"
 export C_INCLUDE_PATH="${NATIVE_GCC}/include"
 export CPLUS_INCLUDE_PATH="${NATIVE_GCC}/include/c++:${NATIVE_GCC}/include"
 export OBJC_INCLUDE_PATH="${NATIVE_GCC}/include"
 export OBJCPLUS_INCLUDE_PATH="${NATIVE_GCC}/include/c++:${NATIVE_GCC}/include"
+
+case "$HOST" in
+    *darwin*)
+        export LIBRARY_PATH="${NATIVE_GCC}/lib"
+        ;;
+    *)
+        NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
+        export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"
+        ;;
+esac
 
 # Set environment variables to point the CROSS toolchain to the right
 # includes/libs for $HOST

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -527,9 +527,8 @@ inspecting signatures in Mach-O binaries.")
                  (list gcc-toolchain-12 "static")
                  (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list ;; Native GCC 10 toolchain
-                 gcc-toolchain-10
-                 (list gcc-toolchain-10 "static")
+           (list ;; Native GCC 11 toolchain
+                 gcc-toolchain-11
                  binutils
                  clang-toolchain-17
                  cmake-minimal


### PR DESCRIPTION
Note that this is just the native compiler, which is used to build the toolchain we use to build the actual binaries.

Partially motivated by #29091, where it could now be a bit confusing if we are explicitly using GCC 10 in our release toolchain, when our minimum required is 11 (this can't be bumped to 12 due to build issues with native tools).

At the same time, remove `gcc-toolchain "static"` from the macOS build env.