### PR TITLE
test: remove immediate tx relay workaround in wallet_groups.py

### DIFF
--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -42,11 +42,6 @@ class WalletGroupTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Setting up")
-        # To take full use of immediate tx relay, all nodes need to be reachable
-        # via inbound peers, i.e. connect first to last to close the circle
-        # (the default test network topology looks like this:
-        #  node0 <-- node1 <-- node2 <-- node3 <-- node4 <-- node5)
-        self.connect_nodes(0, self.num_nodes - 1)
         # Mine some coins
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 


### PR DESCRIPTION
Reverts commit ab4efad51b9ba276ffeb6871931e13772493f7cc (PR #26970). This workaround is not needed anymore, as since #27114 the test sets the noban permission for both in- and outbound connections via the `noban_tx_relay` setting, and we don't have to rely on this topology hack anymore. See commit c985eb854cc86deb747caea5283c17cf51b6a983 (kudos to brunoerg!).

Can be tested by executing `$ time ./test/functional/wallet_groups.py` both on master and PR and verifying that the execution time is roughly equal.