### PR TITLE
rename bitcoin.conf in dist tarball

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -356,7 +356,7 @@ mkdir -p "$DISTSRC"
 
         # copy over the example bitcoin.conf file. if contrib/devtools/gen-bitcoin-conf.sh
         # has not been run before buildling, this file will be a stub
-        cp "${DISTSRC}/share/examples/bitcoin.conf" "${DISTNAME}/"
+        cp "${DISTSRC}/share/examples/bitcoin.conf" "${DISTNAME}/bitcoin.conf.example"
 
         cp -r "${DISTSRC}/share/rpcauth" "${DISTNAME}/share/"
 


### PR DESCRIPTION
Closes: #29139

Rename bitcoin.conf to bitcoin.conf.example in the guix dist tarball.
This avoids confusion that the file is actively used by the binary in bin/ without being renamed.