### PR TITLE
doc: i2p: improve `-i2pacceptincoming` mention

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -79,8 +79,8 @@ one of the networks has issues.
 ## Persistent vs transient I2P addresses
 
 The first time Bitcoin Core connects to the I2P router, it automatically
-generates a persistent I2P address and its corresponding private key by default
-or if `-i2pacceptincoming=1` is set.  The private key is saved in a file named
+generates a persistent I2P address and its corresponding private key by default,
+unless `-i2pacceptincoming=0` is set.  The private key is saved in a file named
 `i2p_private_key` in the Bitcoin Core data directory.  The persistent I2P
 address is used for making outbound connections and accepting inbound
 connections.


### PR DESCRIPTION
In i2p documentation, it says that "the first time Bitcoin Core connects to the I2P router, 
it automatically generates a persistent I2P address and its corresponding private key by 
default _**or if `-i2pacceptincoming=1` is set**_". This is weird, because `-i2pacceptincoming=1` 
by itself does not have any effect. Moreover, `-i2pacceptincoming` is 1 by default anyway.