### PR TITLE
guix: show `*_FLAGS` variables in pre-build output

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -361,6 +361,10 @@ INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
           ...bind-mounted in container to: '$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")'
       ...outputting in: '$(outdir_for_host "$HOST")'
           ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")'
+      ADDITIONAL FLAGS (if set)
+          ADDITIONAL_GUIX_COMMON_FLAGS: ${ADDITIONAL_GUIX_COMMON_FLAGS}
+          ADDITIONAL_GUIX_ENVIRONMENT_FLAGS: ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS}
+          ADDITIONAL_GUIX_TIMEMACHINE_FLAGS: ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS}
 EOF
 
         # Run the build script 'contrib/guix/libexec/build.sh' in the build


### PR DESCRIPTION
For example:
```bash
# ADDITIONAL_GUIX_COMMON_FLAGS set in the ENV
ADDITIONAL_GUIX_ENVIRONMENT_FLAGS="--emulate-fhs" ./contrib/guix/guix-build
<snip>
INFO: Building f751991 for platform triple x86_64-linux-gnu:
      ...using reference timestamp: 1716905119
      ...running at most 10 jobs
      ...from worktree directory: '/bitcoin'
          ...bind-mounted in container to: '/bitcoin'
      ...in build directory: '/bitcoin/guix-build-f75199182133/distsrc-f75199182133-x86_64-linux-gnu'
          ...bind-mounted in container to: '/distsrc-base/distsrc-f75199182133-x86_64-linux-gnu'
      ...outputting in: '/bitcoin/guix-build-f75199182133/output/x86_64-linux-gnu'
          ...bind-mounted in container to: '/outdir-base/x86_64-linux-gnu'
      ADDITIONAL FLAGS (if set)
          ADDITIONAL_GUIX_COMMON_FLAGS: --no-substitutes
          ADDITIONAL_GUIX_ENVIRONMENT_FLAGS: --emulate-fhs
          ADDITIONAL_GUIX_TIMEMACHINE_FLAGS:
```