### PR TITLE
fees: Remove CLIENT_VERSION serialization

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -979,7 +979,7 @@ bool CBlockPolicyEstimator::Write(AutoFile& fileout) const
         longStats->Write(fileout);
     }
     catch (const std::exception&) {
-        LogPrintf("CBlockPolicyEstimator::Write(): unable to write policy estimator data (non-fatal)\n");
+        LogWarning("Unable to write policy estimator data (non-fatal)");
         return false;
     }
     return true;
@@ -992,7 +992,7 @@ bool CBlockPolicyEstimator::Read(AutoFile& filein)
         int nVersionRequired, dummy;
         filein >> nVersionRequired >> dummy;
         if (nVersionRequired > CURRENT_FEES_FILE_VERSION) {
-            throw std::runtime_error(strprintf("up-version (%d) fee estimate file", nVersionRequired));
+            throw std::runtime_error{strprintf("File version (%d) too high to be read.", nVersionRequired)};
         }
 
         // Read fee estimates file into temporary variables so existing data
@@ -1001,7 +1001,7 @@ bool CBlockPolicyEstimator::Read(AutoFile& filein)
         filein >> nFileBestSeenHeight;
 
         if (nVersionRequired < CURRENT_FEES_FILE_VERSION) {
-            LogPrintf("%s: incompatible old fee estimation data (non-fatal). Version: %d\n", __func__, nVersionRequired);
+            LogWarning("Incompatible old fee estimation data (non-fatal). Version: %d", nVersionRequired);
         } else { // nVersionRequired == CURRENT_FEES_FILE_VERSION
             unsigned int nFileHistoricalFirst, nFileHistoricalBest;
             filein >> nFileHistoricalFirst >> nFileHistoricalBest;
@@ -1041,7 +1041,7 @@ bool CBlockPolicyEstimator::Read(AutoFile& filein)
         }
     }
     catch (const std::exception& e) {
-        LogPrintf("CBlockPolicyEstimator::Read(): unable to read policy estimator data (non-fatal): %s\n",e.what());
+        LogWarning("Unable to read policy estimator data (non-fatal): %s", e.what());
         return false;
     }
     return true;


### PR DESCRIPTION
Coupling the fees serialization with CLIENT_VERSION is problematic, because:

* `CLIENT_VERSION` may change, even though the serialization format does not change. This is harmless, but still confusing.
* If a serialization format change was backported (unlikely), it may lead to incorrect results.
* `CLIENT_VERSION` is changed at a different time during the release process than any serialization format change. This is harmless for releases of Bitcoin Core, but may be confusing when using the development branch.
* It is harder to reason about a global `CLIENT_VERSION` when changing the format, than to reason about a versioning local to the module.

Fix all issues by pinning the current version number in the module locally. In the future it can then be modified locally to the module, if needed.