### PR TITLE
build, bench, msvc: Add missing benchmarks

### DIFF
--- a/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj.in
+++ b/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj.in
@@ -10,6 +10,12 @@
   </PropertyGroup>
   <ItemGroup>
 @SOURCE_FILES@
+    <ClCompile Include="..\..\src\bench\coin_selection.cpp" />
+    <ClCompile Include="..\..\src\bench\wallet_balance.cpp" />
+    <ClCompile Include="..\..\src\bench\wallet_create.cpp" />
+    <ClCompile Include="..\..\src\bench\wallet_create_tx.cpp" />
+    <ClCompile Include="..\..\src\bench\wallet_ismine.cpp" />
+    <ClCompile Include="..\..\src\bench\wallet_loading.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoin_consensus\libbitcoin_consensus.vcxproj">

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -51,9 +51,14 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
 static void WalletCreatePlain(benchmark::Bench& bench) { WalletCreate(bench, /*encrypted=*/false); }
 static void WalletCreateEncrypted(benchmark::Bench& bench) { WalletCreate(bench, /*encrypted=*/true); }
 
+#ifndef _MSC_VER
+// TODO: Being built with MSVC, the fs::remove_all() call in
+// the WalletCreate() fails with the error "The process cannot
+// access the file because it is being used by another process."
 #ifdef USE_SQLITE
 BENCHMARK(WalletCreatePlain, benchmark::PriorityLevel::LOW);
 BENCHMARK(WalletCreateEncrypted, benchmark::PriorityLevel::LOW);
+#endif
 #endif
 
 } // namespace wallet


### PR DESCRIPTION
On the master branch, the `bench_bitcoin.vcxproj` MSVC project misses wallet-specific source files.

This PR fixes this issue.

Benchmark run on Windows:
```
> src\bench_bitcoin.exe -filter="CoinSelection|BnBExhaustion|Wallet.*"

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          398,800.00 |            2,507.52 |    1.5% |      0.01 | `BnBExhaustion`
|          584,450.00 |            1,711.01 |    1.5% |      0.01 | `CoinSelection`
|       86,603,650.00 |               11.55 |    0.4% |      1.91 | `WalletAvailableCoins`
|            7,604.00 |          131,509.73 |    0.9% |      0.01 | `WalletBalanceClean`
|          124,028.57 |            8,062.66 |    2.6% |      0.01 | `WalletBalanceDirty`
|            7,587.12 |          131,802.30 |    1.9% |      0.01 | `WalletBalanceMine`
|               48.58 |       20,583,872.99 |    0.9% |      0.01 | `WalletBalanceWatch`
|        2,371,060.00 |              421.75 |    1.3% |      0.13 | `WalletCreateTxUseOnlyPresetInputs`
|       96,861,760.00 |               10.32 |    0.9% |      5.31 | `WalletCreateTxUsePresetInputsAndCoinSelection`
|              280.71 |        3,562,424.13 |    1.5% |      0.01 | `WalletIsMineDescriptors`
|            1,033.47 |          967,618.32 |    0.3% |      0.01 | `WalletIsMineLegacy`
|              282.36 |        3,541,599.91 |    0.5% |      0.01 | `WalletIsMineMigratedDescriptors`
|      484,547,300.00 |                2.06 |    1.0% |      2.43 | `WalletLoadingDescriptors`
|       29,924,300.00 |               33.42 |    0.4% |      0.15 | `WalletLoadingLegacy`
```