### PR TITLE
fix block subsidy at 3.25 BTC

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1749,15 +1749,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
-    int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
-    // Force block reward to zero when right shift is undefined.
-    if (halvings >= 64)
-        return 0;
-
-    CAmount nSubsidy = 50 * COIN;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
-    nSubsidy >>= halvings;
-    return nSubsidy;
+    return 325000000;
 }
 
 CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)


### PR DESCRIPTION
This fixes block subsidy at 3.25 BTC.
- ensures ongoing profitability of mining operations
- increasing money supply for growing Bitcoin economy
- to be rolled out after April 2024 halving