### PR TITLE
Introduce Mining interface

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1457,8 +1457,9 @@ independent (node, wallet, GUI), are defined in
 there are [`interfaces::Chain`](../src/interfaces/chain.h), used by wallet to
 access the node's latest chain state,
 [`interfaces::Node`](../src/interfaces/node.h), used by the GUI to control the
-node, and [`interfaces::Wallet`](../src/interfaces/wallet.h), used by the GUI
-to control an individual wallet. There are also more specialized interface
+node, [`interfaces::Wallet`](../src/interfaces/wallet.h), used by the GUI
+to control an individual wallet and [`interfaces::Mining`](../src/interfaces/mining.h),
+used by RPC to generate block templates. There are also more specialized interface
 types like [`interfaces::Handler`](../src/interfaces/handler.h)
 [`interfaces::ChainClient`](../src/interfaces/chain.h) passed to and from
 various interface methods.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -177,6 +177,7 @@ BITCOIN_CORE_H = \
   interfaces/handler.h \
   interfaces/init.h \
   interfaces/ipc.h \
+  interfaces/mining.h \
   interfaces/node.h \
   interfaces/wallet.h \
   kernel/blockmanager_opts.h \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #include <init/common.h>
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -1117,6 +1118,7 @@ bool AppInitLockDataDirectory()
 bool AppInitInterfaces(NodeContext& node)
 {
     node.chain = node.init->makeChain();
+    node.mining = node.init->makeMining();
     return true;
 }
 

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -30,6 +30,7 @@ public:
     }
     std::unique_ptr<interfaces::Node> makeNode() override { return interfaces::MakeNode(m_node); }
     std::unique_ptr<interfaces::Chain> makeChain() override { return interfaces::MakeChain(m_node); }
+    std::unique_ptr<interfaces::Mining> makeMining() override { return interfaces::MakeMining(m_node); }
     std::unique_ptr<interfaces::WalletLoader> makeWalletLoader(interfaces::Chain& chain) override
     {
         return MakeWalletLoader(chain, *Assert(m_node.args));

--- a/src/init/bitcoin-qt.cpp
+++ b/src/init/bitcoin-qt.cpp
@@ -6,6 +6,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
 #include <interfaces/init.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
@@ -25,6 +26,7 @@ public:
     }
     std::unique_ptr<interfaces::Node> makeNode() override { return interfaces::MakeNode(m_node); }
     std::unique_ptr<interfaces::Chain> makeChain() override { return interfaces::MakeChain(m_node); }
+    std::unique_ptr<interfaces::Mining> makeMining() override { return interfaces::MakeMining(m_node); }
     std::unique_ptr<interfaces::WalletLoader> makeWalletLoader(interfaces::Chain& chain) override
     {
         return MakeWalletLoader(chain, *Assert(m_node.args));

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -6,6 +6,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
 #include <interfaces/init.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
@@ -27,6 +28,7 @@ public:
     }
     std::unique_ptr<interfaces::Node> makeNode() override { return interfaces::MakeNode(m_node); }
     std::unique_ptr<interfaces::Chain> makeChain() override { return interfaces::MakeChain(m_node); }
+    std::unique_ptr<interfaces::Mining> makeMining() override { return interfaces::MakeMining(m_node); }
     std::unique_ptr<interfaces::WalletLoader> makeWalletLoader(interfaces::Chain& chain) override
     {
         return MakeWalletLoader(chain, *Assert(m_node.args));

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -7,6 +7,7 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 
@@ -32,6 +33,7 @@ public:
     virtual ~Init() = default;
     virtual std::unique_ptr<Node> makeNode() { return nullptr; }
     virtual std::unique_ptr<Chain> makeChain() { return nullptr; }
+    virtual std::unique_ptr<Mining> makeMining() { return nullptr; }
     virtual std::unique_ptr<WalletLoader> makeWalletLoader(Chain& chain) { return nullptr; }
     virtual std::unique_ptr<Echo> makeEcho() { return nullptr; }
     virtual Ipc* ipc() { return nullptr; }

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_INTERFACES_MINING_H
 #define BITCOIN_INTERFACES_MINING_H
 
+#include <optional>
 #include <uint256.h>
 
 namespace node {
@@ -29,8 +30,8 @@ public:
     //! If this chain is exclusively used for testing
     virtual bool isTestChain() = 0;
 
-    //! Returns the hash for the tip of this chain, 0 if none
-    virtual uint256 getTipHash() = 0;
+    //! Returns the hash for the tip of this chain
+    virtual std::optional<uint256> getTipHash() = 0;
 
    /**
      * Construct a new block template

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_INTERFACES_MINING_H
 #define BITCOIN_INTERFACES_MINING_H
 
+#include <uint256.h>
+
 namespace node {
 struct NodeContext;
 } // namespace node
@@ -24,6 +26,9 @@ public:
 
     //! If this chain is exclusively used for testing
     virtual bool isTestChain() = 0;
+
+    //! Returns the hash for the tip of this chain, 0 if none
+    virtual uint256 getTipHash() = 0;
 
     /**
      * Check a block is completely valid from start to finish.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -41,6 +41,10 @@ public:
      */
     virtual std::unique_ptr<node::CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool = true) = 0;
 
+    //! Return the number of transaction updates in the mempool,
+    //! used to decide whether to make a new block template.
+    virtual unsigned int getTransactionsUpdated() = 0;
+
     /**
      * Check a block is completely valid from start to finish.
      * Only works on top of our current best block.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -9,6 +9,9 @@ namespace node {
 struct NodeContext;
 } // namespace node
 
+class BlockValidationState;
+class CBlock;
+
 namespace interfaces {
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
@@ -21,6 +24,18 @@ public:
 
     //! If this chain is exclusively used for testing
     virtual bool isTestChain() = 0;
+
+    /**
+     * Check a block is completely valid from start to finish.
+     * Only works on top of our current best block.
+     * Does not check proof-of-work.
+     *
+     * @param[out] state details of why a block failed to validate
+     * @param[in] block the block to validate
+     * @param[in] check_merkle_root call CheckMerkleRoot()
+     * @returns false if any of the checks fail
+     */
+    virtual bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root = true) = 0;
 
     //! Get internal node context. Useful for RPC and testing,
     //! but not accessible across processes.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -30,6 +30,9 @@ public:
     //! If this chain is exclusively used for testing
     virtual bool isTestChain() = 0;
 
+    //! Returns whether IBD is still in progress.
+    virtual bool isInitialBlockDownload() = 0;
+
     //! Returns the hash for the tip of this chain
     virtual std::optional<uint256> getTipHash() = 0;
 

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_MINING_H
+#define BITCOIN_INTERFACES_MINING_H
+
+namespace node {
+struct NodeContext;
+} // namespace node
+
+namespace interfaces {
+
+//! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
+//! ability to create block templates.
+
+class Mining
+{
+public:
+    virtual ~Mining() {}
+
+    //! If this chain is exclusively used for testing
+    virtual bool isTestChain() = 0;
+
+    //! Get internal node context. Useful for RPC and testing,
+    //! but not accessible across processes.
+    virtual node::NodeContext* context() { return nullptr; }
+};
+
+//! Return implementation of Mining interface.
+std::unique_ptr<Mining> MakeMining(node::NodeContext& node);
+
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_MINING_H

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -8,11 +8,13 @@
 #include <uint256.h>
 
 namespace node {
+struct CBlockTemplate;
 struct NodeContext;
 } // namespace node
 
 class BlockValidationState;
 class CBlock;
+class CScript;
 
 namespace interfaces {
 
@@ -29,6 +31,15 @@ public:
 
     //! Returns the hash for the tip of this chain, 0 if none
     virtual uint256 getTipHash() = 0;
+
+   /**
+     * Construct a new block template
+     *
+     * @param[in] script_pub_key the coinbase output
+     * @param[in] use_mempool set false to omit mempool transactions
+     * @returns a block template
+     */
+    virtual std::unique_ptr<node::CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool = true) = 0;
 
     /**
      * Check a block is completely valid from start to finish.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -40,6 +40,14 @@ public:
      * @returns a block template
      */
     virtual std::unique_ptr<node::CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool = true) = 0;
+    /**
+     * Processes new block. A valid new block is automatically relayed to peers.
+     *
+     * @param[in]   block The block we want to process.
+     * @param[out]  new_block A boolean which is set to indicate if the block was first received via this call
+     * @returns     If the block was processed, independently of block validity
+     */
+    virtual bool processNewBlock(const std::shared_ptr<const CBlock>& block, bool* new_block) = 0;
 
     //! Return the number of transaction updates in the mempool,
     //! used to decide whether to make a new block template.

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -7,6 +7,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <interfaces/chain.h>
+#include <interfaces/mining.h>
 #include <kernel/context.h>
 #include <key.h>
 #include <net.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -27,6 +27,7 @@ class PeerManager;
 namespace interfaces {
 class Chain;
 class ChainClient;
+class Mining;
 class Init;
 class WalletLoader;
 } // namespace interfaces
@@ -74,6 +75,7 @@ struct NodeContext {
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
     //! Reference to chain client that should used to load or create wallets
     //! opened by the gui.
+    std::unique_ptr<interfaces::Mining> mining;
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -855,6 +855,11 @@ public:
         return tip->GetBlockHash();
     }
 
+    unsigned int getTransactionsUpdated() override
+    {
+        return context()->mempool->GetTransactionsUpdated();
+    }
+
     bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root) override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <common/args.h>
+#include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <external_signer.h>
 #include <index/blockfilterindex.h>
@@ -842,6 +843,12 @@ public:
     bool isTestChain() override
     {
         return chainman().GetParams().IsTestChain();
+    }
+
+    bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root) override
+    {
+        LOCK(::cs_main);
+        return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, chainman().ActiveChain().Tip(), /*fCheckPOW=*/false, check_merkle_root);
     }
 
     NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -845,6 +845,14 @@ public:
         return chainman().GetParams().IsTestChain();
     }
 
+    uint256 getTipHash() override
+    {
+        LOCK(::cs_main);
+        CBlockIndex* tip{chainman().ActiveChain().Tip()};
+        if (!tip) return uint256{0};
+        return tip->GetBlockHash();
+    }
+
     bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root) override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -32,6 +32,7 @@
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <node/mini_miner.h>
+#include <node/miner.h>
 #include <node/transaction.h>
 #include <node/types.h>
 #include <node/warnings.h>
@@ -857,6 +858,12 @@ public:
     {
         LOCK(::cs_main);
         return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, chainman().ActiveChain().Tip(), /*fCheckPOW=*/false, check_merkle_root);
+    }
+
+    std::unique_ptr<CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool) override
+    {
+        LOCK(::cs_main);
+        return BlockAssembler{chainman().ActiveChainstate(), use_mempool ? context()->mempool.get() : nullptr}.CreateNewBlock(script_pub_key);
     }
 
     NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -855,6 +855,11 @@ public:
         return tip->GetBlockHash();
     }
 
+    bool processNewBlock(const std::shared_ptr<const CBlock>& block, bool* new_block) override
+    {
+        return chainman().ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block);
+    }
+
     unsigned int getTransactionsUpdated() override
     {
         return context()->mempool->GetTransactionsUpdated();

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -14,6 +14,7 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <kernel/chain.h>
@@ -69,6 +70,7 @@ using interfaces::Chain;
 using interfaces::FoundBlock;
 using interfaces::Handler;
 using interfaces::MakeSignalHandler;
+using interfaces::Mining;
 using interfaces::Node;
 using interfaces::WalletLoader;
 using util::Join;
@@ -831,10 +833,26 @@ public:
     ValidationSignals& validation_signals() { return *Assert(m_node.validation_signals); }
     NodeContext& m_node;
 };
+
+class MinerImpl : public Mining
+{
+public:
+    explicit MinerImpl(NodeContext& node) : m_node(node) {}
+
+    bool isTestChain() override
+    {
+        return chainman().GetParams().IsTestChain();
+    }
+
+    NodeContext* context() override { return &m_node; }
+    ChainstateManager& chainman() { return *Assert(m_node.chainman); }
+    NodeContext& m_node;
+};
 } // namespace
 } // namespace node
 
 namespace interfaces {
 std::unique_ptr<Node> MakeNode(node::NodeContext& context) { return std::make_unique<node::NodeImpl>(context); }
 std::unique_ptr<Chain> MakeChain(node::NodeContext& context) { return std::make_unique<node::ChainImpl>(context); }
+std::unique_ptr<Mining> MakeMining(node::NodeContext& context) { return std::make_unique<node::MinerImpl>(context); }
 } // namespace interfaces

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -847,6 +847,11 @@ public:
         return chainman().GetParams().IsTestChain();
     }
 
+    bool isInitialBlockDownload() override
+    {
+        return chainman().IsInitialBlockDownload();
+    }
+
     std::optional<uint256> getTipHash() override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -75,6 +75,7 @@ using interfaces::MakeSignalHandler;
 using interfaces::Mining;
 using interfaces::Node;
 using interfaces::WalletLoader;
+using node::BlockAssembler;
 using util::Join;
 
 namespace node {
@@ -862,8 +863,11 @@ public:
 
     std::unique_ptr<CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool) override
     {
+        BlockAssembler::Options options;
+        ApplyArgsManOptions(gArgs, options);
+
         LOCK(::cs_main);
-        return BlockAssembler{chainman().ActiveChainstate(), use_mempool ? context()->mempool.get() : nullptr}.CreateNewBlock(script_pub_key);
+        return BlockAssembler{chainman().ActiveChainstate(), use_mempool ? context()->mempool.get() : nullptr, options}.CreateNewBlock(script_pub_key);
     }
 
     NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -847,11 +847,11 @@ public:
         return chainman().GetParams().IsTestChain();
     }
 
-    uint256 getTipHash() override
+    std::optional<uint256> getTipHash() override
     {
         LOCK(::cs_main);
         CBlockIndex* tip{chainman().ActiveChain().Tip()};
-        if (!tip) return uint256{0};
+        if (!tip) return {};
         return tip->GetBlockHash();
     }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -80,15 +80,6 @@ void ApplyArgsManOptions(const ArgsManager& args, BlockAssembler::Options& optio
         if (const auto parsed{ParseMoney(*blockmintxfee)}) options.blockMinFeeRate = CFeeRate{*parsed};
     }
 }
-static BlockAssembler::Options ConfiguredOptions()
-{
-    BlockAssembler::Options options;
-    ApplyArgsManOptions(gArgs, options);
-    return options;
-}
-
-BlockAssembler::BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool)
-    : BlockAssembler(chainstate, mempool, ConfiguredOptions()) {}
 
 void BlockAssembler::resetBlock()
 {

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -161,7 +161,6 @@ public:
         bool test_block_validity{true};
     };
 
-    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool);
     explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -339,6 +339,7 @@ static RPCHelpMan generateblock()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
+    Mining& miner = EnsureMining(node);
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     std::vector<CTransactionRef> txs;
@@ -389,8 +390,8 @@ static RPCHelpMan generateblock()
         LOCK(cs_main);
 
         BlockValidationState state;
-        if (!TestBlockValidity(state, chainman.GetParams(), chainman.ActiveChainstate(), block, chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock), false, false)) {
-            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", state.ToString()));
+        if (!miner.testBlockValidity(state, block, /*check_merkle_root=*/false)) {
+            throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("testBlockValidity failed: %s", state.ToString()));
         }
     }
 
@@ -664,6 +665,7 @@ static RPCHelpMan getblocktemplate()
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
+    Mining& miner = EnsureMining(node);
     LOCK(cs_main);
 
     std::string strMode = "template";
@@ -706,11 +708,12 @@ static RPCHelpMan getblocktemplate()
             }
 
             CBlockIndex* const pindexPrev = active_chain.Tip();
-            // TestBlockValidity only supports blocks built on the current Tip
-            if (block.hashPrevBlock != pindexPrev->GetBlockHash())
+            // testBlockValidity only supports blocks built on the current Tip
+            if (block.hashPrevBlock != pindexPrev->GetBlockHash()) {
                 return "inconclusive-not-best-prevblk";
+            }
             BlockValidationState state;
-            TestBlockValidity(state, chainman.GetParams(), active_chainstate, block, pindexPrev, false, true);
+            miner.testBlockValidity(state, block);
             return BIP22ValidationResult(state);
         }
 
@@ -726,7 +729,6 @@ static RPCHelpMan getblocktemplate()
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    Mining& miner = EnsureMining(node);
     if (!miner.isTestChain()) {
         const CConnman& connman = EnsureConnman(node);
         if (connman.GetNodeCount(ConnectionDirection::Both) == 0) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -672,7 +672,6 @@ static RPCHelpMan getblocktemplate()
     UniValue lpval = NullUniValue;
     std::set<std::string> setClientRules;
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    CChain& active_chain = active_chainstate.m_chain;
     if (!request.params[0].isNull())
     {
         const UniValue& oparam = request.params[0].get_obj();
@@ -707,9 +706,8 @@ static RPCHelpMan getblocktemplate()
                 return "duplicate-inconclusive";
             }
 
-            CBlockIndex* const pindexPrev = active_chain.Tip();
             // testBlockValidity only supports blocks built on the current Tip
-            if (block.hashPrevBlock != pindexPrev->GetBlockHash()) {
+            if (block.hashPrevBlock != miner.getTipHash()) {
                 return "inconclusive-not-best-prevblk";
             }
             BlockValidationState state;
@@ -761,7 +759,7 @@ static RPCHelpMan getblocktemplate()
         else
         {
             // NOTE: Spec does not specify behaviour for non-string longpollid, but this makes testing easier
-            hashWatchedChain = active_chain.Tip()->GetBlockHash();
+            hashWatchedChain = miner.getTipHash();
             nTransactionsUpdatedLastLP = nTransactionsUpdatedLast;
         }
 
@@ -806,7 +804,7 @@ static RPCHelpMan getblocktemplate()
     static CBlockIndex* pindexPrev;
     static int64_t time_start;
     static std::unique_ptr<CBlockTemplate> pblocktemplate;
-    if (pindexPrev != active_chain.Tip() ||
+    if (!pindexPrev || pindexPrev->GetBlockHash() != miner.getTipHash() ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
@@ -814,7 +812,7 @@ static RPCHelpMan getblocktemplate()
 
         // Store the pindexBest used before CreateNewBlock, to avoid races
         nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-        CBlockIndex* pindexPrevNew = active_chain.Tip();
+        CBlockIndex* pindexPrevNew = chainman.m_blockman.LookupBlockIndex(miner.getTipHash());
         time_start = GetTime();
 
         // Create new block
@@ -946,7 +944,7 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("longpollid", active_chain.Tip()->GetBlockHash().GetHex() + ToString(nTransactionsUpdatedLast));
+    result.pushKV("longpollid", miner.getTipHash().GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
     result.pushKV("mutable", std::move(aMutable));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -16,6 +16,7 @@
 #include <core_io.h>
 #include <deploymentinfo.h>
 #include <deploymentstatus.h>
+#include <interfaces/mining.h>
 #include <key_io.h>
 #include <net.h>
 #include <node/context.h>
@@ -45,6 +46,7 @@
 
 using node::BlockAssembler;
 using node::CBlockTemplate;
+using interfaces::Mining;
 using node::NodeContext;
 using node::RegenerateCommitments;
 using node::UpdateTime;
@@ -724,7 +726,8 @@ static RPCHelpMan getblocktemplate()
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if (!chainman.GetParams().IsTestChain()) {
+    Mining& miner = EnsureMining(node);
+    if (!miner.isTestChain()) {
         const CConnman& connman = EnsureConnman(node);
         if (connman.GetNodeCount(ConnectionDirection::Both) == 0) {
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, PACKAGE_NAME " is not connected!");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -738,7 +738,6 @@ static RPCHelpMan getblocktemplate()
     }
 
     static unsigned int nTransactionsUpdatedLast;
-    const CTxMemPool& mempool = EnsureMemPool(node);
 
     if (!lpval.isNull())
     {
@@ -774,7 +773,7 @@ static RPCHelpMan getblocktemplate()
                 {
                     // Timeout: Check transactions for update
                     // without holding the mempool lock to avoid deadlocks
-                    if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
+                    if (miner.getTransactionsUpdated() != nTransactionsUpdatedLastLP)
                         break;
                     checktxtime += std::chrono::seconds(10);
                 }
@@ -804,13 +803,13 @@ static RPCHelpMan getblocktemplate()
     static int64_t time_start;
     static std::unique_ptr<CBlockTemplate> pblocktemplate;
     if (!pindexPrev || pindexPrev->GetBlockHash() != miner.getTipHash() ||
-        (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
+        (miner.getTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = nullptr;
 
         // Store the pindexBest used before createNewBlock, to avoid races
-        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
+        nTransactionsUpdatedLast = miner.getTransactionsUpdated();
         CBlockIndex* pindexPrevNew = chainman.m_blockman.LookupBlockIndex(miner.getTipHash());
         time_start = GetTime();
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -735,7 +735,7 @@ static RPCHelpMan getblocktemplate()
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, PACKAGE_NAME " is not connected!");
         }
 
-        if (chainman.IsInitialBlockDownload()) {
+        if (miner.isInitialBlockDownload()) {
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is in initial sync and waiting for blocks...");
         }
     }

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -101,6 +101,14 @@ CConnman& EnsureConnman(const NodeContext& node)
     return *node.connman;
 }
 
+interfaces::Mining& EnsureMining(const NodeContext& node)
+{
+    if (!node.mining) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Node miner not found");
+    }
+    return *node.mining;
+}
+
 PeerManager& EnsurePeerman(const NodeContext& node)
 {
     if (!node.peerman) {

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -18,6 +18,9 @@ class BanMan;
 namespace node {
 struct NodeContext;
 } // namespace node
+namespace interfaces {
+class Mining;
+} // namespace interfaces
 
 node::NodeContext& EnsureAnyNodeContext(const std::any& context);
 CTxMemPool& EnsureMemPool(const node::NodeContext& node);
@@ -31,6 +34,7 @@ ChainstateManager& EnsureAnyChainman(const std::any& context);
 CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
+interfaces::Mining& EnsureMining(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
 AddrMan& EnsureAddrman(const node::NodeContext& node);
 AddrMan& EnsureAnyAddrman(const std::any& context);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -67,7 +67,8 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(scriptPubKey);
+     BlockAssembler::Options options;
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), options}.CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -20,7 +20,8 @@ static void mineBlock(const node::NodeContext& node, std::chrono::seconds block_
 {
     auto curr_time = GetTime<std::chrono::seconds>();
     SetMockTime(block_time); // update time so the block is created with it
-    CBlock block = node::BlockAssembler{node.chainman->ActiveChainstate(), nullptr}.CreateNewBlock(CScript() << OP_TRUE)->block;
+    node::BlockAssembler::Options options;
+    CBlock block = node::BlockAssembler{node.chainman->ActiveChainstate(), nullptr, options}.CreateNewBlock(CScript() << OP_TRUE)->block;
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     SetMockTime(curr_time); // process block at current time

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -374,7 +374,8 @@ CBlock TestChain100Setup::CreateBlock(
     const CScript& scriptPubKey,
     Chainstate& chainstate)
 {
-    CBlock block = BlockAssembler{chainstate, nullptr}.CreateNewBlock(scriptPubKey)->block;
+    BlockAssembler::Options options;
+    CBlock block = BlockAssembler{chainstate, nullptr, options}.CreateNewBlock(scriptPubKey)->block;
 
     Assert(block.vtx.size() == 1);
     for (const CMutableTransaction& tx : txns) {

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -65,7 +65,8 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     static int i = 0;
     static uint64_t time = Params().GenesisBlock().nTime;
 
-    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(CScript{} << i++ << OP_TRUE);
+    BlockAssembler::Options options;
+    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), options}.CreateNewBlock(CScript{} << i++ << OP_TRUE);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;
@@ -329,7 +330,8 @@ BOOST_AUTO_TEST_CASE(witness_commitment_index)
     LOCK(Assert(m_node.chainman)->GetMutex());
     CScript pubKey;
     pubKey << 1 << OP_TRUE;
-    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get()}.CreateNewBlock(pubKey);
+    BlockAssembler::Options options;
+    auto ptemplate = BlockAssembler{m_node.chainman->ActiveChainstate(), m_node.mempool.get(), options}.CreateNewBlock(pubKey);
     CBlock pblock = ptemplate->block;
 
     CTxOut witness;

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -87,7 +87,7 @@ class RPCGenerateTest(BitcoinTestFramework):
         txid1 = miniwallet.send_self_transfer(from_node=node)['txid']
         utxo1 = miniwallet.get_utxo(txid=txid1)
         rawtx2 = miniwallet.create_self_transfer(utxo_to_spend=utxo1)['hex']
-        assert_raises_rpc_error(-25, 'TestBlockValidity failed: bad-txns-inputs-missingorspent', self.generateblock, node, address, [rawtx2, txid1])
+        assert_raises_rpc_error(-25, 'testBlockValidity failed: bad-txns-inputs-missingorspent', self.generateblock, node, address, [rawtx2, txid1])
 
         self.log.info('Fail to generate block with txid not in mempool')
         missing_txid = '0000000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
Introduce a `Mining` interface for the `getblocktemplate`, `generateblock` and other mining RPCs to use now, and for Stratum v2 to use later.

Suggested here: https://github.com/bitcoin/bitcoin/pull/29346#issuecomment-2108528652

The selection of methods added to the interface is mostly based on what the Template Provider in #29432 uses. It could be expanded further so that `rpc/mining.cpp` no longer needs `EnsureMemPool` and `EnsureChainman`.

This PR should be a pure refactor.