### PR TITLE
test: add missing comparison of node1's mempool in MempoolPackagesTest

### DIFF
--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -199,7 +199,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         assert set(mempool1).issubset(set(mempool0))
         for tx in chain[:CUSTOM_ANCESTOR_LIMIT]:
             assert tx in mempool1
-        # Check more detailed check of node1's mempool 
+        # Check more detailed check of node1's mempool
             entry0 = self.nodes[0].getmempoolentry(tx)
             entry1 = self.nodes[1].getmempoolentry(tx)
         # Check transaction unbroadcast info (should be false if in both mempools)
@@ -268,7 +268,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Check parent/child list is correct
             assert_equal(entry1['depends'], entry0['depends'])
         
-
         # Test reorg handling
         # First, the basics:
         self.generate(self.nodes[0], 1)

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -267,7 +267,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(entry1['vsize'], entry0['vsize'])
         # Check parent/child list is correct
             assert_equal(entry1['depends'], entry0['depends'])
-        
         # Test reorg handling
         # First, the basics:
         self.generate(self.nodes[0], 1)

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -199,13 +199,17 @@ class MempoolPackagesTest(BitcoinTestFramework):
         assert set(mempool1).issubset(set(mempool0))
         for tx in chain[:CUSTOM_ANCESTOR_LIMIT]:
             assert tx in mempool1
-        # TODO: more detailed check of node1's mempool (fees etc.)
-        # check transaction unbroadcast info (should be false if in both mempools)
-        mempool = self.nodes[0].getrawmempool(True)
-        for tx in mempool:
-            assert_equal(mempool[tx]['unbroadcast'], False)
-
-        # TODO: test ancestor size limits
+        # Check more detailed check of node1's mempool 
+            entry0 = self.nodes[0].getmempoolentry(tx)
+            entry1 = self.nodes[1].getmempoolentry(tx)
+        # Check transaction unbroadcast info (should be false if in both mempools)
+            assert not entry0['unbroadcast']
+            assert not entry1['unbroadcast']
+        # Check fees, vsize, etc.
+            assert_equal(entry1['fees']['base'], entry0['fees']['base'])
+            assert_equal(entry1['vsize'], entry0['vsize'])
+        # Check parent/child list is correct
+            assert_equal(entry1['depends'], entry0['depends'])
 
         # Now test descendant chain limits
 
@@ -251,9 +255,19 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert tx in mempool1
         for tx in chain[CUSTOM_DESCENDANT_LIMIT:]:
             assert tx not in mempool1
-        # TODO: more detailed check of node1's mempool (fees etc.)
-
-        # TODO: test descendant size limits
+        # More detailed check of node1's mempool (fees etc.)
+        for tx in mempool1:
+            entry0 = self.nodes[0].getmempoolentry(tx)
+            entry1 = self.nodes[1].getmempoolentry(tx)
+        # check transaction unbroadcast info (should be false if in both mempools)
+            assert not entry0['unbroadcast']
+            assert not entry1['unbroadcast']
+        # Check fees, vsize, etc.
+            assert_equal(entry1['fees']['base'], entry0['fees']['base'])
+            assert_equal(entry1['vsize'], entry0['vsize'])
+        # Check parent/child list is correct
+            assert_equal(entry1['depends'], entry0['depends'])
+        
 
         # Test reorg handling
         # First, the basics:


### PR DESCRIPTION
Add missing comparison for TODO comments in `mempool_packages.py`

Also, notice that the ancestor size limits and descendant size limits actually implemented in #21800 , so I removed the todo for those two size limits.