### PR TITLE
test: Fix intermittent issue in wallet_backwards_compatibility.py

### DIFF
--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -172,6 +172,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         # Create another conflicting transaction using RBF
         tx3_id = node_master.sendtoaddress(return_address, 1)
         tx4_id = node_master.bumpfee(tx3_id)["txid"]
+        self.sync_mempools()
         # Abandon transaction, but don't confirm
         node_master.abandontransaction(tx3_id)
 


### PR DESCRIPTION
When creating and replacing a transaction using `bumpfee`, an async update is sent in the form of the `TransactionAddedToMempool` and `TransactionRemovedFromMempool` signals. When `wallet_backwards_compatibility.py` creates `tx3_id` this way and replaces it with `tx4_id`, the `abandontransaction` rpc is called right after. In some cases the `TransactionAddedToMempool` and `TransactionRemovedFromMempool` is handled after the transaction is abandoned in the wallet, and overwrites the transaction's `abandoned` flag. This PR forces the signals to get handled before `abandontransaction` is called by invoking `self.sync_mempools` which calls `syncwithvalidationinterfacequeue` on every node's rpc connection.

This will mitigate the immediate inconsistency observed with the abandontransaction call, but the potential race conditions between the signals and wallet operations may also be useful to note in a separate issue (if it's okay to not address it in this one).

Fixes #29806 