### PR TITLE
lint: [doc] Clarify Windows line endings (CR LF) not to be used

### DIFF
--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -137,9 +137,9 @@ fn lint_trailing_whitespace() -> LintResult {
     if trailing_space {
         Err(r#"
 ^^^
-Trailing whitespace is problematic, because git may warn about it, or editors may remove it by
-default, forcing developers in the future to either undo the changes manually or spend time on
-review.
+Trailing whitespace (including Windows line endings [CR LF]) is problematic, because git may warn
+about it, or editors may remove it by default, forcing developers in the future to either undo the
+changes manually or spend time on review.
 
 Thus, it is best to remove the trailing space now.
 


### PR DESCRIPTION
It has been this case since the linter was introduced years ago. Given a misunderstanding (https://github.com/bitcoin/bitcoin/pull/28074#issuecomment-2088028856), clarify the docs.