### PR TITLE
doc: replace remaining "520" magic nums with MAX_SCRIPT_ELEMENT_SIZE

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5205,7 +5205,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         std::vector<unsigned char> vData;
         vRecv >> vData;
 
-        // Nodes must NEVER send a data item > 520 bytes (the max size for a script data object,
+        // Nodes must NEVER send a data item > MAX_SCRIPT_ELEMENT_SIZE bytes (the max size for a script data object,
         // and thus, the maximum size any matched object can have) in a filteradd message
         bool bad = false;
         if (vData.size() > MAX_SCRIPT_ELEMENT_SIZE) {

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -85,7 +85,7 @@ CTxDestination AddAndGetDestinationForScript(FillableSigningProvider& keystore, 
 {
     // Add script to keystore
     keystore.AddCScript(script);
-    // Note that scripts over 520 bytes are not yet supported.
+    // Note that scripts over MAX_SCRIPT_ELEMENT_SIZE bytes are not yet supported.
     switch (type) {
     case OutputType::LEGACY:
         return ScriptHash(script);

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -111,7 +111,7 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
     for (const CTxIn& txin : tx.vin)
     {
         // Biggest 'standard' txin involving only keys is a 15-of-15 P2SH
-        // multisig with compressed keys (remember the 520 byte limit on
+        // multisig with compressed keys (remember the MAX_SCRIPT_ELEMENT_SIZE byte limit on
         // redeemScript size). That works out to a (15*(33+1))+3=513 byte
         // redeemScript, 513+1+15*(73+1)+3=1627 bytes of scriptSig, which
         // we round off to 1650(MAX_STANDARD_SCRIPTSIG_SIZE) bytes for

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -1054,7 +1054,7 @@ class SegWitTest(BitcoinTestFramework):
 
     @subtest
     def test_max_witness_push_length(self):
-        """Test that witness stack can only allow up to 520 byte pushes."""
+        """Test that witness stack can only allow up to MAX_SCRIPT_ELEMENT_SIZE byte pushes."""
 
         block = self.build_next_block()
 


### PR DESCRIPTION
Noticed these while reviewing BIPs yesterday.

It would be clearer and more future-proof to refer to their constant name.