### PR TITLE
lint: scripted-diff verification also requires GNU grep

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -22,6 +22,11 @@ if ! sed --help 2>&1 | grep -q 'GNU'; then
     exit 1;
 fi
 
+if ! grep --help 2>&1 | grep -q 'GNU'; then
+    echo "Error: the installed grep package is not compatible. Please make sure you have GNU grep installed in your system.";
+    exit 1;
+fi
+
 RET=0
 PREV_BRANCH=$(git name-rev --name-only HEAD)
 PREV_HEAD=$(git rev-parse HEAD)


### PR DESCRIPTION
I noticed while trying to verify all historical `scripted-diff:` commits on macOS that some scripts require GNU sed.

For example 0d6d2b650d1017691f48c9109a6cd020ab46aa73 uses `git grep --perl-regexp`.