### PR TITLE
refactor, bench, fuzz: Drop unneeded `UCharCast` calls

### DIFF
--- a/src/bench/bip324_ecdh.cpp
+++ b/src/bench/bip324_ecdh.cpp
@@ -27,7 +27,7 @@ static void BIP324_ECDH(benchmark::Bench& bench)
 
     bench.batch(1).unit("ecdh").run([&] {
         CKey key;
-        key.Set(UCharCast(key_data.data()), UCharCast(key_data.data()) + 32, true);
+        key.Set(key_data.data(), key_data.data() + 32, true);
         EllSwiftPubKey our_ellswift(our_ellswift_data);
         EllSwiftPubKey their_ellswift(their_ellswift_data);
 

--- a/src/bench/ellswift.cpp
+++ b/src/bench/ellswift.cpp
@@ -17,7 +17,7 @@ static void EllSwiftCreate(benchmark::Bench& bench)
     bench.batch(1).unit("pubkey").run([&] {
         auto ret = key.EllSwiftCreate(MakeByteSpan(entropy));
         /* Use the first 32 bytes of the ellswift encoded public key as next private key. */
-        key.Set(UCharCast(ret.data()), UCharCast(ret.data()) + 32, true);
+        key.Set(ret.data(), ret.data() + 32, true);
         assert(key.IsValid());
         /* Use the last 32 bytes of the ellswift encoded public key as next entropy. */
         std::copy(ret.begin() + 32, ret.begin() + 64, MakeWritableByteSpan(entropy).begin());

--- a/src/test/fuzz/util/descriptor.cpp
+++ b/src/test/fuzz/util/descriptor.cpp
@@ -15,7 +15,7 @@ void MockedDescriptorConverter::Init() {
         // an extended one.
         if (IdIsCompPubKey(i) || IdIsUnCompPubKey(i) || IdIsXOnlyPubKey(i) || IdIsConstPrivKey(i)) {
             CKey privkey;
-            privkey.Set(UCharCast(key_data.begin()), UCharCast(key_data.end()), !IdIsUnCompPubKey(i));
+            privkey.Set(key_data.begin(), key_data.end(), !IdIsUnCompPubKey(i));
             if (IdIsCompPubKey(i) || IdIsUnCompPubKey(i)) {
                 CPubKey pubkey{privkey.GetPubKey()};
                 keys_str[i] = HexStr(pubkey);


### PR DESCRIPTION
The `CKey::Set()` template function handles `std::byte` just fine: https://github.com/bitcoin/bitcoin/blob/b5d21182e5a66110ce2796c2c99da39c8ebf0d72/src/key.h#L105

Noticed in https://github.com/bitcoin/bitcoin/pull/29774#discussion_r1546288181.

