### PR TITLE
Add option dbfilesize to control LevelDB target ("max") file size

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -147,7 +147,6 @@ static leveldb::Options GetOptions(size_t nCacheSize)
         // on corruption in later versions.
         options.paranoid_checks = true;
     }
-    options.max_file_size = std::max(options.max_file_size, DBWRAPPER_MAX_FILE_SIZE);
     SetMaxOpenFiles(&options);
     return options;
 }
@@ -228,6 +227,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     DBContext().iteroptions.fill_cache = false;
     DBContext().syncoptions.sync = true;
     DBContext().options = GetOptions(params.cache_bytes);
+    DBContext().options.max_file_size = params.options.max_file_size;
     DBContext().options.create_if_missing = true;
     if (params.memory_only) {
         DBContext().penv = leveldb::NewMemEnv(leveldb::Env::Default());

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -22,12 +22,15 @@
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
-static const size_t DBWRAPPER_MAX_FILE_SIZE = 32 << 20; // 32 MiB
+
+static constexpr size_t DEFAULT_DB_FILE_SIZE{32};
 
 //! User-controlled performance and debug options.
 struct DBOptions {
     //! Compact database on startup.
     bool force_compact = false;
+    //! Target size of files.
+    size_t max_file_size{DEFAULT_DB_FILE_SIZE << 20};
 };
 
 //! Application-specific storage settings.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,6 +20,7 @@
 #include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
+#include <dbwrapper.h>
 #include <deploymentstatus.h>
 #include <hash.h>
 #include <httprpc.h>
@@ -489,6 +490,11 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbbatchsize", strprintf("Maximum database write batch size in bytes (default: %u)", nDefaultDbBatchSize), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbcache=<n>", strprintf("Maximum database cache size <n> MiB (minimum %d, default: %d). Make sure you have enough RAM. In addition, unused memory allocated to the mempool is shared with this cache (see -maxmempool).", MIN_DB_CACHE >> 20, DEFAULT_DB_CACHE >> 20), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-dbfilesize",
+                   strprintf("Target size of files within databases, in MiB (%u to %u, default: %u).",
+                             1, 1024,
+                             DEFAULT_DB_FILE_SIZE),
+                   ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-allowignoredconf", strprintf("For backwards compatibility, treat an unused %s file in the datadir as a warning, not an error.", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/node/database_args.cpp
+++ b/src/node/database_args.cpp
@@ -14,5 +14,6 @@ void ReadDatabaseArgs(const ArgsManager& args, DBOptions& options)
     // databases), but it'd be easy to parse database-specific options by adding
     // a database_type string or enum parameter to this function.
     if (auto value = args.GetBoolArg("-forcecompactdb")) options.force_compact = *value;
+    if (auto value = args.GetIntArg("-dbfilesize")) options.max_file_size = (*value) << 20;
 }
 } // namespace node


### PR DESCRIPTION
Debug option to control LevelDB file sizes. Since LevelDB seems to always overshoot, "max" didn't seem fitting.

Intended to be followed up with a change to the default in a rebased #30039