### PR TITLE
refactor: Remove unused code from `subprocess.h` header

### DIFF
--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -902,7 +902,6 @@ private:
  *    Command provided in a single string.
  * wait()             - Wait for the child to exit.
  * retcode()          - The return code of the exited child.
- * pid()              - PID of the spawned child.
  * poll()             - Check the status of the running child.
  * send(...)          - Send input to the input channel of the child.
  * communicate(...)   - Get the output/error from the child and close the channels
@@ -955,8 +954,6 @@ public:
 
     execute_process();
   }
-
-  int pid() const noexcept { return child_pid_; }
 
   int retcode() const noexcept { return retcode_; }
 
@@ -1068,7 +1065,7 @@ inline int Popen::wait() noexcept(false)
   return 0;
 #else
   int ret, status;
-  std::tie(ret, status) = util::wait_for_child_exit(pid());
+  std::tie(ret, status) = util::wait_for_child_exit(child_pid_);
   if (ret == -1) {
     if (errno != ECHILD) throw OSError("waitpid failed", errno);
     return 0;

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -902,7 +902,6 @@ private:
  *    Command provided in a single string.
  * wait()             - Wait for the child to exit.
  * retcode()          - The return code of the exited child.
- * poll()             - Check the status of the running child.
  * send(...)          - Send input to the input channel of the child.
  * communicate(...)   - Get the output/error from the child and close the channels
  *                      from the parent side.
@@ -958,8 +957,6 @@ public:
   int retcode() const noexcept { return retcode_; }
 
   int wait() noexcept(false);
-
-  int poll() noexcept(false);
 
   void set_out_buf_cap(size_t cap) { stream_.set_out_buf_cap(cap); }
 
@@ -1075,56 +1072,6 @@ inline int Popen::wait() noexcept(false)
   else return 255;
 
   return 0;
-#endif
-}
-
-inline int Popen::poll() noexcept(false)
-{
-#ifdef __USING_WINDOWS__
-  int ret = WaitForSingleObject(process_handle_, 0);
-  if (ret != WAIT_OBJECT_0) return -1;
-
-  DWORD dretcode_;
-  if (FALSE == GetExitCodeProcess(process_handle_, &dretcode_))
-      throw OSError("GetExitCodeProcess", 0);
-
-  retcode_ = (int)dretcode_;
-  CloseHandle(process_handle_);
-
-  return retcode_;
-#else
-  if (!child_created_) return -1; // TODO: ??
-
-  int status;
-
-  // Returns zero if child is still running
-  int ret = waitpid(child_pid_, &status, WNOHANG);
-  if (ret == 0) return -1;
-
-  if (ret == child_pid_) {
-    if (WIFSIGNALED(status)) {
-      retcode_ = WTERMSIG(status);
-    } else if (WIFEXITED(status)) {
-      retcode_ = WEXITSTATUS(status);
-    } else {
-      retcode_ = 255;
-    }
-    return retcode_;
-  }
-
-  if (ret == -1) {
-    // From subprocess.py
-    // This happens if SIGCHLD is set to be ignored
-    // or waiting for child process has otherwise been disabled
-    // for our process. This child is dead, we cannot get the
-    // status.
-    if (errno == ECHILD) retcode_ = 0;
-    else throw OSError("waitpid failed", errno);
-  } else {
-    retcode_ = ret;
-  }
-
-  return retcode_;
 #endif
 }
 

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -905,12 +905,6 @@ private:
  * send(...)          - Send input to the input channel of the child.
  * communicate(...)   - Get the output/error from the child and close the channels
  *                      from the parent side.
- * input()            - Get the input channel/File pointer. Can be used for
- *                      customizing the way of sending input to child.
- * output()           - Get the output channel/File pointer. Usually used
-                        in case of redirection. See piping examples.
- * error()            - Get the error channel/File pointer. Usually used
-                        in case of redirection.
  */
 class Popen
 {
@@ -994,15 +988,6 @@ public:
   {
     return communicate(nullptr, 0);
   }
-
-  FILE* input()  { return stream_.input(); }
-  FILE* output() { return stream_.output();}
-  FILE* error()  { return stream_.error(); }
-
-  /// Stream close APIs
-  void close_input()  { stream_.input_.reset();  }
-  void close_output() { stream_.output_.reset(); }
-  void close_error()  { stream_.error_.reset();  }
 
 private:
   template <typename F, typename... Args>

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -1027,7 +1027,6 @@ private:
   std::vector<std::string> vargs_;
   std::vector<char*> cargv_;
 
-  bool child_created_ = false;
   // Pid of the child process
   int child_pid_ = -1;
 
@@ -1176,8 +1175,6 @@ inline void Popen::execute_process() noexcept(false)
     close(err_wr_pipe);
     throw OSError("fork failed", errno);
   }
-
-  child_created_ = true;
 
   if (child_pid_ == 0)
   {


### PR DESCRIPTION
This PR continues https://github.com/bitcoin/bitcoin/pull/29961.

Please note that `Popen::poll()` is not required for https://github.com/bitcoin/bitcoin/pull/29868 anymore.