### PR TITLE
bench: enable wallet creation benchmarks on all platforms

### DIFF
--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -34,14 +34,15 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
     bilingual_str error_string;
     std::vector<bilingual_str> warnings;
 
-    fs::path wallet_path = test_setup->m_path_root / strprintf("test_wallet_%d", random.rand32()).c_str();
+    auto wallet_path = fs::PathToString(test_setup->m_path_root / "test_wallet");
     bench.run([&] {
-        auto wallet = CreateWallet(context, wallet_path.utf8string(), /*load_on_start=*/std::nullopt, options, status, error_string, warnings);
+        auto wallet = CreateWallet(context, wallet_path, /*load_on_start=*/std::nullopt, options, status, error_string, warnings);
         assert(status == DatabaseStatus::SUCCESS);
         assert(wallet != nullptr);
 
-        // Cleanup
-        wallet.reset();
+        // Release wallet
+        RemoveWallet(context, wallet, /*load_on_start=*/ std::nullopt);
+        UnloadWallet(std::move(wallet));
         fs::remove_all(wallet_path);
     });
 }
@@ -49,14 +50,9 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
 static void WalletCreatePlain(benchmark::Bench& bench) { WalletCreate(bench, /*encrypted=*/false); }
 static void WalletCreateEncrypted(benchmark::Bench& bench) { WalletCreate(bench, /*encrypted=*/true); }
 
-#ifndef _MSC_VER
-// TODO: Being built with MSVC, the fs::remove_all() call in
-// the WalletCreate() fails with the error "The process cannot
-// access the file because it is being used by another process."
 #ifdef USE_SQLITE
 BENCHMARK(WalletCreatePlain, benchmark::PriorityLevel::LOW);
 BENCHMARK(WalletCreateEncrypted, benchmark::PriorityLevel::LOW);
-#endif
 #endif
 
 } // namespace wallet


### PR DESCRIPTION
Simple fix for #29816.

Since the wallet is appended to the global `WalletContext` during
creation, merely calling `reset()` on the benchmark shared_pointer
is insufficient to destruct the wallet. This no destruction of the
wallet object results in keeping the db connection open, which
was causes the `fs::remove_all()` failure on Windows.