### PR TITLE
test, subprocess: Improve coverage report correctness

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -838,6 +838,7 @@ if test "$use_lcov" = "yes"; then
   AC_SUBST(COV_TOOL_WRAPPER, "cov_tool_wrapper.sh")
   LCOV="$LCOV --gcov-tool $(pwd)/$COV_TOOL_WRAPPER"
 
+  CORE_CPPFLAGS="$CORE_CPPFLAGS -DCODE_COVERAGE"
   AX_CHECK_LINK_FLAG([--coverage], [CORE_LDFLAGS="$CORE_LDFLAGS --coverage"],
     [AC_MSG_ERROR([lcov testing requested but --coverage linker flag does not work])])
   AX_CHECK_COMPILE_FLAG([--coverage],[CORE_CXXFLAGS="$CORE_CXXFLAGS --coverage"],

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -75,6 +75,10 @@ extern "C" {
 #else
   #include <sys/wait.h>
   #include <unistd.h>
+#ifdef CODE_COVERAGE
+void __gcov_dump(void);
+void __gcov_reset(void);
+#endif
 #endif
   #include <csignal>
   #include <fcntl.h>
@@ -1353,6 +1357,13 @@ namespace detail {
       if (stream.err_write_ != -1 && stream.err_write_ > 2)
         close(stream.err_write_);
 
+#ifdef CODE_COVERAGE
+      // Dump counters, they will be lost after exec.
+      __gcov_dump();
+      // If the following call fails, it will be counted.
+      __gcov_reset();
+#endif
+
       // Replace the current image with the executable
       sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
 
@@ -1365,6 +1376,10 @@ namespace detail {
       //ATTN: Can we do something on error here ?
       util::write_n(err_wr_pipe_, err_msg.c_str(), err_msg.length());
     }
+
+#ifdef CODE_COVERAGE
+    __gcov_dump();
+#endif
 
     // Calling application would not get this
     // exit failure


### PR DESCRIPTION
As a child process uses the [`execvp()`](https://linux.die.net/man/3/execvp) call, an explicit dumping of the collected profile information is required.

Coverage:
- on the master branch: 
![image](https://github.com/bitcoin/bitcoin/assets/32963518/36628527-64ef-46de-8a34-68ea1e50d861)

- with this PR: 
![image](https://github.com/bitcoin/bitcoin/assets/32963518/43b67d74-9b50-4b49-8c6b-9519a08d9e0f)

This PR mostly follows [gcc/libgcc/libgcov-interface.c#L320-L332](https://github.com/gcc-mirror/gcc/blob/52d4691294c84793b301ad3cc24e277b8c7efe0b/libgcc/libgcov-interface.c#L320-L332):
```c
/* A wrapper for the execvp function.  Flushes the accumulated
   profiling data, so that they are not lost.  */


int
__gcov_execvp (const char *path, char *const argv[])
{
  /* Dump counters only, they will be lost after exec.  */
  __gcov_dump ();
  int ret = execvp (path, argv);
  /* We reach this code only when execv fails, reset counter then here.  */
  __gcov_reset ();
  return ret;
}
```