### PR TITLE
test: Add missing Assert(mock_time_in >= 0s) to SetMockTime

### DIFF
--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -16,11 +16,11 @@
 
 void UninterruptibleSleep(const std::chrono::microseconds& n) { std::this_thread::sleep_for(n); }
 
-static std::atomic<int64_t> nMockTime(0); //!< For testing
+static std::atomic<std::chrono::seconds> g_mock_time{}; //!< For testing
 
 NodeClock::time_point NodeClock::now() noexcept
 {
-    const std::chrono::seconds mocktime{nMockTime.load(std::memory_order_relaxed)};
+    const auto mocktime{g_mock_time.load(std::memory_order_relaxed)};
     const auto ret{
         mocktime.count() ?
             mocktime :
@@ -33,12 +33,12 @@ void SetMockTime(int64_t nMockTimeIn) { SetMockTime(std::chrono::seconds{nMockTi
 void SetMockTime(std::chrono::seconds mock_time_in)
 {
     Assert(mock_time_in >= 0s);
-    nMockTime.store(mock_time_in.count(), std::memory_order_relaxed);
+    g_mock_time.store(mock_time_in, std::memory_order_relaxed);
 }
 
 std::chrono::seconds GetMockTime()
 {
-    return std::chrono::seconds(nMockTime.load(std::memory_order_relaxed));
+    return g_mock_time.load(std::memory_order_relaxed);
 }
 
 int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -29,14 +29,10 @@ NodeClock::time_point NodeClock::now() noexcept
     return time_point{ret};
 };
 
-void SetMockTime(int64_t nMockTimeIn)
-{
-    Assert(nMockTimeIn >= 0);
-    nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
-}
-
+void SetMockTime(int64_t nMockTimeIn) { SetMockTime(std::chrono::seconds{nMockTimeIn}); }
 void SetMockTime(std::chrono::seconds mock_time_in)
 {
+    Assert(mock_time_in >= 0s);
     nMockTime.store(mock_time_in.count(), std::memory_order_relaxed);
 }
 


### PR DESCRIPTION
Seems odd to have the assert in the *deprecated* function, but not in the other.

Fix this by adding it to the other, and by inlining the deprecated one.

Also, use chrono type for the global mocktime variable.