### PR TITLE
doc: Change GiB to GB in release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -310,12 +310,12 @@ cat "$VERSION"/*/all.SHA256SUMS.asc > SHA256SUMS.asc
 Both variables are used as a guideline for how much space the user needs on their drive in total, not just strictly for the blockchain.
 Note that all values should be taken from a **fully synced** node and have an overhead of 5-10% added on top of its base value.
 
-To calculate `m_assumed_blockchain_size`, take the size in GiB of these directories:
+To calculate `m_assumed_blockchain_size`, take the size in GB of these directories:
 - For `mainnet` -> the data directory, excluding the `/testnet3`, `/signet`, and `/regtest` directories and any overly large files, e.g. a huge `debug.log`
 - For `testnet` -> `/testnet3`
 - For `signet` -> `/signet`
 
-To calculate `m_assumed_chain_state_size`, take the size in GiB of these directories:
+To calculate `m_assumed_chain_state_size`, take the size in GB of these directories:
 - For `mainnet` -> `/chainstate`
 - For `testnet` -> `/testnet3/chainstate`
 - For `signet` -> `/signet/chainstate`


### PR DESCRIPTION
This will make it consistent with the Welcome GUI and code comments which use "GB" for the `m_assumed_blockchain_size` and `m_assumed_chain_state_size` values.

Since they are used as GB values to calculate disk space in GB needed in the GUI, measuring size in GiB here will cause users to run out of space without a graphical warning. The error between units is over 45 GB for the full chain.

This doc is the only place we say they are GiB, and while an 8-10% overhead can account for the unit conversion, we say the overhead was for growth between releases, not abusing the units without conversion.

https://github.com/bitcoin/bitcoin/blob/4c387cb64ff4c74f911b1559fb0ef143ee6c268b/src/kernel/chainparams.h#L106-L109
![image](https://github.com/bitcoin/bitcoin/assets/73506583/e30f0f3b-13e9-44a5-b006-77bfa9059274)

Here is a 3rd spot where the GiB value is presented to the user as GB:
https://github.com/bitcoin/bitcoin/blob/4c387cb64ff4c74f911b1559fb0ef143ee6c268b/src/init.cpp#L1696-L1713

However, it comes right after using the value correctly as GiB (unlike in GUI which uses it as GB). So that may need to be patched to calculate bytes from GB instead of GiB.