### PR TITLE
validation: Make ReplayBlocks interruptible

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -95,17 +95,21 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     size_t count = 0;
     size_t changed = 0;
     assert(!hashBlock.IsNull());
+    bool unfinished_replay{false};
 
     uint256 old_tip = GetBestBlock();
     if (old_tip.IsNull()) {
-        // We may be in the middle of replaying.
+        // We may be in the process of replaying.
         std::vector<uint256> old_heads = GetHeadBlocks();
         if (old_heads.size() == 2) {
             if (old_heads[0] != hashBlock) {
-                LogPrintLevel(BCLog::COINDB, BCLog::Level::Error, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
+                // We haven't reached the target of replaying yet.
+                // This happens if the replay was interrupted by the user.
+                unfinished_replay = true;
+            } else {
+                // Replaying has reached its end, flush the results.
+                old_tip = old_heads[1];
             }
-            assert(old_heads[0] == hashBlock);
-            old_tip = old_heads[1];
         }
     }
 
@@ -113,8 +117,10 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     // transition from old_tip to hashBlock.
     // A vector is used for future extensibility, as we may want to support
     // interrupting after partial writes from multiple independent reorgs.
-    batch.Erase(DB_BEST_BLOCK);
-    batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
+    if (!unfinished_replay) {
+        batch.Erase(DB_BEST_BLOCK);
+        batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
+    }
 
     for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
@@ -144,9 +150,19 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
         }
     }
 
-    // In the last batch, mark the database as consistent with hashBlock again.
-    batch.Erase(DB_HEAD_BLOCKS);
-    batch.Write(DB_BEST_BLOCK, hashBlock);
+    if (unfinished_replay) {
+        // This is called when, during ReplayBlocks, an interrupt is received.
+        // Update the replay origin (saved in second place in DB_HEAD_BLOCKS)
+        // so that the replay can pick up from here after restart.
+        // The replay target remains unchanged.
+        std::vector<uint256> old_heads = GetHeadBlocks();
+        assert(old_heads.size() == 2);
+        batch.Write(DB_HEAD_BLOCKS, Vector(old_heads[0], hashBlock));
+    } else {
+        // In the last batch, mark the database as consistent with hashBlock again.
+        batch.Erase(DB_HEAD_BLOCKS);
+        batch.Write(DB_BEST_BLOCK, hashBlock);
+    }
 
     LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() * (1.0 / 1048576.0));
     bool ret = m_db->WriteBatch(batch);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4918,6 +4918,12 @@ bool Chainstate::ReplayBlocks()
         LogInfo("Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);
         m_chainman.GetNotifications().progress(_("Replaying blocks…"), (int)((nHeight - nForkHeight) * 100.0 / (pindexNew->nHeight - nForkHeight)), false);
         if (!RollforwardBlock(&pindex, cache)) return false;
+        if (m_chainman.m_interrupt) {
+            LogInfo("Flushing intermediate state of replay\n");
+            cache.SetBestBlock(pindex.GetBlockHash());
+            cache.Flush();
+            return false;
+        }
     }
 
     cache.SetBestBlock(pindexNew->GetBlockHash());


### PR DESCRIPTION
This addresses the problem from #11600 that the Rolling Forward process after a crash (`ReplayBlocks()`) is uninterruptible. `ReplayBlocks` can take a long time to finish, and this can be especially annoying to GUI users who are taunted to "press q to shutdown" even though pressing "q" does nothing.

Now, when an interrupt is received during `ReplayBlocks()`, the intermediate progress is saved:
In addition to writing the updated coins to disk, the flush adjusts the lower head block (saved in `DB_HEAD_BLOCKS`), so that with the next restart, the replay continues from where it was stopped without losing progress.

I tested this manually on signet: A situation where `ReplayBlocks()` becomes necessary can be created by syncing with `-dbcrashratio=1` and stopping the node after ~70k blocks. Then, after the next restart, the replay process can be interrupted. I then used the `dumptxoutset` output to check that the final utxo-set hash is unaffected by how many times the process is interrupted.