### PR TITLE
Bugfix: RPC/Mining: getblocktemplate: Delay updating nTransactionsUpdatedLast and time_start until after the new template is cached

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -748,9 +748,9 @@ static RPCHelpMan getblocktemplate()
         pindexPrev = nullptr;
 
         // Store the pindexBest used before CreateNewBlock, to avoid races
-        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
+        auto nTransactionsUpdatedLast_new = mempool.GetTransactionsUpdated();
         CBlockIndex* pindexPrevNew = active_chain.Tip();
-        time_start = GetTime();
+        auto time_start_new = GetTime();
 
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
@@ -759,6 +759,8 @@ static RPCHelpMan getblocktemplate()
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 
         // Need to update only after we know CreateNewBlock succeeded
+        nTransactionsUpdatedLast = nTransactionsUpdatedLast_new;
+        time_start = time_start_new;
         pindexPrev = pindexPrevNew;
     }
     CHECK_NONFATAL(pindexPrev);


### PR DESCRIPTION
This is needed to avoid parallel calls from incorrectly using the stale cached template or (after an OOM) dereferencing a nullptr pblocktemplate

Considering memory overcommit, the worst case scenario likely never occurs, but that possibility is the clear bugfix here.

Aside from that, I wonder if using the stale cache in this race scenario (which is what could happen if this isn't fixed) is better than having N threads all making a new block (with this fix).

A middle ground (and perhaps cleaner than a bunch of static variables) might be to take a lock and have racing requests all wait on the same block creation, but that is not implemented here.