### PR TITLE
test: Add large aligned vmov check for mingw

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -46,6 +46,7 @@ if [ ! -d "${LINT_RUNNER_PATH}" ]; then
 fi
 
 ${CI_RETRY_EXE} pip3 install \
+  capstone==4.0.2 \
   codespell==2.2.6 \
   flake8==6.1.0 \
   lief==0.13.2 \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -7,6 +7,7 @@
              (gnu packages commencement)
              (gnu packages compression)
              (gnu packages cross-base)
+             (gnu packages engineering)
              (gnu packages file)
              (gnu packages gawk)
              (gnu packages gcc)
@@ -512,6 +513,7 @@ inspecting signatures in Mach-O binaries.")
         ;; Git
         git-minimal
         ;; Tests
+        python-capstone
         python-lief)
   (let ((target (getenv "HOST")))
     (cond ((string-suffix? "-mingw32" target)


### PR DESCRIPTION
Add a check for 32-byte (256-bit) and 64-byte (512-bit) aligned AVX memory accesses (vmova instructions), which cause issues combined with a GCC stack alignment bug on Windows. This check is added to the existing symbol-check.py.

Makes use of the capstone disassembler library.

Also add a test to test the behavior of the check on a series of assembly instructions against the expected output.

Closes #28413.