### PR TITLE
wallet, tests: Avoid stringop-overflow warning in PollutePubKey

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -499,8 +499,10 @@ static void TestWatchOnlyPubKey(LegacyScriptPubKeyMan* spk_man, const CPubKey& a
 // Cryptographically invalidate a PubKey whilst keeping length and first byte
 static void PollutePubKey(CPubKey& pubkey)
 {
-    std::vector<unsigned char> pubkey_raw(pubkey.begin(), pubkey.end());
-    std::fill(pubkey_raw.begin()+1, pubkey_raw.end(), 0);
+    assert(pubkey.size() >= 1);
+    std::vector<unsigned char> pubkey_raw;
+    pubkey_raw.push_back(pubkey[0]);
+    pubkey_raw.insert(pubkey_raw.end(), pubkey.size() - 1, 0);
     pubkey = CPubKey(pubkey_raw);
     assert(!pubkey.IsFullyValid());
     assert(pubkey.IsValid());


### PR DESCRIPTION
Fixes  #30114