### PR TITLE
test: remove duplicate `WITNESS_SCALE_FACTOR` constant definition

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -10,7 +10,6 @@ from test_framework.blocktools import (
     create_block,
     add_witness_commitment,
     MAX_BLOCK_SIGOPS_WEIGHT,
-    WITNESS_SCALE_FACTOR,
 )
 from test_framework.messages import (
     COutPoint,
@@ -20,6 +19,7 @@ from test_framework.messages import (
     CTxOut,
     SEQUENCE_FINAL,
     tx_from_hex,
+    WITNESS_SCALE_FACTOR,
 )
 from test_framework.script import (
     ANNEX_TAG,

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -28,6 +28,7 @@ from .messages import (
     ser_uint256,
     tx_from_hex,
     uint256_from_str,
+    WITNESS_SCALE_FACTOR,
 )
 from .script import (
     CScript,
@@ -45,7 +46,6 @@ from .script_util import (
 )
 from .util import assert_equal
 
-WITNESS_SCALE_FACTOR = 4
 MAX_BLOCK_SIGOPS = 20000
 MAX_BLOCK_SIGOPS_WEIGHT = MAX_BLOCK_SIGOPS * WITNESS_SCALE_FACTOR
 


### PR DESCRIPTION
Notice this while working on #29523

- `blocktools.py` and `messages.py` both define `WITNESS_SCALE_FACTOR` constant

https://github.com/bitcoin/bitcoin/blob/99d7538cdb2a0ab7a7a2116cd5f33b95fc52b00e/test/functional/test_framework/blocktools.py#L48

https://github.com/bitcoin/bitcoin/blob/99d7538cdb2a0ab7a7a2116cd5f33b95fc52b00e/test/functional/test_framework/messages.py#L68
- This PR deletes the one in `blocktools.py` and update the tests to only use `WITNESS_SCALE_FACTOR` from `messages.py` 

