### PR TITLE
build: Enable `thread_local` for MinGW-w64 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1042,18 +1042,8 @@ if test "$use_thread_local" = "yes" || test "$use_thread_local" = "auto"; then
     }
     ])],
     [
-     case $host in
-       *mingw*)
-          dnl mingw32's implementation of thread_local has also been shown to behave
-          dnl erroneously under concurrent usage; see:
-          dnl https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
-          AC_MSG_RESULT([no])
-          ;;
-        *)
-          AC_DEFINE([HAVE_THREAD_LOCAL], [1], [Define if thread_local is supported.])
-          AC_MSG_RESULT([yes])
-          ;;
-      esac
+      AC_DEFINE([HAVE_THREAD_LOCAL], [1], [Define if thread_local is supported.])
+      AC_MSG_RESULT([yes])
     ],
     [
       AC_MSG_RESULT([no])


### PR DESCRIPTION
The assumption in the commit 188ca75e5fe4837d16241446558c7566912f67b2 about the broken `thread_local` implementation in GCC was misguided because the initial failure was not due to GCC, but a bug in the Wine
runtime, as evidenced, for example, here:
 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=917307
 - https://bugs.freedesktop.org/show_bug.cgi?id=108662

Consequently, it is safe to re-enable `thread_local` support for MinGW-w64 builds.

Fixes one item from https://github.com/bitcoin/bitcoin/issues/29952.