### PR TITLE
depends: build zeromq with CMake

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,6 +6,7 @@ $(package)_sha256_hash=6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a91
 $(package)_patches = remove_libstd_link.patch
 $(package)_patches += macos_mktemp_check.patch
 $(package)_patches += builtin_sha1.patch
+$(package)_patches += fix_have_windows.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -18,7 +19,8 @@ endef
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
   patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch && \
-  patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch
+  patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -7,6 +7,7 @@ $(package)_patches = remove_libstd_link.patch
 $(package)_patches += macos_mktemp_check.patch
 $(package)_patches += builtin_sha1.patch
 $(package)_patches += fix_have_windows.patch
+$(package)_patches += cmake_minimum.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -20,7 +21,8 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
   patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch && \
   patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch && \
-  patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch
+  patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch && \
+  patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,8 @@ $(package)_version=4.3.5
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
-$(package)_patches=remove_libstd_link.patch
+$(package)_patches = remove_libstd_link.patch
+$(package)_patches += macos_mktemp_check.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -14,7 +15,8 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch
+  patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
+  patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -8,6 +8,7 @@ $(package)_patches += macos_mktemp_check.patch
 $(package)_patches += builtin_sha1.patch
 $(package)_patches += fix_have_windows.patch
 $(package)_patches += cmake_minimum.patch
+$(package)_patches += no_librt.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -22,7 +23,8 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch && \
   patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch && \
-  patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch
+  patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch && \
+  patch -p1 < $($(package)_patch_dir)/no_librt.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -5,6 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
 $(package)_patches = remove_libstd_link.patch
 $(package)_patches += macos_mktemp_check.patch
+$(package)_patches += builtin_sha1.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -16,7 +17,8 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
-  patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch
+  patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch && \
+  patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,6 +3,7 @@ $(package)_version=4.3.5
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
+$(package)_build_subdir=build
 $(package)_patches = remove_libstd_link.patch
 $(package)_patches += macos_mktemp_check.patch
 $(package)_patches += builtin_sha1.patch
@@ -11,11 +12,12 @@ $(package)_patches += cmake_minimum.patch
 $(package)_patches += no_librt.patch
 
 define $(package)_set_vars
-  $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
-  $(package)_config_opts += --disable-perf --disable-curve-keygen --disable-curve --disable-libbsd
-  $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
-  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
-  $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
+  $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DWITH_DOCS=OFF -DWITH_LIBSODIUM=OFF
+  $(package)_config_opts += -DWITH_LIBBSD=OFF -DENABLE_CURVE=OFF -DENABLE_CPACK=OFF
+  $(package)_config_opts += -DBUILD_SHARED=OFF -DBUILD_TESTS=OFF -DZMQ_BUILD_TESTS=OFF
+  $(package)_config_opts += -DENABLE_DRAFTS=OFF -DZMQ_BUILD_TESTS=OFF
+  $(package)_cxxflags += -ffile-prefix-map=$($(package)_extract_dir)=/usr
+  $(package)_config_opts_mingw32 += -DZMQ_WIN32_WINNT=0x0601 -DZMQ_HAVE_IPC=OFF
 endef
 
 define $(package)_preprocess_cmds
@@ -28,17 +30,15 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./autogen.sh && \
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config && \
-  $($(package)_autoconf)
+   $($(package)_cmake) -S .. -B .
 endef
 
 define $(package)_build_cmds
-  $(MAKE) src/libzmq.la
+  $(MAKE)
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install-libLTLIBRARIES install-includeHEADERS install-pkgconfigDATA
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
 
 define $(package)_postprocess_cmds

--- a/depends/patches/zeromq/builtin_sha1.patch
+++ b/depends/patches/zeromq/builtin_sha1.patch
@@ -1,0 +1,17 @@
+Don't use builtin sha1 if not using ws
+
+The builtin SHA1 (ZMQ_USE_BUILTIN_SHA1) is only used in the websocket
+engine (ws_engine.cpp).
+Upstreamed in https://github.com/zeromq/libzmq/pull/4670.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,7 +234,7 @@ if(NOT ZMQ_USE_GNUTLS)
+       endif()
+     endif()
+   endif()
+-  if(NOT ZMQ_USE_NSS)
++  if(ENABLE_WS AND NOT ZMQ_USE_NSS)
+     list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/external/sha1/sha1.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/external/sha1/sha1.h)
+     message(STATUS "Using builtin sha1")

--- a/depends/patches/zeromq/cmake_minimum.patch
+++ b/depends/patches/zeromq/cmake_minimum.patch
@@ -1,0 +1,18 @@
+Set a more sane cmake_minimum_required.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,12 +1,7 @@
+ # CMake build script for ZeroMQ
++cmake_minimum_required(VERSION 3.16)
+ project(ZeroMQ)
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+-  cmake_minimum_required(VERSION 3.0.2)
+-else()
+-  cmake_minimum_required(VERSION 2.8.12)
+-endif()
+-
+ include(CheckIncludeFiles)
+ include(CheckCCompilerFlag)
+ include(CheckCXXCompilerFlag)

--- a/depends/patches/zeromq/fix_have_windows.patch
+++ b/depends/patches/zeromq/fix_have_windows.patch
@@ -1,0 +1,54 @@
+This fixes several instances where _MSC_VER was
+used to determine whether to use afunix.h or not.
+
+See https://github.com/zeromq/libzmq/pull/4678.
+--- a/src/ipc_address.hpp
++++ b/src/ipc_address.hpp
+@@ -7,7 +7,7 @@
+ 
+ #include <string>
+ 
+-#if defined _MSC_VER
++#if defined ZMQ_HAVE_WINDOWS
+ #include <afunix.h>
+ #else
+ #include <sys/socket.h>
+diff --git a/src/ipc_connecter.cpp b/src/ipc_connecter.cpp
+index 3f988745..ed2a0645 100644
+--- a/src/ipc_connecter.cpp
++++ b/src/ipc_connecter.cpp
+@@ -16,7 +16,7 @@
+ #include "ipc_address.hpp"
+ #include "session_base.hpp"
+ 
+-#ifdef _MSC_VER
++#if defined ZMQ_HAVE_WINDOWS
+ #include <afunix.h>
+ #else
+ #include <unistd.h>
+diff --git a/src/ipc_listener.cpp b/src/ipc_listener.cpp
+index 50126040..5428579b 100644
+--- a/src/ipc_listener.cpp
++++ b/src/ipc_listener.cpp
+@@ -17,7 +17,7 @@
+ #include "socket_base.hpp"
+ #include "address.hpp"
+ 
+-#ifdef _MSC_VER
++#ifdef ZMQ_HAVE_WINDOWS
+ #ifdef ZMQ_IOTHREAD_POLLER_USE_SELECT
+ #error On Windows, IPC does not work with POLLER=select, use POLLER=epoll instead, or disable IPC transport
+ #endif
+diff --git a/tests/testutil.cpp b/tests/testutil.cpp
+index bdc80283..6f21e8f6 100644
+--- a/tests/testutil.cpp
++++ b/tests/testutil.cpp
+@@ -7,7 +7,7 @@
+ 
+ #if defined _WIN32
+ #include "../src/windows.hpp"
+-#if defined _MSC_VER
++#if defined ZMQ_HAVE_WINDOWS
+ #if defined ZMQ_HAVE_IPC
+ #include <direct.h>
+ #include <afunix.h>

--- a/depends/patches/zeromq/macos_mktemp_check.patch
+++ b/depends/patches/zeromq/macos_mktemp_check.patch
@@ -1,0 +1,16 @@
+build: fix mkdtemp check on macOS
+
+On macOS, mkdtemp is in unistd.h. Fix the CMake check so that is works.
+Upstreamed in https://github.com/zeromq/libzmq/pull/4668.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -599,7 +599,7 @@ if(NOT MSVC)
+ 
+   check_cxx_symbol_exists(fork unistd.h HAVE_FORK)
+   check_cxx_symbol_exists(gethrtime sys/time.h HAVE_GETHRTIME)
+-  check_cxx_symbol_exists(mkdtemp stdlib.h HAVE_MKDTEMP)
++  check_cxx_symbol_exists(mkdtemp "stdlib.h;unistd.h" HAVE_MKDTEMP)
+   check_cxx_symbol_exists(accept4 sys/socket.h HAVE_ACCEPT4)
+   check_cxx_symbol_exists(strnlen string.h HAVE_STRNLEN)
+ else()

--- a/depends/patches/zeromq/no_librt.patch
+++ b/depends/patches/zeromq/no_librt.patch
@@ -1,0 +1,54 @@
+We don't use librt, so don't try and link against it.
+
+Related to: https://github.com/zeromq/libzmq/pull/4702.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03462271..87ceab3c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -564,13 +564,6 @@ else()
+   check_cxx_symbol_exists(SO_BUSY_POLL sys/socket.h ZMQ_HAVE_BUSY_POLL)
+ endif()
+ 
+-if(NOT MINGW)
+-  find_library(RT_LIBRARY rt)
+-  if(RT_LIBRARY)
+-    set(pkg_config_libs_private "${pkg_config_libs_private} -lrt")
+-  endif()
+-endif()
+-
+ find_package(Threads)
+ 
+ if(WIN32 AND NOT CYGWIN)
+@@ -588,9 +581,7 @@ if(WIN32 AND NOT CYGWIN)
+ endif()
+ 
+ if(NOT MSVC)
+-  set(CMAKE_REQUIRED_LIBRARIES rt)
+   check_cxx_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
+-  set(CMAKE_REQUIRED_LIBRARIES)
+ 
+   check_cxx_symbol_exists(fork unistd.h HAVE_FORK)
+   check_cxx_symbol_exists(gethrtime sys/time.h HAVE_GETHRTIME)
+@@ -1503,10 +1494,6 @@ if(BUILD_SHARED)
+     target_link_libraries(libzmq iphlpapi)
+   endif()
+ 
+-  if(RT_LIBRARY)
+-    target_link_libraries(libzmq -lrt)
+-  endif()
+-
+   if(norm_FOUND)
+       target_link_libraries(libzmq norm::norm)
+   endif()
+@@ -1553,10 +1540,6 @@ if(BUILD_STATIC)
+     target_link_libraries(libzmq-static iphlpapi)
+   endif()
+ 
+-  if(RT_LIBRARY)
+-    target_link_libraries(libzmq-static -lrt)
+-  endif()
+-
+   if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+     add_definitions(-DUNITY_EXCLUDE_MATH_H)
+   endif()


### PR DESCRIPTION
This picks up a change, which is a switch to building zeromq with CMake. It includes a number of patches, some which have already been upstreamed (see each patch for details).