### PR TITLE
wallet: Be able to receive and spend inputs involving MuSig2 aggregate keys

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -383,6 +383,95 @@ std::vector<uint8_t> CKey::CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uin
     return out;
 }
 
+std::optional<uint256> CKey::CreateMuSig2PartialSig(const uint256& sighash, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, MuSig2SecNonce& secnonce, const std::vector<std::pair<uint256, bool>>& tweaks)
+{
+    secp256k1_keypair keypair;
+    if (!secp256k1_keypair_create(secp256k1_context_sign, &keypair, UCharCast(begin()))) return std::nullopt;
+
+    // Get the keyagg cache and aggregate pubkey
+    secp256k1_musig_keyagg_cache keyagg_cache;
+    if (!MuSig2AggregatePubkeys(pubkeys, keyagg_cache, aggregate_pubkey)) return std::nullopt;
+
+    // Check that there are enough pubnonces
+    if (pubnonces.size() != pubkeys.size()) return std::nullopt;
+
+    // Parse the pubnonces
+    std::vector<std::pair<secp256k1_pubkey, secp256k1_musig_pubnonce>> signers_data;
+    std::vector<const secp256k1_musig_pubnonce*> pubnonce_ptrs;
+    std::optional<size_t> our_pubkey_idx;
+    CPubKey our_pubkey = GetPubKey();
+    for (const CPubKey& part_pk : pubkeys) {
+        const auto& pn_it = pubnonces.find(part_pk);
+        if (pn_it == pubnonces.end()) return std::nullopt;
+        const std::vector<uint8_t> pubnonce = pn_it->second;
+        if (pubnonce.size() != MUSIG2_PUBNONCE_SIZE) return std::nullopt;
+        if (part_pk == our_pubkey) {
+            our_pubkey_idx = signers_data.size();
+        }
+
+        auto& [secp_pk, secp_pn] = signers_data.emplace_back();
+
+        if (!secp256k1_ec_pubkey_parse(secp256k1_context_static, &secp_pk, part_pk.data(), part_pk.size())) {
+            return std::nullopt;
+        }
+
+        if (!secp256k1_musig_pubnonce_parse(secp256k1_context_static, &secp_pn, pubnonce.data())) {
+            return std::nullopt;
+        }
+    }
+    if (our_pubkey_idx == std::nullopt) {
+        return std::nullopt;
+    }
+    pubnonce_ptrs.reserve(signers_data.size());
+    for (auto& [_, pn] : signers_data) {
+        pubnonce_ptrs.push_back(&pn);
+    }
+
+    // Aggregate nonces
+    secp256k1_musig_aggnonce aggnonce;
+    if (!secp256k1_musig_nonce_agg(secp256k1_context_static, &aggnonce, pubnonce_ptrs.data(), pubnonce_ptrs.size())) {
+        return std::nullopt;
+    }
+
+    // Apply tweaks
+    for (const auto& [tweak, xonly] : tweaks) {
+        if (xonly) {
+            if (!secp256k1_musig_pubkey_xonly_tweak_add(secp256k1_context_static, nullptr, &keyagg_cache, tweak.data())) {
+                return std::nullopt;
+            }
+        } else if (!secp256k1_musig_pubkey_ec_tweak_add(secp256k1_context_static, nullptr, &keyagg_cache, tweak.data())) {
+            return std::nullopt;
+        }
+    }
+
+    // Create musig_session
+    secp256k1_musig_session session;
+    if (!secp256k1_musig_nonce_process(secp256k1_context_static, &session, &aggnonce, sighash.data(), &keyagg_cache)) {
+        return std::nullopt;
+    }
+
+    // Create partial signature
+    secp256k1_musig_partial_sig psig;
+    if (!secp256k1_musig_partial_sign(secp256k1_context_static, &psig, secnonce.Get(), &keypair, &keyagg_cache, &session)) {
+        return std::nullopt;
+    }
+    // The secnonce must be deleted after signing to prevent nonce reuse.
+    secnonce.Invalidate();
+
+    // Verify partial signature
+    if (!secp256k1_musig_partial_sig_verify(secp256k1_context_static, &psig, &(signers_data.at(*our_pubkey_idx).second), &(signers_data.at(*our_pubkey_idx).first), &keyagg_cache, &session)) {
+        return std::nullopt;
+    }
+
+    // Serialize
+    uint256 sig;
+    if (!secp256k1_musig_partial_sig_serialize(secp256k1_context_static, sig.data(), &psig)) {
+        return std::nullopt;
+    }
+
+    return sig;
+}
+
 CKey GenerateRandomKey(bool compressed) noexcept
 {
     CKey key;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -13,6 +13,7 @@
 #include <secp256k1.h>
 #include <secp256k1_ellswift.h>
 #include <secp256k1_extrakeys.h>
+#include <secp256k1_musig.h>
 #include <secp256k1_recovery.h>
 #include <secp256k1_schnorrsig.h>
 
@@ -347,6 +348,39 @@ ECDHSecret CKey::ComputeBIP324ECDHSecret(const EllSwiftPubKey& their_ellswift, c
 KeyPair CKey::ComputeKeyPair(const uint256* merkle_root) const
 {
     return KeyPair(*this, merkle_root);
+}
+
+std::vector<uint8_t> CKey::CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys)
+{
+    // Get the keyagg cache and aggregate pubkey
+    secp256k1_musig_keyagg_cache keyagg_cache;
+    if (!MuSig2AggregatePubkeys(pubkeys, keyagg_cache, aggregate_pubkey)) return {};
+
+    // Parse participant pubkey
+    CPubKey our_pubkey = GetPubKey();
+    secp256k1_pubkey pubkey;
+    if (!secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, our_pubkey.data(), our_pubkey.size())) {
+        return {};
+    }
+
+    // Generate randomness for nonce
+    uint256 rand;
+    GetStrongRandBytes(rand);
+
+    // Generate nonce
+    secp256k1_musig_pubnonce pubnonce;
+    if (!secp256k1_musig_nonce_gen(secp256k1_context_sign, secnonce.Get(), &pubnonce, rand.data(), UCharCast(begin()), &pubkey, sighash.data(), &keyagg_cache, nullptr)) {
+        return {};
+    }
+
+    // Serialize pubnonce
+    std::vector<uint8_t> out;
+    out.resize(MUSIG2_PUBNONCE_SIZE);
+    if (!secp256k1_musig_pubnonce_serialize(secp256k1_context_static, out.data(), &pubnonce)) {
+        return {};
+    }
+
+    return out;
 }
 
 CKey GenerateRandomKey(bool compressed) noexcept

--- a/src/key.h
+++ b/src/key.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_KEY_H
 #define BITCOIN_KEY_H
 
+#include <musig.h>
 #include <pubkey.h>
 #include <serialize.h>
 #include <support/allocators/secure.h>
@@ -220,6 +221,8 @@ public:
      *                               Merkle root of the script tree).
      */
     KeyPair ComputeKeyPair(const uint256* merkle_root) const;
+
+    std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
 };
 
 CKey GenerateRandomKey(bool compressed = true) noexcept;

--- a/src/key.h
+++ b/src/key.h
@@ -223,6 +223,7 @@ public:
     KeyPair ComputeKeyPair(const uint256* merkle_root) const;
 
     std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
+    std::optional<uint256> CreateMuSig2PartialSig(const uint256& hash, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, MuSig2SecNonce& secnonce, const std::vector<std::pair<uint256, bool>>& tweaks);
 };
 
 CKey GenerateRandomKey(bool compressed = true) noexcept;

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -111,3 +111,10 @@ bool MuSig2SecNonce::IsValid()
 {
     return m_impl->IsValid();
 }
+
+uint256 MuSig2SessionID(const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256& sighash)
+{
+    HashWriter hasher;
+    hasher << script_pubkey << part_pubkey << sighash;
+    return hasher.GetSHA256();
+}

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -51,3 +51,14 @@ std::optional<CPubKey> MuSig2AggregatePubkeys(const std::vector<CPubKey>& pubkey
     }
     return GetCPubKeyFromMuSig2KeyAggCache(keyagg_cache);
 }
+
+CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey)
+{
+    CExtPubKey extpub;
+    extpub.nDepth = 0;
+    std::memset(extpub.vchFingerprint, 0, 4);
+    extpub.nChild = 0;
+    extpub.chaincode = MUSIG_CHAINCODE;
+    extpub.pubkey = pubkey;
+    return extpub;
+}

--- a/src/musig.h
+++ b/src/musig.h
@@ -62,4 +62,6 @@ public:
 
 uint256 MuSig2SessionID(const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256& sighash);
 
+std::optional<std::vector<uint8_t>> CreateMuSig2AggregateSig(const std::vector<CPubKey>& participants, const CPubKey& aggregate_pubkey, const std::vector<std::pair<uint256, bool>>& tweaks, const uint256& sighash, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, const std::map<CPubKey, uint256>& partial_sigs);
+
 #endif // BITCOIN_MUSIG_H

--- a/src/musig.h
+++ b/src/musig.h
@@ -23,4 +23,7 @@ std::optional<CPubKey> GetCPubKeyFromMuSig2KeyAggCache(secp256k1_musig_keyagg_ca
 //! Compute the full aggregate pubkey from the given participant pubkeys in their current order
 std::optional<CPubKey> MuSig2AggregatePubkeys(const std::vector<CPubKey>& pubkeys);
 
+//! Construct the BIP 328 synthetic xpub for a pubkey
+CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey);
+
 #endif // BITCOIN_MUSIG_H

--- a/src/musig.h
+++ b/src/musig.h
@@ -18,11 +18,10 @@ struct secp256k1_musig_secnonce;
 using namespace util::hex_literals;
 constexpr uint256 MUSIG_CHAINCODE{"868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"_hex_u8};
 
-//! Create a secp256k1_musig_keyagg_cache from the pubkeys in their current order. This is necessary for most MuSig2 operations
-bool GetMuSig2KeyAggCache(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache);
-//! Retrieve the full aggregate pubkey from the secp256k1_musig_keyagg_cache
-std::optional<CPubKey> GetCPubKeyFromMuSig2KeyAggCache(secp256k1_musig_keyagg_cache& cache);
-//! Compute the full aggregate pubkey from the given participant pubkeys in their current order
+//! Compute the full aggregate pubkey from the given participant pubkeys in their current order.
+//! Outputs the secp256k1_musig_keyagg_cache and validates that the computed aggregate pubkey matches an expected aggregate pubkey.
+//! This is necessary for most MuSig2 operations.
+std::optional<CPubKey> MuSig2AggregatePubkeys(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache, const std::optional<CPubKey>& expected_aggregate);
 std::optional<CPubKey> MuSig2AggregatePubkeys(const std::vector<CPubKey>& pubkeys);
 
 //! Construct the BIP 328 synthetic xpub for a pubkey

--- a/src/musig.h
+++ b/src/musig.h
@@ -11,6 +11,8 @@
 #include <vector>
 
 struct secp256k1_musig_keyagg_cache;
+class MuSig2SecNonceImpl;
+struct secp256k1_musig_secnonce;
 
 //! MuSig2 chaincode as defined by BIP 328
 using namespace util::hex_literals;
@@ -25,5 +27,36 @@ std::optional<CPubKey> MuSig2AggregatePubkeys(const std::vector<CPubKey>& pubkey
 
 //! Construct the BIP 328 synthetic xpub for a pubkey
 CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey);
+
+/**
+ * MuSig2SecNonce encapsulates a secret nonce in use in a MuSig2 signing session.
+ * Since this nonce persists outside of libsecp256k1 signing code, we must handle
+ * its construction and destruction ourselves.
+ * The secret nonce must be kept a secret, otherwise the private key may be leaked.
+ * As such, it needs to be treated in the same way that CKeys are treated.
+ * So this class handles the secure allocation of the secp256k1_musig_secnonce object
+ * that libsecp256k1 uses, and only gives out references to this object to avoid
+ * any possibility of copies being made. Furthermore, objects of this class are not
+ * copyable to avoid nonce reuse.
+*/
+class MuSig2SecNonce
+{
+private:
+    std::unique_ptr<MuSig2SecNonceImpl> m_impl;
+
+public:
+    MuSig2SecNonce();
+    MuSig2SecNonce(MuSig2SecNonce&&) noexcept;
+    MuSig2SecNonce& operator=(MuSig2SecNonce&&) noexcept;
+    ~MuSig2SecNonce();
+
+    // Delete copy constructors
+    MuSig2SecNonce(const MuSig2SecNonce&) = delete;
+    MuSig2SecNonce& operator=(const MuSig2SecNonce&) = delete;
+
+    secp256k1_musig_secnonce* Get() const;
+    void Invalidate();
+    bool IsValid();
+};
 
 #endif // BITCOIN_MUSIG_H

--- a/src/musig.h
+++ b/src/musig.h
@@ -18,6 +18,8 @@ struct secp256k1_musig_secnonce;
 using namespace util::hex_literals;
 constexpr uint256 MUSIG_CHAINCODE{"868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"_hex_u8};
 
+constexpr size_t MUSIG2_PUBNONCE_SIZE{66};
+
 //! Compute the full aggregate pubkey from the given participant pubkeys in their current order.
 //! Outputs the secp256k1_musig_keyagg_cache and validates that the computed aggregate pubkey matches an expected aggregate pubkey.
 //! This is necessary for most MuSig2 operations.
@@ -57,5 +59,7 @@ public:
     void Invalidate();
     bool IsValid();
 };
+
+uint256 MuSig2SessionID(const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256& sighash);
 
 #endif // BITCOIN_MUSIG_H

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -149,6 +149,13 @@ void PSBTInput::FillSignatureData(SignatureData& sigdata) const
     for (const auto& [hash, preimage] : hash256_preimages) {
         sigdata.hash256_preimages.emplace(std::vector<unsigned char>(hash.begin(), hash.end()), preimage);
     }
+    sigdata.musig2_pubkeys.insert(m_musig2_participants.begin(), m_musig2_participants.end());
+    for (const auto& [agg_key_lh, pubnonces] : m_musig2_pubnonces) {
+        sigdata.musig2_pubnonces[agg_key_lh].insert(pubnonces.begin(), pubnonces.end());
+    }
+    for (const auto& [agg_key_lh, psigs] : m_musig2_partial_sigs) {
+        sigdata.musig2_partial_sigs[agg_key_lh].insert(psigs.begin(), psigs.end());
+    }
 }
 
 void PSBTInput::FromSignatureData(const SignatureData& sigdata)
@@ -196,6 +203,13 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
     for (const auto& [pubkey, leaf_origin] : sigdata.taproot_misc_pubkeys) {
         m_tap_bip32_paths.emplace(pubkey, leaf_origin);
     }
+    m_musig2_participants.insert(sigdata.musig2_pubkeys.begin(), sigdata.musig2_pubkeys.end());
+    for (const auto& [agg_key_lh, pubnonces] : sigdata.musig2_pubnonces) {
+        m_musig2_pubnonces[agg_key_lh].insert(pubnonces.begin(), pubnonces.end());
+    }
+    for (const auto& [agg_key_lh, psigs] : sigdata.musig2_partial_sigs) {
+        m_musig2_partial_sigs[agg_key_lh].insert(psigs.begin(), psigs.end());
+    }
 }
 
 void PSBTInput::Merge(const PSBTInput& input)
@@ -223,6 +237,13 @@ void PSBTInput::Merge(const PSBTInput& input)
     if (m_tap_key_sig.empty() && !input.m_tap_key_sig.empty()) m_tap_key_sig = input.m_tap_key_sig;
     if (m_tap_internal_key.IsNull() && !input.m_tap_internal_key.IsNull()) m_tap_internal_key = input.m_tap_internal_key;
     if (m_tap_merkle_root.IsNull() && !input.m_tap_merkle_root.IsNull()) m_tap_merkle_root = input.m_tap_merkle_root;
+    m_musig2_participants.insert(input.m_musig2_participants.begin(), input.m_musig2_participants.end());
+    for (const auto& [agg_key_lh, pubnonces] : input.m_musig2_pubnonces) {
+        m_musig2_pubnonces[agg_key_lh].insert(pubnonces.begin(), pubnonces.end());
+    }
+    for (const auto& [agg_key_lh, psigs] : input.m_musig2_partial_sigs) {
+        m_musig2_partial_sigs[agg_key_lh].insert(psigs.begin(), psigs.end());
+    }
 }
 
 void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
@@ -252,6 +273,7 @@ void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
         sigdata.taproot_misc_pubkeys.emplace(pubkey, leaf_origin);
         sigdata.tap_pubkeys.emplace(Hash160(pubkey), pubkey);
     }
+    sigdata.musig2_pubkeys.insert(m_musig2_participants.begin(), m_musig2_participants.end());
 }
 
 void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
@@ -274,6 +296,7 @@ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
     for (const auto& [pubkey, leaf_origin] : sigdata.taproot_misc_pubkeys) {
         m_tap_bip32_paths.emplace(pubkey, leaf_origin);
     }
+    m_musig2_participants.insert(sigdata.musig2_pubkeys.begin(), sigdata.musig2_pubkeys.end());
 }
 
 bool PSBTOutput::IsNull() const
@@ -291,6 +314,7 @@ void PSBTOutput::Merge(const PSBTOutput& output)
     if (witness_script.empty() && !output.witness_script.empty()) witness_script = output.witness_script;
     if (m_tap_internal_key.IsNull() && !output.m_tap_internal_key.IsNull()) m_tap_internal_key = output.m_tap_internal_key;
     if (m_tap_tree.empty() && !output.m_tap_tree.empty()) m_tap_tree = output.m_tap_tree;
+    m_musig2_participants.insert(output.m_musig2_participants.begin(), output.m_musig2_participants.end());
 }
 
 bool PSBTInputSigned(const PSBTInput& input)

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -794,7 +794,7 @@ struct PSBTInput
 
                     std::vector<uint8_t> pubnonce;
                     s >> pubnonce;
-                    if (pubnonce.size() != 66) {
+                    if (pubnonce.size() != MUSIG2_PUBNONCE_SIZE) {
                         throw std::ios_base::failure("Input musig2 pubnonce value is not 66 bytes");
                     }
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -224,7 +224,7 @@ public:
     bool Decompress();
 
     //! Derive BIP32 child pubkey.
-    [[nodiscard]] bool Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;
+    [[nodiscard]] bool Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, uint256* bip32_tweak_out = nullptr) const;
 };
 
 class XOnlyPubKey
@@ -379,7 +379,7 @@ struct CExtPubKey {
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     void EncodeWithVersion(unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE]) const;
     void DecodeWithVersion(const unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE]);
-    [[nodiscard]] bool Derive(CExtPubKey& out, unsigned int nChild) const;
+    [[nodiscard]] bool Derive(CExtPubKey& out, unsigned int nChild, uint256* bip32_tweak_out = nullptr) const;
 };
 
 #endif // BITCOIN_PUBKEY_H

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1647,6 +1647,7 @@ std::optional<uint32_t> ParseKeyPathNum(std::span<const char> elem, bool& apostr
  * @param[out] apostrophe only updated if hardened derivation is found
  * @param[out] error parsing error message
  * @param[in] allow_multipath Allows the parsed path to use the multipath specifier
+ * @param[out] has_hardened Records whether the path contains any hardened derivation
  * @returns false if parsing failed
  **/
 [[nodiscard]] bool ParseKeyPath(const std::vector<std::span<const char>>& split, std::vector<KeyPath>& out, bool& apostrophe, std::string& error, bool allow_multipath, bool& has_hardened)

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -641,13 +641,7 @@ public:
             // Make our pubkey provider
             if (IsRangedDerivation() || !m_path.empty()) {
                 // Make the synthetic xpub and construct the BIP32PubkeyProvider
-                CExtPubKey extpub;
-                extpub.nDepth = 0;
-                std::memset(extpub.vchFingerprint, 0, 4);
-                extpub.nChild = 0;
-                extpub.chaincode = MUSIG_CHAINCODE;
-                extpub.pubkey = m_aggregate_pubkey.value();
-
+                CExtPubKey extpub = CreateMuSig2SyntheticXpub(m_aggregate_pubkey.value());
                 m_aggregate_provider = std::make_unique<BIP32PubkeyProvider>(m_expr_index, extpub, m_path, m_derive, /*apostrophe=*/false);
             } else {
                 m_aggregate_provider = std::make_unique<ConstPubkeyProvider>(m_expr_index, m_aggregate_pubkey.value(), /*xonly=*/false);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -355,11 +355,19 @@ static bool SignTaproot(const SigningProvider& provider, const BaseSignatureCrea
 
     // Try key path spending.
     {
-        KeyOriginInfo info;
-        if (provider.GetKeyOriginByXOnly(sigdata.tr_spenddata.internal_key, info)) {
+        KeyOriginInfo internal_key_info;
+        if (provider.GetKeyOriginByXOnly(sigdata.tr_spenddata.internal_key, internal_key_info)) {
             auto it = sigdata.taproot_misc_pubkeys.find(sigdata.tr_spenddata.internal_key);
             if (it == sigdata.taproot_misc_pubkeys.end()) {
-                sigdata.taproot_misc_pubkeys.emplace(sigdata.tr_spenddata.internal_key, std::make_pair(std::set<uint256>(), info));
+                sigdata.taproot_misc_pubkeys.emplace(sigdata.tr_spenddata.internal_key, std::make_pair(std::set<uint256>(), internal_key_info));
+            }
+        }
+
+        KeyOriginInfo output_key_info;
+        if (provider.GetKeyOriginByXOnly(output, output_key_info)) {
+            auto it = sigdata.taproot_misc_pubkeys.find(output);
+            if (it == sigdata.taproot_misc_pubkeys.end()) {
+                sigdata.taproot_misc_pubkeys.emplace(output, std::make_pair(std::set<uint256>(), output_key_info));
             }
         }
 

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -90,6 +90,12 @@ struct SignatureData {
     std::map<std::vector<uint8_t>, std::vector<uint8_t>> hash256_preimages; ///< Mapping from a HASH256 hash to its preimage provided to solve a Script
     std::map<std::vector<uint8_t>, std::vector<uint8_t>> ripemd160_preimages; ///< Mapping from a RIPEMD160 hash to its preimage provided to solve a Script
     std::map<std::vector<uint8_t>, std::vector<uint8_t>> hash160_preimages; ///< Mapping from a HASH160 hash to its preimage provided to solve a Script
+    //! Map MuSig2 aggregate pubkeys to its participants
+    std::map<CPubKey, std::vector<CPubKey>> musig2_pubkeys;
+    //! Mapping from pair of MuSig2 aggregate pubkey, and tapleaf hash to map of MuSig2 participant pubkeys to MuSig2 public nonce
+    std::map<std::pair<CPubKey, uint256>, std::map<CPubKey, std::vector<uint8_t>>> musig2_pubnonces;
+    //! Mapping from pair of MuSig2 aggregate pubkey, and tapleaf hash to map of MuSig2 participant pubkeys to MuSig2 partial signature
+    std::map<std::pair<CPubKey, uint256>, std::map<CPubKey, uint256>> musig2_partial_sigs;
 
     SignatureData() = default;
     explicit SignatureData(const CScript& script) : scriptSig(script) {}

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -35,6 +35,7 @@ public:
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
     virtual bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const =0;
     virtual std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const =0;
+    virtual bool CreateMuSig2PartialSig(const SigningProvider& provider, uint256& partial_sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const =0;
 };
 
 /** A signature creator for transactions. */
@@ -56,6 +57,7 @@ public:
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
     std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const override;
+    bool CreateMuSig2PartialSig(const SigningProvider& provider, uint256& partial_sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const override;
 };
 
 /** A signature checker that accepts all signatures */

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -36,6 +36,7 @@ public:
     virtual bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const =0;
     virtual std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const =0;
     virtual bool CreateMuSig2PartialSig(const SigningProvider& provider, uint256& partial_sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const =0;
+    virtual bool CreateMuSig2AggregateSig(const std::vector<CPubKey>& participants, std::vector<uint8_t>& sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const =0;
 };
 
 /** A signature creator for transactions. */
@@ -58,6 +59,7 @@ public:
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
     std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const override;
     bool CreateMuSig2PartialSig(const SigningProvider& provider, uint256& partial_sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const override;
+    bool CreateMuSig2AggregateSig(const std::vector<CPubKey>& participants, std::vector<uint8_t>& sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const override;
 };
 
 /** A signature checker that accepts all signatures */

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -45,6 +45,8 @@ class MutableTransactionSignatureCreator : public BaseSignatureCreator
     const MutableTransactionSignatureChecker checker;
     const PrecomputedTransactionData* m_txdata;
 
+    std::optional<uint256> ComputeSchnorrSignatureHash(const uint256* leaf_hash, SigVersion sigversion) const;
+
 public:
     MutableTransactionSignatureCreator(const CMutableTransaction& tx LIFETIMEBOUND, unsigned int input_idx, const CAmount& amount, int hash_type);
     MutableTransactionSignatureCreator(const CMutableTransaction& tx LIFETIMEBOUND, unsigned int input_idx, const CAmount& amount, const PrecomputedTransactionData* txdata, int hash_type);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -80,7 +80,7 @@ struct SignatureData {
     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> misc_pubkeys;
     std::vector<unsigned char> taproot_key_path_sig; /// Schnorr signature for key path spending
     std::map<std::pair<XOnlyPubKey, uint256>, std::vector<unsigned char>> taproot_script_sigs; ///< (Partial) schnorr signatures, indexed by XOnlyPubKey and leaf_hash.
-    std::map<XOnlyPubKey, std::pair<std::set<uint256>, KeyOriginInfo>> taproot_misc_pubkeys; ///< Miscellaneous Taproot pubkeys involved in this input along with their leaf script hashes and key origin data. Also includes the Taproot internal key (may have no leaf script hashes).
+    std::map<XOnlyPubKey, std::pair<std::set<uint256>, KeyOriginInfo>> taproot_misc_pubkeys; ///< Miscellaneous Taproot pubkeys involved in this input along with their leaf script hashes and key origin data. Also includes the Taproot internal and output keys (may have no leaf script hashes).
     std::map<CKeyID, XOnlyPubKey> tap_pubkeys; ///< Misc Taproot pubkeys involved in this input, by hash. (Equivalent of misc_pubkeys but for Taproot.)
     std::vector<CKeyID> missing_pubkeys; ///< KeyIDs of pubkeys which could not be found
     std::vector<CKeyID> missing_sigs; ///< KeyIDs of pubkeys for signatures which could not be found

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -23,6 +23,7 @@ class SigningProvider;
 
 struct bilingual_str;
 struct CMutableTransaction;
+struct SignatureData;
 
 /** Interface for signature creators. */
 class BaseSignatureCreator {
@@ -33,6 +34,7 @@ public:
     /** Create a singular (non-script) signature. */
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
     virtual bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const =0;
+    virtual std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const =0;
 };
 
 /** A signature creator for transactions. */
@@ -53,6 +55,7 @@ public:
     const BaseSignatureChecker& Checker() const override { return checker; }
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
+    std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const override;
 };
 
 /** A signature checker that accepts all signatures */

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -58,6 +58,11 @@ std::vector<CPubKey> HidingSigningProvider::GetMuSig2ParticipantPubkeys(const CP
     return m_provider->GetMuSig2ParticipantPubkeys(pubkey);
 }
 
+std::map<CPubKey, std::vector<CPubKey>> HidingSigningProvider::GetAllMuSig2ParticipantPubkeys() const
+{
+    return m_provider->GetAllMuSig2ParticipantPubkeys();
+}
+
 void HidingSigningProvider::SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const
 {
     m_provider->SetMuSig2SecNonce(id, std::move(nonce));
@@ -107,6 +112,11 @@ std::vector<CPubKey> FlatSigningProvider::GetMuSig2ParticipantPubkeys(const CPub
     std::vector<CPubKey> participant_pubkeys;
     LookupHelper(aggregate_pubkeys, pubkey, participant_pubkeys);
     return participant_pubkeys;
+}
+
+std::map<CPubKey, std::vector<CPubKey>> FlatSigningProvider::GetAllMuSig2ParticipantPubkeys() const
+{
+    return aggregate_pubkeys;
 }
 
 void FlatSigningProvider::SetMuSig2SecNonce(const uint256& session_id, MuSig2SecNonce&& nonce) const

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -166,6 +166,7 @@ public:
     virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
     virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
     virtual std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const { return {}; }
+    virtual std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const {return {}; }
     virtual void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const {}
     virtual std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const { return std::nullopt; }
     virtual void DeleteMuSig2Session(const uint256& session_id) const {}
@@ -213,6 +214,7 @@ public:
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
+    std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
     void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
     std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
     void DeleteMuSig2Session(const uint256& session_id) const override;
@@ -236,6 +238,7 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
+    std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
     void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
     std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
     void DeleteMuSig2Session(const uint256& session_id) const override;

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -9,10 +9,14 @@
 #include <addresstype.h>
 #include <attributes.h>
 #include <key.h>
+#include <musig.h>
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <script/script.h>
 #include <sync.h>
+
+#include <functional>
+#include <optional>
 
 struct ShortestVectorFirstComparator
 {
@@ -162,6 +166,9 @@ public:
     virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
     virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
     virtual std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const { return {}; }
+    virtual void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const {}
+    virtual std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const { return std::nullopt; }
+    virtual void DeleteMuSig2Session(const uint256& session_id) const {}
 
     bool GetKeyByXOnly(const XOnlyPubKey& pubkey, CKey& key) const
     {
@@ -206,6 +213,9 @@ public:
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
+    void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
+    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
+    void DeleteMuSig2Session(const uint256& session_id) const override;
 };
 
 struct FlatSigningProvider final : public SigningProvider
@@ -216,6 +226,7 @@ struct FlatSigningProvider final : public SigningProvider
     std::map<CKeyID, CKey> keys;
     std::map<XOnlyPubKey, TaprootBuilder> tr_trees; /** Map from output key to Taproot tree (which can then make the TaprootSpendData */
     std::map<CPubKey, std::vector<CPubKey>> aggregate_pubkeys; /** MuSig2 aggregate pubkeys */
+    std::map<uint256, MuSig2SecNonce>* musig2_secnonces{nullptr};
 
     bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
@@ -225,6 +236,9 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
+    void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
+    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
+    void DeleteMuSig2Session(const uint256& session_id) const override;
 
     FlatSigningProvider& Merge(FlatSigningProvider&& b) LIFETIMEBOUND;
 };

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -52,7 +52,7 @@ constexpr int XONLY_KEYS = 1 << 6; // X-only pubkeys are in use (and thus inferr
 constexpr int MISSING_PRIVKEYS = 1 << 7; // Not all private keys are available, so ToPrivateString will fail.
 constexpr int SIGNABLE_FAILS = 1 << 8; // We can sign with this descriptor, but actually trying to sign will fail
 constexpr int MUSIG = 1 << 9; // This is a MuSig so key counts will have an extra key
-constexpr int MUSIG_DERIVATION = 1 << 10; // MuSig with derivation from the aggregate key
+constexpr int MUSIG_DERIVATION = 1 << 10; // MuSig with BIP 328 derivation from the aggregate key
 constexpr int MIXED_MUSIG = 1 << 11; // Both MuSig and normal key expressions are present
 constexpr int UNIQUE_XPUBS = 1 << 12; // Whether the xpub count should be of unique xpubs
 
@@ -315,6 +315,7 @@ void DoCheck(std::string prv, std::string pub, const std::string& norm_pub, int 
             size_t num_xpubs = CountXpubs(pub1);
             size_t num_unique_xpubs = CountUniqueXpubs(pub1);
             if (flags & MUSIG_DERIVATION) {
+                // Deriving from the aggregate will include the synthetic xpub of the aggregate in the caches and SigningProviders.
                 num_xpubs++;
                 num_unique_xpubs++;
             }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1256,6 +1256,10 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
         FlatSigningProvider master_provider;
         master_provider.keys = GetKeys();
         m_wallet_descriptor.descriptor->ExpandPrivate(index, master_provider, *out_keys);
+
+        // Always include musig_secnonces as this descriptor may have a participant private key
+        // but not a musig() descriptor
+        out_keys->musig2_secnonces = &m_musig2_secnonces;
     }
 
     return out_keys;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -10,6 +10,7 @@
 #include <common/signmessage.h>
 #include <common/types.h>
 #include <logging.h>
+#include <musig.h>
 #include <node/types.h>
 #include <psbt.h>
 #include <script/descriptor.h>
@@ -294,6 +295,19 @@ private:
 
     //! Number of pre-generated keys/scripts (part of the look-ahead process, used to detect payments)
     int64_t m_keypool_size GUARDED_BY(cs_desc_man){DEFAULT_KEYPOOL_SIZE};
+
+    /** Map of a session id to MuSig2 secnonce
+     *
+     * Stores MuSig2 secnonces while the MuSig2 signing session is still ongoing.
+     * Note that these secnonces must not be reused. In order to avoid being tricked into
+     * reusing a nonce, this map is held only in memory and must not be written to disk.
+     * The side effect is that signing sessions cannot persist across restarts, but this
+     * must be done in order to prevent nonce reuse.
+     *
+     * The session id is an arbitrary value set by the signer in order for the signing logic
+     * to find ongoing signing sessions. It is the SHA256 of aggregate xonly key, + participant pubkey + sighash.
+     */
+    mutable std::map<uint256, MuSig2SecNonce> m_musig2_secnonces;
 
     bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -342,6 +342,7 @@ BASE_SCRIPTS = [
     'mempool_datacarrier.py',
     'feature_coinstatsindex.py',
     'wallet_orphanedreward.py',
+    'wallet_musig.py',
     'wallet_timelock.py',
     'p2p_permissions.py',
     'feature_blocksdir.py',

--- a/test/functional/wallet_musig.py
+++ b/test/functional/wallet_musig.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+
+from test_framework.descriptors import descsum_create
+from test_framework.key import H_POINT
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+)
+
+PRIVKEY_RE = re.compile(r"^tr\((.+?)/.+\)#.{8}$")
+PUBKEY_RE = re.compile(r"^tr\((\[.+?\].+?)/.+\)#.{8}$")
+ORIGIN_PATH_RE = re.compile(r"^\[\w{8}(/.*)\].*$")
+MULTIPATH_TWO_RE = re.compile(r"<(\d+);(\d+)>")
+MUSIG_RE = re.compile(r"musig\((.*?)\)")
+PLACEHOLDER_RE = re.compile(r"\$\d")
+
+class WalletMuSigTest(BitcoinTestFramework):
+    WALLET_NUM = 0
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def do_test(self, comment, pattern, sighash_type=None, scriptpath=False, nosign_wallets=None, only_one_musig_wallet=False):
+        self.log.info(f"Testing {comment}")
+        has_internal = MULTIPATH_TWO_RE.search(pattern) is not None
+
+        wallets = []
+        keys = []
+
+        pat = pattern.replace("$H", H_POINT)
+
+        # Figure out how many wallets are needed and create them
+        expected_pubnonces = 0
+        expected_partial_sigs = 0
+        for musig in MUSIG_RE.findall(pat):
+            musig_partial_sigs = 0
+            for placeholder in PLACEHOLDER_RE.findall(musig):
+                wallet_index = int(placeholder[1:])
+                if nosign_wallets is None or wallet_index not in nosign_wallets:
+                    expected_pubnonces += 1
+                else:
+                    musig_partial_sigs = None
+                if musig_partial_sigs is not None:
+                    musig_partial_sigs += 1
+                if wallet_index < len(wallets):
+                    continue
+                wallet_name = f"musig_{self.WALLET_NUM}"
+                self.WALLET_NUM += 1
+                self.nodes[0].createwallet(wallet_name)
+                wallet = self.nodes[0].get_wallet_rpc(wallet_name)
+                wallets.append(wallet)
+
+                for priv_desc in wallet.listdescriptors(True)["descriptors"]:
+                    desc = priv_desc["desc"]
+                    if not desc.startswith("tr("):
+                        continue
+                    privkey = PRIVKEY_RE.search(desc).group(1)
+                    break
+                for pub_desc in wallet.listdescriptors()["descriptors"]:
+                    desc = pub_desc["desc"]
+                    if not desc.startswith("tr("):
+                        continue
+                    pubkey = PUBKEY_RE.search(desc).group(1)
+                    # Since the pubkey is derived from the private key that we have, we need
+                    # to extract and insert the origin path from the pubkey as well.
+                    privkey += ORIGIN_PATH_RE.search(pubkey).group(1)
+                    break
+                keys.append((privkey, pubkey))
+            if musig_partial_sigs is not None:
+                expected_partial_sigs += musig_partial_sigs
+
+        # Construct and import each wallet's musig descriptor that
+        # contains the private key from that wallet and pubkeys of the others
+        for i, wallet in enumerate(wallets):
+            if only_one_musig_wallet and i > 0:
+                continue
+            desc = pat
+            import_descs = []
+            for j, (priv, pub) in enumerate(keys):
+                if j == i:
+                    desc = desc.replace(f"${i}", priv)
+                else:
+                    desc = desc.replace(f"${j}", pub)
+
+            import_descs.append({
+                "desc": descsum_create(desc),
+                "active": True,
+                "timestamp": "now",
+            })
+
+            res = wallet.importdescriptors(import_descs)
+            for r in res:
+                assert_equal(r["success"], True)
+
+        # Check that the wallets agree on the same musig address
+        addr = None
+        change_addr = None
+        for i, wallet in enumerate(wallets):
+            if only_one_musig_wallet and i > 0:
+                continue
+            if addr is None:
+                addr = wallet.getnewaddress(address_type="bech32m")
+            else:
+                assert_equal(addr, wallet.getnewaddress(address_type="bech32m"))
+            if has_internal:
+                if change_addr is None:
+                    change_addr = wallet.getrawchangeaddress(address_type="bech32m")
+                else:
+                    assert_equal(change_addr, wallet.getrawchangeaddress(address_type="bech32m"))
+
+        # Fund that address
+        self.def_wallet.sendtoaddress(addr, 10)
+        self.generate(self.nodes[0], 1)
+
+        # Spend that UTXO
+        utxo = None
+        for i, wallet in enumerate(wallets):
+            if only_one_musig_wallet and i > 0:
+                continue
+            if utxo is None:
+                utxo = wallet.listunspent()[0]
+            else:
+                assert_equal(utxo, wallet.listunspent()[0])
+        psbt = wallets[0].walletcreatefundedpsbt(outputs=[{self.def_wallet.getnewaddress(): 5}], inputs=[utxo], change_type="bech32m", changePosition=1)["psbt"]
+
+        dec_psbt = self.nodes[0].decodepsbt(psbt)
+        assert_equal(len(dec_psbt["inputs"]), 1)
+        assert_equal(len(dec_psbt["inputs"][0]["musig2_participant_pubkeys"]), pattern.count("musig("))
+        if has_internal:
+            assert_equal(len(dec_psbt["outputs"][1]["musig2_participant_pubkeys"]), pattern.count("musig("))
+
+        # Check all participant pubkeys in the input and change output
+        psbt_maps = [dec_psbt["inputs"][0]]
+        if has_internal:
+            psbt_maps.append(dec_psbt["outputs"][1])
+        for psbt_map in psbt_maps:
+            part_pks = set()
+            for agg in psbt_map["musig2_participant_pubkeys"]:
+                for part_pub in agg["participant_pubkeys"]:
+                    part_pks.add(part_pub[2:])
+            # Check that there are as many participants as we expected
+            assert_equal(len(part_pks), len(keys))
+            # Check that each participant has a derivation path
+            for deriv_path in psbt_map["taproot_bip32_derivs"]:
+                if deriv_path["pubkey"] in part_pks:
+                    part_pks.remove(deriv_path["pubkey"])
+            assert_equal(len(part_pks), 0)
+
+        # Add pubnonces
+        nonce_psbts = []
+        for i, wallet in enumerate(wallets):
+            if nosign_wallets and i in nosign_wallets:
+                continue
+            proc = wallet.walletprocesspsbt(psbt=psbt, sighashtype=sighash_type)
+            assert_equal(proc["complete"], False)
+            nonce_psbts.append(proc["psbt"])
+
+        comb_nonce_psbt = self.nodes[0].combinepsbt(nonce_psbts)
+
+        dec_psbt = self.nodes[0].decodepsbt(comb_nonce_psbt)
+        assert_equal(len(dec_psbt["inputs"][0]["musig2_pubnonces"]), expected_pubnonces)
+        for pn in dec_psbt["inputs"][0]["musig2_pubnonces"]:
+            pubkey = pn["aggregate_pubkey"][2:]
+            if pubkey in dec_psbt["inputs"][0]["witness_utxo"]["scriptPubKey"]["hex"]:
+                continue
+            elif "taproot_scripts" in dec_psbt["inputs"][0]:
+                for leaf_scripts in dec_psbt["inputs"][0]["taproot_scripts"]:
+                    if pubkey in leaf_scripts["script"]:
+                        break
+                else:
+                    assert False, "Aggregate pubkey for pubnonce not seen as output key, or in any scripts"
+            else:
+                assert False, "Aggregate pubkey for pubnonce not seen as output key or internal key"
+
+        # Add partial sigs
+        psig_psbts = []
+        for i, wallet in enumerate(wallets):
+            if nosign_wallets and i in nosign_wallets:
+                continue
+            proc = wallet.walletprocesspsbt(psbt=comb_nonce_psbt, sighashtype=sighash_type)
+            assert_equal(proc["complete"], False)
+            psig_psbts.append(proc["psbt"])
+
+        comb_psig_psbt = self.nodes[0].combinepsbt(psig_psbts)
+
+        dec_psbt = self.nodes[0].decodepsbt(comb_psig_psbt)
+        assert_equal(len(dec_psbt["inputs"][0]["musig2_partial_sigs"]), expected_partial_sigs)
+        for ps in dec_psbt["inputs"][0]["musig2_partial_sigs"]:
+            pubkey = ps["aggregate_pubkey"][2:]
+            if pubkey in dec_psbt["inputs"][0]["witness_utxo"]["scriptPubKey"]["hex"]:
+                continue
+            elif "taproot_scripts" in dec_psbt["inputs"][0]:
+                for leaf_scripts in dec_psbt["inputs"][0]["taproot_scripts"]:
+                    if pubkey in leaf_scripts["script"]:
+                        break
+                else:
+                    assert False, "Aggregate pubkey for partial sig not seen as output key or in any scripts"
+            else:
+                assert False, "Aggregate pubkey for partial sig not seen as output key"
+
+        # Non-participant aggregates partial sigs and send
+        finalized = self.nodes[0].finalizepsbt(psbt=comb_psig_psbt, extract=False)
+        assert_equal(finalized["complete"], True)
+        witness = self.nodes[0].decodepsbt(finalized["psbt"])["inputs"][0]["final_scriptwitness"]
+        if scriptpath:
+            assert_greater_than(len(witness), 1)
+        else:
+            assert_equal(len(witness), 1)
+        finalized = self.nodes[0].finalizepsbt(comb_psig_psbt)
+        assert "hex" in finalized
+        self.nodes[0].sendrawtransaction(finalized["hex"])
+
+    def run_test(self):
+        self.def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        self.do_test("rawtr(musig(keys/*))", "rawtr(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*))")
+        self.do_test("rawtr(musig(keys/*)) with ALL|ANYONECANPAY", "rawtr(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*))", "ALL|ANYONECANPAY")
+        self.do_test("tr(musig(keys/*)) no multipath", "tr(musig($0/0/*,$1/1/*,$2/2/*))")
+        self.do_test("tr(musig(keys/*)) 2 index multipath", "tr(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*))")
+        self.do_test("tr(musig(keys/*)) 3 index multipath", "tr(musig($0/<0;1;2>/*,$1/<1;2;3>/*,$2/<2;3;4>/*))")
+        self.do_test("rawtr(musig/*)", "rawtr(musig($0,$1,$2)/<0;1>/*)")
+        self.do_test("tr(musig/*)", "tr(musig($0,$1,$2)/<0;1>/*)")
+        self.do_test("rawtr(musig(keys/*)) without all wallets importing", "rawtr(musig($0/<0;1>/*,$1/<0;1>/*,$2/<0;1>/*))", only_one_musig_wallet=True)
+        self.do_test("tr(musig(keys/*)) without all wallets importing", "tr(musig($0/<0;1>/*,$1/<0;1>/*,$2/<0;1>/*))", only_one_musig_wallet=True)
+        self.do_test("tr(H, pk(musig(keys/*)))", "tr($H,pk(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*)))", scriptpath=True)
+        self.do_test("tr(H,pk(musig/*))", "tr($H,pk(musig($0,$1,$2)/<0;1>/*))", scriptpath=True)
+        self.do_test("tr(H,{pk(musig/*), pk(musig/*)})", "tr($H,{pk(musig($0,$1,$2)/<0;1>/*),pk(musig($3,$4,$5)/0/*)})", scriptpath=True)
+        self.do_test("tr(H,{pk(musig/*), pk(same keys different musig/*)})", "tr($H,{pk(musig($0,$1,$2)/<0;1>/*),pk(musig($1,$2)/0/*)})", scriptpath=True)
+        self.do_test("tr(musig/*,{pk(partial keys diff musig-1/*),pk(partial keys diff musig-2/*)})}", "tr(musig($0,$1,$2)/<3;4>/*,{pk(musig($0,$1)/<5;6>/*),pk(musig($1,$2)/7/*)})")
+        self.do_test("tr(musig/*,{pk(partial keys diff musig-1/*),pk(partial keys diff musig-2/*)})} script-path", "tr(musig($0,$1,$2)/<3;4>/*,{pk(musig($0,$1)/<5;6>/*),pk(musig($1,$2)/7/*)})", scriptpath=True, nosign_wallets=[0])
+
+
+if __name__ == '__main__':
+    WalletMuSigTest(__file__).main()


### PR DESCRIPTION
This PR implements MuSig2 signing so that the wallet can receive and spend from imported `musig(0` descriptors.

The libsecp musig module is enabled so that it can be used for all of the MuSig2 cryptography.

Secnonces are handled in a separate class which holds the libsecp secnonce object in a `secure_unique_ptr`. Since secnonces must not be used, this class has no serialization and will only live in memory. A restart of the software will require a restart of the MuSig2 signing process.