### PR TITLE
bench: Adds a benchmark for CheckInputScripts

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -12,6 +12,7 @@ GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 
 bench_bench_bitcoin_SOURCES = \
   $(RAW_BENCH_FILES) \
+  bench/check_input_scrips.cpp \
   bench/addrman.cpp \
   bench/base58.cpp \
   bench/bech32.cpp \

--- a/src/bench/check_input_scrips.cpp
+++ b/src/bench/check_input_scrips.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+
+#include <validation.h>
+
+#include <array>
+#include <vector>
+#include <script/signingprovider.h>
+#include <test/util/transaction_utils.h>
+
+
+
+static void BenchCheckInputScripts(benchmark::Bench& bench)
+{
+    ECC_Start();
+
+    FillableSigningProvider keystore;
+
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+    std::vector<CMutableTransaction> dummyTransactions =
+        SetupDummyInputs(keystore, coins, {11 * COIN, 50 * COIN, 21 * COIN, 22 * COIN});
+
+    CMutableTransaction t1;
+    t1.vin.resize(3);
+    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    t1.vin[0].prevout.n = 1;
+    t1.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
+    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[1].prevout.n = 0;
+    t1.vin[1].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
+    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[2].prevout.n = 1;
+    t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
+    t1.vout.resize(2);
+    t1.vout[0].nValue = 90 * COIN;
+    t1.vout[0].scriptPubKey << OP_1;
+
+    const CTransactionRef tx1_r{MakeTransactionRef(t1)};
+
+    TxValidationState state_dummy;
+
+
+    PrecomputedTransactionData m_precomputed_txdata;
+
+    bench.unit("script").run([&] {
+        CheckInputScripts(*tx1_r, state_dummy, coins, 0, true, true, m_precomputed_txdata);
+    });
+    ECC_Stop();
+}
+
+
+BENCHMARK(BenchCheckInputScripts, benchmark::PriorityLevel::HIGH);
+

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -133,12 +133,6 @@ const CBlockIndex* Chainstate::FindForkInGlobalIndex(const CBlockLocator& locato
     return m_chain.Genesis();
 }
 
-bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
-                       const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
-                       bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       std::vector<CScriptCheck>* pvChecks = nullptr)
-                       EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
 bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& tx)
 {
     AssertLockHeld(cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -1299,4 +1299,11 @@ bool IsBIP30Repeat(const CBlockIndex& block_index);
 /** Identifies blocks which coinbase output was subsequently overwritten in the UTXO set (see BIP30) */
 bool IsBIP30Unspendable(const CBlockIndex& block_index);
 
+bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
+                       const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
+                       bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                       std::vector<CScriptCheck>* pvChecks = nullptr)
+                       EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+
 #endif // BITCOIN_VALIDATION_H


### PR DESCRIPTION
Creates new benchmark for `CheckInputScripts`

Motivated by this comment https://github.com/bitcoin/bitcoin/issues/17175#issuecomment-543191989

I haven't really done benchmarking a ton before so any comments would be useful

What the benchmark looks like when I run `./src/bench/bench_bitcoin`
```
|           ns/script |            script/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            6,946.20 |          143,963.61 |    5.2% |      0.01 | :wavy_dash: `BenchCheckInputScripts` (Unstable with ~148.0 iters. Increase `minEpochIterations` to e.g. 1480)
```