### PR TITLE
bugfix: update chainman best_header after block reconsideration

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1616,6 +1616,9 @@ static RPCHelpMan reconsiderblock()
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());
     }
 
+    // Update best header
+    WITH_LOCK(::cs_main, chainman.m_best_header = chainman.ActiveChain().Tip());
+
     return UniValue::VNULL;
 },
     };

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -63,12 +63,20 @@ class InvalidateTest(BitcoinTestFramework):
         self.log.info("Verify that we reconsider all ancestors as well")
         blocks = self.generatetodescriptor(self.nodes[1], 10, ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR, sync_fun=self.no_op)
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
+        # Ensure the best-known header is synchronized with the active chain.
+        assert_equal(self.nodes[1].getchainstates()['headers'], self.nodes[1].getblockcount())
         # Invalidate the two blocks at the tip
         self.nodes[1].invalidateblock(blocks[-1])
         self.nodes[1].invalidateblock(blocks[-2])
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-3])
+        # Verify that the best header is updated after invalidating a block.
+        assert_equal(self.nodes[1].getchainstates()['headers'], self.nodes[1].getblockcount())
+
         # Reconsider only the previous tip
         self.nodes[1].reconsiderblock(blocks[-1])
+        # Verify that the best header is updated after reconsidering a block.
+        assert_equal(self.nodes[1].getchainstates()['headers'], self.nodes[1].getblockcount())
+
         # Should be back at the tip by now
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
 


### PR DESCRIPTION
Fixes #26245. I'm doing it because it came to my mind after reviewing #28339.

Inside the `invalidateblock` process, we update the best_header by manually calling `InvalidChainFound` after disconnecting blocks.

We need to do the same for `reconsiderblock` and update the chain `best_header` field after finishing the process.

Note: the only difference between this two commands is that `reconsiderblock` does not have its own separate function, it's a plain RPC command that resets the block index flag and calls `ActivateBestChain`.

The only place we forwardly update the best_header field is within `AddToBlockIndex` which is not called by `reconsiderblock` since the block is already in the block index. Thus why we need to manually update it after reconsidering a block.

Testing Notes:
- Comment the fix line and run the `rpc_invalidateblock.py` test.
- Or, call `invalidateblock` and compare the `getblockchaininfo()` 'headers' num value against `getblockcount()`, then do the same after calling `reconsiderblock()`.