### PR TITLE
ci: Add missing -Wno-error=maybe-uninitialized to armhf task

### DIFF
--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -17,4 +17,4 @@ export RUN_FUNCTIONAL_TESTS=false
 export GOAL="install"
 # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
 # This could be removed once the ABI change warning does not show up by default
-export BITCOIN_CONFIG="--enable-reduce-exports CXXFLAGS=-Wno-psabi"
+export BITCOIN_CONFIG="--enable-reduce-exports CXXFLAGS='-Wno-psabi -Wno-error=maybe-uninitialized'"


### PR DESCRIPTION
This happens after bd597c33e3e58cd3c6b22ed42f8f1fd7ff886bb2 in many pull requests as a silent merge conflict. For example:

* https://github.com/bitcoin/bitcoin/pull/29720#issuecomment-2120847661
* https://github.com/bitcoin/bitcoin/pull/29521#issuecomment-2106542236
* (Probably many undetected, because the CI task was not yet re-run)
* ...