### PR TITLE
build: Disable `_FORTIFY_SOURCE` if using MSan

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_msan.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_msan.sh
@@ -17,8 +17,7 @@ export PACKAGES="ninja-build"
 # BDB generates false-positives and will be removed in future
 export DEP_OPTS="DEBUG=1 NO_BDB=1 NO_QT=1 CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 export GOAL="install"
-# _FORTIFY_SOURCE is not compatible with MSAN.
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer,memory CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -U_FORTIFY_SOURCE'"
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer,memory CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE'"
 export USE_MEMORY_SANITIZER="true"
 export RUN_UNIT_TESTS="false"
 export RUN_FUNCTIONAL_TESTS="false"

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -17,8 +17,7 @@ export PACKAGES="ninja-build"
 # BDB generates false-positives and will be removed in future
 export DEP_OPTS="DEBUG=1 NO_BDB=1 NO_QT=1 CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 export GOAL="install"
-# _FORTIFY_SOURCE is not compatible with MSAN.
-export BITCOIN_CONFIG="--with-sanitizers=memory CPPFLAGS='-U_FORTIFY_SOURCE'"
+export BITCOIN_CONFIG="--with-sanitizers=memory"
 export USE_MEMORY_SANITIZER="true"
 export RUN_FUNCTIONAL_TESTS="false"
 export CCACHE_MAXSIZE=250M

--- a/configure.ac
+++ b/configure.ac
@@ -392,6 +392,19 @@ if test "$use_sanitizers" != ""; then
     extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) { return 0; }
     __attribute__((weak)) // allow for libFuzzer linking
     ]],[[]])])
+
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$SANITIZER_CXXFLAGS $CXXFLAGS"
+  AC_MSG_CHECKING(whether MemorySanitizer is enabled)
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #if defined(__has_feature)
+    #  if __has_feature(memory_sanitizer)
+    #    error "MemorySanitizer is enabled."
+    #  endif
+    #endif
+    ]])], [msan_enabled=no], [msan_enabled=yes])
+  AC_MSG_RESULT([$msan_enabled])
+  CXXFLAGS="$TEMP_CXXFLAGS"
 fi
 
 ERROR_CXXFLAGS=
@@ -923,10 +936,11 @@ if test "$use_hardening" != "no"; then
     ;;
   esac
 
-  dnl When enable_debug is yes, all optimizations are disabled.
+  dnl 1. When enable_debug is yes, all optimizations are disabled.
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.
   dnl Since FORTIFY_SOURCE is a no-op without optimizations, do not enable it when enable_debug is yes.
-  if test "$enable_debug" != "yes"; then
+  dnl 2. FORTIFY_SOURCE causes MSan false positives, so do not enable it when msan_enabled is yes.
+  if test "$enable_debug" != "yes" && test "$msan_enabled" != "yes"; then
     AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=3],[
       AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
         HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
@@ -944,6 +958,10 @@ if test "$use_hardening" != "no"; then
   AX_CHECK_LINK_FLAG([-Wl,-z,separate-code], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,separate-code"], [], [$LDFLAG_WERROR])
   AX_CHECK_LINK_FLAG([-fPIE -pie], [PIE_FLAGS="-fPIE"; HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"], [], [$CXXFLAG_WERROR])
 fi
+if test "$msan_enabled" = "yes"; then
+  AX_CHECK_COMPILE_FLAG([-Wp,-U_FORTIFY_SOURCE], [SANITIZER_CXXFLAGS="$SANITIZER_CXXFLAGS -Wp,-U_FORTIFY_SOURCE"])
+fi
+
 
 dnl These flags are specific to ld64, and may cause issues with other linkers.
 dnl For example: GNU ld will interpret -dead_strip as -de and then try and use


### PR DESCRIPTION
This PR shifts responsibility to disable `_FORTIFY_SOURCE` from the user to the build system, which:
- improves usability
- simplifies the CI and OSS-Fuzz scripts
- is useful for CMake migration as it removes the need to use non-standard `APPEND_CPPFLAGS` in such a corner case
