### PR TITLE
guix: remove `gcc-toolchain static` from Windows build

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -75,9 +75,8 @@ export OBJC_INCLUDE_PATH="${NATIVE_GCC}/include"
 export OBJCPLUS_INCLUDE_PATH="${NATIVE_GCC}/include/c++:${NATIVE_GCC}/include"
 
 case "$HOST" in
-    *darwin*)
-        export LIBRARY_PATH="${NATIVE_GCC}/lib"
-        ;;
+    *darwin*) export LIBRARY_PATH="${NATIVE_GCC}/lib" ;;
+    *mingw*) export LIBRARY_PATH="${NATIVE_GCC}/lib" ;;
     *)
         NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
         export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -517,7 +517,6 @@ inspecting signatures in Mach-O binaries.")
     (cond ((string-suffix? "-mingw32" target)
            (list ;; Native GCC 12 toolchain
                  gcc-toolchain-12
-                 (list gcc-toolchain-12 "static")
                  zip
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
                  nsis-x86_64


### PR DESCRIPTION
The libs in this dir are the following:
```bash
ls /gnu/store/2vnbkrdin4rrf7ygnr80mlcglin4qqa4-gcc-toolchain-12.3.0-static/lib/
libanl.a           libc.a             libdl.a         libm.a
libBrokenLocale.a  libcrypt.a         libg.a          libmcheck.a
libpthread.a       librt.a
libresolv.a        libutil.a
```

These do not need to be propogated into the Windows build environment.

Guix Build (aarch64):
```bash
450c0c4f45f9cb7ed7fc2ef6e7557b6a23004b82c951399da3b7635e8451a076  guix-build-05da2460db89/output/dist-archive/bitcoin-05da2460db89.tar.gz
5df68ab18636090c387bc90297356d0e148b02931d3a99c0f6d33cd268aa072b  guix-build-05da2460db89/output/x86_64-w64-mingw32/SHA256SUMS.part
13e979f60d9296aa11081fbbb360404da9fbb797bb4663ed2d1189d800659b4f  guix-build-05da2460db89/output/x86_64-w64-mingw32/bitcoin-05da2460db89-win64-debug.zip
d1cc78437a96f012a59af7c757bef592f163559e523d45014d7804d0be29a8b8  guix-build-05da2460db89/output/x86_64-w64-mingw32/bitcoin-05da2460db89-win64-setup-unsigned.exe
33a9cfd4475677646bb32c9c45c25bd796ca5adb126590bf556d4e6f9592c676  guix-build-05da2460db89/output/x86_64-w64-mingw32/bitcoin-05da2460db89-win64-unsigned.tar.gz
5d2ee251668d3d31bf378826ab06f98542dd20926cdee2df5c3315e11222a519  guix-build-05da2460db89/output/x86_64-w64-mingw32/bitcoin-05da2460db89-win64.zip
```

Somewhat similar to #29673.