### PR TITLE
Add CheckScriptPushSize to validate script push data size

### DIFF
--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -8,7 +8,8 @@
 #include <primitives/transaction.h>
 #include <consensus/validation.h>
 
-bool CheckScriptPushSize(const CScript& script) {
+bool CheckScriptPushSize(const CScript& script) 
+{
     CScript::const_iterator pc = script.begin();
     opcodetype opcode;
     std::vector<unsigned char> data;
@@ -45,10 +46,10 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-txouttotal-toolarge");
     }
 
-    for (const auto& txout : tx.vout) {
-        if (!CheckScriptPushSize(txout.scriptPubKey)) {
+    for (const auto& txout : tx.vout) 
+    {
+        if (!CheckScriptPushSize(txout.scriptPubKey))
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-output-script-too-large");
-        }
     }
 
     // Check for duplicate inputs (see CVE-2018-17144)

--- a/src/consensus/tx_check.h
+++ b/src/consensus/tx_check.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CONSENSUS_TX_CHECK_H
 #define BITCOIN_CONSENSUS_TX_CHECK_H
 
+#include <script/script.h>
+
 /**
  * Context-independent transaction checking code that can be called outside the
  * bitcoin server and doesn't depend on chain or mempool state. Transaction
@@ -15,6 +17,7 @@
 class CTransaction;
 class TxValidationState;
 
+bool CheckScriptPushSize(const CScript& script);
 bool CheckTransaction(const CTransaction& tx, TxValidationState& state);
 
 #endif // BITCOIN_CONSENSUS_TX_CHECK_H

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -988,4 +988,15 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     }
 }
 
+BOOST_AUTO_TEST_CASE(check_script_push_size_tests)
+{
+    CScript scriptWithinLimit;
+    scriptWithinLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE, 0x00); // Data dentro do limite
+    BOOST_CHECK(CheckScriptPushSize(scriptWithinLimit) == true);
+
+    CScript scriptExceedsLimit;
+    scriptExceedsLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE + 1, 0x00); // Data excede o limite
+    BOOST_CHECK(CheckScriptPushSize(scriptExceedsLimit) == false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -991,11 +991,11 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 BOOST_AUTO_TEST_CASE(check_script_push_size_tests)
 {
     CScript scriptWithinLimit;
-    scriptWithinLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE, 0x00); // Data dentro do limite
+    scriptWithinLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE, 0x00); // Data within limit
     BOOST_CHECK(CheckScriptPushSize(scriptWithinLimit) == true);
 
     CScript scriptExceedsLimit;
-    scriptExceedsLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE + 1, 0x00); // Data excede o limite
+    scriptExceedsLimit << std::vector<unsigned char>(MAX_SCRIPT_ELEMENT_SIZE + 1, 0x00); // Data exceeds limit
     BOOST_CHECK(CheckScriptPushSize(scriptExceedsLimit) == false);
 }
 


### PR DESCRIPTION
This pull request adds a new function `CheckScriptPushSize` to the transaction validation logic to ensure that the push data within script elements does not exceed the maximum allowed size, as defined by `MAX_SCRIPT_ELEMENT_SIZE`.

### Motivation and Context
Scripts within transaction outputs are not currently checked for the size of their push data elements. This oversight could potentially allow for scripts with oversized data elements, which might introduce security risks and non-standard transactions into the blockchain. By enforcing this check, we ensure that all scripts adhere to the existing size constraints, improving the robustness of transaction validation.

### Changes
- Added `CheckScriptPushSize` function to `tx_check.cpp`.
- Integrated this function into the `CheckTransaction` routine to validate each output's `scriptPubKey`.

### Testing
Unit tests have been updated to include tests for `CheckScriptPushSize`:
- `check_script_push_size_tests` ensures that scripts with data elements within and beyond the allowed size are handled correctly.

### Impact
This change does not affect the existing blockchain data but will apply to all new transactions, preventing the inclusion of any transactions that violate script size rules in future blocks.

Please review the changes and provide feedback.
