### PR TITLE
kernel, refactor: return error status on all fatal errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.
     steps:
       - name: Determine fetch depth
-        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 1000))" >> "$GITHUB_ENV"
       - &ANNOTATION_PR_NUMBER
         name: Annotate with pull request number
         # This annotation is machine-readable and can be used to assign a check

--- a/ci/test/00_setup_env_native_previous_releases.sh
+++ b/ci/test/00_setup_env_native_previous_releases.sh
@@ -22,7 +22,7 @@ export BITCOIN_CONFIG="\
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_FLAGS='-funsigned-char -Werror' \
  -DCMAKE_C_FLAGS_DEBUG='-g2 -O2' \
- -DCMAKE_CXX_FLAGS='-funsigned-char -Werror' \
+ -DCMAKE_CXX_FLAGS='-funsigned-char -Werror -Wno-error=maybe-uninitialized' \
  -DCMAKE_CXX_FLAGS_DEBUG='-g2 -O2' \
  -DAPPEND_CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE' \
 "

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 using node::BlockCreateOptions;
@@ -47,8 +48,9 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(txr);
+            auto [res, flush_result]{test_setup->m_node.chainman->ProcessTransaction(txr)};
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            assert(flush_result);
         }
     }
 

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -8,6 +8,7 @@
 #include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/validation.h>
+#include <kernel/result.h>
 #include <key.h>
 #include <node/blockstorage.h>
 #include <policy/feerate.h>

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -10,6 +10,7 @@
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <validation.h>
 
@@ -69,7 +70,7 @@ static void LoadExternalBlockFile(benchmark::Bench& bench)
             // "rb" is "binary, O_RDONLY", positioned to the start of the file.
             // The file will be closed by LoadExternalBlockFile().
             AutoFile file{fsbridge::fopen(blkfile, "rb")};
-            testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
+            Assert(testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent));
         });
     fs::remove(blkfile);
 }

--- a/src/bench/readwriteblock.cpp
+++ b/src/bench/readwriteblock.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <bench/data/block413567.raw.h>
 #include <flatfile.h>
+#include <kernel/result.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -35,7 +36,8 @@ static void WriteBlockBench(benchmark::Bench& bench)
     bench.run([&] {
         LOCK(::cs_main);
         const auto pos{blockman.WriteBlock(block, 413'567)};
-        assert(!pos.IsNull());
+        assert(pos);
+        assert(!pos->IsNull());
     });
 }
 
@@ -45,10 +47,11 @@ static void ReadBlockBench(benchmark::Bench& bench)
     auto& blockman{testing_setup->m_node.chainman->m_blockman};
     const auto& test_block{CreateTestBlock()};
     const auto& expected_hash{test_block.GetHash()};
-    const auto& pos{WITH_LOCK(::cs_main, return blockman.WriteBlock(test_block, 413'567))};
+    const auto pos{WITH_LOCK(::cs_main, return blockman.WriteBlock(test_block, 413'567))};
+    assert(pos);
     bench.run([&] {
         CBlock block;
-        const auto success{blockman.ReadBlock(block, pos, expected_hash)};
+        const auto success{blockman.ReadBlock(block, *pos, expected_hash)};
         assert(success);
     });
 }
@@ -58,9 +61,10 @@ static void ReadRawBlockBench(benchmark::Bench& bench)
     const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN)};
     auto& blockman{testing_setup->m_node.chainman->m_blockman};
     const auto pos{WITH_LOCK(::cs_main, return blockman.WriteBlock(CreateTestBlock(), 413'567))};
+    assert(pos);
     bench.run([&] {
-        const auto res{blockman.ReadRawBlock(pos)};
-        assert(res);
+        const auto success{blockman.ReadRawBlock(*pos)};
+        assert(success);
     });
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2051,7 +2051,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &kernel_notifications, &node] {
         ScheduleBatchPriority();
         // Import blocks and ActivateBestChain()
-        ImportBlocks(chainman, vImportFiles);
+        (void)ImportBlocks(chainman, vImportFiles);
         // An interrupted import may return without activating genesis. Wake
         // the init thread's genesis wait, which is otherwise only notified
         // on blockTip, and that never fires when the import was interrupted

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -149,6 +149,7 @@ using http_bitcoin::InitHTTPServer;
 using http_bitcoin::InterruptHTTPServer;
 using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
+using kernel::FlushResult;
 using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
@@ -379,7 +380,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (const auto& chainstate : node.chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)chainstate->ForceFlushStateToDisk();
             }
         }
     }
@@ -406,7 +407,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (const auto& chainstate : node.chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)chainstate->ForceFlushStateToDisk();
                 chainstate->ResetCoinsViews();
             }
         }
@@ -1317,7 +1318,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
+FlushResult<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1416,7 +1417,7 @@ util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
+    auto catch_exceptions = [](auto&& f) -> FlushResult<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
@@ -1963,7 +1964,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LOCK(cs_main);
             for (const auto& chainstate : chainman.m_chainstates) {
                 uiInterface.InitMessage(_("Pruning blockstore…"));
-                chainstate->PruneAndFlush();
+                (void)chainstate->PruneAndFlush();
             }
         }
     } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2075,7 +2075,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         // Load mempool from disk
         if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
-            LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
+            (void)LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
             pool->SetLoadTried(!chainman.m_interrupt);
         }
     });

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -149,11 +149,11 @@ using http_bitcoin::InitHTTPServer;
 using http_bitcoin::InterruptHTTPServer;
 using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1317,7 +1317,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1340,7 +1340,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1376,12 +1376,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1416,28 +1416,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1873,13 +1873,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1893,15 +1894,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -148,6 +148,7 @@
 using common::InvalidPortErrMsg;
 using common::ResolveErrMsg;
 
+using kernel::FlushResult;
 using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
@@ -379,7 +380,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (const auto& chainstate : node.chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)chainstate->ForceFlushStateToDisk();
             }
         }
     }
@@ -406,7 +407,7 @@ void Shutdown(NodeContext& node)
         LOCK(cs_main);
         for (const auto& chainstate : node.chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                (void)chainstate->ForceFlushStateToDisk();
                 chainstate->ResetCoinsViews();
             }
         }
@@ -1371,7 +1372,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
+FlushResult<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1470,7 +1471,7 @@ util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
+    auto catch_exceptions = [](auto&& f) -> FlushResult<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
@@ -2019,7 +2020,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LOCK(cs_main);
             for (const auto& chainstate : chainman.m_chainstates) {
                 uiInterface.InitMessage(_("Pruning blockstore…"));
-                chainstate->PruneAndFlush();
+                (void)chainstate->PruneAndFlush();
             }
         }
     } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -148,11 +148,11 @@
 using common::InvalidPortErrMsg;
 using common::ResolveErrMsg;
 
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1371,7 +1371,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1394,7 +1394,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1430,12 +1430,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1470,28 +1470,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1911,13 +1911,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1931,15 +1932,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2131,7 +2131,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         // Load mempool from disk
         if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
-            LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
+            (void)LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
             pool->SetLoadTried(!chainman.m_interrupt);
         }
     });

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2107,7 +2107,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &kernel_notifications, &node] {
         ScheduleBatchPriority();
         // Import blocks and ActivateBestChain()
-        ImportBlocks(chainman, vImportFiles);
+        (void)ImportBlocks(chainman, vImportFiles);
         // An interrupted import may return without activating genesis. Wake
         // the init thread's genesis wait, which is otherwise only notified
         // on blockTip, and that never fires when the import was interrupted

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(bitcoinkernel
   ../util/fs.cpp
   ../util/fs_helpers.cpp
   ../util/hasher.cpp
+  ../util/messages.cpp
   ../util/moneystr.cpp
   ../util/rbf.cpp
   ../util/signalinterrupt.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -16,6 +16,7 @@
 #include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/notifications_interface.h>
+#include <kernel/result.h>
 #include <kernel/warning.h>
 #include <logging.h>
 #include <node/blockstorage.h>
@@ -1129,7 +1130,8 @@ void btck_chainstate_manager_destroy(btck_ChainstateManager* chainman)
         LOCK(btck_ChainstateManager::get(chainman).m_chainman->GetMutex());
         for (const auto& chainstate : btck_ChainstateManager::get(chainman).m_chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                auto flush_result{chainstate->ForceFlushStateToDisk()};
+                if (!flush_result) LogError("%s", util::ErrorString(flush_result).original);
                 chainstate->ResetCoinsViews();
             }
         }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1151,7 +1151,8 @@ int btck_chainstate_manager_import_blocks(btck_ChainstateManager* chainman, cons
             }
         }
         auto& chainman_ref{*btck_ChainstateManager::get(chainman).m_chainman};
-        node::ImportBlocks(chainman_ref, import_files);
+        auto result{node::ImportBlocks(chainman_ref, import_files)};
+        if (!result) LogError("%s", util::ErrorString(result).original);
         WITH_LOCK(::cs_main, chainman_ref.UpdateIBDStatus());
     } catch (const std::exception& e) {
         LogError("Failed to import blocks: %s", e.what());

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1377,11 +1377,13 @@ int btck_chainstate_manager_process_block(
     int* _new_block)
 {
     bool new_block;
-    auto result = btck_ChainstateManager::get(chainman).m_chainman->ProcessNewBlock(btck_Block::get(block), /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    kernel::FlushResult<void, kernel::AbortFailure> process_result;
+    bool accepted = btck_ChainstateManager::get(chainman).m_chainman->ProcessNewBlock(btck_Block::get(block), /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block, process_result);
+    if (!process_result) LogError("%s", util::ErrorString(process_result).original);
     if (_new_block) {
         *_new_block = new_block ? 1 : 0;
     }
-    return result ? 0 : -1;
+    return accepted ? 0 : -1;
 }
 
 btck_BlockValidationState* btck_chainstate_manager_process_block_header(

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -49,8 +49,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1050,14 +1050,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         kernel::CacheSizes cache_sizes{DEFAULT_KERNEL_CACHE};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1394,11 +1394,13 @@ int btck_chainstate_manager_process_block(
     int* _new_block)
 {
     bool new_block;
-    auto result = btck_ChainstateManager::get(chainman).m_chainman->ProcessNewBlock(btck_Block::get(block), /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    kernel::FlushResult<void, kernel::AbortFailure> process_result;
+    bool accepted = btck_ChainstateManager::get(chainman).m_chainman->ProcessNewBlock(btck_Block::get(block), /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block, process_result);
+    if (!process_result) LogError("%s", util::ErrorString(process_result).original);
     if (_new_block) {
         *_new_block = new_block ? 1 : 0;
     }
-    return result ? 0 : -1;
+    return accepted ? 0 : -1;
 }
 
 btck_BlockValidationState* btck_chainstate_manager_process_block_header(

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1168,7 +1168,8 @@ int btck_chainstate_manager_import_blocks(btck_ChainstateManager* chainman, cons
             }
         }
         auto& chainman_ref{*btck_ChainstateManager::get(chainman).m_chainman};
-        node::ImportBlocks(chainman_ref, import_files);
+        auto result{node::ImportBlocks(chainman_ref, import_files)};
+        if (!result) LogError("%s", util::ErrorString(result).original);
         WITH_LOCK(::cs_main, chainman_ref.UpdateIBDStatus());
     } catch (const std::exception& e) {
         LogError("Failed to import blocks: %s", e.what());

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -16,6 +16,7 @@
 #include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/notifications_interface.h>
+#include <kernel/result.h>
 #include <kernel/warning.h>
 #include <logging.h>
 #include <node/blockstorage.h>
@@ -1146,7 +1147,8 @@ void btck_chainstate_manager_destroy(btck_ChainstateManager* chainman)
         LOCK(btck_ChainstateManager::get(chainman).m_chainman->GetMutex());
         for (const auto& chainstate : btck_ChainstateManager::get(chainman).m_chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
+                auto flush_result{chainstate->ForceFlushStateToDisk()};
+                if (!flush_result) LogError("%s", util::ErrorString(flush_result).original);
                 chainstate->ResetCoinsViews();
             }
         }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -51,8 +51,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1101,14 +1101,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         const kernel::CacheSizes cache_sizes{WITH_LOCK(opts.m_mutex, return opts.m_db_cache_bytes)};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/kernel/result.h
+++ b/src/kernel/result.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_RESULT_H
+#define BITCOIN_KERNEL_RESULT_H
+
+#include <util/messages.h>
+#include <util/result.h>
+
+//! @file Kernel result types for use with util::Result.
+//!
+//! Currently, many kernel functions trigger flushes and node shutdowns at low
+//! levels deep within the code. This can make it hard to reason about when a
+//! particular kernel function call might trigger a flush or shutdown.
+//!
+//! Ideally, low level functions would not trigger flushes and shutdowns at all,
+//! but would just return information so higher level code can determine when to
+//! flush and shut down. However, implementing this would require significant
+//! restructuring of code and probably change external behavior. In the
+//! meantime, FlushStatus and AbortFailure result types below can be used to
+//! provide a consistent indication to callers of when shutdowns and flushes are
+//! triggered, and which functions can and cannot trigger them.
+
+namespace kernel {
+//! Result type for functions that might trigger flushes, indicating whether
+//! flushes were skipped, performed successfully, or failed.
+enum class FlushStatus { SKIPPED, SUCCESS, FAILURE };
+
+//! Result type for functions that might trigger fatal errors and need to abort
+//! the node, indicating whether a fatal error did occur.
+struct AbortFailure {
+    bool fatal{false};
+};
+
+template <typename SuccessType = void, typename FailureType = void>
+using FlushResult = util::Result<SuccessType, FailureType, FlushStatus>;
+} // namespace kernel
+
+namespace util {
+template<>
+struct ResultTraits<kernel::FlushStatus>
+{
+    static void update(kernel::FlushStatus& dst, kernel::FlushStatus&& src)
+    {
+        using kernel::FlushStatus;
+        if (dst == FlushStatus::FAILURE || src == FlushStatus::FAILURE) {
+            dst = FlushStatus::FAILURE;
+        } else if (dst == FlushStatus::SUCCESS || src == FlushStatus::SUCCESS) {
+            dst = FlushStatus::SUCCESS;
+        } else {
+            dst = FlushStatus::SKIPPED;
+        }
+    }
+};
+
+template<>
+struct ResultTraits<kernel::AbortFailure>
+{
+    static void update(kernel::AbortFailure& dst, kernel::AbortFailure&& src)
+    {
+        dst.fatal |= src.fatal;
+    }
+};
+} // namespace util
+
+#endif // BITCOIN_KERNEL_RESULT_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1663,7 +1663,7 @@ void PeerManagerImpl::ReattemptPrivateBroadcast(CScheduler& scheduler)
         for (const auto& stale_tx : stale_txs) {
             // Only hold lock per single submission
             LOCK(cs_main);
-            auto mempool_acceptable = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
+            auto [mempool_acceptable, flush_result] = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
             if (mempool_acceptable.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 LogDebug(BCLog::PRIVBROADCAST,
                          "Reattempting broadcast of stale txid=%s wtxid=%s",
@@ -3271,7 +3271,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
     CTransactionRef porphanTx = nullptr;
 
     while (CTransactionRef porphanTx = m_txdownloadman.GetTxToReconsider(peer.m_id)) {
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
+        auto [result, flush_result]{m_chainman.ProcessTransaction(porphanTx)};
         const TxValidationState& state = result.m_state;
         const Txid& orphanHash = porphanTx->GetHash();
         const Wtxid& orphan_wtxid = porphanTx->GetWitnessHash();
@@ -4525,7 +4525,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             }
 
             if (package_to_validate) {
-                const auto package_result{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
+                auto [package_result, process_result]{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
                 LogDebug(BCLog::TXPACKAGES, "package evaluation for %s: %s\n", package_to_validate->ToString(),
                          package_result.m_state.IsValid() ? "package accepted" : "package rejected");
                 ProcessPackageResult(package_to_validate.value(), package_result);
@@ -4536,7 +4536,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // ReceivedTx should not be telling us to validate the tx and a package.
         Assume(!package_to_validate.has_value());
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(ptx);
+        auto [result, flush_result]{m_chainman.ProcessTransaction(ptx)};
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -4545,7 +4545,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
         if (state.IsInvalid()) {
             if (auto package_to_validate{ProcessInvalidTx(pfrom.GetId(), ptx, state, /*first_time_failure=*/true)}) {
-                const auto package_result{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
+                auto [package_result, process_result]{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
                 LogDebug(BCLog::TXPACKAGES, "package evaluation for %s: %s\n", package_to_validate->ToString(),
                          package_result.m_state.IsValid() ? "package accepted" : "package rejected");
                 ProcessPackageResult(package_to_validate.value(), package_result);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -88,6 +88,8 @@
 
 using kernel::ChainstateRole;
 using namespace util::hex_literals;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 
 TRACEPOINT_SEMAPHORE(net, inbound_message);
 TRACEPOINT_SEMAPHORE(net, misbehaving_connection);
@@ -3465,7 +3467,8 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked)
 {
     bool new_block{false};
-    m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block);
+    FlushResult<void, AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    (void)m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block, process_result);
     if (new_block) {
         node.m_last_block_time = GetTime<std::chrono::seconds>();
         // In case this block came from a different peer than we requested

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1753,7 +1753,7 @@ void PeerManagerImpl::ReattemptPrivateBroadcast(CScheduler& scheduler)
         for (const auto& stale_tx : stale_txs) {
             // Only hold lock per single submission
             LOCK(cs_main);
-            auto mempool_acceptable = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
+            auto [mempool_acceptable, flush_result] = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
             if (mempool_acceptable.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 LogDebug(BCLog::PRIVBROADCAST,
                          "Reattempting broadcast of stale txid=%s wtxid=%s",
@@ -3482,7 +3482,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
     LOCK2(::cs_main, m_tx_download_mutex);
 
     while (CTransactionRef porphanTx = m_txdownloadman.GetTxToReconsider(peer.m_id)) {
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
+        auto [result, flush_result]{m_chainman.ProcessTransaction(porphanTx)};
         const TxValidationState& state = result.m_state;
         const Txid& orphanHash = porphanTx->GetHash();
         const Wtxid& orphan_wtxid = porphanTx->GetWitnessHash();
@@ -4752,7 +4752,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             }
 
             if (package_to_validate) {
-                const auto package_result{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
+                auto [package_result, process_result]{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
                 LogDebug(BCLog::TXPACKAGES, "package evaluation for %s: %s\n", package_to_validate->ToString(),
                          package_result.m_state.IsValid() ? "package accepted" : "package rejected");
                 ProcessPackageResult(package_to_validate.value(), package_result);
@@ -4763,7 +4763,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // ReceivedTx should not be telling us to validate the tx and a package.
         Assume(!package_to_validate.has_value());
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(ptx);
+        auto [result, flush_result]{m_chainman.ProcessTransaction(ptx)};
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -4772,7 +4772,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
         if (state.IsInvalid()) {
             if (auto package_to_validate{ProcessInvalidTx(pfrom.GetId(), ptx, state, /*first_time_failure=*/true)}) {
-                const auto package_result{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
+                auto [package_result, process_result]{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate->m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt)};
                 LogDebug(BCLog::TXPACKAGES, "package evaluation for %s: %s\n", package_to_validate->ToString(),
                          package_result.m_state.IsValid() ? "package accepted" : "package rejected");
                 ProcessPackageResult(package_to_validate.value(), package_result);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -91,6 +91,8 @@
 
 using kernel::ChainstateRole;
 using namespace util::hex_literals;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 
 TRACEPOINT_SEMAPHORE(net, inbound_message);
 TRACEPOINT_SEMAPHORE(net, misbehaving_connection);
@@ -3676,7 +3678,8 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked)
 {
     bool new_block{false};
-    m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block);
+    FlushResult<void, AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    (void)m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block, process_result);
     if (new_block) {
         node.m_last_block_time = GetTime<std::chrono::seconds>();
         // In case this block came from a different peer than we requested

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -53,6 +53,10 @@
 #include <stdexcept>
 #include <system_error>
 #include <unordered_map>
+#include <variant>
+
+using kernel::FlushResult;
+using kernel::FlushStatus;
 
 namespace kernel {
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
@@ -747,43 +751,52 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
     return true;
 }
 
-bool BlockManager::FlushUndoFile(int block_file, bool finalize)
+FlushResult<> BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
+    FlushResult<> result;
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
     if (!m_undo_file_seq.Flush(undo_pos_old, finalize)) {
-        m_opts.notifications.flushError(_("Flushing undo file to disk failed. This is likely the result of an I/O error."));
-        return false;
+        auto error{_("Flushing undo file to disk failed. This is likely the result of an I/O error.")};
+        m_opts.notifications.flushError(error);
+        result.update(util::Error{std::move(error)});
+        result.update(util::Info{FlushStatus::FAILURE});
+    } else {
+        result.update(util::Info{FlushStatus::SUCCESS});
     }
-    return true;
+    return result;
 }
 
-bool BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
+FlushResult<> BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
 {
     AssertLockHeld(::cs_main);
-    bool success = true;
+    FlushResult<> result;
 
     if (m_blockfile_info.size() < 1) {
         // Return if we haven't loaded any blockfiles yet. This happens during
         // chainstate init, when we call ChainstateManager::MaybeRebalanceCaches() (which
         // then calls FlushStateToDisk()), resulting in a call to this function before we
         // have populated `m_blockfile_info` via LoadBlockIndexDB().
-        return true;
+        return result;
     }
     assert(static_cast<int>(m_blockfile_info.size()) > blockfile_num);
 
     FlatFilePos block_pos_old(blockfile_num, m_blockfile_info[blockfile_num].nSize);
     if (!m_block_file_seq.Flush(block_pos_old, fFinalize)) {
-        m_opts.notifications.flushError(_("Flushing block file to disk failed. This is likely the result of an I/O error."));
-        success = false;
+        auto error{_("Flushing block file to disk failed. This is likely the result of an I/O error.")};
+        m_opts.notifications.flushError(error);
+        result.update(util::Error{std::move(error)});
+        result.update(util::Info{FlushStatus::FAILURE});
+    } else {
+        result.update(util::Info{FlushStatus::SUCCESS});
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
     // e.g. during IBD or a sync after a node going offline
     if (!fFinalize || finalize_undo) {
-        if (!FlushUndoFile(blockfile_num, finalize_undo)) {
-            success = false;
+        if (!(FlushUndoFile(blockfile_num, finalize_undo) >> result)) {
+            result.update(util::Error{});
         }
     }
-    return success;
+    return result;
 }
 
 BlockfileType BlockManager::BlockfileTypeForHeight(int height)
@@ -794,7 +807,7 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
     return (height >= *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
 }
 
-bool BlockManager::FlushChainstateBlockFile(int tip_height)
+FlushResult<> BlockManager::FlushChainstateBlockFile(int tip_height)
 {
     AssertLockHeld(::cs_main);
     auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
@@ -805,7 +818,7 @@ bool BlockManager::FlushChainstateBlockFile(int tip_height)
         return FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
     }
     // No need to log warnings in this case.
-    return true;
+    return {};
 }
 
 uint64_t BlockManager::CalculateCurrentUsage()
@@ -850,6 +863,7 @@ fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos) const
 FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime)
 {
     AssertLockHeld(::cs_main);
+    FlushResult<> result; // TODO Return this result!
     const BlockfileType chain_type = BlockfileTypeForHeight(nHeight);
 
     if (!m_blockfile_cursors[chain_type]) {
@@ -910,10 +924,12 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // data may be inconsistent after a crash if the flush is called during
         // a reindex. A flush error might also leave some of the data files
         // untrimmed.
-        if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
-            LogWarning(
+        if (!(FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo) >> result)) {
+            auto warning{Untranslated(strprintf(
                           "Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
-                          last_blockfile, finalize_undo, nFile);
+                          last_blockfile, finalize_undo, nFile))};
+            LogWarning("%s\n", warning.original);
+            result.messages().warnings.push_back(std::move(warning));
         }
         // No undo data yet in the new file, so reset our undo-height tracking.
         m_blockfile_cursors[chain_type] = BlockfileCursor{nFile};
@@ -980,6 +996,7 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
 
 bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
 {
+    FlushResult<> result; // TODO Return this result!
     AssertLockHeld(::cs_main);
     const BlockfileType type = BlockfileTypeForHeight(block.nHeight);
     auto& cursor = *Assert(m_blockfile_cursors[type]);
@@ -1032,8 +1049,10 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
             // the caller would assume the undo data not to be written, when in
             // fact it is. Note though, that a failed flush might leave the data
             // file untrimmed.
-            if (!FlushUndoFile(pos.nFile, true)) {
-                LogWarning("Failed to flush undo file %05i\n", pos.nFile);
+            if (!(FlushUndoFile(pos.nFile, true) >> result)) {
+                auto warning{Untranslated(strprintf("Failed to flush undo file %05i\n", pos.nFile))};
+                LogWarning("%s\n", warning.original);
+                result.messages().warnings.push_back(std::move(warning));
             }
         } else if (pos.nFile == cursor.file_num && block.nHeight > cursor.undo_height) {
             cursor.undo_height = block.nHeight;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1319,6 +1319,7 @@ public:
 
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths)
 {
+    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
     ImportingNow imp{chainman.m_blockman.m_importing};
 
     // -reindex
@@ -1368,8 +1369,9 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
     }
 
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
-    if (auto result = chainman.ActivateBestChains(); !result) {
-        chainman.GetNotifications().fatalError(util::ErrorString(result));
+    if (auto activate_result = chainman.ActivateBestChains(); !activate_result) {
+        chainman.GetNotifications().fatalError(util::ErrorString(activate_result));
+        activate_result >> result;
     }
     // End scope of ImportingNow
 }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1317,9 +1317,9 @@ public:
     }
 };
 
-void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths)
+FlushResult<InterruptResult, AbortFailure> ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths)
 {
-    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
+    FlushResult<InterruptResult, AbortFailure> result;
     ImportingNow imp{chainman.m_blockman.m_importing};
 
     // -reindex
@@ -1344,7 +1344,8 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
             chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent) >> result;
             if (chainman.m_interrupt) {
                 LogInfo("Interrupt requested. Exit reindexing.");
-                return;
+                result.update(Interrupted{});
+                return result;
             }
         }
         WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
@@ -1364,7 +1365,8 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
             chainman.LoadExternalBlockFile(file) >> result;
             if (chainman.m_interrupt) {
                 LogInfo("Interrupt requested. Exit block importing.");
-                return;
+                result.update(Interrupted{});
+                return result;
             }
         } else {
             LogWarning("Could not open blocks file %s", fs::PathToString(path));
@@ -1374,9 +1376,10 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     if (auto activate_result = chainman.ActivateBestChains(); !activate_result) {
         chainman.GetNotifications().fatalError(util::ErrorString(activate_result));
-        activate_result >> result;
+        result.update(activate_result);
     }
     // End scope of ImportingNow
+    return result;
 }
 
 std::ostream& operator<<(std::ostream& os, const BlockfileType& type) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -58,6 +58,8 @@
 using kernel::AbortFailure;
 using kernel::FlushResult;
 using kernel::FlushStatus;
+using kernel::Interrupted;
+using kernel::InterruptResult;
 
 namespace kernel {
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
@@ -442,18 +444,20 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     return pindex;
 }
 
-bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+util::Result<InterruptResult, AbortFailure> BlockManager::LoadBlockIndexData(const std::optional<uint256>& snapshot_blockhash)
 {
     if (!m_block_tree_db->LoadBlockIndexGuts(
             GetConsensus(), [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, m_interrupt)) {
-        return false;
+        if (m_interrupt) return Interrupted{};
+        return util::Error{};
     }
 
     if (snapshot_blockhash) {
         const std::optional<AssumeutxoData> maybe_au_data = GetParams().AssumeutxoForBlockhash(*snapshot_blockhash);
         if (!maybe_au_data) {
-            m_opts.notifications.fatalError(strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString()));
-            return false;
+            auto error{strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString())};
+            m_opts.notifications.fatalError(error);
+            return {util::Error{std::move(error)}, AbortFailure{.fatal = true}};
         }
         const AssumeutxoData& au_data = *Assert(maybe_au_data);
         m_snapshot_height = au_data.height;
@@ -480,10 +484,11 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
 
     CBlockIndex* previous_index{nullptr};
     for (CBlockIndex* pindex : vSortedByHeight) {
-        if (m_interrupt) return false;
+        if (m_interrupt) return Interrupted{};
         if (previous_index && pindex->nHeight > previous_index->nHeight + 1) {
-            LogError("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
-            return false;
+            auto error{Untranslated(strprintf("block index is non-contiguous, index of height %d missing", previous_index->nHeight + 1))};
+            LogError("%s: %s\n", __func__, error.original);
+            return util::Error{std::move(error)};
         }
         previous_index = pindex;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
@@ -528,7 +533,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
         }
     }
 
-    return true;
+    return {};
 }
 
 void BlockManager::WriteBlockIndexDB()
@@ -550,11 +555,12 @@ void BlockManager::WriteBlockIndexDB()
     m_block_tree_db->WriteBatchSync(vFiles, max_blockfile, vBlocks);
 }
 
-bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+util::Result<InterruptResult, AbortFailure> BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
 {
     AssertLockHeld(::cs_main);
-    if (!LoadBlockIndex(snapshot_blockhash)) {
-        return false;
+    auto result{LoadBlockIndexData(snapshot_blockhash)};
+    if (!result || IsInterrupted(*result)) {
+        return result;
     }
     int max_blockfile_num{0};
 
@@ -586,7 +592,8 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++) {
         FlatFilePos pos(*it, 0);
         if (OpenBlockFile(pos, /*fReadOnly=*/true).IsNull()) {
-            return false;
+            result.update(util::Error{});
+            return result;
         }
     }
 
@@ -609,7 +616,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     m_block_tree_db->ReadReindexing(fReindexing);
     if (fReindexing) m_blockfiles_indexed = false;
 
-    return true;
+    return result;
 }
 
 void BlockManager::ScanAndUnlinkAlreadyPrunedFiles()

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -55,6 +55,7 @@
 #include <unordered_map>
 #include <variant>
 
+using kernel::AbortFailure;
 using kernel::FlushResult;
 using kernel::FlushStatus;
 
@@ -860,10 +861,10 @@ fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos) const
     return m_block_file_seq.FileName(pos);
 }
 
-FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime)
+FlushResult<FlatFilePos, AbortFailure> BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime)
 {
     AssertLockHeld(::cs_main);
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<FlatFilePos, AbortFailure> result;
     const BlockfileType chain_type = BlockfileTypeForHeight(nHeight);
 
     if (!m_blockfile_cursors[chain_type]) {
@@ -941,15 +942,18 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
     bool out_of_space;
     size_t bytes_allocated = m_block_file_seq.Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        m_opts.notifications.fatalError(_("Disk space is too low!"));
-        return {};
+        auto error{_("Disk space is too low!")};
+        m_opts.notifications.fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return result;
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
     }
 
     m_dirty_fileinfo.insert(nFile);
-    return pos;
+    result.update(pos);
+    return result;
 }
 
 void BlockManager::UpdateBlockInfo(const CBlock& block, unsigned int nHeight, const FlatFilePos& pos)
@@ -973,7 +977,7 @@ void BlockManager::UpdateBlockInfo(const CBlock& block, unsigned int nHeight, co
     m_dirty_fileinfo.insert(nFile);
 }
 
-bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
+util::Result<void, AbortFailure> BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
 {
     AssertLockHeld(::cs_main);
     pos.nFile = nFile;
@@ -985,18 +989,20 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     bool out_of_space;
     size_t bytes_allocated = m_undo_file_seq.Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return FatalError(m_opts.notifications, state, _("Disk space is too low!"));
+        auto error{_("Disk space is too low!")};
+        FatalError(m_opts.notifications, state, error);
+        return {util::Error{std::move(error)}, AbortFailure{.fatal = true}};
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
     }
 
-    return true;
+    return {};
 }
 
-bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+FlushResult<void, AbortFailure> BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
 {
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     AssertLockHeld(::cs_main);
     const BlockfileType type = BlockfileTypeForHeight(block.nHeight);
     auto& cursor = *Assert(m_blockfile_cursors[type]);
@@ -1005,16 +1011,21 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
     if (block.GetUndoPos().IsNull()) {
         FlatFilePos pos;
         const auto blockundo_size{static_cast<uint32_t>(GetSerializeSize(blockundo))};
-        if (!FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD)) {
-            LogError("FindUndoPos failed for %s while writing block undo", pos.ToString());
-            return false;
+        if (!(FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD) >> result)) {
+            auto error{Untranslated(strprintf("FindUndoPos failed for %s while writing block undo", pos.ToString()))};
+            LogError("%s", error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
 
         // Open history file to append
         AutoFile file{OpenUndoFile(pos)};
         if (file.IsNull()) {
             LogError("OpenUndoFile failed for %s while writing block undo", pos.ToString());
-            return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
+            auto error{_("Failed to write undo data.")};
+            FatalError(m_opts.notifications, state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
         {
             BufferedWriter fileout{file};
@@ -1035,7 +1046,10 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         // Make sure that the file is closed before we call `FlushUndoFile`.
         if (file.fclose() != 0) {
             LogError("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
-            return FatalError(m_opts.notifications, state, _("Failed to close block undo file."));
+            auto error{_("Failed to close block undo file.")};
+            FatalError(m_opts.notifications, state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
 
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
@@ -1063,7 +1077,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         m_dirty_blockindex.insert(&block);
     }
 
-    return true;
+    return result;
 }
 
 bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::optional<uint256>& expected_hash) const
@@ -1164,38 +1178,42 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
     }
 }
 
-FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
+FlushResult<FlatFilePos, AbortFailure> BlockManager::WriteBlock(const CBlock& block, int nHeight)
 {
     AssertLockHeld(::cs_main);
     const unsigned int block_size{static_cast<unsigned int>(GetSerializeSize(TX_WITH_WITNESS(block)))};
-    FlatFilePos pos{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
-    if (pos.IsNull()) {
-        LogError("FindNextBlockPos failed for %s while writing block", pos.ToString());
-        return FlatFilePos();
+    auto result{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
+    if (!result || result->IsNull()) {
+        auto error{Untranslated(strprintf("FindNextBlockPos failed for %s while writing block", (result ? *result : FlatFilePos{}).ToString()))};
+        LogError("%s", error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
-    AutoFile file{OpenBlockFile(pos, /*fReadOnly=*/false)};
+    AutoFile file{OpenBlockFile(*result, /*fReadOnly=*/false)};
     if (file.IsNull()) {
-        LogError("OpenBlockFile failed for %s while writing block", pos.ToString());
-        m_opts.notifications.fatalError(_("Failed to write block."));
-        return FlatFilePos();
+        LogError("OpenBlockFile failed for %s while writing block", result->ToString());
+        auto error{_("Failed to write block.")};
+        m_opts.notifications.fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return result;
     }
     {
         BufferedWriter fileout{file};
 
         // Write index header
         fileout << GetParams().MessageStart() << block_size;
-        pos.nPos += STORAGE_HEADER_BYTES;
+        result->nPos += STORAGE_HEADER_BYTES;
         // Write block
         fileout << TX_WITH_WITNESS(block);
     }
 
     if (file.fclose() != 0) {
-        LogError("Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
+        LogError("Failed to close block file %s: %s", result->ToString(), SysErrorString(errno));
         m_opts.notifications.fatalError(_("Failed to close file when writing block."));
         return FlatFilePos();
     }
 
-    return pos;
+    return result;
 }
 
 static auto InitBlocksdirXorKey(const BlockManager::Options& opts)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1340,7 +1340,8 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
                 break; // This error is logged in OpenBlockFile
             }
             LogInfo("Reindexing block file blk%05u.dat (%d%% complete)...", (unsigned int)nFile, nFile * 100 / total_files);
-            chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
+            // Propagate flush messages to result, but do not treat flush failure as an ImportBlocks failure.
+            chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent) >> result;
             if (chainman.m_interrupt) {
                 LogInfo("Interrupt requested. Exit reindexing.");
                 return;
@@ -1350,7 +1351,8 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         chainman.m_blockman.m_blockfiles_indexed = true;
         LogInfo("Reindexing finished");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
-        (void)chainman.LoadGenesisBlock();
+        // Propagate flush messages to result, but do not treat flush failure as an ImportBlocks failure.
+        chainman.LoadGenesisBlock() >> result;
     }
 
     // -loadblock=
@@ -1358,7 +1360,8 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         AutoFile file{fsbridge::fopen(path, "rb")};
         if (!file.IsNull()) {
             LogInfo("Importing blocks file %s...", fs::PathToString(path));
-            chainman.LoadExternalBlockFile(file);
+            // Propagate flush messages to result, but do not treat flush failure as an ImportBlocks failure.
+            chainman.LoadExternalBlockFile(file) >> result;
             if (chainman.m_interrupt) {
                 LogInfo("Interrupt requested. Exit block importing.");
                 return;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -26,6 +26,7 @@
 #include <util/fs.h>
 #include <util/hasher.h>
 #include <util/obfuscation.h>
+#include <util/result.h>
 
 #include <algorithm>
 #include <array>
@@ -224,9 +225,9 @@ private:
      * The nAddSize argument passed to this function should include not just the size of the serialized CBlock, but also the size of
      * separator fields (STORAGE_HEADER_BYTES).
      */
-    [[nodiscard]] FlatFilePos FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<FlatFilePos, kernel::AbortFailure> FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     [[nodiscard]] kernel::FlushResult<> FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<void, kernel::AbortFailure> FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     AutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;
 
@@ -383,7 +384,7 @@ public:
     /** Get block file info entry for one block file */
     CBlockFileInfo* GetBlockFileInfo(size_t n) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    bool WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk and update block file statistics.
@@ -394,7 +395,7 @@ public:
      * @returns in case of success, the position to which the block was written to
      *          in case of an error, an empty FlatFilePos
      */
-    FlatFilePos WriteBlock(const CBlock& block, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<FlatFilePos, kernel::AbortFailure> WriteBlock(const CBlock& block, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Update blockfile info while processing a block during reindex. The block must be available on disk.
      *

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -486,7 +486,7 @@ public:
 };
 
 // Calls ActivateBestChain() even if no blocks are imported.
-void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
+[[nodiscard]] kernel::FlushResult<kernel::InterruptResult, kernel::AbortFailure> ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
 } // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -14,6 +14,7 @@
 #include <kernel/cs_main.h>
 #include <kernel/messagestartchars.h>
 #include <kernel/result.h>
+#include <kernel/notifications_interface.h>
 #include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
@@ -207,7 +208,7 @@ private:
      * per index entry (nStatus, nChainWork, nTimeMax, etc.) as well as peripheral
      * collections like m_dirty_blockindex.
      */
-    bool LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+    [[nodiscard]] util::Result<kernel::InterruptResult, kernel::AbortFailure> LoadBlockIndexData(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return false if block file or undo file flushing fails. */
@@ -361,7 +362,7 @@ public:
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 
     void WriteBlockIndexDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+    [[nodiscard]] util::Result<kernel::InterruptResult, kernel::AbortFailure> LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -13,6 +13,7 @@
 #include <kernel/chainparams.h>
 #include <kernel/cs_main.h>
 #include <kernel/messagestartchars.h>
+#include <kernel/result.h>
 #include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
@@ -209,10 +210,10 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return false if block file or undo file flushing fails. */
-    [[nodiscard]] bool FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<> FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Return false if undo file flushing fails. */
-    [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
+    [[nodiscard]] kernel::FlushResult<> FlushUndoFile(int block_file, bool finalize = false);
 
     /**
      * Helper function performing various preparations before a block can be saved to disk:
@@ -224,8 +225,8 @@ private:
      * separator fields (STORAGE_HEADER_BYTES).
      */
     [[nodiscard]] FlatFilePos FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    [[nodiscard]] bool FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    [[nodiscard]] bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<> FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     AutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -44,12 +44,12 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets m_blockfiles_indexed based on the disk flag!
-    if (!chainman.LoadBlockIndex()) {
-        if (chainman.m_interrupt) {
-            result.update(Interrupted{});
-        } else {
-            result.update({util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE});
-        }
+    auto load_result{chainman.LoadBlockIndex() >> result};
+    if (!load_result) {
+        result.update({util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE});
+        return result;
+    } else if (IsInterrupted(*load_result) || chainman.m_interrupt) {
+        result.update(Interrupted{});
         return result;
     }
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -39,28 +39,33 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
 {
     if (chainman.m_interrupt) return Interrupted{};
 
+    util::Result<InterruptResult, ChainstateLoadError> result;
+
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets m_blockfiles_indexed based on the disk flag!
     if (!chainman.LoadBlockIndex()) {
         if (chainman.m_interrupt) {
-            return Interrupted{};
+            result.update(Interrupted{});
         } else {
-            return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
+            result.update({util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE});
         }
+        return result;
     }
 
     if (!chainman.BlockIndex().empty() &&
             !chainman.m_blockman.LookupBlockIndex(chainman.GetConsensus().hashGenesisBlock)) {
         // If the loaded chain has a wrong genesis, bail out immediately
         // (we're likely using a testnet datadir, or the other way around).
-        return {util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
+        result.update({util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB});
+        return result;
     }
 
     // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
     // in the past, but is now trying to run unpruned.
     if (chainman.m_blockman.m_have_pruned && !options.prune) {
-        return {util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE};
+        result.update({util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE});
+        return result;
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -68,7 +73,8 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
     // (otherwise we use the one already on disk).
     // This is called again in ImportBlocks after the reindex completes.
     if (chainman.m_blockman.m_blockfiles_indexed && !chainman.LoadGenesisBlock()) {
-        return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
+        result.update({util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE});
+        return result;
     }
 
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -108,15 +114,17 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {
-            return {util::Error{_("Unsupported chainstate database format found. "
+            result.update({util::Error{_("Unsupported chainstate database format found. "
                                          "Please restart with -reindex-chainstate. This will "
                                          "rebuild the chainstate database.")},
-                                       ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
+                                       ChainstateLoadError::FAILURE_INCOMPATIBLE_DB});
+            return result;
         }
 
         // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (!chainstate->ReplayBlocks()) {
-            return {util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE};
+            result.update({util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE});
+            return result;
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
@@ -126,7 +134,8 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
         if (!is_coinsview_empty(*chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block
             if (!chainstate->LoadChainTip()) {
-                return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
+                result.update({util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE});
+                return result;
             }
             assert(chainstate->m_chain.Tip() != nullptr);
         }
@@ -142,8 +151,9 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
     const auto& chainstates{chainman.m_chainstates};
     if (std::any_of(chainstates.begin(), chainstates.end(),
                     [](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-        return {util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                      chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE};
+        result.update({util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                             chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE});
+        return result;
     };
 
     // Now that chainstates are loaded and we're able to flush to
@@ -151,7 +161,7 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
     // on the condition of each chainstate.
     chainman.MaybeRebalanceCaches();
 
-    return {};
+    return result;
 }
 
 util::Result<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -26,20 +26,22 @@
 #include <cassert>
 #include <vector>
 
+using kernel::AbortFailure;
 using kernel::CacheSizes;
+using kernel::FlushResult;
 using kernel::Interrupted;
 using kernel::InterruptResult;
 
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
 // to ChainstateManager::InitializeChainstate().
-static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInitialization(
+static FlushResult<InterruptResult, ChainstateLoadError> CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     if (chainman.m_interrupt) return Interrupted{};
 
-    util::Result<InterruptResult, ChainstateLoadError> result;
+    FlushResult<InterruptResult, ChainstateLoadError> result;
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
@@ -159,15 +161,16 @@ static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInit
     // Now that chainstates are loaded and we're able to flush to
     // disk, rebalance the coins caches to desired levels based
     // on the condition of each chainstate.
-    chainman.MaybeRebalanceCaches();
+    // Ignore failure value, do not treat flush error as failure.
+    chainman.MaybeRebalanceCaches() >> result;
 
     return result;
 }
 
-util::Result<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                                                  const ChainstateLoadOptions& options)
+FlushResult<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                                 const ChainstateLoadOptions& options)
 {
-    util::Result<InterruptResult, ChainstateLoadError> result;
+    FlushResult<InterruptResult, ChainstateLoadError> result;
     if (!chainman.AssumedValidBlock().IsNull()) {
         LogInfo("Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
     } else {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -27,35 +27,40 @@
 #include <vector>
 
 using kernel::CacheSizes;
+using kernel::Interrupted;
+using kernel::InterruptResult;
 
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
 // to ChainstateManager::InitializeChainstate().
-static ChainstateLoadResult CompleteChainstateInitialization(
+static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return Interrupted{};
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets m_blockfiles_indexed based on the disk flag!
     if (!chainman.LoadBlockIndex()) {
-        if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
-        return {ChainstateLoadStatus::FAILURE, _("Error loading block database")};
+        if (chainman.m_interrupt) {
+            return Interrupted{};
+        } else {
+            return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
+        }
     }
 
     if (!chainman.BlockIndex().empty() &&
             !chainman.m_blockman.LookupBlockIndex(chainman.GetConsensus().hashGenesisBlock)) {
         // If the loaded chain has a wrong genesis, bail out immediately
         // (we're likely using a testnet datadir, or the other way around).
-        return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Incorrect or no genesis block found. Wrong datadir for network?")};
+        return {util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
     }
 
     // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
     // in the past, but is now trying to run unpruned.
     if (chainman.m_blockman.m_have_pruned && !options.prune) {
-        return {ChainstateLoadStatus::FAILURE, _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")};
+        return {util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE};
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -63,7 +68,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // (otherwise we use the one already on disk).
     // This is called again in ImportBlocks after the reindex completes.
     if (chainman.m_blockman.m_blockfiles_indexed && !chainman.LoadGenesisBlock()) {
-        return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+        return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
     }
 
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -93,7 +98,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
                 /*should_wipe=*/options.wipe_chainstate_db);
         } catch (dbwrapper_error& err) {
             LogError("%s\n", err.what());
-            return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
+            return {util::Error{_("Error opening coins database")}, ChainstateLoadError::FAILURE};
         }
 
         if (options.coins_error_cb) {
@@ -103,14 +108,15 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {
-            return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Unsupported chainstate database format found. "
-                                                                     "Please restart with -reindex-chainstate. This will "
-                                                                     "rebuild the chainstate database.")};
+            return {util::Error{_("Unsupported chainstate database format found. "
+                                         "Please restart with -reindex-chainstate. This will "
+                                         "rebuild the chainstate database.")},
+                                       ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
         }
 
         // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (!chainstate->ReplayBlocks()) {
-            return {ChainstateLoadStatus::FAILURE, _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")};
+            return {util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE};
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
@@ -120,7 +126,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         if (!is_coinsview_empty(*chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block
             if (!chainstate->LoadChainTip()) {
-                return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+                return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
             }
             assert(chainstate->m_chain.Tip() != nullptr);
         }
@@ -136,8 +142,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     const auto& chainstates{chainman.m_chainstates};
     if (std::any_of(chainstates.begin(), chainstates.end(),
                     [](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-        return {ChainstateLoadStatus::FAILURE, strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                                         chainman.GetConsensus().SegwitHeight)};
+        return {util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                      chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE};
     };
 
     // Now that chainstates are loaded and we're able to flush to
@@ -145,12 +151,13 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // on the condition of each chainstate.
     chainman.MaybeRebalanceCaches();
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                                  const ChainstateLoadOptions& options)
 {
+    util::Result<InterruptResult, ChainstateLoadError> result;
     if (!chainman.AssumedValidBlock().IsNull()) {
         LogInfo("Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
     } else {
@@ -183,14 +190,15 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         validated_cs.SetTargetBlock(nullptr);
         LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
         if (!chainman.DeleteChainstate(*assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
+            result.update({util::Error{Untranslated("Couldn't remove snapshot chainstate.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
         assumeutxo_cs = nullptr;
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-    if (init_status != ChainstateLoadStatus::SUCCESS) {
-        return {init_status, init_error};
+    result.update(CompleteChainstateInitialization(chainman, options));
+    if (!result || IsInterrupted(*result)) {
+        return result;
     }
 
     // If a snapshot chainstate was fully validated by a background chainstate during
@@ -210,7 +218,8 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogInfo("[snapshot] cleaning up unneeded background chainstate, then reinitializing");
         if (!chainman.ValidatedSnapshotCleanup(validated_cs, *assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Background chainstate cleanup failed unexpectedly.")};
+            result.update({util::Error{Untranslated("Background chainstate cleanup failed unexpectedly.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with
@@ -224,20 +233,22 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-        if (init_status != ChainstateLoadStatus::SUCCESS) {
-            return {init_status, init_error};
+        auto result{CompleteChainstateInitialization(chainman, options)};
+        if (!result || IsInterrupted(*result)) {
+            return result;
         }
     } else {
-        return {ChainstateLoadStatus::FAILURE_FATAL, _(
+        result.update({util::Error{_(
            "UTXO snapshot failed to validate. "
-           "Restart to resume normal initial block download, or try loading a different snapshot.")};
+           "Restart to resume normal initial block download, or try loading a different snapshot.")},
+           ChainstateLoadError::FAILURE_FATAL});
+        return result;
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.wipe_chainstate_db || chainstate.CoinsTip().GetBestBlock().IsNull();
@@ -245,36 +256,42 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
 
     LOCK(cs_main);
 
+    util::Result<InterruptResult, ChainstateLoadError> result;
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
             if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
-                                                         "This may be due to your computer's date and time being set incorrectly. "
-                                                         "Only rebuild the block database if you are sure that your computer's date and time are correct")};
+                result.update({util::Error{_("The block database contains a block which appears to be from the future. "
+                                             "This may be due to your computer's date and time being set incorrectly. "
+                                             "Only rebuild the block database if you are sure that your computer's date and time are correct")},
+                               ChainstateLoadError::FAILURE});
+                return result;
             }
 
-            VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
+            VerifyDBResult verify_result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
                 options.check_blocks);
-            switch (result) {
+            switch (verify_result) {
             case VerifyDBResult::SUCCESS:
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:
                 break;
             case VerifyDBResult::INTERRUPTED:
-                return {ChainstateLoadStatus::INTERRUPTED, _("Block verification was interrupted")};
+                result.update(Interrupted{});
+                return result;
             case VerifyDBResult::CORRUPTED_BLOCK_DB:
-                return {ChainstateLoadStatus::FAILURE, _("Corrupted block database detected")};
+                result.update({util::Error{_("Corrupted block database detected")}, ChainstateLoadError::FAILURE});
+                return result;
             case VerifyDBResult::SKIPPED_L3_CHECKS:
                 if (options.require_full_verification) {
-                    return {ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE, _("Insufficient dbcache for block verification")};
+                    result.update({util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE});
+                    return result;
                 }
                 break;
             } // no default case, so the compiler can warn about missing cases
         }
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 } // namespace node

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -19,6 +19,7 @@
 #include <util/log.h>
 #include <util/signalinterrupt.h>
 #include <util/time.h>
+#include <util/overloaded.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -264,7 +265,7 @@ FlushResult<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManag
     return result;
 }
 
-util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
+FlushResult<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.wipe_chainstate_db || chainstate.CoinsTip().GetBestBlock().IsNull();
@@ -272,7 +273,7 @@ util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(Chains
 
     LOCK(cs_main);
 
-    util::Result<InterruptResult, ChainstateLoadError> result;
+    FlushResult<InterruptResult, ChainstateLoadError> result;
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
@@ -284,27 +285,25 @@ util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(Chains
                 return result;
             }
 
-            VerifyDBResult verify_result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
+            auto verify_result{CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
-                options.check_blocks);
-            switch (verify_result) {
-            case VerifyDBResult::SUCCESS:
-            case VerifyDBResult::SKIPPED_MISSING_BLOCKS:
-                break;
-            case VerifyDBResult::INTERRUPTED:
-                result.update(Interrupted{});
-                return result;
-            case VerifyDBResult::CORRUPTED_BLOCK_DB:
+                options.check_blocks) >> result};
+            if (verify_result) {
+                std::visit(util::Overloaded{
+                    [&](VerifySuccess) {},
+                    [&](SkippedMissingBlocks) {},
+                    [&](SkippedL3Checks) {
+                        if (options.require_full_verification) {
+                            result.update({util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE});
+                        }
+                    },
+                    [&](kernel::Interrupted) {
+                       result.update(Interrupted{});
+                    }}, *verify_result);
+            } else {
                 result.update({util::Error{_("Corrupted block database detected")}, ChainstateLoadError::FAILURE});
-                return result;
-            case VerifyDBResult::SKIPPED_L3_CHECKS:
-                if (options.require_full_verification) {
-                    result.update({util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE});
-                    return result;
-                }
-                break;
-            } // no default case, so the compiler can warn about missing cases
+            }
         }
     }
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -222,9 +222,12 @@ FlushResult<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManag
     // snapshot is actually validated? Because this entails unusual
     // filesystem operations to move leveldb data directories around, and that seems
     // too risky to do in the middle of normal runtime.
+    FlushResult<void, AbortFailure> snapshot_result;
     auto snapshot_completion{assumeutxo_cs
-                             ? chainman.MaybeValidateSnapshot(validated_cs, *assumeutxo_cs)
+                             ? chainman.MaybeValidateSnapshot(validated_cs, *assumeutxo_cs, snapshot_result)
                              : SnapshotCompletionResult::SKIPPED};
+    // Ignore failure value, do not treat flush error as failure.
+    snapshot_result >> result;
 
     if (snapshot_completion == SnapshotCompletionResult::SKIPPED) {
         // do nothing; expected case

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
+#include <kernel/notifications_interface.h>
+#include <util/result.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -41,34 +43,16 @@ struct ChainstateLoadOptions {
 //! case, and treat other cases as errors. More complex applications may want to
 //! try reindexing in the generic failure case, and pass an interrupt callback
 //! and exit cleanly in the interrupted case.
-enum class ChainstateLoadStatus {
-    SUCCESS,
+enum class ChainstateLoadError {
     FAILURE, //!< Generic failure which reindexing may fix
     FAILURE_FATAL, //!< Fatal error which should not prompt to reindex
     FAILURE_INCOMPATIBLE_DB,
     FAILURE_INSUFFICIENT_DBCACHE,
-    INTERRUPTED,
 };
 
-//! Chainstate load status code and optional error string.
-using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
-
-/** This sequence can have 4 types of outcomes:
- *
- *  1. Success
- *  2. Shutdown requested
- *    - nothing failed but a shutdown was triggered in the middle of the
- *      sequence
- *  3. Soft failure
- *    - a failure that might be recovered from with a reindex
- *  4. Hard failure
- *    - a failure that definitively cannot be recovered from with a reindex
- *
- *  LoadChainstate returns a (status code, error string) tuple.
- */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options);
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
+                                                                          const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -52,7 +52,7 @@ enum class ChainstateLoadError {
 
 kernel::FlushResult<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
                                                                                  const ChainstateLoadOptions& options);
-util::Result<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
+kernel::FlushResult<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -50,8 +50,8 @@ enum class ChainstateLoadError {
     FAILURE_INSUFFICIENT_DBCACHE,
 };
 
-util::Result<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
-                                                                          const ChainstateLoadOptions& options);
+kernel::FlushResult<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
+                                                                                 const ChainstateLoadOptions& options);
 util::Result<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -25,6 +25,7 @@
 #include <interfaces/rpc.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
+#include <kernel/result.h>
 #include <key.h>
 #include <logging.h>
 #include <mapport.h>
@@ -95,6 +96,7 @@ using interfaces::Node;
 using interfaces::Rpc;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
+using kernel::FlushResult;
 using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
@@ -1018,7 +1020,10 @@ public:
     bool checkBlock(const CBlock& block, const node::BlockCheckOptions& options, std::string& reason, std::string& debug) override
     {
         LOCK(chainman().GetMutex());
-        BlockValidationState state{TestBlockValidity(chainman().ActiveChainstate(), block, /*check_pow=*/options.check_pow, /*check_merkle_root=*/options.check_merkle_root)};
+        BlockValidationState state;
+        if (auto result{TestBlockValidity(chainman().ActiveChainstate(), block, /*check_pow=*/options.check_pow, /*check_merkle_root=*/options.check_merkle_root)}; !result) {
+            state = std::move(result.error());
+        }
         reason = state.GetRejectReason();
         debug = state.GetDebugMessage();
         return state.IsValid();

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -25,6 +25,7 @@
 #include <interfaces/rpc.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
+#include <kernel/result.h>
 #include <key.h>
 #include <logging.h>
 #include <mapport.h>
@@ -97,6 +98,7 @@ using interfaces::Node;
 using interfaces::Rpc;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
+using kernel::FlushResult;
 using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
@@ -1018,7 +1020,10 @@ public:
     bool checkBlock(const CBlock& block, const node::BlockCheckOptions& options, std::string& reason, std::string& debug) override
     {
         LOCK(chainman().GetMutex());
-        BlockValidationState state{TestBlockValidity(chainman().ActiveChainstate(), block, /*check_pow=*/options.check_pow, /*check_merkle_root=*/options.check_merkle_root)};
+        BlockValidationState state;
+        if (auto result{TestBlockValidity(chainman().ActiveChainstate(), block, /*check_pow=*/options.check_pow, /*check_merkle_root=*/options.check_merkle_root)}; !result) {
+            state = std::move(result.error());
+        }
         reason = state.GetRejectReason();
         debug = state.GetDebugMessage();
         return state.IsValid();

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -34,20 +34,28 @@
 #include <vector>
 
 using fsbridge::FopenFn;
+using kernel::FlushResult;
+using kernel::Interrupted;
+using kernel::InterruptResult;
 
 namespace node {
 
 static const uint64_t MEMPOOL_DUMP_VERSION_NO_XOR_KEY{1};
 static const uint64_t MEMPOOL_DUMP_VERSION{2};
 
-bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active_chainstate, ImportMempoolOptions&& opts)
+FlushResult<InterruptResult> LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active_chainstate, ImportMempoolOptions&& opts)
 {
-    if (load_path.empty()) return false;
+    FlushResult<InterruptResult> result;
+    if (load_path.empty()) {
+        result.update(util::Error{});
+        return result;
+    }
 
     AutoFile file{opts.mockable_fopen_function(load_path, "rb")};
     if (file.IsNull()) {
         LogInfo("Failed to open mempool file. Continuing anyway.\n");
-        return false;
+        result.update(util::Error{});
+        return result;
     }
 
     int64_t count = 0;
@@ -68,7 +76,8 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             file >> obfuscation;
             file.SetObfuscation(obfuscation);
         } else {
-            return false;
+            result.update(util::Error{});
+            return result;
         }
 
         uint64_t total_txns_to_load;
@@ -102,7 +111,9 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             }
             if (nTime > TicksSinceEpoch<std::chrono::seconds>(now - pool.m_opts.expiry)) {
                 LOCK(cs_main);
-                const auto& accepted = AcceptToMemoryPool(active_chainstate, tx, nTime, /*bypass_limits=*/false, /*test_accept=*/false);
+                auto [accepted, flush_result] = AcceptToMemoryPool(active_chainstate, tx, nTime, /*bypass_limits=*/false, /*test_accept=*/false);
+                // Ignore failure value, do not treat flush error as failure.
+                flush_result >> result;
                 if (accepted.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                     ++count;
                 } else {
@@ -119,8 +130,10 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             } else {
                 ++expired;
             }
-            if (active_chainstate.m_chainman.m_interrupt)
-                return false;
+            if (active_chainstate.m_chainman.m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
         }
         std::map<Txid, CAmount> mapDeltas;
         file >> mapDeltas;
@@ -143,11 +156,12 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
         }
     } catch (const std::exception& e) {
         LogInfo("Failed to deserialize mempool data on file: %s. Continuing anyway.\n", e.what());
-        return false;
+        result.update(util::Error{});
+        return result;
     }
 
     LogInfo("Imported mempool transactions from file: %i succeeded, %i failed, %i expired, %i already there, %i waiting for initial broadcast\n", count, failed, expired, already_there, unbroadcast);
-    return true;
+    return result;
 }
 
 bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mockable_fopen_function, bool skip_file_commit)

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_NODE_MEMPOOL_PERSIST_H
 #define BITCOIN_NODE_MEMPOOL_PERSIST_H
 
+#include <node/blockstorage.h>
+#include <kernel/result.h>
 #include <util/fs.h>
 
 class Chainstate;
@@ -24,7 +26,7 @@ struct ImportMempoolOptions {
     bool apply_unbroadcast_set{true};
 };
 /** Import the file and attempt to add its contents to the mempool. */
-bool LoadMempool(CTxMemPool& pool, const fs::path& load_path,
+kernel::FlushResult<kernel::InterruptResult> LoadMempool(CTxMemPool& pool, const fs::path& load_path,
                  Chainstate& active_chainstate,
                  ImportMempoolOptions&& opts);
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,6 +15,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <interfaces/types.h>
+#include <kernel/result.h>
 #include <node/blockstorage.h>
 #include <node/kernel_notifications.h>
 #include <node/mining_args.h>
@@ -229,8 +230,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     pblock->nNonce         = 0;
 
     if (m_options.test_block_validity) {
-        if (BlockValidationState state{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
-            throw std::runtime_error(strprintf("TestBlockValidity failed: %s", state.ToString()));
+        if (auto result{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !result) {
+            throw std::runtime_error(strprintf("TestBlockValidity failed: %s", result.error().ToString()));
         }
     }
     const auto time_2{SteadyClock::now()};
@@ -399,7 +400,8 @@ bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock
     // behavior.
     auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block);
+    kernel::FlushResult<void, kernel::AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block, process_result);
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
 
     if (new_block && !*new_block && accepted) {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,6 +15,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <interfaces/types.h>
+#include <kernel/result.h>
 #include <node/blockstorage.h>
 #include <node/kernel_notifications.h>
 #include <node/mining_args.h>
@@ -229,8 +230,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     pblock->nNonce         = 0;
 
     if (m_options.test_block_validity) {
-        if (BlockValidationState state{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
-            throw std::runtime_error(strprintf("TestBlockValidity failed: %s", state.ToString()));
+        if (auto result{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !result) {
+            throw std::runtime_error(strprintf("TestBlockValidity failed: %s", result.error().ToString()));
         }
     }
     const auto time_2{SteadyClock::now()};
@@ -401,7 +402,8 @@ bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock
     auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
     bool new_block;
-    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    kernel::FlushResult<void, kernel::AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block, process_result);
     // No queue drain is needed. The BlockChecked notification used above is
     // emitted synchronously by ProcessNewBlock, unlike most validation signals.
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -75,7 +75,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
             if (check_max_fee || broadcast_method == TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ true);
+                auto [result, flush_result]{node.chainman->ProcessTransaction(tx, /*test_accept=*/ true)};
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
                 } else if (check_max_fee && result.m_base_fees.value() > max_tx_fee) {
@@ -88,7 +88,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
             case TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL:
                 // Try to submit the transaction to the mempool.
                 {
-                    const MempoolAcceptResult result =
+                    auto [result, flush_result] =
                         node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
                     if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                         return HandleATMPError(result.m_state, err_string);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1289,8 +1289,9 @@ static RPCMethod verifychain()
     LOCK(cs_main);
 
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    return CVerifyDB(chainman.GetNotifications()).VerifyDB(
-               active_chainstate, chainman.GetParams().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth) == VerifyDBResult::SUCCESS;
+    auto verify_result{CVerifyDB(chainman.GetNotifications()).VerifyDB(
+        active_chainstate, chainman.GetParams().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth)};
+    return verify_result && std::holds_alternative<VerifySuccess>(*verify_result);
 },
     };
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1709,7 +1709,7 @@ static RPCMethod preciousblock()
     }
 
     BlockValidationState state;
-    chainman.ActiveChainstate().PreciousBlock(state, pblockindex);
+    (void)chainman.ActiveChainstate().PreciousBlock(state, pblockindex);
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());
@@ -1733,7 +1733,7 @@ void InvalidateBlock(ChainstateManager& chainman, const uint256 block_hash) {
     (void)chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
 
     if (state.IsValid()) {
-        chainman.ActiveChainstate().ActivateBestChain(state);
+        (void)chainman.ActiveChainstate().ActivateBestChain(state);
     }
 
     if (!state.IsValid()) {
@@ -1779,7 +1779,7 @@ void ReconsiderBlock(ChainstateManager& chainman, uint256 block_hash) {
     }
 
     BlockValidationState state;
-    chainman.ActiveChainstate().ActivateBestChain(state);
+    (void)chainman.ActiveChainstate().ActivateBestChain(state);
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -968,7 +968,7 @@ static RPCMethod pruneblockchain()
         height = chainHeight - MIN_BLOCKS_TO_KEEP;
     }
 
-    PruneBlockFilesManual(active_chainstate, height);
+    (void)PruneBlockFilesManual(active_chainstate, height);
     return GetPruneHeight(chainman.m_blockman, active_chain).value_or(-1);
 },
     };
@@ -1081,7 +1081,7 @@ static RPCMethod gettxoutsetinfo()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+    (void)active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
     const CCoinsViewDB& coins_view{WITH_LOCK(::cs_main, return active_chainstate.CoinsDB())};
     BlockManager& blockman{active_chainstate.m_blockman};
@@ -2440,7 +2440,7 @@ static RPCMethod scantxoutset()
             ChainstateManager& chainman = EnsureChainman(node);
             LOCK(cs_main);
             Chainstate& active_chainstate = chainman.ActiveChainstate();
-            active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+            (void)active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
             pcursor = active_chainstate.CoinsDB().Cursor();
             tip = CHECK_NONFATAL(active_chainstate.m_chain.Tip());
         }
@@ -3246,7 +3246,7 @@ UniValue CreateRolledBackUTXOSnapshot(
         {
             LOCK(::cs_main);
             tip = chainstate.m_chain.Tip();
-            chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+            (void)chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
             cursor = chainstate.CoinsDB().Cursor();
         }
         temp_cache.SetBestBlock(tip->GetBlockHash());
@@ -3364,7 +3364,7 @@ PrepareUTXOSnapshot(
         //
         AssertLockHeld(::cs_main);
 
-        chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+        (void)chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
         maybe_stats = GetUTXOStats(chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
         if (!maybe_stats) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1730,7 +1730,7 @@ void InvalidateBlock(ChainstateManager& chainman, const uint256 block_hash) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         }
     }
-    chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
+    (void)chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
 
     if (state.IsValid()) {
         chainman.ActiveChainstate().ActivateBestChain(state);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -968,7 +968,7 @@ static RPCMethod pruneblockchain()
         height = chainHeight - MIN_BLOCKS_TO_KEEP;
     }
 
-    PruneBlockFilesManual(active_chainstate, height);
+    (void)PruneBlockFilesManual(active_chainstate, height);
     return GetPruneHeight(chainman.m_blockman, active_chain).value_or(-1);
 },
     };
@@ -1081,7 +1081,7 @@ static RPCMethod gettxoutsetinfo()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+    (void)active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
     const CCoinsViewDB& coins_view{WITH_LOCK(::cs_main, return active_chainstate.CoinsDB())};
     BlockManager& blockman{active_chainstate.m_blockman};
@@ -2441,7 +2441,7 @@ static RPCMethod scantxoutset()
             ChainstateManager& chainman = EnsureChainman(node);
             LOCK(cs_main);
             Chainstate& active_chainstate = chainman.ActiveChainstate();
-            active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+            (void)active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
             pcursor = active_chainstate.CoinsDB().Cursor();
             tip = CHECK_NONFATAL(active_chainstate.m_chain.Tip());
         }
@@ -3251,7 +3251,7 @@ UniValue CreateRolledBackUTXOSnapshot(
         {
             LOCK(::cs_main);
             tip = chainstate.m_chain.Tip();
-            chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+            (void)chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
             cursor = chainstate.CoinsDB().Cursor();
         }
         temp_cache.SetBestBlock(tip->GetBlockHash());
@@ -3369,7 +3369,7 @@ PrepareUTXOSnapshot(
         //
         AssertLockHeld(::cs_main);
 
-        chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
+        (void)chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
         maybe_stats = GetUTXOStats(chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
         if (!maybe_stats) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -357,9 +357,12 @@ static RPCMethod testmempoolaccept()
             Chainstate& chainstate = chainman.ActiveChainstate();
             const PackageMempoolAcceptResult package_result = [&] {
                 LOCK(::cs_main);
-                if (txns.size() > 1) return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true, /*client_maxfeerate=*/{});
-                return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(txns[0], /*test_accept=*/true));
+                if (txns.size() > 1) {
+                    auto [mempool_accept, flush_result]{ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+                    return mempool_accept;
+                }
+                auto [mempool_accept, flush_result]{chainman.ProcessTransaction(txns[0], /*test_accept=*/true)};
+                return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(), mempool_accept);
             }();
 
             UniValue rpc_result(UniValue::VARR);
@@ -1426,7 +1429,7 @@ static RPCMethod submitpackage()
             NodeContext& node = EnsureAnyNodeContext(request.context);
             CTxMemPool& mempool = EnsureMemPool(node);
             Chainstate& chainstate = EnsureChainman(node).ActiveChainstate();
-            const auto package_result = WITH_LOCK(::cs_main, return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/ false, client_maxfeerate));
+            auto [package_result, flush_result]{WITH_LOCK(::cs_main, return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/ false, client_maxfeerate))};
 
             std::string package_msg = "success";
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -365,9 +365,12 @@ static RPCMethod testmempoolaccept()
             Chainstate& chainstate = chainman.ActiveChainstate();
             const PackageMempoolAcceptResult package_result = [&] {
                 LOCK(::cs_main);
-                if (txns.size() > 1) return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true, /*client_maxfeerate=*/{});
-                return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(txns[0], /*test_accept=*/true));
+                if (txns.size() > 1) {
+                    auto [mempool_accept, flush_result]{ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+                    return mempool_accept;
+                }
+                auto [mempool_accept, flush_result]{chainman.ProcessTransaction(txns[0], /*test_accept=*/true)};
+                return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(), mempool_accept);
             }();
 
             UniValue rpc_result(UniValue::VARR);
@@ -1444,7 +1447,7 @@ static RPCMethod submitpackage()
             NodeContext& node = EnsureAnyNodeContext(request.context);
             CTxMemPool& mempool = EnsureMemPool(node);
             Chainstate& chainstate = EnsureChainman(node).ActiveChainstate();
-            const auto package_result = WITH_LOCK(::cs_main, return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/ false, client_maxfeerate));
+            auto [package_result, flush_result]{WITH_LOCK(::cs_main, return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/ false, client_maxfeerate))};
 
             std::string package_msg = "success";
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include <core_io.h>
 #include <crypto/hex_base.h>
 #include <interfaces/types.h>
+#include <kernel/result.h>
 #include <key_io.h>
 #include <net.h>
 #include <netbase.h>
@@ -80,6 +81,8 @@
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;
 using interfaces::Mining;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockAssembler;
 using node::GetMinimumTime;
 using node::NodeContext;
@@ -185,7 +188,8 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock&& block, uint64_t&
 
     if (!process_new_block) return true;
 
-    if (!chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr)) {
+    FlushResult<void, AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    if (!chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr, process_result)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
     }
 
@@ -420,8 +424,8 @@ static RPCMethod generateblock()
         block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
         RegenerateCommitments(block, chainman);
 
-        if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
-            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", state.ToString()));
+        if (auto result{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !result) {
+            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", result.error().ToString()));
         }
     }
 
@@ -778,7 +782,11 @@ static RPCMethod getblocktemplate()
                 return "duplicate-inconclusive";
             }
 
-            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true));
+            BlockValidationState state;
+            if (auto result{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true)}; !result) {
+                state = std::move(result.error());
+            }
+            return BIP22ValidationResult(state);
         }
 
         const UniValue& aClientRules = oparam.find_value("rules");
@@ -1122,7 +1130,8 @@ static RPCMethod submitblock()
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    FlushResult<void, AbortFailure> process_result;
+    bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block, process_result);
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include <core_io.h>
 #include <crypto/hex_base.h>
 #include <interfaces/types.h>
+#include <kernel/result.h>
 #include <key_io.h>
 #include <net.h>
 #include <netbase.h>
@@ -80,6 +81,8 @@
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;
 using interfaces::Mining;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockAssembler;
 using node::GetMinimumTime;
 using node::NodeContext;
@@ -185,7 +188,8 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock&& block, uint64_t&
 
     if (!process_new_block) return true;
 
-    if (!chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr)) {
+    FlushResult<void, AbortFailure> process_result; // Ignore flush and fatal error information, only care whether block is accepted.
+    if (!chainman.ProcessNewBlock(block_out, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr, process_result)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
     }
 
@@ -420,8 +424,8 @@ static RPCMethod generateblock()
         block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
         RegenerateCommitments(block, chainman);
 
-        if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
-            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", state.ToString()));
+        if (auto result{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !result) {
+            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", result.error().ToString()));
         }
     }
 
@@ -779,7 +783,11 @@ static RPCMethod getblocktemplate()
                 return "duplicate-inconclusive";
             }
 
-            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true));
+            BlockValidationState state;
+            if (auto result{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true)}; !result) {
+                state = std::move(result.error());
+            }
+            return BIP22ValidationResult(state);
         }
 
         const UniValue& aClientRules = oparam.find_value("rules");
@@ -1124,7 +1132,8 @@ static RPCMethod submitblock()
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    FlushResult<void, AbortFailure> process_result;
+    bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block, process_result);
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -29,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
         BOOST_REQUIRE(index.Init());
         index.Sync();
         if (do_flush) {
-            chainstate.ForceFlushStateToDisk();
+            BOOST_CHECK(chainstate.ForceFlushStateToDisk());
             m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
         }
         BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, expected_sync_height);

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -76,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
             BOOST_REQUIRE(index->Init());
             index->Sync();
             if (do_flush) {
-                chainstate.ForceFlushStateToDisk();
+                BOOST_CHECK(chainstate.ForceFlushStateToDisk());
                 m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
             }
             BOOST_CHECK_EQUAL(index->GetSummary().best_block_height, expected_sync_height);
@@ -118,7 +118,7 @@ BOOST_FIXTURE_TEST_CASE(index_unclean_shutdown, TestChain100Setup)
     Chainstate& chainstate = Assert(m_node.chainman)->ActiveChainstate();
     const CChainParams& params = Params();
     const int tip_height{WITH_LOCK(cs_main, return chainstate.m_chain.Height())};
-    chainstate.ForceFlushStateToDisk();
+    Assert(chainstate.ForceFlushStateToDisk());
     // Drain the notification before registering any index.
     m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
     for (const auto& [index_name, make_index] : INDEX_FACTORIES) {

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -42,7 +42,9 @@
 #include <utility>
 #include <vector>
 
+using kernel::AbortFailure;
 using kernel::ChainstateRole;
+using kernel::FlushResult;
 
 using IndexFactory = std::function<std::unique_ptr<BaseIndex>(node::NodeContext&)>;
 
@@ -138,7 +140,9 @@ BOOST_FIXTURE_TEST_CASE(index_unclean_shutdown, TestChain100Setup)
                 LOCK(cs_main);
                 BlockValidationState state;
                 BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
-                BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
+                FlushResult<void, AbortFailure> accept_result;
+                BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, accept_result, &new_block_index, true, nullptr, nullptr, true));
+                BOOST_CHECK(accept_result);
                 CCoinsViewCache view(&chainstate.CoinsTip());
                 BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
             }
@@ -224,7 +228,9 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, TestChain100Setup)
     BOOST_REQUIRE(BuildChain(m_node, prev_tip, GetScriptForDestination(PKHash(GenerateRandomKey().GetPubKey())), 3, fork));
 
     for (const auto& block : fork) {
-        BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr, process_result));
+        BOOST_CHECK(process_result);
     }
 
     // The index thread is blocked and not done

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -126,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE(invalidate_block, TestChain100Setup)
     auto* orig_tip = active.Tip();
     int height_to_invalidate = orig_tip->nHeight - 10;
     auto* tip_to_invalidate = active[height_to_invalidate];
-    m_node.chainman->ActiveChainstate().InvalidateBlock(state, tip_to_invalidate);
+    BOOST_CHECK(m_node.chainman->ActiveChainstate().InvalidateBlock(state, tip_to_invalidate));
 
     // tip_to_invalidate just got invalidated, so it's BLOCK_FAILED_VALID
     WITH_LOCK(::cs_main, assert(tip_to_invalidate->nStatus & BLOCK_FAILED_VALID));

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -42,6 +42,8 @@
 #include <utility>
 #include <vector>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockManager;
 
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
@@ -197,7 +199,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
+        BOOST_CHECK(process_result);
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -215,7 +219,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
+        BOOST_CHECK(process_result);
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -246,7 +252,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     // Reorg back to chain A.
      for (size_t i = 2; i < 4; i++) {
          const auto& block = chainA[i];
-         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+         FlushResult<void, AbortFailure> process_result;
+         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
+         BOOST_CHECK(process_result);
      }
 
      // Check that chain A and B blocks can be retrieved.
@@ -393,7 +401,9 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
     BOOST_REQUIRE(BuildChain(prev_tip, GetScriptForDestination(PKHash(GenerateRandomKey().GetPubKey())), 3, fork));
 
     for (const auto& block : fork) {
-        BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr, process_result));
+        BOOST_CHECK(process_result);
     }
 
     // Unblock the index thread so it can process the reorg

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockManager;
 
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
@@ -131,7 +133,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -149,7 +152,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+        FlushResult<void, AbortFailure> process_result;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -180,7 +184,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     // Reorg back to chain A.
      for (size_t i = 2; i < 4; i++) {
          const auto& block = chainA[i];
-         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr));
+         FlushResult<void, AbortFailure> process_result;
+         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(block, true, true, nullptr, process_result));
      }
 
      // Check that chain A and B blocks can be retrieved.

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
     // simulate adding a genesis block normally
     LOCK(::cs_main);
-    BOOST_CHECK_EQUAL(blockman.WriteBlock(params->GenesisBlock(), 0).nPos, STORAGE_HEADER_BYTES);
+    BOOST_CHECK_EQUAL(Assert(blockman.WriteBlock(params->GenesisBlock(), 0))->nPos, STORAGE_HEADER_BYTES);
     // simulate what happens during reindex
     // simulate a well-formed genesis block being found at offset 8 in the blk00000.dat file
     // the block is found at offset 8 because there is an 8 byte serialization header
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     // this is a check to make sure that https://github.com/bitcoin/bitcoin/issues/21379 does not recur
     // 8 bytes (for serialization header) + 285 (for serialized genesis block) = 293
     // add another 8 bytes for the second block's serialization header and we get 293 + 8 = 301
-    FlatFilePos actual{blockman.WriteBlock(params->GenesisBlock(), 1)};
+    FlatFilePos actual{*Assert(blockman.WriteBlock(params->GenesisBlock(), 1))};
     BOOST_CHECK_EQUAL(actual.nPos, STORAGE_HEADER_BYTES + ::GetSerializeSize(TX_WITH_WITNESS(params->GenesisBlock())) + STORAGE_HEADER_BYTES);
 }
 
@@ -262,10 +262,10 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
     BOOST_CHECK_EQUAL(blockman.CalculateCurrentUsage(), 0);
 
     // Write the first block to a new location.
-    FlatFilePos pos1{blockman.WriteBlock(block1, /*nHeight=*/1)};
+    FlatFilePos pos1{*Assert(blockman.WriteBlock(block1, /*nHeight=*/1))};
 
     // Write second block
-    FlatFilePos pos2{blockman.WriteBlock(block2, /*nHeight=*/2)};
+    FlatFilePos pos2{*Assert(blockman.WriteBlock(block2, /*nHeight=*/2))};
 
     // Two blocks in the file
     BOOST_CHECK_EQUAL(blockman.CalculateCurrentUsage(), (TEST_BLOCK_SIZE + STORAGE_HEADER_BYTES) * 2);

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -77,8 +77,8 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
 
     {
         LOCK2(m_node.chainman->GetMutex(), chainstate.MempoolMutex());
-        chainstate.DisconnectTip(state_dummy, nullptr);
-        chainstate.DisconnectTip(state_dummy, nullptr);
+        BOOST_CHECK(chainstate.DisconnectTip(state_dummy, nullptr));
+        BOOST_CHECK(chainstate.DisconnectTip(state_dummy, nullptr));
     }
 
     BOOST_CHECK_EQUAL(second_from_tip->pprev, chainstate.m_chain.Tip());

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -95,7 +95,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->RegisterSharedValidationInterface(sub);
 
     // ActivateBestChain back to tip
-    chainstate.ActivateBestChain(state_dummy, nullptr);
+    BOOST_CHECK(chainstate.ActivateBestChain(state_dummy, nullptr));
     BOOST_CHECK_EQUAL(tip, chainstate.m_chain.Tip());
     // Check that we flushed inside ActivateBestChain while we were at the
     // second block from tip, since FlushStateToDisk is called with PERIODIC

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -34,18 +34,18 @@ BOOST_FIXTURE_TEST_CASE(chainstate_write_interval, TestingSetup)
     FakeNodeClock clock{};
 
     // The first periodic flush sets m_next_write and does not flush
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    BOOST_CHECK(chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     clock += DATABASE_WRITE_INTERVAL_MIN - 1min;
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    BOOST_CHECK(chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
     clock += DATABASE_WRITE_INTERVAL_MAX;
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    BOOST_CHECK(chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC));
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(sub->m_did_flush);
 }
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     BOOST_CHECK_EQUAL(second_from_tip->pprev, chainstate.m_chain.Tip());
 
     // Set m_next_write to current time
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::FORCE_FLUSH);
+    BOOST_CHECK(chainstate.FlushStateToDisk(state_dummy, FlushStateMode::FORCE_FLUSH));
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip->pprev);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -27,7 +27,9 @@
 #include <span>
 #include <vector>
 
+using kernel::AbortFailure;
 using kernel::ChainstateRole;
+using kernel::FlushResult;
 
 BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 
@@ -103,7 +105,9 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             LOCK(cs_main);
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
-            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
+            FlushResult<void, AbortFailure> accept_result;
+            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, accept_result, &new_block_index, true, nullptr, nullptr, true));
+            BOOST_CHECK(accept_result);
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }

--- a/src/test/fuzz/connect_block.cpp
+++ b/src/test/fuzz/connect_block.cpp
@@ -211,7 +211,7 @@ void AddExtraTxsToMempool(TestingSetup& setup)
 
         LOCK(::cs_main);
         // Add transaction to the mempool.
-        const MempoolAcceptResult ctx_result = setup.m_node.chainman->ProcessTransaction(MakeTransactionRef(ctx));
+        auto [ctx_result, ctx_flush] = setup.m_node.chainman->ProcessTransaction(MakeTransactionRef(ctx));
         Assert(ctx_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
 
         Assert(setup.m_node.chainman->ActiveChainstate().GetMempool()->size() == i);

--- a/src/test/fuzz/connect_block.cpp
+++ b/src/test/fuzz/connect_block.cpp
@@ -469,12 +469,12 @@ FUZZ_TARGET(connect_block, .init = initialize_connect_block)
 
     // Try to connect the block.
     BlockValidationState state;
-    bool connected = active_chainstate.ConnectBlock(block,
-                                                    state,
-                                                    &new_index,
-                                                    active_coins,
-                                                    /*fJustCheck=*/true);
-    Assert(connected == state.IsValid());
+    auto connect_result = active_chainstate.ConnectBlock(block,
+                                                         state,
+                                                         &new_index,
+                                                         active_coins,
+                                                         /*fJustCheck=*/true);
+    Assert(bool(connect_result) == state.IsValid());
 }
 
 } // namespace

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -39,9 +39,9 @@ FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_fil
         // Corresponds to the -reindex case (track orphan blocks across files).
         FlatFilePos flat_file_pos;
         std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
-        g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent);
+        Assert(g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent));
     } else {
         // Corresponds to the -loadblock= case (orphan blocks aren't tracked across files).
-        g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file);
+        Assert(g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file));
     }
 }

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -341,8 +341,8 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
 
         auto single_submit = txs.size() == 1;
 
-        const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}));
+        auto [result_package, process_result]{WITH_LOCK(::cs_main,
+                                    return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}))};
 
         const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
@@ -515,13 +515,15 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
             client_maxfeerate = CFeeRate(fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(-1, 50 * COIN), 100);
         }
 
-        const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, client_maxfeerate));
+        auto [result_package, process_result]{WITH_LOCK(::cs_main,
+                                    return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, client_maxfeerate))};
+        Assert(process_result);
 
         // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
         // can be a source of divergence.
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
-                                   /*bypass_limits=*/false, /*test_accept=*/!single_submit));
+        auto [res, flush_result]{WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+                                   /*bypass_limits=*/false, /*test_accept=*/!single_submit))};
+        Assert(flush_result);
         const bool passed = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
 
         node.validation_signals->SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -135,7 +135,8 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
         // Now try to add those transactions back, as though a reorg happened.
         std::vector<Txid> hashes_to_update;
         for (const auto& tx : block_template->block.vtx) {
-            const auto res = AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false);
+            auto [res, flush_result]{AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false)};
+            Assert(flush_result);
             if (res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 hashes_to_update.push_back(tx->GetHash());
             } else {
@@ -357,8 +358,9 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
         // Make sure ProcessNewPackage on one transaction works.
         // The result is not guaranteed to be the same as what is returned by ATMP.
-        const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{}));
+        auto [result_package, process_result]{WITH_LOCK(::cs_main,
+                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{}))};
+        Assert(process_result);
         // If something went wrong due to a package-specific policy, it might not return a
         // validation result for the transaction.
         if (result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {
@@ -368,7 +370,8 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false));
+        auto [res, flush_result]{WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false))};
+        Assert(flush_result);
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
@@ -475,7 +478,8 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         ever_bypassed_limits |= bypass_limits;
 
         const auto tx = MakeTransactionRef(mut_tx);
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        auto [res, flush_result]{WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false))};
+        Assert(flush_result);
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -161,7 +161,8 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
         // Now try to add those transactions back, as though a reorg happened.
         std::vector<Txid> hashes_to_update;
         for (const auto& tx : block_template->block.vtx) {
-            const auto res = AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false);
+            auto [res, flush_result]{AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false)};
+            Assert(flush_result);
             if (res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 hashes_to_update.push_back(tx->GetHash());
             } else {
@@ -405,8 +406,9 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
         // Make sure ProcessNewPackage on one transaction works.
         // The result is not guaranteed to be the same as what is returned by ATMP.
-        const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{}));
+        auto [result_package, process_result]{WITH_LOCK(::cs_main,
+                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true, /*client_maxfeerate=*/{}))};
+        Assert(process_result);
         // If something went wrong due to a package-specific policy, it might not return a
         // validation result for the transaction.
         if (result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {
@@ -416,7 +418,8 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false));
+        auto [res, flush_result]{WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false))};
+        Assert(flush_result);
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
@@ -523,7 +526,8 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         ever_bypassed_limits |= bypass_limits;
 
         const auto tx = MakeTransactionRef(mut_tx);
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        auto [res, flush_result]{WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false))};
+        Assert(flush_result);
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -58,7 +58,7 @@ void sanity_check_snapshot()
     // Connect the chain to the tmp chainman and sanity check the chainparams snapshot values.
     LOCK(cs_main);
     auto& cs{node.chainman->ActiveChainstate()};
-    cs.ForceFlushStateToDisk(/*wipe_cache=*/false);
+    Assert(cs.ForceFlushStateToDisk(/*wipe_cache=*/false));
     const auto stats{*Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::HASH_SERIALIZED, cs.CoinsDB(), node.chainman->m_blockman))};
     const auto cp_au_data{*Assert(node.chainman->GetParams().AssumeutxoForHeight(2 * COINBASE_MATURITY))};
     Assert(stats.nHeight == cp_au_data.height);

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -100,7 +100,7 @@ FUZZ_TARGET(utxo_total_supply)
     };
     const auto UpdateUtxoStats = [&](bool wipe_cache) {
         LOCK(chainman.GetMutex());
-        chainman.ActiveChainstate().ForceFlushStateToDisk(wipe_cache);
+        Assert(chainman.ActiveChainstate().ForceFlushStateToDisk(wipe_cache));
         utxo_stats = std::move(
             *Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::NONE, chainman.ActiveChainstate().CoinsDB(), chainman.m_blockman, {})));
         // Check that miner can't print more money than they are allowed to

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(findCommonAncestor, TestChain100Setup)
     auto* orig_tip = active.Tip();
     for (int i = 0; i < 10; ++i) {
         BlockValidationState state;
-        m_node.chainman->ActiveChainstate().InvalidateBlock(state, active.Tip());
+        BOOST_CHECK(m_node.chainman->ActiveChainstate().InvalidateBlock(state, active.Tip()));
     }
     BOOST_CHECK_EQUAL(active.Height(), orig_tip->nHeight - 10);
     coinbaseKey.MakeNewKey(true);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -53,6 +53,7 @@
 using namespace util::hex_literals;
 using interfaces::BlockTemplate;
 using interfaces::Mining;
+using kernel::FlushResult;
 using node::BlockAssembler;
 using node::BlockCreateOptions;
 

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -22,6 +22,10 @@
 #include <cstdint>
 #include <memory>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
+
+
 BOOST_FIXTURE_TEST_SUITE(peerman_tests, RegTestingSetup)
 
 /** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
@@ -38,7 +42,9 @@ static void mineBlock(node::NodeContext& node, FakeNodeClock& clock, std::chrono
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     clock.set(curr_time); // process block at current time
-    Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+    FlushResult<void, AbortFailure> process_result;
+    Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr, process_result));
+    Assert(process_result);
     node.validation_signals->SyncWithValidationInterfaceQueue(); // drain events queue
 }
 

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -182,6 +182,12 @@ void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... 
     BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
+BOOST_AUTO_TEST_CASE(check_sizes)
+{
+    static_assert(sizeof(util::Result<int>) == sizeof(void*)*2);
+    static_assert(sizeof(util::Result<void>) == sizeof(void*));
+}
+
 BOOST_AUTO_TEST_CASE(check_returned)
 {
     ExpectResult(VoidSuccessFn(), true, {});

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -149,6 +149,26 @@ BOOST_AUTO_TEST_CASE(check_returned)
     ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
 }
 
+BOOST_AUTO_TEST_CASE(check_update)
+{
+    // Test using Update method to change a result value from success -> error,
+    // and error->success.
+    util::Result<int, FnError> result;
+    ExpectSuccess(result, {}, 0);
+    result.update({util::Error{Untranslated("error")}, ERR1});
+    ExpectError(result, Untranslated("error"), ERR1);
+    result.update(2);
+    ExpectSuccess(result, Untranslated(""), 2);
+
+    // Test the same thing but with non-copyable success and error types.
+    util::Result<NoCopy, NoCopy> result2{0};
+    ExpectSuccess(result2, {}, 0);
+    result2.update({util::Error{Untranslated("error")}, 3});
+    ExpectError(result2, Untranslated("error"), 3);
+    result2.update(4);
+    ExpectSuccess(result2, Untranslated(""), 4);
+}
+
 BOOST_AUTO_TEST_CASE(check_dereference_operators)
 {
     util::Result<std::pair<int, std::string>> mutable_result;

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <util/result.h>
 
 #include <boost/test/unit_test.hpp>
@@ -33,6 +34,34 @@ std::ostream& operator<<(std::ostream& os, const NoCopy& o)
     return os << "NoCopy(" << *o.m_n << ")";
 }
 
+struct NoCopyNoMove {
+    NoCopyNoMove(int n) : m_n{n} {}
+    NoCopyNoMove(const NoCopyNoMove&) = delete;
+    NoCopyNoMove(NoCopyNoMove&&) = delete;
+    int m_n;
+};
+
+bool operator==(const NoCopyNoMove& a, const NoCopyNoMove& b)
+{
+    return a.m_n == b.m_n;
+}
+
+std::ostream& operator<<(std::ostream& os, const NoCopyNoMove& o)
+{
+    os << "NoCopyNoMove(" << o.m_n << ")";
+    return os;
+}
+
+util::Result<void> VoidSuccessFn()
+{
+    return {};
+}
+
+util::Result<void> VoidErrorFn()
+{
+    return util::Error{Untranslated("void error.")};
+}
+
 util::Result<int> IntFn(int i, bool success)
 {
     if (success) return i;
@@ -45,21 +74,46 @@ util::Result<bilingual_str> StrFn(bilingual_str s, bool success)
     return util::Error{Untranslated(strprintf("str %s error.", s.original))};
 }
 
-util::Result<NoCopy> NoCopyFn(int i, bool success)
+util::Result<NoCopy, NoCopy> NoCopyFn(int i, bool success)
 {
     if (success) return {i};
-    return util::Error{Untranslated(strprintf("nocopy %i error.", i))};
+    return {util::Error{Untranslated(strprintf("nocopy %i error.", i))}, i};
 }
 
-template <typename T>
-void ExpectResult(const util::Result<T>& result, bool success, const bilingual_str& str)
+util::Result<NoCopyNoMove, NoCopyNoMove> NoCopyNoMoveFn(int i, bool success)
+{
+    if (success) return {i};
+    return {util::Error{Untranslated(strprintf("nocopynomove %i error.", i))}, i};
+}
+
+enum FnError { ERR1, ERR2 };
+
+util::Result<int, FnError> IntErrorFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("int %i error.", i))}, i % 2 ? ERR1 : ERR2};
+}
+
+util::Result<NoCopyNoMove, FnError> EnumErrorFn(FnError ret)
+{
+    return {util::Error{Untranslated("enum error.")}, ret};
+}
+
+util::Result<int, int> TruthyFalsyFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("error value %i.", i))}, i};
+}
+
+template <typename T, typename F>
+void ExpectResult(const util::Result<T, F>& result, bool success, const bilingual_str& str)
 {
     BOOST_CHECK_EQUAL(bool(result), success);
     BOOST_CHECK_EQUAL(util::ErrorString(result), str);
 }
 
-template <typename T, typename... Args>
-void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args&&... args)
+template <typename T, typename F, typename... Args>
+void ExpectSuccess(const util::Result<T, F>& result, const bilingual_str& str, Args&&... args)
 {
     ExpectResult(result, true, str);
     BOOST_CHECK_EQUAL(result.has_value(), true);
@@ -68,20 +122,42 @@ void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args
     BOOST_CHECK_EQUAL(&result.value(), &*result);
 }
 
-template <typename T, typename... Args>
-void ExpectFail(const util::Result<T>& result, const bilingual_str& str)
+template <typename T, typename F, typename... Args>
+void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... args)
 {
     ExpectResult(result, false, str);
+    F expect_error{std::forward<Args>(args)...};
+    BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
 BOOST_AUTO_TEST_CASE(check_returned)
 {
+    ExpectResult(VoidSuccessFn(), true, {});
+    ExpectResult(VoidErrorFn(), false, Untranslated("void error."));
     ExpectSuccess(IntFn(5, true), {}, 5);
-    ExpectFail(IntFn(5, false), Untranslated("int 5 error."));
+    ExpectResult(IntFn(5, false), false, Untranslated("int 5 error."));
     ExpectSuccess(NoCopyFn(5, true), {}, 5);
-    ExpectFail(NoCopyFn(5, false), Untranslated("nocopy 5 error."));
+    ExpectError(NoCopyFn(5, false), Untranslated("nocopy 5 error."), 5);
+    ExpectSuccess(NoCopyNoMoveFn(5, true), {}, 5);
+    ExpectError(NoCopyNoMoveFn(5, false), Untranslated("nocopynomove 5 error."), 5);
     ExpectSuccess(StrFn(Untranslated("S"), true), {}, Untranslated("S"));
-    ExpectFail(StrFn(Untranslated("S"), false), Untranslated("str S error."));
+    ExpectResult(StrFn(Untranslated("S"), false), false, Untranslated("str S error."));
+    ExpectError(EnumErrorFn(ERR2), Untranslated("enum error."), ERR2);
+    ExpectSuccess(TruthyFalsyFn(0, true), {}, 0);
+    ExpectError(TruthyFalsyFn(0, false), Untranslated("error value 0."), 0);
+    ExpectSuccess(TruthyFalsyFn(1, true), {}, 1);
+    ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
+}
+
+BOOST_AUTO_TEST_CASE(check_dereference_operators)
+{
+    util::Result<std::pair<int, std::string>> mutable_result;
+    const auto& const_result{mutable_result};
+    mutable_result.value() = {1, "23"};
+    BOOST_CHECK_EQUAL(mutable_result->first, 1);
+    BOOST_CHECK_EQUAL(const_result->second, "23");
+    (*mutable_result).first = 5;
+    BOOST_CHECK_EQUAL((*const_result).first, 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_value_or)
@@ -92,6 +168,20 @@ BOOST_AUTO_TEST_CASE(check_value_or)
     BOOST_CHECK_EQUAL(NoCopyFn(10, false).value_or(20), 20);
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), true).value_or(Untranslated("B")), Untranslated("A"));
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), false).value_or(Untranslated("B")), Untranslated("B"));
+}
+
+struct Derived : NoCopyNoMove {
+    using NoCopyNoMove::NoCopyNoMove;
+};
+
+util::Result<std::unique_ptr<NoCopyNoMove>> DerivedToBaseFn(util::Result<std::unique_ptr<Derived>> derived)
+{
+    return derived;
+}
+
+BOOST_AUTO_TEST_CASE(derived_to_base)
+{
+    BOOST_CHECK_EQUAL(*Assert(*Assert(DerivedToBaseFn(std::make_unique<Derived>(5)))), 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -222,7 +222,7 @@ BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
         if (parent_recent_rej_recon) txdownload_impl.RecentRejectsReconsiderableFilter().insert(single_parent->GetHash().ToUint256());
         if (parent_recent_conf) txdownload_impl.RecentConfirmedTransactionsFilter().insert(single_parent->GetHash().ToUint256());
         if (parent_in_mempool) {
-            const auto mempool_result = WITH_LOCK(::cs_main, return m_node.chainman->ProcessTransaction(single_parent));
+            auto [mempool_result, flush_result]{WITH_LOCK(::cs_main, return m_node.chainman->ProcessTransaction(single_parent))};
             BOOST_CHECK(mempool_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             coinbase_idx += 1;
             assert(coinbase_idx < m_coinbase_txns.size());

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -220,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
         if (parent_recent_rej_recon) txdownload_impl.RecentRejectsReconsiderableFilter().insert(single_parent->GetHash().ToUint256());
         if (parent_recent_conf) txdownload_impl.RecentConfirmedTransactionsFilter().insert(single_parent->GetHash().ToUint256());
         if (parent_in_mempool) {
-            const auto mempool_result = WITH_LOCK(::cs_main, return m_node.chainman->ProcessTransaction(single_parent));
+            auto [mempool_result, flush_result]{WITH_LOCK(::cs_main, return m_node.chainman->ProcessTransaction(single_parent))};
             BOOST_CHECK(mempool_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             coinbase_idx += 1;
             assert(coinbase_idx < m_coinbase_txns.size());

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -223,7 +223,8 @@ BOOST_AUTO_TEST_CASE(package_validation_tests)
                                                    /*output_amount=*/CAmount(48 * COIN), /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
     Package package_parent_child{tx_parent, tx_child};
-    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    auto [result_parent_child, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_parent_child, result_parent_child, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -242,7 +243,8 @@ BOOST_AUTO_TEST_CASE(package_validation_tests)
     CTransactionRef giant_ptx = create_placeholder_tx(999, 999);
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > DEFAULT_CLUSTER_SIZE_LIMIT_KVB * 1000);
     Package package_single_giant{giant_ptx};
-    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    auto [result_single_large, process_result_single]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_single);
     if (auto err_single_large{CheckPackageMempoolAcceptResult(package_single_giant, result_single_large, /*expect_valid=*/false, nullptr)}) {
         BOOST_ERROR(err_single_large.value());
     } else {
@@ -373,8 +375,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
                                                  /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
         package_unrelated.emplace_back(MakeTransactionRef(mtx));
     }
-    auto result_unrelated_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_unrelated_submit, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result);
     // We don't expect m_tx_results for each transaction when basic sanity checks haven't passed.
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
@@ -413,8 +416,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // 3 Generations is not allowed.
     {
-        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_3gen_submit, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         BOOST_CHECK(result_3gen_submit.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -430,8 +434,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
         mtx_parent_invalid.vin[0].scriptWitness = bad_witness;
         CTransactionRef tx_parent_invalid = MakeTransactionRef(mtx_parent_invalid);
         Package package_invalid_parent{tx_parent_invalid, tx_child};
-        auto result_quit_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [result_quit_early, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_parent_invalid{CheckPackageMempoolAcceptResult(package_invalid_parent, result_quit_early, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent_invalid.value());
         } else {
@@ -447,8 +452,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // Submit package with parent + child.
     {
-        const auto submit_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_parent_child, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_parent_child.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_parent_child.m_state.GetRejectReason());
@@ -469,8 +475,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // Already-in-mempool transactions should be detected and de-duplicated.
     {
-        const auto submit_deduped = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_deduped, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_deduped{CheckPackageMempoolAcceptResult(package_parent_child, submit_deduped, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_deduped.value());
         } else {
@@ -501,8 +508,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
         Package package_missing_parent{tx_parent_1, tx_child_missing_parent};
 
-        const auto result_missing_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_missing_parent, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_missing_parent{CheckPackageMempoolAcceptResult(package_missing_parent, result_missing_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_missing_parent.value());
         } else {
@@ -521,15 +529,17 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
         // Submit parent2 ahead of time, should become ok.
         Package package_just_parent2{tx_parent_2};
         expected_pool_size += 1;
-        const auto result_just_parent2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_just_parent2, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_just_parent2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_just_parent2, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result2);
         if (auto err_parent2{CheckPackageMempoolAcceptResult(package_just_parent2, result_just_parent2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent2.value());
         }
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
-        const auto result_parent_already_in = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_parent_already_in, process_result_in]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                                package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result_in);
         expected_pool_size += 2;
         if (auto err_parent_already_in{CheckPackageMempoolAcceptResult(package_missing_parent, result_parent_already_in, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent_already_in.value());
@@ -557,11 +567,12 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
     CTransactionRef tx_single = MakeTransactionRef(mtx_single);
     Package package_tx_single{tx_single};
-    const auto result_single_tx = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_tx_single, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_single_tx, process_result_single_tx]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_tx_single, /*test_accept=*/false, /*client_maxfeerate=*/{})};
     expected_pool_size += 1;
     BOOST_CHECK_MESSAGE(result_single_tx.m_state.IsValid(),
                         "Package validation unexpectedly failed: " << result_single_tx.m_state.ToString());
+    BOOST_CHECK(process_result_single_tx);
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     // Parent and Child. Both submitted by themselves through the ProcessNewPackage interface.
@@ -573,7 +584,8 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(50 * COIN) - high_fee, /*submit=*/false);
     CTransactionRef tx_parent = MakeTransactionRef(mtx_parent);
     Package package_just_parent{tx_parent};
-    const auto result_just_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_just_parent, process_result_just_parent]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_just_parent);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_just_parent, result_just_parent, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -594,7 +606,8 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                    /*output_amount=*/CAmount(50 * COIN) - 2 * high_fee, /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
     Package package_just_child{tx_child};
-    const auto result_just_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_just_child, process_result_just_child]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_just_child);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_just_child, result_just_child, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -614,9 +627,9 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(49 * COIN - 1), /*submit=*/false);
     CTransactionRef tx_single_low_fee = MakeTransactionRef(mtx_single_low_fee);
     Package package_tx_single_low_fee{tx_single_low_fee};
-    const auto result_single_tx_low_fee = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_tx_single_low_fee, /*test_accept=*/false, /*client_maxfeerate=*/{});
-
+    auto [result_single_tx_low_fee, process_result_single_tx_low_fee]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_tx_single_low_fee, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_single_tx_low_fee);
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     BOOST_CHECK(!result_single_tx_low_fee.m_state.IsValid());
@@ -687,16 +700,18 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // same-txid-different-witness.
     {
         Package package_parent_child1{ptx_parent, ptx_child1};
-        const auto submit_witness1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_witness1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result1);
         if (auto err_witness1{CheckPackageMempoolAcceptResult(package_parent_child1, submit_witness1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness1.value());
         }
 
         // Child2 would have been validated individually.
         Package package_parent_child2{ptx_parent, ptx_child2};
-        const auto submit_witness2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_witness2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result2);
         if (auto err_witness2{CheckPackageMempoolAcceptResult(package_parent_child2, submit_witness2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness2.value());
         } else {
@@ -709,8 +724,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
 
         // Deduplication should work when wtxid != txid. Submit package with the already-in-mempool
         // transactions again, which should not fail.
-        const auto submit_segwit_dedup = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_segwit_dedup, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_segwit_dedup{CheckPackageMempoolAcceptResult(package_parent_child1, submit_segwit_dedup, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_segwit_dedup.value());
         } else {
@@ -740,8 +756,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // We already submitted child1 above.
     {
         Package package_child2_grandchild{ptx_child2, ptx_grandchild};
-        const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_spend_ignored, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_spend_ignored{CheckPackageMempoolAcceptResult(package_child2_grandchild, submit_spend_ignored, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_spend_ignored.value());
         } else {
@@ -804,8 +821,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    auto [parent2_v2_result, flush_result]{m_node.chainman->ProcessTransaction(ptx_parent2_v2)};
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+    BOOST_CHECK(flush_result);
     package_mixed.push_back(ptx_parent2_v1);
 
     // parent3 will be a new transaction. Put a low feerate to make it invalid on its own.
@@ -839,7 +857,8 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // parent3 should be accepted
     // child should be accepted
     {
-        const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{});
+        auto [mixed_result, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_mixed{CheckPackageMempoolAcceptResult(package_mixed, mixed_result, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_mixed.value());
         } else {
@@ -902,8 +921,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), child_value - coinbase_value);
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [submit_cpfp_deprio, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_cpfp_deprio{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp_deprio, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp_deprio.value());
         } else {
@@ -924,8 +944,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     // child pays enough for the package feerate to meet the threshold.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [submit_cpfp, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_cpfp{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp.value());
         } else {
@@ -976,8 +997,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
 
     // Cheap package should fail for being too low fee.
     {
-        const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_package_too_low, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_package_too_low{CheckPackageMempoolAcceptResult(package_still_too_low, submit_package_too_low, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_package_too_low.value());
         } else {
@@ -1002,8 +1024,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     m_node.mempool->PrioritiseTransaction(tx_child_cheap->GetHash(), 1 * COIN);
     // Now that the child's fees have "increased" by 1 BTC, the cheap package should succeed.
     {
-        const auto submit_prioritised_package = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_prioritised_package, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_prioritised{CheckPackageMempoolAcceptResult(package_still_too_low, submit_prioritised_package, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_prioritised.value());
         } else {
@@ -1050,8 +1073,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     // Parent pays 1 BTC and child pays none. The parent should be accepted without the child.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_rich_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_rich_parent, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_rich_parent{CheckPackageMempoolAcceptResult(package_rich_parent, submit_rich_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_rich_parent.value());
         } else {
@@ -1108,7 +1132,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         package2.push_back(tx_child_2);
 
         LOCK(m_node.mempool->cs);
-        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, /*test_accept=*/false, std::nullopt);
+        auto [submit1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, /*test_accept=*/false, std::nullopt)};
+        BOOST_CHECK(process_result1);
         if (auto err_1{CheckPackageMempoolAcceptResult(package1, submit1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_1.value());
         }
@@ -1121,7 +1146,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         expected_pool_size += 2;
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
-        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, /*test_accept=*/false, std::nullopt);
+        auto [submit2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, /*test_accept=*/false, std::nullopt)};
+        BOOST_CHECK(process_result2);
         if (auto err_2{CheckPackageMempoolAcceptResult(package2, submit2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_2.value());
         }
@@ -1170,7 +1196,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         // 1 parent paying 199sat, 1 child paying 1300sat.
         Package package3{tx_parent_3, tx_child_3};
 
-        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process_result1);
         if (auto err_1{CheckPackageMempoolAcceptResult(package1, submit1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_1.value());
         }
@@ -1183,7 +1210,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
 
         // This replacement is actually not package rbf; the parent carries enough fees
         // to replace the entire package on its own.
-        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, false, std::nullopt);
+        auto [submit2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, false, std::nullopt)};
+        BOOST_CHECK(process_result2);
         if (auto err_2{CheckPackageMempoolAcceptResult(package2, submit2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_2.value());
         }
@@ -1194,7 +1222,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
         // Package RBF, in which the replacement transaction's child sponsors the fees to meet RBF feerate rules
-        const auto submit3 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package3, false, std::nullopt);
+        auto [submit3, process_result3]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package3, false, std::nullopt)};
+        BOOST_CHECK(process_result3);
         if (auto err_3{CheckPackageMempoolAcceptResult(package3, submit3, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_3.value());
         }
@@ -1218,12 +1247,14 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
 
         // Finally, check that we can prioritise tx_child_1 to get package1 into the mempool.
         // It should not be possible to resubmit package1 and get it in without prioritisation.
-        const auto submit4 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit4, process4]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process4);
         if (auto err_4{CheckPackageMempoolAcceptResult(package1, submit4, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_4.value());
         }
         m_node.mempool->PrioritiseTransaction(tx_child_1->GetHash(), 1363);
-        const auto submit5 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit5, process5]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process5);
         if (auto err_5{CheckPackageMempoolAcceptResult(package1, submit5, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_5.value());
         }

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -223,7 +223,8 @@ BOOST_AUTO_TEST_CASE(package_validation_tests)
                                                    /*output_amount=*/CAmount(48 * COIN), /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
     Package package_parent_child{tx_parent, tx_child};
-    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    auto [result_parent_child, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_parent_child, result_parent_child, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -242,7 +243,8 @@ BOOST_AUTO_TEST_CASE(package_validation_tests)
     CTransactionRef giant_ptx = create_placeholder_tx(999, 999);
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > DEFAULT_CLUSTER_SIZE_LIMIT_KVB * 1000);
     Package package_single_giant{giant_ptx};
-    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{});
+    auto [result_single_large, process_result_single]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_single);
     if (auto err_single_large{CheckPackageMempoolAcceptResult(package_single_giant, result_single_large, /*expect_valid=*/false, nullptr)}) {
         BOOST_ERROR(err_single_large.value());
     } else {
@@ -373,8 +375,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
                                                  /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
         package_unrelated.emplace_back(MakeTransactionRef(mtx));
     }
-    auto result_unrelated_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_unrelated_submit, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                     package_unrelated, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result);
     // We don't expect m_tx_results for each transaction when basic sanity checks haven't passed.
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
@@ -413,8 +416,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // 3 Generations is not allowed.
     {
-        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_3gen_submit, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_3gen, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         BOOST_CHECK(result_3gen_submit.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -430,8 +434,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
         mtx_parent_invalid.vin[0].scriptWitness = bad_witness;
         CTransactionRef tx_parent_invalid = MakeTransactionRef(mtx_parent_invalid);
         Package package_invalid_parent{tx_parent_invalid, tx_child};
-        auto result_quit_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [result_quit_early, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_invalid_parent, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_parent_invalid{CheckPackageMempoolAcceptResult(package_invalid_parent, result_quit_early, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent_invalid.value());
         } else {
@@ -447,8 +452,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // Submit package with parent + child.
     {
-        const auto submit_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_parent_child, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_parent_child.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_parent_child.m_state.GetRejectReason());
@@ -469,8 +475,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
     // Already-in-mempool transactions should be detected and de-duplicated.
     {
-        const auto submit_deduped = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_deduped, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                      package_parent_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_deduped{CheckPackageMempoolAcceptResult(package_parent_child, submit_deduped, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_deduped.value());
         } else {
@@ -501,8 +508,9 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
 
         Package package_missing_parent{tx_parent_1, tx_child_missing_parent};
 
-        const auto result_missing_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_missing_parent, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                             package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_missing_parent{CheckPackageMempoolAcceptResult(package_missing_parent, result_missing_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_missing_parent.value());
         } else {
@@ -521,15 +529,17 @@ BOOST_AUTO_TEST_CASE(package_submission_tests)
         // Submit parent2 ahead of time, should become ok.
         Package package_just_parent2{tx_parent_2};
         expected_pool_size += 1;
-        const auto result_just_parent2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_just_parent2, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_just_parent2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_just_parent2, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result2);
         if (auto err_parent2{CheckPackageMempoolAcceptResult(package_just_parent2, result_just_parent2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent2.value());
         }
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
-        const auto result_parent_already_in = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [result_parent_already_in, process_result_in]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                                package_missing_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result_in);
         expected_pool_size += 2;
         if (auto err_parent_already_in{CheckPackageMempoolAcceptResult(package_missing_parent, result_parent_already_in, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_parent_already_in.value());
@@ -557,11 +567,12 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
     CTransactionRef tx_single = MakeTransactionRef(mtx_single);
     Package package_tx_single{tx_single};
-    const auto result_single_tx = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_tx_single, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_single_tx, process_result_single_tx]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_tx_single, /*test_accept=*/false, /*client_maxfeerate=*/{})};
     expected_pool_size += 1;
     BOOST_CHECK_MESSAGE(result_single_tx.m_state.IsValid(),
                         "Package validation unexpectedly failed: " << result_single_tx.m_state.ToString());
+    BOOST_CHECK(process_result_single_tx);
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     // Parent and Child. Both submitted by themselves through the ProcessNewPackage interface.
@@ -573,7 +584,8 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(50 * COIN) - high_fee, /*submit=*/false);
     CTransactionRef tx_parent = MakeTransactionRef(mtx_parent);
     Package package_just_parent{tx_parent};
-    const auto result_just_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_just_parent, process_result_just_parent]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_just_parent);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_just_parent, result_just_parent, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -594,7 +606,8 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                    /*output_amount=*/CAmount(50 * COIN) - 2 * high_fee, /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
     Package package_just_child{tx_child};
-    const auto result_just_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_child, /*test_accept=*/false, /*client_maxfeerate=*/{});
+    auto [result_just_child, process_result_just_child]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_just_child, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_just_child);
     if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_just_child, result_just_child, /*expect_valid=*/true, nullptr)}) {
         BOOST_ERROR(err_parent_child.value());
     } else {
@@ -614,9 +627,9 @@ BOOST_AUTO_TEST_CASE(package_single_tx)
                                                     /*output_amount=*/CAmount(49 * COIN - 1), /*submit=*/false);
     CTransactionRef tx_single_low_fee = MakeTransactionRef(mtx_single_low_fee);
     Package package_tx_single_low_fee{tx_single_low_fee};
-    const auto result_single_tx_low_fee = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_tx_single_low_fee, /*test_accept=*/false, /*client_maxfeerate=*/{});
-
+    auto [result_single_tx_low_fee, process_result_single_tx_low_fee]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_tx_single_low_fee, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+    BOOST_CHECK(process_result_single_tx_low_fee);
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     BOOST_CHECK(!result_single_tx_low_fee.m_state.IsValid());
@@ -687,16 +700,18 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // same-txid-different-witness.
     {
         Package package_parent_child1{ptx_parent, ptx_child1};
-        const auto submit_witness1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_witness1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result1);
         if (auto err_witness1{CheckPackageMempoolAcceptResult(package_parent_child1, submit_witness1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness1.value());
         }
 
         // Child2 would have been validated individually.
         Package package_parent_child2{ptx_parent, ptx_child2};
-        const auto submit_witness2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_witness2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_parent_child2, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result2);
         if (auto err_witness2{CheckPackageMempoolAcceptResult(package_parent_child2, submit_witness2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_witness2.value());
         } else {
@@ -709,8 +724,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
 
         // Deduplication should work when wtxid != txid. Submit package with the already-in-mempool
         // transactions again, which should not fail.
-        const auto submit_segwit_dedup = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_segwit_dedup, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                           package_parent_child1, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_segwit_dedup{CheckPackageMempoolAcceptResult(package_parent_child1, submit_segwit_dedup, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_segwit_dedup.value());
         } else {
@@ -740,8 +756,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // We already submitted child1 above.
     {
         Package package_child2_grandchild{ptx_child2, ptx_grandchild};
-        const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_spend_ignored, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                            package_child2_grandchild, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_spend_ignored{CheckPackageMempoolAcceptResult(package_child2_grandchild, submit_spend_ignored, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_spend_ignored.value());
         } else {
@@ -804,8 +821,9 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    auto [parent2_v2_result, flush_result]{m_node.chainman->ProcessTransaction(ptx_parent2_v2)};
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+    BOOST_CHECK(flush_result);
     package_mixed.push_back(ptx_parent2_v1);
 
     // parent3 will be a new transaction. Put a low feerate to make it invalid on its own.
@@ -839,7 +857,8 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     // parent3 should be accepted
     // child should be accepted
     {
-        const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{});
+        auto [mixed_result, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_mixed{CheckPackageMempoolAcceptResult(package_mixed, mixed_result, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_mixed.value());
         } else {
@@ -902,8 +921,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), child_value - coinbase_value);
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [submit_cpfp_deprio, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_cpfp_deprio{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp_deprio, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp_deprio.value());
         } else {
@@ -924,8 +944,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     // child pays enough for the package feerate to meet the threshold.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{});
+        auto [submit_cpfp, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_cpfp, /*test_accept=*/ false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_cpfp{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_cpfp.value());
         } else {
@@ -976,8 +997,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
 
     // Cheap package should fail for being too low fee.
     {
-        const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_package_too_low, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                   package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_package_too_low{CheckPackageMempoolAcceptResult(package_still_too_low, submit_package_too_low, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_package_too_low.value());
         } else {
@@ -1002,8 +1024,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     m_node.mempool->PrioritiseTransaction(tx_child_cheap->GetHash(), 1 * COIN);
     // Now that the child's fees have "increased" by 1 BTC, the cheap package should succeed.
     {
-        const auto submit_prioritised_package = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_prioritised_package, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                                  package_still_too_low, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_prioritised{CheckPackageMempoolAcceptResult(package_still_too_low, submit_prioritised_package, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_prioritised.value());
         } else {
@@ -1050,8 +1073,9 @@ BOOST_AUTO_TEST_CASE(package_cpfp_tests)
     // Parent pays 1 BTC and child pays none. The parent should be accepted without the child.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_rich_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{});
+        auto [submit_rich_parent, process_result]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                          package_rich_parent, /*test_accept=*/false, /*client_maxfeerate=*/{})};
+        BOOST_CHECK(process_result);
         if (auto err_rich_parent{CheckPackageMempoolAcceptResult(package_rich_parent, submit_rich_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_rich_parent.value());
         } else {
@@ -1108,7 +1132,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         package2.push_back(tx_child_2);
 
         LOCK(m_node.mempool->cs);
-        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, /*test_accept=*/false, std::nullopt);
+        auto [submit1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, /*test_accept=*/false, std::nullopt)};
+        BOOST_CHECK(process_result1);
         if (auto err_1{CheckPackageMempoolAcceptResult(package1, submit1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_1.value());
         }
@@ -1121,7 +1146,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         expected_pool_size += 2;
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
-        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, /*test_accept=*/false, std::nullopt);
+        auto [submit2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, /*test_accept=*/false, std::nullopt)};
+        BOOST_CHECK(process_result2);
         if (auto err_2{CheckPackageMempoolAcceptResult(package2, submit2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_2.value());
         }
@@ -1171,7 +1197,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         // 1 parent paying 199sat, 1 child paying 1300sat.
         Package package3{tx_parent_3, tx_child_3};
 
-        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit1, process_result1]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process_result1);
         if (auto err_1{CheckPackageMempoolAcceptResult(package1, submit1, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_1.value());
         }
@@ -1184,7 +1211,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
 
         // This replacement is actually not package rbf; the parent carries enough fees
         // to replace the entire package on its own.
-        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, false, std::nullopt);
+        auto [submit2, process_result2]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, false, std::nullopt)};
+        BOOST_CHECK(process_result2);
         if (auto err_2{CheckPackageMempoolAcceptResult(package2, submit2, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_2.value());
         }
@@ -1195,7 +1223,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
         // Package RBF, in which the replacement transaction's child sponsors the fees to meet RBF feerate rules
-        const auto submit3 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package3, false, std::nullopt);
+        auto [submit3, process_result3]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package3, false, std::nullopt)};
+        BOOST_CHECK(process_result3);
         if (auto err_3{CheckPackageMempoolAcceptResult(package3, submit3, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_3.value());
         }
@@ -1219,12 +1248,14 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
 
         // Finally, check that we can prioritise tx_child_1 to get package1 into the mempool.
         // It should not be possible to resubmit package1 and get it in without prioritisation.
-        const auto submit4 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit4, process4]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process4);
         if (auto err_4{CheckPackageMempoolAcceptResult(package1, submit4, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_4.value());
         }
         m_node.mempool->PrioritiseTransaction(tx_child_1->GetHash(), 1363);
-        const auto submit5 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        auto [submit5, process5]{ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt)};
+        BOOST_CHECK(process5);
         if (auto err_5{CheckPackageMempoolAcceptResult(package1, submit5, /*expect_valid=*/true, m_node.mempool.get())}) {
             BOOST_ERROR(err_5.value());
         }

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -41,7 +41,8 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx));
+    auto [result, flush_result]{m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx))};
+    BOOST_CHECK(flush_result);
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -39,7 +39,8 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(tx));
+        auto [result, flush_result]{m_node.chainman->ProcessTransaction(MakeTransactionRef(tx))};
+        BOOST_CHECK(flush_result);
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -86,7 +86,7 @@ CreateAndActivateUTXOSnapshot(
             chain.InitCoinsCache(1_MiB);
             chain.CoinsTip().SetBestBlock(gen_hash);
             chain.LoadChainTip();
-            node.chainman->MaybeRebalanceCaches();
+            Assert(node.chainman->MaybeRebalanceCaches());
 
             // Reset the HAVE_DATA flags below the snapshot height, simulating
             // never-having-downloaded them in the first place.

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -109,7 +109,8 @@ CreateAndActivateUTXOSnapshot(
             chain.PopulateBlockIndexCandidates();
         }
         BlockValidationState state;
-        if (!node.chainman->ActiveChainstate().ActivateBestChain(state)) {
+        auto activate_result{node.chainman->ActiveChainstate().ActivateBestChain(state)};
+        if (!activate_result) {
             throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
         }
         Assert(

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -29,6 +29,8 @@
 #include <optional>
 #include <utility>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::NodeContext;
 
 COutPoint generatetoaddress(const NodeContext& node, const std::string& address)
@@ -116,7 +118,9 @@ COutPoint ProcessBlock(const NodeContext& node, const std::shared_ptr<CBlock>& b
     bool new_block;
     BlockValidationStateCatcher bvsc{block->GetHash()};
     node.validation_signals->RegisterValidationInterface(&bvsc);
-    const bool processed{chainman.ProcessNewBlock(block, true, true, &new_block)};
+    FlushResult<void, AbortFailure> process_result;
+    const bool processed{chainman.ProcessNewBlock(block, true, true, &new_block, process_result)};
+    assert(process_result);
     const bool duplicate{!new_block && processed};
     assert(!duplicate);
     node.validation_signals->UnregisterValidationInterface(&bvsc);

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -29,6 +29,8 @@
 #include <optional>
 #include <utility>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::NodeContext;
 
 COutPoint generatetoaddress(const NodeContext& node, const std::string& address)
@@ -157,7 +159,9 @@ COutPoint ProcessBlock(const NodeContext& node, const std::shared_ptr<CBlock>& b
     bool new_block;
     BlockValidationStateCatcher bvsc{block->GetHash()};
     node.validation_signals->RegisterValidationInterface(&bvsc);
-    const bool processed{chainman.ProcessNewBlock(block, true, true, &new_block)};
+    FlushResult<void, AbortFailure> process_result;
+    const bool processed{chainman.ProcessNewBlock(block, true, true, &new_block, process_result)};
+    assert(process_result);
     const bool duplicate{!new_block && processed};
     assert(!duplicate);
     node.validation_signals->UnregisterValidationInterface(&bvsc);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -366,7 +366,8 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     m_node.notifications->setChainstateLoaded(true);
 
     BlockValidationState state;
-    if (!chainman.ActiveChainstate().ActivateBestChain(state)) {
+    auto activate_result{chainman.ActiveChainstate().ActivateBestChain(state)};
+    if (!activate_result) {
         throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
     }
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -96,6 +96,8 @@
 #include <utility>
 
 using namespace util::hex_literals;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::KernelNotifications;
@@ -471,7 +473,9 @@ CBlock TestChain100Setup::CreateAndProcessBlock(
 {
     CBlock block = this->CreateBlock(txns, scriptPubKey);
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr);
+    FlushResult<void, AbortFailure> process_result;
+    (void)Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr, process_result);
+    Assert(process_result);
 
     return block;
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -359,11 +359,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -357,11 +357,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -549,8 +549,9 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn));
+        auto [result, flush_result]{m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn))};
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        Assert(flush_result);
     }
     return mempool_txn;
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -96,6 +96,8 @@
 #include <utility>
 
 using namespace util::hex_literals;
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::KernelNotifications;
@@ -473,7 +475,9 @@ CBlock TestChain100Setup::CreateAndProcessBlock(
 {
     CBlock block = this->CreateBlock(txns, scriptPubKey);
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr);
+    FlushResult<void, AbortFailure> process_result;
+    (void)Assert(m_node.chainman)->ProcessNewBlock(shared_pblock, true, true, nullptr, process_result);
+    Assert(process_result);
 
     return block;
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -551,8 +551,9 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn));
+        auto [result, flush_result]{m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn))};
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        Assert(flush_result);
     }
     return mempool_txn;
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -368,7 +368,8 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     m_node.notifications->setChainstateLoaded(true);
 
     BlockValidationState state;
-    if (!chainman.ActiveChainstate().ActivateBestChain(state)) {
+    auto activate_result{chainman.ActiveChainstate().ActivateBestChain(state)};
+    if (!activate_result) {
         throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
     }
 }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -298,8 +298,9 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx);
+                auto [result, flush_result]{m_node.chainman->ProcessTransaction(tx)};
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+                BOOST_CHECK(flush_result);
             }
         }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -34,7 +34,9 @@
 #include <utility>
 #include <vector>
 
+using kernel::AbortFailure;
 using kernel::ChainstateRole;
+using kernel::FlushResult;
 
 namespace validation_block_tests {
 struct MinerTestingSetup : public RegTestingSetup {
@@ -177,9 +179,11 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
         BuildChain(Params().GenesisBlock().GetHash(), 100, 15, 10, 500, blocks);
     }
 
+    FlushResult<void, AbortFailure> process_result;
     bool ignored;
     // Connect the genesis block and drain any outstanding events
-    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<CBlock>(Params().GenesisBlock()), true, true, &ignored));
+    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<CBlock>(Params().GenesisBlock()), true, true, &ignored, process_result));
+    BOOST_CHECK(process_result);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
 
     // subscribe to events (this subscriber will validate event ordering)
@@ -202,14 +206,18 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             FastRandomContext insecure;
             for (int i = 0; i < 1000; i++) {
                 const auto& block = blocks[insecure.randrange(blocks.size() - 1)];
-                Assert(m_node.chainman)->ProcessNewBlock(block, true, true, &ignored);
+                FlushResult<void, AbortFailure> process_result;
+                (void)Assert(m_node.chainman)->ProcessNewBlock(block, true, true, &ignored, process_result);
+                Assert(process_result);
             }
 
             // to make sure that eventually we process the full chain - do it here
             for (const auto& block : blocks) {
                 if (block->vtx.size() == 1) {
-                    bool processed = Assert(m_node.chainman)->ProcessNewBlock(block, true, true, &ignored);
+                    FlushResult<void, AbortFailure> process_result;
+                    bool processed = Assert(m_node.chainman)->ProcessNewBlock(block, true, true, &ignored, process_result);
                     assert(processed);
+                    Assert(process_result);
                 }
             }
         });
@@ -247,7 +255,10 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
 {
     bool ignored;
     auto ProcessBlock = [&](std::shared_ptr<const CBlock> block) -> bool {
-        return Assert(m_node.chainman)->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&ignored);
+        FlushResult<void, AbortFailure> process_result;
+        bool ret{Assert(m_node.chainman)->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&ignored, process_result)};
+        BOOST_CHECK(process_result);
+        return ret;
     };
 
     // Process all mined blocks

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -56,18 +56,18 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
 
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
+        BOOST_CHECK(c1.ResizeCoinsCaches(
             16_MiB, // upsizing the coinsview cache
             4_MiB // downsizing the coinsdb cache
-        );
+        ));
 
         // View should still have the coin cached, since we haven't destructed the cache on upsize.
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
+        BOOST_CHECK(c1.ResizeCoinsCaches(
             4_MiB, // downsizing the coinsview cache
             8_MiB // upsizing the coinsdb cache
-        );
+        ));
 
         // The view cache should be empty since we had to destruct to downsize.
         BOOST_CHECK(!c1.CoinsTip().HaveCoinInCache(outpoint));

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -162,7 +162,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     }
 
     // UpdateTip is called here
-    bool block_added = background_cs.ActivateBestChain(state, pblockone);
+    auto block_added{background_cs.ActivateBestChain(state, pblockone)};
 
     // Ensure tip is as expected
     BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), pblockone->GetHash());

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -31,6 +31,9 @@
 
 class CTxMemPool;
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
+
 BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, ChainTestingSetup)
 
 //! Test resizing coins-related Chainstate caches during runtime.
@@ -91,7 +94,9 @@ BOOST_FIXTURE_TEST_CASE(connect_tip_does_not_cache_inputs_on_failed_connect, Tes
 
     const auto tip{WITH_LOCK(cs_main, return chainstate.m_chain.Tip()->GetBlockHash())};
     const CBlock block{CreateBlock({tx}, CScript{} << OP_TRUE)};
-    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<CBlock>(block), true, true, nullptr));
+    FlushResult<void, AbortFailure> process_result;
+    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<CBlock>(block), true, true, nullptr, process_result));
+    BOOST_CHECK(process_result);
 
     LOCK(cs_main);
     BOOST_CHECK_EQUAL(tip, chainstate.m_chain.Tip()->GetBlockHash()); // block rejected
@@ -156,9 +161,11 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
         LOCK(::cs_main);
         bool checked = CheckBlock(*pblockone, state, chainparams.GetConsensus());
         BOOST_CHECK(checked);
+        FlushResult<void, AbortFailure> accept_result;
         bool accepted = chainman.AcceptBlock(
-            pblockone, state, &pindex, true, nullptr, &newblock, true);
+            pblockone, state, accept_result, &pindex, true, nullptr, &newblock, true);
         BOOST_CHECK(accepted);
+        BOOST_CHECK(accept_result);
     }
 
     // UpdateTip is called here

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -498,7 +498,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
             cs->ClearBlockIndexCandidates();
             BOOST_CHECK(cs->setBlockIndexCandidates.empty());
         }
-        chainman.LoadBlockIndex();
+        BOOST_CHECK(chainman.LoadBlockIndex());
         for (const auto& cs : chainman.m_chainstates) {
             cs->PopulateBlockIndexCandidates();
         }
@@ -611,7 +611,7 @@ BOOST_FIXTURE_TEST_CASE(loadblockindex_invalid_descendants, TestChain100Setup)
     child->nStatus = (child->nStatus & ~BLOCK_FAILED_VALID);
 
     // Reload block index to recompute block status validity flags.
-    m_node.chainman->LoadBlockIndex();
+    BOOST_CHECK(m_node.chainman->LoadBlockIndex());
 
     // check grand_parent, parent, child is marked as BLOCK_FAILED_VALID after reloading the block index
     BOOST_CHECK(grand_parent->nStatus & BLOCK_FAILED_VALID);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -666,7 +666,7 @@ BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)
         chainstate.ResetBlockFailureFlags(block99);
         chainman.RecalculateBestHeader();
     }
-    chainstate.ActivateBestChain(state);
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state));
     BOOST_REQUIRE(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()) == block100);
 
     {
@@ -698,7 +698,7 @@ BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)
         chainstate.ResetBlockFailureFlags(block99);
         chainman.RecalculateBestHeader();
     }
-    chainstate.ActivateBestChain(state);
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state));
     {
         LOCK(chainman.GetMutex());
         BOOST_CHECK(!(block98->nStatus & BLOCK_FAILED_VALID));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -30,6 +30,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
@@ -804,8 +806,10 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     const uint256 snapshot_tip_hash = WITH_LOCK(chainman.GetMutex(),
         return chainman.ActiveTip()->GetBlockHash());
 
-    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs));
+    FlushResult<void, AbortFailure> process_result;
+    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs, process_result));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SUCCESS);
+    BOOST_CHECK(process_result);
 
     BOOST_CHECK(WITH_LOCK(::cs_main, return chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::VALIDATED));
     BOOST_CHECK(WITH_LOCK(::cs_main, return chainman.CurrentChainstate().m_from_snapshot_blockhash));
@@ -817,8 +821,9 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     BOOST_CHECK(active_cs.m_coinsdb_cache_size_bytes > db_cache_before_complete);
 
     // Trying completion again should return false.
-    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs));
+    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs, process_result));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SKIPPED);
+    BOOST_CHECK(process_result);
 
     // The invalid snapshot path should not have been used.
     fs::path snapshot_invalid_dir = gArgs.GetDataDirNet() / "chainstate_snapshot_INVALID";
@@ -888,8 +893,10 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, Sna
 
     {
         ASSERT_DEBUG_LOG("failed to validate the -assumeutxo snapshot state");
-        res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validation_chainstate, unvalidated_cs));
+        FlushResult<void, AbortFailure> process_result;
+        res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validation_chainstate, unvalidated_cs, process_result));
         BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+        BOOST_CHECK(!process_result);
     }
 
     {

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -135,7 +135,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c1.InitCoinsCache(8_MiB);
-        manager.MaybeRebalanceCaches();
+        BOOST_CHECK(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_EQUAL(c1.m_coinstip_cache_size_bytes, max_cache);
@@ -161,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c2.InitCoinsCache(8_MiB);
-        manager.MaybeRebalanceCaches();
+        BOOST_CHECK(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_CLOSE(double(c1.m_coinstip_cache_size_bytes), max_cache * 0.05, 1);
@@ -416,7 +416,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             LOCK(chainman.GetMutex());
             for (const auto& cs : chainman.m_chainstates) {
-                if (cs->CanFlushToDisk()) cs->ForceFlushStateToDisk();
+                if (cs->CanFlushToDisk()) BOOST_CHECK(cs->ForceFlushStateToDisk());
             }
         }
         {

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -675,7 +675,7 @@ BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)
         chainstate.ResetBlockFailureFlags(block99);
         chainman.RecalculateBestHeader();
     }
-    chainstate.ActivateBestChain(state);
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state));
     BOOST_REQUIRE(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()) == block100);
 
     {
@@ -707,7 +707,7 @@ BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)
         chainstate.ResetBlockFailureFlags(block99);
         chainman.RecalculateBestHeader();
     }
-    chainstate.ActivateBestChain(state);
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state));
     {
         LOCK(chainman.GetMutex());
         BOOST_CHECK(!(block98->nStatus & BLOCK_FAILED_VALID));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -30,6 +30,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using kernel::AbortFailure;
+using kernel::FlushResult;
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
@@ -813,8 +815,10 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     const uint256 snapshot_tip_hash = WITH_LOCK(chainman.GetMutex(),
         return chainman.ActiveTip()->GetBlockHash());
 
-    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs));
+    FlushResult<void, AbortFailure> process_result;
+    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs, process_result));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SUCCESS);
+    BOOST_CHECK(process_result);
 
     BOOST_CHECK(WITH_LOCK(::cs_main, return chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::VALIDATED));
     BOOST_CHECK(WITH_LOCK(::cs_main, return chainman.CurrentChainstate().m_from_snapshot_blockhash));
@@ -826,8 +830,9 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     BOOST_CHECK(active_cs.m_coinsdb_cache_size_bytes > db_cache_before_complete);
 
     // Trying completion again should return false.
-    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs));
+    res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs, process_result));
     BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SKIPPED);
+    BOOST_CHECK(process_result);
 
     // The invalid snapshot path should not have been used.
     fs::path snapshot_invalid_dir = gArgs.GetDataDirNet() / "chainstate_snapshot_INVALID";
@@ -897,8 +902,10 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, Sna
 
     {
         ASSERT_DEBUG_LOG("failed to validate the -assumeutxo snapshot state");
-        res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validation_chainstate, unvalidated_cs));
+        FlushResult<void, AbortFailure> process_result;
+        res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validation_chainstate, unvalidated_cs, process_result));
         BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+        BOOST_CHECK(!process_result);
     }
 
     {

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -507,7 +507,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
             cs->ClearBlockIndexCandidates();
             BOOST_CHECK(cs->setBlockIndexCandidates.empty());
         }
-        chainman.LoadBlockIndex();
+        BOOST_CHECK(chainman.LoadBlockIndex());
         for (const auto& cs : chainman.m_chainstates) {
             cs->PopulateBlockIndexCandidates();
         }
@@ -620,7 +620,7 @@ BOOST_FIXTURE_TEST_CASE(loadblockindex_invalid_descendants, TestChain100Setup)
     child->nStatus = (child->nStatus & ~BLOCK_FAILED_VALID);
 
     // Reload block index to recompute block status validity flags.
-    m_node.chainman->LoadBlockIndex();
+    BOOST_CHECK(m_node.chainman->LoadBlockIndex());
 
     // check grand_parent, parent, child is marked as BLOCK_FAILED_VALID after reloading the block index
     BOOST_CHECK(grand_parent->nStatus & BLOCK_FAILED_VALID);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -144,7 +144,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c1.InitCoinsCache(8_MiB);
-        manager.MaybeRebalanceCaches();
+        BOOST_CHECK(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_EQUAL(c1.m_coinstip_cache_size_bytes, max_cache);
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     {
         LOCK(::cs_main);
         c2.InitCoinsCache(8_MiB);
-        manager.MaybeRebalanceCaches();
+        BOOST_CHECK(manager.MaybeRebalanceCaches());
     }
 
     BOOST_CHECK_EQUAL(c1.m_coinstip_cache_size_bytes, size_t(max_cache * 0.05));
@@ -425,7 +425,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             LOCK(chainman.GetMutex());
             for (const auto& cs : chainman.m_chainstates) {
-                if (cs->CanFlushToDisk()) cs->ForceFlushStateToDisk();
+                if (cs->CanFlushToDisk()) BOOST_CHECK(cs->ForceFlushStateToDisk());
             }
         }
         {

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  messages.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  messages.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/messages.cpp
+++ b/src/util/messages.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+#include <initializer_list>
+#include <iterator>
+#include <util/messages.h>
+#include <util/translation.h>
+
+namespace util {
+bilingual_str JoinMessages(const Messages& messages)
+{
+    bilingual_str result;
+    for (const auto& messages : {messages.errors, messages.warnings}) {
+        for (const auto& message : messages) {
+            if (!result.empty()) result += Untranslated(" ");
+            result += message;
+        }
+    }
+    return result;
+}
+
+void MoveMessages(Messages& dst, Messages& src)
+{
+    dst.errors.insert(dst.errors.end(), std::make_move_iterator(src.errors.begin()), std::make_move_iterator(src.errors.end()));
+    dst.warnings.insert(dst.warnings.end(), std::make_move_iterator(src.warnings.begin()), std::make_move_iterator(src.warnings.end()));
+    src.errors.clear();
+    src.warnings.clear();
+}
+} // namespace util

--- a/src/util/messages.h
+++ b/src/util/messages.h
@@ -1,0 +1,53 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+//! @file util/messages.h defines helper function and types that can be used
+//! with the util::Result class to deal with error and warning messages. It
+//! keeps the message representation separate from the implementation of the
+//! Result class, allowing each to be understood and changed more easily.
+
+#ifndef BITCOIN_UTIL_MESSAGES_H
+#define BITCOIN_UTIL_MESSAGES_H
+
+#include <util/translation.h>
+
+#include <string>
+#include <vector>
+
+namespace util {
+//! Default MessagesType for Result class, simple list of errors and warnings.
+struct Messages {
+    std::vector<bilingual_str> errors{};
+    std::vector<bilingual_str> warnings{};
+};
+
+//! Wrapper object to pass an error string to the Result constructor.
+struct Error {
+    bilingual_str message;
+};
+//! Wrapper object to pass a warning string to the Result constructor.
+struct Warning {
+    bilingual_str message;
+};
+
+//! Helper function to join messages in space separated string.
+bilingual_str JoinMessages(const Messages& messages);
+
+//! Helper function to move messages from one instance to another.
+void MoveMessages(Messages& dst, Messages& src);
+
+//! Join error and warning messages in a space separated string. This is
+//! intended for simple applications where there's probably only one error or
+//! warning message to report, but multiple messages should not be lost if they
+//! are present. More complicated applications should use Result::messages_ptr()
+//! method directly.
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
+{
+    const auto* messages{result.messages_ptr()};
+    return messages ? JoinMessages(*messages) : bilingual_str{};
+}
+} // namespace util
+
+#endif // BITCOIN_UTIL_MESSAGES_H

--- a/src/util/messages.h
+++ b/src/util/messages.h
@@ -31,6 +31,13 @@ struct Warning {
     bilingual_str message;
 };
 
+//! Wrapper object to pass an InfoType object to the result constructor.
+template <typename T>
+struct Info {
+    Info(T&& value) : m_value(value) {}
+    T& m_value;
+};
+
 //! Helper function to join messages in space separated string.
 bilingual_str JoinMessages(const Messages& messages);
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -65,7 +65,7 @@ namespace util {
 //!    return result;
 //!
 //! It also provides an update() method which is useful for returning early on
-//! failures and for combining results of the same type.
+//! errors and for combining results of the same type.
 //!
 //!    Result<Value> result;
 //!    if (!(DoSomething() >> result)) {

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -18,13 +18,13 @@
 #include <vector>
 
 namespace util {
-//! The Result<SuccessType, ErrorType, MessagesType> class provides
+//! The Result<SuccessType, ErrorType, InfoType, MessagesType> class provides
 //! an efficient way for functions to return structured result information, as
-//! well as descriptive error messages.
+//! well as descriptive error and warning messages.
 //!
 //! Logically, a result object is equivalent to:
 //!
-//!     tuple<variant<SuccessType, ErrorType>, MessagesType>
+//!     tuple<variant<SuccessType, ErrorType>, InfoType, MessagesType>
 //!
 //! But the physical representation is more efficient because it avoids
 //! allocating memory for ErrorType and MessagesType fields unless there is an
@@ -33,7 +33,7 @@ namespace util {
 //! Result<SuccessType> objects support the same operators as
 //! std::optional<SuccessType>, such as !result, *result, result->member, to
 //! make SuccessType values easy to access. They also provide
-//! result.error() and result.messages() methods to
+//! result.error(), result.info(), and result.messages() methods to
 //! access other parts of the result. A simple usage example is:
 //!
 //!    Result<int> AddNumbers(int a, int b)
@@ -83,7 +83,7 @@ namespace util {
 //! appending data instead of overwriting it where possible. This can be
 //! controlled by specializing the `ResultTraits` class below, which is used by
 //! the `ResultUpdate()` function.
-template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = Messages>
+template <typename SuccessType = void, typename ErrorType = void, typename InfoType = void, typename MessagesType = Messages>
 class Result;
 
 //! Traits class that can be specialized to control the way result types are
@@ -116,10 +116,36 @@ void ResultUpdate(auto&& dst_fn, T& src)
 //! Substitute for std::monostate that doesn't depend on std::variant.
 struct Monostate{};
 
+//! Implementation note: Result class inherits from an InfoHolder class holding an
+//! IntoType value, a FailDataHolder class holding a unique_ptr to ErrorType
+//! and MessagesTypes values, and a SuccessHolder class holding a SuccessType
+//! value in an anonymous union.
+//!
+//! To take advantage of the Empty Base Optimization, inheritance is linear with
+//! FailDataHolder inheriting from InfoHolder, SuccessHolder inheriting from
+//! FailDataHolder, and Holder classes specializing for void so no space is used
+//! when void types are specified.
+//! @{
+//! Container for InfoType, providing public info() method.
+template <typename InfoType>
+class InfoHolder
+{
+protected:
+    InfoType m_info{};
+public:
+    // Public accessors.
+    const InfoType& info() const LIFETIMEBOUND { return m_info; }
+    InfoType& info() LIFETIMEBOUND { return m_info; }
+};
+
+//! Specialization of InfoHolder when InfoType is void.
+template <>
+class InfoHolder<void> {};
+
 //! Container for ErrorType and MessagesType, providing public operator
 //! bool(), error(), messages_ptr(), and messages() methods.
-template <typename ErrorType, typename MessagesType>
-class FailDataHolder
+template <typename ErrorType, typename InfoType, typename MessagesType>
+class FailDataHolder : public InfoHolder<InfoType>
 {
 protected:
     struct FailData {
@@ -148,8 +174,8 @@ public:
 //! Container for SuccessType, providing public accessor methods similar to
 //! std::optional methods to access the success value. There is a specialization
 //! of this class for the void success type.
-template <typename SuccessType, typename ErrorType, typename MessagesType>
-class SuccessHolder : public FailDataHolder<ErrorType, MessagesType>
+template <typename SuccessType, typename ErrorType, typename InfoType, typename MessagesType>
+class SuccessHolder : public FailDataHolder<ErrorType, InfoType, MessagesType>
 {
 protected:
     //! Success value embedded in an anonymous union so it doesn't need to be
@@ -182,20 +208,21 @@ public:
 };
 
 //! Specialization of SuccessHolder when SuccessType is void.
-template <typename ErrorType, typename MessagesType>
-class SuccessHolder<void, ErrorType, MessagesType> : public FailDataHolder<ErrorType, MessagesType>
+template <typename ErrorType, typename InfoType, typename MessagesType>
+class SuccessHolder<void, ErrorType, InfoType, MessagesType> : public FailDataHolder<ErrorType, InfoType, MessagesType>
 {
 };
 //! @}
 } // namespace detail
 
 // Result type class, documented at the top of this file.
-template <typename SuccessType_, typename ErrorType_, typename MessagesType_>
-class Result : public detail::SuccessHolder<SuccessType_, ErrorType_, MessagesType_>
+template <typename SuccessType_, typename ErrorType_, typename InfoType_, typename MessagesType_>
+class Result : public detail::SuccessHolder<SuccessType_, ErrorType_, InfoType_, MessagesType_>
 {
 public:
     using SuccessType = SuccessType_;
     using ErrorType = ErrorType_;
+    using InfoType = InfoType_;
     using MessagesType = MessagesType_;
     static constexpr bool is_result{true};
 
@@ -220,7 +247,7 @@ public:
     }
 
     //! Update this result by moving from another result object. Existing
-    //! success, error, and messages values are updated using
+    //! success, error, info, and messages values are updated using
     //! ResultTraits::update calls so state can be combined instead of
     //! overwritten.
     Result& update(Result&& other) LIFETIMEBOUND
@@ -234,7 +261,7 @@ public:
     Result& operator=(Result&&) = delete;
 
 protected:
-    template <typename, typename, typename>
+    template <typename, typename, typename, typename>
     friend class Result;
 
     //! Helper function to construct a new success or error value using the
@@ -268,7 +295,7 @@ protected:
         construct<construct_error>(result, std::forward<Args>(args)...);
     }
 
-    //! Move success, error, and message values from source Result object to
+    //! Move success, error, info, and message values source Result object to
     //! destination object. Existing values are updated using
     //! ResultTraits::update calls so state can be combined instead of
     //! overwritten.
@@ -280,7 +307,7 @@ protected:
     template <bool DstConstructed, typename DstResult, typename SrcResult>
     static void move(DstResult& dst, SrcResult& src)
     {
-        // Use operator>> to move messages values first, then move
+        // Use operator>> to move info and messages values first, then move
         // success or error value below.
         src >> dst;
         // If DstConstructed is true, it means dst has either a success value or
@@ -346,6 +373,9 @@ requires (std::decay_t<SrcResult>::is_result)
 decltype(auto) operator>>(SrcResult&& src LIFETIMEBOUND, DstResult&& dst)
 {
     using SrcType = std::decay_t<SrcResult>;
+    if constexpr (!std::is_same_v<typename SrcType::InfoType, void>) {
+        detail::ResultUpdate([&]()->auto& { return dst.info(); }, src.info());
+    }
     if (src.messages_ptr()) {
         detail::ResultUpdate([&]()->auto& { return dst.messages(); }, src.messages());
     }
@@ -384,6 +414,16 @@ struct ResultTraits<Warning> {
     static void construct(ResultType& dst, Warning&& src)
     {
        dst.messages().warnings.push_back(std::move(src.message));
+    }
+};
+
+//! ResultTraits specialization for Info struct.
+template<typename T>
+struct ResultTraits<Info<T>> {
+    template<typename ResultType>
+    static void construct(ResultType& dst, Info<T>&& src)
+    {
+       dst.info() = std::move(src.m_value);
     }
 };
 } // namespace util

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -8,7 +8,13 @@
 #include <attributes.h>
 #include <util/translation.h>
 
-#include <variant>
+#include <cassert>
+#include <memory>
+#include <new>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace util {
 
@@ -16,31 +22,159 @@ struct Error {
     bilingual_str message;
 };
 
-//! The util::Result class provides a standard way for functions to return
-//! either error messages or result values.
+//! The Result<SuccessType, ErrorType, MessagesType> class provides
+//! an efficient way for functions to return structured result information, as
+//! well as descriptive error messages.
 //!
-//! It is intended for high-level functions that need to report error strings to
-//! end users. Lower-level functions that don't need this error-reporting and
-//! that only need error-handling should avoid util::Result and instead use
-//! util::Expected, std::optional, std::variant, or custom structs
-//! and enum types to return function results.
+//! Logically, a result object is equivalent to:
 //!
-//! Usage examples can be found in \example ../test/result_tests.cpp, but in
-//! general code returning `util::Result<T>` values is very similar to code
-//! returning `std::optional<T>` values. Existing functions returning
-//! `std::optional<T>` can be updated to return `util::Result<T>` and return
-//! error strings usually just replacing `return std::nullopt;` with `return
-//! util::Error{error_string};`.
-template <class M>
-class Result
+//!     tuple<variant<SuccessType, ErrorType>, MessagesType>
+//!
+//! But the physical representation is more efficient because it avoids
+//! allocating memory for ErrorType and MessagesType fields unless there is an
+//! error.
+//!
+//! Result<SuccessType> objects support the same operators as
+//! std::optional<SuccessType>, such as !result, *result, result->member, to
+//! make SuccessType values easy to access. They also provide
+//! result.error() and result.messages() methods to
+//! access other parts of the result. A simple usage example is:
+//!
+//!    Result<int> AddNumbers(int a, int b)
+//!    {
+//!        if (b == 0) return util::Error{_("Not adding 0, that's dumb.")};
+//!        return a + b;
+//!    }
+//!
+//!    void TryAddNumbers(int a, int b)
+//!    {
+//!        if (auto result = AddNumbers(a, b)) {
+//!            LogInfo("%i + %i = %i\n", a, b, *result);
+//!        } else {
+//!            LogInfo("Error: %s\n", util::ErrorString(result).translated);
+//!        }
+//!    }
+//!
+//! The `Result` class is superset of `std::expected`, providing additional
+//! features for combining results from different functions and returning error
+//! messages for users instead of just error values for callers.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+class Result;
+
+//! Traits class that can be specialized to control the way result types are
+//! combined and constructed. Specializations provide a construct() method to be
+//! accepted as special arguments to the Result constructor, and a
+//! construct_error bool member indicating whether to construct error values
+//! instead of success values on use.
+template<typename T>
+struct ResultTraits {};
+
+namespace detail {
+//! Substitute for std::monostate that doesn't depend on std::variant.
+struct Monostate{};
+
+//! Container for ErrorType and MessagesType, providing public operator
+//! bool(), error(), messages_ptr(), and messages() methods.
+template <typename ErrorType, typename MessagesType>
+class FailDataHolder
 {
-private:
-    using T = std::conditional_t<std::is_same_v<M, void>, std::monostate, M>;
+protected:
+    struct FailData {
+        std::optional<std::conditional_t<std::is_same_v<ErrorType, void>, Monostate, ErrorType>> error{};
+        MessagesType messages{};
+    };
+    std::unique_ptr<FailData> m_fail_data;
 
-    std::variant<bilingual_str, T> m_variant;
+    // Private accessor, create FailData if it doesn't exist.
+    FailData& fail_data() LIFETIMEBOUND
+    {
+        if (!m_fail_data) m_fail_data = std::make_unique<FailData>();
+        return *m_fail_data;
+    }
 
-    //! Disallow copy constructor, require Result to be moved for efficiency.
-    Result(const Result&) = delete;
+public:
+    // Public accessors.
+    explicit operator bool() const { return !m_fail_data || !m_fail_data->error; }
+    const auto& error() const LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    auto& error() LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    const auto* messages_ptr() const LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto* messages_ptr() LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto& messages() LIFETIMEBOUND { return fail_data().messages; }
+};
+
+//! Container for SuccessType, providing public accessor methods similar to
+//! std::optional methods to access the success value. There is a specialization
+//! of this class for the void success type.
+template <typename SuccessType, typename ErrorType, typename MessagesType>
+class SuccessHolder : public FailDataHolder<ErrorType, MessagesType>
+{
+protected:
+    //! Success value embedded in an anonymous union so it doesn't need to be
+    //! constructed if the result is holding a error value,
+    union { SuccessType m_success; };
+
+    //! Empty constructor that needs to be declared because the class contains a union.
+    SuccessHolder() {}
+    ~SuccessHolder() { if (*this) m_success.~SuccessType(); }
+
+public:
+    // Public accessors.
+    bool has_value() const { return bool{*this}; }
+    const SuccessType& value() const LIFETIMEBOUND { assert(has_value()); return m_success; }
+    SuccessType& value() LIFETIMEBOUND { assert(has_value()); return m_success; }
+    template <class U>
+    SuccessType value_or(U&& default_value) const&
+    {
+        return has_value() ? value() : std::forward<U>(default_value);
+    }
+    template <class U>
+    SuccessType value_or(U&& default_value) &&
+    {
+        return has_value() ? std::move(value()) : std::forward<U>(default_value);
+    }
+    const SuccessType* operator->() const LIFETIMEBOUND { return &value(); }
+    const SuccessType& operator*() const LIFETIMEBOUND { return value(); }
+    SuccessType* operator->() LIFETIMEBOUND { return &value(); }
+    SuccessType& operator*() LIFETIMEBOUND { return value(); }
+};
+
+//! Specialization of SuccessHolder when SuccessType is void.
+template <typename ErrorType, typename MessagesType>
+class SuccessHolder<void, ErrorType, MessagesType> : public FailDataHolder<ErrorType, MessagesType>
+{
+};
+//! @}
+} // namespace detail
+
+// Result type class, documented at the top of this file.
+template <typename SuccessType_, typename ErrorType_, typename MessagesType_>
+class Result : public detail::SuccessHolder<SuccessType_, ErrorType_, MessagesType_>
+{
+public:
+    using SuccessType = SuccessType_;
+    using ErrorType = ErrorType_;
+    using MessagesType = MessagesType_;
+    static constexpr bool is_result{true};
+
+    //! Construct a Result object setting a success or error value. Initial
+    //! special arguments with ResultTraits::construct methods are processed
+    //! first, and then remaining arguments are passed to the SuccessType
+    //! constructor if this is a successful result or to the FailType
+    //! constructor otherwise.
+    template <typename... Args>
+    Result(Args&&... args)
+    {
+        construct</*Error=*/false>(*this, std::forward<Args>(args)...);
+    }
+
+    //! Move-construct a Result object from another Result object, moving the
+    //! success or error value and messages.
+    template <typename O>
+    requires (std::decay_t<O>::is_result)
+    Result(O&& other)
+    {
+        move(*this, other);
+    }
 
     //! Disallow operator= to avoid confusion in the future when the Result
     //! class gains support for richer error reporting, and callers should have
@@ -49,50 +183,96 @@ private:
     Result& operator=(const Result&) = delete;
     Result& operator=(Result&&) = delete;
 
-    template <typename FT>
-    friend bilingual_str ErrorString(const Result<FT>& result);
+protected:
+    template <typename, typename, typename>
+    friend class Result;
 
-public:
-    Result() : m_variant{std::in_place_index_t<1>{}, std::monostate{}} {}  // constructor for void
-    Result(T obj) : m_variant{std::in_place_index_t<1>{}, std::move(obj)} {}
-    Result(Error error) : m_variant{std::in_place_index_t<0>{}, std::move(error.message)} {}
-    Result(Result&&) = default;
-    ~Result() = default;
+    //! Helper function to construct a new success or error value using the
+    //! arguments provided.
+    template <bool Error, typename Result, typename... Args>
+    static void construct(Result& result, Args&&... args)
+    {
+        if constexpr (Error) {
+            static_assert(sizeof...(args) > 0 || !std::is_scalar_v<ErrorType>,
+                "Refusing to default-construct error value with int, float, enum, or pointer type, please specify an explicit error value.");
+            result.fail_data().error.emplace(std::forward<Args>(args)...);
+        } else if constexpr (std::is_same_v<typename Result::SuccessType, void>) {
+            static_assert(sizeof...(args) == 0, "Error: Arguments cannot be passed to a Result<void> constructor.");
+        } else {
+            new (&result.m_success) typename Result::SuccessType{std::forward<Args>(args)...};
+        }
+    }
 
-    //! std::optional methods, so functions returning optional<T> can change to
-    //! return Result<T> with minimal changes to existing code, and vice versa.
-    bool has_value() const noexcept { return m_variant.index() == 1; }
-    const T& value() const LIFETIMEBOUND
+    //! Overload for construct() for special arguments with
+    //! ResultTraits::construct method defined.
+    template <bool Error, typename Result, typename T, typename... Args>
+    requires requires { ResultTraits<std::decay_t<T>>::construct(std::declval<Result&>(), std::declval<T&&>()); }
+    static void construct(Result& result, T&& arg, Args&&... args)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        using Traits = ResultTraits<std::decay_t<T>>;
+        constexpr bool construct_error{Error || []{
+            if constexpr (requires { Traits::construct_error; }) return Traits::construct_error;
+            return false;
+        }()};
+        Traits::construct(result, std::forward<T>(arg));
+        construct<construct_error>(result, std::forward<Args>(args)...);
     }
-    T& value() LIFETIMEBOUND
+
+    //! Move success, error, and message values from source Result object to
+    //! destination object.
+    //! The source and destination results are not required to have the same
+    //! types, and assigning void source types to non-void destinations type is
+    //! allowed, since no source information is lost. But assigning non-void
+    //! source types to void destination types is not allowed, since this would
+    //! discard source information.
+    template <typename DstResult, typename SrcResult>
+    static void move(DstResult& dst, SrcResult& src)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        // Move messages values first, then move success or error value below.
+        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
+            dst.messages() = std::move(*src.messages_ptr());
+        }
+        // At this point dst has no success or error value set. Can assert
+        // there is no error value.
+        assert(dst);
+        if (src) {
+            // src has a success value, so move it to dst. If the src success
+            // type is void and the dst success type is non-void, just
+            // initialize the dst success value by default initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{std::move(src.m_success)};
+            } else if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{};
+            }
+        } else {
+            // src has a error value, so move it to dst. If the src error
+            // type is void, just initialize the dst error value by default
+            // initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::ErrorType, void>) {
+                dst.fail_data().error.emplace(std::move(src.error()));
+            } else {
+                dst.fail_data().error.emplace();
+            }
+        }
     }
-    template <class U>
-    T value_or(U&& default_value) const&
-    {
-        return has_value() ? value() : std::forward<U>(default_value);
-    }
-    template <class U>
-    T value_or(U&& default_value) &&
-    {
-        return has_value() ? std::move(value()) : std::forward<U>(default_value);
-    }
-    explicit operator bool() const noexcept { return has_value(); }
-    const T* operator->() const LIFETIMEBOUND { return &value(); }
-    const T& operator*() const LIFETIMEBOUND { return value(); }
-    T* operator->() LIFETIMEBOUND { return &value(); }
-    T& operator*() LIFETIMEBOUND { return value(); }
 };
 
-template <typename T>
-bilingual_str ErrorString(const Result<T>& result)
+//! ResultTraits specialization for Error struct.
+template<>
+struct ResultTraits<Error> {
+    static constexpr bool construct_error{true};
+
+    template<typename ResultType>
+    static void construct(ResultType& dst, Error&& src)
+    {
+       dst.messages() = std::move(src.message);
+    }
+};
+
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
 {
-    return result ? bilingual_str{} : std::get<0>(result.m_variant);
+    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
 }
 } // namespace util
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <attributes.h>
+#include <util/messages.h> // IWYU pragma: export
 #include <util/translation.h>
 
 #include <cassert>
@@ -17,11 +18,6 @@
 #include <vector>
 
 namespace util {
-
-struct Error {
-    bilingual_str message;
-};
-
 //! The Result<SuccessType, ErrorType, MessagesType> class provides
 //! an efficient way for functions to return structured result information, as
 //! well as descriptive error messages.
@@ -58,18 +54,65 @@ struct Error {
 //! The `Result` class is superset of `std::expected`, providing additional
 //! features for combining results from different functions and returning error
 //! messages for users instead of just error values for callers.
-template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+//!
+//! It provides an >> operator to move messages between results without
+//! affecting success and error values.
+//!
+//!    Result<void> result;
+//!    auto r1 = DoSomething() >> result;
+//!    auto r2 = DoSomethingElse() >> result;
+//!    ...
+//!    return result;
+//!
+//! It also provides an update() method which is useful for returning early on
+//! failures and for combining results of the same type.
+//!
+//!    Result<Value> result;
+//!    if (!(DoSomething() >> result)) {
+//!        result.update(Error{_("DoSomething failed.")});
+//!        return result;
+//!    }
+//!    if (!result.update(DoSomethingElse())) {
+//!        result.update(Error{_("DoSomethingElse failed.")});
+//!        return result;
+//!    }
+//!    result.update(...);
+//!    return result;
+//!
+//! Semantically, the update() method merges state from different results,
+//! appending data instead of overwriting it where possible. This can be
+//! controlled by specializing the `ResultTraits` class below, which is used by
+//! the `ResultUpdate()` function.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = Messages>
 class Result;
 
 //! Traits class that can be specialized to control the way result types are
-//! combined and constructed. Specializations provide a construct() method to be
-//! accepted as special arguments to the Result constructor, and a
-//! construct_error bool member indicating whether to construct error values
-//! instead of success values on use.
+//! combined and constructed. Specializations can provide an update() method
+//! merging information from a source object to a destination object. They can
+//! also define an empty() method to avoid updates if a source object contains
+//! no data. They can also define a construct() method to be accepted as
+//! special arguments to the Result constructor, and a construct_error bool
+//! member indicating whether to construct error values instead of success
+//! values on use.
 template<typename T>
 struct ResultTraits {};
 
 namespace detail {
+//! Helper to use ResultTraits and update dst if src is nonempty.
+template<typename T>
+void ResultUpdate(auto&& dst_fn, T& src)
+{
+    using Traits = ResultTraits<T>;
+    if constexpr (requires { Traits::empty; }) {
+        if (Traits::empty(src)) return;
+    }
+    if constexpr (requires { Traits::update; }) {
+        Traits::update(dst_fn(), std::move(src));
+    } else {
+        dst_fn() = std::move(src);
+    }
+}
+
 //! Substitute for std::monostate that doesn't depend on std::variant.
 struct Monostate{};
 
@@ -176,7 +219,10 @@ public:
         move</*DstConstructed=*/false>(*this, other);
     }
 
-    //! Update this result by moving from another result object.
+    //! Update this result by moving from another result object. Existing
+    //! success, error, and messages values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     Result& update(Result&& other) LIFETIMEBOUND
     {
         move</*DstConstructed=*/true>(*this, other);
@@ -184,9 +230,7 @@ public:
     }
 
     //! Disallow operator= and require explicit Result::update() calls to avoid
-    //! confusion in the future when the Result class gains support for richer
-    //! error reporting, and callers should have ability to set a new result
-    //! value without clearing existing error messages.
+    //! accidentally clearing messages when combining results.
     Result& operator=(Result&&) = delete;
 
 protected:
@@ -225,7 +269,9 @@ protected:
     }
 
     //! Move success, error, and message values from source Result object to
-    //! destination object.
+    //! destination object. Existing values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     //! The source and destination results are not required to have the same
     //! types, and assigning void source types to non-void destinations type is
     //! allowed, since no source information is lost. But assigning non-void
@@ -234,16 +280,27 @@ protected:
     template <bool DstConstructed, typename DstResult, typename SrcResult>
     static void move(DstResult& dst, SrcResult& src)
     {
-        // Move messages values first, then move success or error value below.
-        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
-            dst.messages() = std::move(*src.messages_ptr());
-        }
+        // Use operator>> to move messages values first, then move
+        // success or error value below.
+        src >> dst;
         // If DstConstructed is true, it means dst has either a success value or
-        // a error value set, which needs to be destroyed and replaced. If
+        // a error value set, which needs to be updated or replaced. If
         // DstConstructed is false, then dst is being constructed now and has no
         // values set.
         if constexpr (DstConstructed) {
-            if (dst) {
+            if (dst && src) {
+                // dst and src both hold success values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return *dst; }, *src);
+                }
+                return;
+            } else if (!dst && !src) {
+                // dst and src both hold error values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::ErrorType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return dst.error(); }, src.error());
+                }
+                return;
+            } else if (dst) {
                 // dst has a success value, so destroy it before replacing it with src error value
                 if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
                     using DstSuccess = typename DstResult::SuccessType;
@@ -281,6 +338,33 @@ protected:
     }
 };
 
+//! Move information from a source Result object to a destination object. It
+//! only moves InfoType and MessagesType values without affecting SuccessType or
+//! ErrorType values of either Result object.
+template <typename SrcResult, typename DstResult>
+requires (std::decay_t<SrcResult>::is_result)
+decltype(auto) operator>>(SrcResult&& src LIFETIMEBOUND, DstResult&& dst)
+{
+    using SrcType = std::decay_t<SrcResult>;
+    if (src.messages_ptr()) {
+        detail::ResultUpdate([&]()->auto& { return dst.messages(); }, src.messages());
+    }
+    return static_cast<SrcType&&>(src);
+}
+
+//! ResultTraits specialization for Messages struct.
+template<>
+struct ResultTraits<Messages> {
+    static void update(Messages& dst, Messages&& src)
+    {
+        MoveMessages(dst, src);
+    }
+    static bool empty(const Messages& src)
+    {
+        return src.errors.empty() && src.warnings.empty();
+    }
+};
+
 //! ResultTraits specialization for Error struct.
 template<>
 struct ResultTraits<Error> {
@@ -289,15 +373,19 @@ struct ResultTraits<Error> {
     template<typename ResultType>
     static void construct(ResultType& dst, Error&& src)
     {
-       dst.messages() = std::move(src.message);
+       dst.messages().errors.push_back(std::move(src.message));
     }
 };
 
-template <typename Result>
-bilingual_str ErrorString(const Result& result)
-{
-    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
-}
+//! ResultTraits specialization for Warning struct.
+template<>
+struct ResultTraits<Warning> {
+    template<typename ResultType>
+    static void construct(ResultType& dst, Warning&& src)
+    {
+       dst.messages().warnings.push_back(std::move(src.message));
+    }
+};
 } // namespace util
 
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5630,6 +5630,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
+    util::Result<CBlockIndex*> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5638,25 +5639,30 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         LOCK(::cs_main);
 
         if (this->CurrentChainstate().m_from_snapshot_blockhash) {
-            return util::Error{Untranslated("Can't activate a snapshot-based chainstate more than once")};
+            result.update(util::Error{Untranslated("Can't activate a snapshot-based chainstate more than once")});
+            return result;
         }
+
         if (!GetParams().AssumeutxoForBlockhash(base_blockhash).has_value()) {
             auto available_heights = GetParams().GetAvailableSnapshotHeights();
             std::string heights_formatted = util::Join(available_heights, ", ", [&](const auto& i) { return util::ToString(i); });
-            return util::Error{Untranslated(strprintf("assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s",
+            result.update(util::Error{Untranslated(strprintf("assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s",
                 base_blockhash.ToString(),
-                heights_formatted))};
+                heights_formatted))});
+            return result;
         }
 
         snapshot_start_block = m_blockman.LookupBlockIndex(base_blockhash);
         if (!snapshot_start_block) {
-            return util::Error{Untranslated(strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again",
-                          base_blockhash.ToString()))};
+            result.update(util::Error{Untranslated(strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again",
+                          base_blockhash.ToString()))});
+            return result;
         }
 
         bool start_block_invalid = snapshot_start_block->nStatus & BLOCK_FAILED_VALID;
         if (start_block_invalid) {
-            return util::Error{Untranslated(strprintf("The base block header (%s) is part of an invalid chain", base_blockhash.ToString()))};
+            result.update(util::Error{Untranslated(strprintf("The base block header (%s) is part of an invalid chain", base_blockhash.ToString()))});
+            return result;
         }
 
         if (!m_best_header || m_best_header->GetAncestor(snapshot_start_block->nHeight) != snapshot_start_block) {
@@ -5665,7 +5671,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
         auto mempool{CurrentChainstate().GetMempool()};
         if (mempool && mempool->size() > 0) {
-            return util::Error{Untranslated("Can't activate a snapshot when mempool not empty")};
+            result.update(util::Error{Untranslated("Can't activate a snapshot when mempool not empty")});
+            return result;
         }
     }
 
@@ -5715,6 +5722,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     }
 
     auto cleanup_bad_snapshot = [&](bilingual_str reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        result.update(util::Error{std::move(reason)});
         this->MaybeRebalanceCaches();
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
@@ -5730,12 +5738,13 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
                     "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
             }
         }
-        return util::Error{std::move(reason)};
     };
 
     if (auto res{this->PopulateAndValidateSnapshot(*snapshot_chainstate, coins_file, metadata)}; !res) {
         LOCK(::cs_main);
-        return cleanup_bad_snapshot(Untranslated(strprintf("Population failed: %s", util::ErrorString(res).original)));
+        cleanup_bad_snapshot(Untranslated("Population failed:"));
+        res >> result;
+        return result;
     }
 
     LOCK(::cs_main);  // cs_main required for rest of snapshot activation.
@@ -5744,13 +5753,15 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     // work chain than the active chainstate; a user could have loaded a snapshot
     // very late in the IBD process, and we wouldn't want to load a useless chainstate.
     if (!CBlockIndexWorkComparator()(ActiveTip(), snapshot_chainstate->m_chain.Tip())) {
-        return cleanup_bad_snapshot(Untranslated("work does not exceed active chainstate"));
+        cleanup_bad_snapshot(Untranslated("work does not exceed active chainstate"));
+        return result;
     }
     // If not in-memory, persist the base blockhash for use during subsequent
     // initialization.
     if (!in_memory) {
         if (!node::WriteSnapshotBaseBlockhash(*snapshot_chainstate)) {
-            return cleanup_bad_snapshot(Untranslated("could not write base blockhash"));
+            cleanup_bad_snapshot(Untranslated("could not write base blockhash"));
+            return result;
         }
     }
 
@@ -5764,7 +5775,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
     this->MaybeRebalanceCaches();
-    return snapshot_start_block;
+    result.update(snapshot_start_block);
+    return result;
 }
 
 static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_loaded)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3258,12 +3258,12 @@ void Chainstate::PruneBlockIndexCandidates() {
  *
  * @returns true unless a system error occurred
  */
-bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
+FlushResult<void, AbortFailure> Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
 
@@ -3280,8 +3280,10 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
-            FatalError(m_chainman.GetNotifications(), state, _("Failed to disconnect block."));
-            return false;
+            auto error{_("Failed to disconnect block.")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
         fBlocksDisconnected = true;
     }
@@ -3320,7 +3322,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
                     // Make the mempool consistent with the current tip, just in case
                     // any observers try to use it before shutdown.
                     MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
-                    return false;
+                    result.update(util::Error{});
+                    return result;
                 }
             } else {
                 PruneBlockIndexCandidates();
@@ -3343,7 +3346,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
     CheckForkWarningConditions();
 
-    return true;
+    return result;
 }
 
 static SynchronizationState GetSynchronizationState(bool init, bool blockfiles_indexed)
@@ -3393,7 +3396,7 @@ static void LimitValidationInterfaceQueue(ValidationSignals& signals) LOCKS_EXCL
     }
 }
 
-bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
+FlushResult<> Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
 {
     AssertLockNotHeld(m_chainstate_mutex);
 
@@ -3409,13 +3412,16 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // we use m_chainstate_mutex to enforce mutual exclusion so that only one caller may execute this function at a time
     LOCK(m_chainstate_mutex);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
 
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
-        LogError("%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
-        return Assume(false);
+        auto error{Untranslated(STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."))};
+        LogError("%s", error.original);
+        Assume(false);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
     CBlockIndex *pindexMostWork = nullptr;
@@ -3458,9 +3464,10 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                 // in case snapshot validation is completed during ActivateBestChainStep, the
                 // result of GetRole() changes from BACKGROUND to NORMAL.
                const ChainstateRole chainstate_role{this->GetRole()};
-                if (!ActivateBestChainStep(state, *pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connected_blocks)) {
+                if (!(ActivateBestChainStep(state, *pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connected_blocks) >> result)) {
                     // A system error occurred
-                    return false;
+                    result.update(util::Error{});
+                    return result;
                 }
                 blocks_connected = true;
 
@@ -3481,7 +3488,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                     break;
                 }
             } while (!m_chain.Tip() || (starting_tip && CBlockIndexWorkComparator()(m_chain.Tip(), starting_tip)));
-            if (!blocks_connected) return true;
+            if (!blocks_connected) return result;
 
             const CBlockIndex* pindexFork = starting_tip ? m_chain.FindFork(*starting_tip) : nullptr;
             bool still_in_ibd = m_chainman.IsInitialBlockDownload();
@@ -3532,7 +3539,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
             // Write changes periodically to disk, after relay.
             if (!(FlushStateToDisk(state, FlushStateMode::PERIODIC) >> result)) {
                 result.update(util::Error{});
-                return false;
+                return result;
             }
 
             reached_target = ReachedTarget();
@@ -3561,10 +3568,10 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
     m_chainman.CheckBlockIndex();
 
-    return true;
+    return result;
 }
 
-bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+FlushResult<> Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
@@ -3572,7 +3579,7 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         LOCK(cs_main);
         if (pindex->nChainWork < m_chain.Tip()->nChainWork) {
             // Nothing to do, this block is not at the tip.
-            return true;
+            return {};
         }
         if (m_chain.Tip()->nChainWork > m_chainman.nLastPreciousChainwork) {
             // The chain has been extended since the last call, reset the counter.
@@ -4496,6 +4503,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
 {
     AssertLockNotHeld(cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     {
         CBlockIndex *pindex = nullptr;
@@ -4528,14 +4536,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     NotifyHeaderTip();
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActiveChainstate().ActivateBestChain(state, block)) {
+    if (!(ActiveChainstate().ActivateBestChain(state, block) >> result)) {
         LogError("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
         return false;
     }
 
     Chainstate* bg_chain{WITH_LOCK(cs_main, return HistoricalChainstate())};
     BlockValidationState bg_state;
-    if (bg_chain && !bg_chain->ActivateBestChain(bg_state, block)) {
+    if (bg_chain && !(bg_chain->ActivateBestChain(bg_state, block) >> result)) {
         LogError("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
         return false;
      }
@@ -5074,6 +5082,7 @@ void ChainstateManager::LoadExternalBlockFile(
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
 {
+    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
@@ -5169,7 +5178,7 @@ void ChainstateManager::LoadExternalBlockFile(
                 // was interrupted by the user.
                 if (hash == params.GetConsensus().hashGenesisBlock && WITH_LOCK(::cs_main, return ActiveHeight()) == -1) {
                     BlockValidationState state;
-                    if (!ActiveChainstate().ActivateBestChain(state, nullptr)) {
+                    if (!(ActiveChainstate().ActivateBestChain(state, nullptr) >> result)) {
                         break;
                     }
                 }
@@ -5182,8 +5191,9 @@ void ChainstateManager::LoadExternalBlockFile(
                     // until after all of the block files are loaded. ActivateBestChain can be
                     // called by concurrent network message processing. but, that is not
                     // reliable for the purpose of pruning while importing.
-                    if (auto result{ActivateBestChains()}; !result) {
-                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(result).original);
+                    if (auto activate_result{ActivateBestChains()}; !activate_result) {
+                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(activate_result).original);
+                        activate_result >> result;
                         break;
                     }
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4726,17 +4726,17 @@ CVerifyDB::~CVerifyDB()
     m_notifications.progress(bilingual_str{}, 100, false);
 }
 
-VerifyDBResult CVerifyDB::VerifyDB(
+FlushResult<VerifyDBResult> CVerifyDB::VerifyDB(
     Chainstate& chainstate,
     const Consensus::Params& consensus_params,
     CCoinsView& coinsview,
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<VerifyDBResult> result;
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
-        return VerifyDBResult::SUCCESS;
+        return result;
     }
 
     // Verify blocks in the best chain
@@ -4778,22 +4778,28 @@ VerifyDBResult CVerifyDB::VerifyDB(
         CBlock block;
         // check level 0: read from disk
         if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-            LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-            return VerifyDBResult::CORRUPTED_BLOCK_DB;
+            auto error{Untranslated(strprintf("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+            LogError("%s", error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params)) {
-            LogError("Verification error: found bad block at %d, hash=%s (%s)",
-                      pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
-            return VerifyDBResult::CORRUPTED_BLOCK_DB;
+            auto error{Untranslated(strprintf("Verification error: found bad block at %d, hash=%s (%s)",
+                      pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString()))};
+            LogError("%s", error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         // check level 2: verify undo validity
         if (nCheckLevel >= 2 && pindex) {
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
                 if (!chainstate.m_blockman.ReadBlockUndo(undo, *pindex)) {
-                    LogError("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                    return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                    auto error{Untranslated(strprintf("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                    LogError("%s", error.original);
+                    result.update(util::Error{std::move(error)});
+                    return result;
                 }
             }
         }
@@ -4805,8 +4811,10 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                    return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                    auto error{Untranslated(strprintf("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                    LogError("%s", error.original);
+                    result.update(util::Error{std::move(error)});
+                    return result;
                 }
                 if (res == DISCONNECT_UNCLEAN) {
                     nGoodTransactions = 0;
@@ -4818,11 +4826,16 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 skipped_l3_checks = true;
             }
         }
-        if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
+        if (chainstate.m_chainman.m_interrupt) {
+            result.update(Interrupted{});
+            return result;
+        }
     }
     if (pindexFailure) {
-        LogError("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
-        return VerifyDBResult::CORRUPTED_BLOCK_DB;
+        auto error{Untranslated(strprintf("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions))};
+        LogError("%s", error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
     if (skipped_l3_checks) {
         LogWarning("Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
@@ -4844,14 +4857,21 @@ VerifyDBResult CVerifyDB::VerifyDB(
             pindex = chainstate.m_chain.Next(*pindex);
             CBlock block;
             if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-                LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                auto error{Untranslated(strprintf("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                LogError("%s", error.original);
+                result.update(util::Error{std::move(error)});
+                return result;
             }
             if (!(chainstate.ConnectBlock(block, state, pindex, coins) >> result)) {
-                LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
-                return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                auto error{Untranslated(strprintf("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString()))};
+                LogError("%s", error.original);
+                result.update(util::Error{std::move(error)});
+                return result;
             }
-            if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
+            if (chainstate.m_chainman.m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
         }
     }
 
@@ -4861,12 +4881,11 @@ VerifyDBResult CVerifyDB::VerifyDB(
     }
 
     if (skipped_l3_checks) {
-        return VerifyDBResult::SKIPPED_L3_CHECKS;
+        result.update(SkippedL3Checks{});
+    } else if (skipped_no_block_data) {
+        result.update(SkippedMissingBlocks{});
     }
-    if (skipped_no_block_data) {
-        return VerifyDBResult::SKIPPED_MISSING_BLOCKS;
-    }
-    return VerifyDBResult::SUCCESS;
+    return result;
 }
 
 /** Apply the effects of a block on the utxo cache, ignoring that it may already have been applied. */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3158,7 +3158,11 @@ bool Chainstate::ConnectTip(
     // will be true and this->setBlockIndexCandidates will not have additional
     // blocks.
     Chainstate& current_cs{m_chainman.CurrentChainstate()};
-    m_chainman.MaybeValidateSnapshot(*this, current_cs);
+    FlushResult<void, AbortFailure> snapshot_result;
+    // Snapshot validation failure does not prevent connecting the block; only flush
+    // messages from the snapshot validation are propagated to the caller via result.
+    (void)m_chainman.MaybeValidateSnapshot(*this, current_cs, snapshot_result);
+    snapshot_result >> result;
 
     connected_blocks.emplace_back(pindexNew, std::move(block_to_connect));
     return true;
@@ -5671,12 +5675,12 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return destroyed && !fs::exists(db_path);
 }
 
-FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
+FlushResult<CBlockIndex*, AbortFailure> ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
-    FlushResult<CBlockIndex*> result;
+    FlushResult<CBlockIndex*, AbortFailure> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5782,8 +5786,10 @@ FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
             snapshot_chainstate.reset();
             bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
-                GetNotifications().fatalError(strprintf(_("Failed to remove snapshot chainstate dir (%s). "
-                    "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
+                auto error{strprintf(_("Failed to remove snapshot chainstate dir (%s). "
+                    "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir))};
+                GetNotifications().fatalError(error);
+                result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
             }
         }
     };
@@ -6065,9 +6071,8 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 // ActivateBestChain, on a separate thread that should not require cs_main to
 // hash, because the UTXO set is only hashed after the historical chainstate
 // reaches its target block and is no longer changing.
-SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs)
+SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs, FlushResult<void, AbortFailure>& result)
 {
-    FlushResult<> result; // TODO Return this result!
     AssertLockHeld(cs_main);
 
     // If the snapshot does not need to be validated...
@@ -6117,10 +6122,12 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
         }
 
         GetNotifications().fatalError(user_error);
+        result.update({util::Error{std::move(user_error)}, AbortFailure{.fatal = true}});
     };
 
     CCoinsViewDB& validated_coins_db = validated_cs.CoinsDB();
-    // Ignore failure value, do not treat flush error as failure.
+    // Propagate flush messages to result, but do not treat a flush failure as a
+    // snapshot validation failure.
     validated_cs.ForceFlushStateToDisk() >> result;
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
@@ -6174,7 +6181,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
     validated_cs.m_target_utxohash = AssumeutxoHash{validated_cs_stats->hashSerialized};
-    // Ignore failure value, do not treat flush error as failure.
+    // Propagate flush messages to result, but do not treat a flush failure as a
+    // snapshot validation failure.
     this->MaybeRebalanceCaches() >> result;
 
     return SnapshotCompletionResult::SUCCESS;
@@ -6389,12 +6397,14 @@ std::optional<int> ChainstateManager::BlocksAheadOfTip() const
     return std::nullopt;
 }
 
-bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs)
+util::Result<void, AbortFailure> ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs)
 {
     AssertLockHeld(::cs_main);
+    util::Result<void, AbortFailure> result;
     if (unvalidated_cs.m_assumeutxo != Assumeutxo::VALIDATED) {
         // No need to clean up.
-        return false;
+        result.update(util::Error{});
+        return result;
     }
 
     const fs::path validated_path{validated_cs.StoragePath()};
@@ -6413,16 +6423,18 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
     LogInfo("[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
               fs::PathToString(validated_path));
 
-    auto rename_failed_abort = [this](
+    auto rename_failed_abort = [&](
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
         LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
-        GetNotifications().fatalError(strprintf(_(
+        auto error{strprintf(_(
             "Rename of '%s' -> '%s' failed. "
             "Cannot clean up the background chainstate leveldb directory."),
-            fs::PathToString(p_old), fs::PathToString(p_new)));
+            fs::PathToString(p_old), fs::PathToString(p_new))};
+        GetNotifications().fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
     };
 
     try {
@@ -6453,7 +6465,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         LogInfo("[snapshot] deleted background chainstate directory (%s)",
                 fs::PathToString(validated_path));
     }
-    return true;
+    return result;
 }
 
 std::pair<int, int> Chainstate::GetPruneRange(int last_height_can_prune) const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -84,6 +84,9 @@ using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
 using kernel::FlushResult;
+using kernel::Interrupted;
+using kernel::InterruptResult;
+using kernel::IsInterrupted;
 using kernel::Notifications;
 
 using fsbridge::FopenFn;
@@ -4935,13 +4938,14 @@ void Chainstate::PopulateBlockIndexCandidates()
     }
 }
 
-bool ChainstateManager::LoadBlockIndex()
+util::Result<InterruptResult, AbortFailure> ChainstateManager::LoadBlockIndex()
 {
     AssertLockHeld(cs_main);
+    util::Result<InterruptResult, AbortFailure> result;
     // Load block index from databases
     if (m_blockman.m_blockfiles_indexed) {
-        bool ret{m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash)};
-        if (!ret) return false;
+        result.update(m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash));
+        if (!result || IsInterrupted(*result)) return result;
 
         m_blockman.ScanAndUnlinkAlreadyPrunedFiles();
 
@@ -4950,7 +4954,10 @@ bool ChainstateManager::LoadBlockIndex()
                   CBlockIndexHeightOnlyComparator());
 
         for (CBlockIndex* pindex : vSortedByHeight) {
-            if (m_interrupt) return false;
+            if (m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
             if (pindex->nStatus & BLOCK_FAILED_VALID && (!m_best_invalid || pindex->nChainWork > m_best_invalid->nChainWork)) {
                 m_best_invalid = pindex;
             }
@@ -4958,7 +4965,7 @@ bool ChainstateManager::LoadBlockIndex()
                 m_best_header = pindex;
         }
     }
-    return true;
+    return result;
 }
 
 bool ChainstateManager::LoadGenesisBlock()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2315,12 +2315,12 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+FlushResult<void, AbortFailure> Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                                CCoinsViewCache& view, bool fJustCheck)
 {
     AssertLockHeld(cs_main);
     assert(pindex);
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
 
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
@@ -2346,10 +2346,15 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
             // problems.
-            return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
+            auto error{_("Corrupt block found indicating potential hardware failure; shutting down")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
-        return false;
+        auto error{Untranslated(strprintf("Consensus::CheckBlock: %s", state.ToString()))};
+        LogError("%s: %s\n", __func__, error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
     // verify that the view's current state corresponds to the previous block
@@ -2363,7 +2368,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (block_hash == params.GetConsensus().hashGenesisBlock) {
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
-        return true;
+        return result;
     }
 
     const char* script_check_reason;
@@ -2643,7 +2648,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     }
     if (!state.IsValid()) {
         LogInfo("Block validation error: %s", state.ToString());
-        return false;
+        result.update(util::Error{Untranslated(state.ToString())});
+        return result;
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_verify += time_4 - time_2;
@@ -2654,12 +2660,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<MillisecondsDouble>(m_chainman.time_verify) / m_chainman.num_blocks_total);
 
     if (fJustCheck) {
-        return true;
+        return result;
     }
 
     if (!(m_blockman.WriteBlockUndo(blockundo, state, *pindex) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
 
     const auto time_5{SteadyClock::now()};
@@ -2693,7 +2699,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         Ticks<std::chrono::nanoseconds>(time_5 - time_start)
     );
 
-    return true;
+    return result;
 }
 
 CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState()
@@ -2979,12 +2985,12 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
   * disconnectpool (note that the caller is responsible for mempool consistency
   * in any case).
   */
-bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
+FlushResult<> Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2993,7 +2999,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlock(block, *pindexDelete)) {
         LogError("DisconnectTip(): Failed to read block\n");
-        return false;
+        result.update(util::Error{});
+        return result;
     }
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
@@ -3002,7 +3009,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
-            return false;
+            result.update(util::Error{});
+            return result;
         }
         view.Flush(/*reallocate_cache=*/false); // local CCoinsViewCache goes out of scope
     }
@@ -3023,7 +3031,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Write the chain state to disk, if necessary.
     if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
 
     if (disconnectpool && m_mempool) {
@@ -3043,7 +3051,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     if (m_chainman.m_options.signals) {
         m_chainman.m_options.signals->BlockDisconnected(std::move(pblock), pindexDelete);
     }
-    return true;
+    return result;
 }
 
 struct ConnectedBlock {
@@ -3057,7 +3065,7 @@ struct ConnectedBlock {
  *
  * The block is added to connected_blocks if connection succeeds.
  */
-bool Chainstate::ConnectTip(
+FlushResult<void, AbortFailure> Chainstate::ConnectTip(
     BlockValidationState& state,
     CBlockIndex* pindexNew,
     std::shared_ptr<const CBlock> block_to_connect,
@@ -3068,13 +3076,16 @@ bool Chainstate::ConnectTip(
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
     assert(pindexNew->pprev == m_chain.Tip());
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     // Read block from disk.
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
         if (!m_blockman.ReadBlock(*pblockNew, *pindexNew)) {
-            return FatalError(m_chainman.GetNotifications(), state, _("Failed to read block."));
+            auto error{_("Failed to read block")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
         block_to_connect = std::move(pblockNew);
     } else {
@@ -3090,15 +3101,17 @@ bool Chainstate::ConnectTip(
     {
         CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
         const auto reset_guard{view.StartFetching(*block_to_connect)};
-        bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
+        bool rv = bool{ConnectBlock(*block_to_connect, state, pindexNew, view) >> result};
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);
         }
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
-            return false;
+            auto error{Untranslated(strprintf("ConnectBlock %s failed, %s", pindexNew->GetBlockHash().ToString(), state.ToString()))};
+            LogError("%s: %s\n", __func__, error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         time_3 = SteadyClock::now();
         m_chainman.time_connect_total += time_3 - time_2;
@@ -3118,7 +3131,7 @@ bool Chainstate::ConnectTip(
     // Write the chain state to disk, if necessary.
     if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
     const auto time_5{SteadyClock::now()};
     m_chainman.time_chainstate += time_5 - time_4;
@@ -3165,7 +3178,7 @@ bool Chainstate::ConnectTip(
     snapshot_result >> result;
 
     connected_blocks.emplace_back(pindexNew, std::move(block_to_connect));
-    return true;
+    return result;
 }
 
 /**
@@ -3258,7 +3271,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     bool fBlocksDisconnected = false;
     DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
     while (m_chain.Tip() && m_chain.Tip() != pindexFork) {
-        if (!DisconnectTip(state, &disconnectpool)) {
+        if (!(DisconnectTip(state, &disconnectpool) >> result)) {
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
             // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
@@ -3292,7 +3305,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
         // Connect new blocks.
         for (CBlockIndex* pindexConnect : vpindexToConnect | std::views::reverse) {
-            if (!ConnectTip(state, pindexConnect, pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>(), connected_blocks, disconnectpool)) {
+            if (!(ConnectTip(state, pindexConnect, pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>(), connected_blocks, disconnectpool) >> result)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
@@ -3582,15 +3595,18 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
     return ActivateBestChain(state, std::shared_ptr<const CBlock>());
 }
 
-bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)
+FlushResult<> Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
 
     // Genesis block can't be invalidated
     assert(pindex);
-    if (pindex->nHeight == 0) return false;
+    if (pindex->nHeight == 0) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // We do not allow ActivateBestChain() to run while InvalidateBlock() is
     // running, as that could cause the tip to change while we disconnect
@@ -3645,7 +3661,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // ActivateBestChain considers blocks already in m_chain
         // unconditionally valid already, so force disconnect away from it.
         DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
-        bool ret = DisconnectTip(state, &disconnectpool);
+        bool ret = bool{DisconnectTip(state, &disconnectpool) >> result};
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding
         // transactions back to the mempool if disconnecting was successful,
@@ -3653,7 +3669,10 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // keeping the mempool up to date is probably futile anyway).
         // Propagate flush messages to result, but do not treat flush failure as a block invalidation failure.
         MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret) >> result;
-        if (!ret) return false;
+        if (!ret) {
+            result.update(util::Error{});
+            return result;
+        }
         CBlockIndex* new_tip{m_chain.Tip()};
         assert(disconnected_tip->pprev == new_tip);
 
@@ -3713,7 +3732,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         LOCK(cs_main);
         if (m_chain.Contains(*to_mark_failed)) {
             // If the to-be-marked invalid block is in the active chain, something is interfering and we can't proceed.
-            return false;
+            result.update(util::Error{});
+            return result;
         }
 
         // Mark pindex as invalid if it never was in the main chain
@@ -3759,7 +3779,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
             m_chainman.m_options.signals->ActiveTipChange(*Assert(m_chain.Tip()), m_chainman.IsInitialBlockDownload());
         }
     }
-    return true;
+    return result;
 }
 
 void Chainstate::SetBlockFailureFlags(CBlockIndex* invalid_block)
@@ -4549,6 +4569,7 @@ BlockValidationState TestBlockValidity(
     // 2. To prevent a CheckBlock() race condition for fChecked, see ProcessNewBlock()
     AssertLockHeld(chainstate.m_chainman.GetMutex());
 
+    FlushResult<> result; // TODO Return this result!
     BlockValidationState state;
     CBlockIndex* tip{Assert(chainstate.m_chain.Tip())};
 
@@ -4600,8 +4621,9 @@ BlockValidationState TestBlockValidity(
     CCoinsViewCache view_dummy(&chainstate.CoinsTip());
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
-    if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
+    if(!(chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true) >> result)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
+        result.update(util::Error{});
         return state;
     }
 
@@ -4698,6 +4720,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
         return VerifyDBResult::SUCCESS;
@@ -4811,7 +4834,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
-            if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
+            if (!(chainstate.ConnectBlock(block, state, pindex, coins) >> result)) {
                 LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -305,11 +305,12 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     return true;
 }
 
-void Chainstate::MaybeUpdateMempoolForReorg(
+FlushResult<> Chainstate::MaybeUpdateMempoolForReorg(
     DisconnectedBlockTransactions& disconnectpool,
     bool fAddToMempool)
 {
-    if (!m_mempool) return;
+    FlushResult<> result;
+    if (!m_mempool) return result;
 
     AssertLockHeld(cs_main);
     AssertLockHeld(m_mempool->cs);
@@ -324,10 +325,14 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         auto it = queuedTx.rbegin();
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
-            if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
-                    /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
-                        MempoolAcceptResult::ResultType::VALID) {
+            bool remove{!fAddToMempool || (*it)->IsCoinBase()};
+            if (!remove) {
+                auto [mempool_result, flush_result] = AcceptToMemoryPool(*this, *it, GetTime(),
+                    /*bypass_limits=*/true, /*test_accept=*/false);
+                flush_result >> result;
+                remove = mempool_result.m_result_type != MempoolAcceptResult::ResultType::VALID;
+            }
+            if (remove) {
                 // If the transaction doesn't make it in to the mempool, remove any
                 // transactions that depend on it (which would now be orphans).
                 m_mempool->removeRecursive(**it, MemPoolRemovalReason::REORG);
@@ -399,6 +404,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
     m_mempool->removeForReorg(m_chain, filter_final_and_mature);
     // Re-limit mempool size, in case we added any transactions
     LimitMempoolSize(*m_mempool, this->CoinsTip());
+    return result;
 }
 
 /**
@@ -1784,7 +1790,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
 } // anon namespace
 
-MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
 {
     AssertLockHeld(::cs_main);
@@ -1813,10 +1819,10 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
     auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
-    return result;
+    return {std::move(result), std::move(flush_result)};
 }
 
-PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
+std::tuple<PackageMempoolAcceptResult, FlushResult<void, AbortFailure>> ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
                                                    const Package& package, bool test_accept, const std::optional<CFeeRate>& client_maxfeerate)
 {
     AssertLockHeld(cs_main);
@@ -1845,7 +1851,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
     auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
-    return result;
+    return {std::move(result), std::move(flush_result)};
 }
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
@@ -3240,6 +3246,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
 
@@ -3250,7 +3257,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
         if (!DisconnectTip(state, &disconnectpool)) {
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
-            MaybeUpdateMempoolForReorg(disconnectpool, false);
+            // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
+            MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
 
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
@@ -3294,7 +3302,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
                     // A system error occurred (disk space, database error, ...).
                     // Make the mempool consistent with the current tip, just in case
                     // any observers try to use it before shutdown.
-                    MaybeUpdateMempoolForReorg(disconnectpool, false);
+                    MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
                     return false;
                 }
             } else {
@@ -3311,7 +3319,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     if (fBlocksDisconnected) {
         // If any blocks were disconnected, disconnectpool may be non empty.  Add
         // any disconnected transactions back to the mempool.
-        MaybeUpdateMempoolForReorg(disconnectpool, true);
+        // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
+        MaybeUpdateMempoolForReorg(disconnectpool, true) >> result;
     }
     if (m_mempool) m_mempool->check(this->CoinsTip(), this->m_chain.Height() + 1);
 
@@ -3573,6 +3582,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     // Genesis block can't be invalidated
     assert(pindex);
@@ -3637,7 +3647,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // transactions back to the mempool if disconnecting was successful,
         // and we're not doing a very deep invalidation (in which case
         // keeping the mempool up to date is probably futile anyway).
-        MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret);
+        // Propagate flush messages to result, but do not treat flush failure as a block invalidation failure.
+        MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret) >> result;
         if (!ret) return false;
         CBlockIndex* new_tip{m_chain.Tip()};
         assert(disconnected_tip->pprev == new_tip);
@@ -4508,14 +4519,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     return true;
 }
 
-MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
 {
     AssertLockHeld(cs_main);
     Chainstate& active_chainstate = ActiveChainstate();
     if (!active_chainstate.GetMempool()) {
         TxValidationState state;
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
-        return MempoolAcceptResult::Failure(state);
+        return {MempoolAcceptResult::Failure(state), FlushResult<>{}};
     }
     auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -82,6 +82,7 @@ using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
+using kernel::FlushResult;
 using kernel::Notifications;
 
 using fsbridge::FopenFn;
@@ -2717,6 +2718,7 @@ bool Chainstate::FlushStateToDisk(
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
+    FlushResult<> result; // TODO Return this result!
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2794,8 +2796,10 @@ bool Chainstate::FlushStateToDisk(
                 // First make sure all block and undo data is flushed to disk.
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                if (!(m_blockman.FlushChainstateBlockFile(m_chain.Height()) >> result)) {
+                    auto warning{Untranslated({"Failed to flush block file."})};
+                    LogWarning("%s: %s\n", __func__, warning.original);
+                    result.messages().warnings.push_back(std::move(warning));
                 }
             }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4388,9 +4388,8 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
+bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, FlushResult<void, AbortFailure>& result, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
-    FlushResult<> result; // TODO Return this result!
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4447,6 +4446,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
         LogError("%s: %s\n", __func__, state.ToString());
+        result.update(util::Error{Untranslated(state.ToString())});
         return false;
     }
 
@@ -4475,7 +4475,10 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return FatalError(GetNotifications(), state, strprintf(_("System error while saving block to disk: %s"), e.what()));
+        auto error{strprintf(_("System error while saving block to disk: %s"), e.what())};
+        FatalError(GetNotifications(), state, error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return false;
     }
 
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate
@@ -4500,10 +4503,9 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     return true;
 }
 
-bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
+bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, FlushResult<void, AbortFailure>& result)
 {
     AssertLockNotHeld(cs_main);
-    FlushResult<> result; // TODO Return this result!
 
     {
         CBlockIndex *pindex = nullptr;
@@ -4522,7 +4524,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {
             // Store to disk
-            ret = AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            ret = AcceptBlock(block, state, result, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
         if (!ret) {
             if (m_options.signals) {
@@ -4565,8 +4567,7 @@ std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> ChainstateManag
     return result;
 }
 
-
-BlockValidationState TestBlockValidity(
+FlushResult<void, BlockValidationState> TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
     const bool check_pow,
@@ -4577,13 +4578,14 @@ BlockValidationState TestBlockValidity(
     // 2. To prevent a CheckBlock() race condition for fChecked, see ProcessNewBlock()
     AssertLockHeld(chainstate.m_chainman.GetMutex());
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<void, BlockValidationState> result;
     BlockValidationState state;
     CBlockIndex* tip{Assert(chainstate.m_chain.Tip())};
 
     if (block.hashPrevBlock != *Assert(tip->phashBlock)) {
         state.Invalid({}, "inconclusive-not-best-prevblk");
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
@@ -4591,7 +4593,8 @@ BlockValidationState TestBlockValidity(
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     /**
@@ -4611,12 +4614,14 @@ BlockValidationState TestBlockValidity(
 
     if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman, tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     if (!ContextualCheckBlock(block, state, chainstate.m_chainman, tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // We don't want ConnectBlock to update the actual chainstate, so create
@@ -4631,14 +4636,14 @@ BlockValidationState TestBlockValidity(
     // Set fJustCheck to true in order to update, and not clear, validation caches.
     if(!(chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true) >> result)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        result.update(util::Error{});
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // Ensure no check returned successfully while also setting an invalid state.
     if (!state.IsValid()) NONFATAL_UNREACHABLE();
 
-    return state;
+    return result;
 }
 
 /* This function is called from the RPC code for pruneblockchain */
@@ -5044,11 +5049,11 @@ util::Result<InterruptResult, AbortFailure> ChainstateManager::LoadBlockIndex()
     return result;
 }
 
-bool ChainstateManager::LoadGenesisBlock()
+FlushResult<> ChainstateManager::LoadGenesisBlock()
 {
     LOCK(cs_main);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
     const CBlock& genesis_block{GetParams().GenesisBlock()};
 
     // Check whether we're already initialized by checking for genesis in
@@ -5056,7 +5061,7 @@ bool ChainstateManager::LoadGenesisBlock()
     // set based on the coins db, not the block index db, which is the only
     // thing loaded at this point.
     if (m_blockman.m_block_index.contains(genesis_block.GetHash())) {
-        return true;
+        return result;
     }
 
     try {
@@ -5065,24 +5070,26 @@ bool ChainstateManager::LoadGenesisBlock()
             auto error{Untranslated("writing genesis block to disk failed")};
             LogError("%s: %s\n", __func__, error.original);
             result.update(util::Error{std::move(error)});
-            return false;
+            return result;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
         ReceivedBlockTransactions(genesis_block, pindex, *blockPos);
     } catch (const std::runtime_error& e) {
-        LogError("Failed to write genesis block: %s", e.what());
-        return false;
+        auto error{Untranslated(strprintf("failed to write genesis block: %s", e.what()))};
+        LogError("%s: %s\n", __func__, error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
-    return true;
+    return result;
 }
 
-void ChainstateManager::LoadExternalBlockFile(
+FlushResult<InterruptResult, AbortFailure> ChainstateManager::LoadExternalBlockFile(
     AutoFile& file_in,
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
 {
-    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
+    FlushResult<InterruptResult, AbortFailure> result;
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
@@ -5096,7 +5103,10 @@ void ChainstateManager::LoadExternalBlockFile(
         // such as a block fails to deserialize.
         uint64_t nRewind = blkdat.GetPos();
         while (!blkdat.eof()) {
-            if (m_interrupt) return;
+            if (m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
 
             blkdat.SetPos(nRewind);
             nRewind++; // start one byte further next time, in case of failure
@@ -5157,10 +5167,19 @@ void ChainstateManager::LoadExternalBlockFile(
                         blkdat >> TX_WITH_WITNESS(*pblock);
                         nRewind = blkdat.GetPos();
 
+                        FlushResult<void, AbortFailure> accept_result;
                         BlockValidationState state;
-                        if (AcceptBlock(pblock, state, nullptr, true, dbp, nullptr, true)) {
+                        if (AcceptBlock(pblock, state, accept_result, nullptr, true, dbp, nullptr, true)) {
                             nLoaded++;
                         }
+                        // Propagate flush messages but not flush success/failure (AcceptBlock
+                        // intentionally succeeds even when its internal flush fails). Note:
+                        // AcceptBlock may set `state` to an error as a flush side effect even
+                        // when it returns true, so state.IsError() below can trigger from flush
+                        // failures as well as block validation failures — preserving pre-existing
+                        // behavior. See AcceptBlock comment and:
+                        // https://github.com/bitcoin/bitcoin/pull/35570#issuecomment-4758227624
+                        accept_result >> result;
                         if (state.IsError()) {
                             break;
                         }
@@ -5216,11 +5235,14 @@ void ChainstateManager::LoadExternalBlockFile(
                             const auto& block_hash{pblockrecursive->GetHash()};
                             LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
                             LOCK(cs_main);
+                            FlushResult<void, AbortFailure> accept_result;
                             BlockValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
+                            if (AcceptBlock(pblockrecursive, dummy, accept_result, nullptr, true, &it->second, nullptr, true)) {
                                 nLoaded++;
                                 queue.push_back(block_hash);
                             }
+                            // Propagate flush messages but not flush success/failure (see AcceptBlock comment).
+                            accept_result >> result;
                         }
                         range.first++;
                         blocks_with_unknown_parent->erase(it);
@@ -5243,9 +5265,12 @@ void ChainstateManager::LoadExternalBlockFile(
             }
         }
     } catch (const std::runtime_error& e) {
-        GetNotifications().fatalError(strprintf(_("System error while loading external block file: %s"), e.what()));
+        auto error{strprintf(_("System error while loading external block file: %s"), e.what())};
+        GetNotifications().fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
     }
     LogInfo("Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    return result;
 }
 
 bool ChainstateManager::ShouldCheckBlockIndex() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -78,6 +78,7 @@
 #include <tuple>
 #include <utility>
 
+using kernel::AbortFailure;
 using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
@@ -2310,6 +2311,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 {
     AssertLockHeld(cs_main);
     assert(pindex);
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
 
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
@@ -2646,7 +2648,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
+    if (!(m_blockman.WriteBlockUndo(blockundo, state, *pindex) >> result)) {
+        result.update(util::Error{});
         return false;
     }
 
@@ -4317,6 +4320,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
+    FlushResult<> result; // TODO Return this result!
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4390,11 +4394,14 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             blockPos = *dbp;
             m_blockman.UpdateBlockInfo(block, pindex->nHeight, blockPos);
         } else {
-            blockPos = m_blockman.WriteBlock(block, pindex->nHeight);
-            if (blockPos.IsNull()) {
-                state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
+            auto pos{m_blockman.WriteBlock(block, pindex->nHeight) >> result};
+            if (!pos || pos->IsNull()) {
+                auto error{Untranslated("Failed to find position to write new block to disk")};
+                state.Error(strprintf("%s: %s", __func__, error.original));
+                result.update(util::Error{std::move(error)});
                 return false;
             }
+            blockPos = *pos;
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
@@ -4958,6 +4965,7 @@ bool ChainstateManager::LoadGenesisBlock()
 {
     LOCK(cs_main);
 
+    FlushResult<> result; // TODO Return this result!
     const CBlock& genesis_block{GetParams().GenesisBlock()};
 
     // Check whether we're already initialized by checking for genesis in
@@ -4969,13 +4977,15 @@ bool ChainstateManager::LoadGenesisBlock()
     }
 
     try {
-        FlatFilePos blockPos{m_blockman.WriteBlock(genesis_block, 0)};
-        if (blockPos.IsNull()) {
-            LogError("Writing genesis block to disk failed");
+        auto blockPos{m_blockman.WriteBlock(genesis_block, 0) >> result};
+        if (!blockPos || blockPos->IsNull()) {
+            auto error{Untranslated("writing genesis block to disk failed")};
+            LogError("%s: %s\n", __func__, error.original);
+            result.update(util::Error{std::move(error)});
             return false;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
-        ReceivedBlockTransactions(genesis_block, pindex, blockPos);
+        ReceivedBlockTransactions(genesis_block, pindex, *blockPos);
     } catch (const std::runtime_error& e) {
         LogError("Failed to write genesis block: %s", e.what());
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1812,7 +1812,7 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
     return result;
 }
 
@@ -1844,7 +1844,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     }
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
     return result;
 }
 
@@ -2717,14 +2717,14 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
-bool Chainstate::FlushStateToDisk(
+FlushResult<void, AbortFailure> Chainstate::FlushStateToDisk(
     BlockValidationState &state,
     FlushStateMode mode,
     int nManualPruneHeight)
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2794,7 +2794,10 @@ bool Chainstate::FlushStateToDisk(
 
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                auto error{_("Disk space is too low!")};
+                FatalError(m_chainman.GetNotifications(), state, error);
+                result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+                return result;
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2829,7 +2832,10 @@ bool Chainstate::FlushStateToDisk(
                 // an overestimation, as most will delete an existing entry or
                 // overwrite one. Still, use a conservative safety factor of 2.
                 if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetDirtyCount())) {
-                    return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                    auto error{_("Disk space is too low!")};
+                    FatalError(m_chainman.GetNotifications(), state, error);
+                    result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+                    return result;
                 }
                 // Flush the chainstate (which may refer to block index entries).
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
@@ -2863,26 +2869,37 @@ bool Chainstate::FlushStateToDisk(
         }
     }
     } catch (const std::runtime_error& e) {
-        return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));
+        auto error{strprintf(_("System error while flushing: %s"), e.what())};
+        FatalError(m_chainman.GetNotifications(), state, error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return result;
     }
-    return true;
+    return result;
 }
 
-void Chainstate::ForceFlushStateToDisk(bool wipe_cache)
+FlushResult<> Chainstate::ForceFlushStateToDisk(bool wipe_cache)
 {
+    FlushResult<> result;
     BlockValidationState state;
-    if (!this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC)) {
-        LogWarning("Failed to force flush state (%s)", state.ToString());
+    if (!(this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC) >> result)) {
+        auto error{Untranslated(strprintf("Failed to force flush state (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
-void Chainstate::PruneAndFlush()
+FlushResult<> Chainstate::PruneAndFlush()
 {
+    FlushResult<> result;
     BlockValidationState state;
     m_blockman.m_check_for_pruning = true;
-    if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
-        LogWarning("Failed to flush state (%s)", state.ToString());
+    if (!(this->FlushStateToDisk(state, FlushStateMode::NONE) >> result)) {
+        auto error{Untranslated(strprintf("Failed to flush state (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
 static void UpdateTipLog(
@@ -2961,6 +2978,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    FlushResult<> result; // TODO Return this result!
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2997,7 +3015,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     }
 
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
+        result.update(util::Error{});
         return false;
     }
 
@@ -3043,6 +3062,7 @@ bool Chainstate::ConnectTip(
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
     assert(pindexNew->pprev == m_chain.Tip());
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
     // Read block from disk.
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
@@ -3090,7 +3110,8 @@ bool Chainstate::ConnectTip(
              Ticks<SecondsDouble>(m_chainman.time_flush),
              Ticks<MillisecondsDouble>(m_chainman.time_flush) / m_chainman.num_blocks_total);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
+        result.update(util::Error{});
         return false;
     }
     const auto time_5{SteadyClock::now()};
@@ -3362,6 +3383,8 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // we use m_chainstate_mutex to enforce mutual exclusion so that only one caller may execute this function at a time
     LOCK(m_chainstate_mutex);
 
+    FlushResult<> result; // TODO Return this result!
+
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
@@ -3476,11 +3499,13 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
             if (exited_ibd) {
                 // If a background chainstate is in use, we may need to rebalance our
                 // allocation of caches once a chainstate exits initial block download.
-                m_chainman.MaybeRebalanceCaches();
+                // Propagate flush messages to result, but do not treat a cache rebalance failure as a chain activation failure.
+                m_chainman.MaybeRebalanceCaches() >> result;
             }
 
             // Write changes periodically to disk, after relay.
-            if (!FlushStateToDisk(state, FlushStateMode::PERIODIC)) {
+            if (!(FlushStateToDisk(state, FlushStateMode::PERIODIC) >> result)) {
+                result.update(util::Error{});
                 return false;
             }
 
@@ -4419,13 +4444,14 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     // chainstate (particularly if we haven't implemented pruning with
     // background validation yet).
     //
+    // Ignore failure value, do not treat flush error as failure.
     // Flush errors (e.g. low disk space during pruning) are ignored, so that
     // callers can't mistreat a flush failure as a block validation failure.
     // The fatal error notification inside FlushStateToDisk still fires,
     // so the node will shut down on unrecoverable flush errors regardless.
     // For state a dummy value is used, and the return value is ignored.
     BlockValidationState flush_state_ignore;
-    (void)ActiveChainstate().FlushStateToDisk(flush_state_ignore, FlushStateMode::NONE);
+    ActiveChainstate().FlushStateToDisk(flush_state_ignore, FlushStateMode::NONE) >> result;
 
     CheckBlockIndex();
 
@@ -4571,13 +4597,17 @@ BlockValidationState TestBlockValidity(
 }
 
 /* This function is called from the RPC code for pruneblockchain */
-void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
+FlushResult<void, AbortFailure> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
     BlockValidationState state;
-    if (!active_chainstate.FlushStateToDisk(
-            state, FlushStateMode::NONE, nManualPruneHeight)) {
-        LogWarning("Failed to flush state after manual prune (%s)", state.ToString());
+    FlushResult<void, AbortFailure> result{active_chainstate.FlushStateToDisk(
+            state, FlushStateMode::NONE, nManualPruneHeight)};
+    if (!result) {
+        auto error{Untranslated(strprintf("Failed to flush state after manual prune (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
 bool Chainstate::LoadChainTip()
@@ -5503,13 +5533,13 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+FlushResult<void, AbortFailure> Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
 {
     AssertLockHeld(::cs_main);
     if (coinstip_size == m_coinstip_cache_size_bytes &&
             coinsdb_size == m_coinsdb_cache_size_bytes) {
         // Cache sizes are unchanged, no need to continue.
-        return true;
+        return {};
     }
     size_t old_coinstip_size = m_coinstip_cache_size_bytes;
     m_coinstip_cache_size_bytes = coinstip_size;
@@ -5522,16 +5552,14 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
         this->ToString(), coinstip_size / double(1_MiB));
 
     BlockValidationState state;
-    bool ret;
 
     if (coinstip_size > old_coinstip_size) {
         // Likely no need to flush if cache sizes have grown.
-        ret = FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
+        return FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
     } else {
         // Otherwise, flush state to disk and deallocate the in-memory coins map.
-        ret = FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH);
+        return FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH);
     }
-    return ret;
 }
 
 double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) const
@@ -5632,12 +5660,12 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return destroyed && !fs::exists(db_path);
 }
 
-util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
+FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
-    util::Result<CBlockIndex*> result;
+    FlushResult<CBlockIndex*> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5710,9 +5738,10 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
         // Temporarily resize the active coins cache to make room for the newly-created
         // snapshot chain.
+        // Propagate flush messages to result, but do not treat a cache resize failure as a snapshot activation failure.
         this->ActiveChainstate().ResizeCoinsCaches(
             static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC),
-            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC));
+            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC)) >> result;
     }
 
     auto snapshot_chainstate = WITH_LOCK(::cs_main,
@@ -5730,7 +5759,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     auto cleanup_bad_snapshot = [&](bilingual_str reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         result.update(util::Error{std::move(reason)});
-        this->MaybeRebalanceCaches();
+        // Propagate flush messages to result, but do not treat a cache rebalance failure as a snapshot activation failure.
+        this->MaybeRebalanceCaches() >> result;
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
         // has been created, so only attempt removal if we got that far.
@@ -5781,7 +5811,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     LogInfo("[snapshot] (%.2f MB)",
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
-    this->MaybeRebalanceCaches();
+    // Propagate flush messages to result, but do not treat a cache rebalance failure as a snapshot activation failure.
+    this->MaybeRebalanceCaches() >> result;
     result.update(snapshot_start_block);
     return result;
 }
@@ -6025,6 +6056,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 // reaches its target block and is no longer changing.
 SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs)
 {
+    FlushResult<> result; // TODO Return this result!
     AssertLockHeld(cs_main);
 
     // If the snapshot does not need to be validated...
@@ -6077,7 +6109,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
     };
 
     CCoinsViewDB& validated_coins_db = validated_cs.CoinsDB();
-    validated_cs.ForceFlushStateToDisk();
+    // Ignore failure value, do not treat flush error as failure.
+    validated_cs.ForceFlushStateToDisk() >> result;
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
     if (!maybe_au_data) {
@@ -6130,7 +6163,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
     validated_cs.m_target_utxohash = AssumeutxoHash{validated_cs_stats->hashSerialized};
-    this->MaybeRebalanceCaches();
+    // Ignore failure value, do not treat flush error as failure.
+    this->MaybeRebalanceCaches() >> result;
 
     return SnapshotCompletionResult::SUCCESS;
 }
@@ -6141,36 +6175,44 @@ Chainstate& ChainstateManager::ActiveChainstate() const
     return CurrentChainstate();
 }
 
-void ChainstateManager::MaybeRebalanceCaches()
+FlushResult<> ChainstateManager::MaybeRebalanceCaches()
 {
     AssertLockHeld(::cs_main);
+    FlushResult<> result;
+    auto resize_caches = [&](Chainstate& chainstate, const auto&... args) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        if (!(chainstate.ResizeCoinsCaches(args...) >> result)) {
+            result.update(util::Error{});
+        }
+    };
+
     Chainstate& current_cs{CurrentChainstate()};
     Chainstate* historical_cs{HistoricalChainstate()};
     if (!historical_cs && !current_cs.m_from_snapshot_blockhash) {
         // Allocate everything to the IBD chainstate. This will always happen
         // when we are not using a snapshot.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        resize_caches(current_cs, m_total_coinstip_cache, m_total_coinsdb_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
         LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        resize_caches(current_cs, m_total_coinstip_cache, m_total_coinsdb_cache);
     } else {
         // If both chainstates exist, determine who needs more cache based on IBD status.
         //
         // Note: shrink caches first so that we don't inadvertently overwhelm available memory.
         if (IsInitialBlockDownload()) {
-            historical_cs->ResizeCoinsCaches(
+            resize_caches(*historical_cs,
                 m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            current_cs.ResizeCoinsCaches(
+            resize_caches(current_cs,
                 m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
         } else {
-            current_cs.ResizeCoinsCaches(
+            resize_caches(current_cs,
                 m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            historical_cs->ResizeCoinsCaches(
+            resize_caches(*historical_cs,
                 m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
         }
     }
+    return result;
 }
 
 void ChainstateManager::ResetChainstates()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4718,17 +4718,17 @@ CVerifyDB::~CVerifyDB()
     m_notifications.progress(bilingual_str{}, 100, false);
 }
 
-VerifyDBResult CVerifyDB::VerifyDB(
+FlushResult<VerifyDBResult> CVerifyDB::VerifyDB(
     Chainstate& chainstate,
     const Consensus::Params& consensus_params,
     CCoinsView& coinsview,
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<VerifyDBResult> result;
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
-        return VerifyDBResult::SUCCESS;
+        return result;
     }
 
     // Verify blocks in the best chain
@@ -4770,22 +4770,28 @@ VerifyDBResult CVerifyDB::VerifyDB(
         CBlock block;
         // check level 0: read from disk
         if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-            LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-            return VerifyDBResult::CORRUPTED_BLOCK_DB;
+            auto error{Untranslated(strprintf("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+            LogError("%s", error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params)) {
-            LogError("Verification error: found bad block at %d, hash=%s (%s)",
-                      pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
-            return VerifyDBResult::CORRUPTED_BLOCK_DB;
+            auto error{Untranslated(strprintf("Verification error: found bad block at %d, hash=%s (%s)",
+                      pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString()))};
+            LogError("%s", error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         // check level 2: verify undo validity
         if (nCheckLevel >= 2 && pindex) {
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
                 if (!chainstate.m_blockman.ReadBlockUndo(undo, *pindex)) {
-                    LogError("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                    return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                    auto error{Untranslated(strprintf("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                    LogError("%s", error.original);
+                    result.update(util::Error{std::move(error)});
+                    return result;
                 }
             }
         }
@@ -4797,8 +4803,10 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                    return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                    auto error{Untranslated(strprintf("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                    LogError("%s", error.original);
+                    result.update(util::Error{std::move(error)});
+                    return result;
                 }
                 if (res == DISCONNECT_UNCLEAN) {
                     nGoodTransactions = 0;
@@ -4810,11 +4818,16 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 skipped_l3_checks = true;
             }
         }
-        if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
+        if (chainstate.m_chainman.m_interrupt) {
+            result.update(Interrupted{});
+            return result;
+        }
     }
     if (pindexFailure) {
-        LogError("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
-        return VerifyDBResult::CORRUPTED_BLOCK_DB;
+        auto error{Untranslated(strprintf("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions))};
+        LogError("%s", error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
     if (skipped_l3_checks) {
         LogWarning("Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
@@ -4836,14 +4849,21 @@ VerifyDBResult CVerifyDB::VerifyDB(
             pindex = chainstate.m_chain.Next(*pindex);
             CBlock block;
             if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-                LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-                return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                auto error{Untranslated(strprintf("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString()))};
+                LogError("%s", error.original);
+                result.update(util::Error{std::move(error)});
+                return result;
             }
             if (!(chainstate.ConnectBlock(block, state, pindex, coins) >> result)) {
-                LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
-                return VerifyDBResult::CORRUPTED_BLOCK_DB;
+                auto error{Untranslated(strprintf("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString()))};
+                LogError("%s", error.original);
+                result.update(util::Error{std::move(error)});
+                return result;
             }
-            if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
+            if (chainstate.m_chainman.m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
         }
     }
 
@@ -4853,12 +4873,11 @@ VerifyDBResult CVerifyDB::VerifyDB(
     }
 
     if (skipped_l3_checks) {
-        return VerifyDBResult::SKIPPED_L3_CHECKS;
+        result.update(SkippedL3Checks{});
+    } else if (skipped_no_block_data) {
+        result.update(SkippedMissingBlocks{});
     }
-    if (skipped_no_block_data) {
-        return VerifyDBResult::SKIPPED_MISSING_BLOCKS;
-    }
-    return VerifyDBResult::SUCCESS;
+    return result;
 }
 
 /** Apply the effects of a block on the utxo cache, ignoring that it may already have been applied. */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5622,6 +5622,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
+    util::Result<CBlockIndex*> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5630,25 +5631,30 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         LOCK(::cs_main);
 
         if (this->CurrentChainstate().m_from_snapshot_blockhash) {
-            return util::Error{Untranslated("Can't activate a snapshot-based chainstate more than once")};
+            result.update(util::Error{Untranslated("Can't activate a snapshot-based chainstate more than once")});
+            return result;
         }
+
         if (!GetParams().AssumeutxoForBlockhash(base_blockhash).has_value()) {
             auto available_heights = GetParams().GetAvailableSnapshotHeights();
             std::string heights_formatted = util::Join(available_heights, ", ", [&](const auto& i) { return util::ToString(i); });
-            return util::Error{Untranslated(strprintf("assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s",
+            result.update(util::Error{Untranslated(strprintf("assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s",
                 base_blockhash.ToString(),
-                heights_formatted))};
+                heights_formatted))});
+            return result;
         }
 
         snapshot_start_block = m_blockman.LookupBlockIndex(base_blockhash);
         if (!snapshot_start_block) {
-            return util::Error{Untranslated(strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again",
-                          base_blockhash.ToString()))};
+            result.update(util::Error{Untranslated(strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again",
+                          base_blockhash.ToString()))});
+            return result;
         }
 
         bool start_block_invalid = snapshot_start_block->nStatus & BLOCK_FAILED_VALID;
         if (start_block_invalid) {
-            return util::Error{Untranslated(strprintf("The base block header (%s) is part of an invalid chain", base_blockhash.ToString()))};
+            result.update(util::Error{Untranslated(strprintf("The base block header (%s) is part of an invalid chain", base_blockhash.ToString()))});
+            return result;
         }
 
         if (!m_best_header || m_best_header->GetAncestor(snapshot_start_block->nHeight) != snapshot_start_block) {
@@ -5657,7 +5663,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
         auto mempool{CurrentChainstate().GetMempool()};
         if (mempool && mempool->size() > 0) {
-            return util::Error{Untranslated("Can't activate a snapshot when mempool not empty")};
+            result.update(util::Error{Untranslated("Can't activate a snapshot when mempool not empty")});
+            return result;
         }
     }
 
@@ -5707,6 +5714,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     }
 
     auto cleanup_bad_snapshot = [&](bilingual_str reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        result.update(util::Error{std::move(reason)});
         this->MaybeRebalanceCaches();
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
@@ -5722,12 +5730,13 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
                     "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
             }
         }
-        return util::Error{std::move(reason)};
     };
 
     if (auto res{this->PopulateAndValidateSnapshot(*snapshot_chainstate, coins_file, metadata)}; !res) {
         LOCK(::cs_main);
-        return cleanup_bad_snapshot(Untranslated(strprintf("Population failed: %s", util::ErrorString(res).original)));
+        cleanup_bad_snapshot(Untranslated("Population failed:"));
+        res >> result;
+        return result;
     }
 
     LOCK(::cs_main);  // cs_main required for rest of snapshot activation.
@@ -5736,13 +5745,15 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     // work chain than the active chainstate; a user could have loaded a snapshot
     // very late in the IBD process, and we wouldn't want to load a useless chainstate.
     if (!CBlockIndexWorkComparator()(ActiveTip(), snapshot_chainstate->m_chain.Tip())) {
-        return cleanup_bad_snapshot(Untranslated("work does not exceed active chainstate"));
+        cleanup_bad_snapshot(Untranslated("work does not exceed active chainstate"));
+        return result;
     }
     // If not in-memory, persist the base blockhash for use during subsequent
     // initialization.
     if (!in_memory) {
         if (!node::WriteSnapshotBaseBlockhash(*snapshot_chainstate)) {
-            return cleanup_bad_snapshot(Untranslated("could not write base blockhash"));
+            cleanup_bad_snapshot(Untranslated("could not write base blockhash"));
+            return result;
         }
     }
 
@@ -5756,7 +5767,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
     this->MaybeRebalanceCaches();
-    return snapshot_start_block;
+    result.update(snapshot_start_block);
+    return result;
 }
 
 static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_loaded)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4380,9 +4380,8 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
+bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, FlushResult<void, AbortFailure>& result, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
-    FlushResult<> result; // TODO Return this result!
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4439,6 +4438,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
         LogError("%s: %s\n", __func__, state.ToString());
+        result.update(util::Error{Untranslated(state.ToString())});
         return false;
     }
 
@@ -4467,7 +4467,10 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return FatalError(GetNotifications(), state, strprintf(_("System error while saving block to disk: %s"), e.what()));
+        auto error{strprintf(_("System error while saving block to disk: %s"), e.what())};
+        FatalError(GetNotifications(), state, error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return false;
     }
 
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate
@@ -4492,10 +4495,9 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     return true;
 }
 
-bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
+bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, FlushResult<void, AbortFailure>& result)
 {
     AssertLockNotHeld(cs_main);
-    FlushResult<> result; // TODO Return this result!
 
     {
         CBlockIndex *pindex = nullptr;
@@ -4514,7 +4516,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {
             // Store to disk
-            ret = AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            ret = AcceptBlock(block, state, result, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
         if (!ret) {
             if (m_options.signals) {
@@ -4557,8 +4559,7 @@ std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> ChainstateManag
     return result;
 }
 
-
-BlockValidationState TestBlockValidity(
+FlushResult<void, BlockValidationState> TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
     const bool check_pow,
@@ -4569,13 +4570,14 @@ BlockValidationState TestBlockValidity(
     // 2. To prevent a CheckBlock() race condition for fChecked, see ProcessNewBlock()
     AssertLockHeld(chainstate.m_chainman.GetMutex());
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<void, BlockValidationState> result;
     BlockValidationState state;
     CBlockIndex* tip{Assert(chainstate.m_chain.Tip())};
 
     if (block.hashPrevBlock != *Assert(tip->phashBlock)) {
         state.Invalid({}, "inconclusive-not-best-prevblk");
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
@@ -4583,7 +4585,8 @@ BlockValidationState TestBlockValidity(
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     /**
@@ -4603,12 +4606,14 @@ BlockValidationState TestBlockValidity(
 
     if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman, tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     if (!ContextualCheckBlock(block, state, chainstate.m_chainman, tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // We don't want ConnectBlock to update the actual chainstate, so create
@@ -4623,14 +4628,14 @@ BlockValidationState TestBlockValidity(
     // Set fJustCheck to true in order to update, and not clear, validation caches.
     if(!(chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true) >> result)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
-        result.update(util::Error{});
-        return state;
+        result.update({util::Error{}, std::move(state)});
+        return result;
     }
 
     // Ensure no check returned successfully while also setting an invalid state.
     if (!state.IsValid()) NONFATAL_UNREACHABLE();
 
-    return state;
+    return result;
 }
 
 /* This function is called from the RPC code for pruneblockchain */
@@ -5036,11 +5041,11 @@ util::Result<InterruptResult, AbortFailure> ChainstateManager::LoadBlockIndex()
     return result;
 }
 
-bool ChainstateManager::LoadGenesisBlock()
+FlushResult<> ChainstateManager::LoadGenesisBlock()
 {
     LOCK(cs_main);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
     const CBlock& genesis_block{GetParams().GenesisBlock()};
 
     // Check whether we're already initialized by checking for genesis in
@@ -5048,7 +5053,7 @@ bool ChainstateManager::LoadGenesisBlock()
     // set based on the coins db, not the block index db, which is the only
     // thing loaded at this point.
     if (m_blockman.m_block_index.contains(genesis_block.GetHash())) {
-        return true;
+        return result;
     }
 
     try {
@@ -5057,24 +5062,26 @@ bool ChainstateManager::LoadGenesisBlock()
             auto error{Untranslated("writing genesis block to disk failed")};
             LogError("%s: %s\n", __func__, error.original);
             result.update(util::Error{std::move(error)});
-            return false;
+            return result;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
         ReceivedBlockTransactions(genesis_block, pindex, *blockPos);
     } catch (const std::runtime_error& e) {
-        LogError("Failed to write genesis block: %s", e.what());
-        return false;
+        auto error{Untranslated(strprintf("failed to write genesis block: %s", e.what()))};
+        LogError("%s: %s\n", __func__, error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
-    return true;
+    return result;
 }
 
-void ChainstateManager::LoadExternalBlockFile(
+FlushResult<InterruptResult, AbortFailure> ChainstateManager::LoadExternalBlockFile(
     AutoFile& file_in,
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
 {
-    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
+    FlushResult<InterruptResult, AbortFailure> result;
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
@@ -5088,7 +5095,10 @@ void ChainstateManager::LoadExternalBlockFile(
         // such as a block fails to deserialize.
         uint64_t nRewind = blkdat.GetPos();
         while (!blkdat.eof()) {
-            if (m_interrupt) return;
+            if (m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
 
             blkdat.SetPos(nRewind);
             nRewind++; // start one byte further next time, in case of failure
@@ -5149,10 +5159,19 @@ void ChainstateManager::LoadExternalBlockFile(
                         blkdat >> TX_WITH_WITNESS(*pblock);
                         nRewind = blkdat.GetPos();
 
+                        FlushResult<void, AbortFailure> accept_result;
                         BlockValidationState state;
-                        if (AcceptBlock(pblock, state, nullptr, true, dbp, nullptr, true)) {
+                        if (AcceptBlock(pblock, state, accept_result, nullptr, true, dbp, nullptr, true)) {
                             nLoaded++;
                         }
+                        // Propagate flush messages but not flush success/failure (AcceptBlock
+                        // intentionally succeeds even when its internal flush fails). Note:
+                        // AcceptBlock may set `state` to an error as a flush side effect even
+                        // when it returns true, so state.IsError() below can trigger from flush
+                        // failures as well as block validation failures — preserving pre-existing
+                        // behavior. See AcceptBlock comment and:
+                        // https://github.com/bitcoin/bitcoin/pull/35570#issuecomment-4758227624
+                        accept_result >> result;
                         if (state.IsError()) {
                             break;
                         }
@@ -5208,11 +5227,14 @@ void ChainstateManager::LoadExternalBlockFile(
                             const auto& block_hash{pblockrecursive->GetHash()};
                             LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
                             LOCK(cs_main);
+                            FlushResult<void, AbortFailure> accept_result;
                             BlockValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
+                            if (AcceptBlock(pblockrecursive, dummy, accept_result, nullptr, true, &it->second, nullptr, true)) {
                                 nLoaded++;
                                 queue.push_back(block_hash);
                             }
+                            // Propagate flush messages but not flush success/failure (see AcceptBlock comment).
+                            accept_result >> result;
                         }
                         range.first++;
                         blocks_with_unknown_parent->erase(it);
@@ -5235,9 +5257,12 @@ void ChainstateManager::LoadExternalBlockFile(
             }
         }
     } catch (const std::runtime_error& e) {
-        GetNotifications().fatalError(strprintf(_("System error while loading external block file: %s"), e.what()));
+        auto error{strprintf(_("System error while loading external block file: %s"), e.what())};
+        GetNotifications().fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
     }
     LogInfo("Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    return result;
 }
 
 bool ChainstateManager::ShouldCheckBlockIndex() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2302,12 +2302,12 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+FlushResult<void, AbortFailure> Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                                CCoinsViewCache& view, bool fJustCheck)
 {
     AssertLockHeld(cs_main);
     assert(pindex);
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
 
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
@@ -2333,10 +2333,15 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
             // problems.
-            return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
+            auto error{_("Corrupt block found indicating potential hardware failure; shutting down")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
-        return false;
+        auto error{Untranslated(strprintf("Consensus::CheckBlock: %s", state.ToString()))};
+        LogError("%s: %s\n", __func__, error.original);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
     // verify that the view's current state corresponds to the previous block
@@ -2350,7 +2355,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (block_hash == params.GetConsensus().hashGenesisBlock) {
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
-        return true;
+        return result;
     }
 
     const char* script_check_reason;
@@ -2630,7 +2635,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     }
     if (!state.IsValid()) {
         LogInfo("Block validation error: %s", state.ToString());
-        return false;
+        result.update(util::Error{Untranslated(state.ToString())});
+        return result;
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_verify += time_4 - time_2;
@@ -2641,12 +2647,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<MillisecondsDouble>(m_chainman.time_verify) / m_chainman.num_blocks_total);
 
     if (fJustCheck) {
-        return true;
+        return result;
     }
 
     if (!(m_blockman.WriteBlockUndo(blockundo, state, *pindex) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
 
     const auto time_5{SteadyClock::now()};
@@ -2680,7 +2686,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         Ticks<std::chrono::nanoseconds>(time_5 - time_start)
     );
 
-    return true;
+    return result;
 }
 
 CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState()
@@ -2966,12 +2972,12 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
   * disconnectpool (note that the caller is responsible for mempool consistency
   * in any case).
   */
-bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
+FlushResult<> Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2980,7 +2986,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlock(block, *pindexDelete)) {
         LogError("DisconnectTip(): Failed to read block\n");
-        return false;
+        result.update(util::Error{});
+        return result;
     }
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
@@ -2989,7 +2996,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
-            return false;
+            result.update(util::Error{});
+            return result;
         }
         view.Flush(/*reallocate_cache=*/false); // local CCoinsViewCache goes out of scope
     }
@@ -3010,7 +3018,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Write the chain state to disk, if necessary.
     if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
 
     if (disconnectpool && m_mempool) {
@@ -3030,7 +3038,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     if (m_chainman.m_options.signals) {
         m_chainman.m_options.signals->BlockDisconnected(std::move(pblock), pindexDelete);
     }
-    return true;
+    return result;
 }
 
 struct ConnectedBlock {
@@ -3044,7 +3052,7 @@ struct ConnectedBlock {
  *
  * The block is added to connected_blocks if connection succeeds.
  */
-bool Chainstate::ConnectTip(
+FlushResult<void, AbortFailure> Chainstate::ConnectTip(
     BlockValidationState& state,
     CBlockIndex* pindexNew,
     std::shared_ptr<const CBlock> block_to_connect,
@@ -3055,13 +3063,16 @@ bool Chainstate::ConnectTip(
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
     assert(pindexNew->pprev == m_chain.Tip());
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     // Read block from disk.
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
         if (!m_blockman.ReadBlock(*pblockNew, *pindexNew)) {
-            return FatalError(m_chainman.GetNotifications(), state, _("Failed to read block."));
+            auto error{_("Failed to read block")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
         block_to_connect = std::move(pblockNew);
     } else {
@@ -3077,15 +3088,17 @@ bool Chainstate::ConnectTip(
     {
         CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
         const auto reset_guard{view.StartFetching(*block_to_connect)};
-        bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
+        bool rv = bool{ConnectBlock(*block_to_connect, state, pindexNew, view) >> result};
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);
         }
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
-            return false;
+            auto error{Untranslated(strprintf("ConnectBlock %s failed, %s", pindexNew->GetBlockHash().ToString(), state.ToString()))};
+            LogError("%s: %s\n", __func__, error.original);
+            result.update(util::Error{std::move(error)});
+            return result;
         }
         time_3 = SteadyClock::now();
         m_chainman.time_connect_total += time_3 - time_2;
@@ -3105,7 +3118,7 @@ bool Chainstate::ConnectTip(
     // Write the chain state to disk, if necessary.
     if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
         result.update(util::Error{});
-        return false;
+        return result;
     }
     const auto time_5{SteadyClock::now()};
     m_chainman.time_chainstate += time_5 - time_4;
@@ -3157,7 +3170,7 @@ bool Chainstate::ConnectTip(
     snapshot_result >> result;
 
     connected_blocks.emplace_back(pindexNew, std::move(block_to_connect));
-    return true;
+    return result;
 }
 
 /**
@@ -3250,7 +3263,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     bool fBlocksDisconnected = false;
     DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
     while (m_chain.Tip() && m_chain.Tip() != pindexFork) {
-        if (!DisconnectTip(state, &disconnectpool)) {
+        if (!(DisconnectTip(state, &disconnectpool) >> result)) {
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
             // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
@@ -3284,7 +3297,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
         // Connect new blocks.
         for (CBlockIndex* pindexConnect : vpindexToConnect | std::views::reverse) {
-            if (!ConnectTip(state, pindexConnect, pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>(), connected_blocks, disconnectpool)) {
+            if (!(ConnectTip(state, pindexConnect, pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>(), connected_blocks, disconnectpool) >> result)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
@@ -3574,15 +3587,18 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
     return ActivateBestChain(state, std::shared_ptr<const CBlock>());
 }
 
-bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)
+FlushResult<> Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
 
     // Genesis block can't be invalidated
     assert(pindex);
-    if (pindex->nHeight == 0) return false;
+    if (pindex->nHeight == 0) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // We do not allow ActivateBestChain() to run while InvalidateBlock() is
     // running, as that could cause the tip to change while we disconnect
@@ -3637,7 +3653,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // ActivateBestChain considers blocks already in m_chain
         // unconditionally valid already, so force disconnect away from it.
         DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
-        bool ret = DisconnectTip(state, &disconnectpool);
+        bool ret = bool{DisconnectTip(state, &disconnectpool) >> result};
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding
         // transactions back to the mempool if disconnecting was successful,
@@ -3645,7 +3661,10 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // keeping the mempool up to date is probably futile anyway).
         // Propagate flush messages to result, but do not treat flush failure as a block invalidation failure.
         MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret) >> result;
-        if (!ret) return false;
+        if (!ret) {
+            result.update(util::Error{});
+            return result;
+        }
         CBlockIndex* new_tip{m_chain.Tip()};
         assert(disconnected_tip->pprev == new_tip);
 
@@ -3705,7 +3724,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         LOCK(cs_main);
         if (m_chain.Contains(*to_mark_failed)) {
             // If the to-be-marked invalid block is in the active chain, something is interfering and we can't proceed.
-            return false;
+            result.update(util::Error{});
+            return result;
         }
 
         // Mark pindex as invalid if it never was in the main chain
@@ -3751,7 +3771,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
             m_chainman.m_options.signals->ActiveTipChange(*Assert(m_chain.Tip()), m_chainman.IsInitialBlockDownload());
         }
     }
-    return true;
+    return result;
 }
 
 void Chainstate::SetBlockFailureFlags(CBlockIndex* invalid_block)
@@ -4541,6 +4561,7 @@ BlockValidationState TestBlockValidity(
     // 2. To prevent a CheckBlock() race condition for fChecked, see ProcessNewBlock()
     AssertLockHeld(chainstate.m_chainman.GetMutex());
 
+    FlushResult<> result; // TODO Return this result!
     BlockValidationState state;
     CBlockIndex* tip{Assert(chainstate.m_chain.Tip())};
 
@@ -4592,8 +4613,9 @@ BlockValidationState TestBlockValidity(
     CCoinsViewCache view_dummy(&chainstate.CoinsTip());
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
-    if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
+    if(!(chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true) >> result)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
+        result.update(util::Error{});
         return state;
     }
 
@@ -4690,6 +4712,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
         return VerifyDBResult::SUCCESS;
@@ -4803,7 +4826,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
-            if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
+            if (!(chainstate.ConnectBlock(block, state, pindex, coins) >> result)) {
                 LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3150,7 +3150,11 @@ bool Chainstate::ConnectTip(
     // will be true and this->setBlockIndexCandidates will not have additional
     // blocks.
     Chainstate& current_cs{m_chainman.CurrentChainstate()};
-    m_chainman.MaybeValidateSnapshot(*this, current_cs);
+    FlushResult<void, AbortFailure> snapshot_result;
+    // Snapshot validation failure does not prevent connecting the block; only flush
+    // messages from the snapshot validation are propagated to the caller via result.
+    (void)m_chainman.MaybeValidateSnapshot(*this, current_cs, snapshot_result);
+    snapshot_result >> result;
 
     connected_blocks.emplace_back(pindexNew, std::move(block_to_connect));
     return true;
@@ -5663,12 +5667,12 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return destroyed && !fs::exists(db_path);
 }
 
-FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
+FlushResult<CBlockIndex*, AbortFailure> ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
-    FlushResult<CBlockIndex*> result;
+    FlushResult<CBlockIndex*, AbortFailure> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5774,8 +5778,10 @@ FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
             snapshot_chainstate.reset();
             bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
-                GetNotifications().fatalError(strprintf(_("Failed to remove snapshot chainstate dir (%s). "
-                    "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
+                auto error{strprintf(_("Failed to remove snapshot chainstate dir (%s). "
+                    "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir))};
+                GetNotifications().fatalError(error);
+                result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
             }
         }
     };
@@ -6057,9 +6063,8 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 // ActivateBestChain, on a separate thread that should not require cs_main to
 // hash, because the UTXO set is only hashed after the historical chainstate
 // reaches its target block and is no longer changing.
-SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs)
+SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs, FlushResult<void, AbortFailure>& result)
 {
-    FlushResult<> result; // TODO Return this result!
     AssertLockHeld(cs_main);
 
     // If the snapshot does not need to be validated...
@@ -6109,10 +6114,12 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
         }
 
         GetNotifications().fatalError(user_error);
+        result.update({util::Error{std::move(user_error)}, AbortFailure{.fatal = true}});
     };
 
     CCoinsViewDB& validated_coins_db = validated_cs.CoinsDB();
-    // Ignore failure value, do not treat flush error as failure.
+    // Propagate flush messages to result, but do not treat a flush failure as a
+    // snapshot validation failure.
     validated_cs.ForceFlushStateToDisk() >> result;
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
@@ -6166,7 +6173,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
     validated_cs.m_target_utxohash = AssumeutxoHash{validated_cs_stats->hashSerialized};
-    // Ignore failure value, do not treat flush error as failure.
+    // Propagate flush messages to result, but do not treat a flush failure as a
+    // snapshot validation failure.
     this->MaybeRebalanceCaches() >> result;
 
     return SnapshotCompletionResult::SUCCESS;
@@ -6381,12 +6389,14 @@ std::optional<int> ChainstateManager::BlocksAheadOfTip() const
     return std::nullopt;
 }
 
-bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs)
+util::Result<void, AbortFailure> ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs)
 {
     AssertLockHeld(::cs_main);
+    util::Result<void, AbortFailure> result;
     if (unvalidated_cs.m_assumeutxo != Assumeutxo::VALIDATED) {
         // No need to clean up.
-        return false;
+        result.update(util::Error{});
+        return result;
     }
 
     const fs::path validated_path{validated_cs.StoragePath()};
@@ -6405,16 +6415,18 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
     LogInfo("[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
               fs::PathToString(validated_path));
 
-    auto rename_failed_abort = [this](
+    auto rename_failed_abort = [&](
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
         LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
-        GetNotifications().fatalError(strprintf(_(
+        auto error{strprintf(_(
             "Rename of '%s' -> '%s' failed. "
             "Cannot clean up the background chainstate leveldb directory."),
-            fs::PathToString(p_old), fs::PathToString(p_new)));
+            fs::PathToString(p_old), fs::PathToString(p_new))};
+        GetNotifications().fatalError(error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
     };
 
     try {
@@ -6445,7 +6457,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         LogInfo("[snapshot] deleted background chainstate directory (%s)",
                 fs::PathToString(validated_path));
     }
-    return true;
+    return result;
 }
 
 std::pair<int, int> Chainstate::GetPruneRange(int last_height_can_prune) const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -84,6 +84,9 @@ using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
 using kernel::FlushResult;
+using kernel::Interrupted;
+using kernel::InterruptResult;
+using kernel::IsInterrupted;
 using kernel::Notifications;
 
 using fsbridge::FopenFn;
@@ -4927,13 +4930,14 @@ void Chainstate::PopulateBlockIndexCandidates()
     }
 }
 
-bool ChainstateManager::LoadBlockIndex()
+util::Result<InterruptResult, AbortFailure> ChainstateManager::LoadBlockIndex()
 {
     AssertLockHeld(cs_main);
+    util::Result<InterruptResult, AbortFailure> result;
     // Load block index from databases
     if (m_blockman.m_blockfiles_indexed) {
-        bool ret{m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash)};
-        if (!ret) return false;
+        result.update(m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash));
+        if (!result || IsInterrupted(*result)) return result;
 
         m_blockman.ScanAndUnlinkAlreadyPrunedFiles();
 
@@ -4942,7 +4946,10 @@ bool ChainstateManager::LoadBlockIndex()
                   CBlockIndexHeightOnlyComparator());
 
         for (CBlockIndex* pindex : vSortedByHeight) {
-            if (m_interrupt) return false;
+            if (m_interrupt) {
+                result.update(Interrupted{});
+                return result;
+            }
             if (pindex->nStatus & BLOCK_FAILED_VALID && (!m_best_invalid || pindex->nChainWork > m_best_invalid->nChainWork)) {
                 m_best_invalid = pindex;
             }
@@ -4950,7 +4957,7 @@ bool ChainstateManager::LoadBlockIndex()
                 m_best_header = pindex;
         }
     }
-    return true;
+    return result;
 }
 
 bool ChainstateManager::LoadGenesisBlock()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -82,6 +82,7 @@ using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
+using kernel::FlushResult;
 using kernel::Notifications;
 
 using fsbridge::FopenFn;
@@ -2704,6 +2705,7 @@ bool Chainstate::FlushStateToDisk(
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
+    FlushResult<> result; // TODO Return this result!
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2781,8 +2783,10 @@ bool Chainstate::FlushStateToDisk(
                 // First make sure all block and undo data is flushed to disk.
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                if (!(m_blockman.FlushChainstateBlockFile(m_chain.Height()) >> result)) {
+                    auto warning{Untranslated({"Failed to flush block file."})};
+                    LogWarning("%s: %s\n", __func__, warning.original);
+                    result.messages().warnings.push_back(std::move(warning));
                 }
             }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -78,6 +78,7 @@
 #include <tuple>
 #include <utility>
 
+using kernel::AbortFailure;
 using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
@@ -2297,6 +2298,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 {
     AssertLockHeld(cs_main);
     assert(pindex);
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
 
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
@@ -2633,7 +2635,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
+    if (!(m_blockman.WriteBlockUndo(blockundo, state, *pindex) >> result)) {
+        result.update(util::Error{});
         return false;
     }
 
@@ -4309,6 +4312,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
+    FlushResult<> result; // TODO Return this result!
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4382,11 +4386,14 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             blockPos = *dbp;
             m_blockman.UpdateBlockInfo(block, pindex->nHeight, blockPos);
         } else {
-            blockPos = m_blockman.WriteBlock(block, pindex->nHeight);
-            if (blockPos.IsNull()) {
-                state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
+            auto pos{m_blockman.WriteBlock(block, pindex->nHeight) >> result};
+            if (!pos || pos->IsNull()) {
+                auto error{Untranslated("Failed to find position to write new block to disk")};
+                state.Error(strprintf("%s: %s", __func__, error.original));
+                result.update(util::Error{std::move(error)});
                 return false;
             }
+            blockPos = *pos;
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
@@ -4950,6 +4957,7 @@ bool ChainstateManager::LoadGenesisBlock()
 {
     LOCK(cs_main);
 
+    FlushResult<> result; // TODO Return this result!
     const CBlock& genesis_block{GetParams().GenesisBlock()};
 
     // Check whether we're already initialized by checking for genesis in
@@ -4961,13 +4969,15 @@ bool ChainstateManager::LoadGenesisBlock()
     }
 
     try {
-        FlatFilePos blockPos{m_blockman.WriteBlock(genesis_block, 0)};
-        if (blockPos.IsNull()) {
-            LogError("Writing genesis block to disk failed");
+        auto blockPos{m_blockman.WriteBlock(genesis_block, 0) >> result};
+        if (!blockPos || blockPos->IsNull()) {
+            auto error{Untranslated("writing genesis block to disk failed")};
+            LogError("%s: %s\n", __func__, error.original);
+            result.update(util::Error{std::move(error)});
             return false;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
-        ReceivedBlockTransactions(genesis_block, pindex, blockPos);
+        ReceivedBlockTransactions(genesis_block, pindex, *blockPos);
     } catch (const std::runtime_error& e) {
         LogError("Failed to write genesis block: %s", e.what());
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -305,11 +305,12 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     return true;
 }
 
-void Chainstate::MaybeUpdateMempoolForReorg(
+FlushResult<> Chainstate::MaybeUpdateMempoolForReorg(
     DisconnectedBlockTransactions& disconnectpool,
     bool fAddToMempool)
 {
-    if (!m_mempool) return;
+    FlushResult<> result;
+    if (!m_mempool) return result;
 
     AssertLockHeld(cs_main);
     AssertLockHeld(m_mempool->cs);
@@ -324,10 +325,14 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         auto it = queuedTx.rbegin();
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
-            if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
-                    /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
-                        MempoolAcceptResult::ResultType::VALID) {
+            bool remove{!fAddToMempool || (*it)->IsCoinBase()};
+            if (!remove) {
+                auto [mempool_result, flush_result] = AcceptToMemoryPool(*this, *it, GetTime(),
+                    /*bypass_limits=*/true, /*test_accept=*/false);
+                flush_result >> result;
+                remove = mempool_result.m_result_type != MempoolAcceptResult::ResultType::VALID;
+            }
+            if (remove) {
                 // If the transaction doesn't make it in to the mempool, remove any
                 // transactions that depend on it (which would now be orphans).
                 m_mempool->removeRecursive(**it, MemPoolRemovalReason::REORG);
@@ -399,6 +404,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
     m_mempool->removeForReorg(m_chain, filter_final_and_mature);
     // Re-limit mempool size, in case we added any transactions
     LimitMempoolSize(*m_mempool, this->CoinsTip());
+    return result;
 }
 
 /**
@@ -1773,7 +1779,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
 } // anon namespace
 
-MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
 {
     AssertLockHeld(::cs_main);
@@ -1801,10 +1807,10 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
     auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
-    return result;
+    return {std::move(result), std::move(flush_result)};
 }
 
-PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
+std::tuple<PackageMempoolAcceptResult, FlushResult<void, AbortFailure>> ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
                                                    const Package& package, bool test_accept, const std::optional<CFeeRate>& client_maxfeerate)
 {
     AssertLockHeld(cs_main);
@@ -1832,7 +1838,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
     auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
-    return result;
+    return {std::move(result), std::move(flush_result)};
 }
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
@@ -3232,6 +3238,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
 
@@ -3242,7 +3249,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
         if (!DisconnectTip(state, &disconnectpool)) {
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
-            MaybeUpdateMempoolForReorg(disconnectpool, false);
+            // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
+            MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
 
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
@@ -3286,7 +3294,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
                     // A system error occurred (disk space, database error, ...).
                     // Make the mempool consistent with the current tip, just in case
                     // any observers try to use it before shutdown.
-                    MaybeUpdateMempoolForReorg(disconnectpool, false);
+                    MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
                     return false;
                 }
             } else {
@@ -3303,7 +3311,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     if (fBlocksDisconnected) {
         // If any blocks were disconnected, disconnectpool may be non empty.  Add
         // any disconnected transactions back to the mempool.
-        MaybeUpdateMempoolForReorg(disconnectpool, true);
+        // Propagate flush messages to result, but do not treat flush failure as a chain activation failure.
+        MaybeUpdateMempoolForReorg(disconnectpool, true) >> result;
     }
     if (m_mempool) m_mempool->check(this->CoinsTip(), this->m_chain.Height() + 1);
 
@@ -3565,6 +3574,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     // Genesis block can't be invalidated
     assert(pindex);
@@ -3629,7 +3639,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // transactions back to the mempool if disconnecting was successful,
         // and we're not doing a very deep invalidation (in which case
         // keeping the mempool up to date is probably futile anyway).
-        MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret);
+        // Propagate flush messages to result, but do not treat flush failure as a block invalidation failure.
+        MaybeUpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret) >> result;
         if (!ret) return false;
         CBlockIndex* new_tip{m_chain.Tip()};
         assert(disconnected_tip->pprev == new_tip);
@@ -4500,14 +4511,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     return true;
 }
 
-MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+std::tuple<MempoolAcceptResult, FlushResult<void, AbortFailure>> ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
 {
     AssertLockHeld(cs_main);
     Chainstate& active_chainstate = ActiveChainstate();
     if (!active_chainstate.GetMempool()) {
         TxValidationState state;
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
-        return MempoolAcceptResult::Failure(state);
+        return {MempoolAcceptResult::Failure(state), FlushResult<>{}};
     }
     auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1800,7 +1800,7 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
     return result;
 }
 
@@ -1831,7 +1831,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     }
     // Ensure the coins cache is still within limits.
     BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    auto flush_result{active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC)};
     return result;
 }
 
@@ -2704,14 +2704,14 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
-bool Chainstate::FlushStateToDisk(
+FlushResult<void, AbortFailure> Chainstate::FlushStateToDisk(
     BlockValidationState &state,
     FlushStateMode mode,
     int nManualPruneHeight)
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2781,7 +2781,10 @@ bool Chainstate::FlushStateToDisk(
 
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                auto error{_("Disk space is too low!")};
+                FatalError(m_chainman.GetNotifications(), state, error);
+                result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+                return result;
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2816,7 +2819,10 @@ bool Chainstate::FlushStateToDisk(
                 // an overestimation, as most will delete an existing entry or
                 // overwrite one. Still, use a conservative safety factor of 2.
                 if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetDirtyCount())) {
-                    return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                    auto error{_("Disk space is too low!")};
+                    FatalError(m_chainman.GetNotifications(), state, error);
+                    result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+                    return result;
                 }
                 // Flush the chainstate (which may refer to block index entries).
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
@@ -2850,26 +2856,37 @@ bool Chainstate::FlushStateToDisk(
         }
     }
     } catch (const std::runtime_error& e) {
-        return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));
+        auto error{strprintf(_("System error while flushing: %s"), e.what())};
+        FatalError(m_chainman.GetNotifications(), state, error);
+        result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+        return result;
     }
-    return true;
+    return result;
 }
 
-void Chainstate::ForceFlushStateToDisk(bool wipe_cache)
+FlushResult<> Chainstate::ForceFlushStateToDisk(bool wipe_cache)
 {
+    FlushResult<> result;
     BlockValidationState state;
-    if (!this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC)) {
-        LogWarning("Failed to force flush state (%s)", state.ToString());
+    if (!(this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC) >> result)) {
+        auto error{Untranslated(strprintf("Failed to force flush state (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
-void Chainstate::PruneAndFlush()
+FlushResult<> Chainstate::PruneAndFlush()
 {
+    FlushResult<> result;
     BlockValidationState state;
     m_blockman.m_check_for_pruning = true;
-    if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
-        LogWarning("Failed to flush state (%s)", state.ToString());
+    if (!(this->FlushStateToDisk(state, FlushStateMode::NONE) >> result)) {
+        auto error{Untranslated(strprintf("Failed to flush state (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
 static void UpdateTipLog(
@@ -2948,6 +2965,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    FlushResult<> result; // TODO Return this result!
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2984,7 +3002,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     }
 
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
+        result.update(util::Error{});
         return false;
     }
 
@@ -3030,6 +3049,7 @@ bool Chainstate::ConnectTip(
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
     assert(pindexNew->pprev == m_chain.Tip());
+    FlushResult<void, AbortFailure> result; // TODO Return this result!
     // Read block from disk.
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
@@ -3077,7 +3097,8 @@ bool Chainstate::ConnectTip(
              Ticks<SecondsDouble>(m_chainman.time_flush),
              Ticks<MillisecondsDouble>(m_chainman.time_flush) / m_chainman.num_blocks_total);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    if (!(FlushStateToDisk(state, FlushStateMode::IF_NEEDED) >> result)) {
+        result.update(util::Error{});
         return false;
     }
     const auto time_5{SteadyClock::now()};
@@ -3354,6 +3375,8 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // we use m_chainstate_mutex to enforce mutual exclusion so that only one caller may execute this function at a time
     LOCK(m_chainstate_mutex);
 
+    FlushResult<> result; // TODO Return this result!
+
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
@@ -3468,11 +3491,13 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
             if (exited_ibd) {
                 // If a background chainstate is in use, we may need to rebalance our
                 // allocation of caches once a chainstate exits initial block download.
-                m_chainman.MaybeRebalanceCaches();
+                // Propagate flush messages to result, but do not treat a cache rebalance failure as a chain activation failure.
+                m_chainman.MaybeRebalanceCaches() >> result;
             }
 
             // Write changes periodically to disk, after relay.
-            if (!FlushStateToDisk(state, FlushStateMode::PERIODIC)) {
+            if (!(FlushStateToDisk(state, FlushStateMode::PERIODIC) >> result)) {
+                result.update(util::Error{});
                 return false;
             }
 
@@ -4411,13 +4436,14 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     // chainstate (particularly if we haven't implemented pruning with
     // background validation yet).
     //
+    // Ignore failure value, do not treat flush error as failure.
     // Flush errors (e.g. low disk space during pruning) are ignored, so that
     // callers can't mistreat a flush failure as a block validation failure.
     // The fatal error notification inside FlushStateToDisk still fires,
     // so the node will shut down on unrecoverable flush errors regardless.
     // For state a dummy value is used, and the return value is ignored.
     BlockValidationState flush_state_ignore;
-    (void)ActiveChainstate().FlushStateToDisk(flush_state_ignore, FlushStateMode::NONE);
+    ActiveChainstate().FlushStateToDisk(flush_state_ignore, FlushStateMode::NONE) >> result;
 
     CheckBlockIndex();
 
@@ -4563,13 +4589,17 @@ BlockValidationState TestBlockValidity(
 }
 
 /* This function is called from the RPC code for pruneblockchain */
-void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
+FlushResult<void, AbortFailure> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
     BlockValidationState state;
-    if (!active_chainstate.FlushStateToDisk(
-            state, FlushStateMode::NONE, nManualPruneHeight)) {
-        LogWarning("Failed to flush state after manual prune (%s)", state.ToString());
+    FlushResult<void, AbortFailure> result{active_chainstate.FlushStateToDisk(
+            state, FlushStateMode::NONE, nManualPruneHeight)};
+    if (!result) {
+        auto error{Untranslated(strprintf("Failed to flush state after manual prune (%s)", state.ToString()))};
+        LogWarning("%s", error.original);
+        result.update(util::Error{std::move(error)});
     }
+    return result;
 }
 
 bool Chainstate::LoadChainTip()
@@ -5495,13 +5525,13 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+FlushResult<void, AbortFailure> Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
 {
     AssertLockHeld(::cs_main);
     if (coinstip_size == m_coinstip_cache_size_bytes &&
             coinsdb_size == m_coinsdb_cache_size_bytes) {
         // Cache sizes are unchanged, no need to continue.
-        return true;
+        return {};
     }
     size_t old_coinstip_size = m_coinstip_cache_size_bytes;
     m_coinstip_cache_size_bytes = coinstip_size;
@@ -5514,16 +5544,14 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
         this->ToString(), coinstip_size / double(1_MiB));
 
     BlockValidationState state;
-    bool ret;
 
     if (coinstip_size > old_coinstip_size) {
         // Likely no need to flush if cache sizes have grown.
-        ret = FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
+        return FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
     } else {
         // Otherwise, flush state to disk and deallocate the in-memory coins map.
-        ret = FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH);
+        return FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH);
     }
-    return ret;
 }
 
 double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) const
@@ -5624,12 +5652,12 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return destroyed && !fs::exists(db_path);
 }
 
-util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
+FlushResult<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,
         bool in_memory)
 {
-    util::Result<CBlockIndex*> result;
+    FlushResult<CBlockIndex*> result;
     uint256 base_blockhash = metadata.m_base_blockhash;
 
     CBlockIndex* snapshot_start_block{};
@@ -5702,9 +5730,10 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
         // Temporarily resize the active coins cache to make room for the newly-created
         // snapshot chain.
+        // Propagate flush messages to result, but do not treat a cache resize failure as a snapshot activation failure.
         this->ActiveChainstate().ResizeCoinsCaches(
             static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC),
-            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC));
+            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC)) >> result;
     }
 
     auto snapshot_chainstate = WITH_LOCK(::cs_main,
@@ -5722,7 +5751,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     auto cleanup_bad_snapshot = [&](bilingual_str reason) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         result.update(util::Error{std::move(reason)});
-        this->MaybeRebalanceCaches();
+        // Propagate flush messages to result, but do not treat a cache rebalance failure as a snapshot activation failure.
+        this->MaybeRebalanceCaches() >> result;
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
         // has been created, so only attempt removal if we got that far.
@@ -5773,7 +5803,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
     LogInfo("[snapshot] (%.2f MB)",
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
-    this->MaybeRebalanceCaches();
+    // Propagate flush messages to result, but do not treat a cache rebalance failure as a snapshot activation failure.
+    this->MaybeRebalanceCaches() >> result;
     result.update(snapshot_start_block);
     return result;
 }
@@ -6017,6 +6048,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 // reaches its target block and is no longer changing.
 SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs)
 {
+    FlushResult<> result; // TODO Return this result!
     AssertLockHeld(cs_main);
 
     // If the snapshot does not need to be validated...
@@ -6069,7 +6101,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
     };
 
     CCoinsViewDB& validated_coins_db = validated_cs.CoinsDB();
-    validated_cs.ForceFlushStateToDisk();
+    // Ignore failure value, do not treat flush error as failure.
+    validated_cs.ForceFlushStateToDisk() >> result;
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
     if (!maybe_au_data) {
@@ -6122,7 +6155,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
     validated_cs.m_target_utxohash = AssumeutxoHash{validated_cs_stats->hashSerialized};
-    this->MaybeRebalanceCaches();
+    // Ignore failure value, do not treat flush error as failure.
+    this->MaybeRebalanceCaches() >> result;
 
     return SnapshotCompletionResult::SUCCESS;
 }
@@ -6133,36 +6167,44 @@ Chainstate& ChainstateManager::ActiveChainstate() const
     return CurrentChainstate();
 }
 
-void ChainstateManager::MaybeRebalanceCaches()
+FlushResult<> ChainstateManager::MaybeRebalanceCaches()
 {
     AssertLockHeld(::cs_main);
+    FlushResult<> result;
+    auto resize_caches = [&](Chainstate& chainstate, const auto&... args) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        if (!(chainstate.ResizeCoinsCaches(args...) >> result)) {
+            result.update(util::Error{});
+        }
+    };
+
     Chainstate& current_cs{CurrentChainstate()};
     Chainstate* historical_cs{HistoricalChainstate()};
     if (!historical_cs && !current_cs.m_from_snapshot_blockhash) {
         // Allocate everything to the IBD chainstate. This will always happen
         // when we are not using a snapshot.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        resize_caches(current_cs, m_total_coinstip_cache, m_total_coinsdb_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
         LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        resize_caches(current_cs, m_total_coinstip_cache, m_total_coinsdb_cache);
     } else {
         // If both chainstates exist, determine who needs more cache based on IBD status.
         //
         // Note: shrink caches first so that we don't inadvertently overwhelm available memory.
         if (IsInitialBlockDownload()) {
-            historical_cs->ResizeCoinsCaches(
+            resize_caches(*historical_cs,
                 m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            current_cs.ResizeCoinsCaches(
+            resize_caches(current_cs,
                 m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
         } else {
-            current_cs.ResizeCoinsCaches(
+            resize_caches(current_cs,
                 m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            historical_cs->ResizeCoinsCaches(
+            resize_caches(*historical_cs,
                 m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
         }
     }
+    return result;
 }
 
 void ChainstateManager::ResetChainstates()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3250,12 +3250,12 @@ void Chainstate::PruneBlockIndexCandidates() {
  *
  * @returns true unless a system error occurred
  */
-bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
+FlushResult<void, AbortFailure> Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
-    FlushResult<void, AbortFailure> result; // TODO Return this result!
+    FlushResult<void, AbortFailure> result;
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
 
@@ -3272,8 +3272,10 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
-            FatalError(m_chainman.GetNotifications(), state, _("Failed to disconnect block."));
-            return false;
+            auto error{_("Failed to disconnect block.")};
+            FatalError(m_chainman.GetNotifications(), state, error);
+            result.update({util::Error{std::move(error)}, AbortFailure{.fatal = true}});
+            return result;
         }
         fBlocksDisconnected = true;
     }
@@ -3312,7 +3314,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
                     // Make the mempool consistent with the current tip, just in case
                     // any observers try to use it before shutdown.
                     MaybeUpdateMempoolForReorg(disconnectpool, false) >> result;
-                    return false;
+                    result.update(util::Error{});
+                    return result;
                 }
             } else {
                 PruneBlockIndexCandidates();
@@ -3335,7 +3338,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
     CheckForkWarningConditions();
 
-    return true;
+    return result;
 }
 
 static SynchronizationState GetSynchronizationState(bool init, bool blockfiles_indexed)
@@ -3385,7 +3388,7 @@ static void LimitValidationInterfaceQueue(ValidationSignals& signals) LOCKS_EXCL
     }
 }
 
-bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
+FlushResult<> Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
 {
     AssertLockNotHeld(m_chainstate_mutex);
 
@@ -3401,13 +3404,16 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // we use m_chainstate_mutex to enforce mutual exclusion so that only one caller may execute this function at a time
     LOCK(m_chainstate_mutex);
 
-    FlushResult<> result; // TODO Return this result!
+    FlushResult<> result;
 
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
-        LogError("%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
-        return Assume(false);
+        auto error{Untranslated(STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."))};
+        LogError("%s", error.original);
+        Assume(false);
+        result.update(util::Error{std::move(error)});
+        return result;
     }
 
     CBlockIndex *pindexMostWork = nullptr;
@@ -3450,9 +3456,10 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                 // in case snapshot validation is completed during ActivateBestChainStep, the
                 // result of GetRole() changes from BACKGROUND to NORMAL.
                const ChainstateRole chainstate_role{this->GetRole()};
-                if (!ActivateBestChainStep(state, *pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connected_blocks)) {
+                if (!(ActivateBestChainStep(state, *pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connected_blocks) >> result)) {
                     // A system error occurred
-                    return false;
+                    result.update(util::Error{});
+                    return result;
                 }
                 blocks_connected = true;
 
@@ -3473,7 +3480,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                     break;
                 }
             } while (!m_chain.Tip() || (starting_tip && CBlockIndexWorkComparator()(m_chain.Tip(), starting_tip)));
-            if (!blocks_connected) return true;
+            if (!blocks_connected) return result;
 
             const CBlockIndex* pindexFork = starting_tip ? m_chain.FindFork(*starting_tip) : nullptr;
             bool still_in_ibd = m_chainman.IsInitialBlockDownload();
@@ -3524,7 +3531,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
             // Write changes periodically to disk, after relay.
             if (!(FlushStateToDisk(state, FlushStateMode::PERIODIC) >> result)) {
                 result.update(util::Error{});
-                return false;
+                return result;
             }
 
             reached_target = ReachedTarget();
@@ -3553,10 +3560,10 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
     m_chainman.CheckBlockIndex();
 
-    return true;
+    return result;
 }
 
-bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+FlushResult<> Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
@@ -3564,7 +3571,7 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         LOCK(cs_main);
         if (pindex->nChainWork < m_chain.Tip()->nChainWork) {
             // Nothing to do, this block is not at the tip.
-            return true;
+            return {};
         }
         if (m_chain.Tip()->nChainWork > m_chainman.nLastPreciousChainwork) {
             // The chain has been extended since the last call, reset the counter.
@@ -4488,6 +4495,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
 {
     AssertLockNotHeld(cs_main);
+    FlushResult<> result; // TODO Return this result!
 
     {
         CBlockIndex *pindex = nullptr;
@@ -4520,14 +4528,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     NotifyHeaderTip();
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActiveChainstate().ActivateBestChain(state, block)) {
+    if (!(ActiveChainstate().ActivateBestChain(state, block) >> result)) {
         LogError("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
         return false;
     }
 
     Chainstate* bg_chain{WITH_LOCK(cs_main, return HistoricalChainstate())};
     BlockValidationState bg_state;
-    if (bg_chain && !bg_chain->ActivateBestChain(bg_state, block)) {
+    if (bg_chain && !(bg_chain->ActivateBestChain(bg_state, block) >> result)) {
         LogError("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
         return false;
      }
@@ -5066,6 +5074,7 @@ void ChainstateManager::LoadExternalBlockFile(
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
 {
+    FlushResult<InterruptResult, AbortFailure> result; // TODO Return this result!
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
@@ -5161,7 +5170,7 @@ void ChainstateManager::LoadExternalBlockFile(
                 // was interrupted by the user.
                 if (hash == params.GetConsensus().hashGenesisBlock && WITH_LOCK(::cs_main, return ActiveHeight()) == -1) {
                     BlockValidationState state;
-                    if (!ActiveChainstate().ActivateBestChain(state, nullptr)) {
+                    if (!(ActiveChainstate().ActivateBestChain(state, nullptr) >> result)) {
                         break;
                     }
                 }
@@ -5174,8 +5183,9 @@ void ChainstateManager::LoadExternalBlockFile(
                     // until after all of the block files are loaded. ActivateBestChain can be
                     // called by concurrent network message processing. but, that is not
                     // reliable for the purpose of pruning while importing.
-                    if (auto result{ActivateBestChains()}; !result) {
-                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(result).original);
+                    if (auto activate_result{ActivateBestChains()}; !activate_result) {
+                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(activate_result).original);
+                        activate_result >> result;
                         break;
                     }
                 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -423,13 +423,10 @@ bool IsBlockMutated(const CBlock& block, bool check_witness_root);
 /** Return the sum of the claimed work on a given set of headers. No verification of PoW is done. */
 arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers);
 
-enum class VerifyDBResult {
-    SUCCESS,
-    CORRUPTED_BLOCK_DB,
-    INTERRUPTED,
-    SKIPPED_L3_CHECKS,
-    SKIPPED_MISSING_BLOCKS,
-};
+struct VerifySuccess{};
+struct SkippedL3Checks{};
+struct SkippedMissingBlocks{};
+using VerifyDBResult = std::variant<VerifySuccess, kernel::Interrupted, SkippedL3Checks, SkippedMissingBlocks>;
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB
@@ -440,7 +437,7 @@ private:
 public:
     explicit CVerifyDB(kernel::Notifications& notifications);
     ~CVerifyDB();
-    [[nodiscard]] VerifyDBResult VerifyDB(
+    [[nodiscard]] kernel::FlushResult<VerifyDBResult> VerifyDB(
         Chainstate& chainstate,
         const Consensus::Params& consensus_params,
         CCoinsView& coinsview,

--- a/src/validation.h
+++ b/src/validation.h
@@ -1111,7 +1111,7 @@ public:
     //! - Wait for our headers chain to include the base block of the snapshot.
     //! - "Fast forward" the tip of the new chainstate to the base of the snapshot.
     //! - Construct the new Chainstate and add it to m_chainstates.
-    [[nodiscard]] kernel::FlushResult<CBlockIndex*> ActivateSnapshot(
+    [[nodiscard]] kernel::FlushResult<CBlockIndex*, kernel::AbortFailure> ActivateSnapshot(
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! Try to validate an assumeutxo snapshot by using a validated historical
@@ -1122,7 +1122,7 @@ public:
     //! whether the hash matches. The INVALID case should not happen in practice
     //! because the software should refuse to load unrecognized snapshots, but
     //! if it does happen, it is a fatal error.
-    SnapshotCompletionResult MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] SnapshotCompletionResult MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs, kernel::FlushResult<void, kernel::AbortFailure>& result) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Return current chainstate targeting the most-work, network tip.
     Chainstate& CurrentChainstate() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex())
@@ -1361,7 +1361,7 @@ public:
     //! directories are moved or deleted.
     //!
     //! @sa node/chainstate:LoadChainstate()
-    bool ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<void, kernel::AbortFailure> ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Get range of historical blocks to download.
     std::optional<std::pair<const CBlockIndex*, const CBlockIndex*>> GetHistoricalBlockRange() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -275,7 +275,7 @@ struct PackageMempoolAcceptResult
  *
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
-MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+[[nodiscard]] std::tuple<MempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -289,7 +289,7 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
 * If a transaction fails, validation will exit early and some results may be missing. It is also
 * possible for the package to be partially submitted.
 */
-PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
+[[nodiscard]] std::tuple<PackageMempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
                                                    const Package& txns, bool test_accept, const std::optional<CFeeRate>& client_maxfeerate)
                                                    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -885,7 +885,7 @@ protected:
      * Passing fAddToMempool=false will skip trying to add the transactions back,
      * and instead just erase from the mempool as needed.
      */
-    void MaybeUpdateMempoolForReorg(
+    [[nodiscard]] kernel::FlushResult<> MaybeUpdateMempoolForReorg(
         DisconnectedBlockTransactions& disconnectpool,
         bool fAddToMempool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
@@ -1312,7 +1312,7 @@ public:
      * @param[in]  tx              The transaction to submit for mempool acceptance.
      * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
+    [[nodiscard]] std::tuple<MempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/src/validation.h
+++ b/src/validation.h
@@ -412,7 +412,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
  *
  * For signets the challenge verification is skipped when check_pow is false.
  */
-BlockValidationState TestBlockValidity(
+kernel::FlushResult<void, BlockValidationState> TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
     bool check_pow,
@@ -1092,7 +1092,7 @@ public:
     size_t m_total_coinsdb_cache{0};
 
     /// Ensures a genesis block is in the block tree, possibly writing one to disk.
-    [[nodiscard]] bool LoadGenesisBlock();
+    [[nodiscard]] kernel::FlushResult<> LoadGenesisBlock();
 
     //! Instantiate a new chainstate.
     //!
@@ -1238,7 +1238,7 @@ public:
      *                                              unknown parent, key is parent block hash
      *                                              (only used for reindex)
      * */
-    void LoadExternalBlockFile(
+    [[nodiscard]] kernel::FlushResult<kernel::InterruptResult, kernel::AbortFailure> LoadExternalBlockFile(
         AutoFile& file_in,
         FlatFilePos* dbp = nullptr,
         std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
@@ -1265,9 +1265,10 @@ public:
      *                               block header is already present in block
      *                               index then this parameter has no effect)
      * @param[out]  new_block A boolean which is set to indicate if the block was first received via this call
+     * @param[out]  result    Errors from saving or flushing the block.
      * @returns     If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block) LOCKS_EXCLUDED(cs_main);
+    [[nodiscard]] bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, kernel::FlushResult<void, kernel::AbortFailure>& result) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Process incoming block headers.
@@ -1294,15 +1295,24 @@ public:
      * @param[in]   min_pow_checked True if proof-of-work anti-DoS checks have
      *                              been done by caller for headers chain
      *
-     * @param[out]  state       The state of the block validation.
+     * @param[out]  state       The state of the block validation. Note: if an
+     *                          internal flush fails inside this function, state
+     *                          may also be set to an error as a side effect even
+     *                          when the function returns true. See implementation
+     *                          comment for details.
+     * @param[out]  result      Flush messages and errors from saving or flushing
+     *                          the block. Flush success/failure does not affect
+     *                          the return value, but messages are propagated here.
      * @param[out]  ppindex     Optional return parameter to get the
      *                          CBlockIndex pointer for this block.
      * @param[out]  fNewBlock   Optional return parameter to indicate if the
      *                          block is new to our storage.
      *
-     * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
+     * @returns   False if the block or block header is invalid; true otherwise.
+     *            Errors from saving or flushing to disk are reported in `result`
+     *            and do not affect the return value.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, kernel::FlushResult<void, kernel::AbortFailure>& result, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -18,6 +18,7 @@
 #include <kernel/chainparams.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/cs_main.h> // IWYU pragma: export
+#include <kernel/result.h>
 #include <node/blockstorage.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
@@ -107,7 +108,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);
 
 /** Prune block files up to a given height */
-void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);
+[[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);
 
 /**
 * Validation result for a transaction evaluated by MemPoolAccept (single or package).
@@ -725,7 +726,7 @@ public:
 
     //! Resize the CoinsViews caches dynamically and flush state to disk.
     //! @returns true unless an error occurred during the flush.
-    bool ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
@@ -739,17 +740,17 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool FlushStateToDisk(
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> FlushStateToDisk(
         BlockValidationState& state,
         FlushStateMode mode,
         int nManualPruneHeight = 0);
 
     //! Flush all changes to disk.
-    void ForceFlushStateToDisk(bool wipe_cache = true);
+    [[nodiscard]] kernel::FlushResult<> ForceFlushStateToDisk(bool wipe_cache = true);
 
     //! Prune blockfiles from the disk if necessary and then flush chainstate changes
     //! if we pruned.
-    void PruneAndFlush();
+    [[nodiscard]] kernel::FlushResult<> PruneAndFlush();
 
     /**
      * Find the best known block, and make it the tip of the block chain. The
@@ -1110,7 +1111,7 @@ public:
     //! - Wait for our headers chain to include the base block of the snapshot.
     //! - "Fast forward" the tip of the new chainstate to the base of the snapshot.
     //! - Construct the new Chainstate and add it to m_chainstates.
-    [[nodiscard]] util::Result<CBlockIndex*> ActivateSnapshot(
+    [[nodiscard]] kernel::FlushResult<CBlockIndex*> ActivateSnapshot(
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! Try to validate an assumeutxo snapshot by using a validated historical
@@ -1319,7 +1320,7 @@ public:
 
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.
-    void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<> MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Update uncommitted block structures (currently: only the witness reserved

--- a/src/validation.h
+++ b/src/validation.h
@@ -427,13 +427,10 @@ bool IsBlockMutated(const CBlock& block, bool check_witness_root);
 /** Return the sum of the claimed work on a given set of headers. No verification of PoW is done. */
 arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers);
 
-enum class VerifyDBResult {
-    SUCCESS,
-    CORRUPTED_BLOCK_DB,
-    INTERRUPTED,
-    SKIPPED_L3_CHECKS,
-    SKIPPED_MISSING_BLOCKS,
-};
+struct VerifySuccess{};
+struct SkippedL3Checks{};
+struct SkippedMissingBlocks{};
+using VerifyDBResult = std::variant<VerifySuccess, kernel::Interrupted, SkippedL3Checks, SkippedMissingBlocks>;
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB
@@ -444,7 +441,7 @@ private:
 public:
     explicit CVerifyDB(kernel::Notifications& notifications);
     ~CVerifyDB();
-    [[nodiscard]] VerifyDBResult VerifyDB(
+    [[nodiscard]] kernel::FlushResult<VerifyDBResult> VerifyDB(
         Chainstate& chainstate,
         const Consensus::Params& consensus_params,
         CCoinsView& coinsview,

--- a/src/validation.h
+++ b/src/validation.h
@@ -782,11 +782,11 @@ public:
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Apply the effects of a block disconnection on the UTXO set.
-    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] kernel::FlushResult<> DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     // Manual block validity manipulation:
     /** Mark a block as precious and reorganize.
@@ -798,7 +798,7 @@ public:
         LOCKS_EXCLUDED(::cs_main);
 
     /** Mark a block as invalid. */
-    bool InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
+    [[nodiscard]] kernel::FlushResult<> InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -857,7 +857,7 @@ public:
 
 protected:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
-    bool ConnectTip(
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectTip(
         BlockValidationState& state,
         CBlockIndex* pindexNew,
         std::shared_ptr<const CBlock> block_to_connect,

--- a/src/validation.h
+++ b/src/validation.h
@@ -773,7 +773,7 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool ActivateBestChain(
+    [[nodiscard]] kernel::FlushResult<> ActivateBestChain(
         BlockValidationState& state,
         std::shared_ptr<const CBlock> pblock = nullptr)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
@@ -793,7 +793,7 @@ public:
      *
      * May not be called in a validationinterface callback.
      */
-    bool PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+    [[nodiscard]] kernel::FlushResult<> PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -856,7 +856,7 @@ public:
     std::pair<int, int> GetPruneRange(int last_height_can_prune) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 protected:
-    bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectTip(
         BlockValidationState& state,
         CBlockIndex* pindexNew,

--- a/src/validation.h
+++ b/src/validation.h
@@ -1315,7 +1315,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex
-    bool LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] util::Result<kernel::InterruptResult, kernel::AbortFailure> LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.

--- a/src/validation.h
+++ b/src/validation.h
@@ -769,7 +769,7 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool ActivateBestChain(
+    [[nodiscard]] kernel::FlushResult<> ActivateBestChain(
         BlockValidationState& state,
         std::shared_ptr<const CBlock> pblock = nullptr)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
@@ -789,7 +789,7 @@ public:
      *
      * May not be called in a validationinterface callback.
      */
-    bool PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+    [[nodiscard]] kernel::FlushResult<> PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -852,7 +852,7 @@ public:
     std::pair<int, int> GetPruneRange(int last_height_can_prune) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 protected:
-    bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectTip(
         BlockValidationState& state,
         CBlockIndex* pindexNew,

--- a/src/validation.h
+++ b/src/validation.h
@@ -408,7 +408,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
  *
  * For signets the challenge verification is skipped when check_pow is false.
  */
-BlockValidationState TestBlockValidity(
+kernel::FlushResult<void, BlockValidationState> TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
     bool check_pow,
@@ -1088,7 +1088,7 @@ public:
     size_t m_total_coinsdb_cache{0};
 
     /// Ensures a genesis block is in the block tree, possibly writing one to disk.
-    [[nodiscard]] bool LoadGenesisBlock();
+    [[nodiscard]] kernel::FlushResult<> LoadGenesisBlock();
 
     //! Instantiate a new chainstate.
     //!
@@ -1234,7 +1234,7 @@ public:
      *                                              unknown parent, key is parent block hash
      *                                              (only used for reindex)
      * */
-    void LoadExternalBlockFile(
+    [[nodiscard]] kernel::FlushResult<kernel::InterruptResult, kernel::AbortFailure> LoadExternalBlockFile(
         AutoFile& file_in,
         FlatFilePos* dbp = nullptr,
         std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
@@ -1261,9 +1261,10 @@ public:
      *                               block header is already present in block
      *                               index then this parameter has no effect)
      * @param[out]  new_block A boolean which is set to indicate if the block was first received via this call
+     * @param[out]  result    Errors from saving or flushing the block.
      * @returns     If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block) LOCKS_EXCLUDED(cs_main);
+    [[nodiscard]] bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, kernel::FlushResult<void, kernel::AbortFailure>& result) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Process incoming block headers.
@@ -1290,15 +1291,24 @@ public:
      * @param[in]   min_pow_checked True if proof-of-work anti-DoS checks have
      *                              been done by caller for headers chain
      *
-     * @param[out]  state       The state of the block validation.
+     * @param[out]  state       The state of the block validation. Note: if an
+     *                          internal flush fails inside this function, state
+     *                          may also be set to an error as a side effect even
+     *                          when the function returns true. See implementation
+     *                          comment for details.
+     * @param[out]  result      Flush messages and errors from saving or flushing
+     *                          the block. Flush success/failure does not affect
+     *                          the return value, but messages are propagated here.
      * @param[out]  ppindex     Optional return parameter to get the
      *                          CBlockIndex pointer for this block.
      * @param[out]  fNewBlock   Optional return parameter to indicate if the
      *                          block is new to our storage.
      *
-     * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
+     * @returns   False if the block or block header is invalid; true otherwise.
+     *            Errors from saving or flushing to disk are reported in `result`
+     *            and do not affect the return value.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, kernel::FlushResult<void, kernel::AbortFailure>& result, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -778,11 +778,11 @@ public:
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Apply the effects of a block disconnection on the UTXO set.
-    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    [[nodiscard]] kernel::FlushResult<> DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     // Manual block validity manipulation:
     /** Mark a block as precious and reorganize.
@@ -794,7 +794,7 @@ public:
         LOCKS_EXCLUDED(::cs_main);
 
     /** Mark a block as invalid. */
-    bool InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
+    [[nodiscard]] kernel::FlushResult<> InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -853,7 +853,7 @@ public:
 
 protected:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
-    bool ConnectTip(
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ConnectTip(
         BlockValidationState& state,
         CBlockIndex* pindexNew,
         std::shared_ptr<const CBlock> block_to_connect,

--- a/src/validation.h
+++ b/src/validation.h
@@ -18,6 +18,7 @@
 #include <kernel/chainparams.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/cs_main.h> // IWYU pragma: export
+#include <kernel/result.h>
 #include <node/blockstorage.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
@@ -107,7 +108,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);
 
 /** Prune block files up to a given height */
-void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);
+[[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);
 
 /**
 * Validation result for a transaction evaluated by MemPoolAccept (single or package).
@@ -721,7 +722,7 @@ public:
 
     //! Resize the CoinsViews caches dynamically and flush state to disk.
     //! @returns true unless an error occurred during the flush.
-    bool ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
@@ -735,17 +736,17 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool FlushStateToDisk(
+    [[nodiscard]] kernel::FlushResult<void, kernel::AbortFailure> FlushStateToDisk(
         BlockValidationState& state,
         FlushStateMode mode,
         int nManualPruneHeight = 0);
 
     //! Flush all changes to disk.
-    void ForceFlushStateToDisk(bool wipe_cache = true);
+    [[nodiscard]] kernel::FlushResult<> ForceFlushStateToDisk(bool wipe_cache = true);
 
     //! Prune blockfiles from the disk if necessary and then flush chainstate changes
     //! if we pruned.
-    void PruneAndFlush();
+    [[nodiscard]] kernel::FlushResult<> PruneAndFlush();
 
     /**
      * Find the best known block, and make it the tip of the block chain. The
@@ -1106,7 +1107,7 @@ public:
     //! - Wait for our headers chain to include the base block of the snapshot.
     //! - "Fast forward" the tip of the new chainstate to the base of the snapshot.
     //! - Construct the new Chainstate and add it to m_chainstates.
-    [[nodiscard]] util::Result<CBlockIndex*> ActivateSnapshot(
+    [[nodiscard]] kernel::FlushResult<CBlockIndex*> ActivateSnapshot(
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! Try to validate an assumeutxo snapshot by using a validated historical
@@ -1315,7 +1316,7 @@ public:
 
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.
-    void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] kernel::FlushResult<> MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Update uncommitted block structures (currently: only the witness reserved

--- a/src/validation.h
+++ b/src/validation.h
@@ -1311,7 +1311,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex
-    bool LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] util::Result<kernel::InterruptResult, kernel::AbortFailure> LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.

--- a/src/validation.h
+++ b/src/validation.h
@@ -1107,7 +1107,7 @@ public:
     //! - Wait for our headers chain to include the base block of the snapshot.
     //! - "Fast forward" the tip of the new chainstate to the base of the snapshot.
     //! - Construct the new Chainstate and add it to m_chainstates.
-    [[nodiscard]] kernel::FlushResult<CBlockIndex*> ActivateSnapshot(
+    [[nodiscard]] kernel::FlushResult<CBlockIndex*, kernel::AbortFailure> ActivateSnapshot(
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! Try to validate an assumeutxo snapshot by using a validated historical
@@ -1118,7 +1118,7 @@ public:
     //! whether the hash matches. The INVALID case should not happen in practice
     //! because the software should refuse to load unrecognized snapshots, but
     //! if it does happen, it is a fatal error.
-    SnapshotCompletionResult MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] SnapshotCompletionResult MaybeValidateSnapshot(Chainstate& validated_cs, Chainstate& unvalidated_cs, kernel::FlushResult<void, kernel::AbortFailure>& result) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Return current chainstate targeting the most-work, network tip.
     Chainstate& CurrentChainstate() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex())
@@ -1357,7 +1357,7 @@ public:
     //! directories are moved or deleted.
     //!
     //! @sa node/chainstate:LoadChainstate()
-    bool ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] util::Result<void, kernel::AbortFailure> ValidatedSnapshotCleanup(Chainstate& validated_cs, Chainstate& unvalidated_cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Get range of historical blocks to download.
     std::optional<std::pair<const CBlockIndex*, const CBlockIndex*>> GetHistoricalBlockRange() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -271,7 +271,7 @@ struct PackageMempoolAcceptResult
  *
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
-MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
+[[nodiscard]] std::tuple<MempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
                                        int64_t accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -285,7 +285,7 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
 * If a transaction fails, validation will exit early and some results may be missing. It is also
 * possible for the package to be partially submitted.
 */
-PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
+[[nodiscard]] std::tuple<PackageMempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> ProcessNewPackage(Chainstate& active_chainstate, CTxMemPool& pool,
                                                    const Package& txns, bool test_accept, const std::optional<CFeeRate>& client_maxfeerate)
                                                    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -881,7 +881,7 @@ protected:
      * Passing fAddToMempool=false will skip trying to add the transactions back,
      * and instead just erase from the mempool as needed.
      */
-    void MaybeUpdateMempoolForReorg(
+    [[nodiscard]] kernel::FlushResult<> MaybeUpdateMempoolForReorg(
         DisconnectedBlockTransactions& disconnectpool,
         bool fAddToMempool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
@@ -1308,7 +1308,7 @@ public:
      * @param[in]  tx              The transaction to submit for mempool acceptance.
      * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
+    [[nodiscard]] std::tuple<MempoolAcceptResult, kernel::FlushResult<void, kernel::AbortFailure>> ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2948,7 +2948,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2431,7 +2431,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2439,7 +2439,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2956,7 +2956,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -10,6 +10,7 @@ The assumeutxo value generated and used here is committed to in
 `CRegTestParams::m_assumeutxo_data` in `src/kernel/chainparams.cpp`.
 """
 import contextlib
+import os
 
 from dataclasses import dataclass
 from test_framework.blocktools import (
@@ -185,9 +186,10 @@ class AssumeutxoTest(BitcoinTestFramework):
             with self.nodes[0].assert_debug_log([log_msg]):
                 self.nodes[0].assert_start_raises_init_error(expected_msg=error_msg)
 
-        expected_error_msg = "Error: A fatal internal error occurred, see debug.log for details: Assumeutxo data not found for the given blockhash '7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a'."
-        error_details = "Assumeutxo data not found for the given blockhash"
-        expected_error(log_msg=error_details, error_msg=expected_error_msg)
+        assumeutxo_error = "Assumeutxo data not found for the given blockhash '7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a'."
+        blockindex_error = "Error loading block database"
+        expected_error_msg = f"Error: A fatal internal error occurred, see debug.log for details: {assumeutxo_error}{os.linesep}Error: {assumeutxo_error} {blockindex_error}"
+        expected_error(log_msg=assumeutxo_error, error_msg=expected_error_msg)
 
         # resurrect node again
         (chainstate_snapshot_path / "base_blockhash").unlink()


### PR DESCRIPTION
Return util::Result objects from all functions that can trigger fatal errors.

There are many validation functions that handle failures by calling `AbortNode` and triggering shutdowns, without returning error information to their callers. This makes error handling in libbitcoinkernel application code difficult, because the only way to handle these errors is to register for [notification callbacks](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/notifications_interface.h). Improve this by making all functions that trigger fatal errors return util::Result objects with the error information.

This PR is a pure refactoring that returns extra result information from functions without changing their behavior. It's a possible alternative to and subset of #29642, which adds similar return information but also makes behavior changes and exposes a FatalError type.

---

<!-- begin based-on -->
**This is based on #25665.** The non-base commits are:

- [`c9210e8bde1` refactor, kernel: Add FlushStatus / FlushResult types](https://github.com/bitcoin/bitcoin/pull/29700/commits/c9210e8bde1175c71d5b40933e96effc0dc59c80)
- [`7605f8c76e4` refactor: Add InfoType field to util::Result](https://github.com/bitcoin/bitcoin/pull/29700/commits/7605f8c76e468d0699c42ed442fb5b5ac7f3191d)
- [`6a4d8d348dc` refactor, blockstorage: Return FlushResult from flush methods](https://github.com/bitcoin/bitcoin/pull/29700/commits/6a4d8d348dc64c5971e403317483523d832c0f5b)
- [`bbeea8fea98` refactor, blockstorage: Return fatal errors from block writes](https://github.com/bitcoin/bitcoin/pull/29700/commits/bbeea8fea98b0631c13f6f7c2858ce5f3235e6fb)
- [`af5f1a91b4b` refactor, validation: Switch to result.Update](https://github.com/bitcoin/bitcoin/pull/29700/commits/af5f1a91b4b4be4cab751ca2d92b3d22cc29947e)
- [`1827122486d` refactor, blockstorage: Return fatal error from LoadBlockIndex](https://github.com/bitcoin/bitcoin/pull/29700/commits/1827122486da452ad2db67f9105132c4d65d3775)
- [`6a7e6805df7` refactor, validation: Return fatal errors from FlushStateToDisk](https://github.com/bitcoin/bitcoin/pull/29700/commits/6a7e6805df73111008021da381f23bafa399f7ea)
- [`2639ec156a7` refactor, validation: Return fatal errors from mempool accept functions](https://github.com/bitcoin/bitcoin/pull/29700/commits/2639ec156a75d831f3c54b93cde2b0138d2860ed)
- [`0ce542edd31` refactor, validation: Return fatal errors from assumeutxo snapshot functions](https://github.com/bitcoin/bitcoin/pull/29700/commits/0ce542edd310548894f9881a7cc00a7aa04f5347)
- [`f0e3a6c845f` refactor, validation: Return fatal errors from block connect functions](https://github.com/bitcoin/bitcoin/pull/29700/commits/f0e3a6c845fbe52d814226949f5ddfef933c494e)
- [`986c77e69d2` refactor, validation: Return fatal errors from activate best chain functions](https://github.com/bitcoin/bitcoin/pull/29700/commits/986c77e69d23f8ddf281f995d9a2ee2ae1eaf8f1)
- [`d555f9b1278` refactor, validation: Return fatal errors from new block functions](https://github.com/bitcoin/bitcoin/pull/29700/commits/d555f9b127860b4ff6432945da1d13d63f898b1d)
- [`1c3e64c0bd6` refactor, blockstorage: Return fatal error from ImportBlocks](https://github.com/bitcoin/bitcoin/pull/29700/commits/1c3e64c0bd6ec7957d76c7b81e0ba11cb883bfe7)
- [`f8ad69966f7` refactor, validation: Return more errors from VerifyDB](https://github.com/bitcoin/bitcoin/pull/29700/commits/f8ad69966f72a0f8be7310d32b626d8ef9530fdb)<!-- end -->