### PR TITLE
depends: set two CMake options globally

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -181,6 +181,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                LDFLAGS="$$($(1)_ldflags)" \
                cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" \
                -DCMAKE_INSTALL_LIBDIR=lib/ \
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                $$($(1)_config_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -170,12 +170,18 @@ ifneq ($($(1)_ldflags),)
 $(1)_autoconf += LDFLAGS="$$($(1)_ldflags)"
 endif
 
+# We hardcode the library install path to "lib" to match the PKG_CONFIG_PATH
+# setting in depends/config.site.in, which also hardcodes "lib".
+# Without this setting, CMake by default would use the OS library
+# directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 $(1)_cmake=env CC="$$($(1)_cc)" \
                CFLAGS="$$($(1)_cppflags) $$($(1)_cflags)" \
                CXX="$$($(1)_cxx)" \
                CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
                LDFLAGS="$$($(1)_ldflags)" \
-             cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" $$($(1)_config_opts)
+               cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" \
+               -DCMAKE_INSTALL_LIBDIR=lib/ \
+               $$($(1)_config_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -163,7 +163,7 @@ From the [Gentoo Wiki entry](https://wiki.gentoo.org/wiki/Project:Quality_Assura
 >  ecosystem, as it leads to a massive number of unnecessary rebuilds.
 
 Where possible, packages are built with Position Independant Code. Either using
-the autotools `--with-pic` flag, or `DCMAKE_POSITION_INDEPENDENT_CODE` with CMake.
+the Autotools `--with-pic` flag, or `CMAKE_POSITION_INDEPENDENT_CODE` with CMake.
 
 ## Secondary dependencies:
 

--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -5,15 +5,10 @@ $(package)_download_file=$(native_$(package)_download_file)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 
-# Hardcode library install path to "lib" to match the PKG_CONFIG_PATH
-# setting in depends/config.site.in, which also hardcodes "lib".
-# Without this setting, cmake by default would use the OS library
-# directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 define $(package)_set_vars :=
   $(package)_config_opts := -DBUILD_TESTING=OFF
   $(package)_config_opts += -DWITH_OPENSSL=OFF
   $(package)_config_opts += -DWITH_ZLIB=OFF
-  $(package)_config_opts += -DCMAKE_INSTALL_LIBDIR=lib/
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -8,12 +8,7 @@ ifneq ($(host),$(build))
 $(package)_dependencies += native_capnp
 endif
 
-# Hardcode library install path to "lib" to match the PKG_CONFIG_PATH
-# setting in depends/config.site.in, which also hardcodes "lib".
-# Without this setting, cmake by default would use the OS library
-# directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 define $(package)_set_vars :=
-$(package)_config_opts += -DCMAKE_INSTALL_LIBDIR=lib/
 $(package)_config_opts += -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -9,7 +9,6 @@ $(package)_dependencies += native_capnp
 endif
 
 define $(package)_set_vars :=
-$(package)_config_opts += -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
 $(package)_config_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"


### PR DESCRIPTION
Set `CMAKE_INSTALL_LIBDIR=lib/` and `CMAKE_POSITION_INDEPENDENT_CODE=ON` globally in depends, rather than per-package. `CMAKE_INSTALL_LIBDIR=lib/` is needed to override the annoying [`GNUInstallDirs`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) `lib` vs `lib64` behaviour, and we always want PIC code. The PIC commit is the counterpart to the same Autotools change in #29488. I'm PRing these commits as I have a CMake branch building on top, and want to avoid adding the same workarounds to every package we are going to touch, but these can go in separately as the build should be tested for existing packages (i.e multiprocess).