### PR TITLE
refactor: Use type-safe time in txorphanage

### DIFF
--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -9,6 +9,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <sync.h>
+#include <util/time.h>
 
 #include <map>
 #include <set>
@@ -73,7 +74,7 @@ protected:
     struct OrphanTx {
         CTransactionRef tx;
         NodeId fromPeer;
-        int64_t nTimeExpire;
+        NodeSeconds nTimeExpire;
         size_t list_pos;
     };
 


### PR DESCRIPTION
This allows to remove manual conversions like multiplication by `60`, and uses a type-safe type instead of a raw `int64_t`.