### PR TITLE
i2p: fix and improve logs

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -146,7 +146,7 @@ bool Session::Listen(Connection& conn)
         conn.sock = StreamAccept();
         return true;
     } catch (const std::runtime_error& e) {
-        Log("Error listening: %s", e.what());
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Error, "Couldn't listen: %s\n", e.what());
         CheckControlSock();
     }
     return false;
@@ -202,7 +202,7 @@ bool Session::Accept(Connection& conn)
         return true;
     }
 
-    Log("Error accepting%s: %s", disconnect ? " (will close the session)" : "", errmsg);
+    LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Error accepting%s: %s\n", disconnect ? " (will close the session)" : "", errmsg);
     if (disconnect) {
         LOCK(m_mutex);
         Disconnect();
@@ -217,7 +217,7 @@ bool Session::Connect(const CService& to, Connection& conn, bool& proxy_error)
     // Refuse connecting to arbitrary ports. We don't specify any destination port to the SAM proxy
     // when connecting (SAM 3.1 does not use ports) and it forces/defaults it to I2P_SAM31_PORT.
     if (to.GetPort() != I2P_SAM31_PORT) {
-        Log("Error connecting to %s, connection refused due to arbitrary port %s", to.ToStringAddrPort(), to.GetPort());
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Error connecting to %s, connection refused due to arbitrary port %s\n", to.ToStringAddrPort(), to.GetPort());
         proxy_error = false;
         return false;
     }
@@ -265,7 +265,7 @@ bool Session::Connect(const CService& to, Connection& conn, bool& proxy_error)
 
         throw std::runtime_error(strprintf("\"%s\"", connect_reply.full));
     } catch (const std::runtime_error& e) {
-        Log("Error connecting to %s: %s", to.ToStringAddrPort(), e.what());
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Error connecting to %s: %s\n", to.ToStringAddrPort(), e.what());
         CheckControlSock();
         return false;
     }
@@ -281,12 +281,6 @@ std::string Session::Reply::Get(const std::string& key) const
             strprintf("Missing %s= in the reply to \"%s\": \"%s\"", key, request, full));
     }
     return pos->second.value();
-}
-
-template <typename... Args>
-void Session::Log(const std::string& fmt, const Args&... args) const
-{
-    LogPrint(BCLog::I2P, "%s\n", tfm::format(fmt, args...));
 }
 
 Session::Reply Session::SendRequestAndGetReply(const Sock& sock,
@@ -344,7 +338,7 @@ void Session::CheckControlSock()
 
     std::string errmsg;
     if (m_control_sock && !m_control_sock->IsConnected(errmsg)) {
-        Log("Control socket error: %s", errmsg);
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Control socket error: %s\n", errmsg);
         Disconnect();
     }
 }
@@ -414,7 +408,7 @@ void Session::CreateIfNotCreatedAlready()
     const auto session_type = m_transient ? "transient" : "persistent";
     const auto session_id = GetRandHash().GetHex().substr(0, 10); // full is overkill, too verbose in the logs
 
-    Log("Creating %s SAM session %s with %s", session_type, session_id, m_control_host.ToString());
+    LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Creating %s SAM session %s with %s\n", session_type, session_id, m_control_host.ToString());
 
     auto sock = Hello();
 
@@ -451,7 +445,7 @@ void Session::CreateIfNotCreatedAlready()
     m_session_id = session_id;
     m_control_sock = std::move(sock);
 
-    Log("%s SAM session %s created, my address=%s",
+    LogPrintLevel(BCLog::I2P, BCLog::Level::Info, "%s SAM session %s created, my address=%s\n",
         Capitalize(session_type),
         m_session_id,
         m_my_addr.ToStringAddrPort());
@@ -482,9 +476,9 @@ void Session::Disconnect()
 {
     if (m_control_sock) {
         if (m_session_id.empty()) {
-            Log("Destroying incomplete SAM session");
+            LogPrintLevel(BCLog::I2P, BCLog::Level::Info, "Destroying incomplete SAM session\n");
         } else {
-            Log("Destroying SAM session %s", m_session_id);
+            LogPrintLevel(BCLog::I2P, BCLog::Level::Info, "Destroying SAM session %s\n", m_session_id);
         }
         m_control_sock.reset();
     }

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -202,7 +202,11 @@ bool Session::Accept(Connection& conn)
         return true;
     }
 
-    LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Error accepting%s: %s\n", disconnect ? " (will close the session)" : "", errmsg);
+    if (*m_interrupt) {
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Accept was interrupted\n");
+    } else {
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Debug, "Error accepting%s: %s\n", disconnect ? " (will close the session)" : "", errmsg);
+    }
     if (disconnect) {
         LOCK(m_mutex);
         Disconnect();

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -157,14 +157,6 @@ private:
     };
 
     /**
-     * Log a message in the `BCLog::I2P` category.
-     * @param[in] fmt printf(3)-like format string.
-     * @param[in] args printf(3)-like arguments that correspond to `fmt`.
-     */
-    template <typename... Args>
-    void Log(const std::string& fmt, const Args&... args) const;
-
-    /**
      * Send request and get a reply from the SAM proxy.
      * @param[in] sock A socket that is connected to the SAM proxy.
      * @param[in] request Raw request to send, a newline terminator is appended to it.


### PR DESCRIPTION
This PR improves and fixes i2p logs (joint work with vasild). 

- It replaces `LogPrint` to `LogPrintLevel` so we can log according to the severity.
- Fix log when interruption happens during `Accept`. Before this PR, when an interruption happens, it just logs "Error accepting:", no reason is logged as it does for other situations. This PR changes it to log "Accept interrupted".
- Log errors according to the severity. Stuff like creating SAM session, destroying SAM session, etc... are logged as 'debug'.