### PR TITLE
ThreadSanitizer: Fix #29767

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -162,9 +162,9 @@ void BaseIndex::Sync()
             const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
             if (!pindex_next) {
                 SetBestBlockIndex(pindex);
-                m_synced = true;
                 // No need to handle errors in Commit. See rationale above.
                 Commit();
+                m_synced = true;
                 break;
             }
             if (pindex_next->pprev != pindex && !Rewind(pindex, pindex_next->pprev)) {


### PR DESCRIPTION
I think this problem https://github.com/bitcoin/bitcoin/issues/29767#issue-2216373048 is because of 
in BaseIndex::Sync
https://github.com/bitcoin/bitcoin/blob/61de64df6790077857faba84796bb874b59c5d15/src/index/base.cpp#L163-L168
Setup m_synced = true; before Commit(); 
So this may cause a race condition window to BaseIndex::BlockConnected
https://github.com/bitcoin/bitcoin/blob/61de64df6790077857faba84796bb874b59c5d15/src/index/base.cpp#L271-L274
So i try to fix it with move m_synced = true after Commit().
Also see comment of Sync():
https://github.com/bitcoin/bitcoin/blob/61de64df6790077857faba84796bb874b59c5d15/src/index/base.h#L151-L156
I am a newcomer interested in Bitcoin, trying to become a member of the Bitcoin Core development team. Please give me some feedback if you could, as I may be doing something wrong. Thank you!
