### PR TITLE
p2p: Allow 1P1C to fetch parent from compact block extra_txn

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -194,6 +194,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                             help="use BIP324 v2 connections between all nodes by default")
         parser.add_argument("--v1transport", dest="v1transport", default=False, action="store_true",
                             help="Explicitly use v1 transport (can be used to overwrite global --v2transport option)")
+        parser.add_argument("--noextratxn", dest="noextratxn", default=False, action="store_true",
+                            help="No extra transactions for compact blocks")
 
         self.add_options(parser)
         # Running TestShell in a Jupyter notebook causes an additional -f argument

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -185,6 +185,7 @@ BASE_SCRIPTS = [
     'rpc_misc.py',
     'p2p_1p1c_network.py',
     'p2p_opportunistic_1p1c.py',
+    'p2p_opportunistic_1p1c.py --noextratxn',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
     'wallet_avoid_mixing_output_types.py --descriptors',


### PR DESCRIPTION
One relatively common pattern of 1P1C relay is receiving
a just-below-minfee parent, dropping it and marking it
as reconsiderable, then fetching it again from the peer
once the child is added to the orphanage.

A cache of dropped parents would be useful, and it turns
out we're already opportunistically storing transactions
like this for compact blocks as "extra transactions".
Use this size-limited cache to potentially fetch a
reconsiderable parent from memory, and submit for validation.