### PR TITLE
depends: fix Qt to not use `-q` with `ar`

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -74,8 +74,7 @@ fi
 if [ "$USE_BUSY_BOX" = "true" ]; then
   echo "Setup to use BusyBox utils"
   # tar excluded for now because it requires passing in the exact archive type in ./depends (fixed in later BusyBox version)
-  # ar excluded for now because it does not recognize the -q option in ./depends (unknown if fixed)
-  for util in $(busybox --list | grep -v "^ar$" | grep -v "^tar$" ); do ln -s "$(command -v busybox)" "${BINS_SCRATCH_DIR}/$util"; done
+  for util in $(busybox --list | grep -v "^tar$" ); do ln -s "$(command -v busybox)" "${BINS_SCRATCH_DIR}/$util"; done
   # Print BusyBox version
   patch --help
 fi

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -19,6 +19,7 @@ $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += duplicate_lcqpafonts.patch
 $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fix-macos-linker.patch
+$(package)_patches += remove_gnu_ar_flag.patch
 $(package)_patches += memory_resource.patch
 $(package)_patches += utc_from_string_no_optimize.patch
 $(package)_patches += windows_lto.patch
@@ -249,6 +250,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/memory_resource.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
   patch -p1 -i $($(package)_patch_dir)/duplicate_lcqpafonts.patch && \
+  patch -p1 -i $($(package)_patch_dir)/remove_gnu_ar_flag.patch && \
   patch -p1 -i $($(package)_patch_dir)/utc_from_string_no_optimize.patch && \
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
   patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \

--- a/depends/patches/qt/remove_gnu_ar_flag.patch
+++ b/depends/patches/qt/remove_gnu_ar_flag.patch
@@ -1,0 +1,14 @@
+Qt insists on using -q with ar, which breaks when using
+BusyBox utils. Replace The one broken instance with just
+rc.
+--- a/qtbase/qmake/generators/unix/unixmake2.cpp
++++ b/qtbase/qmake/generators/unix/unixmake2.cpp
+@@ -225,7 +225,7 @@ UnixMakefileGenerator::writeMakeParts(QTextStream &t)
+                                            << fixLibFlags("QMAKE_LIBS_PRIVATE").join(' ') << Qt::endl;
+     }
+ 
+-    t << "AR            = " << var("QMAKE_AR") << Qt::endl;
++    t << "AR            = ar cs" << Qt::endl;
+     t << "RANLIB        = " << var("QMAKE_RANLIB") << Qt::endl;
+     t << "SED           = " << var("QMAKE_STREAM_EDITOR") << Qt::endl;
+     t << "STRIP         = " << var("QMAKE_STRIP") << Qt::endl;


### PR DESCRIPTION
BusyBox `ar` doesn't implement `q`, so replace the Qt usage of `ar cqs` with `ar cs`, which should work properly everywhere. Played around with making this work a different way, but couldn't seem to make it work properly. Open to other working suggestions (our other `AR` substitution still works correctly, it's just this single qmake bootstrap build invocation that is an issue.