### PR TITLE
doc: Correct pull request prefix for scripts and tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ the pull request affects. Valid areas as:
   - `net` or `p2p` for changes to the peer-to-peer network code
   - `refactor` for structural changes that do not change behavior
   - `rpc`, `rest` or `zmq` for changes to the RPC, REST or ZMQ APIs
-  - `script` for changes to the scripts and tools
+  - `contrib` or `cli` for changes to the scripts and tools
   - `test`, `qa` or `ci` for changes to the unit tests, QA tests or CI code
   - `util` or `lib` for changes to the utils or libraries
   - `wallet` for changes to the wallet code


### PR DESCRIPTION
`script` is confusing, because in the context of Bitcoin, it usually means Bitcoin script (c.f. `CScript` in `script.h`, or pull requests such as https://github.com/bitcoin/bitcoin/pull/27122 using the prefix).

This could be fixed by renaming it to `scripts` (with a plural `s` at the end), however, looking at the current usage `contrib` and `cli` seem more common (https://github.com/bitcoin/bitcoin/pull/29687, https://github.com/bitcoin/bitcoin/pull/26953, https://github.com/bitcoin/bitcoin/pull/26584, https://github.com/bitcoin/bitcoin/pull/24864, https://github.com/bitcoin/bitcoin/pull/30074, https://github.com/bitcoin/bitcoin/pull/29433 ...)