### PR TITLE
test: fix StopIteration exception in p2p_node_network_limited.py

### DIFF
--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -92,7 +92,8 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         # Wait until the full_node is headers-wise sync
         best_block_hash = pruned_node.getbestblockhash()
-        self.wait_until(lambda: next(filter(lambda x: x['hash'] == best_block_hash, full_node.getchaintips()))['status'] == "headers-only")
+        default_value = {'status': ''}  # No status
+        self.wait_until(lambda: next(filter(lambda x: x['hash'] == best_block_hash, full_node.getchaintips()), default_value)['status'] == "headers-only")
 
         # Now, since the node aims to download a window of 1024 blocks,
         # ensure it requests the blocks below the threshold only (with a


### PR DESCRIPTION
Fixes #29731

The `next()` call throws an exception if the default parameter is omitted and the iterator is exhausted.
Fix it by providing a default value.

The failure can be tested by commenting out lines 90 and 91 in the test (the `self.connect_nodes(2, 0)`). Since there is no connection, the node in question retrieves a single element in the 'getchaintips()' call. This scenario without the fix, aborts the test right away, throwing an `StopIteration` exception, and with the fix, the test properly waits until the timeout (`wait_until()` call).