### PR TITLE
depends: build libqrencode with CMake

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -499,6 +499,7 @@ inspecting signatures in Mach-O binaries.")
         gzip
         xz
         ;; Build tools
+        cmake-minimal
         gnu-make
         libtool
         autoconf-2.71
@@ -532,7 +533,6 @@ inspecting signatures in Mach-O binaries.")
                  (list gcc-toolchain-10 "static")
                  binutils
                  clang-toolchain-17
-                 cmake-minimal
                  python-signapple
                  zip))
           (else '())))))

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -3,20 +3,22 @@ $(package)_version=4.1.1
 $(package)_download_path=https://fukuchi.org/works/qrencode/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=e455d9732f8041cf5b9c388e345a641fd15707860f928e94507b1961256a6923
+$(package)_patches=cmake_fixups.patch
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --without-tools --without-tests --without-png
-$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
-$(package)_config_opts += --disable-dependency-tracking --enable-option-checking
+$(package)_config_opts := -DWITH_TOOLS=NO -DWITH_TESTS=NO -DGPROF=OFF -DCOVERAGE=OFF
+$(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_PNG=TRUE -DWITHOUT_PNG=ON
+$(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ICONV=TRUE
 $(package)_cflags += -Wno-int-conversion -Wno-implicit-function-declaration
 endef
 
 define $(package)_preprocess_cmds
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub use
+  patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch
 endef
 
+
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  $($(package)_cmake) -S . -B .
 endef
 
 define $(package)_build_cmds
@@ -25,8 +27,4 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
-endef
-
-define $(package)_postprocess_cmds
-  rm lib/*.la
 endef

--- a/depends/patches/qrencode/cmake_fixups.patch
+++ b/depends/patches/qrencode/cmake_fixups.patch
@@ -1,0 +1,23 @@
+cmake: set minimum version to 3.5
+
+Correct some dev warning output.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 773e037..a558145 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(QRencode VERSION 4.1.1 LANGUAGES C)
+ 
+@@ -20,7 +20,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ set(CMAKE_THREAD_PREFER_PTHREAD ON)
+ find_package(Threads)
+ find_package(PNG)
+-find_package(Iconv)
++find_package(ICONV)
+ 
+ if(CMAKE_USE_PTHREADS_INIT)
+     add_definitions(-DHAVE_LIBPTHREAD=1)


### PR DESCRIPTION
Switch to building libqrencode with CMake. Note that upstream (https://github.com/fukuchi/libqrencode) hasn't seen any activity for ~4 years, so the odds of getting anything upstream seems low, but I've made two minor changes to the source here, which I will PR in any case.

From an initial look I couldn't find any significant difference between the Autotools and CMake produced libs. As part of this change we move cmake-minimal in Guix into the global package set.