### PR TITLE
guix: remove bzip2 from deps

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -499,7 +499,6 @@ inspecting signatures in Mach-O binaries.")
         moreutils
         ;; Compression and archiving
         tar
-        bzip2
         gzip
         xz
         ;; Build tools

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
 $(package)_version=1.81.0
 $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
-$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
+$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.gz
+$(package)_sha256_hash=205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,8 +1,8 @@
 package=fontconfig
 $(package)_version=2.12.6
 $(package)_download_path=https://www.freedesktop.org/software/fontconfig/release/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=064b9ebf060c9e77011733ac9dc0e2ce92870b574cca2405e11f5353a683c334
 $(package)_dependencies=freetype expat
 $(package)_patches=gperf_header_regen.patch
 

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -1,8 +1,8 @@
 package=libXau
 $(package)_version=1.0.9
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=1f123d8304b082ad63a9e89376400a3b1d4c29e67e3ea07b3f659cccca690eea
 $(package)_dependencies=xproto
 
 # When updating this package, check the default value of

--- a/depends/packages/libxcb_util.mk
+++ b/depends/packages/libxcb_util.mk
@@ -1,8 +1,8 @@
 package=libxcb_util
 $(package)_version=0.4.0
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-$($(package)_version).tar.bz2
-$(package)_sha256_hash=46e49469cb3b594af1d33176cd7565def2be3fa8be4371d62271fabb5eae50e9
+$(package)_file_name=xcb-util-$($(package)_version).tar.gz
+$(package)_sha256_hash=0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7
 $(package)_dependencies=libxcb
 
 define $(package)_set_vars

--- a/depends/packages/libxcb_util_image.mk
+++ b/depends/packages/libxcb_util_image.mk
@@ -1,8 +1,8 @@
 package=libxcb_util_image
 $(package)_version=0.4.0
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-image-$($(package)_version).tar.bz2
-$(package)_sha256_hash=2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
+$(package)_file_name=xcb-util-image-$($(package)_version).tar.gz
+$(package)_sha256_hash=cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42
 $(package)_dependencies=libxcb libxcb_util
 
 define $(package)_set_vars

--- a/depends/packages/libxcb_util_keysyms.mk
+++ b/depends/packages/libxcb_util_keysyms.mk
@@ -1,8 +1,8 @@
 package=libxcb_util_keysyms
 $(package)_version=0.4.0
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-keysyms-$($(package)_version).tar.bz2
-$(package)_sha256_hash=0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
+$(package)_file_name=xcb-util-keysyms-$($(package)_version).tar.gz
+$(package)_sha256_hash=0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96
 $(package)_dependencies=libxcb xproto
 
 define $(package)_set_vars

--- a/depends/packages/libxcb_util_render.mk
+++ b/depends/packages/libxcb_util_render.mk
@@ -1,8 +1,8 @@
 package=libxcb_util_render
 $(package)_version=0.3.9
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-renderutil-$($(package)_version).tar.bz2
-$(package)_sha256_hash=c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
+$(package)_file_name=xcb-util-renderutil-$($(package)_version).tar.gz
+$(package)_sha256_hash=55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5
 $(package)_dependencies=libxcb
 
 define $(package)_set_vars

--- a/depends/packages/libxcb_util_wm.mk
+++ b/depends/packages/libxcb_util_wm.mk
@@ -1,8 +1,8 @@
 package=libxcb_util_wm
 $(package)_version=0.4.1
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-wm-$($(package)_version).tar.bz2
-$(package)_sha256_hash=28bf8179640eaa89276d2b0f1ce4285103d136be6c98262b6151aaee1d3c2a3f
+$(package)_file_name=xcb-util-wm-$($(package)_version).tar.gz
+$(package)_sha256_hash=038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334
 $(package)_dependencies=libxcb
 
 define $(package)_set_vars

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,8 +1,8 @@
 package=qrencode
 $(package)_version=4.1.1
 $(package)_download_path=https://fukuchi.org/works/qrencode/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=e455d9732f8041cf5b9c388e345a641fd15707860f928e94507b1961256a6923
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=da448ed4f52aba6bcb0cd48cac0dd51b8692bccc4cd127431402fca6f8171e8e
 $(package)_patches=cmake_fixups.patch
 
 define $(package)_set_vars

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -1,8 +1,8 @@
 package=xproto
 $(package)_version=7.0.31
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/proto
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=6d755eaae27b45c5cc75529a12855fed5de5969b367ed05003944cf901ed43c7
 
 define $(package)_set_vars
 $(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs


### PR DESCRIPTION
This moves packages in depends that use `.tar.bzip2` to `.tar.gz` (which is what we use for our own release tarballs). Doing so means we can drop `bzip2` from our Guix release env. You can observe that Guix building master without it would currently fail:
```diff
diff --git a/contrib/guix/manifest.scm b/contrib/guix/manifest.scm
index 8f13c642d3..96818c7748 100644
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -499,7 +499,6 @@ inspecting signatures in Mach-O binaries.")
         moreutils
         ;; Compression and archiving
         tar
-        bzip2
         gzip
         xz
         ;; Build tools
```
`FORCE_DIRTY_WORKTREE=1 ./contrib/guix/guix-build`
```bash
Extracting boost...
/sources/boost_1_81_0.tar.bz2: OK
tar (child): lbzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

Guix Build:
```bash
8f6959d01ae972bae1340dfaf18753607152eca9844e6d8c4fa128314a4ba762  guix-build-b8e084b9781e/output/aarch64-linux-gnu/SHA256SUMS.part
3c9c1cc000e3e6b7c2853c9d530c9afa1c880a43e7ab4c766aaa88283ff0908c  guix-build-b8e084b9781e/output/aarch64-linux-gnu/bitcoin-b8e084b9781e-aarch64-linux-gnu-debug.tar.gz
f45fbece697b450538aded11f568e92b2af391e873e113c3038d022eff41688f  guix-build-b8e084b9781e/output/aarch64-linux-gnu/bitcoin-b8e084b9781e-aarch64-linux-gnu.tar.gz
08295d770c11b2057206f98aaf4123007c7475bd942840d048f5f9d5efec1ce1  guix-build-b8e084b9781e/output/arm-linux-gnueabihf/SHA256SUMS.part
0a0db6967168019b8b890ec4d31b3a87a88c4956b703938ec4447d514cfc231e  guix-build-b8e084b9781e/output/arm-linux-gnueabihf/bitcoin-b8e084b9781e-arm-linux-gnueabihf-debug.tar.gz
3d1538e8bf4edfb66a4875198dfa90b79dcfe44eb9c4e76e47d73a18175c838a  guix-build-b8e084b9781e/output/arm-linux-gnueabihf/bitcoin-b8e084b9781e-arm-linux-gnueabihf.tar.gz
87e7805155dbed3bd64763f199ea63843ed8c4eb37873753c7e60b0b42565eaf  guix-build-b8e084b9781e/output/arm64-apple-darwin/SHA256SUMS.part
fa33590296aeae2b738b023a4cbf2de4a4e06662a5f7d407c251a8af714bd587  guix-build-b8e084b9781e/output/arm64-apple-darwin/bitcoin-b8e084b9781e-arm64-apple-darwin-unsigned.tar.gz
32b8fbbdf240f9f08e44c7bb0a8ea2e8a40537e59ec2231cf6635edc6592f226  guix-build-b8e084b9781e/output/arm64-apple-darwin/bitcoin-b8e084b9781e-arm64-apple-darwin-unsigned.zip
d176f3b7c8140c8dfde03bd87fd5abd4a89b497ba11fa6849bc92a33cb621a07  guix-build-b8e084b9781e/output/arm64-apple-darwin/bitcoin-b8e084b9781e-arm64-apple-darwin.tar.gz
5273b17087e3565ab042a7989cfba71cf1629331d0267137d7eccabee1a06a13  guix-build-b8e084b9781e/output/dist-archive/bitcoin-b8e084b9781e.tar.gz
b84a9180181994a6a17a1c2a4701f8ba5a82654233d5a8afcf596d28dd8b3924  guix-build-b8e084b9781e/output/powerpc64-linux-gnu/SHA256SUMS.part
fd3396f6b64425a31b5a3565ab4d8a1c1668c291349a0f9e9b8904dad04ee24c  guix-build-b8e084b9781e/output/powerpc64-linux-gnu/bitcoin-b8e084b9781e-powerpc64-linux-gnu-debug.tar.gz
73cb4bd2a67934c93ea8e3f3bc04b8917627ec09d75c151bb01977bba97522c8  guix-build-b8e084b9781e/output/powerpc64-linux-gnu/bitcoin-b8e084b9781e-powerpc64-linux-gnu.tar.gz
15938e7f0f71303b96566d60e3b255816e7fd70d628601e592e1d6840eb8d2a1  guix-build-b8e084b9781e/output/riscv64-linux-gnu/SHA256SUMS.part
408b4973865e3a77be833438f71181fd88acd0490127257b3667309e8421030e  guix-build-b8e084b9781e/output/riscv64-linux-gnu/bitcoin-b8e084b9781e-riscv64-linux-gnu-debug.tar.gz
a5c02144ffb79cfa0179ff0d7ac0f81192ef1d3b1acfad334adf486e50b776bb  guix-build-b8e084b9781e/output/riscv64-linux-gnu/bitcoin-b8e084b9781e-riscv64-linux-gnu.tar.gz
de904843d8bb8601a2d763701ebb929e61b447e01040267a12149a2902489535  guix-build-b8e084b9781e/output/x86_64-apple-darwin/SHA256SUMS.part
414cb3cf3fa10b9a3cda47e98858222f01fdd164371dd54761642e6793099849  guix-build-b8e084b9781e/output/x86_64-apple-darwin/bitcoin-b8e084b9781e-x86_64-apple-darwin-unsigned.tar.gz
6ce43d7f007bf17eca16d3ee48190318e09aacd82c5396f9565e6345ec6bd2fa  guix-build-b8e084b9781e/output/x86_64-apple-darwin/bitcoin-b8e084b9781e-x86_64-apple-darwin-unsigned.zip
24eba9c0dd1312a68c2b2a800cc915595e343c0ead982b6cbe025abe7a7bff19  guix-build-b8e084b9781e/output/x86_64-apple-darwin/bitcoin-b8e084b9781e-x86_64-apple-darwin.tar.gz
2869a01ce847298950a91b3b8514bc8fa39cc274a8e9cd4f68f4f038c1bb3040  guix-build-b8e084b9781e/output/x86_64-linux-gnu/SHA256SUMS.part
3f63e1d3b19b640d3994074b344d595bcd6fca420a1a8669b63b4ad22978308b  guix-build-b8e084b9781e/output/x86_64-linux-gnu/bitcoin-b8e084b9781e-x86_64-linux-gnu-debug.tar.gz
ccc3eb8eb56c1596981e81c8c95cadee3db799ed69b0cd1fb1e102da10adacfb  guix-build-b8e084b9781e/output/x86_64-linux-gnu/bitcoin-b8e084b9781e-x86_64-linux-gnu.tar.gz
1ff6dab6dcde9ddbbe407cca02119c4a5d545034c91389a1c647020902b7b40e  guix-build-b8e084b9781e/output/x86_64-w64-mingw32/SHA256SUMS.part
a91c2247fd9d886e3f3ada551c0a4f9f7ffc4874e07ea5ab9de14f2743b9b8c7  guix-build-b8e084b9781e/output/x86_64-w64-mingw32/bitcoin-b8e084b9781e-win64-debug.zip
6fbc8d5df571fd535990370009bdfcbb37b9697c33446a08eadb1279ba6e4649  guix-build-b8e084b9781e/output/x86_64-w64-mingw32/bitcoin-b8e084b9781e-win64-setup-unsigned.exe
38f7a981fd2999c1e138860e1ddc183dafec090d867e37f5ab5c2d48ad4ef9ee  guix-build-b8e084b9781e/output/x86_64-w64-mingw32/bitcoin-b8e084b9781e-win64-unsigned.tar.gz
88aca0a40a64a289617aad060a9ccf8c78bc6a201470720d8caf48d793d5207f  guix-build-b8e084b9781e/output/x86_64-w64-mingw32/bitcoin-b8e084b9781e-win64.zip
```