### PR TITLE
doc: update mention of generating bitcoin.conf

### DIFF
--- a/doc/init.md
+++ b/doc/init.md
@@ -43,8 +43,8 @@ This allows for running bitcoind without having to do any manual configuration.
 `conf`, `pid`, and `wallet` accept relative paths which are interpreted as
 relative to the data directory. `wallet` *only* supports relative paths.
 
-For an example configuration file that describes the configuration settings,
-see `share/examples/bitcoin.conf`.
+To generate an example configuration file that describes the configuration settings,
+see [contrib/devtools/README.md](../contrib/devtools/README.md#gen-bitcoin-confsh).
 
 Paths
 ---------------------------------


### PR DESCRIPTION
Closes #30153.

This PR updates `doc/init.md` to mention generating an example bitcoin.conf instead of referencing the placeholder `share/examples/bitcoin.conf`. Also changes the code-formatted text to a markdown link.

## Background

- Two years ago, `share/examples/bitcoin.conf` was replaced with [a placeholder file](https://github.com/bitcoin/bitcoin/commit/b483084d866c16d97a34251ae652bac94f85f61d). To see an example `bitcoin.conf`, the user now runs the `contrib/devtools/gen-bitcoin-conf.sh` script, which replaces the placeholder file with the parsed contents of `bitcoind --help`.

- The instructions in `init.md` about an example `bitcoin.conf` haven't changed significantly since they were [added almost 10 years ago](https://github.com/bitcoin/bitcoin/blame/234bfbf6a5fcba37e510e9cb6c1f2a629cd0290e/doc/init.md#L39). They should be updated to improve clarity.
