### PR TITLE
depends: suggest GNU patch for macOS <= 13

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -44,6 +44,13 @@ Common `host-platform-triplet`s for cross compilation are:
 
 The paths are automatically configured and no other options are needed unless targeting [Android](../doc/build-android.md).
 
+### Install the required dependencies: macOS
+
+If building BerkeleyDB fails on macOS 13 or older, install the GNU version
+of patch:
+
+    brew install gpatch
+
 ### Install the required dependencies: Ubuntu & Debian
 
 #### For macOS cross compilation


### PR DESCRIPTION
Fixes #29792

Adds a note to `depends/README.md` that on older versions of macOS you _may_ need to use GNU patch. I phrased as a troubleshooting hint, rather than make it a default recommendation, because:

1. so far only I ran into it, and fanquake couldn't reproduce
2. BDB is only used for the legacy wallet, which itself is deprecated
3. it seems better to replace as few default tools on macOS as possible

The instructions in `build-osx.md` don't even mention depends, so I don't touch those here.