### PR TITLE
Policy: Enforce witness script size limit for tapscript

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -272,8 +272,11 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
                 const auto& control_block = SpanPopBack(stack);
-                SpanPopBack(stack); // Ignore script
+                const auto& tapscript = SpanPopBack(stack);
                 if (control_block.empty()) return false; // Empty control block is invalid
+                if (tapscript.size() > MAX_STANDARD_TAPSCRIPT_SIZE) {
+                    return false;
+                }
                 if ((control_block[0] & TAPROOT_LEAF_MASK) == TAPROOT_LEAF_TAPSCRIPT) {
                     // Leaf version 0xc0 (aka Tapscript, see BIP 342)
                     for (const auto& item : stack) {

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -45,6 +45,8 @@ static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE{80};
 static constexpr unsigned int MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE{80};
 /** The maximum size in bytes of a standard witnessScript */
 static constexpr unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE{3600};
+/** The maximum size in bytes of a standard BIP 342 script (Taproot, leaf version 0xc0) */
+static constexpr unsigned int MAX_STANDARD_TAPSCRIPT_SIZE{3600};
 /** The maximum size of a standard ScriptSig */
 static constexpr unsigned int MAX_STANDARD_SCRIPTSIG_SIZE{1650};
 /** Min feerate for defining dust.

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1046,7 +1046,7 @@ def spenders_taproot_active():
     # Test that pushing a MAX_SCRIPT_ELEMENT_SIZE byte stack element is valid, but one longer is not.
     add_spender(spenders, "tapscript/pushmaxlimit", leaf="t25", **common, **SINGLE_SIG, failure={"leaf": "t26"}, **ERR_PUSH_LIMIT)
     # Test that 999-of-999 multisig works (but 1000-of-1000 triggers stack size limits)
-    add_spender(spenders, "tapscript/bigmulti", leaf="t33", **common, inputs=big_spend_inputs, num=999, failure={"leaf": "t34", "num": 1000}, **ERR_STACK_SIZE)
+    add_spender(spenders, "tapscript/bigmulti", leaf="t33", standard=False, **common, inputs=big_spend_inputs, num=999, failure={"leaf": "t34", "num": 1000}, **ERR_STACK_SIZE)
     # Test that the CLEANSTACK rule is consensus critical in tapscript
     add_spender(spenders, "tapscript/cleanstack", leaf="t36", tap=tap, inputs=[b'\x01'], failure={"inputs": [b'\x01', b'\x01']}, **ERR_CLEANSTACK)
 

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -208,6 +208,7 @@ class WalletMiniscriptTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
+        self.extra_args = [["-acceptnonstdtxn"]]
         self.rpc_timeout = 180
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -193,7 +193,7 @@ class WalletTaprootTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [['-keypool=100'], ['-keypool=100']]
+        self.extra_args = [['-acceptnonstdtxn', '-keypool=100'], ['-keypool=100']]
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
Tapscript is missing the policy size limit check. The limit is inconsistent between witness and scriptSig, so for now this uses the (higher) witness size limit.

We should probably unify these on a single limit size (and make it configurable?), but for now this just addresses the oversight the same way it is for the other checks.