### PR TITLE
ci: Temporarily disable bpfcc-tools

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 # Only install BCC tracing packages in Cirrus CI.
 if [[ "${CIRRUS_CI}" == "true" ]]; then
-  BPFCC_PACKAGE="bpfcc-tools linux-headers-$(uname --kernel-release)"
+  BPFCC_PACKAGE="" # Temporarily disabled "bpfcc-tools linux-headers-$(uname --kernel-release)"
   export CI_CONTAINER_CAP="--privileged -v /sys/kernel:/sys/kernel:rw"
 else
   BPFCC_PACKAGE=""


### PR DESCRIPTION
This works around package install errors, such as https://github.com/bitcoin/bitcoin/runs/23354020361. Should be possible to reproduce locally via `apt update && apt install bpfcc-tools` on noble:

```
 python3-bpfcc : Depends: libbpfcc (>= 0.29.1+ds-1ubuntu4) but it is not going to be installed