### PR TITLE
p2p: detect addnode cjdns peers in GetAddedNodeInfo()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2832,7 +2832,7 @@ std::vector<AddedNodeInfo> CConnman::GetAddedNodeInfo(bool include_connected) co
     }
 
     for (const auto& addr : lAddresses) {
-        CService service(LookupNumeric(addr.m_added_node, GetDefaultPort(addr.m_added_node)));
+        CService service{MaybeFlipIPv6toCJDNS(LookupNumeric(addr.m_added_node, GetDefaultPort(addr.m_added_node)))};
         AddedNodeInfo addedNode{addr, CService(), false, false};
         if (service.IsValid()) {
             // strAddNode is an IP:port

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -108,6 +108,12 @@ BOOST_AUTO_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection)
     AddPeer(id, nodes, *peerman, *connman, ConnectionType::BLOCK_RELAY, /*onion_peer=*/true);
     AddPeer(id, nodes, *peerman, *connman, ConnectionType::INBOUND);
 
+    // Add a CJDNS peer connection.
+    AddPeer(id, nodes, *peerman, *connman, ConnectionType::INBOUND, /*onion_peer=*/false,
+            /*address=*/"[fc00:3344:5566:7788:9900:aabb:ccdd:eeff]:1234");
+    BOOST_CHECK(nodes.back()->IsInboundConn());
+    BOOST_CHECK_EQUAL(nodes.back()->ConnectedThroughNetwork(), Network::NET_CJDNS);
+
     BOOST_TEST_MESSAGE("Call AddNode() for all the peers");
     for (auto node : connman->TestNodes()) {
         BOOST_CHECK(connman->AddNode({/*m_added_node=*/node->addr.ToStringAddrPort(), /*m_use_v2transport=*/true}));


### PR DESCRIPTION
Addnode peers connected to us via the cjdns network are currently not detected by `CConnman::GetAddedNodeInfo()`, i.e. `fConnected` is always false. This causes the following issues:

- RPC `getaddednodeinfo` incorrectly shows them as not connected

- `CConnman::ThreadOpenAddedConnections()` continually retries to connect them

Fix the issue and add a unit regression test. Extracted from #28248. Suggest running the test with:

`./src/test/test_bitcoin -t net_peer_connection_tests -l test_suite`