### PR TITLE
doc: suggest only necessary Qt packages for installation on FreeBSD

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,6 +1,6 @@
 # FreeBSD Build Guide
 
-**Updated for FreeBSD [12.3](https://www.freebsd.org/releases/12.3R/announce/)**
+**Updated for FreeBSD [14.0](https://www.freebsd.org/releases/14.0R/announce/)**
 
 This guide describes how to build bitcoind, command-line utilities, and GUI on FreeBSD.
 
@@ -64,10 +64,11 @@ sh/bash: export BDB_PREFIX=[path displayed above]
 #### GUI Dependencies
 ###### Qt5
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install `qt5`. Skip if you don't intend to use the GUI.
+Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install the necessary parts of Qt. Skip if you don't intend to use the GUI.
 ```bash
-pkg install qt5
+pkg install qt5-buildtools qt5-core qt5-gui qt5-linguisttools qt5-testlib qt5-widgets
 ```
+
 ###### libqrencode
 
 The GUI can encode addresses in a QR Code. To build in QR support for the GUI, install `libqrencode`. Skip if not using the GUI or don't want QR code functionality.


### PR DESCRIPTION
The previously suggested `qt5` package is a meta package that does not
install anything itself but depends on a bunch of others and is used as
a convenience to install "everything" Qt5 related: 270 packages / 3 GiB.

We only need a subset of those which amounts to 79 packages / 381 MiB,
so suggest just that.

For comparison:

```
pkg install qt5
Updating local repository catalogue...
local repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The following 270 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
	Imath: 3.1.11
	abseil: 20230125.3
	alsa-lib: 1.2.11
	alsa-plugins: 1.2.7.1_3
	aom: 3.8.2
	assimp: 5.4.0
	avahi-app: 0.8_2
	brotli: 1.1.0,1
	consolekit2: 1.2.6_3
	cups: 2.4.7_2
	curl: 8.7.1
	cyrus-sasl: 2.1.28_4
	dav1d: 1.4.1
	dbus: 1.14.10_5,1
	dbus-glib: 0.112_1
	dejavu: 2.37_3
	dotconf: 1.3_1
	double-conversion: 3.3.0
	duktape-lib: 2.7.0
	encodings: 1.1.0,1
	espeak-ng: 1.51.1_5
	expat: 2.6.2
	ffmpeg: 6.1.1_5,1
	fftw3: 3.3.10_5
	fftw3-float: 3.3.10_5
	flac: 1.4.3_1,1
	font-bh-ttf: 1.0.3_5
	font-misc-ethiopic: 1.0.4
	font-misc-meltho: 1.0.3_5
	fontconfig: 2.15.0_2,1
	freetds: 1.4.12,1
	freetype2: 2.13.2
	fribidi: 1.0.13_1
	gdbm: 1.23
	gdk-pixbuf2: 2.42.10_2
	gettext-runtime: 0.22.5
	giflib: 5.2.1_1
	glib: 2.80.0,2
	gmp: 6.3.0
	gnome_subr: 1.0
	gnutls: 3.8.5_1
	graphite2: 1.3.14
	groff: 1.23.0_3
	gstreamer1: 1.22.10
	gstreamer1-plugins: 1.22.10_1
	gstreamer1-plugins-bad: 1.22.10_2
	harfbuzz: 8.4.0
	hicolor-icon-theme: 0.17
	hidapi: 0.14.0
	highway: 1.1.0
	hunspell: 1.7.2_1
	icu: 74.2_1,1
	indexinfo: 0.3.1
	iso-codes: 4.15.0
	jasper: 4.2.3
	jbigkit: 2.1_2
	jpeg-turbo: 3.0.2
	jsoncpp: 1.9.5
	lame: 3.100_5
	lcms2: 2.16_1
	libICE: 1.1.0_2,1
	libSM: 1.2.3_1,1
	libX11: 1.8.9,1
	libXScrnSaver: 1.2.4_1
	libXau: 1.0.9_1
	libXcomposite: 0.4.6_1,1
	libXcursor: 1.2.2
	libXdamage: 1.1.6
	libXdmcp: 1.1.5
	libXext: 1.3.6,1
	libXfixes: 6.0.0_1
	libXi: 1.8_1,1
	libXmu: 1.1.4,1
	libXrandr: 1.5.2_1
	libXrender: 0.9.10_2
	libXt: 1.3.0,1
	libXtst: 1.2.3_3
	libXv: 1.0.12_1,1
	libass: 0.17.1_2
	libcbor: 0.11.0
	libcjson: 1.7.17
	libdaemon: 0.14_1
	libdeflate: 1.20
	libdrm: 2.4.120_1,1
	libedit: 3.1.20230828_1,1
	libepoll-shim: 0.0.20230411
	libevdev: 1.13.1
	libevent: 2.1.12
	libffi: 3.4.4_1
	libfido2: 1.14.0
	libfontenc: 1.1.8
	libgcrypt: 1.10.3_1
	libglvnd: 1.7.0
	libgpg-error: 1.48
	libgudev: 237
	libiconv: 1.17_1
	libidn2: 2.3.7
	libinput: 1.25.0
	libjxl: 0.10.2
	libltdl: 2.4.7
	liblz4: 1.9.4_1,1
	libmng: 2.0.3_1
	libmtdev: 1.1.6_1
	libmysofa: 1.3.2
	libnghttp2: 1.61.0
	libnice: 0.1.21_2
	libogg: 1.3.5,4
	libpaper: 1.1.28_1
	libpci: 3.12.0
	libpciaccess: 0.18
	libplacebo: 6.338.2
	libpsl: 0.21.5
	libsndfile: 1.2.2_1
	libsoxr: 0.1.3_3
	libssh2: 1.11.0_1,3
	libtasn1: 4.19.0_1
	libudev-devd: 0.5.2
	libunibreak: 6.1,1
	libunistring: 1.2
	libunwind: 20240221
	libv4l: 1.23.0_4
	libva: 2.21.0
	libvdpau: 1.5
	libvorbis: 1.3.7_2,3
	libvpx: 1.14.0
	libwacom: 1.5_1
	libx264: 0.164.3095
	libxcb: 1.17.0
	libxkbcommon: 1.6.0_2
	libxkbfile: 1.1.3
	libxml2: 2.11.7
	libxslt: 1.1.37_1
	llvm15: 15.0.7_10
	lua53: 5.3.6_1
	minizip: 1.2.11_1
	mkfontscale: 1.2.3
	mpdecimal: 4.0.0
	mpg123: 1.32.5
	mysql80-client: 8.0.35
	nettle: 3.9.1
	nspr: 4.35
	nss: 3.99
	openal-soft: 1.21.1_4
	openexr: 3.2.4
	openh264: 2.3.0,2
	openldap26-client: 2.6.7
	opus: 1.5.2
	orc: 0.4.36
	p11-kit: 0.25.3_2
	pcaudiolib: 1.2_1
	pciids: 20240331
	pcre2: 10.43
	perl5: 5.36.3_1
	png: 1.6.43
	polkit: 124_3
	postgresql15-client: 15.6
	psutils: 1.17_6
	pulseaudio: 16.1_4
	py39-evdev: 1.6.0
	py39-packaging: 24.0
	py39-pyudev: 0.22.0
	py39-setuptools: 63.1.0_1
	py39-six: 1.16.0
	python39: 3.9.18_2
	qt5: 5.15.13
	qt5-3d: 5.15.13p0
	qt5-assistant: 5.15.13p4
	qt5-buildtools: 5.15.13p142
	qt5-charts: 5.15.13p0
	qt5-concurrent: 5.15.13p142
	qt5-connectivity: 5.15.13p4
	qt5-core: 5.15.13p142
	qt5-datavis3d: 5.15.13p0
	qt5-dbus: 5.15.13p142
	qt5-declarative: 5.15.13p30
	qt5-declarative-test: 5.15.13p30
	qt5-designer: 5.15.13p4
	qt5-doc: 5.12.2
	qt5-examples: 5.15.13
	qt5-gamepad: 5.15.13p0
	qt5-graphicaleffects: 5.15.13p0
	qt5-gui: 5.15.13p142
	qt5-help: 5.15.13p4
	qt5-imageformats: 5.15.13p7
	qt5-l10n: 5.15.13p0
	qt5-linguist: 5.15.13p4
	qt5-linguisttools: 5.15.13p4
	qt5-location: 5.15.13p6
	qt5-multimedia: 5.15.13p2
	qt5-network: 5.15.13p142
	qt5-networkauth: 5.15.13p0
	qt5-opengl: 5.15.13p142
	qt5-pixeltool: 5.15.13p4
	qt5-printsupport: 5.15.13p142
	qt5-qdbus: 5.15.13p4
	qt5-qdbusviewer: 5.15.13p4
	qt5-qdoc: 5.15.13p4
	qt5-qdoc-data: 5.15.13
	qt5-qev: 5.15.13p4
	qt5-qmake: 5.15.13p142
	qt5-qtdiag: 5.15.13p4
	qt5-qtpaths: 5.15.13p4
	qt5-qtplugininfo: 5.15.13p4
	qt5-quick3d: 5.15.13p1
	qt5-quickcontrols: 5.15.13p0
	qt5-quickcontrols2: 5.15.13p5
	qt5-quicktimeline: 5.15.13p0
	qt5-remoteobjects: 5.15.13p0
	qt5-script: 5.15.16p0_2
	qt5-scripttools: 5.15.16p0_1
	qt5-scxml: 5.15.13p0
	qt5-sensors: 5.15.13p0
	qt5-serialbus: 5.15.13p0
	qt5-serialport: 5.15.13p0
	qt5-speech: 5.15.13p1
	qt5-sql: 5.15.13p142
	qt5-sqldrivers-mysql: 5.15.13p142
	qt5-sqldrivers-odbc: 5.15.13p142
	qt5-sqldrivers-pgsql: 5.15.13p142
	qt5-sqldrivers-sqlite2: 5.15.13p142
	qt5-sqldrivers-sqlite3: 5.15.13p142
	qt5-sqldrivers-tds: 5.15.13p142
	qt5-svg: 5.15.13p6
	qt5-testlib: 5.15.13p142
	qt5-uiplugin: 5.15.13p4
	qt5-uitools: 5.15.13p4
	qt5-virtualkeyboard: 5.15.13p0
	qt5-webchannel: 5.15.13p3
	qt5-webengine: 5.15.16.p9
	qt5-webglplugin: 5.15.13p0
	qt5-websockets: 5.15.13p2
	qt5-websockets-qml: 5.15.13p2
	qt5-webview: 5.15.13p0
	qt5-widgets: 5.15.13p142
	qt5-x11extras: 5.15.13p0
	qt5-xml: 5.15.13p142
	qt5-xmlpatterns: 5.15.13p0
	re2: 20240401
	readline: 8.2.10
	shaderc: 2024.0
	shared-mime-info: 2.2_2
	snappy: 1.2.0
	speech-dispatcher: 0.11.2_4
	speexdsp: 1.2.1
	sqlite: 2.8.17_5
	sqlite3: 3.45.1,1
	svt-av1: 2.0.0
	tiff: 4.4.0_3
	uchardet: 0.0.8_1
	unixODBC: 2.3.12_1
	vmaf: 3.0.0
	vulkan-headers: 1.3.283
	vulkan-loader: 1.3.283
	wayland: 1.22.0
	webp: 1.4.0
	webrtc-audio-processing0: 0.3.1_3
	x265: 3.5_1
	xcb-util: 0.4.1,1
	xcb-util-image: 0.4.1
	xcb-util-keysyms: 0.4.1
	xcb-util-renderutil: 0.3.10
	xcb-util-wm: 0.4.2
	xdg-utils: 1.1.3_4
	xkeyboard-config: 2.41_4
	xorg-fonts-truetype: 7.7_1
	xorgproto: 2023.2
	xprop: 1.2.7
	xset: 1.2.5_1
	xxhash: 0.8.2_1
	zstd: 1.5.6

Number of packages to be installed: 270

The process will require 3 GiB more space.

Proceed with this action? [y/N]:
```

```
pkg install qt5-buildtools qt5-core qt5-gui qt5-linguisttools qt5-testlib qt5-widgets
Updating local repository catalogue...
local repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The following 79 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
	brotli: 1.1.0,1
	dbus: 1.14.10_5,1
	dejavu: 2.37_3
	double-conversion: 3.3.0
	encodings: 1.1.0,1
	expat: 2.6.2
	font-bh-ttf: 1.0.3_5
	font-misc-ethiopic: 1.0.4
	font-misc-meltho: 1.0.3_5
	fontconfig: 2.15.0_2,1
	freetype2: 2.13.2
	gettext-runtime: 0.22.5
	glib: 2.80.0,2
	graphite2: 1.3.14
	harfbuzz: 8.4.0
	hicolor-icon-theme: 0.17
	icu: 74.2_1,1
	indexinfo: 0.3.1
	jpeg-turbo: 3.0.2
	libICE: 1.1.0_2,1
	libSM: 1.2.3_1,1
	libX11: 1.8.9,1
	libXau: 1.0.9_1
	libXdmcp: 1.1.5
	libXext: 1.3.6,1
	libXfixes: 6.0.0_1
	libXi: 1.8_1,1
	libXmu: 1.1.4,1
	libXrender: 0.9.10_2
	libXt: 1.3.0,1
	libepoll-shim: 0.0.20230411
	libevdev: 1.13.1
	libffi: 3.4.4_1
	libfontenc: 1.1.8
	libglvnd: 1.7.0
	libgudev: 237
	libiconv: 1.17_1
	libinput: 1.25.0
	liblz4: 1.9.4_1,1
	libmtdev: 1.1.6_1
	libudev-devd: 0.5.2
	libwacom: 1.5_1
	libxcb: 1.17.0
	libxkbcommon: 1.6.0_2
	libxml2: 2.11.7
	mkfontscale: 1.2.3
	mpdecimal: 4.0.0
	pcre2: 10.43
	png: 1.6.43
	py39-evdev: 1.6.0
	py39-packaging: 24.0
	py39-pyudev: 0.22.0
	py39-setuptools: 63.1.0_1
	py39-six: 1.16.0
	python39: 3.9.18_2
	qt5-buildtools: 5.15.13p142
	qt5-core: 5.15.13p142
	qt5-dbus: 5.15.13p142
	qt5-gui: 5.15.13p142
	qt5-linguisttools: 5.15.13p4
	qt5-network: 5.15.13p142
	qt5-testlib: 5.15.13p142
	qt5-widgets: 5.15.13p142
	qt5-xml: 5.15.13p142
	readline: 8.2.10
	vulkan-headers: 1.3.283
	wayland: 1.22.0
	xcb-util: 0.4.1,1
	xcb-util-image: 0.4.1
	xcb-util-keysyms: 0.4.1
	xcb-util-renderutil: 0.3.10
	xcb-util-wm: 0.4.2
	xdg-utils: 1.1.3_4
	xkeyboard-config: 2.41_4
	xorg-fonts-truetype: 7.7_1
	xorgproto: 2023.2
	xprop: 1.2.7
	xset: 1.2.5_1
	zstd: 1.5.6

Number of packages to be installed: 79

The process will require 381 MiB more space.

Proceed with this action? [y/N]:
```