### PR TITLE
Enhance signet chain configuration in bitcoin.conf

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -5,6 +5,7 @@
 
 #include <common/args.h>
 
+#include <hash.h>
 #include <chainparamsbase.h>
 #include <common/settings.h>
 #include <logging.h>
@@ -277,6 +278,18 @@ fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value)
     return result.has_filename() ? result : result.parent_path();
 }
 
+fs::path ArgsManager::GetSignetDataDir() const
+{
+    const std::string base_data_dir = BaseParams().DataDir();
+    const std::string signet_challenge_str = GetArg("-signetchallenge", "");
+    if (!signet_challenge_str.empty()) {
+        std::vector<uint8_t> signet_challenge = ParseHex(signet_challenge_str);
+        const auto data_dir_suffix = HexStr(Hash160(signet_challenge)).substr(0, 8);
+        return fs::PathFromString(base_data_dir + "_" + data_dir_suffix);
+    }
+    return fs::PathFromString(base_data_dir);
+}
+
 fs::path ArgsManager::GetBlocksDirPath() const
 {
     LOCK(cs_args);
@@ -296,7 +309,12 @@ fs::path ArgsManager::GetBlocksDirPath() const
         path = GetDataDirBase();
     }
 
-    path /= fs::PathFromString(BaseParams().DataDir());
+    if (GetChainType() == ChainType::SIGNET) {
+        path /= GetSignetDataDir();
+    } else {
+        path /= fs::PathFromString(BaseParams().DataDir());
+    }
+
     path /= "blocks";
     fs::create_directories(path);
     return path;
@@ -322,7 +340,11 @@ fs::path ArgsManager::GetDataDir(bool net_specific) const
     }
 
     if (net_specific && !BaseParams().DataDir().empty()) {
-        path /= fs::PathFromString(BaseParams().DataDir());
+        if (GetChainType() == ChainType::SIGNET) {
+            path /= GetSignetDataDir();
+        } else {
+            path /= fs::PathFromString(BaseParams().DataDir());
+        }
     }
 
     return path;

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -394,6 +394,33 @@ std::vector<common::SettingsValue> ArgsManager::GetSectionArg(const std::string&
     return result;
 }
 
+template <typename Key, typename Value, typename SectionKey>
+void ArgsManager::AddConfigArg(const Key& key, const Value& value, SectionKey sectionKey)
+{
+    auto& section = m_settings.ro_config[sectionKey];
+    section[key].push_back(value);
+}
+
+void ArgsManager::UpdateConfigFromSection(const std::string& section, const std::string& strArg)
+{
+    auto arg = GetSectionArg(section, strArg);
+    for(auto& sv : arg) {
+        LOCK(cs_args);
+        AddConfigArg(strArg, sv, m_network);
+    }
+}
+
+void ArgsManager::ReadSignetChainConfigs()
+{
+    const std::string SIGNET_CHAIN_PREFIX = "signet_";
+
+    const std::string chain = GetArg("-chain", "");
+    if (chain.starts_with(SIGNET_CHAIN_PREFIX)){
+        UpdateConfigFromSection(chain, "signetchallenge");
+        UpdateConfigFromSection(chain, "seednode");
+    }
+}
+
 std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
 {
     std::vector<std::string> result;

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -379,6 +379,21 @@ std::optional<const ArgsManager::Command> ArgsManager::GetCommand() const
     return ret;
 }
 
+std::vector<common::SettingsValue> ArgsManager::GetSectionArg(const std::string& section, const std::string& strArg) const
+{
+    std::vector<common::SettingsValue> result;
+    LOCK(cs_args);
+    if (auto* _section = common::FindKey(m_settings.ro_config, section)) {
+        if (auto* values = common::FindKey(*_section, strArg)) {
+            for (int i = 0; i < values->size(); i++) {
+                result.push_back((*values)[i]);
+            }
+
+        }
+    }
+    return result;
+}
+
 std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
 {
     std::vector<std::string> result;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -211,6 +211,14 @@ protected:
     std::optional<const Command> GetCommand() const;
 
     /**
+     * Get signet data directory path.
+     * If a signet-challange argument is provided, it is used in constructing the directory path.
+     *
+     * @return The path to the signet data directory.
+    */
+    fs::path GetSignetDataDir() const;
+
+    /**
      * Get blocks directory path
      *
      * @return Blocks path which is network specific

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -245,6 +245,15 @@ protected:
     void ClearPathCache();
 
     /**
+     * Retrieves values associated with a specified argument in a given configuration section.
+     *
+     * @param section section in m_settings.ro_config to seach
+     * @param strArg Argument to get (e.g. "-foo")
+     * @return Vector of string values for the argument in the configuration file.
+     */
+    std::vector<common::SettingsValue> GetSectionArg(const std::string& section, const std::string& strArg) const;
+
+    /**
      * Return a vector of strings of the given argument
      *
      * @param strArg Argument to get (e.g. "-foo")

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -254,6 +254,29 @@ protected:
     std::vector<common::SettingsValue> GetSectionArg(const std::string& section, const std::string& strArg) const;
 
     /**
+     * Adds a configuration argument to a specified section in the configuration settings.
+     *
+     * @param key The key to be added to the configuration section.
+     * @param value The value to be associated with the specified key.
+     * @param sectionKey The section key identifying the section where the key-value pair will be added.
+     */
+    template <typename Key, typename Value, typename SectionKey>
+    void AddConfigArg(const Key& key, const Value& value, SectionKey sectionKey);
+
+    /**
+     * Updates the configuration settings by adding arguments from a specified section.
+     *
+     * @param section The name of the section from which to retrieve arguments.
+     * @param strArg The key whose associated arguments are to be retrieved and added to the configuration settings.
+     */
+    void UpdateConfigFromSection(const std::string& section, const std::string& strArg);
+
+    /**
+     * Read singnet chain args if signet chain arg is provided 
+    */
+    void ReadSignetChainConfigs();
+
+    /**
      * Return a vector of strings of the given argument
      *
      * @param strArg Argument to get (e.g. "-foo")

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -196,6 +196,9 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
             for (const std::string& conf_file_name : conf_file_names) {
                 tfm::format(std::cerr, "warning: -includeconf cannot be used from included files; ignoring -includeconf=%s\n", conf_file_name);
             }
+
+            // Read signet args of the provided chain and update the signet config
+            ReadSignetChainConfigs();
         }
     }
 

--- a/src/util/chaintype.cpp
+++ b/src/util/chaintype.cpp
@@ -29,7 +29,7 @@ std::optional<ChainType> ChainTypeFromString(std::string_view chain)
         return ChainType::MAIN;
     } else if (chain == "test") {
         return ChainType::TESTNET;
-    } else if (chain == "signet") {
+    } else if (chain == "signet" || chain.starts_with("signet_") ) {
         return ChainType::SIGNET;
     } else if (chain == "regtest") {
         return ChainType::REGTEST;

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -5,6 +5,7 @@
 """Test basic signet functionality"""
 
 from decimal import Decimal
+from os import path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -72,6 +73,12 @@ class SignetBasicTest(BitcoinTestFramework):
         self.log.info("pregenerated signet blocks check (incompatible solution)")
 
         assert_equal(self.nodes[4].submitblock(signet_blocks[0]), 'bad-signet-blksig')
+
+        self.log.info("Test that the signet data directory with -signetchallenge=51 is 'signet_da1745e9'")
+        assert_equal(path.basename(self.nodes[0].chain_path), "signet_da1745e9")
+
+        self.log.info("Test that the main signet data directory is 'signet'")
+        assert_equal(path.basename(self.nodes[3].chain_path), "signet")
 
         self.log.info("test that signet logs the network magic on node start")
         with self.nodes[0].assert_debug_log(["Signet derived magic (message start)"]):

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -94,7 +94,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(self.nodes[0].cli("-named", "echo", "arg0=0", "arg1=1", "arg2=2", "arg1=3").send_cli(), ['0', '3', '2'])
         assert_raises_rpc_error(-8, "Parameter args specified multiple times", self.nodes[0].cli("-named", "echo", "args=[0,1,2,3]", "4", "5", "6", ).send_cli)
 
-        user, password = get_auth_cookie(self.nodes[0].datadir_path, self.chain)
+        user, password = get_auth_cookie(self.nodes[0].datadir_path, self.nodes[0].get_chain())
 
         self.log.info("Test -stdinrpcpass option")
         assert_equal(BLOCKS, self.nodes[0].cli(f'-rpcuser={user}', '-stdinrpcpass', input=password).getblockcount())

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -58,7 +58,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.nodes[0].rpchost = None
         self.start_nodes([node_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir_path, 0, self.chain, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
+        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir_path, 0, self.nodes[0].get_chain(), "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -35,6 +35,7 @@ from .util import (
     p2p_port,
     wait_until_helper_internal,
 )
+from .script import hash160
 
 
 class TestStatus(Enum):
@@ -536,10 +537,20 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 descriptors=self.options.descriptors,
                 v2transport=self.options.v2transport,
             )
+            if self.chain == "signet":
+                test_node_i.signet_chain = self.get_signet_chain(args)
             self.nodes.append(test_node_i)
             if not test_node_i.version_is_at_least(170000):
                 # adjust conf for pre 17
                 test_node_i.replace_in_config([('[regtest]', '')])
+
+    def get_signet_chain(self, args):
+        for arg in args:
+            if arg.startswith('-signetchallenge'):
+                signetchallenge = arg.split('=')[1]
+                data_dir_suffix = hash160(bytes.fromhex(signetchallenge)).hex()[0:8]
+                return f"signet_{data_dir_suffix}"
+        return 'signet'
 
     def start_node(self, i, *args, **kwargs):
         """Start a bitcoind"""

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -82,6 +82,7 @@ class TestNode():
         self.stdout_dir = self.datadir_path / "stdout"
         self.stderr_dir = self.datadir_path / "stderr"
         self.chain = chain
+        self.signet_chain = ""
         self.rpchost = rpchost
         self.rpc_timeout = timewait
         self.binary = bitcoind
@@ -174,6 +175,9 @@ class TestNode():
             AddressKeyPair('mzRe8QZMfGi58KyWCse2exxEFry2sfF2Y7', 'cPiRWE8KMjTRxH1MWkPerhfoHFn5iHPWVK5aPqjW8NxmdwenFinJ'),
     ]
 
+    def get_chain(self):
+        return self.signet_chain if self.chain == 'signet' else self.chain
+
     def get_deterministic_priv_key(self):
         """Return a deterministic priv key in base58, that only depends on the node's index"""
         assert len(self.PRIV_KEYS) == MAX_NODES
@@ -256,7 +260,7 @@ class TestNode():
                     f'bitcoind exited with status {self.process.returncode} during initialization. {str_error}'))
             try:
                 rpc = get_rpc_proxy(
-                    rpc_url(self.datadir_path, self.index, self.chain, self.rpchost),
+                    rpc_url(self.datadir_path, self.index, self.get_chain(), self.rpchost),
                     self.index,
                     timeout=self.rpc_timeout // 2,  # Shorter timeout to allow for one retry in case of ETIMEDOUT
                     coveragedir=self.coverage_dir,
@@ -320,7 +324,7 @@ class TestNode():
         poll_per_s = 4
         for _ in range(poll_per_s * self.rpc_timeout):
             try:
-                get_auth_cookie(self.datadir_path, self.chain)
+                get_auth_cookie(self.datadir_path, self.get_chain())
                 self.log.debug("Cookie credentials successfully retrieved")
                 return
             except ValueError:  # cookie file not found and no rpcuser or rpcpassword; bitcoind is still starting
@@ -439,7 +443,7 @@ class TestNode():
 
     @property
     def chain_path(self) -> Path:
-        return self.datadir_path / self.chain
+        return self.datadir_path / self.get_chain()
 
     @property
     def debug_log_path(self) -> Path:

--- a/test/functional/tool_signet_miner.py
+++ b/test/functional/tool_signet_miner.py
@@ -32,8 +32,8 @@ class SignetMinerTest(BitcoinTestFramework):
         privkey = ECKey()
         privkey.set(CHALLENGE_PRIVATE_KEY, True)
         pubkey = privkey.get_pubkey().get_bytes()
-        challenge = key_to_p2wpkh_script(pubkey)
-        self.extra_args = [[f'-signetchallenge={challenge.hex()}']]
+        self.challenge = key_to_p2wpkh_script(pubkey)
+        self.extra_args = [[f'-signetchallenge={self.challenge.hex()}']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_cli()
@@ -48,10 +48,11 @@ class SignetMinerTest(BitcoinTestFramework):
         # generate block with signet miner tool
         base_dir = self.config["environment"]["SRCDIR"]
         signet_miner_path = os.path.join(base_dir, "contrib", "signet", "miner")
+        # breakpoint()
         subprocess.run([
                 sys.executable,
                 signet_miner_path,
-                f'--cli={node.cli.binary} -datadir={node.cli.datadir}',
+                f'--cli={node.cli.binary} -datadir={node.cli.datadir} -signetchallenge={self.challenge.hex()}',
                 'generate',
                 f'--address={node.getnewaddress()}',
                 f'--grind-cmd={self.options.bitcoinutil} grind',


### PR DESCRIPTION
## !! Draft for feedback on the approach !!

Follow up to https://github.com/bitcoin/bitcoin/pull/29838 following https://github.com/bitcoin/bitcoin/pull/29838#issuecomment-2063151580 and https://github.com/bitcoin/bitcoin/pull/29838#issuecomment-2070170967

This PR builds upon the changes introduced in https://github.com/bitcoin/bitcoin/pull/29838, which enabled the ability to run multiple Signet instances with distinct data directories. Now, it extends this functionality by allowing users to configure Signet chain specifics directly in bitcoin.conf.

Users can define multiple Signet chains by specifying configurations (see below) and specifying which signet chain to run on the chain variable:

```
chain=signet_xxxx

[signet_xxxx]
seednode=x.x.x.x
signetchallenge=xxxxxxxxxx

[signet_yyyy]
seednode=y.y.y.y
signetchallenge=yyyyyyyyy

#main signet
[signet]
seednode=z.z.z.z
signetchallenge=zzzzzzzzzzzzz
```
