### PR TITLE
guix: build GCC with --enable-standard-branch-protection

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -423,6 +423,7 @@ inspecting signatures in Mach-O binaries.")
             (list "--enable-initfini-array=yes",
                   "--enable-default-ssp=yes",
                   "--enable-default-pie=yes",
+                  "--enable-standard-branch-protection=yes",
                   building-on)))
         ((#:phases phases)
           `(modify-phases ,phases


### PR DESCRIPTION
This is one change extracted from #24123 (which now produces fully BTI & PAC enabled bins), which will mean that everything in depends, for Guix builds, is compiled using `-mbranch-protection=standard`.

Turning this on by default, is similar to what we already do with `--enable-default-ssp`, `--enable-default-pie` etc.

See: https://gcc.gnu.org/install/specific.html#aarch64-x-x

> To enable Branch Target Identification Mechanism and Return Address Signing by default at configure time use the `--enable-standard-branch-protection` option.

> This is equivalent to having `-mbranch-protection=standard` during compilation. This can be explicitly disabled during compilation by passing the `-mbranch-protection=none` option which turns off all types of branch protections.