### PR TITLE
Fix typo in expat.mk.

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df47
 
 # -D_DEFAULT_SOURCE defines __USE_MISC, which exposes additional
 # definitions in endian.h, which are required for a working
-# endianess check in configure when building with -flto.
+# endianness check in configure when building with -flto.
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking


### PR DESCRIPTION
Fix one typo.

This will help every developer who hates typos.