### PR TITLE
util, refactor: Switch to value-initialization

### DIFF
--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -16,4 +16,4 @@ export GOAL="deploy"
 # Prior to 11.0.0, the mingw-w64 headers were missing noreturn attributes, causing warnings when
 # cross-compiling for Windows. https://sourceforge.net/p/mingw-w64/bugs/306/
 # https://github.com/mingw-w64/mingw-w64/commit/1690994f515910a31b9fb7c7bd3a52d4ba987abe
-export BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests CXXFLAGS='-Wno-return-type -Wno-error=maybe-uninitialized -Wno-error=array-bounds'"
+export BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests CXXFLAGS='-Wno-return-type -Wno-error=array-bounds'"

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -181,7 +181,7 @@ template <typename T>
 std::optional<T> ToIntegral(std::string_view str)
 {
     static_assert(std::is_integral<T>::value);
-    T result;
+    T result{};
     const auto [first_nonmatching, error_condition] = std::from_chars(str.data(), str.data() + str.size(), result);
     if (first_nonmatching != str.data() + str.size() || error_condition != std::errc{}) {
         return std::nullopt;


### PR DESCRIPTION
This PR allows to avoid false positive `-Wmaybe-uninitialized` warnings when cross-compiling for Windows.