### PR TITLE
doc: add guidance for RPC to developer notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1460,6 +1460,12 @@ A few guidelines for introducing and reviewing new RPC interfaces:
   - *Rationale*: JSON strings are Unicode strings, not byte strings, and
     RFC8259 requires JSON to be encoded as UTF-8.
 
+A few guidelines for modifying existing RPC interfaces:
+
+- It's preferable to avoid changing an RPC in a backward-incompatible manner, but in that case, add an associated `-deprecatedrpc=` option to retain previous RPC behavior during the deprecation period. Backward-incompatible changes include: data type changes (e.g. from `{"warnings":""}` to `{"warnings":[]}`, changing a value from a string to a number, etc.), logical meaning changes of a value, or key name changes (e.g. `{"warning":""}` to `{"warnings":""}`). Adding a key to an object is generally considered backward-compatible. Include a release note that refers the user to the RPC help for details of feature deprecation and re-enabling previous behavior. [Example RPC help](https://github.com/bitcoin/bitcoin/blob/94f0adcc/src/rpc/blockchain.cpp#L1316-L1323).
+
+  - *Rationale*: Changes in RPC JSON structure can break downstream application compatibility. Implementation of `deprecatedrpc` provides a grace period for downstream applications to migrate. Release notes provide notification to downstream users.
+
 Internal interface guidelines
 -----------------------------
 


### PR DESCRIPTION
Adds guidance statements to the RPC interface section of the developer notes with examples of when to implement `-deprecatedrpc=`.

Wanted to increase awareness of preferred RPC implementation approaches for newer contributors.

This implements some of what's discussed in https://github.com/bitcoin/bitcoin/issues/29912#issuecomment-2081678433

Opinions may differ, so please don't be shy.  We want to make RPC as solid/safe as possible.

Examples of discussions where guidelines/context might have added value:
https://github.com/bitcoin/bitcoin/pull/30212#issuecomment-2347371722
https://github.com/bitcoin/bitcoin/pull/29845#discussion_r1571053657
https://github.com/bitcoin/bitcoin/pull/30381#pullrequestreview-2160865613
https://github.com/bitcoin/bitcoin/pull/29954#issuecomment-2103628952
https://github.com/bitcoin/bitcoin/pull/30410#pullrequestreview-2167870869
https://github.com/bitcoin/bitcoin/pull/30713
https://github.com/bitcoin/bitcoin/pull/30381
https://github.com/bitcoin/bitcoin/pull/29060#pullrequestreview-2406688998

