### PR TITLE
doc: add LLVM instruction for macOS < 13

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -51,6 +51,20 @@ To install, run the following from your terminal:
 brew install automake libtool boost pkg-config libevent
 ```
 
+For macOS 11 (Big Sur) and 12 (Monterey) you need to install a more recent version of llvm.
+
+``` bash
+brew install llvm
+```
+
+And append the following to the configure commands below:
+
+``` bash
+CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++
+```
+
+Try `llvm@17` if compilation fails with the default version of llvm.
+
 ### 4. Clone Bitcoin repository
 
 `git` should already be installed by default on your system.


### PR DESCRIPTION
#29208 bumped clang to 14, which users of old macOS versions need to install manually. This PR adds instructions.

Xcode 14.3.1 ships clang 14.0.3 (14.0.0 is broken, see #29918):
https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)

The system requirements for that is macOS Ventura 13.0 or later: https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3_1-release-notes#

Homebrew itself officially supports macOS 12 or later, but _may_ still work on macOS 11: https://docs.brew.sh/Installation

Fwiw macOS 11 Big Sur last got an update in September 2023, so Apple has not _entirely_ written it off: https://en.wikipedia.org/wiki/MacOS_Big_Sur