### PR TITLE
test: added test coverage to loadtxoutset could not open file

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -152,6 +152,12 @@ class AssumeutxoTest(BitcoinTestFramework):
 
         self.restart_node(2, extra_args=self.extra_args[2])
 
+    def test_invalid_file_path(self):
+        self.log.info("Test bitcoind should fail when file path is invalid.")
+        node = self.nodes[0]
+        path = node.datadir_path / node.chain / "invalid" / "path"
+        assert_raises_rpc_error(-8, "Couldn't open file {} for reading.".format(path), node.loadtxoutset, path)
+
     def run_test(self):
         """
         Bring up two (disconnected) nodes, mine some new blocks on the first,
@@ -236,6 +242,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.test_invalid_mempool_state(dump_output['path'])
         self.test_invalid_snapshot_scenarios(dump_output['path'])
         self.test_invalid_chainstate_scenarios()
+        self.test_invalid_file_path()
 
         self.log.info(f"Loading snapshot into second node from {dump_output['path']}")
         loaded = n1.loadtxoutset(dump_output['path'])


### PR DESCRIPTION
The functional test coverage did not cover the rpc error of "Couldn't open file..." for loadtxoutset and this test adds coverage for it

This adds coverage to this line
https://github.com/bitcoin/bitcoin/blob/master/src/rpc/blockchain.cpp#L2777