### PR TITLE
test: remove duplicated ban test

### DIFF
--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -77,6 +77,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setmocktime(old_time)
         self.nodes[1].setban("127.0.0.0/32", "add")
         self.nodes[1].setban("127.0.0.0/24", "add")
+        self.nodes[1].setban("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion", "add")
         self.nodes[1].setban("192.168.0.1", "add", 1)  # ban for 1 seconds
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19", "add", 1000)  # ban for 1000 seconds
         listBeforeShutdown = self.nodes[1].listbanned()
@@ -85,13 +86,13 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("setban: test banning with absolute timestamp")
         self.nodes[1].setban("192.168.0.2", "add", old_time + 120, True)
 
-        # Move time forward by 3 seconds so the third ban has expired
+        # Move time forward by 3 seconds so the fourth ban has expired
         self.nodes[1].setmocktime(old_time + 3)
-        assert_equal(len(self.nodes[1].listbanned()), 4)
+        assert_equal(len(self.nodes[1].listbanned()), 5)
 
         self.log.info("Test ban_duration and time_remaining")
         for ban in self.nodes[1].listbanned():
-            if ban["address"] in ["127.0.0.0/32", "127.0.0.0/24"]:
+            if ban["address"] in ["127.0.0.0/32", "127.0.0.0/24", "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"]:
                 assert_equal(ban["ban_duration"], 86400)
                 assert_equal(ban["time_remaining"], 86397)
             elif ban["address"] == "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19":
@@ -108,6 +109,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])
         assert_equal("192.168.0.2/32", listAfterShutdown[2]['address'])
         assert_equal("/19" in listAfterShutdown[3]['address'], True)
+        assert_equal("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion", listAfterShutdown[4]['address'])
 
         # Clear ban lists
         self.nodes[1].clearbanned()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -64,18 +64,8 @@ class SetBanTests(BitcoinTestFramework):
         assert self.is_banned(node, tor_addr)
         assert not self.is_banned(node, ip_addr)
 
-        self.log.info("Test the ban list is preserved through restart")
-
-        self.restart_node(1)
-        assert self.is_banned(node, tor_addr)
-        assert not self.is_banned(node, ip_addr)
-
         node.setban(tor_addr, "remove")
         assert not self.is_banned(self.nodes[1], tor_addr)
-        assert not self.is_banned(node, ip_addr)
-
-        self.restart_node(1)
-        assert not self.is_banned(node, tor_addr)
         assert not self.is_banned(node, ip_addr)
 
         self.log.info("Test -bantime")


### PR DESCRIPTION
Test the ban list is preserved through restart has been done by both `rpc_setban` and `p2p_disconnect_ban`. Since `p2p_disconnect_ban` does it in a more elegant way, we can keep only it and remove the other one.

https://github.com/bitcoin/bitcoin/blob/bf1b6383dbbfdd0c96a161d4693a48bf3a6b6150/test/functional/p2p_disconnect_ban.py#L74-L110
