### PR TITLE
test: use sleepy wait-for-log in reindex readonly

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -85,7 +85,7 @@ class InitStressTest(BitcoinTestFramework):
 
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will exit after line {terminate_line}")
-            with node.wait_for_debug_log([terminate_line]):
+            with node.busy_wait_for_debug_log([terminate_line]):
                 node.start(extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'])
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()

--- a/test/functional/feature_reindex_readonly.py
+++ b/test/functional/feature_reindex_readonly.py
@@ -75,7 +75,7 @@ class BlockstoreReindexTest(BitcoinTestFramework):
 
         if undo_immutable:
             self.log.debug("Attempt to restart and reindex the node with the unwritable block file")
-            with self.nodes[0].wait_for_debug_log([b"Reindexing finished"]):
+            with self.nodes[0].assert_debug_log(["Reindexing finished"], timeout=60):
                 self.start_node(0, extra_args=['-reindex', '-fastprune'])
             assert block_count == self.nodes[0].getblockcount()
             undo_immutable()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -490,7 +490,7 @@ class TestNode():
         self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
 
     @contextlib.contextmanager
-    def wait_for_debug_log(self, expected_msgs, timeout=60):
+    def busy_wait_for_debug_log(self, expected_msgs, timeout=60):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         Return:


### PR DESCRIPTION
Also rename the busy wait-for-log method to prevent recurrence. See https://github.com/bitcoin/bitcoin/pull/27039#discussion_r1532578152