### PR TITLE
test: Fix intermittent issue in p2p_handshake.py

### DIFF
--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -41,6 +41,7 @@ class P2PHandshakeTest(BitcoinTestFramework):
             peer.sync_with_ping()
             peer.peer_disconnect()
             peer.wait_for_disconnect()
+        self.wait_until(lambda: len(node.getpeerinfo()) == 0)
 
     def test_desirable_service_flags(self, node, service_flag_tests, desirable_service_flags, expect_disconnect):
         """Check that connecting to a peer either fails or succeeds depending on its offered


### PR DESCRIPTION
When establishing outbound connections [`TestNode` --------> `P2PConnection`], `P2PConnection` listens for a single connection from `TestNode` on a [port which is fixed based on `p2p_idx`](https://github.com/bitcoin/bitcoin/blob/312f54278fd972ba3557c6a5b805fd244a063959/test/functional/test_framework/p2p.py#L746).

If we reuse the same port when disconnecting and establishing connections again, we might hit this scenario where:
- disconnection is done on python side for `P2PConnection`
- disconnection not complete on c++ side for `TestNode`
- we're trying to establish a new connection on same port again

Prevent this scenario from happening by ensuring disconnection on c++ side for TestNode as well.

One way to reproduce this on master would be adding a sleep statement before disconnection happens on c++ side.

```diff
diff --git a/src/net.cpp b/src/net.cpp
index e388f05b03..62507d1f39 100644
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2112,6 +2112,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                 if (!pnode->fDisconnect) {
                     LogPrint(BCLog::NET, "socket closed for peer=%d\n", pnode->GetId());
                 }
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 pnode->CloseSocketDisconnect();
             }
             else if (nBytes < 0)
```