### PR TITLE
clang-tidy: Add `bugprone-move-forwarding-reference` check

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -2,6 +2,7 @@ Checks: '
 -*,
 bitcoin-*,
 bugprone-argument-comment,
+bugprone-move-forwarding-reference,
 bugprone-string-constructor,
 bugprone-use-after-move,
 bugprone-lambda-function-name,


### PR DESCRIPTION
This PR adds [`bugprone-move-forwarding-reference`](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/move-forwarding-reference.html) to the clang-tidy checks.