### PR TITLE
test: use assert_greater_than util

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -798,7 +798,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(57)
         self.next_block(58, spend=out[17])
         tx = CTransaction()
-        assert len(out[17].vout) < 42
+        assert_greater_than(42, len(out[17].vout))
         tx.vin.append(CTxIn(COutPoint(out[17].sha256, 42), CScript([OP_TRUE]), SEQUENCE_FINAL))
         tx.vout.append(CTxOut(0, b""))
         tx.calc_sha256()

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -227,7 +227,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
         self.generate(index_node, 1, sync_fun=self.no_op)
         res10 = index_node.gettxoutsetinfo('muhash')
-        assert res8['txouts'] < res10['txouts']
+        assert_greater_than(res10['txouts'], res8['txouts'])
 
         self.log.info("Test that the index works with -reindex")
 

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -28,6 +28,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -103,7 +103,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
                 new_size = len(node.getrawmempool())
                 # Error out if we have something stuck in the mempool, as this
                 # would likely be a bug.
-                assert new_size < mempool_size
+                assert_greater_than(mempool_size, new_size)
                 mempool_size = new_size
 
         return self.wallet.get_utxo(txid=tx["txid"], vout=tx["sent_vout"])

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -14,6 +14,7 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -41,7 +41,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert_equal(set(node.getrawmempool()), set())
         confirmed_txns = set(node.getblock(blocks[0])['tx'] + node.getblock(blocks[1])['tx'])
         # Checks that all spend txns are contained in the mined blocks
-        assert spends_ids < confirmed_txns
+        assert_greater_than(confirmed_txns, spends_ids)
 
         # Use invalidateblock to re-org back
         node.invalidateblock(blocks[0])
@@ -54,7 +54,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # mempool should be empty, all txns confirmed
         assert_equal(set(node.getrawmempool()), set())
         confirmed_txns = set(node.getblock(blocks[0])['tx'])
-        assert spends_ids < confirmed_txns
+        assert_greater_than(confirmed_txns, spends_ids)
 
 
 if __name__ == '__main__':

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -5,7 +5,10 @@
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+   assert_equal,
+   assert_greater_than,
+)
 from test_framework.wallet import MiniWallet
 
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -113,7 +113,7 @@ class AddrTest(BitcoinTestFramework):
             addr.time = self.mocktime + random.randrange(-100, 100)
             addr.nServices = P2P_SERVICES
             if sequential_ips:
-                assert self.counter < 256 ** 2  # Don't allow the returned ip addresses to wrap.
+                assert_greater_than(256 ** 2, self.counter) # Don't allow the returned ip addresses to wrap.
                 addr.ip = f"123.123.{self.counter // 256}.{self.counter % 256}"
                 self.counter += 1
             else:

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -84,6 +84,7 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     softfork_active,
     assert_raises_rpc_error,
 )

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -847,7 +847,7 @@ class SegWitTest(BitcoinTestFramework):
         assert self.nodes[0].getbestblockhash() != block.hash
 
         block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.pop()
-        assert block.get_weight() < MAX_BLOCK_WEIGHT
+        assert_greater_than(MAX_BLOCK_WEIGHT, block.get_weight())
         assert_equal(None, self.nodes[0].submitblock(block.serialize().hex()))
 
         assert self.nodes[0].getbestblockhash() == block.hash
@@ -1885,7 +1885,7 @@ class SegWitTest(BitcoinTestFramework):
         extra_sigops_available = MAX_SIGOP_COST % sigops_per_script
 
         # We chose the number of checkmultisigs/checksigs to make this work:
-        assert extra_sigops_available < 100  # steer clear of MAX_OPS_PER_SCRIPT
+        assert_greater_than(100, extra_sigops_available) # steer clear of MAX_OPS_PER_SCRIPT
 
         # This script, when spent with the first
         # N(=MAX_SIGOP_COST//sigops_per_script) outputs of our transaction,

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -85,7 +85,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer.wait_for_verack()
         verack_index = [i for i, msg in enumerate(peer.messages) if msg.msgtype == b'verack'][0]
         sendtxrcncl_index = [i for i, msg in enumerate(peer.messages) if msg.msgtype == b'sendtxrcncl'][0]
-        assert sendtxrcncl_index < verack_index
+        assert_greater_than(verack_index, sendtxrcncl_index)
         self.nodes[0].disconnect_p2ps()
 
         self.log.info('SENDTXRCNCL on pre-WTXID version should not be sent')

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -19,7 +19,10 @@ from test_framework.p2p import (
     P2P_VERSION,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+)
 
 class PeerNoVerack(P2PInterface):
     def __init__(self, wtxidrelay=True):

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -339,7 +339,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res['bestblock'], node.getblockhash(HEIGHT))
         size = res['disk_size']
         assert size > 6400
-        assert size < 64000
+        assert_greater_than(64000, size)
         assert_equal(len(res['bestblock']), 64)
         assert_equal(len(res['hash_serialized_3']), 64)
 
@@ -433,7 +433,7 @@ class BlockchainTest(BitcoinTestFramework):
         difficulty = self.nodes[0].getdifficulty()
         # 1 hash in 2 should be valid, so difficulty should be 1/2**31
         # binary => decimal => binary math is why we do this check
-        assert abs(difficulty * 2**31 - 1) < 0.0001
+        assert_greater_than(0.0001, abs(difficulty * 2**31 - 1))
 
     def _test_getnetworkhashps(self):
         self.log.info("Test getnetworkhashps")
@@ -475,7 +475,7 @@ class BlockchainTest(BitcoinTestFramework):
 
         # This should be 2 hashes every 10 minutes or 1/300
         hashes_per_second = self.nodes[0].getnetworkhashps()
-        assert abs(hashes_per_second * 300 - 1) < 0.0001
+        assert_greater_than(0.0001, abs(hashes_per_second * 300 - 1))
 
         # Test setting the first param of getnetworkhashps to -1 returns the average network
         # hashes per second from the last difficulty change.

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -144,7 +144,8 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         balw = self.wallet.get_balance()
 
         height = node0.getblockchaininfo()["blocks"]
-        assert 150 < height < 350
+        assert_greater_than(350, height)
+        assert_greater_than(height, 150)
         total = 149 * 50 + (height - 149 - 100) * 25
         assert bal1 == 0
         assert bal2 == self.moved

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -17,6 +17,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
+    assert_greater_than,
 )
 from test_framework.wallet_util import generate_keypair
 from test_framework.wallet import (

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -163,7 +163,7 @@ def create_tx_with_script(prevtx, n, script_sig=b"", *, amount, script_pub_key=C
        Can optionally pass scriptPubKey and scriptSig, default is anyone-can-spend output.
     """
     tx = CTransaction()
-    assert n < len(prevtx.vout)
+    assert_greater_than(len(prevtx.vout), n)
     tx.vin.append(CTxIn(COutPoint(prevtx.sha256, n), script_sig, SEQUENCE_FINAL))
     tx.vout.append(CTxOut(amount, script_pub_key))
     tx.calc_sha256()

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -43,7 +43,10 @@ from .script_util import (
     keys_to_multisig_script,
     script_to_p2wsh_script,
 )
-from .util import assert_equal
+from .util import (
+    assert_equal,
+    assert_greater_than,
+)
 
 WITNESS_SCALE_FACTOR = 4
 MAX_BLOCK_SIGOPS = 20000

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -13,6 +13,8 @@ import struct
 import array
 import os
 
+from .util import assert_greater_than
+
 # STATE_ESTABLISHED = '01'
 # STATE_SYN_SENT  = '02'
 # STATE_SYN_RECV = '03'

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -135,7 +135,7 @@ def addr_to_hex(addr):
                 if i == 0 or i == (len(addr)-1): # skip empty component at beginning or end
                     continue
                 x += 1 # :: skips to suffix
-                assert x < 2
+                assert_greater_than(2, x)
             else: # two bytes per component
                 val = int(comp, 16)
                 sub[x].append(val >> 8)

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -80,6 +80,7 @@ from test_framework.util import (
     MAX_NODES,
     p2p_port,
     wait_until_helper_internal,
+    assert_greater_than,
 )
 from test_framework.v2_p2p import (
     EncryptedP2PState,

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -745,7 +745,8 @@ class NetworkThread(threading.Thread):
         for connections, call `callback`."""
 
         if port is None:
-            assert 0 < idx <= MAX_NODES
+            assert_greater_than(idx, 0)
+            assert idx <= MAX_NODES
             port = p2p_port(MAX_NODES - idx)
         if addr is None:
             addr = '127.0.0.1'

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -13,6 +13,7 @@ import unittest
 
 from .key import TaggedHash, tweak_add_pubkey, compute_xonly_pubkey
 
+
 from .messages import (
     CTransaction,
     CTxOut,

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -12,7 +12,7 @@ import struct
 import unittest
 
 from .key import TaggedHash, tweak_add_pubkey, compute_xonly_pubkey
-
+from .util import assert_greater_than
 
 from .messages import (
     CTransaction,
@@ -814,7 +814,7 @@ def BIP341_sha_outputs(txTo):
 
 def TaprootSignatureMsg(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT):
     assert (len(txTo.vin) == len(spent_utxos))
-    assert (input_index < len(txTo.vin))
+    assert_greater_than(len(txTo.vin), input_index)
     out_type = SIGHASH_ALL if hash_type == 0 else hash_type & 3
     in_type = hash_type & SIGHASH_ANYONECANPAY
     spk = spent_utxos[input_index].scriptPubKey

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -16,6 +16,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -54,7 +54,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: alice.abandontransaction(txid=txA))
 
         newbalance = alice.getbalance()
-        assert balance - newbalance < Decimal("0.001")  #no more than fees lost
+        assert_greater_than(Decimal("0.001"), balance - newbalance) #no more than fees lost
         balance = newbalance
 
         # Disconnect nodes so node0's transactions don't get into node1's mempool

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -740,7 +740,7 @@ def test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address):
 
 def test_bumpfee_metadata(self, rbf_node, dest_address):
     self.log.info('Test that bumped txn metadata persists to new txn record')
-    assert rbf_node.getbalance() < 49
+    assert_greater_than(49, rbf_node.getbalance())
     self.generatetoaddress(rbf_node, 101, rbf_node.getnewaddress())
     rbfid = rbf_node.sendtoaddress(dest_address, 49, "comment value", "to value")
     bumped_tx = rbf_node.bumpfee(rbfid)

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -105,7 +105,7 @@ class TxConflicts(BitcoinTestFramework):
 
         self.log.info("Verify, after the reorg, that Tx_A was accepted, and tx_AB and its Child_Tx are conflicting now")
         # Tx A was accepted, Tx AB was not.
-        assert conflicted_AB_tx["confirmations"] < 0
+        assert_greater_than(0, conflicted_AB_tx["confirmations"])
         assert conflicted_A_tx["confirmations"] > 0
 
         # Conflicted tx should have confirmations set to the confirmations of the most conflicting tx

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -13,6 +13,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
         assert_equal,
+        assert_greater_than,
 )
 
 class TxConflicts(BitcoinTestFramework):

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -6,6 +6,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 from test_framework.blocktools import (

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -46,7 +46,8 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
-        assert 0 < tx['locktime'] <= 201
+        assert_greater_than(tx['locktime'], 0)
+        assert tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate


### PR DESCRIPTION
In the functional tests there are lots of cases where we assert < which we now swap with assert_greater_than to be more readable

This is motivated/uses logic from this PR which was closed https://github.com/bitcoin/bitcoin/pull/28528
This partially helps https://github.com/bitcoin/bitcoin/issues/23119

I've broken it up to just assert_greater_than to keep the PR smaller as suggested in https://github.com/bitcoin/bitcoin/pull/28528#issuecomment-1959945805

[Similar change for assert_not_equal](https://github.com/bitcoin/bitcoin/pull/29500)

I did not use the scripted-diff for the last commit since it either included a <= or there was already a () which did not match the pattern of the rest

if you run this command on this branch it should come back empty
`git grep -nri -e "assert .*< " --and --not -e "assert .*!=" -- ./test/functional`