### PR TITLE
depends: Fix build of Qt for 32-bit platforms with recent glibc

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -22,6 +22,7 @@ $(package)_patches += fix-macos-linker.patch
 $(package)_patches += memory_resource.patch
 $(package)_patches += utc_from_string_no_optimize.patch
 $(package)_patches += windows_lto.patch
+$(package)_patches += zlib-timebits64.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=24d4c58bc2a40c0f44f59ee64af4192c7d0038c1e45af61646cfc5b65058f271
@@ -251,6 +252,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/utc_from_string_no_optimize.patch && \
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
   patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \
+  patch -p1 -i $($(package)_patch_dir)/zlib-timebits64.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/zlib-timebits64.patch
+++ b/depends/patches/qt/zlib-timebits64.patch
@@ -1,0 +1,31 @@
+From a566e156b3fa07b566ddbf6801b517a9dba04fa3 Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Sat, 29 Jul 2023 22:13:09 -0700
+Subject: [PATCH] Avoid compiler complaints if _TIME_BITS defined when building
+ zlib.
+
+zlib does not use time_t, so _TIME_BITS is irrelevant. However it
+may be defined anyway as part of a sledgehammer indiscriminately
+applied to all builds.
+
+From https://github.com/madler/zlib/commit/a566e156b3fa07b566ddbf6801b517a9dba04fa3.patch
+---
+ qtbase/src/3rdparty/zlib/src/gzguts.h | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/qtbase/src/3rdparty/zlib/src/gzguts.h b/qtbase/src/3rdparty/zlib/src/gzguts.h
+index e23f831f5..f9375047e 100644
+--- a/qtbase/src/3rdparty/zlib/src/gzguts.h
++++ b/qtbase/src/3rdparty/zlib/src/gzguts.h
+@@ -26,9 +26,8 @@
+ #  ifndef _LARGEFILE_SOURCE
+ #    define _LARGEFILE_SOURCE 1
+ #  endif
+-#  ifdef _FILE_OFFSET_BITS
+-#    undef _FILE_OFFSET_BITS
+-#  endif
++#  undef _FILE_OFFSET_BITS
++#  undef _TIME_BITS
+ #endif
+ 
+ #ifdef HAVE_HIDDEN


### PR DESCRIPTION
The 32 to 64-bit `time_t` transition causes a build failure in the built-in zlib about conflicting `_TIME_BITS` and `_FILE_OFFSET_BITS`.

Note that zlib doesn't use `time_t` at all, so it is a false alarm.

Take the following patch from upstream zlib:
https://github.com/madler/zlib/commit/a566e156b3fa07b566ddbf6801b517a9dba04fa3.patch

Closes #29980.