### PR TITLE
net: Replace ifname check with IFF_LOOPBACK in Discover

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3077,8 +3077,7 @@ void Discover()
         {
             if (ifa->ifa_addr == nullptr) continue;
             if ((ifa->ifa_flags & IFF_UP) == 0) continue;
-            if (strcmp(ifa->ifa_name, "lo") == 0) continue;
-            if (strcmp(ifa->ifa_name, "lo0") == 0) continue;
+            if ((ifa->ifa_flags & IFF_LOOPBACK) != 0) continue;
             if (ifa->ifa_addr->sa_family == AF_INET)
             {
                 struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);

--- a/src/net.h
+++ b/src/net.h
@@ -137,8 +137,7 @@ struct CSerializedNetMsg {
 /**
  * Look up IP addresses from all interfaces on the machine and add them to the
  * list of local addresses to self-advertise.
- * The loopback interface is skipped and only the first address from each
- * interface is used.
+ * The loopback interface is skipped.
  */
 void Discover();
 


### PR DESCRIPTION
Checking the interface name is kind of brittle. In the age of network namespaces and containers, there is no reason a loopback interface can't be called differently.

Check for the `IFF_LOOPBACK` flag to detect loopback interface instead.

Also remove a misleading comment in Discover's doc comment.