### PR TITLE
policy: restrict all TRUC (v3) transactions to 10kvB

### DIFF
--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -24,11 +24,13 @@ static constexpr unsigned int V3_DESCENDANT_LIMIT{2};
 /** Maximum number of transactions including a V3 tx and all its mempool ancestors. */
 static constexpr unsigned int V3_ANCESTOR_LIMIT{2};
 
+/** Maximum sigop-adjusted virtual size of all v3 transactions. */
+static constexpr int64_t V3_MAX_VSIZE{10000};
 /** Maximum sigop-adjusted virtual size of a tx which spends from an unconfirmed v3 transaction. */
 static constexpr int64_t V3_CHILD_MAX_VSIZE{1000};
 // These limits are within the default ancestor/descendant limits.
-static_assert(V3_CHILD_MAX_VSIZE + MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR <= DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * 1000);
-static_assert(V3_CHILD_MAX_VSIZE + MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR <= DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * 1000);
+static_assert(V3_MAX_VSIZE + V3_CHILD_MAX_VSIZE <= DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * 1000);
+static_assert(V3_MAX_VSIZE + V3_CHILD_MAX_VSIZE <= DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * 1000);
 
 /** Must be called for every transaction, even if not v3. Not strictly necessary for transactions
  * accepted through AcceptMultipleTransactions.
@@ -40,6 +42,7 @@ static_assert(V3_CHILD_MAX_VSIZE + MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR
  * 4. A v3's descendant set, including itself, must be within V3_DESCENDANT_LIMIT.
  * 5. If a v3 tx has any unconfirmed ancestors, the tx's sigop-adjusted vsize must be within
  * V3_CHILD_MAX_VSIZE.
+ * 6. A v3 tx must be within V3_MAX_VSIZE.
  *
  *
  * @param[in]   mempool_ancestors       The in-mempool ancestors of ptx.

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -125,9 +125,15 @@ void CheckMempoolV3Invariants(const CTxMemPool& tx_pool)
     for (const auto& tx_info : tx_pool.infoAll()) {
         const auto& entry = *Assert(tx_pool.GetEntry(tx_info.tx->GetHash()));
         if (tx_info.tx->nVersion == 3) {
+            // Check that special maximum virtual size is respected
+            Assert(entry.GetTxSize() <= V3_MAX_VSIZE);
+
             // Check that special v3 ancestor/descendant limits and rules are always respected
             Assert(entry.GetCountWithDescendants() <= V3_DESCENDANT_LIMIT);
             Assert(entry.GetCountWithAncestors() <= V3_ANCESTOR_LIMIT);
+            Assert(entry.GetSizeWithDescendants() <= V3_MAX_VSIZE + V3_CHILD_MAX_VSIZE);
+            Assert(entry.GetSizeWithAncestors() <= V3_MAX_VSIZE + V3_CHILD_MAX_VSIZE);
+
             // If this transaction has at least 1 ancestor, it's a "child" and has restricted weight.
             if (entry.GetCountWithAncestors() > 1) {
                 Assert(entry.GetTxSize() <= V3_CHILD_MAX_VSIZE);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -953,7 +953,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // If the new transaction is relatively small (up to 40k weight)
         // and has at most one ancestor (ie ancestor limit of 2, including
         // the new transaction), allow it if its parent has exactly the
-        // descendant limit descendants.
+        // descendant limit descendants. The transaction also cannot be v3,
+        // as its topology restrictions do not allow a second child.
         //
         // This allows protocols which rely on distrusting counterparties
         // being able to broadcast descendants of an unconfirmed transaction
@@ -967,7 +968,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             .descendant_size_vbytes = maybe_rbf_limits.descendant_size_vbytes + EXTRA_DESCENDANT_TX_SIZE_LIMIT,
         };
         const auto error_message{util::ErrorString(ancestors).original};
-        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT) {
+        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT || ws.m_ptx->nVersion == 3) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
         }
         ancestors = m_pool.CalculateMemPoolAncestors(*entry, cpfp_carve_out_limits);


### PR DESCRIPTION
Opening for discussion / conceptual review.

We like the idea of a smaller maximum transaction size because:
- It lowers potential replacement cost (i.e. harder to do Rule 3 pinning via gigantic transaction)
- They are easier to bin-pack in block template production
- They equate to a tighter memory limit in data structures that are bounded by a number of transactions (e.g. orphanage and vExtraTxnForCompact). For example, the current memory bounds for orphanage is 100KvB * 100 = 40MB, and guaranteeing 1 tx per peer would require reserving a pretty large space.

History for `MAX_STANDARD_TX_WEIGHT=100KvB` (copied from https://github.com/bitcoin/bitcoin/pull/29873#issuecomment-2115459510):
- 2010-09-13 In https://github.com/bitcoin/bitcoin/commit/3df62878c3cece15a8921fbbdee7859ee9368768 satoshi added a 100kB (MAX_BLOCK_SIZE_GEN/5 with MBS_GEN = MAX_BLOCK_SIZE/2) limit on new transactions in CreateTransaction()
- 2013-02-04 https://github.com/bitcoin/bitcoin/pull/2273 In gavin gave that constant a name, and made it apply to transaction relay as well

Lowering `MAX_STANDARD_TX_WEIGHT` for all txns is not being proposed, as there are existing apps/protocols that rely on large transactions. However, it's been brought up that we should consider this for TRUCs (which is especially designed to avoid Rule 3 pinning).

This reduction should be ok because using nVersion=3 isn't standard yet, so this wouldn't break somebody's existing use case. If we find that this is too small, we can always increase it later. Decreasing would be much more difficult.
~[Expected size of a commitment transaction](https://github.com/lightning/bolts/blob/master/03-transactions.md#expected-weight-of-the-commitment-transaction) is within (900 + 172 * 483 + 224) / 4 = 21050vB~ EDIT: this is incorrect, but perhaps not something that should affect how we choose this number.