### PR TITLE
build: remove `--enable-lcov-branch-coverage`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,12 +238,6 @@ AC_ARG_ENABLE([lcov],
   [use_lcov=$enableval],
   [use_lcov=no])
 
-AC_ARG_ENABLE([lcov-branch-coverage],
-  [AS_HELP_STRING([--enable-lcov-branch-coverage],
-  [enable lcov testing branch coverage (default is no)])],
-  [use_lcov_branch=yes],
-  [use_lcov_branch=no])
-
 AC_ARG_ENABLE([zmq],
   [AS_HELP_STRING([--disable-zmq],
   [disable ZMQ notifications])],
@@ -821,10 +815,8 @@ if test "$use_lcov" = "yes"; then
   AX_CHECK_COMPILE_FLAG([--coverage],[CORE_CXXFLAGS="$CORE_CXXFLAGS --coverage"],
     [AC_MSG_ERROR([lcov testing requested but --coverage flag does not work])])
   CORE_CXXFLAGS="$CORE_CXXFLAGS -Og"
-fi
 
-if test "$use_lcov_branch" != "no"; then
-  AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
+  AC_SUBST(LCOV_OPTS)
 fi
 
 dnl Check for endianness

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -497,6 +497,10 @@ make cov
 # unit and functional tests.
 ```
 
+Additional LCOV options can be specified using `LCOV_OPTS`, but may be dependant
+on the version of LCOV. For example, when using LCOV `2.x`, branch coverage can be
+enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`, when configuring.
+
 ### Performance profiling with perf
 
 Profiling is a good way to get a precise idea of where time is being spent in

--- a/doc/release-notes-30192.md
+++ b/doc/release-notes-30192.md
@@ -1,0 +1,6 @@
+Build
+-----
+
+`--enable-lcov-branch-coverage` has been removed, given
+incompatibilities between lcov version 1 & 2. `LCOV_OPTS`
+should be used to set any options instead.


### PR DESCRIPTION
This supports lcov `2.x` in the sense that we are no-longer hardcoding version specific options, and instead will use the `LCOV_OPTS` variable (which is the more flexible thing to do in any case). It's also quite likely that devs are already having to pass extra options to lcov `2.x`, given it's more stringent in terms of coverage generation and error checking. See this thread for an example: https://github.com/linux-test-project/lcov/issues/238.

Tested on one machine (LCOV 2.0, gcc 13.2) with:
```bash
./autogen.sh
./configure --enable-lcov CXXFLAGS="-fprofile-update=prefer-atomic" LCOV_OPTS="--rc branch_coverage=1 --ignore-errors mismatch"
make
make cov
<snip>
Processing file src/netaddress.cpp
  lines=521 hit=480 functions=72 hit=72 branches=675 hit=499
Overall coverage rate:
  lines......: 81.8% (79362 of 97002 lines)
  functions......: 77.8% (10356 of 13310 functions)
  branches......: 49.6% (130628 of 263196 branches)
```

and another machine (LCOV 2.1, Clang 18.1.3) with:
```bash
./autogen.sh
./configure --enable-lcov CC=clang CXX=clang++ LCOV_OPTS="--rc branch_coverage=1 --ignore-errors mismatch,inconsistent"
make
make cov
<snip>
    Processing file src/util/strencodings.cpp
      lines=315 hit=311 functions=38 hit=38 branches=425 hit=357
    Overall coverage rate:
      source files: 622
      lines.......: 79.8% (70311 of 88132 lines)
      functions...: 78.1% (13968 of 17881 functions)
      branches....: 44.5% (157551 of 354317 branches)
    Message summary:
      101 warning messages:
        count: 1
        inconsistent: 100
      3528 ignore messages:
        inconsistent: 3528
```

Related to #28468.