### PR TITLE
refactor: Rename `subprocess.hpp` to follow our header name conventions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -320,7 +320,7 @@ BITCOIN_CORE_H = \
   util/sock.h \
   util/spanparsing.h \
   util/string.h \
-  util/subprocess.hpp \
+  util/subprocess.h \
   util/syserror.h \
   util/task_runner.h \
   util/thread.h \

--- a/src/common/run_command.cpp
+++ b/src/common/run_command.cpp
@@ -12,7 +12,7 @@
 #include <univalue.h>
 
 #ifdef ENABLE_EXTERNAL_SIGNER
-#include <util/subprocess.hpp>
+#include <util/subprocess.h>
 #endif // ENABLE_EXTERNAL_SIGNER
 
 UniValue RunCommandParseJSON(const std::string& str_command, const std::string& str_std_in)

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -11,7 +11,7 @@
 #include <univalue.h>
 
 #ifdef ENABLE_EXTERNAL_SIGNER
-#include <util/subprocess.hpp>
+#include <util/subprocess.h>
 #endif // ENABLE_EXTERNAL_SIGNER
 
 #include <boost/test/unit_test.hpp>

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -33,8 +33,8 @@ Documentation for C++ subprocessing library.
 @version 1.0.0
 */
 
-#ifndef SUBPROCESS_HPP
-#define SUBPROCESS_HPP
+#ifndef BITCOIN_UTIL_SUBPROCESS_H
+#define BITCOIN_UTIL_SUBPROCESS_H
 
 #include <algorithm>
 #include <cassert>
@@ -1609,4 +1609,4 @@ namespace detail {
 
 }
 
-#endif // SUBPROCESS_HPP
+#endif // BITCOIN_UTIL_SUBPROCESS_H

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -36,6 +36,8 @@ Documentation for C++ subprocessing library.
 #ifndef BITCOIN_UTIL_SUBPROCESS_H
 #define BITCOIN_UTIL_SUBPROCESS_H
 
+#include <util/syserror.h>
+
 #include <algorithm>
 #include <cassert>
 #include <csignal>
@@ -150,7 +152,7 @@ class OSError: public std::runtime_error
 {
 public:
   OSError(const std::string& err_msg, int err_code):
-    std::runtime_error( err_msg + ": " + std::strerror(err_code) )
+    std::runtime_error(err_msg + ": " + SysErrorString(err_code))
   {}
 };
 


### PR DESCRIPTION
This PR renames the header `*.hpp` --> `*.h` and adjusts the header guard name, which makes it available for processing by linters.

Fixed the following linter warning:
```
The locale dependent function strerror(...) appears to be used:
src/util/subprocess.h:    std::runtime_error( err_msg + ": " + std::strerror(err_code) )

Unnecessary locale dependence can cause bugs that are very tricky to isolate and fix. Please avoid using locale-dependent functions if possible.

Advice not applicable in this specific case? Add an exception by updating the ignore list in /bitcoin/test/lint/lint-locale-dependence.py
^---- failure generated from lint-locale-dependence.py
```