### PR TITLE
Correct '-dbcache' to '-prune'

### DIFF
--- a/doc/design/assumeutxo.md
+++ b/doc/design/assumeutxo.md
@@ -16,7 +16,7 @@ load it.
 A pruned node can load a snapshot. To save space, it's possible to delete the
 snapshot file as soon as `loadtxoutset` finishes.
 
-The minimum `-dbcache` setting is 550 MiB, but this functionality ignores that
+The minimum `-prune` setting is 550 MiB, but this functionality ignores that
 minimum and uses at least 1100 MiB.
 
 As the background sync continues there will be temporarily two chainstate


### PR DESCRIPTION
This looks like a typo, '-prune' is doubled not the '-dbcache' by my understanding.