### PR TITLE
Fix typos in `subprocess.hpp`

### DIFF
--- a/src/util/subprocess.hpp
+++ b/src/util/subprocess.hpp
@@ -1,6 +1,8 @@
+// Based on the https://github.com/arun11299/cpp-subprocess project.
+
 /*!
 
-Documentation for C++ subprocessing libraray.
+Documentation for C++ subprocessing library.
 
 @copyright The code is licensed under the [MIT
   License](http://opensource.org/licenses/MIT):
@@ -106,7 +108,7 @@ namespace subprocess {
 // from pipe
 static const size_t SP_MAX_ERR_BUF_SIZ = 1024;
 
-// Default buffer capcity for OutBuffer and ErrBuffer.
+// Default buffer capacity for OutBuffer and ErrBuffer.
 // If the data exceeds this capacity, the buffer size is grown
 // by 1.5 times its previous capacity
 static const size_t DEFAULT_BUF_CAP_BYTES = 8192;
@@ -312,8 +314,8 @@ namespace util
   inline env_map_t MapFromWindowsEnvironment(){
       wchar_t *variable_strings_ptr;
       wchar_t *environment_strings_ptr;
-      std::wstring delimeter(L"=");
-      int del_len = delimeter.length();
+      std::wstring delimiter(L"=");
+      int del_len = delimiter.length();
       env_map_t mapped_environment;
 
       // Get a pointer to the environment block.
@@ -335,7 +337,7 @@ namespace util
           // Create a string from Variable String
           env_string_t current_line(variable_strings_ptr);
           // Find the first "equals" sign.
-          auto pos = current_line.find(delimeter);
+          auto pos = current_line.find(delimiter);
           // Assuming it's not missing ...
           if(pos!=std::wstring::npos){
               // ... parse the key and value.
@@ -433,8 +435,8 @@ namespace util
    * Function: join
    * Parameters:
    * [in] vec : Vector of strings which needs to be joined to form
-   *            a single string with words seperated by a seperator char.
-   *  [in] sep : String used to seperate 2 words in the joined string.
+   *            a single string with words separated by a separator char.
+   *  [in] sep : String used to separate 2 words in the joined string.
    *             Default constructed to ' ' (space).
    *  [out] string: Joined string.
    */
@@ -655,7 +657,7 @@ namespace util
  * Default value is 0.
  */
 struct bufsize {
-  explicit bufsize(int siz): bufsiz(siz) {}
+  explicit bufsize(int sz): bufsiz(sz) {}
   int  bufsiz = 0;
 };
 
@@ -711,7 +713,7 @@ struct string_arg
 };
 
 /*!
- * Option to specify the executable name seperately
+ * Option to specify the executable name separately
  * from the args sequence.
  * In this case the cmd args must only contain the
  * options required for this executable.
@@ -728,7 +730,7 @@ struct executable: string_arg
  * Option to set the current working directory
  * of the spawned process.
  *
- * Eg: cwd{"/som/path/x"}
+ * Eg: cwd{"/some/path/x"}
  */
 struct cwd: string_arg
 {
@@ -852,7 +854,7 @@ struct error
     wr_ch_ = fd;
   }
   explicit error(IOTYPE typ) {
-    assert ((typ == PIPE || typ == STDOUT) && "STDERR not aloowed");
+    assert ((typ == PIPE || typ == STDOUT) && "STDERR not allowed");
     if (typ == PIPE) {
 #ifndef __USING_WINDOWS__
       std::tie(rd_ch_, wr_ch_) = util::pipe_cloexec();
@@ -874,7 +876,7 @@ struct error
 // ATTN: Can be used only to execute functions with no
 // arguments and returning void.
 // Could have used more efficient methods, ofcourse, but
-// that wont yield me the consistent syntax which I am
+// that won't yield me the consistent syntax which I am
 // aiming for. If you know, then please do let me know.
 
 class preexec_func
@@ -1211,10 +1213,10 @@ private:
  * 9. communicate(...)   - Get the output/error from the child and close the channels
  *                         from the parent side.
  *10. input()            - Get the input channel/File pointer. Can be used for
- *                         cutomizing the way of sending input to child.
+ *                         customizing the way of sending input to child.
  *11. output()           - Get the output channel/File pointer. Usually used
                            in case of redirection. See piping examples.
- *12. error()            - Get the error channel/File poiner. Usually used
+ *12. error()            - Get the error channel/File pointer. Usually used
                            in case of redirection.
  *13. start_process()    - Start the child process. Only to be used when
  *                         `defer_spawn` option was provided in Popen constructor.
@@ -1358,7 +1360,7 @@ private:
 
   // Command in string format
   std::string args_;
-  // Comamnd provided as sequence
+  // Command provided as sequence
   std::vector<std::string> vargs_;
   std::vector<char*> cargv_;
 

--- a/test/lint/lint-spelling.py
+++ b/test/lint/lint-spelling.py
@@ -14,7 +14,7 @@ from subprocess import check_output, STDOUT, CalledProcessError
 from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 
 IGNORE_WORDS_FILE = 'test/lint/spelling.ignore-words.txt'
-FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/guix/patches", ":(exclude)src/util/subprocess.hpp"]
+FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/guix/patches"]
 FILES_ARGS += [f":(exclude){dir}" for dir in SHARED_EXCLUDED_SUBTREES]
 
 


### PR DESCRIPTION
Resolves one item in the https://github.com/bitcoin/bitcoin/pull/28981#pullrequestreview-1991272752:
>    - Remove linter exclusions and fix all issues.

Based on upstream https://github.com/arun11299/cpp-subprocess/pull/101.