### PR TITLE
fuzz: Some `test/fuzz/test_runner.py` improvements

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -104,7 +104,7 @@ def main():
         logging.error("Must have fuzz executable built")
         sys.exit(1)
 
-    fuzz_bin=os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz')
+    fuzz_bin=os.getenv("BITCOINFUZZ", default=os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'))
 
     # Build list of tests
     test_list_all = parse_test_list(


### PR DESCRIPTION
These changes are split from https://github.com/bitcoin/bitcoin/pull/29774 and can be beneficial on their own.

The new `BITCOINFUZZ` environment variable complements the already existing set of variables used by tests: https://github.com/bitcoin/bitcoin/blob/b5d21182e5a66110ce2796c2c99da39c8ebf0d72/test/functional/test_framework/test_framework.py#L238-L243