### PR TITLE
test: remove unneeded `-maxorphantx=1000` settings

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -28,7 +28,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.extra_args = [
             [
-                "-maxorphantx=1000",
                 "-limitancestorcount=50",
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -21,7 +21,6 @@ from test_framework.wallet import MiniWallet
 class MempoolPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-maxorphantx=1000"]]
 
     def chain_tx(self, utxos_to_spend, *, num_outputs=1):
         return self.wallet.send_self_transfer_multi(

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -31,10 +31,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.noban_tx_relay = True
         self.extra_args = [
             [
-                "-maxorphantx=1000",
             ],
             [
-                "-maxorphantx=1000",
                 "-limitancestorcount={}".format(CUSTOM_ANCESTOR_LIMIT),
                 "-limitdescendantcount={}".format(CUSTOM_DESCENDANT_LIMIT),
             ],


### PR DESCRIPTION
It's unclear what the motivation for increasing the orphan pool is here, and it seems that this not needed at all. None of these tests involve orphan transactions explicitly, and if they would occur occasionally, there is no good reason to prefer a value of 1000 over the default of 100 (see DEFAULT_MAX_ORPHAN_TRANSACTIONS).