### PR TITLE
test: Fix `test/streams_tests.cpp` compilation on SunOS / illumos

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -143,8 +143,8 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     BOOST_CHECK_EQUAL(reader.size(), 5U);
     BOOST_CHECK(!reader.empty());
 
-    // Read a single byte as a signed char.
-    signed char b;
+    // Read a single byte as a int8_t.
+    int8_t b;
     reader >> b;
     BOOST_CHECK_EQUAL(b, -1);
     BOOST_CHECK_EQUAL(reader.size(), 4U);


### PR DESCRIPTION
On systems where `int8_t` is defined as `char`, the `{S,Uns}erialize(Stream&, signed char)` functions become undefined.

This PR resolves the issue by testing `{S,Uns}erialize(Stream&, int8_t)` instead.

No behavior change on systems where `int8_t` is defined as `signed char`, which is the case for most other systems.

Fixes https://github.com/bitcoin/bitcoin/issues/29884.

An alternative approach is mentioned in https://github.com/bitcoin/bitcoin/issues/29884#issuecomment-2058434577 as well.