### PR TITLE
util: remove unused cpp-subprocess options

### DIFF
--- a/src/util/subprocess.hpp
+++ b/src/util/subprocess.hpp
@@ -155,19 +155,6 @@ public:
 };
 
 //--------------------------------------------------------------------
-
-//Environment Variable types
-#ifndef _MSC_VER
-	using env_string_t = std::string;
-	using env_char_t = char;
-#else
-	using env_string_t = std::wstring;
-	using env_char_t = wchar_t;
-#endif
-using env_map_t = std::map<env_string_t, env_string_t>;
-using env_vector_t = std::vector<env_char_t>;
-
-//--------------------------------------------------------------------
 namespace util
 {
   template <typename R>
@@ -305,100 +292,6 @@ namespace util
     if (!SetHandleInformation(*child_handle, HANDLE_FLAG_INHERIT, 0))
       throw OSError("SetHandleInformation", 0);
   }
-
-  // env_map_t MapFromWindowsEnvironment()
-  // * Imports current Environment in a C-string table
-  // * Parses the strings by splitting on the first "=" per line
-  // * Creates a map of the variables
-  // * Returns the map
-  inline env_map_t MapFromWindowsEnvironment(){
-      wchar_t *variable_strings_ptr;
-      wchar_t *environment_strings_ptr;
-      std::wstring delimiter(L"=");
-      int del_len = delimiter.length();
-      env_map_t mapped_environment;
-
-      // Get a pointer to the environment block.
-      environment_strings_ptr = GetEnvironmentStringsW();
-      // If the returned pointer is NULL, exit.
-      if (environment_strings_ptr == NULL)
-      {
-          throw OSError("GetEnvironmentStringsW", 0);
-      }
-
-      // Variable strings are separated by NULL byte, and the block is
-      // terminated by a NULL byte.
-
-      variable_strings_ptr = (wchar_t *) environment_strings_ptr;
-
-      //Since the environment map ends with a null, we can loop until we find it.
-      while (*variable_strings_ptr)
-      {
-          // Create a string from Variable String
-          env_string_t current_line(variable_strings_ptr);
-          // Find the first "equals" sign.
-          auto pos = current_line.find(delimiter);
-          // Assuming it's not missing ...
-          if(pos!=std::wstring::npos){
-              // ... parse the key and value.
-              env_string_t key = current_line.substr(0, pos);
-              env_string_t value = current_line.substr(pos + del_len);
-              // Map the entry.
-              mapped_environment[key] = value;
-          }
-          // Jump to next line in the environment map.
-          variable_strings_ptr += std::wcslen(variable_strings_ptr) + 1;
-      }
-      // We're done with the old environment map buffer.
-      FreeEnvironmentStringsW(environment_strings_ptr);
-
-      // Return the map.
-      return mapped_environment;
-  }
-
-  // env_vector_t WindowsEnvironmentVectorFromMap(const env_map_t &source_map)
-  // * Creates a vector buffer for the new environment string table
-  // * Copies in the mapped variables
-  // * Returns the vector
-  inline env_vector_t WindowsEnvironmentVectorFromMap(const env_map_t &source_map)
-  {
-	// Make a new environment map buffer.
-	env_vector_t environment_map_buffer;
-	// Give it some space.
-	environment_map_buffer.reserve(4096);
-
-	// And fill'er up.
-	for(auto kv: source_map){
-	  // Create the line
-	  env_string_t current_line(kv.first); current_line += L"="; current_line += kv.second;
-	  // Add the line to the buffer.
-	  std::copy(current_line.begin(), current_line.end(), std::back_inserter(environment_map_buffer));
-	  // Append a null
-	  environment_map_buffer.push_back(0);
-	}
-	// Append one last null because of how Windows does it's environment maps.
-	environment_map_buffer.push_back(0);
-
-	return environment_map_buffer;
-  }
-
-  // env_vector_t CreateUpdatedWindowsEnvironmentVector(const env_map_t &changes_map)
-  // * Merges host environment with new mapped variables
-  // * Creates and returns string vector based on map
-  inline env_vector_t CreateUpdatedWindowsEnvironmentVector(const env_map_t &changes_map){
-	// Import the environment map
-	env_map_t environment_map = MapFromWindowsEnvironment();
-    // Merge in the changes with overwrite
-	for(auto& it: changes_map)
-	{
-		environment_map[it.first] = it.second;
-	}
-    // Create a Windows-usable Environment Map Buffer
-    env_vector_t environment_map_strings_vector = WindowsEnvironmentVectorFromMap(environment_map);
-
-	return environment_map_strings_vector;
-  }
-
 #endif
 
   /*!
@@ -657,22 +550,6 @@ struct executable: string_arg
 };
 
 /*!
- * Option to specify environment variables required by
- * the spawned process.
- *
- * Eg: environment{{ {"K1", "V1"}, {"K2", "V2"},... }}
- */
-struct environment
-{
-  environment(env_map_t&& env):
-    env_(std::move(env)) {}
-  explicit environment(const env_map_t& env):
-    env_(env) {}
-  env_map_t env_;
-};
-
-
-/*!
  * Used for redirecting input/output/error
  */
 enum IOTYPE {
@@ -887,7 +764,6 @@ struct ArgumentDeducer
   ArgumentDeducer(Popen* p): popen_(p) {}
 
   void set_option(executable&& exe);
-  void set_option(environment&& env);
   void set_option(input&& inp);
   void set_option(output&& out);
   void set_option(error&& err);
@@ -1214,7 +1090,6 @@ private:
 #endif
 
   std::string exe_name_;
-  env_map_t env_;
 
   // Command in string format
   std::string args_;
@@ -1335,13 +1210,6 @@ inline void Popen::kill(int sig_num)
 inline void Popen::execute_process() noexcept(false)
 {
 #ifdef __USING_WINDOWS__
-  void* environment_string_table_ptr = nullptr;
-  env_vector_t environment_string_vector;
-  if(this->env_.size()){
-	  environment_string_vector = util::CreateUpdatedWindowsEnvironmentVector(env_);
-	  environment_string_table_ptr = (void*)environment_string_vector.data();
-  }
-
   if (exe_name_.length()) {
     this->vargs_.insert(this->vargs_.begin(), this->exe_name_);
     this->populate_c_argv();
@@ -1388,7 +1256,7 @@ inline void Popen::execute_process() noexcept(false)
                             NULL,         // primary thread security attributes
                             TRUE,         // handles are inherited
                             creation_flags,	// creation flags
-                            environment_string_table_ptr,  // use provided environment
+                            NULL,         // use parent's environment
                             NULL,         // use parent's current directory
                             &siStartInfo, // STARTUPINFOW pointer
                             &piProcInfo); // receives PROCESS_INFORMATION
@@ -1493,10 +1361,6 @@ namespace detail {
     popen_->exe_name_ = std::move(exe.arg_value);
   }
 
-  inline void ArgumentDeducer::set_option(environment&& env) {
-    popen_->env_ = std::move(env.env_);
-  }
-
   inline void ArgumentDeducer::set_option(input&& inp) {
     if (inp.rd_ch_ != -1) popen_->stream_.read_from_parent_ = inp.rd_ch_;
     if (inp.wr_ch_ != -1) popen_->stream_.write_to_child_ = inp.wr_ch_;
@@ -1566,14 +1430,7 @@ namespace detail {
         close(stream.err_write_);
 
       // Replace the current image with the executable
-      if (parent_->env_.size()) {
-        for (auto& kv : parent_->env_) {
-          setenv(kv.first.c_str(), kv.second.c_str(), 1);
-        }
-        sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
-      } else {
-        sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
-      }
+      sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
 
       if (sys_ret == -1) throw OSError("execve failed", errno);
 

--- a/src/util/subprocess.hpp
+++ b/src/util/subprocess.hpp
@@ -431,26 +431,6 @@ namespace util
   }
 
 
-  /*!
-   * Function: join
-   * Parameters:
-   * [in] vec : Vector of strings which needs to be joined to form
-   *            a single string with words separated by a separator char.
-   *  [in] sep : String used to separate 2 words in the joined string.
-   *             Default constructed to ' ' (space).
-   *  [out] string: Joined string.
-   */
-  static inline
-  std::string join(const std::vector<std::string>& vec,
-                   const std::string& sep = " ")
-  {
-    std::string res;
-    for (auto& elem : vec) res.append(elem + sep);
-    res.erase(--res.end());
-    return res;
-  }
-
-
 #ifndef __USING_WINDOWS__
   /*!
    * Function: set_clo_on_exec
@@ -694,11 +674,6 @@ struct close_fds {
 struct session_leader {
   explicit session_leader(bool sl): leader_(sl) {}
   bool leader_ = false;
-};
-
-struct shell {
-  explicit shell(bool s): shell_(s) {}
-  bool shell_ = false;
 };
 
 /*!
@@ -1011,7 +986,6 @@ struct ArgumentDeducer
   void set_option(bufsize&& bsiz);
   void set_option(environment&& env);
   void set_option(defer_spawn&& defer);
-  void set_option(shell&& sh);
   void set_option(input&& inp);
   void set_option(output&& out);
   void set_option(error&& err);
@@ -1350,7 +1324,6 @@ private:
   bool defer_process_start_ = false;
   bool close_fds_ = false;
   bool has_preexec_fn_ = false;
-  bool shell_ = false;
   bool session_leader_ = false;
 
   std::string exe_name_;
@@ -1492,10 +1465,6 @@ inline void Popen::kill(int sig_num)
 inline void Popen::execute_process() noexcept(false)
 {
 #ifdef __USING_WINDOWS__
-  if (this->shell_) {
-    throw OSError("shell not currently supported on windows", 0);
-  }
-
   void* environment_string_table_ptr = nullptr;
   env_vector_t environment_string_vector;
   if(this->env_.size()){
@@ -1588,14 +1557,6 @@ inline void Popen::execute_process() noexcept(false)
   int err_rd_pipe, err_wr_pipe;
   std::tie(err_rd_pipe, err_wr_pipe) = util::pipe_cloexec();
 
-  if (shell_) {
-    auto new_cmd = util::join(vargs_);
-    vargs_.clear();
-    vargs_.insert(vargs_.begin(), {"/bin/sh", "-c"});
-    vargs_.push_back(new_cmd);
-    populate_c_argv();
-  }
-
   if (exe_name_.length()) {
     vargs_.insert(vargs_.begin(), exe_name_);
     populate_c_argv();
@@ -1676,10 +1637,6 @@ namespace detail {
 
   inline void ArgumentDeducer::set_option(defer_spawn&& defer) {
     popen_->defer_process_start_ = defer.defer;
-  }
-
-  inline void ArgumentDeducer::set_option(shell&& sh) {
-    popen_->shell_ = sh.shell_;
   }
 
   inline void ArgumentDeducer::set_option(session_leader&& sleader) {

--- a/src/util/subprocess.hpp
+++ b/src/util/subprocess.hpp
@@ -642,20 +642,6 @@ struct bufsize {
 };
 
 /*!
- * Option to close all file descriptors
- * when the child process is spawned.
- * The close fd list does not include
- * input/output/error if they are explicitly
- * set as part of the Popen arguments.
- *
- * Default value is false.
- */
-struct close_fds {
-  explicit close_fds(bool c): close_all(c) {}
-  bool close_all = false;
-};
-
-/*!
  * Base class for all arguments involving string value.
  */
 struct string_arg
@@ -929,7 +915,6 @@ struct ArgumentDeducer
   void set_option(input&& inp);
   void set_option(output&& out);
   void set_option(error&& err);
-  void set_option(close_fds&& cfds);
 
 private:
   Popen* popen_ = nullptr;
@@ -1255,8 +1240,6 @@ private:
   std::future<void> cleanup_future_;
 #endif
 
-  bool close_fds_ = false;
-
   std::string exe_name_;
   std::string cwd_;
   env_map_t env_;
@@ -1572,10 +1555,6 @@ namespace detail {
     if (err.rd_ch_ != -1) popen_->stream_.err_read_ = err.rd_ch_;
   }
 
-  inline void ArgumentDeducer::set_option(close_fds&& cfds) {
-    popen_->close_fds_ = cfds.close_all;
-  }
-
 
   inline void Child::execute_child() {
 #ifndef __USING_WINDOWS__
@@ -1621,17 +1600,6 @@ namespace detail {
 
       if (stream.err_write_ != -1 && stream.err_write_ > 2)
         close(stream.err_write_);
-
-      // Close all the inherited fd's except the error write pipe
-      if (parent_->close_fds_) {
-        int max_fd = sysconf(_SC_OPEN_MAX);
-        if (max_fd == -1) throw OSError("sysconf failed", errno);
-
-        for (int i = 3; i < max_fd; i++) {
-          if (i == err_wr_pipe_) continue;
-          close(i);
-        }
-      }
 
       // Change the working directory if provided
       if (parent_->cwd_.length()) {

--- a/src/util/subprocess.hpp
+++ b/src/util/subprocess.hpp
@@ -632,16 +632,6 @@ namespace util
  */
 
 /*!
- * The buffer size of the stdin/stdout/stderr
- * streams of the child process.
- * Default value is 0.
- */
-struct bufsize {
-  explicit bufsize(int sz): bufsiz(sz) {}
-  int  bufsiz = 0;
-};
-
-/*!
  * Base class for all arguments involving string value.
  */
 struct string_arg
@@ -910,7 +900,6 @@ struct ArgumentDeducer
 
   void set_option(executable&& exe);
   void set_option(cwd&& cwdir);
-  void set_option(bufsize&& bsiz);
   void set_option(environment&& env);
   void set_option(input&& inp);
   void set_option(output&& out);
@@ -1064,9 +1053,6 @@ public:// Yes they are public
   HANDLE g_hChildStd_ERR_Rd = nullptr;
   HANDLE g_hChildStd_ERR_Wr = nullptr;
 #endif
-
-  // Buffer size for the IO streams
-  int bufsiz_ = 0;
 
   // Pipes for communicating with child
 
@@ -1525,10 +1511,6 @@ namespace detail {
     popen_->cwd_ = std::move(cwdir.arg_value);
   }
 
-  inline void ArgumentDeducer::set_option(bufsize&& bsiz) {
-    popen_->stream_.bufsiz_ = bsiz.bufsiz;
-  }
-
   inline void ArgumentDeducer::set_option(environment&& env) {
     popen_->env_ = std::move(env.env_);
   }
@@ -1658,16 +1640,7 @@ namespace detail {
 
     for (auto& h : handles) {
       if (h == nullptr) continue;
-      switch (bufsiz_) {
-      case 0:
-        setvbuf(h, nullptr, _IONBF, BUFSIZ);
-        break;
-      case 1:
-        setvbuf(h, nullptr, _IONBF, BUFSIZ);
-        break;
-      default:
-        setvbuf(h, nullptr, _IOFBF, bufsiz_);
-      };
+      setvbuf(h, nullptr, _IONBF, BUFSIZ);
     }
   #endif
   }


### PR DESCRIPTION
The newly introduced cpp-subprocess library provides a good number of options for the `Popen` class:
https://github.com/bitcoin/bitcoin/blob/0de63b8b46eff5cda85b4950062703324ba65a80/src/util/subprocess.hpp#L1009-L1020
Some of them are either not fully implemented (`shell`, missing an implementation on Windows), implemented in an ugly way (e.g. using "Impoverished, meager, needy, truly needy version of type erasure" for `preexec_func` according to the author's own words) or simply unlikely to be ever needed for our external signer use-case (`defer_spawn`). Instead of maintaining incomplete and/or unneeded code, I'd suggest to get rid of it and only keep support for options if there is a strong reason for it.