### PR TITLE
wallet: fix unrelated parent conflict doesn't cause child tx to be marked as conflict

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,6 +7,7 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
+#include <kernel/mempool_removal_reason.h>
 #include <primitives/transaction.h> // For CTransactionRef
 #include <util/result.h>
 
@@ -26,7 +27,6 @@ class CRPCCommand;
 class CScheduler;
 class Coin;
 class uint256;
-enum class MemPoolRemovalReason;
 enum class RBFTransactionState;
 enum class ChainstateRole;
 struct bilingual_str;
@@ -316,7 +316,7 @@ public:
     public:
         virtual ~Notifications() = default;
         virtual void transactionAddedToMempool(const CTransactionRef& tx) {}
-        virtual void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {}
+        virtual void transactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason) {}
         virtual void blockConnected(ChainstateRole role, const BlockInfo& block) {}
         virtual void blockDisconnected(const BlockInfo& block) {}
         virtual void updatedBlockTip() {}

--- a/src/kernel/mempool_removal_reason.cpp
+++ b/src/kernel/mempool_removal_reason.cpp
@@ -9,13 +9,8 @@
 
 std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
 {
-    switch (r) {
-        case MemPoolRemovalReason::EXPIRY: return "expiry";
-        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
-        case MemPoolRemovalReason::REORG: return "reorg";
-        case MemPoolRemovalReason::BLOCK: return "block";
-        case MemPoolRemovalReason::CONFLICT: return "conflict";
-        case MemPoolRemovalReason::REPLACED: return "replaced";
-    }
-    assert(false);
+    return std::visit([](auto&& arg) {
+        return arg.toString();
+    },
+                      r);
 }

--- a/src/kernel/mempool_removal_reason.h
+++ b/src/kernel/mempool_removal_reason.h
@@ -5,20 +5,77 @@
 #ifndef BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
 #define BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
 
+#include <primitives/transaction.h>
+#include <uint256.h>
+
 #include <string>
+#include <variant>
 
 /** Reason why a transaction was removed from the mempool,
  * this is passed to the notification signal.
  */
-enum class MemPoolRemovalReason {
-    EXPIRY,      //!< Expired from mempool
-    SIZELIMIT,   //!< Removed in size limiting
-    REORG,       //!< Removed for reorganization
-    BLOCK,       //!< Removed for block
-    CONFLICT,    //!< Removed for conflict with in-block transaction
-    REPLACED,    //!< Removed for replacement
+
+struct ExpiryReason {
+    std::string toString() const noexcept
+    {
+        return "expiry";
+    }
 };
 
+struct SizeLimitReason {
+    std::string toString() const noexcept
+    {
+        return "sizelimit";
+    }
+};
+
+struct ReorgReason {
+    std::string toString() const noexcept
+    {
+        return "reorg";
+    }
+};
+
+struct BlockReason {
+    std::string toString() const noexcept
+    {
+        return "block";
+    }
+};
+
+struct ConflictReason {
+    uint256 conflicting_block_hash;
+    unsigned int conflicting_block_height;
+
+    explicit ConflictReason(const uint256& conflicting_block_hash, int conflicting_block_height) : conflicting_block_hash(conflicting_block_hash), conflicting_block_height(conflicting_block_height) {}
+    ConflictReason(std::nullptr_t, int conflicting_block_height) = delete;
+
+    std::string toString() const noexcept
+    {
+        return "conflict";
+    }
+};
+
+struct ReplacedReason {
+    std::optional<CTransactionRef> replacement_tx;
+
+    explicit ReplacedReason(const std::optional<CTransactionRef> replacement_tx) : replacement_tx(replacement_tx) {}
+    ReplacedReason(std::nullptr_t) = delete;
+
+    std::string toString() const noexcept
+    {
+        return "replaced";
+    }
+};
+
+using MemPoolRemovalReason = std::variant<ExpiryReason, SizeLimitReason, ReorgReason, BlockReason, ConflictReason, ReplacedReason>;
+
 std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
+
+template <typename T>
+bool IsReason(const MemPoolRemovalReason& reason)
+{
+    return std::get_if<T>(&reason) != nullptr;
+}
 
 #endif // BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -458,7 +458,7 @@ public:
     {
         m_notifications->transactionAddedToMempool(tx.info.m_tx);
     }
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t mempool_sequence) override
     {
         m_notifications->transactionRemovedFromMempool(tx, reason);
     }

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -582,7 +582,7 @@ void CBlockPolicyEstimator::TransactionAddedToMempool(const NewMempoolTransactio
     processTransaction(tx);
 }
 
-void CBlockPolicyEstimator::TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason /*unused*/, uint64_t /*unused*/)
+void CBlockPolicyEstimator::TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& /*unused*/, uint64_t /*unused*/)
 {
     removeTx(tx->GetHash());
 }

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -266,7 +266,7 @@ protected:
     /** Overridden from CValidationInterface. */
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t /*unused*/) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason /*unused*/, uint64_t /*unused*/) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& /*unused*/, uint64_t /*unused*/) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
     void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int nBlockHeight) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <pow.h>
+#include <primitives/transaction.h>
 #include <streams.h>
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
@@ -89,7 +90,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 1);
 
         size_t poolSize = pool.size();
-        pool.removeRecursive(*block.vtx[2], MemPoolRemovalReason::REPLACED);
+        pool.removeRecursive(*block.vtx[2], ReplacedReason(MakeTransactionRef(CTransaction(CMutableTransaction()))));
         BOOST_CHECK_EQUAL(pool.size(), poolSize - 1);
 
         CBlock block2;

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -72,7 +72,7 @@ struct OutpointsUpdater final : public CValidationInterface {
         }
     }
 
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t /* mempool_sequence */) override
     {
         // outpoints spent by this tx are now available
         for (const auto& input : tx->vin) {
@@ -98,7 +98,7 @@ struct TransactionsDelta final : public CValidationInterface {
         m_added.insert(tx.info.m_tx);
     }
 
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t /* mempool_sequence */) override
     {
         // Transactions may be entered and booted any number of times
          m_added.erase(tx);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -71,7 +71,7 @@ struct TransactionsDelta final : public CValidationInterface {
         Assert(m_added.insert(tx.info.m_tx).second);
     }
 
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t /* mempool_sequence */) override
     {
         Assert(m_removed.insert(tx).second);
     }
@@ -107,7 +107,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
     const auto info_all = tx_pool.infoAll();
     if (!info_all.empty()) {
         const auto& tx_to_remove = *PickValue(fuzzed_data_provider, info_all).tx;
-        WITH_LOCK(tx_pool.cs, tx_pool.removeRecursive(tx_to_remove, MemPoolRemovalReason::BLOCK /* dummy */));
+        WITH_LOCK(tx_pool.cs, tx_pool.removeRecursive(tx_to_remove, BlockReason{} /* dummy */));
         assert(tx_pool.size() < info_all.size());
         WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
     }

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -4,8 +4,10 @@
 
 #include <common/system.h>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <uint256.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>
@@ -15,7 +17,7 @@
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
 
-static constexpr auto REMOVAL_REASON_DUMMY = MemPoolRemovalReason::REPLACED;
+static const auto REMOVAL_REASON_DUMMY = ReplacedReason(MakeTransactionRef(CTransaction(CMutableTransaction())));
 
 class MemPoolTest final : public CTxMemPool
 {
@@ -401,7 +403,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     /* after tx6 is mined, tx7 should move up in the sort */
     std::vector<CTransactionRef> vtx;
     vtx.push_back(MakeTransactionRef(tx6));
-    pool.removeForBlock(vtx, 1);
+    pool.removeForBlock(vtx, uint256::ZERO, 1);
 
     sortedOrder.erase(sortedOrder.begin()+1);
     // Ties are broken by hash
@@ -561,7 +563,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
     // ... we should keep the same min fee until we get a block
-    pool.removeForBlock(vtx, 1);
+    pool.removeForBlock(vtx, uint256::ZERO, 1);
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/2.0));
     // ... then feerate should drop 1/2 each halflife

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -192,7 +192,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     // Test that packages above the min relay fee do get included, even if one
     // of the transactions is below the min relay fee
     // Remove the low fee transaction and replace with a higher fee transaction
-    tx_mempool.removeRecursive(CTransaction(tx), MemPoolRemovalReason::REPLACED);
+    tx_mempool.removeRecursive(CTransaction(tx), ReplacedReason(MakeTransactionRef(CTransaction(CMutableTransaction()))));
     tx.vout[0].nValue -= 2; // Now we should be just over the min relay fee
     hashLowFeeTx = tx.GetHash();
     AddToMempool(tx_mempool, entry.Fee(feeToUse + 2).FromTx(tx));

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
         {
             LOCK(mpool.cs);
-            mpool.removeForBlock(block, ++blocknum);
+            mpool.removeForBlock(block, uint256::ZERO, ++blocknum);
         }
 
         block.clear();
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // We haven't decayed the moving average enough so we still have enough data points in every bucket
     while (blocknum < 250) {
         LOCK(mpool.cs);
-        mpool.removeForBlock(block, ++blocknum);
+        mpool.removeForBlock(block, uint256::ZERO, ++blocknum);
     }
 
     // Wait for fee estimator to catch up
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         }
         {
             LOCK(mpool.cs);
-            mpool.removeForBlock(block, ++blocknum);
+            mpool.removeForBlock(block, uint256::ZERO, ++blocknum);
         }
     }
 
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
     {
         LOCK(mpool.cs);
-        mpool.removeForBlock(block, 266);
+        mpool.removeForBlock(block, uint256::ZERO, 266);
     }
     block.clear();
 
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
         {
             LOCK(mpool.cs);
-            mpool.removeForBlock(block, ++blocknum);
+            mpool.removeForBlock(block, uint256::ZERO, ++blocknum);
         }
 
         block.clear();

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
         BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHash());
     }
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 1U);
-    WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[0]}, MemPoolRemovalReason::CONFLICT));
+    WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[0]}, ConflictReason(uint256::ZERO, 1)));
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 0U);
 
     // Test 3: ... and should be rejected if spend2 is in the memory pool
@@ -92,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
         BOOST_CHECK(m_node.chainman->ActiveChain().Tip()->GetBlockHash() != block.GetHash());
     }
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 1U);
-    WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[1]}, MemPoolRemovalReason::CONFLICT));
+    WITH_LOCK(m_node.mempool->cs, m_node.mempool->removeRecursive(CTransaction{spends[1]}, ConflictReason(uint256::ZERO, 1)));
     BOOST_CHECK_EQUAL(m_node.mempool->size(), 0U);
 
     // Final sanity test: first spend in *m_node.mempool, second in block, that's OK:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,10 +18,11 @@
 #include <policy/packages.h>
 #include <primitives/transaction.h>
 #include <sync.h>
+#include <uint256.h>
 #include <util/epochguard.h>
+#include <util/feefrac.h>
 #include <util/hasher.h>
 #include <util/result.h>
-#include <util/feefrac.h>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>
@@ -454,7 +455,7 @@ public:
     void check(const CCoinsViewCache& active_coins_tip, int64_t spendheight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 
-    void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeRecursive(const CTransaction& tx, const MemPoolRemovalReason& reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** After reorg, filter the entries that would no longer be valid in the next block, and update
      * the entries' cached LockPoints if needed.  The mempool does not have any knowledge of
      * consensus rules. It just applies the callable function and removes the ones for which it
@@ -463,8 +464,8 @@ public:
      *                                        and updates an entry's LockPoints.
      * */
     void removeForReorg(CChain& chain, std::function<bool(txiter)> filter_final_and_mature) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void removeConflicts(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeConflicts(const CTransaction& tx, const uint256& blockHash, unsigned int nBlockHeight) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeForBlock(const std::vector<CTransactionRef>& vtx, const uint256& blockHash, unsigned int nBlockHeight) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb, bool wtxid=false);
     bool isSpent(const COutPoint& outpoint) const;
@@ -719,7 +720,7 @@ private:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(setEntries& stage, bool updateDescendants, const MemPoolRemovalReason& reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the
@@ -770,7 +771,8 @@ private:
      *  transactions in a chain before we've updated all the state for the
      *  removal.
      */
-    void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeUnchecked(txiter entry, const MemPoolRemovalReason& reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
 public:
     /** visited marks a CTxMemPoolEntry as having been traversed
      * during the lifetime of the most recently created Epoch::Guard

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -198,7 +198,8 @@ void ValidationSignals::TransactionAddedToMempool(const NewMempoolTransactionInf
                           tx.info.m_tx->GetWitnessHash().ToString());
 }
 
-void ValidationSignals::TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) {
+void ValidationSignals::TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t mempool_sequence)
+{
     auto event = [tx, reason, mempool_sequence, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.TransactionRemovedFromMempool(tx, reason, mempool_sequence); });
     };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -8,6 +8,7 @@
 
 #include <kernel/chain.h>
 #include <kernel/cs_main.h>
+#include <kernel/mempool_removal_reason.h>
 #include <primitives/transaction.h> // CTransaction(Ref)
 #include <sync.h>
 
@@ -25,7 +26,6 @@ class BlockValidationState;
 class CBlock;
 class CBlockIndex;
 struct CBlockLocator;
-enum class MemPoolRemovalReason;
 struct RemovedMempoolTransactionInfo;
 struct NewMempoolTransactionInfo;
 
@@ -104,7 +104,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) {}
+    virtual void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t mempool_sequence) {}
     /*
      * Notifies listeners of transactions removed from the mempool as
      * as a result of new block being connected.
@@ -220,7 +220,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void ActiveTipChange(const CBlockIndex&, bool);
     void TransactionAddedToMempool(const NewMempoolTransactionInfo&, uint64_t mempool_sequence);
-    void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
+    void TransactionRemovedFromMempool(const CTransactionRef&, const MemPoolRemovalReason&, uint64_t mempool_sequence);
     void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>&, unsigned int nBlockHeight);
     void BlockConnected(ChainstateRole, const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -78,7 +78,7 @@ struct TxStateUnrecognized {
 using TxState = std::variant<TxStateConfirmed, TxStateInMempool, TxStateBlockConflicted, TxStateInactive, TxStateUnrecognized>;
 
 //! Subset of states transaction sync logic is implemented to handle.
-using SyncTxState = std::variant<TxStateConfirmed, TxStateInMempool, TxStateInactive>;
+using SyncTxState = std::variant<TxStateConfirmed, TxStateInMempool, TxStateInactive, TxStateBlockConflicted>;
 
 //! Try to interpret deserialized TxStateUnrecognized data as a recognized state.
 static inline TxState TxStateInterpretSerialized(TxStateUnrecognized data)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1248,6 +1248,18 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             }
         }
 
+        if (auto* conf = std::get_if<TxStateBlockConflicted>(&state)) {
+            WalletLogPrintf("A transaction in block %s conflicts with wallet transaction %s\n", conf->conflicting_block_hash.ToString(), ptx->GetHash().ToString());
+            auto try_updating_state = [&](CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
+                if (std::get_if<TxStateBlockConflicted>(&wtx.m_state)) return TxUpdate::UNCHANGED;
+
+                wtx.m_state = TxStateBlockConflicted(conf->conflicting_block_hash, conf->conflicting_block_height);
+                return TxUpdate::CHANGED;
+            };
+            // Iterate over all its outputs, and mark transactions in the wallet that spend them conflicted too.
+            RecursiveUpdateTxState(ptx->GetHash(), try_updating_state);
+        }
+
         bool fExisted = mapWallet.count(tx.GetHash()) != 0;
         if (fExisted && !fUpdate) return false;
         if (fExisted || IsMine(tx) || IsFromMe(tx))
@@ -1464,6 +1476,22 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, const Mem
     if (it != mapWallet.end()) {
         RefreshMempoolStatus(it->second, chain());
     }
+
+    auto* replaced_reason = std::get_if<ReplacedReason>(&reason);
+
+    // Check if wallet transaction is being replaced by a parent transaction which is not from this wallet
+    if (IsFromMe(*tx) && replaced_reason != nullptr && replaced_reason->replacement_tx.has_value() && !IsFromMe(*replaced_reason->replacement_tx.value())) {
+        m_unrelated_conflict_tx_watchlist.insert(std::make_pair(replaced_reason->replacement_tx.value()->GetHash(), tx));
+    }
+
+    auto iter = m_unrelated_conflict_tx_watchlist.find(tx->GetHash());
+    if (iter != m_unrelated_conflict_tx_watchlist.end()) {
+        // The replacement tx was removed from the mempool, remove it from map
+        // This new replacement tx may not conflict with the original tx
+        // so leave wallet tx to remain as TxStateInactive
+        m_unrelated_conflict_tx_watchlist.erase(iter);
+    }
+
     // Handle transactions that were removed from the mempool because they
     // conflict with transactions in a newly connected block.
     if (IsReason<ConflictReason>(reason)) {
@@ -1527,6 +1555,13 @@ void CWallet::blockConnected(ChainstateRole role, const interfaces::BlockInfo& b
 
     // Scan block
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
+        auto it = m_unrelated_conflict_tx_watchlist.find(block.data->vtx[index]->GetHash());
+        if (it != m_unrelated_conflict_tx_watchlist.end()) {
+            // A conflicting unrelated parent transaction was confirmed in a block
+            // Mark child wallet tx as conflicted
+            SyncTransaction(it->second, TxStateBlockConflicted(block.hash, block.height));
+        }
+
         SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)});
         transactionRemovedFromMempool(block.data->vtx[index], BlockReason{});
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1457,7 +1457,8 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
     }
 }
 
-void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {
+void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason)
+{
     LOCK(cs_wallet);
     auto it = mapWallet.find(tx->GetHash());
     if (it != mapWallet.end()) {
@@ -1465,7 +1466,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
     }
     // Handle transactions that were removed from the mempool because they
     // conflict with transactions in a newly connected block.
-    if (reason == MemPoolRemovalReason::CONFLICT) {
+    if (IsReason<ConflictReason>(reason)) {
         // Trigger external -walletnotify notifications for these transactions.
         // Set Status::UNCONFIRMED instead of Status::CONFLICTED for a few reasons:
         //
@@ -1527,7 +1528,7 @@ void CWallet::blockConnected(ChainstateRole role, const interfaces::BlockInfo& b
     // Scan block
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
         SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)});
-        transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
+        transactionRemovedFromMempool(block.data->vtx[index], BlockReason{});
     }
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -11,6 +11,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <kernel/cs_main.h>
+#include <kernel/mempool_removal_reason.h>
 #include <logging.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
@@ -56,7 +57,6 @@ class CKeyID;
 class CPubKey;
 class Coin;
 class SigningProvider;
-enum class MemPoolRemovalReason;
 enum class SigningResult;
 namespace common {
 enum class PSBTError;
@@ -631,7 +631,7 @@ public:
         uint256 last_failed_block;
     };
     ScanResult ScanForWalletTransactions(const uint256& start_block, int start_height, std::optional<int> max_height, const WalletRescanReserver& reserver, bool fUpdate, const bool save_progress);
-    void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) override;
+    void transactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason) override;
     /** Set the next time this wallet should resend transactions to 12-36 hours from now, ~1 day on average. */
     void SetNextResend() { m_next_resend = GetDefaultNextResend(); }
     /** Return true if all conditions for periodically resending transactions are met. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -429,6 +429,15 @@ private:
     std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks;
 
     /**
+     * Tracks txids of txs that replace parents of wallet transactions.
+     * The key is the txid of the replacing transaction which may be unrelated to this wallet and
+     * the value is the replaced transaction which is related to this wallet.
+     * On blockConnected, the wallet checks the block for replacement txids stored in this map,
+     * if found, the wallet marks the child wallet tx as 'CONFLICTED'
+     */
+    std::unordered_map<Txid, CTransactionRef, SaltedTxidHasher> m_unrelated_conflict_tx_watchlist GUARDED_BY(cs_wallet);
+
+    /**
      * Catch wallet up to current chain, scanning new blocks, updating the best
      * block locator and m_last_block_processed, and registering for
      * notifications about new blocks and transactions.

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -166,7 +166,7 @@ void CZMQNotificationInterface::TransactionAddedToMempool(const NewMempoolTransa
     });
 }
 
-void CZMQNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason, uint64_t mempool_sequence)
+void CZMQNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, const MemPoolRemovalReason& reason, uint64_t mempool_sequence)
 {
     // Called for all non-block inclusion reasons
     const CTransaction& tx = *ptx;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -34,7 +34,7 @@ protected:
 
     // CValidationInterface
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t mempool_sequence) override;
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) override;
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, const MemPoolRemovalReason& reason, uint64_t mempool_sequence) override;
     void BlockConnected(ChainstateRole role, const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;


### PR DESCRIPTION
This PR implements a fix for the issue described in https://github.com/bitcoin/bitcoin/issues/29435.

The problem is that the wallet is unable to abandon transactions that have unrelated parent conflicts. The solution implemented here, augments the mempool transaction `REPLACED` signal with the double-spending transaction which the wallet stores and watches for in Block notifications. A map is added to the wallet to track conflicting tx ids and their child transactions.  The entry is erased when the double-spending tx is removed from MemPool.
