### PR TITLE
test: expand LimitOrphan and EraseForPeer coverage

### DIFF
--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -12,12 +12,6 @@
 
 #include <cassert>
 
-/** Expiration time for orphan transactions */
-static constexpr auto ORPHAN_TX_EXPIRE_TIME{20min};
-/** Minimum time between orphan transactions expire time checks */
-static constexpr auto ORPHAN_TX_EXPIRE_INTERVAL{5min};
-
-
 bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 {
     LOCK(m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -14,6 +14,11 @@
 #include <map>
 #include <set>
 
+/** Expiration time for orphan transactions */
+static constexpr auto ORPHAN_TX_EXPIRE_TIME{20min};
+/** Minimum time between orphan transactions expire time checks */
+static constexpr auto ORPHAN_TX_EXPIRE_INTERVAL{5min};
+
 /** A class to track orphan transactions (failed on TX_MISSING_INPUTS)
  * Since we cannot distinguish orphans from bad transactions with
  * non-existent inputs, we heavily limit the number of orphans


### PR DESCRIPTION
Inspired by refactorings in #30000 as the coverage appeared a bit sparse.

Added some minimal border value testing, timeouts, and tightened existing assertions.