### PR TITLE
depends: Do not consider `CC` environment variable for detecting system

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -49,7 +49,7 @@ FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 C_STANDARD ?= c11
 CXX_STANDARD ?= c++20
 
-BUILD = $(shell ./config.guess)
+BUILD = $(shell unset CC && ./config.guess)
 PATCHES_PATH = $(BASEDIR)/patches
 BASEDIR = $(CURDIR)
 HASH_LENGTH:=11


### PR DESCRIPTION
On the master branch @ 3c88eac28e8984893746caebb313dc3b2fca90db, consider the following commands in the `depends` subdirectory:
```sh
$ make print-build HOST=i686-pc-linux-gnu CC="clang -m32"
build=x86_64-pc-linux-gnu
$ make print-host HOST=i686-pc-linux-gnu CC="clang -m32"
host=i686-pc-linux-gnu
```
The printed variable values are expected.

However, switching the `CC` variable context from Makefile to the shell environment breaks expectations:
```sh
$ CC="clang -m32" make print-build HOST=i686-pc-linux-gnu
build=i686-pc-linux-gnu
$ CC="clang -m32" make print-host HOST=i686-pc-linux-gnu
host=i686-pc-linux-gnu
```

This PR fixes this issue.

#### UPDATE 2026-01-20

On the master branch @ 7f5ebef56a0f2bad7df30252b11da3e33cb3c144:
```
$ gmake print-build HOST=i686-pc-linux-gnu CC="clang -m32"
build=i686-pc-linux-gnu
$ gmake print-host HOST=i686-pc-linux-gnu CC="clang -m32"
host=i686-pc-linux-gnu
```