### PR TITLE
depends: fix mingw-w64 Qt DEBUG=1 build

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -177,6 +177,7 @@ $(package)_config_opts_mingw32 += -xplatform win32-g++
 $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXX = '$($(package)_cxx)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cxxflags) $($(package)_cppflags)'"
+$(package)_config_opts_mingw32 += "QMAKE_LINK = '$($(package)_cxx)'"
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LIB = '$($(package)_ar) rc'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"


### PR DESCRIPTION
The issue is that compilation is done with `x86_64-w64-mingw32-g++-posix`, but then linking is done with `x86_64-w64-mingw32-g++`.

I'm guessing this has been broken since #24131 (01d1845a80ae48d741deea695ddce95d940ab0d8), but have not checked.

Fixes #29734.
Unblocks #29527 (`DEBUG=1` builds can be tested).