### PR TITLE
p2p: Fill reconciliation sets (Erlay) attempt 2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,7 +233,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/transaction.cpp
   node/txdownloadman_impl.cpp
   node/txorphanage.cpp
-  node/txreconciliation.cpp
+  node/txreconciliation_impl.cpp
   node/utxo_snapshot.cpp
   node/warnings.cpp
   noui.cpp

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -117,6 +117,9 @@ public:
     /** Relay transaction to all peers. */
     virtual void RelayTransaction(const Txid& txid, const Wtxid& wtxid) = 0;
 
+    /** Get the amount of inbounds (first) and outbounds fanout peers (second). */
+    virtual std::pair<size_t, size_t> GetFanoutPeersCount() = 0;
+
     /** Send ping message to all peers */
     virtual void SendPings() = 0;
 

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -28,20 +28,15 @@ class TxReconciliationState
 {
 public:
     /**
-     * TODO: This field is public to ignore -Wunused-private-field. Make private once used in
-     * the following commits.
-     *
      * Reconciliation protocol assumes using one role consistently: either a reconciliation
      * initiator (requesting sketches), or responder (sending sketches). This defines our role,
      * based on the direction of the p2p connection.
-     *
      */
     bool m_we_initiate;
 
     /**
      * TODO: These fields are public to ignore -Wunused-private-field. Make private once used in
      * the following commits.
-     *
      * These values are used to salt short IDs, which is necessary for transaction reconciliations.
      */
     uint64_t m_k0, m_k1;

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_TXRECONCILIATION_H
 
 #include <net.h>
+#include <util/hasher.h>
 
 namespace node {
 /** Static salt component used to compute short txids for sketch construction, see BIP-330. */
@@ -33,6 +34,14 @@ public:
      * based on the direction of the p2p connection.
      */
     bool m_we_initiate;
+
+    /**
+     * Store all wtxids that we would announce to the peer (policy checks passed, etc.)
+     * in this set instead of announcing them right away. When reconciliation time comes, we will
+     * compute a compressed representation of this set (a "sketch") and use it to efficiently
+     * reconcile this set with a set on the peer's side.
+     */
+    std::unordered_set<Wtxid, SaltedWtxidHasher> m_local_set;
 
     /**
      * TODO: These fields are public to ignore -Wunused-private-field. Make private once used in

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -61,6 +61,12 @@ public:
      */
     uint32_t ComputeShortID(const Wtxid& wtxid) const;
 
+    /**
+     * Check whether a given wtxid has a short ID collision with an existing transaction in the peer's reconciliation state.
+     * If a collision is found, sets collision to the wtxid of the conflicting transaction.
+    */
+    bool HasCollision(const Wtxid& wtxid, Wtxid& collision, uint32_t &short_id);
+
 private:
     /** These values are used to salt short IDs, which is necessary for transaction reconciliations. */
     uint64_t m_k0, m_k1;

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -6,84 +6,47 @@
 #define BITCOIN_NODE_TXRECONCILIATION_H
 
 #include <net.h>
-#include <sync.h>
 
-#include <memory>
-#include <tuple>
-
-/** Supported transaction reconciliation protocol version */
-static constexpr uint32_t TXRECONCILIATION_VERSION{1};
-
-enum class ReconciliationRegisterResult {
-    NOT_FOUND,
-    SUCCESS,
-    ALREADY_REGISTERED,
-    PROTOCOL_VIOLATION,
-};
+namespace node {
+/** Static salt component used to compute short txids for sketch construction, see BIP-330. */
+const std::string RECON_STATIC_SALT = "Tx Relay Salting";
+const HashWriter RECON_SALT_HASHER = TaggedHash(RECON_STATIC_SALT);
 
 /**
- * Transaction reconciliation is a way for nodes to efficiently announce transactions.
- * This object keeps track of all txreconciliation-related communications with the peers.
- * The high-level protocol is:
- * 0.  Txreconciliation protocol handshake.
- * 1.  Once we receive a new transaction, add it to the set instead of announcing immediately.
- * 2.  At regular intervals, a txreconciliation initiator requests a sketch from a peer, where a
- *     sketch is a compressed representation of short form IDs of the transactions in their set.
- * 3.  Once the initiator received a sketch from the peer, the initiator computes a local sketch,
- *     and combines the two sketches to attempt finding the difference in *sets*.
- * 4a. If the difference was not larger than estimated, see SUCCESS below.
- * 4b. If the difference was larger than estimated, initial txreconciliation fails. The initiator
- *     requests a larger sketch via an extension round (allowed only once).
- *     - If extension succeeds (a larger sketch is sufficient), see SUCCESS below.
- *     - If extension fails (a larger sketch is insufficient), see FAILURE below.
- *
- * SUCCESS. The initiator knows full symmetrical difference and can request what the initiator is
- *          missing and announce to the peer what the peer is missing.
- *
- * FAILURE. The initiator notifies the peer about the failure and announces all transactions from
- *          the corresponding set. Once the peer received the failure notification, the peer
- *          announces all transactions from their set.
-
- * This is a modification of the Erlay protocol (https://arxiv.org/abs/1905.10518) with two
- * changes (sketch extensions instead of bisections, and an extra INV exchange round), both
- * are motivated in BIP-330.
+ * Salt (specified by BIP-330) constructed from contributions from both peers. It is used
+ * to compute transaction short IDs, which are then used to construct a sketch representing a set
+ * of transactions we want to announce to the peer.
  */
-class TxReconciliationTracker
+inline uint256 ComputeSalt(uint64_t salt1, uint64_t salt2)
 {
-private:
-    class Impl;
-    const std::unique_ptr<Impl> m_impl;
+    // According to BIP-330, salts should be combined in ascending order.
+    return (HashWriter(RECON_SALT_HASHER) << std::min(salt1, salt2) << std::max(salt1, salt2)).GetSHA256();
+}
 
+/** Keeps track of txreconciliation-related per-peer state. */
+class TxReconciliationState
+{
 public:
-    explicit TxReconciliationTracker(uint32_t recon_version);
-    ~TxReconciliationTracker();
+    /**
+     * TODO: This field is public to ignore -Wunused-private-field. Make private once used in
+     * the following commits.
+     *
+     * Reconciliation protocol assumes using one role consistently: either a reconciliation
+     * initiator (requesting sketches), or responder (sending sketches). This defines our role,
+     * based on the direction of the p2p connection.
+     *
+     */
+    bool m_we_initiate;
 
     /**
-     * Step 0. Generates initial part of the state (salt) required to reconcile txs with the peer.
-     * The salt is used for short ID computation required for txreconciliation.
-     * The function returns the salt.
-     * A peer can't participate in future txreconciliations without this call.
-     * This function must be called only once per peer.
+     * TODO: These fields are public to ignore -Wunused-private-field. Make private once used in
+     * the following commits.
+     *
+     * These values are used to salt short IDs, which is necessary for transaction reconciliations.
      */
-    uint64_t PreRegisterPeer(NodeId peer_id);
+    uint64_t m_k0, m_k1;
 
-    /**
-     * Step 0. Once the peer agreed to reconcile txs with us, generate the state required to track
-     * ongoing reconciliations. Must be called only after pre-registering the peer and only once.
-     */
-    ReconciliationRegisterResult RegisterPeer(NodeId peer_id, bool is_peer_inbound,
-                                              uint32_t peer_recon_version, uint64_t remote_salt);
-
-    /**
-     * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
-     * After this, we won't be able to reconcile transactions with the peer.
-     */
-    void ForgetPeer(NodeId peer_id);
-
-    /**
-     * Check if a peer is registered to reconcile transactions with us.
-     */
-    bool IsPeerRegistered(NodeId peer_id) const;
+    TxReconciliationState(bool we_initiate, uint64_t k0, uint64_t k1) : m_we_initiate(we_initiate), m_k0(k0), m_k1(k1) {}
 };
-
+} // namespace node
 #endif // BITCOIN_NODE_TXRECONCILIATION_H

--- a/src/node/txreconciliation_impl.cpp
+++ b/src/node/txreconciliation_impl.cpp
@@ -37,7 +37,7 @@ public:
         AssertLockNotHeld(m_txreconciliation_mutex);
         LOCK(m_txreconciliation_mutex);
 
-        LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Pre-register peer=%d\n", peer_id);
+        LogDebug(BCLog::TXRECONCILIATION, "Pre-register peer=%d.\n", peer_id);
         const uint64_t local_salt{FastRandomContext().rand64()};
 
         // We do this exactly once per peer (which are unique by NodeId, see GetNewNodeId) so it's
@@ -68,8 +68,7 @@ public:
         // v1 is the lowest version, so suggesting something below must be a protocol violation.
         if (recon_version < 1) return ReconciliationError::PROTOCOL_VIOLATION;
 
-        LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Register peer=%d (inbound=%i)\n",
-                      peer_id, is_peer_inbound);
+        LogDebug(BCLog::TXRECONCILIATION, "Register peer=%d (inbound=%i).\n", peer_id, is_peer_inbound);
 
         const uint256 full_salt{ComputeSalt(local_salt, remote_salt)};
         peer_state->second = TxReconciliationState(!is_peer_inbound, full_salt.GetUint64(0), full_salt.GetUint64(1));
@@ -90,7 +89,7 @@ public:
         AssertLockNotHeld(m_txreconciliation_mutex);
         LOCK(m_txreconciliation_mutex);
         if (m_states.erase(peer_id)) {
-            LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Forget txreconciliation state of peer=%d\n", peer_id);
+            LogDebug(BCLog::TXRECONCILIATION, "Forget txreconciliation state of peer=%d.\n", peer_id);
         }
     }
 };

--- a/src/node/txreconciliation_impl.cpp
+++ b/src/node/txreconciliation_impl.cpp
@@ -14,6 +14,13 @@
 #include <variant>
 
 namespace node {
+uint32_t TxReconciliationState::ComputeShortID(const Wtxid& wtxid) const
+{
+    const uint64_t s = SipHashUint256(m_k0, m_k1, wtxid.ToUint256());
+    const uint32_t short_txid = 1 + (s & 0xFFFFFFFF);
+    return short_txid;
+}
+
 /** Actual implementation for TxReconciliationTracker's data structure. */
 class TxReconciliationTrackerImpl {
 private:

--- a/src/node/txreconciliation_impl.cpp
+++ b/src/node/txreconciliation_impl.cpp
@@ -21,6 +21,19 @@ uint32_t TxReconciliationState::ComputeShortID(const Wtxid& wtxid) const
     return short_txid;
 }
 
+bool TxReconciliationState::HasCollision(const Wtxid& wtxid, Wtxid& collision, uint32_t &short_id)
+{
+    short_id = TxReconciliationState::ComputeShortID(wtxid);
+    const auto iter = m_short_id_mapping.find(short_id);
+
+    if (iter != m_short_id_mapping.end()) {
+        collision = iter->second;
+        return true;
+    }
+
+    return false;
+}
+
 /** Actual implementation for TxReconciliationTracker's data structure. */
 class TxReconciliationTrackerImpl {
 private:
@@ -58,13 +71,12 @@ private:
 public:
     explicit TxReconciliationTrackerImpl(uint32_t recon_version) : m_recon_version(recon_version) {}
 
-    uint64_t PreRegisterPeer(NodeId peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    uint64_t PreRegisterPeer(NodeId peer_id, uint64_t local_salt) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
     {
         AssertLockNotHeld(m_txreconciliation_mutex);
         LOCK(m_txreconciliation_mutex);
 
         LogDebug(BCLog::TXRECONCILIATION, "Pre-register peer=%d.\n", peer_id);
-        const uint64_t local_salt{FastRandomContext().rand64()};
 
         // We do this exactly once per peer (which are unique by NodeId, see GetNewNodeId) so it's
         // safe to assume we don't have this record yet.
@@ -148,8 +160,19 @@ public:
         auto peer_state = GetRegisteredPeerState(peer_id);
         if (!peer_state) return AddToSetError(ReconciliationError::NOT_FOUND);
 
-        // TODO: We should compute the short_id here here first and see if there's any collision
-        // if so, return AddToSetResult::Collision(wtxid)
+        // Bypass if the wtxid is already in the set
+        if (peer_state->m_local_set.contains(wtxid)) {
+            LogDebug(BCLog::TXRECONCILIATION, "%s already in reconciliation set for peer=%d. Bypassing.\n", wtxid.ToString(), peer_id);
+            return std::nullopt;
+        }
+
+        // Make sure there is no short id collision between the wtxid we are trying to add
+        // and any existing one in the reconciliation set
+        uint32_t short_id;
+        Wtxid collision;
+        if (peer_state->HasCollision(wtxid, collision, short_id)) {
+            return AddToSetError(ReconciliationError::SHORTID_COLLISION, collision);
+        }
 
         // Transactions which don't make it to the set due to the limit are announced via fanout.
         if (peer_state->m_local_set.size() >= MAX_RECONSET_SIZE) {
@@ -157,10 +180,8 @@ public:
             return AddToSetError(ReconciliationError::FULL_RECON_SET);
         }
 
-        // The caller currently keeps track of the per-peer transaction announcements, so it
-        // should not attempt to add same tx to the set twice. However, if that happens, we will
-        // simply ignore it.
         if (peer_state->m_local_set.insert(wtxid).second) {
+            peer_state->m_short_id_mapping.emplace(short_id, wtxid);
             LogDebug(BCLog::TXRECONCILIATION, "Added %s to the reconciliation set for peer=%d. Now the set contains %i transactions.\n",
                 wtxid.ToString(), peer_id, peer_state->m_local_set.size());
         }
@@ -177,6 +198,7 @@ public:
 
         const bool removed = peer_state->m_local_set.erase(wtxid) > 0;
         if (removed) {
+            peer_state->m_short_id_mapping.erase(peer_state->ComputeShortID(wtxid));
             LogDebug(BCLog::TXRECONCILIATION, "Removed %s from the reconciliation set for peer=%d. Now the set contains %i transactions.\n",
                 wtxid.ToString(), peer_id, peer_state->m_local_set.size());
         } else {
@@ -245,7 +267,13 @@ TxReconciliationTracker::~TxReconciliationTracker() = default;
 
 uint64_t TxReconciliationTracker::PreRegisterPeer(NodeId peer_id)
 {
-    return m_impl->PreRegisterPeer(peer_id);
+    const uint64_t local_salt{FastRandomContext().rand64()};
+    return m_impl->PreRegisterPeer(peer_id, local_salt);
+}
+
+void TxReconciliationTracker::PreRegisterPeerWithSalt(NodeId peer_id, uint64_t local_salt)
+{
+    m_impl->PreRegisterPeer(peer_id, local_salt);
 }
 
 std::optional<ReconciliationError> TxReconciliationTracker::RegisterPeer(NodeId peer_id, bool is_peer_inbound, uint32_t peer_recon_version, uint64_t remote_salt)

--- a/src/node/txreconciliation_impl.h
+++ b/src/node/txreconciliation_impl.h
@@ -116,6 +116,10 @@ public:
      * the peer just announced the transaction to us. Returns whether the wtxid was removed.
      */
     bool TryRemovingFromSet(NodeId peer_id, const Wtxid& wtxid);
+
+    /** Whether a given inbound peer is currently flagged for fanout. */
+    bool IsInboundFanoutTarget(NodeId peer_id);
+
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXRECONCILIATION_IMPL_H

--- a/src/node/txreconciliation_impl.h
+++ b/src/node/txreconciliation_impl.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_TXRECONCILIATION_IMPL_H
+#define BITCOIN_NODE_TXRECONCILIATION_IMPL_H
+
+#include <node/txreconciliation.h>
+
+namespace node {
+class TxReconciliationTrackerImpl;
+
+/** Supported transaction reconciliation protocol version */
+static constexpr uint32_t TXRECONCILIATION_VERSION{1};
+
+enum class ReconciliationRegisterResult
+{
+    NOT_FOUND,
+    SUCCESS,
+    ALREADY_REGISTERED,
+    PROTOCOL_VIOLATION,
+};
+
+/**
+ * Transaction reconciliation is a way for nodes to efficiently announce transactions.
+ * This class keeps track of all txreconciliation-related communications with the peers.
+ * The high-level protocol is:
+ * 0.  txreconciliation protocol handshake.
+ * 1.  Once we receive a new transaction, add it to the set instead of announcing immediately.
+ * 2.  At regular intervals, a txreconciliation initiator requests a sketch from a peer, where a
+ *     sketch is a compressed representation of short form IDs of the transactions in their set.
+ * 3.  Once the initiator received a sketch from the peer, the initiator computes a local sketch,
+ *     and combines the two sketches to attempt finding the difference in *sets*.
+ * 4.  If the difference was not larger than estimated, see SUCCESS below.
+ * 5.  If the difference was larger than estimated, initial txreconciliation fails. The initiator
+ *     requests a larger sketch via an extension round (allowed only once).
+ *      - If extension succeeds (a larger sketch is sufficient), see SUCCESS below.
+ *      - If extension fails (a larger sketch is insufficient), see FAILURE below.
+ *
+ * SUCCESS. The initiator knows the full symmetrical difference and can request what the initiator
+ *          is missing and announces to the peer what the peer is missing.
+ *
+ * FAILURE. The initiator notifies the peer about the failure and announces all transactions from
+ *          the corresponding set. Once the peer received the failure notification, the peer
+ *          announces all transactions from their set.
+
+ * This is a modification of the Erlay protocol (https://arxiv.org/abs/1905.10518) with two
+ * changes (sketch extensions instead of bisections, and an extra INV exchange round), both
+ * are motivated in BIP-330.
+ */
+class TxReconciliationTracker {
+    const std::unique_ptr<TxReconciliationTrackerImpl> m_impl;
+
+public:
+    explicit TxReconciliationTracker(uint32_t recon_version);
+    ~TxReconciliationTracker();
+
+    /**
+     * Step 0. Generates initial part of the state (salt) required to reconcile txs with the peer.
+     * The salt is used for short ID computation required for txreconciliation.
+     * The function returns the salt.
+     * A peer can't participate in future txreconciliations without this call.
+     * This function must be called only once per peer.
+     */
+    uint64_t PreRegisterPeer(NodeId peer_id);
+
+    /**
+     * Step 0. Once the peer agreed to reconcile txs with us, generate the state required to track
+     * ongoing reconciliations. Must be called only after pre-registering the peer and only once.
+     */
+    ReconciliationRegisterResult RegisterPeer(NodeId peer_id, bool is_peer_inbound, uint32_t peer_recon_version, uint64_t remote_salt);
+
+    /** Check if a peer is registered to reconcile transactions with us. */
+    bool IsPeerRegistered(NodeId peer_id) const;
+
+    /**
+     * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
+     * After this, we won't be able to reconcile transactions with the peer.
+     */
+    void ForgetPeer(NodeId peer_id);
+};
+} // namespace node
+#endif // BITCOIN_NODE_TXRECONCILIATION_IMPL_H

--- a/src/node/txreconciliation_impl.h
+++ b/src/node/txreconciliation_impl.h
@@ -98,6 +98,9 @@ public:
      */
     uint64_t PreRegisterPeer(NodeId peer_id);
 
+    /** For testing purposes only. This SHOULD NEVER be used in production. */
+    void PreRegisterPeerWithSalt(NodeId peer_id, uint64_t local_salt);
+
     /**
      * Step 0. Once the peer agreed to reconcile txs with us, generate the state required to track
      * ongoing reconciliations. Must be called only after pre-registering.

--- a/src/node/txreconciliation_impl.h
+++ b/src/node/txreconciliation_impl.h
@@ -13,11 +13,14 @@ class TxReconciliationTrackerImpl;
 /** Supported transaction reconciliation protocol version */
 static constexpr uint32_t TXRECONCILIATION_VERSION{1};
 
-enum class ReconciliationRegisterResult
+enum class ReconciliationError
 {
     NOT_FOUND,
-    SUCCESS,
     ALREADY_REGISTERED,
+    WRONG_PHASE,
+    WRONG_ROLE,
+    FULL_RECON_SET,
+    SHORTID_COLLISION,
     PROTOCOL_VIOLATION,
 };
 
@@ -66,9 +69,10 @@ public:
 
     /**
      * Step 0. Once the peer agreed to reconcile txs with us, generate the state required to track
-     * ongoing reconciliations. Must be called only after pre-registering the peer and only once.
+     * ongoing reconciliations. Must be called only after pre-registering.
+     * Returns a error if the registering proccess fails for any reason, nullopt otherwise.
      */
-    ReconciliationRegisterResult RegisterPeer(NodeId peer_id, bool is_peer_inbound, uint32_t peer_recon_version, uint64_t remote_salt);
+    std::optional<ReconciliationError> RegisterPeer(NodeId peer_id, bool is_peer_inbound, uint32_t peer_recon_version, uint64_t remote_salt);
 
     /** Check if a peer is registered to reconcile transactions with us. */
     bool IsPeerRegistered(NodeId peer_id) const;

--- a/src/node/txreconciliation_impl.h
+++ b/src/node/txreconciliation_impl.h
@@ -19,6 +19,16 @@ static constexpr uint32_t TXRECONCILIATION_VERSION{1};
  */
 constexpr size_t MAX_RECONSET_SIZE = 3000;
 
+/**
+ * Announce transactions via full wtxid to a limited number of inbound and outbound peers.
+ * Justification for these values are provided here:
+ * TODO: ADD link to justification based on simulation results */
+constexpr double INBOUND_FANOUT_DESTINATIONS_FRACTION = 0.1;
+constexpr size_t OUTBOUND_FANOUT_THRESHOLD = 4;
+
+/** Interval for inbound peer fanout selection. The subset is rotated on a timer. */
+static constexpr auto INBOUND_FANOUT_ROTATION_INTERVAL{10min};
+
 enum class ReconciliationError
 {
     NOT_FOUND,
@@ -120,6 +130,14 @@ public:
     /** Whether a given inbound peer is currently flagged for fanout. */
     bool IsInboundFanoutTarget(NodeId peer_id);
 
+    /** Picks a different subset of inbound peers to fanout to. */
+    void RotateInboundFanoutTargets();
+
+    /** Get the next time the inbound peer subset should be rotated. */
+    std::chrono::microseconds GetNextInboundPeerRotationTime();
+
+    /** Update the next inbound peer rotation time. */
+    void SetNextInboundPeerRotationTime(std::chrono::microseconds next_time);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXRECONCILIATION_IMPL_H

--- a/src/test/txreconciliation_tests.cpp
+++ b/src/test/txreconciliation_tests.cpp
@@ -3,10 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/txreconciliation.h>
+#include <node/txreconciliation_impl.h>
 
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+
+using namespace node;
 
 BOOST_FIXTURE_TEST_SUITE(txreconciliation_tests, BasicTestingSetup)
 
@@ -19,31 +22,49 @@ BOOST_AUTO_TEST_CASE(RegisterPeerTest)
     tracker.PreRegisterPeer(0);
 
     // Invalid version.
-    BOOST_CHECK_EQUAL(tracker.RegisterPeer(/*peer_id=*/0, /*is_peer_inbound=*/true,
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(/*peer_id=*/0, /*is_peer_inbound=*/true,
                                            /*peer_recon_version=*/0, salt),
                       ReconciliationRegisterResult::PROTOCOL_VIOLATION);
 
     // Valid registration (inbound and outbound peers).
     BOOST_REQUIRE(!tracker.IsPeerRegistered(0));
-    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(0, true, 1, salt), ReconciliationRegisterResult::SUCCESS);
-    BOOST_CHECK(tracker.IsPeerRegistered(0));
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(0, true, TXRECONCILIATION_VERSION, salt), ReconciliationRegisterResult::SUCCESS);
+    BOOST_REQUIRE(tracker.IsPeerRegistered(0));
     BOOST_REQUIRE(!tracker.IsPeerRegistered(1));
     tracker.PreRegisterPeer(1);
-    BOOST_REQUIRE(tracker.RegisterPeer(1, false, 1, salt) == ReconciliationRegisterResult::SUCCESS);
-    BOOST_CHECK(tracker.IsPeerRegistered(1));
+    BOOST_REQUIRE(tracker.RegisterPeer(1, false, TXRECONCILIATION_VERSION, salt) == ReconciliationRegisterResult::SUCCESS);
+    BOOST_REQUIRE(tracker.IsPeerRegistered(1));
 
     // Reconciliation version is higher than ours, should be able to register.
     BOOST_REQUIRE(!tracker.IsPeerRegistered(2));
     tracker.PreRegisterPeer(2);
-    BOOST_REQUIRE(tracker.RegisterPeer(2, true, 2, salt) == ReconciliationRegisterResult::SUCCESS);
-    BOOST_CHECK(tracker.IsPeerRegistered(2));
+    BOOST_REQUIRE(tracker.RegisterPeer(2, true, TXRECONCILIATION_VERSION+1, salt) == ReconciliationRegisterResult::SUCCESS);
+    BOOST_REQUIRE(tracker.IsPeerRegistered(2));
 
     // Try registering for the second time.
-    BOOST_REQUIRE(tracker.RegisterPeer(1, false, 1, salt) == ReconciliationRegisterResult::ALREADY_REGISTERED);
+    BOOST_REQUIRE(tracker.RegisterPeer(1, false, TXRECONCILIATION_VERSION, salt) == ReconciliationRegisterResult::ALREADY_REGISTERED);
 
     // Do not register if there were no pre-registration for the peer.
-    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(100, true, 1, salt), ReconciliationRegisterResult::NOT_FOUND);
-    BOOST_CHECK(!tracker.IsPeerRegistered(100));
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(100, true, TXRECONCILIATION_VERSION, salt), ReconciliationRegisterResult::NOT_FOUND);
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(100));
+}
+
+BOOST_AUTO_TEST_CASE(IsPeerRegisteredTest)
+{
+    TxReconciliationTracker tracker(TXRECONCILIATION_VERSION);
+    NodeId peer_id0 = 0;
+
+    // Non-registered of simply pre-registered peers not count a registered.
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
+    tracker.PreRegisterPeer(peer_id0);
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
+
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, /*peer_recon_version=*/true, TXRECONCILIATION_VERSION, 1), ReconciliationRegisterResult::SUCCESS);
+    BOOST_REQUIRE(tracker.IsPeerRegistered(peer_id0));
+
+    // Forgotten peers do not count either.
+    tracker.ForgetPeer(peer_id0);
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
 }
 
 BOOST_AUTO_TEST_CASE(ForgetPeerTest)
@@ -52,33 +73,23 @@ BOOST_AUTO_TEST_CASE(ForgetPeerTest)
     NodeId peer_id0 = 0;
 
     // Removing peer after pre-registering works and does not let to register the peer.
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
     tracker.PreRegisterPeer(peer_id0);
     tracker.ForgetPeer(peer_id0);
-    BOOST_CHECK_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::NOT_FOUND);
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, /*is_peer_inbound=*/true, TXRECONCILIATION_VERSION, 1), ReconciliationRegisterResult::NOT_FOUND);
 
     // Removing peer after it is registered works.
     tracker.PreRegisterPeer(peer_id0);
     BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
-    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::SUCCESS);
-    BOOST_CHECK(tracker.IsPeerRegistered(peer_id0));
+    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, /*is_peer_inbound=*/true, TXRECONCILIATION_VERSION, 1), ReconciliationRegisterResult::SUCCESS);
+    BOOST_REQUIRE(tracker.IsPeerRegistered(peer_id0));
     tracker.ForgetPeer(peer_id0);
-    BOOST_CHECK(!tracker.IsPeerRegistered(peer_id0));
-}
-
-BOOST_AUTO_TEST_CASE(IsPeerRegisteredTest)
-{
-    TxReconciliationTracker tracker(TXRECONCILIATION_VERSION);
-    NodeId peer_id0 = 0;
-
-    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
-    tracker.PreRegisterPeer(peer_id0);
     BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
 
-    BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::SUCCESS);
-    BOOST_CHECK(tracker.IsPeerRegistered(peer_id0));
-
-    tracker.ForgetPeer(peer_id0);
-    BOOST_CHECK(!tracker.IsPeerRegistered(peer_id0));
+    // Removing a non-existing peer does nothing
+    NodeId not_a_peer_id = 1;
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(not_a_peer_id));
+    tracker.ForgetPeer(not_a_peer_id);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txreconciliation_tests.cpp
+++ b/src/test/txreconciliation_tests.cpp
@@ -92,4 +92,78 @@ BOOST_AUTO_TEST_CASE(ForgetPeerTest)
     tracker.ForgetPeer(not_a_peer_id);
 }
 
+BOOST_AUTO_TEST_CASE(AddToSetTest)
+{
+    TxReconciliationTracker tracker(TXRECONCILIATION_VERSION);
+    NodeId peer_id0 = 0;
+    FastRandomContext frc{/*fDeterministic=*/true};
+
+    Wtxid wtxid{Wtxid::FromUint256(frc.rand256())};
+
+    // If the peer is not registered, adding to the set fails
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
+    auto error = tracker.AddToSet(peer_id0, wtxid).value();
+    BOOST_REQUIRE_EQUAL(error.m_error, ReconciliationError::NOT_FOUND);
+    BOOST_REQUIRE(!error.m_collision.has_value());
+
+    // As long as the peer is registered, adding a new wtxid to the set should work
+    tracker.PreRegisterPeer(peer_id0);
+    BOOST_REQUIRE(!tracker.RegisterPeer(peer_id0, /*is_peer_inbound=*/true, TXRECONCILIATION_VERSION, 1).has_value());
+    BOOST_REQUIRE(tracker.IsPeerRegistered(peer_id0));
+    BOOST_REQUIRE(!tracker.AddToSet(peer_id0, wtxid).has_value());
+
+    // If the peer is dropped, adding wtxids to its set should fail
+    tracker.ForgetPeer(peer_id0);
+    Wtxid wtxid2{Wtxid::FromUint256(frc.rand256())};
+    error = tracker.AddToSet(peer_id0, wtxid2).value();
+    BOOST_REQUIRE_EQUAL(error.m_error, ReconciliationError::NOT_FOUND);
+    BOOST_REQUIRE(!error.m_collision.has_value());
+
+    NodeId peer_id1 = 1;
+    tracker.PreRegisterPeer(peer_id1);
+    BOOST_REQUIRE(!tracker.RegisterPeer(peer_id1, /*is_peer_inbound=*/true, TXRECONCILIATION_VERSION, 1).has_value());
+    BOOST_REQUIRE(tracker.IsPeerRegistered(peer_id1));
+
+    // As long as the peer is registered and the transaction is not in the set, adding it should succeed
+    for (size_t i = 0; i < MAX_RECONSET_SIZE; ++i)
+        BOOST_REQUIRE(!tracker.AddToSet(peer_id1, Wtxid::FromUint256(frc.rand256())).has_value());
+
+    // Adding one item over the limit should fail
+    error = tracker.AddToSet(peer_id1, Wtxid::FromUint256(frc.rand256())).value();
+    BOOST_REQUIRE_EQUAL(error.m_error, ReconciliationError::FULL_RECON_SET);
+    BOOST_REQUIRE(!error.m_collision.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(TryRemovingFromSetTest)
+{
+    TxReconciliationTracker tracker(TXRECONCILIATION_VERSION);
+    NodeId peer_id0 = 0;
+    FastRandomContext frc{/*fDeterministic=*/true};
+
+    Wtxid wtxid{Wtxid::FromUint256(frc.rand256())};
+
+    // If the peer is not registered, removing will fail
+    BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
+    BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
+
+    // This holds even if the peer is just pre-registered
+    tracker.PreRegisterPeer(peer_id0);
+    BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
+
+    // If the peer is registered but the transaction is not part of the set, this will fail too
+    BOOST_REQUIRE(!tracker.RegisterPeer(peer_id0, /*is_peer_inbound=*/true, TXRECONCILIATION_VERSION, 1).has_value());
+    BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
+
+    // Only if the transaction is found the method will return true
+    BOOST_REQUIRE(!tracker.AddToSet(peer_id0, wtxid).has_value());
+    BOOST_REQUIRE(tracker.TryRemovingFromSet(peer_id0, wtxid));
+    // Removing twice won't work
+    BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
+
+    // And removing after forgetting the peer won't work either
+    BOOST_REQUIRE(!tracker.AddToSet(peer_id0, wtxid).has_value());
+    tracker.ForgetPeer(peer_id0);
+    BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a re-attempt of https://github.com/bitcoin/bitcoin/pull/28765

The new approach differs from the previous in how peers are selected for fanout:

For Erlay-enabled peers, fanout targets are chosen for each transaction individually. Once the fanout target is reached, the transaction is reconciled with the rest of our peers. Whether a peer is selected for fanout depends on factors like peer type (inbound or outbound), how the transaction was received (via fanout or reconciliation), and how many of our peers are already aware of it.

For outbound peers:
If the transaction was received through fanout (or we originated it), we set a fanout rate threshold `OUTBOUND_FANOUT_THRESHOLD{4}`. As long as the transaction has been announced to (or received from) fewer than this number of peers, we continue faning out based on the order in which peers' Poisson timers go off.

If the transaction was received via reconciliation, we simply reconcile it with the rest of our peers.

For inbound peers:
We select a subset of inbound peers as fanout targets and send all transactions to them within a set time interval. Once the interval ends, the selection is randomly rotated.

This approach helps scale the transaction fanout rate for outbound peers by approximating how widely a transaction has already been propagated. For inbound peers, we use a random selection strategy to prevent them from easily exploiting our heuristic.

You may notice 398078a8a92725f33ac28107f8fa045e02b2c5bd is not currently being used. It is likely to be dropped and brought back in a follow-up. Currently, we are picking Erlay fanout targets independently of whether we already have other non-erlay peers (which are always fanout). We may want to scale the selection based on non-Erlay connections, but I think that can be addressed on it's own PR.

Erlay Project Tracking: https://github.com/bitcoin/bitcoin/issues/30249