### PR TITLE
refactor, fuzz: Make 64-bit shift explicit

### DIFF
--- a/build_msvc/fuzz/fuzz.vcxproj
+++ b/build_msvc/fuzz/fuzz.vcxproj
@@ -80,11 +80,6 @@
       <Project>{18430fef-6b61-4c53-b396-718e02850f1b}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemDefinitionGroup>
-     <ClCompile>
-       <DisableSpecificWarnings>4018;4244;4267;4334;4715;4805</DisableSpecificWarnings>
-     </ClCompile>
-  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\common.vcxproj" />

--- a/src/test/fuzz/poolresource.cpp
+++ b/src/test/fuzz/poolresource.cpp
@@ -63,9 +63,9 @@ public:
     {
         if (m_total_allocated > 0x1000000) return;
         size_t alignment_bits = m_provider.ConsumeIntegralInRange<size_t>(0, 7);
-        size_t alignment = 1 << alignment_bits;
+        size_t alignment = size_t{1} << alignment_bits;
         size_t size_bits = m_provider.ConsumeIntegralInRange<size_t>(0, 16 - alignment_bits);
-        size_t size = m_provider.ConsumeIntegralInRange<size_t>(1U << size_bits, (1U << (size_bits + 1)) - 1U) << alignment_bits;
+        size_t size = m_provider.ConsumeIntegralInRange<size_t>(size_t{1} << size_bits, (size_t{1} << (size_bits + 1)) - 1U) << alignment_bits;
         Allocate(size, alignment);
     }
 


### PR DESCRIPTION
This PR fixes MSVC warning [C4334](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334) in the fuzzing code. Similar to https://github.com/bitcoin/bitcoin/pull/26252.

All `DisableSpecificWarnings` dropped from `fuzz.vcxproj` as all remained are inherited from `common.init.vcxproj`.

Required to simplify warning suppression porting to the CMake-based build system.