### PR TITLE
doc: add dustThreshold explain of P2SH & P2TR

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -43,6 +43,11 @@
  *   so dust is a spendable txout less than
  *   98*dustRelayFee/1000 (in satoshis).
  *   294 satoshis at the default rate of 3000 sat/kvB.
+ * - A typical spendable segwit P2TR txout is 43 bytes big, and will
+ *   need a CTxIn of at least 57（used 67, see reason below） bytes to spend:
+ *   so dust is a spendable txout less than
+ *   110*dustRelayFee/1000 (in satoshis).
+ *   330 satoshis at the default rate of 3000 sat/kvB.
  *
  * The actual dust threshold is calculated by determining the cost to
  * spend the output at the current fee rate and comparing it to the

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -23,22 +23,37 @@
 #include <cstddef>
 #include <vector>
 
+/**
+ * Calculate the dust threshold for an output based on the given fee rate.
+ *
+ * "Dust" is defined in terms of dustRelayFee, which has units satoshis-per-kilobyte.
+ * If you'd pay more in fees than the value of the output to spend something, then we consider it dust.
+ *
+ * Definitions for different output types:
+ * - A typical spendable non-segwit P2PKH txout is 34 bytes big, and will
+ *   need a CTxIn of at least 148 bytes to spend:
+ *   so dust is a spendable txout less than 182*dustRelayFee/1000 (in satoshis).
+ *   546 satoshis at the default rate of 3000 sat/kvB.
+ * - A typical spendable non-segwit P2SH txout is 32 bytes big, and will
+ *   need a CTxIn of at least 148 bytes to spend:
+ *   so dust is a spendable txout less than 180*dustRelayFee/1000 (in satoshis).
+ *   540 satoshis at the default rate of 3000 sat/kvB.
+ * - A typical spendable segwit P2WPKH txout is 31 bytes big, and will
+ *   need a CTxIn of at least 67 bytes to spend:
+ *   so dust is a spendable txout less than
+ *   98*dustRelayFee/1000 (in satoshis).
+ *   294 satoshis at the default rate of 3000 sat/kvB.
+ *
+ * The actual dust threshold is calculated by determining the cost to
+ * spend the output at the current fee rate and comparing it to the
+ * output's value.
+ *
+ * @param txout The transaction output to evaluate.
+ * @param dustRelayFeeIn The fee rate used for calculating dust, in satoshis-per-kilobyte.
+ * @return The calculated dust threshold in satoshis.
+ */
 CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 {
-    // "Dust" is defined in terms of dustRelayFee,
-    // which has units satoshis-per-kilobyte.
-    // If you'd pay more in fees than the value of the output
-    // to spend something, then we consider it dust.
-    // A typical spendable non-segwit txout is 34 bytes big, and will
-    // need a CTxIn of at least 148 bytes to spend:
-    // so dust is a spendable txout less than
-    // 182*dustRelayFee/1000 (in satoshis).
-    // 546 satoshis at the default rate of 3000 sat/kvB.
-    // A typical spendable segwit P2WPKH txout is 31 bytes big, and will
-    // need a CTxIn of at least 67 bytes to spend:
-    // so dust is a spendable txout less than
-    // 98*dustRelayFee/1000 (in satoshis).
-    // 294 satoshis at the default rate of 3000 sat/kvB.
     if (txout.scriptPubKey.IsUnspendable())
         return 0;
 


### PR DESCRIPTION
The calculation of dust in Bitcoin has different values for different payment types.
For non-Witness: (148 + vout size)*rate
For Witness: (67+vout size)*rate

According to our calculation logic, our common P2PKH is 546, P2SH is 540, the minimum value of Witness is P2WPKH is 294, and P2TR is 330

However, the comments only mentioned P2PKH’s 546 and P2WPKH’s 294, which is inconsistent with the code logic.

These four payment types are very common in BTC wallets, so I think it is necessary to update the comments