### PR TITLE
Fix typos in description.md and wallet_util.py

### DIFF
--- a/depends/description.md
+++ b/depends/description.md
@@ -11,7 +11,7 @@ on new hosts.
 ### No reliance on timestamps
 
 File presence is used to determine what needs to be built. This makes the
-results distributable and easily digestable by automated builders.
+results distributable and easily digestible by automated builders.
 
 ### Each build only has its specified dependencies available at build-time.
 

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -165,7 +165,7 @@ class WalletUnlock():
 class TestFrameworkWalletUtil(unittest.TestCase):
     def test_calculate_input_weight(self):
         SKELETON_BYTES = 32 + 4 + 4  # prevout-txid, prevout-index, sequence
-        SMALL_LEN_BYTES = 1  # bytes needed for encoding scriptSig / witness item lenghts < 253
+        SMALL_LEN_BYTES = 1  # bytes needed for encoding scriptSig / witness item lengths < 253
         LARGE_LEN_BYTES = 3  # bytes needed for encoding scriptSig / witness item lengths >= 253
 
         # empty scriptSig, no witness


### PR DESCRIPTION
Fix typos in description.md.
`digestable` => `digestible`
`lenghts` => `lengths`