### PR TITLE
functional test: ensure confirmed utxo being sourced for 2nd chain

### DIFF
--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -41,7 +41,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for _ in range(DEFAULT_ANCESTOR_LIMIT - 4):
             utxo, = self.chain_tx([utxo])
             chain.append(utxo)
-        second_chain, = self.chain_tx([self.wallet.get_utxo()])
+        second_chain, = self.chain_tx([self.wallet.get_utxo(confirmed_only=True)])
 
         # Check mempool has DEFAULT_ANCESTOR_LIMIT + 1 transactions in it
         assert_equal(len(self.nodes[0].getrawmempool()), DEFAULT_ANCESTOR_LIMIT + 1)


### PR DESCRIPTION
The test could fail/stop testing what we want if non-confirmed utxos become sourced through some internal change to `MiniWallet`; better to just fetch confirmed explicitly.