### PR TITLE
Compare `COutPoints` lexicographically

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -8,6 +8,7 @@
 
 #include <attributes.h>
 #include <consensus/amount.h>
+#include <crypto/common.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -15,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <ios>
 #include <limits>
 #include <memory>
@@ -43,7 +45,12 @@ public:
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {
-        return std::tie(a.hash, a.n) < std::tie(b.hash, b.n);
+        // Compare outpoints based on their 36-byte serialization (<txid little-endian>:<vout little-endian>)
+        if (a.hash != b.hash) return a.hash < b.hash;
+        uint8_t a_vout[4], b_vout[4];
+        WriteLE32(a_vout, a.n);
+        WriteLE32(b_vout, b.n);
+        return std::memcmp(a_vout, b_vout, 4) < 0;
     }
 
     friend bool operator==(const COutPoint& a, const COutPoint& b)


### PR DESCRIPTION
Broken out from #28122 

---

BIP352 requires the smallest output lexicographically, which is my primary motivation for adding this as the default way of compare `COutPoint`s (e.g. https://github.com/bitcoin/bitcoin/blob/5b06ccf1dc63f56dbc35368a37b9a72af671f15f/src/common/bip352.cpp#L149)

Outside of needing this for #28122 , I think it makes more sense to compare `COutPoints` by their serialization for any use case that needs ordering since the serialization is what appears in the final transaction. I also didn't see any existing places in the code where we order outpoints, so this change doesn't conflict with any current use cases that I can see. If there is a need to order inputs by their `vout` field (e.g. for an RPC output), something like

```c++
std::sort(outpoints.begin(), outpoints.end(), [](const COutPoint& a, const COutPoint& b) { return a.vout < b.vout; });
```

seems preferable, rather than first comparing `a.hash < b.hash`.