### PR TITLE
fuzz: don't allow adding duplicate transactions to the mempool

### DIFF
--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -72,7 +72,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
             available.insert(i);
         }
 
-        if (add_to_mempool) {
+        if (add_to_mempool && !pool.exists(GenTxid::Txid(tx->GetHash()))) {
             LOCK2(cs_main, pool.cs);
             pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx));
             available.insert(i);


### PR DESCRIPTION
Filter duplicate transaction ids from being added to the mempool in the `partially_downloaded_block` fuzz target.

I think a prerequisite for calling `CTxMemPool::addUnchecked` should be that the underlying txid doesn't already exist in the mempool (otherwise `addUnchecked` would need a way to return failure, which we don't currently have).