### PR TITLE
feefrac: avoid explicitly computing diagram; compare based on chunks

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -191,13 +191,13 @@ std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(
                                                 int64_t replacement_vsize)
 {
     // Require that the replacement strictly improves the mempool's feerate diagram.
-    const auto diagram_results{pool.CalculateFeerateDiagramsForRBF(replacement_fees, replacement_vsize, direct_conflicts, all_conflicts)};
+    const auto chunk_results{pool.CalculateChunksForRBF(replacement_fees, replacement_vsize, direct_conflicts, all_conflicts)};
 
-    if (!diagram_results.has_value()) {
-        return std::make_pair(DiagramCheckError::UNCALCULABLE, util::ErrorString(diagram_results).original);
+    if (!chunk_results.has_value()) {
+        return std::make_pair(DiagramCheckError::UNCALCULABLE, util::ErrorString(chunk_results).original);
     }
 
-    if (!std::is_gt(CompareFeerateDiagram(diagram_results.value().second, diagram_results.value().first))) {
+    if (!std::is_gt(CompareChunks(chunk_results.value().second, chunk_results.value().first))) {
         return std::make_pair(DiagramCheckError::FAILURE, "insufficient feerate: does not improve feerate diagram");
     }
     return std::nullopt;

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -82,43 +82,4 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
 
 }
 
-BOOST_AUTO_TEST_CASE(build_diagram_test)
-{
-    FeeFrac p1{1000, 100};
-    FeeFrac empty{0, 0};
-    FeeFrac zero_fee{0, 1};
-    FeeFrac oversized_1{4611686000000, 4000000};
-    FeeFrac oversized_2{184467440000000, 100000};
-
-    // Diagram-building will reorder chunks
-    std::vector<FeeFrac> chunks;
-    chunks.push_back(p1);
-    chunks.push_back(zero_fee);
-    chunks.push_back(empty);
-    chunks.push_back(oversized_1);
-    chunks.push_back(oversized_2);
-
-    // Caller in charge of sorting chunks in case chunk size limit
-    // differs from cluster size limit
-    std::sort(chunks.begin(), chunks.end(), [](const FeeFrac& a, const FeeFrac& b) { return a > b; });
-
-    // Chunks are now sorted in reverse order (largest first)
-    BOOST_CHECK(chunks[0] == empty); // empty is considered "highest" fee
-    BOOST_CHECK(chunks[1] == oversized_2);
-    BOOST_CHECK(chunks[2] == oversized_1);
-    BOOST_CHECK(chunks[3] == p1);
-    BOOST_CHECK(chunks[4] == zero_fee);
-
-    std::vector<FeeFrac> generated_diagram{BuildDiagramFromChunks(chunks)};
-    BOOST_CHECK(generated_diagram.size() == 1 + chunks.size());
-
-    // Prepended with an empty, then the chunks summed in order as above
-    BOOST_CHECK(generated_diagram[0] == empty);
-    BOOST_CHECK(generated_diagram[1] == empty);
-    BOOST_CHECK(generated_diagram[2] == oversized_2);
-    BOOST_CHECK(generated_diagram[3] == oversized_2 + oversized_1);
-    BOOST_CHECK(generated_diagram[4] == oversized_2 + oversized_1 + p1);
-    BOOST_CHECK(generated_diagram[5] == oversized_2 + oversized_1 + p1 + zero_fee);
-}
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/feeratediagram.cpp
+++ b/src/test/fuzz/feeratediagram.cpp
@@ -16,6 +16,20 @@
 
 namespace {
 
+/** Takes the pre-computed and topologically-valid chunks and generates a fee diagram which starts at FeeFrac of (0, 0) */
+std::vector<FeeFrac> BuildDiagramFromChunks(const Span<const FeeFrac> chunks)
+{
+    std::vector<FeeFrac> diagram;
+    diagram.reserve(chunks.size() + 1);
+
+    diagram.emplace_back(0, 0);
+    for (auto& chunk : chunks) {
+        diagram.emplace_back(diagram.back() + chunk);
+    }
+    return diagram;
+}
+
+
 /** Evaluate a diagram at a specific size, returning the fee as a fraction.
  *
  * Fees in diagram cannot exceed 2^32, as the returned evaluation could overflow
@@ -103,7 +117,7 @@ FUZZ_TARGET(build_and_compare_feerate_diagram)
     assert(diagram1.front() == empty);
     assert(diagram2.front() == empty);
 
-    auto real = CompareFeerateDiagram(diagram1, diagram2);
+    auto real = CompareChunks(chunks1, chunks2);
     auto sim = CompareDiagrams(diagram1, diagram2);
     assert(real == sim);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1280,7 +1280,7 @@ std::optional<std::string> CTxMemPool::CheckConflictTopology(const setEntries& d
     return std::nullopt;
 }
 
-util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::CalculateFeerateDiagramsForRBF(CAmount replacement_fees, int64_t replacement_vsize, const setEntries& direct_conflicts, const setEntries& all_conflicts)
+util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::CalculateChunksForRBF(CAmount replacement_fees, int64_t replacement_vsize, const setEntries& direct_conflicts, const setEntries& all_conflicts)
 {
     Assume(replacement_vsize > 0);
 
@@ -1335,7 +1335,6 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
 
     // No topology restrictions post-chunking; sort
     std::sort(old_chunks.begin(), old_chunks.end(), std::greater());
-    std::vector<FeeFrac> old_diagram = BuildDiagramFromChunks(old_chunks);
 
     std::vector<FeeFrac> new_chunks;
 
@@ -1365,6 +1364,5 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
 
     // No topology restrictions post-chunking; sort
     std::sort(new_chunks.begin(), new_chunks.end(), std::greater());
-    std::vector<FeeFrac> new_diagram = BuildDiagramFromChunks(new_chunks);
-    return std::make_pair(old_diagram, new_diagram);
+    return std::make_pair(old_chunks, new_chunks);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -738,7 +738,7 @@ public:
     }
 
     /**
-     * Calculate the old and new mempool feerate diagrams relating to the
+     * Calculate the sorted chunks for the old and new mempool relating to the
      * clusters that would be affected by a potential replacement transaction.
      * (replacement_fees, replacement_vsize) values are gathered from a
      * proposed set of replacement transactions that are considered as a single
@@ -752,7 +752,7 @@ public:
      * @param[in] all_conflicts       All transactions that would be removed
      * @return old and new diagram pair respectively, or an error string if the conflicts don't match a calculable topology
      */
-    util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateFeerateDiagramsForRBF(CAmount replacement_fees, int64_t replacement_vsize, const setEntries& direct_conflicts, const setEntries& all_conflicts) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateChunksForRBF(CAmount replacement_fees, int64_t replacement_vsize, const setEntries& direct_conflicts, const setEntries& all_conflicts) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /* Check that all direct conflicts are in a cluster size of two or less. Each
      * direct conflict may be in a separate cluster.

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -146,15 +146,14 @@ struct FeeFrac
     }
 };
 
-/** Takes the pre-computed and topologically-valid chunks and generates a fee diagram which starts at FeeFrac of (0, 0) */
-std::vector<FeeFrac> BuildDiagramFromChunks(Span<const FeeFrac> chunks);
-
-/** Compares two feerate diagrams. The shorter one is implicitly
- * extended with a horizontal straight line.
+/** Compare the feerate diagrams implied by the provided sorted chunks data.
  *
- * A feerate diagram consists of a list of (fee, size) points with the property that size
- * is strictly increasing and that the first entry is (0, 0).
+ * The implied diagram for each starts at (0, 0), then contains for each chunk the cumulative fee
+ * and size up to that chunk, and then extends infinitely to the right with a horizontal line.
+ *
+ * The caller must guarantee that the sum of the FeeFracs in either of the chunks' data set do not
+ * overflow (so sum fees < 2^63, and sum sizes < 2^31).
  */
-std::partial_ordering CompareFeerateDiagram(Span<const FeeFrac> dia0, Span<const FeeFrac> dia1);
+std::partial_ordering CompareChunks(Span<const FeeFrac> chunks0, Span<const FeeFrac> chunks1);
 
 #endif // BITCOIN_UTIL_FEEFRAC_H


### PR DESCRIPTION
This merges the `BuildDiagramFromChunks` and `CompareFeeRateDiagram` introduced in #29242 into a single `CompareChunks` function, which operates on sorted chunk data rather than diagrams, instead computing the diagram on the fly.

This avoids the need for the construction of an intermediary diagram object, and removes the slightly arbitrary "all diagrams must start at (0, 0)" requirement.

Not a big deal, but I think the result is a bit cleaner and not really more complicated.