### PR TITLE
build, macos: Drop unused `osx_volname` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,6 @@ db4/
 # clang-check
 *.plist
 
-osx_volname
 dist/
 
 /guix-build-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -118,9 +118,6 @@ OSX_APP_BUILT=$(OSX_APP)/Contents/PkgInfo $(OSX_APP)/Contents/Resources/empty.lp
   $(OSX_APP)/Contents/Resources/bitcoin.icns $(OSX_APP)/Contents/Info.plist \
   $(OSX_APP)/Contents/MacOS/Bitcoin-Qt $(OSX_APP)/Contents/Resources/Base.lproj/InfoPlist.strings
 
-osx_volname:
-	echo $(OSX_VOLNAME) >$@
-
 if BUILD_DARWIN
 $(OSX_ZIP): $(OSX_APP_BUILT) $(OSX_PACKAGING)
 	$(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) $(OSX_VOLNAME) -translations-dir=$(QT_TRANSLATION_DIR) -zip
@@ -338,7 +335,7 @@ clean-docs:
 clean-local: clean-docs
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ fuzz.coverage/ test/tmp/ cache/ $(OSX_APP)
 	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache share/rpcauth/__pycache__
-	rm -rf osx_volname dist/ test/lint/test_runner/target/ test/lint/__pycache__
+	rm -rf dist/ test/lint/test_runner/target/ test/lint/__pycache__
 
 test-security-check:
 if TARGET_DARWIN

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -300,11 +300,9 @@ mkdir -p "$DISTSRC"
 
     case "$HOST" in
         *darwin*)
-            make osx_volname ${V:+V=1}
             make deploydir ${V:+V=1}
             mkdir -p "unsigned-app-${HOST}"
             cp  --target-directory="unsigned-app-${HOST}" \
-                osx_volname \
                 contrib/macdeploy/detached-sig-create.sh
             mv --target-directory="unsigned-app-${HOST}" dist
             (


### PR DESCRIPTION
The `osx_volname` makefile target was introduced in https://github.com/bitcoin/bitcoin/pull/7192 and was used to pass the package name to Gitian scripts as a content of the `osx_volname` file.

With the current Guix scripts, the `osx_volname` file is never read. Therefore, its creation might be omitted.

My Guix builds:
```
x86_64
5e2d254e207d53784621c8df331c9bf4a969da667d185992402f48a5ac49f563  guix-build-eff19fa1c8d7/output/arm64-apple-darwin/SHA256SUMS.part
089dba70685893aca5e7c8ce1d53a07380e87ca50eda8b3a2a75aeaeb1d28e48  guix-build-eff19fa1c8d7/output/arm64-apple-darwin/bitcoin-eff19fa1c8d7-arm64-apple-darwin-unsigned.tar.gz
390c57197c6ab4aefdde1c665d5e4ebdfb4ae5e553f8f93b017f2fad1093d110  guix-build-eff19fa1c8d7/output/arm64-apple-darwin/bitcoin-eff19fa1c8d7-arm64-apple-darwin-unsigned.zip
e1edde7ca28bf26aea8d956b1d3c1725a475f2a9c148f5c36b651db4b814091c  guix-build-eff19fa1c8d7/output/arm64-apple-darwin/bitcoin-eff19fa1c8d7-arm64-apple-darwin.tar.gz
d0096ea73a5f75cc4d3cef4ef1761ae3e48c8a63aff918f07371c5c88896e4e6  guix-build-eff19fa1c8d7/output/dist-archive/bitcoin-eff19fa1c8d7.tar.gz
51b4affb9fd6f8aea05b7d25d29f017d0a0a145395f457caa14b9af9646b035b  guix-build-eff19fa1c8d7/output/x86_64-apple-darwin/SHA256SUMS.part
b1df081ecf636a92754e673e5388d1d988653d4646f0b0446a4c9f14d865a265  guix-build-eff19fa1c8d7/output/x86_64-apple-darwin/bitcoin-eff19fa1c8d7-x86_64-apple-darwin-unsigned.tar.gz
62e09926029d176da950d3e3db7ff8ae6cbe4c0b2ea17b084fc1d28565f91475  guix-build-eff19fa1c8d7/output/x86_64-apple-darwin/bitcoin-eff19fa1c8d7-x86_64-apple-darwin-unsigned.zip
477dcb2382cbd447bd88a3b644b4bd736f5b67d66d42cb73fe31ffc153d3e181  guix-build-eff19fa1c8d7/output/x86_64-apple-darwin/bitcoin-eff19fa1c8d7-x86_64-apple-darwin.tar.gz
```