### PR TITLE
Encapsulate warnings in generalized node::Warnings and remove globals

### DIFF
--- a/doc/release-notes-30058.md
+++ b/doc/release-notes-30058.md
@@ -1,0 +1,7 @@
+- When running with -alertnotify, an alert can now be raised multiple
+times instead of just once. Previously, it was only raised when unknown
+new consensus rules were activated, whereas the scope has now been
+increased to include all kernel warnings. Specifically, alerts will now
+also be raised when an invalid chain with a large amount of work has
+been detected. Additional warnings may be added in the future.
+(#30058)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -196,6 +196,7 @@ BITCOIN_CORE_H = \
   kernel/messagestartchars.h \
   kernel/notifications_interface.h \
   kernel/validation_cache_sizes.h \
+  kernel/warning.h \
   key.h \
   key_io.h \
   logging.h \
@@ -996,8 +997,7 @@ libbitcoinkernel_la_SOURCES = \
   util/tokenpipe.cpp \
   validation.cpp \
   validationinterface.cpp \
-  versionbits.cpp \
-  warnings.cpp
+  versionbits.cpp
 
 # Required for obj/build.h to be generated first.
 # More details: https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -239,6 +239,7 @@ BITCOIN_CORE_H = \
   node/types.h \
   node/utxo_snapshot.h \
   node/validation_cache_args.h \
+  node/warnings.h \
   noui.h \
   outputtype.h \
   policy/v3_policy.h \
@@ -367,7 +368,6 @@ BITCOIN_CORE_H = \
   wallet/wallettool.h \
   wallet/walletutil.h \
   walletinitinterface.h \
-  warnings.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h \
@@ -444,6 +444,7 @@ libbitcoin_node_a_SOURCES = \
   node/txreconciliation.cpp \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \
+  node/warnings.cpp \
   noui.cpp \
   policy/v3_policy.cpp \
   policy/fees.cpp \
@@ -721,7 +722,6 @@ libbitcoin_common_a_SOURCES = \
   script/sign.cpp \
   script/signingprovider.cpp \
   script/solver.cpp \
-  warnings.cpp \
   $(BITCOIN_CORE_H)
 #
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -118,6 +118,7 @@ BITCOIN_TESTS =\
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/node_warnings_tests.cpp \
   test/orphanage_tests.cpp \
   test/peerman_tests.cpp \
   test/pmt_tests.cpp \

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -16,6 +16,7 @@
 #include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/validation_cache_sizes.h>
+#include <kernel/warning.h>
 
 #include <consensus/validation.h>
 #include <core_io.h>
@@ -28,6 +29,7 @@
 #include <util/fs.h>
 #include <util/signalinterrupt.h>
 #include <util/task_runner.h>
+#include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
 
@@ -86,9 +88,13 @@ int main(int argc, char* argv[])
         {
             std::cout << "Progress: " << title.original << ", " << progress_percent << ", " << resume_possible << std::endl;
         }
-        void warning(const bilingual_str& warning) override
+        void warningSet(kernel::Warning id, const bilingual_str& message) override
         {
-            std::cout << "Warning: " << warning.original << std::endl;
+            std::cout << "Warning " << static_cast<int>(id) << " set: " << message.original << std::endl;
+        }
+        void warningUnset(kernel::Warning id) override
+        {
+            std::cout << "Warning " << static_cast<int>(id) << " unset" << std::endl;
         }
         void flushError(const bilingual_str& message) override
         {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -17,6 +17,7 @@
 #include <kernel/context.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
+#include <node/warnings.h>
 #include <noui.h>
 #include <util/check.h>
 #include <util/exception.h>
@@ -180,6 +181,8 @@ static bool AppInit(NodeContext& node)
             // InitError will have been called with detailed error, which ends up on console
             return false;
         }
+
+        node.warnings = std::make_unique<node::Warnings>();
 
         node.kernel = std::make_unique<kernel::Context>();
         node.ecc_context = std::make_unique<ECC_Context>();

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -17,7 +17,6 @@
 #include <util/thread.h>
 #include <util/translation.h>
 #include <validation.h> // For g_chainman
-#include <warnings.h>
 
 #include <string>
 #include <utility>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -30,7 +30,7 @@ template <typename... Args>
 void BaseIndex::FatalErrorf(const char* fmt, const Args&... args)
 {
     auto message = tfm::format(fmt, args...);
-    node::AbortNode(m_chain->context()->shutdown, m_chain->context()->exit_status, Untranslated(message));
+    node::AbortNode(m_chain->context()->shutdown, m_chain->context()->exit_status, Untranslated(message), m_chain->context()->warnings.get());
 }
 
 CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1486,7 +1486,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7: load block chain
 
-    node.notifications = std::make_unique<KernelNotifications>(*Assert(node.shutdown), node.exit_status);
+    node.notifications = std::make_unique<KernelNotifications>(*Assert(node.shutdown), node.exit_status, *Assert(node.warnings));
     ReadNotificationArgs(args, *node.notifications);
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
@@ -1639,7 +1639,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,
                                      node.banman.get(), chainman,
-                                     *node.mempool, peerman_opts);
+                                     *node.mempool, *node.warnings,
+                                     peerman_opts);
     validation_signals.RegisterValidationInterface(node.peerman.get());
 
     // ********************************************************* Step 8: start indexers

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -16,6 +16,8 @@ namespace kernel {
 
 //! Result type for use with std::variant to indicate that an operation should be interrupted.
 struct Interrupted{};
+enum class Warning;
+
 
 //! Simple result type for functions that need to propagate an interrupt status and don't have other return values.
 using InterruptResult = std::variant<std::monostate, Interrupted>;
@@ -38,7 +40,8 @@ public:
     [[nodiscard]] virtual InterruptResult blockTip(SynchronizationState state, CBlockIndex& index) { return {}; }
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
-    virtual void warning(const bilingual_str& warning) {}
+    virtual void warningSet(Warning id, const bilingual_str& message) {}
+    virtual void warningUnset(Warning id) {}
 
     //! The flush error notification is sent to notify the user that an error
     //! occurred while flushing block data to disk. Kernel code may ignore flush

--- a/src/kernel/warning.h
+++ b/src/kernel/warning.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_WARNING_H
+#define BITCOIN_KERNEL_WARNING_H
+
+namespace kernel {
+enum class Warning {
+    UNKNOWN_NEW_RULES_ACTIVATED,
+    LARGE_WORK_INVALID_CHAIN,
+};
+} // namespace kernel
+#endif // BITCOIN_KERNEL_WARNING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -16,6 +16,10 @@ class CChainParams;
 class CTxMemPool;
 class ChainstateManager;
 
+namespace node {
+class Warnings;
+} // namespace node
+
 /** Whether transaction reconciliation protocol should be enabled by default. */
 static constexpr bool DEFAULT_TXRECONCILIATION_ENABLE{false};
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
@@ -73,7 +77,7 @@ public:
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, Options opts);
+                                             CTxMemPool& pool, node::Warnings& warnings, Options opts);
     virtual ~PeerManager() { }
 
     /**

--- a/src/node/abort.cpp
+++ b/src/node/abort.cpp
@@ -15,9 +15,9 @@
 
 namespace node {
 
-void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& message)
+void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& message, node::Warnings* warnings)
 {
-    g_warnings.Set(Warning::FATAL_INTERNAL_ERROR, message);
+    if (warnings) warnings->Set(Warning::FATAL_INTERNAL_ERROR, message);
     InitError(_("A fatal internal error occurred, see debug.log for details: ") + message);
     exit_status.store(EXIT_FAILURE);
     if (shutdown && !(*shutdown)()) {

--- a/src/node/abort.cpp
+++ b/src/node/abort.cpp
@@ -12,13 +12,12 @@
 
 #include <atomic>
 #include <cstdlib>
-#include <string>
 
 namespace node {
 
 void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& message)
 {
-    SetMiscWarning(message);
+    g_warnings.Set(Warning::FATAL_INTERNAL_ERROR, message);
     InitError(_("A fatal internal error occurred, see debug.log for details: ") + message);
     exit_status.store(EXIT_FAILURE);
     if (shutdown && !(*shutdown)()) {

--- a/src/node/abort.cpp
+++ b/src/node/abort.cpp
@@ -6,9 +6,9 @@
 
 #include <logging.h>
 #include <node/interface_ui.h>
+#include <node/warnings.h>
 #include <util/signalinterrupt.h>
 #include <util/translation.h>
-#include <warnings.h>
 
 #include <atomic>
 #include <cstdlib>

--- a/src/node/abort.h
+++ b/src/node/abort.h
@@ -14,7 +14,8 @@ class SignalInterrupt;
 } // namespace util
 
 namespace node {
-void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& message);
+class Warnings;
+void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, const bilingual_str& message, node::Warnings* warnings);
 } // namespace node
 
 #endif // BITCOIN_NODE_ABORT_H

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -13,6 +13,7 @@
 #include <net_processing.h>
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
+#include <node/warnings.h>
 #include <policy/fees.h>
 #include <scheduler.h>
 #include <txmempool.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -39,6 +39,7 @@ class SignalInterrupt;
 
 namespace node {
 class KernelNotifications;
+class Warnings;
 
 //! NodeContext struct containing references to chain state and connection
 //! state.
@@ -81,6 +82,8 @@ struct NodeContext {
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
     std::atomic<int> exit_status{EXIT_SUCCESS};
+    //! Manages all the node warnings
+    std::unique_ptr<node::Warnings> warnings;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -93,7 +93,7 @@ public:
     explicit NodeImpl(NodeContext& context) { setContext(&context); }
     void initLogging() override { InitLogging(args()); }
     void initParameterInteraction() override { InitParameterInteraction(args()); }
-    bilingual_str getWarnings() override { return Join(GetWarnings(), Untranslated("<hr />")); }
+    bilingual_str getWarnings() override { return Join(node::g_warnings.GetMessages(), Untranslated("<hr />")); }
     int getExitStatus() override { return Assert(m_context)->exit_status.load(); }
     uint32_t getLogCategories() override { return LogInstance().GetCategoryMask(); }
     bool baseInitialize() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -93,7 +93,7 @@ public:
     explicit NodeImpl(NodeContext& context) { setContext(&context); }
     void initLogging() override { InitLogging(args()); }
     void initParameterInteraction() override { InitParameterInteraction(args()); }
-    bilingual_str getWarnings() override { return Join(node::g_warnings.GetMessages(), Untranslated("<hr />")); }
+    bilingual_str getWarnings() override { return Join(Assert(m_context->warnings)->GetMessages(), Untranslated("<hr />")); }
     int getExitStatus() override { return Assert(m_context)->exit_status.load(); }
     uint32_t getLogCategories() override { return LogInstance().GetCategoryMask(); }
     bool baseInitialize() override
@@ -101,6 +101,7 @@ public:
         if (!AppInitBasicSetup(args(), Assert(context())->exit_status)) return false;
         if (!AppInitParameterInteraction(args())) return false;
 
+        m_context->warnings = std::make_unique<node::Warnings>();
         m_context->kernel = std::make_unique<kernel::Context>();
         m_context->ecc_context = std::make_unique<ECC_Context>();
         if (!AppInitSanityChecks(*m_context->kernel)) return false;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -32,6 +32,7 @@
 #include <node/mini_miner.h>
 #include <node/transaction.h>
 #include <node/types.h>
+#include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -53,7 +54,6 @@
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
-#include <warnings.h>
 
 #include <config/bitcoin-config.h> // IWYU pragma: keep
 

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -29,7 +29,6 @@ using util::ReplaceAll;
 
 static void AlertNotify(const std::string& strMessage)
 {
-    uiInterface.NotifyAlertChanged();
 #if HAVE_SYSTEM
     std::string strCmd = gArgs.GetArg("-alertnotify", "");
     if (strCmd.empty()) return;

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -10,6 +10,7 @@
 #include <common/args.h>
 #include <common/system.h>
 #include <kernel/context.h>
+#include <kernel/warning.h>
 #include <logging.h>
 #include <node/abort.h>
 #include <node/interface_ui.h>
@@ -46,16 +47,6 @@ static void AlertNotify(const std::string& strMessage)
 #endif
 }
 
-static void DoWarning(const bilingual_str& warning)
-{
-    static bool fWarned = false;
-    node::SetMiscWarning(warning);
-    if (!fWarned) {
-        AlertNotify(warning.original);
-        fWarned = true;
-    }
-}
-
 namespace node {
 
 kernel::InterruptResult KernelNotifications::blockTip(SynchronizationState state, CBlockIndex& index)
@@ -80,9 +71,16 @@ void KernelNotifications::progress(const bilingual_str& title, int progress_perc
     uiInterface.ShowProgress(title.translated, progress_percent, resume_possible);
 }
 
-void KernelNotifications::warning(const bilingual_str& warning)
+void KernelNotifications::warningSet(kernel::Warning id, const bilingual_str& message)
 {
-    DoWarning(warning);
+    if (node::g_warnings.Set(id, message)) {
+        AlertNotify(message.original);
+    }
+}
+
+void KernelNotifications::warningUnset(kernel::Warning id)
+{
+    g_warnings.Unset(id);
 }
 
 void KernelNotifications::flushError(const bilingual_str& message)

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -72,25 +72,25 @@ void KernelNotifications::progress(const bilingual_str& title, int progress_perc
 
 void KernelNotifications::warningSet(kernel::Warning id, const bilingual_str& message)
 {
-    if (node::g_warnings.Set(id, message)) {
+    if (m_warnings.Set(id, message)) {
         AlertNotify(message.original);
     }
 }
 
 void KernelNotifications::warningUnset(kernel::Warning id)
 {
-    g_warnings.Unset(id);
+    m_warnings.Unset(id);
 }
 
 void KernelNotifications::flushError(const bilingual_str& message)
 {
-    AbortNode(&m_shutdown, m_exit_status, message);
+    AbortNode(&m_shutdown, m_exit_status, message, &m_warnings);
 }
 
 void KernelNotifications::fatalError(const bilingual_str& message)
 {
     node::AbortNode(m_shutdown_on_fatal_error ? &m_shutdown : nullptr,
-                    m_exit_status, message);
+                    m_exit_status, message, &m_warnings);
 }
 
 void ReadNotificationArgs(const ArgsManager& args, KernelNotifications& notifications)

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -13,12 +13,12 @@
 #include <logging.h>
 #include <node/abort.h>
 #include <node/interface_ui.h>
+#include <node/warnings.h>
 #include <util/check.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>
-#include <warnings.h>
 
 #include <cstdint>
 #include <string>
@@ -49,7 +49,7 @@ static void AlertNotify(const std::string& strMessage)
 static void DoWarning(const bilingual_str& warning)
 {
     static bool fWarned = false;
-    SetMiscWarning(warning);
+    node::SetMiscWarning(warning);
     if (!fWarned) {
         AlertNotify(warning.original);
         fWarned = true;

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -15,6 +15,10 @@ class CBlockIndex;
 enum class SynchronizationState;
 struct bilingual_str;
 
+namespace kernel {
+enum class Warning;
+} // namespace kernel
+
 namespace util {
 class SignalInterrupt;
 } // namespace util
@@ -34,7 +38,9 @@ public:
 
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 
-    void warning(const bilingual_str& warning) override;
+    void warningSet(kernel::Warning id, const bilingual_str& message) override;
+
+    void warningUnset(kernel::Warning id) override;
 
     void flushError(const bilingual_str& message) override;
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -25,12 +25,14 @@ class SignalInterrupt;
 
 namespace node {
 
+class Warnings;
 static constexpr int DEFAULT_STOPATHEIGHT{0};
 
 class KernelNotifications : public kernel::Notifications
 {
 public:
-    KernelNotifications(util::SignalInterrupt& shutdown, std::atomic<int>& exit_status) : m_shutdown(shutdown), m_exit_status{exit_status} {}
+    KernelNotifications(util::SignalInterrupt& shutdown, std::atomic<int>& exit_status, node::Warnings& warnings)
+        : m_shutdown(shutdown), m_exit_status{exit_status}, m_warnings{warnings} {}
 
     [[nodiscard]] kernel::InterruptResult blockTip(SynchronizationState state, CBlockIndex& index) override;
 
@@ -53,6 +55,7 @@ public:
 private:
     util::SignalInterrupt& m_shutdown;
     std::atomic<int>& m_exit_status;
+    node::Warnings& m_warnings;
 };
 
 void ReadNotificationArgs(const ArgsManager& args, KernelNotifications& notifications);

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <logging.h>
-#include <node/interface_ui.h>
 #include <node/timeoffsets.h>
 #include <node/warnings.h>
 #include <sync.h>
@@ -50,7 +49,6 @@ bool TimeOffsets::WarnIfOutOfSync() const
     auto median{std::max(Median(), std::chrono::seconds(std::numeric_limits<int64_t>::min() + 1))};
     if (std::chrono::abs(median) <= WARN_THRESHOLD) {
         node::g_warnings.Unset(node::Warning::CLOCK_OUT_OF_SYNC);
-        uiInterface.NotifyAlertChanged();
         return false;
     }
 
@@ -64,6 +62,5 @@ bool TimeOffsets::WarnIfOutOfSync() const
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
     LogWarning("%s\n", msg.original);
     node::g_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
-    uiInterface.NotifyAlertChanged();
     return true;
 }

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -49,7 +49,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
     // when median == std::numeric_limits<int64_t>::min(), calling std::chrono::abs is UB
     auto median{std::max(Median(), std::chrono::seconds(std::numeric_limits<int64_t>::min() + 1))};
     if (std::chrono::abs(median) <= WARN_THRESHOLD) {
-        node::SetMedianTimeOffsetWarning(std::nullopt);
+        node::g_warnings.Unset(node::Warning::CLOCK_OUT_OF_SYNC);
         uiInterface.NotifyAlertChanged();
         return false;
     }
@@ -63,7 +63,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
         "RPC methods to get more info."
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
     LogWarning("%s\n", msg.original);
-    node::SetMedianTimeOffsetWarning(msg);
+    node::g_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
     uiInterface.NotifyAlertChanged();
     return true;
 }

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -48,7 +48,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
     // when median == std::numeric_limits<int64_t>::min(), calling std::chrono::abs is UB
     auto median{std::max(Median(), std::chrono::seconds(std::numeric_limits<int64_t>::min() + 1))};
     if (std::chrono::abs(median) <= WARN_THRESHOLD) {
-        node::g_warnings.Unset(node::Warning::CLOCK_OUT_OF_SYNC);
+        m_warnings.Unset(node::Warning::CLOCK_OUT_OF_SYNC);
         return false;
     }
 
@@ -61,6 +61,6 @@ bool TimeOffsets::WarnIfOutOfSync() const
         "RPC methods to get more info."
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
     LogWarning("%s\n", msg.original);
-    node::g_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
+    m_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
     return true;
 }

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -5,11 +5,11 @@
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <node/timeoffsets.h>
+#include <node/warnings.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <warnings.h>
 
 #include <algorithm>
 #include <chrono>
@@ -49,7 +49,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
     // when median == std::numeric_limits<int64_t>::min(), calling std::chrono::abs is UB
     auto median{std::max(Median(), std::chrono::seconds(std::numeric_limits<int64_t>::min() + 1))};
     if (std::chrono::abs(median) <= WARN_THRESHOLD) {
-        SetMedianTimeOffsetWarning(std::nullopt);
+        node::SetMedianTimeOffsetWarning(std::nullopt);
         uiInterface.NotifyAlertChanged();
         return false;
     }
@@ -63,7 +63,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
         "RPC methods to get more info."
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
     LogWarning("%s\n", msg.original);
-    SetMedianTimeOffsetWarning(msg);
+    node::SetMedianTimeOffsetWarning(msg);
     uiInterface.NotifyAlertChanged();
     return true;
 }

--- a/src/node/timeoffsets.h
+++ b/src/node/timeoffsets.h
@@ -11,8 +11,16 @@
 #include <cstddef>
 #include <deque>
 
+namespace node {
+class Warnings;
+} // namespace node
+
 class TimeOffsets
 {
+public:
+    TimeOffsets(node::Warnings& warnings) : m_warnings{warnings} {}
+
+private:
     //! Maximum number of timeoffsets stored.
     static constexpr size_t MAX_SIZE{50};
     //! Minimum difference between system and network time for a warning to be raised.
@@ -22,6 +30,8 @@ class TimeOffsets
     /** The observed time differences between our local clock and those of our outbound peers. A
      * positive offset means our peer's clock is ahead of our local clock. */
     std::deque<std::chrono::seconds> m_offsets GUARDED_BY(m_mutex){};
+
+    node::Warnings& m_warnings;
 
 public:
     /** Add a new time offset sample. */

--- a/src/node/warnings.cpp
+++ b/src/node/warnings.cpp
@@ -17,8 +17,6 @@
 #include <vector>
 
 namespace node {
-Warnings g_warnings;
-
 Warnings::Warnings()
 {
     // Pre-release build warning
@@ -54,17 +52,17 @@ std::vector<bilingual_str> Warnings::GetMessages() const
     return messages;
 }
 
-UniValue GetWarningsForRpc(bool use_deprecated)
+UniValue GetWarningsForRpc(const Warnings& warnings, bool use_deprecated)
 {
     if (use_deprecated) {
-        const auto all_warnings{g_warnings.GetMessages()};
-        return all_warnings.empty() ? "" : all_warnings.back().original;
+        const auto all_messages{warnings.GetMessages()};
+        return all_messages.empty() ? "" : all_messages.back().original;
     }
 
-    UniValue warnings{UniValue::VARR};
-    for (auto&& warning : g_warnings.GetMessages()) {
-        warnings.push_back(std::move(warning.original));
+    UniValue messages{UniValue::VARR};
+    for (auto&& message : warnings.GetMessages()) {
+        messages.push_back(std::move(message.original));
     }
-    return warnings;
+    return messages;
 }
 } // namespace node

--- a/src/node/warnings.cpp
+++ b/src/node/warnings.cpp
@@ -8,6 +8,7 @@
 #include <node/warnings.h>
 
 #include <common/system.h>
+#include <node/interface_ui.h>
 #include <sync.h>
 #include <univalue.h>
 #include <util/translation.h>
@@ -31,12 +32,15 @@ bool Warnings::Set(warning_type id, bilingual_str message)
 {
     LOCK(m_mutex);
     const auto& [_, inserted]{m_warnings.insert({id, std::move(message)})};
+    if (inserted) uiInterface.NotifyAlertChanged();
     return inserted;
 }
 
 bool Warnings::Unset(warning_type id)
 {
-    return WITH_LOCK(m_mutex, return m_warnings.erase(id));
+    auto success{WITH_LOCK(m_mutex, return m_warnings.erase(id))};
+    if (success) uiInterface.NotifyAlertChanged();
+    return success;
 }
 
 std::vector<bilingual_str> Warnings::GetMessages() const

--- a/src/node/warnings.h
+++ b/src/node/warnings.h
@@ -31,7 +31,7 @@ enum class Warning {
  * @brief Manages warning messages within a node.
  *
  * The Warnings class provides mechanisms to set, unset, and retrieve
- * warning messages.
+ * warning messages. It updates the GUI when warnings are changed.
  *
  * This class is designed to be non-copyable to ensure warnings
  * are managed centrally.
@@ -52,7 +52,7 @@ public:
      * @brief Set a warning message. If a warning with the specified
      *        `id` is already active, false is returned and the new
      *        warning is ignored. If `id` does not yet exist, the
-     *        warning is set, and true is returned.
+     *        warning is set, the UI is updated, and true is returned.
      *
      * @param[in]   id  Unique identifier of the warning.
      * @param[in]   message Warning message to be shown.
@@ -63,8 +63,9 @@ public:
     bool Set(warning_type id, bilingual_str message) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
     /**
      * @brief Unset a warning message. If a warning with the specified
-     *        `id` is active, it is unset, and true is returned.
-     *        Otherwise, no warning is unset and false is returned.
+     *        `id` is active, it is unset, the UI is updated, and true
+     *        is returned. Otherwise, no warning is unset and false is
+     *        returned.
      *
      * @param[in]   id  Unique identifier of the warning.
      *

--- a/src/node/warnings.h
+++ b/src/node/warnings.h
@@ -7,13 +7,13 @@
 #define BITCOIN_NODE_WARNINGS_H
 
 #include <sync.h>
+#include <util/translation.h>
 
 #include <map>
 #include <variant>
 #include <vector>
 
 class UniValue;
-struct bilingual_str;
 
 namespace kernel {
 enum class Warning;
@@ -79,14 +79,12 @@ public:
 };
 
 /**
- * RPC helper function that wraps g_warnings.GetMessages().
+ * RPC helper function that wraps warnings.GetMessages().
  *
  * Returns a UniValue::VSTR with the latest warning if use_deprecated is
  * set to true, or a UniValue::VARR with all warnings otherwise.
  */
-UniValue GetWarningsForRpc(bool use_deprecated);
-
-extern Warnings g_warnings;
+UniValue GetWarningsForRpc(const Warnings& warnings, bool use_deprecated);
 } // namespace node
 
 #endif // BITCOIN_NODE_WARNINGS_H

--- a/src/node/warnings.h
+++ b/src/node/warnings.h
@@ -6,26 +6,86 @@
 #ifndef BITCOIN_NODE_WARNINGS_H
 #define BITCOIN_NODE_WARNINGS_H
 
-#include <optional>
-#include <string>
+#include <sync.h>
+
+#include <map>
+#include <variant>
 #include <vector>
 
 class UniValue;
 struct bilingual_str;
 
+namespace kernel {
+enum class Warning;
+} // namespace kernel
+
 namespace node {
-void SetMiscWarning(const bilingual_str& warning);
-void SetfLargeWorkInvalidChainFound(bool flag);
-/** Pass std::nullopt to disable the warning */
-void SetMedianTimeOffsetWarning(std::optional<bilingual_str> warning);
-/** Return potential problems detected by the node. */
-std::vector<bilingual_str> GetWarnings();
+enum class Warning {
+    CLOCK_OUT_OF_SYNC,
+    PRE_RELEASE_TEST_BUILD,
+    FATAL_INTERNAL_ERROR,
+};
+
 /**
- * RPC helper function that wraps GetWarnings. Returns a UniValue::VSTR
- * with the latest warning if use_deprecated is set to true, or a
- * UniValue::VARR with all warnings otherwise.
+ * @class Warnings
+ * @brief Manages warning messages within a node.
+ *
+ * The Warnings class provides mechanisms to set, unset, and retrieve
+ * warning messages.
+ *
+ * This class is designed to be non-copyable to ensure warnings
+ * are managed centrally.
+ */
+class Warnings
+{
+    typedef std::variant<kernel::Warning, node::Warning> warning_type;
+
+    mutable Mutex m_mutex;
+    std::map<warning_type, bilingual_str> m_warnings GUARDED_BY(m_mutex);
+
+public:
+    Warnings();
+    //! A warnings instance should always be passed by reference, never copied.
+    Warnings(const Warnings&) = delete;
+    Warnings& operator=(const Warnings&) = delete;
+    /**
+     * @brief Set a warning message. If a warning with the specified
+     *        `id` is already active, false is returned and the new
+     *        warning is ignored. If `id` does not yet exist, the
+     *        warning is set, and true is returned.
+     *
+     * @param[in]   id  Unique identifier of the warning.
+     * @param[in]   message Warning message to be shown.
+     *
+     * @returns true if the warning was indeed set (i.e. there is no
+     *          active warning with this `id`), otherwise false.
+     */
+    bool Set(warning_type id, bilingual_str message) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /**
+     * @brief Unset a warning message. If a warning with the specified
+     *        `id` is active, it is unset, and true is returned.
+     *        Otherwise, no warning is unset and false is returned.
+     *
+     * @param[in]   id  Unique identifier of the warning.
+     *
+     * @returns true if the warning was indeed unset (i.e. there is an
+     *          active warning with this `id`), otherwise false.
+     */
+    bool Unset(warning_type id) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Return potential problems detected by the node, sorted by the
+     * warning_type id */
+    std::vector<bilingual_str> GetMessages() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+};
+
+/**
+ * RPC helper function that wraps g_warnings.GetMessages().
+ *
+ * Returns a UniValue::VSTR with the latest warning if use_deprecated is
+ * set to true, or a UniValue::VARR with all warnings otherwise.
  */
 UniValue GetWarningsForRpc(bool use_deprecated);
+
+extern Warnings g_warnings;
 } // namespace node
 
 #endif // BITCOIN_NODE_WARNINGS_H

--- a/src/node/warnings.h
+++ b/src/node/warnings.h
@@ -3,20 +3,29 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WARNINGS_H
-#define BITCOIN_WARNINGS_H
+#ifndef BITCOIN_NODE_WARNINGS_H
+#define BITCOIN_NODE_WARNINGS_H
 
 #include <optional>
 #include <string>
 #include <vector>
 
+class UniValue;
 struct bilingual_str;
 
+namespace node {
 void SetMiscWarning(const bilingual_str& warning);
 void SetfLargeWorkInvalidChainFound(bool flag);
 /** Pass std::nullopt to disable the warning */
 void SetMedianTimeOffsetWarning(std::optional<bilingual_str> warning);
 /** Return potential problems detected by the node. */
 std::vector<bilingual_str> GetWarnings();
+/**
+ * RPC helper function that wraps GetWarnings. Returns a UniValue::VSTR
+ * with the latest warning if use_deprecated is set to true, or a
+ * UniValue::VARR with all warnings otherwise.
+ */
+UniValue GetWarningsForRpc(bool use_deprecated);
+} // namespace node
 
-#endif // BITCOIN_WARNINGS_H
+#endif // BITCOIN_NODE_WARNINGS_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -29,6 +29,7 @@
 #include <node/context.h>
 #include <node/transaction.h>
 #include <node/utxo_snapshot.h>
+#include <node/warnings.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
@@ -1308,7 +1309,7 @@ RPCHelpMan getblockchaininfo()
         }
     }
 
-    obj.pushKV("warnings", GetNodeWarnings(IsDeprecatedRPCEnabled("warnings")));
+    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1309,7 +1309,8 @@ RPCHelpMan getblockchaininfo()
         }
     }
 
-    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    obj.pushKV("warnings", node::GetWarningsForRpc(*CHECK_NONFATAL(node.warnings), IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -455,7 +455,7 @@ static RPCHelpMan getmininginfo()
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
-    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
+    obj.pushKV("warnings", node::GetWarningsForRpc(*CHECK_NONFATAL(node.warnings), IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include <net.h>
 #include <node/context.h>
 #include <node/miner.h>
+#include <node/warnings.h>
 #include <pow.h>
 #include <rpc/blockchain.h>
 #include <rpc/mining.h>
@@ -454,7 +455,7 @@ static RPCHelpMan getmininginfo()
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
-    obj.pushKV("warnings", GetNodeWarnings(IsDeprecatedRPCEnabled("warnings")));
+    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -716,7 +716,7 @@ static RPCHelpMan getnetworkinfo()
         }
     }
     obj.pushKV("localaddresses", std::move(localAddresses));
-    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
+    obj.pushKV("warnings", node::GetWarningsForRpc(*CHECK_NONFATAL(node.warnings), IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,6 +16,7 @@
 #include <netbase.h>
 #include <node/context.h>
 #include <node/protocol_version.h>
+#include <node/warnings.h>
 #include <policy/settings.h>
 #include <protocol.h>
 #include <rpc/blockchain.h>
@@ -715,7 +716,7 @@ static RPCHelpMan getnetworkinfo()
         }
     }
     obj.pushKV("localaddresses", std::move(localAddresses));
-    obj.pushKV("warnings", GetNodeWarnings(IsDeprecatedRPCEnabled("warnings")));
+    obj.pushKV("warnings", node::GetWarningsForRpc(IsDeprecatedRPCEnabled("warnings")));
     return obj;
 },
     };

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -5,17 +5,17 @@
 #include <config/bitcoin-config.h> // IWYU pragma: keep
 
 #include <clientversion.h>
-#include <core_io.h>
 #include <common/args.h>
 #include <common/messages.h>
 #include <common/types.h>
 #include <consensus/amount.h>
-#include <script/interpreter.h>
+#include <core_io.h>
 #include <key_io.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <script/interpreter.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <tinyformat.h>
@@ -25,7 +25,6 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>
-#include <warnings.h>
 
 #include <algorithm>
 #include <iterator>
@@ -1381,18 +1380,4 @@ void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj)
 {
     if (warnings.empty()) return;
     obj.pushKV("warnings", BilingualStringsToUniValue(warnings));
-}
-
-UniValue GetNodeWarnings(bool use_deprecated)
-{
-    if (use_deprecated) {
-        const auto all_warnings{GetWarnings()};
-        return all_warnings.empty() ? "" : all_warnings.back().original;
-    }
-
-    UniValue warnings{UniValue::VARR};
-    for (auto&& warning : GetWarnings()) {
-        warnings.push_back(std::move(warning.original));
-    }
-    return warnings;
 }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -503,6 +503,4 @@ private:
 void PushWarnings(const UniValue& warnings, UniValue& obj);
 void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj);
 
-UniValue GetNodeWarnings(bool use_deprecated);
-
 #endif // BITCOIN_RPC_UTIL_H

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -27,7 +27,7 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(ArgsManager{}, ChainType::MAIN)};
-    KernelNotifications notifications{*Assert(m_node.shutdown), m_node.exit_status};
+    KernelNotifications notifications{*Assert(m_node.shutdown), m_node.exit_status, *Assert(m_node.warnings)};
     const BlockManager::Options blockman_opts{
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
@@ -134,7 +134,7 @@ BOOST_FIXTURE_TEST_CASE(blockmanager_block_data_availability, TestChain100Setup)
 
 BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
 {
-    KernelNotifications notifications{*Assert(m_node.shutdown), m_node.exit_status};
+    KernelNotifications notifications{*Assert(m_node.shutdown), m_node.exit_status, *Assert(m_node.warnings)};
     node::BlockManager::Options blockman_opts{
         .chainparams = Params(),
         .blocks_dir = m_args.GetBlocksDirPath(),

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 {
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
 {
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
     constexpr int max_outbound_block_relay{MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     constexpr int64_t MINIMUM_CONNECT_TIME{30};
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, {});
+    auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/fuzz/timeoffsets.cpp
+++ b/src/test/fuzz/timeoffsets.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/timeoffsets.h>
+#include <node/warnings.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/util/setup_common.h>
@@ -19,7 +20,8 @@ void initialize_timeoffsets()
 FUZZ_TARGET(timeoffsets, .init = initialize_timeoffsets)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    TimeOffsets offsets{};
+    node::Warnings warnings{};
+    TimeOffsets offsets{warnings};
     LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 4'000) {
         (void)offsets.Median();
         offsets.Add(std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<std::chrono::seconds::rep>()});

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -84,7 +84,7 @@ static void AddPeer(NodeId& id, std::vector<CNode*>& nodes, PeerManager& peerman
 BOOST_AUTO_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection)
 {
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
-    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
     NodeId id{0};
     std::vector<CNode*> nodes;
 

--- a/src/test/node_warnings_tests.cpp
+++ b/src/test/node_warnings_tests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+
+#include <node/warnings.h>
+#include <util/translation.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(node_warnings_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(warnings)
+{
+    node::Warnings warnings;
+    // On pre-release builds, a warning is generated automatically
+    warnings.Unset(node::Warning::PRE_RELEASE_TEST_BUILD);
+
+    // For these tests, we don't care what the exact warnings are, so
+    // just refer to them as warning_1 and warning_2
+    const auto warning_1{node::Warning::CLOCK_OUT_OF_SYNC};
+    const auto warning_2{node::Warning::FATAL_INTERNAL_ERROR};
+
+    // Ensure we start without any warnings
+    BOOST_CHECK(warnings.GetMessages().size() == 0);
+    // Add two warnings
+    BOOST_CHECK(warnings.Set(warning_1, _("warning 1")));
+    BOOST_CHECK(warnings.Set(warning_2, _("warning 2")));
+    // Unset the second one
+    BOOST_CHECK(warnings.Unset(warning_2));
+    // Since it's already been unset, this should return false
+    BOOST_CHECK(!warnings.Unset(warning_2));
+    // We should now be able to set w2 again
+    BOOST_CHECK(warnings.Set(warning_2, _("warning 2 - revision 1")));
+    // Setting w2 again should return false since it's already set
+    BOOST_CHECK(!warnings.Set(warning_2, _("warning 2 - revision 2")));
+
+    // Verify messages are correct
+    const auto messages{warnings.GetMessages()};
+    BOOST_CHECK(messages.size() == 2);
+    BOOST_CHECK(messages[0].original == "warning 1");
+    BOOST_CHECK(messages[1].original == "warning 2 - revision 1");
+
+    // Clearing all warnings should also clear all messages
+    BOOST_CHECK(warnings.Unset(warning_1));
+    BOOST_CHECK(warnings.Unset(warning_2));
+    BOOST_CHECK(warnings.GetMessages().size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -31,7 +31,7 @@ static void mineBlock(const node::NodeContext& node, std::chrono::seconds block_
 // Verifying when network-limited peer connections are desirable based on the node's proximity to the tip
 BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
 {
-    std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, {});
+    std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
     auto consensus = m_node.chainman->GetParams().GetConsensus();
 
     // Check we start connecting to full nodes

--- a/src/test/timeoffsets_tests.cpp
+++ b/src/test/timeoffsets_tests.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <node/timeoffsets.h>
+#include <node/warnings.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -24,7 +25,8 @@ BOOST_FIXTURE_TEST_SUITE(timeoffsets_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(timeoffsets)
 {
-    TimeOffsets offsets{};
+    node::Warnings warnings{};
+    TimeOffsets offsets{warnings};
     BOOST_CHECK(offsets.Median() == 0s);
 
     AddMulti(offsets, {{0s, -1s, -2s, -3s}});
@@ -50,7 +52,8 @@ BOOST_AUTO_TEST_CASE(timeoffsets)
 
 static bool IsWarningRaised(const std::vector<std::chrono::seconds>& check_offsets)
 {
-    TimeOffsets offsets{};
+    node::Warnings warnings{};
+    TimeOffsets offsets{warnings};
     AddMulti(offsets, check_offsets);
     return offsets.WarnIfOutOfSync();
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -31,6 +31,7 @@
 #include <node/miner.h>
 #include <node/peerman_args.h>
 #include <node/validation_cache_args.h>
+#include <node/warnings.h>
 #include <noui.h>
 #include <policy/fees.h>
 #include <policy/fees_args.h>
@@ -182,6 +183,7 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, const std::vecto
     InitLogging(*m_node.args);
     AppInitParameterInteraction(*m_node.args);
     LogInstance().StartLogging();
+    m_node.warnings = std::make_unique<node::Warnings>();
     m_node.kernel = std::make_unique<kernel::Context>();
     m_node.ecc_context = std::make_unique<ECC_Context>();
     SetupEnvironment();
@@ -230,10 +232,11 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
     bilingual_str error{};
     m_node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(m_node), error);
     Assert(error.empty());
+    m_node.warnings = std::make_unique<node::Warnings>();
 
     m_cache_sizes = CalculateCacheSizes(m_args);
 
-    m_node.notifications = std::make_unique<KernelNotifications>(*Assert(m_node.shutdown), m_node.exit_status);
+    m_node.notifications = std::make_unique<KernelNotifications>(*Assert(m_node.shutdown), m_node.exit_status, *Assert(m_node.warnings));
 
     const ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
@@ -322,7 +325,8 @@ TestingSetup::TestingSetup(
     peerman_opts.deterministic_rng = true;
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, peerman_opts);
+                                       *m_node.mempool, *m_node.warnings,
+                                       peerman_opts);
 
     {
         CConnman::Options options;

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -378,7 +378,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.GetAll().size(), 0);
-            m_node.notifications = std::make_unique<KernelNotifications>(*Assert(m_node.shutdown), m_node.exit_status);
+            m_node.notifications = std::make_unique<KernelNotifications>(*Assert(m_node.shutdown), m_node.exit_status, *Assert(m_node.warnings));
             const ChainstateManager::Options chainman_opts{
                 .chainparams = ::Params(),
                 .datadir = chainman.m_options.datadir,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -31,6 +31,7 @@
 #include <logging/timer.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
+#include <node/warnings.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>
@@ -62,7 +63,6 @@
 #include <util/trace.h>
 #include <util/translation.h>
 #include <validationinterface.h>
-#include <warnings.h>
 
 #include <algorithm>
 #include <cassert>
@@ -1922,9 +1922,9 @@ void Chainstate::CheckForkWarningConditions()
 
     if (m_chainman.m_best_invalid && m_chainman.m_best_invalid->nChainWork > m_chain.Tip()->nChainWork + (GetBlockProof(*m_chain.Tip()) * 6)) {
         LogPrintf("%s: Warning: Found invalid chain at least ~6 blocks longer than our best chain.\nChain state database corruption likely.\n", __func__);
-        SetfLargeWorkInvalidChainFound(true);
+        node::SetfLargeWorkInvalidChainFound(true);
     } else {
-        SetfLargeWorkInvalidChainFound(false);
+        node::SetfLargeWorkInvalidChainFound(false);
     }
 }
 


### PR DESCRIPTION
This PR:
- moves warnings from common to the node library and into the node namespace (as suggested in https://github.com/bitcoin/bitcoin/pull/29845#discussion_r1570069541)
- generalizes the warnings interface to `Warnings::Set()` and `Warnings::Unset()` methods, instead of having a separate function and globals for each warning. As a result, this simplifies the `kernel::Notifications` interface.
- removes warnings.cpp from the kernel library
- removes warning globals
- adds testing for the warning logic

Behaviour change introduced:
- the `-alertnotify` command is executed for all `KernelNotifications::warningSet` calls, which now also covers the `LARGE_WORK_INVALID_CHAIN` warning
- the GUI is updated automatically whenever a warning is (un)set, covering some code paths where it previously wouldn't be, e.g. when `node::AbortNode()` is called, or for the `LARGE_WORK_INVALID_CHAIN` warning

Some discussion points:
- ~is `const std::string& id` the best way to refer to warnings? Enums are an obvious alternative, but since we need to define warnings across libraries, strings seem like a straightforward solution.~ _edit: updated approach to use `node::Warning` and `kernel::Warning` enums._