### PR TITLE
Bugfix: Correct first-run free space checks

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -312,13 +312,13 @@ cat "$VERSION"/*/all.SHA256SUMS.asc > SHA256SUMS.asc
 Both variables are used as a guideline for how much space the user needs on their drive in total, not just strictly for the blockchain.
 Note that all values should be taken from a **fully synced** node and have an overhead of 5-10% added on top of its base value.
 
-To calculate `m_assumed_blockchain_size`, take the size in GiB of these directories:
+To calculate `m_assumed_blockchain_size`, take the size in GB of these directories:
 - For `mainnet` -> the data directory, excluding the `/testnet3`, `/testnet4`, `/signet`, and `/regtest` directories and any overly large files, e.g. a huge `debug.log`
 - For `testnet` -> `/testnet3`
 - For `testnet4` -> `/testnet4`
 - For `signet` -> `/signet`
 
-To calculate `m_assumed_chain_state_size`, take the size in GiB of these directories:
+To calculate `m_assumed_chain_state_size`, take the size in GB of these directories:
 - For `mainnet` -> `/chainstate`
 - For `testnet` -> `/testnet3/chainstate`
 - For `testnet4` -> `/testnet4/chainstate`

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -80,6 +80,7 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
@@ -1931,7 +1932,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                     "Approximately %u GB of data will be stored in this directory."
                 ),
                 fs::quoted(fs::PathToString(args.GetBlocksDirPath())),
-                chainparams.AssumedBlockchainSize()
+                CeilDiv(additional_bytes_needed, 1'000'000'000)
             ));
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1919,7 +1919,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // On first startup, warn on low block storage space
     if (!do_reindex && !do_reindex_chainstate && chain_active_height <= 1) {
-        uint64_t assumed_chain_bytes{chainparams.AssumedBlockchainSize() * 1024 * 1024 * 1024};
+        uint64_t assumed_chain_bytes{chainparams.AssumedBlockchainSize() * 1'000'000'000};
         uint64_t additional_bytes_needed{
             chainman.m_blockman.IsPruneMode() ?
                 std::min(chainman.m_blockman.GetPruneTarget(), assumed_chain_bytes) :

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1833,4 +1833,47 @@ BOOST_AUTO_TEST_CASE(mib_string_literal_test)
     BOOST_CHECK_EXCEPTION(operator""_MiB(static_cast<unsigned long long>(max_mib) + 1), std::overflow_error, HasReason("MiB value too large for size_t byte conversion"));
 }
 
+BOOST_AUTO_TEST_CASE(ceil_div_test)
+{
+    // Return type is effectively the wider of the two types.
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(uint32_t{0}, uint32_t{1})), uint32_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(uint32_t{0}, uint64_t{1})), uint64_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(uint64_t{0}, uint32_t{1})), uint64_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(size_t{0}, uint32_t{1})), size_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(uint32_t{0}, size_t{1})), size_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(size_t{0}, size_t{1})), size_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(size_t{0}, uint64_t{1})), uint64_t>));
+    BOOST_CHECK((std::is_same_v<decltype(CeilDiv(uint64_t{0}, size_t{1})), uint64_t>));
+
+    // Basic ceiling division: exact divisions and rounding up.
+    BOOST_CHECK_EQUAL(CeilDiv(0ULL, 1ULL), 0ULL);
+    BOOST_CHECK_EQUAL(CeilDiv(1ULL, 1ULL), 1ULL);
+    BOOST_CHECK_EQUAL(CeilDiv(2ULL, 2ULL), 1ULL);
+    BOOST_CHECK_EQUAL(CeilDiv(3ULL, 2ULL), 2ULL);
+    BOOST_CHECK_EQUAL(CeilDiv(5ULL, 3ULL), 2ULL);
+
+    // Works with size_t.
+    BOOST_CHECK_EQUAL(CeilDiv(size_t{0}, size_t{1}), size_t{0});
+    BOOST_CHECK_EQUAL(CeilDiv(size_t{3}, size_t{2}), size_t{2});
+
+    // Works with uint32_t.
+    BOOST_CHECK_EQUAL(CeilDiv(0U, 1U), 0U);
+    BOOST_CHECK_EQUAL(CeilDiv(3U, 2U), 2U);
+
+    // CeilDiv avoids overflow at max values.
+    constexpr uint64_t max_u64{std::numeric_limits<uint64_t>::max()};
+    BOOST_CHECK_EQUAL(CeilDiv(max_u64, 2ULL), (max_u64 / 2) + 1);
+
+    // Mixed types: size_t dividend with uint32_t divisor.
+    constexpr size_t max_u32_as_size{std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK_EQUAL(CeilDiv(max_u32_as_size, uint32_t{2}), (max_u32_as_size / 2) + 1);
+}
+
+BOOST_AUTO_TEST_CASE(ceil_div_zero_divisor_test)
+{
+    test_only_CheckFailuresAreExceptionsNotAborts check_failures;
+    BOOST_CHECK_THROW((void)CeilDiv(1ULL, 0ULL), NonFatalCheckError);
+    BOOST_CHECK_THROW((void)CeilDiv(size_t{1}, size_t{0}), NonFatalCheckError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_UTIL_OVERFLOW_H
 #define BITCOIN_UTIL_OVERFLOW_H
 
+#include <util/check.h>
+
 #include <climits>
 #include <concepts>
 #include <limits>
@@ -47,6 +49,21 @@ template <class T>
         }
     }
     return i + j;
+}
+
+/**
+ * @brief Integer ceiling division (for non-negative values).
+ *
+ * Computes the smallest integer q such that q * divisor >= dividend.
+ * Both dividend and divisor must be non-negative, and divisor must be non-zero.
+ *
+ * The implementation avoids overflow that can occur with `(dividend + divisor - 1) / divisor`.
+ */
+template <std::integral Dividend, std::integral Divisor>
+[[nodiscard]] constexpr auto CeilDiv(const Dividend dividend, const Divisor divisor)
+{
+    Assert(dividend >= 0 && divisor > 0);
+    return dividend / divisor + (dividend % divisor != 0);
 }
 
 /**


### PR DESCRIPTION
It's not clear what `m_assumed_*_size` are actually set based on, but historically it was in GB, not GiB, and that's still used in the GUI which is more user-facing.

Could just as easily change the GUI if GiB is preferred.