### PR TITLE
lint: fixed typo in test_runner causing linter warning

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -647,7 +647,7 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
                     break
 
                 if "[Errno 28] No space left on device" in stdout:
-                    sys.exit(f"Early exiting after test failure due to insuffient free space in {tmpdir}\n"
+                    sys.exit(f"Early exiting after test failure due to insufficient free space in {tmpdir}\n"
                              f"Test execution data left in {tmpdir}.\n"
                              f"Additional storage is needed to execute testing.")
 


### PR DESCRIPTION
introduced in https://github.com/bitcoin/bitcoin/commit/357ad110548d726021547d85b5b2bfcf3191d7e3

This typo is causing an error in the linter, fixing this should remove this warning

```
test/functional/test_runner.py:651: insuffient ==> insufficient
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/spelling.ignore-words.txt
```

[link to cirrus ci warning](https://cirrus-ci.com/task/5926490804584448?logs=lint#L741)