### PR TITLE
fuzz: increase `txorphan` harness stability

### DIFF
--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -119,7 +119,6 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
     LOCK(m_mutex);
 
     unsigned int nEvicted = 0;
-    static NodeSeconds nNextSweep;
     auto nNow{Now<NodeSeconds>()};
     if (nNextSweep <= nNow) {
         // Sweep out expired orphan pool entries:

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -120,7 +120,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
 
     unsigned int nEvicted = 0;
     auto nNow{Now<NodeSeconds>()};
-    if (nNextSweep <= nNow) {
+    if (m_next_sweep <= nNow) {
         // Sweep out expired orphan pool entries:
         int nErased = 0;
         auto nMinExpTime{nNow + ORPHAN_TX_EXPIRE_TIME - ORPHAN_TX_EXPIRE_INTERVAL};
@@ -135,7 +135,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
             }
         }
         // Sweep again 5 minutes after the next entry that expires in order to batch the linear scan.
-        nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
+        m_next_sweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
         if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     while (m_orphans.size() > max_orphans)

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -105,6 +105,9 @@ protected:
 
     /** Erase an orphan by wtxid */
     int EraseTxNoLock(const Wtxid& wtxid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
+    /** Timestamp for the next scheduled sweep of expired orphans */
+    NodeSeconds nNextSweep GUARDED_BY(m_mutex){0s};
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -107,7 +107,7 @@ protected:
     int EraseTxNoLock(const Wtxid& wtxid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
 
     /** Timestamp for the next scheduled sweep of expired orphans */
-    NodeSeconds nNextSweep GUARDED_BY(m_mutex){0s};
+    NodeSeconds m_next_sweep GUARDED_BY(m_mutex){0s};
 };
 
 #endif // BITCOIN_TXORPHANAGE_H


### PR DESCRIPTION
This moves `nNextSweep` from being a static variable in `LimitOrphans` to being a member of the `TxOrphanage` class. This improves the stability of the `txorphan` fuzz harness, as each orphanage (created every iteration) now has its own value for `nNextSweep`.