### PR TITLE
Feature: Use different datadirs for different signets

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -5,6 +5,7 @@
 
 #include <common/args.h>
 
+#include <hash.h>
 #include <chainparamsbase.h>
 #include <common/settings.h>
 #include <logging.h>
@@ -283,6 +284,18 @@ fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value)
     return result.has_filename() ? result : result.parent_path();
 }
 
+fs::path ArgsManager::GetSignetDataDir() const
+{
+    const std::string base_data_dir = BaseParams().DataDir();
+    const std::string signet_challenge_str = GetArg("-signetchallenge", "");
+    if (!signet_challenge_str.empty()) {
+        std::vector<uint8_t> signet_challenge = ParseHex(signet_challenge_str);
+        const auto data_dir_suffix = HexStr(Hash160(signet_challenge)).substr(0, 8);
+        return fs::PathFromString(base_data_dir + "_" + data_dir_suffix);
+    }
+    return fs::PathFromString(base_data_dir);
+}
+
 fs::path ArgsManager::GetBlocksDirPath() const
 {
     LOCK(cs_args);
@@ -302,7 +315,12 @@ fs::path ArgsManager::GetBlocksDirPath() const
         path = GetDataDirBase();
     }
 
-    path /= fs::PathFromString(BaseParams().DataDir());
+    if (GetChainType() == ChainType::SIGNET) {
+        path /= GetSignetDataDir();
+    } else {
+        path /= fs::PathFromString(BaseParams().DataDir());
+    }
+
     path /= "blocks";
     fs::create_directories(path);
     return path;
@@ -328,7 +346,11 @@ fs::path ArgsManager::GetDataDir(bool net_specific) const
     }
 
     if (net_specific && !BaseParams().DataDir().empty()) {
-        path /= fs::PathFromString(BaseParams().DataDir());
+        if (GetChainType() == ChainType::SIGNET) {
+            path /= GetSignetDataDir();
+        } else {
+            path /= fs::PathFromString(BaseParams().DataDir());
+        }
     }
 
     return path;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -214,6 +214,14 @@ protected:
     std::optional<const Command> GetCommand() const;
 
     /**
+     * Get signet data directory path.
+     * If a signet-challenge argument is provided, it is used in constructing the directory path.
+     *
+     * @return The path to the signet data directory.
+    */
+    fs::path GetSignetDataDir() const;
+
+    /**
      * Get blocks directory path
      *
      * @return Blocks path which is network specific

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -5,6 +5,7 @@
 """Test basic signet functionality"""
 
 from decimal import Decimal
+from os import path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -100,6 +101,23 @@ class SignetBasicTest(BitcoinTestFramework):
         self.log.info("pregenerated signet blocks check (incompatible solution)")
 
         assert_equal(self.nodes[4].submitblock(signet_blocks[0]), 'bad-signet-blksig')
+
+        def assert_node_datadir(node, expected_dirname):
+            datadir = node.chain_path
+            self.log.info(f"Checking node datadir: {datadir}")
+            assert_equal(path.basename(datadir), expected_dirname)
+
+            assert datadir.is_dir() # check if the directory exists
+
+            #check if the directory is being used
+            rpc_log_path = node.getrpcinfo()['logpath']
+            assert rpc_log_path.startswith(str(datadir))
+
+        self.log.info("Test that the signet data directory with -signetchallenge=51 is 'signet_da1745e9'")
+        assert_node_datadir(self.nodes[0], "signet_da1745e9")
+
+        self.log.info("Test that the main signet data directory is 'signet'")
+        assert_node_datadir(self.nodes[3], "signet")
 
         self.log.info("test that signet logs the network magic on node start")
         with self.nodes[0].assert_debug_log(["Signet derived magic (message start)"]):

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -134,7 +134,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(self.nodes[0].cli("-named", "echo", "arg0=0", "arg1=1", "arg2=2", "arg1=3").send_cli(), ['0', '3', '2'])
         assert_raises_rpc_error(-8, "Parameter args specified multiple times", self.nodes[0].cli("-named", "echo", "args=[0,1,2,3]", "4", "5", "6", ).send_cli)
 
-        user, password = get_auth_cookie(self.nodes[0].datadir_path, self.chain)
+        user, password = get_auth_cookie(self.nodes[0].datadir_path, self.nodes[0].get_chain())
 
         self.log.info("Test -stdinrpcpass option")
         assert_equal(BLOCKS, self.nodes[0].cli(f'-rpcuser={user}', '-stdinrpcpass', input=password).getblockcount())

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -72,7 +72,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.nodes[0].rpchost = None
         self.start_nodes([node_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir_path, 0, self.chain, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
+        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir_path, 0, self.nodes[0].get_chain(), "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -40,6 +40,7 @@ from .util import (
     wait_until_helper_internal,
     wallet_importprivkey,
 )
+from .script import hash160
 
 
 class TestStatus(Enum):
@@ -499,10 +500,20 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 i,
                 get_datadir_path(self.options.tmpdir, i),
                 **init)
+            if self.chain == "signet":
+                test_node_i.signet_chain = self.get_signet_chain(args)
             self.nodes.append(test_node_i)
             if not test_node_i.version_is_at_least(170000):
                 # adjust conf for pre 17
                 test_node_i.replace_in_config([('[regtest]', '')])
+
+    def get_signet_chain(self, args):
+        for arg in args:
+            if arg.startswith('-signetchallenge'):
+                signetchallenge = arg.split('=')[1]
+                data_dir_suffix = hash160(bytes.fromhex(signetchallenge)).hex()[0:8]
+                return f"signet_{data_dir_suffix}"
+        return 'signet'
 
     def start_node(self, i, *args, **kwargs):
         """Start a bitcoind"""

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -105,6 +105,7 @@ class TestNode():
         self.stdout_dir = self.datadir_path / "stdout"
         self.stderr_dir = self.datadir_path / "stderr"
         self.chain = chain
+        self.signet_chain = ""
         self.rpchost = rpchost
         self.rpc_timeout = timewait  # Already multiplied by timeout_factor
         self.timeout_factor = timeout_factor
@@ -215,6 +216,9 @@ class TestNode():
             AddressKeyPair('mzRe8QZMfGi58KyWCse2exxEFry2sfF2Y7', 'cPiRWE8KMjTRxH1MWkPerhfoHFn5iHPWVK5aPqjW8NxmdwenFinJ'),
     ]
 
+    def get_chain(self):
+        return self.signet_chain if self.signet_chain and self.chain == 'signet' else self.chain
+
     def get_deterministic_priv_key(self):
         """Return a deterministic priv key in base58, that only depends on the node's index"""
         assert len(self.PRIV_KEYS) == MAX_NODES
@@ -317,7 +321,7 @@ class TestNode():
                     f'bitcoind exited with status {self.process.returncode} during initialization. {str_error}'))
             try:
                 rpc = get_rpc_proxy(
-                    rpc_url(self.datadir_path, self.index, self.chain, self.rpchost),
+                    rpc_url(self.datadir_path, self.index, self.get_chain(), self.rpchost),
                     self.index,
                     timeout=self.rpc_timeout // 2,  # Shorter timeout to allow for one retry in case of ETIMEDOUT
                     coveragedir=self.coverage_dir,
@@ -392,7 +396,7 @@ class TestNode():
         poll_per_s = 4
         for _ in range(poll_per_s * self.rpc_timeout):
             try:
-                get_auth_cookie(self.datadir_path, self.chain)
+                get_auth_cookie(self.datadir_path, self.get_chain())
                 self.log.debug("Cookie credentials successfully retrieved")
                 return
             except ValueError:  # cookie file not found and no rpcuser or rpcpassword; bitcoind is still starting
@@ -517,7 +521,7 @@ class TestNode():
 
     @property
     def chain_path(self) -> Path:
-        return self.datadir_path / self.chain
+        return self.datadir_path / self.get_chain()
 
     @property
     def debug_log_path(self) -> Path:


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/27494

When the `-signetchallenge` argument is provided, the hash-160 of the challenge is appended to the data directory name. This ensures that each signet has its own distinct data directory, following the naming convention `signet_XXXXXXX`.

Note:
The behaviour of the default signet remains unchanged

### Update:

When the `-signetchallenge` argument is provided, `the first 8 characters of the hash-160 of the challenge` are appended to the data directory name. This ensures that each signet has its own distinct data directory, following the naming convention `signet_XXXXXXX`.

