### PR TITLE
doc: Bash is needed in gen_id and is not installed on FreeBSD by default

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -85,6 +85,10 @@ For linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 
+### Install the required dependencies: FreeBSD
+
+    pkg install bash
+
 ### Install the required dependencies: OpenBSD
 
     pkg_add bash gtar


### PR DESCRIPTION
On FreeBSD 14.0, in the `depends` directory:

- without `bash`:
```
$ gmake print-bdb_build_id_long
env: bash: No such file or directory
env: bash: No such file or directory
bdb_build_id_long=bdb-4.8.30-4b0c6f8e95251b9c6731844fc34111c04b75fd9f15c671d6e34f2a4d014ec1be-release  
$ gmake print-final_build_id
env: bash: No such file or directory
env: bash: No such file or directory
final_build_id=722b2d3e264
```

- with `bash`:
```
$ gmake print-bdb_build_id_long 
bdb_build_id_long=bdb-4.8.30-4b0c6f8e95251b9c6731844fc34111c04b75fd9f15c671d6e34f2a4d014ec1be-release  1ed47cefe468014c79dedb275cf921f44ab28d91dd56bf94712409b81326d765
$ gmake print-final_build_id
final_build_id=7b4f9aaa683
```