### PR TITLE
test: fix intermittent failure in p2p_compactblocks_hb.py

### DIFF
--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -32,10 +32,15 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
         self.connect_nodes(peer, 0)
         self.generate(self.nodes[0], 1)
         self.disconnect_nodes(peer, 0)
-        status_to = [self.peer_info(1, i)['bip152_hb_to'] for i in range(2, 6)]
-        status_from = [self.peer_info(i, 1)['bip152_hb_from'] for i in range(2, 6)]
-        assert_equal(status_to, status_from)
-        return status_to
+
+        def status_to():
+            return [self.peer_info(1, i)['bip152_hb_to'] for i in range(2, 6)]
+
+        def status_from():
+            return [self.peer_info(i, 1)['bip152_hb_from'] for i in range(2, 6)]
+
+        self.wait_until(lambda: status_to() == status_from())
+        return status_to()
 
     def run_test(self):
         self.log.info("Testing reserved high-bandwidth mode slot for outbound peer...")


### PR DESCRIPTION
Fixes #29860

As a result of node1 receiving a block, it sends out SENDCMPCT messages to some of its peers to update the high-bandwidth status. We need to wait until those are received and processed by the peers to avoid intermittent failures. Before, we'd only wait until all peers have synced with the new block (within `generate`) which is not sufficient.

I could reproduce the failure by adding a `std::this_thread::sleep_for(std::chrono::milliseconds(1000));` sleep to the [net_processing code](https://github.com/bitcoin/bitcoin/blob/c7567d9223a927a88173ff04eeb4f54a5c02b43d/src/net_processing.cpp#L3763) that processes `NetMsgType::SENDCMPCT`.

