### PR TITLE
doc: Update the developer mailing list address.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,10 @@ Discussion about codebase improvements happens in GitHub issues and pull
 requests.
 
 The developer
-[mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
+[mailing list](https://groups.google.com/g/bitcoindev)
 should be used to discuss complicated or controversial consensus or P2P protocol changes before working on
 a patch set.
+Archives can be found on [https://gnusha.org/pi/bitcoindev/](https://gnusha.org/pi/bitcoindev/).
 
 
 Contributor Workflow

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -44,7 +44,7 @@ related to the DNS seed operation.
 If these expectations cannot be satisfied the operator should
 discontinue providing services and contact the active Bitcoin
 Core development team as well as posting on
-[bitcoin-dev](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev).
+[bitcoin-dev](https://groups.google.com/g/bitcoindev).
 
 Behavior outside of these expectations may be reasonable in some
 situations but should be discussed in public in advance.


### PR DESCRIPTION
The developer mailing list was migrated to Google Groups in February 2024 as announced in https://groups.google.com/g/bitcoindev/c/aewBuV6k-LI.

In this patch, I decided to add a link to the [archives maintained by the Linux Foundation](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/) as linked in the [old mailing list page](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev).

A reasonable alternative would be link to the [new archives](https://gnusha.org/pi/bitcoindev/) linked in the [migration announcement message](https://groups.google.com/g/bitcoindev/c/aewBuV6k-LI). I'm not sure about the status of the archive migration, probably the old archives are more comprehensive to this date.
