### PR TITLE
test: Fix multiprocess CI timeout in p2p_tx_download

### DIFF
--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -265,7 +265,8 @@ class TxDownloadTest(BitcoinTestFramework):
         self.generate(self.wallet, 1, sync_fun=self.no_op)
         peer.sync_with_ping()
         peer.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(low_fee_tx['wtxid'], 16))]))
-        node.bumpmocktime(MAX_GETDATA_INBOUND_WAIT)
+        node.setmocktime(int(time.time()))
+        node.bumpmocktime(MAX_GETDATA_INBOUND_WAIT + 300)
         peer.wait_for_getdata([int(low_fee_tx['wtxid'], 16)])
 
     def run_test(self):


### PR DESCRIPTION
This addresses multiprocess CI failures in `p2p_tx_download.py`, likely introduced by #29827.

Example failure: https://cirrus-ci.com/task/5622109341220864

I was having a hard time reproducing or rationalizing the root cause of the issue but it seemed very likely the mock time wasn't working as expected without another reset and I got a successful run with it when I temporarily introduced it to another PR I am working on: https://cirrus-ci.com/task/5109555795853312

