### PR TITLE
test: Fix intermittent timeout in p2p_tx_download.py

### DIFF
--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -284,17 +284,22 @@ class TxDownloadTest(BitcoinTestFramework):
 
         # Run each test against new bitcoind instances, as setting mocktimes has long-term effects on when
         # the next trickle relay event happens.
-        for test in [self.test_in_flight_max, self.test_inv_block, self.test_tx_requests,
-                     self.test_rejects_filter_reset]:
+        for test, with_inbounds in [
+            (self.test_in_flight_max, True),
+            (self.test_inv_block, True),
+            (self.test_tx_requests, True),
+            (self.test_rejects_filter_reset, False),
+        ]:
             self.stop_nodes()
             self.start_nodes()
             self.connect_nodes(1, 0)
             # Setup the p2p connections
             self.peers = []
-            for node in self.nodes:
-                for _ in range(NUM_INBOUND):
-                    self.peers.append(node.add_p2p_connection(TestP2PConn()))
-            self.log.info("Nodes are setup with {} incoming connections each".format(NUM_INBOUND))
+            if with_inbounds:
+                for node in self.nodes:
+                    for _ in range(NUM_INBOUND):
+                        self.peers.append(node.add_p2p_connection(TestP2PConn()))
+                self.log.info("Nodes are setup with {} incoming connections each".format(NUM_INBOUND))
             test()
 
 


### PR DESCRIPTION
Currently the test passes, but may fail during shutdown, because blocks and transactions are synced with `NUM_INBOUND` * `self.num_nodes` peers, which may take a long time.

There is no need for this test to have this amount of inbounds.

So avoid the extraneous inbounds to speed up the test and avoid the intermittent test failures.