### PR TITLE
depends: pass verbose through to cmake based makefiles

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -182,6 +182,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" \
                -DCMAKE_INSTALL_LIBDIR=lib/ \
                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+               -DCMAKE_VERBOSE_MAKEFILE:BOOL=$(V) \
                $$($(1)_config_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"


### PR DESCRIPTION
While testing https://github.com/bitcoin/bitcoin/pull/29708 I was not able to enable verbose output to check which flags were being given to the compiler.

With this PR, running depends with V=1 will enable verbose output from makefiles generated by cmake.

How to test:

```shell
make -C depends libnatpmp V=1
```