### PR TITLE
build: Consider `SOURCE_DATE_EPOCH` in Guix environment only

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,8 +129,7 @@ deploydir: $(OSX_ZIP)
 else !BUILD_DARWIN
 APP_DIST_DIR=$(top_builddir)/dist
 
-$(OSX_ZIP): deploydir
-	if [ -n "$(SOURCE_DATE_EPOCH)" ]; then find $(APP_DIST_DIR) -exec touch -d @$(SOURCE_DATE_EPOCH) {} +; fi
+$(OSX_ZIP):
 	cd $(APP_DIST_DIR) && find . | sort | $(ZIP) -X@ $@
 
 $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(OSX_APP_BUILT) $(OSX_PACKAGING)

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -143,6 +143,9 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   MAYBE_TOKEN="--"
 fi
 
+if [[ $HOST = *-darwin && $GOAL = deploy ]]; then
+  bash -c "${MAYBE_BEAR} ${MAYBE_TOKEN} make $MAKEJOBS deploydir" || ( echo "Build failure. Verbose build follows." && make deploydir V=1 ; false )
+fi
 bash -c "${MAYBE_BEAR} ${MAYBE_TOKEN} make $MAKEJOBS $GOAL" || ( echo "Build failure. Verbose build follows." && make "$GOAL" V=1 ; false )
 
 bash -c "${PRINT_CCACHE_STATISTICS}"

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -302,6 +302,9 @@ mkdir -p "$DISTSRC"
         *darwin*)
             make osx_volname ${V:+V=1}
             make deploydir ${V:+V=1}
+            find dist -print0 | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+            make deploy ${V:+V=1} OSX_ZIP="${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
+
             mkdir -p "unsigned-app-${HOST}"
             cp  --target-directory="unsigned-app-${HOST}" \
                 osx_volname \
@@ -315,7 +318,6 @@ mkdir -p "$DISTSRC"
                     | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.tar.gz" \
                     || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.tar.gz" && exit 1 )
             )
-            make deploy ${V:+V=1} OSX_ZIP="${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
             ;;
     esac
     (


### PR DESCRIPTION
The [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) environment variable is supposed to be used to achieve build reproducibility.

However, using it outside Guix scripts for local builds on macOS is not meaningful.

This PR makes usage of `SOURCE_DATE_EPOCH` for macOS consistent with other platforms and simplifies [upcoming](https://github.com/hebasto/bitcoin/pull/129) CMake-based build system scripts.
