### PR TITLE
depends: consolidate dependency docs

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -43,9 +43,13 @@ The paths are automatically configured and no other options are needed.
 
 ### Install the required dependencies: Ubuntu & Debian
 
+#### Common
+
+    apt install automake bison cmake curl libtool make patch pkg-config python3 xz-utils
+
 #### For macOS cross compilation
 
-    sudo apt-get install curl bsdmainutils cmake zip
+    sudo apt-get install g++ zip
 
 Note: You must obtain the macOS SDK before proceeding with a cross-compile.
 Under the depends directory, create a subdirectory named `SDKs`.
@@ -60,7 +64,7 @@ For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-ex
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils bsdmainutils pkg-config python3 patch bison
+    sudo apt-get install g++-multilib binutils
 
 For linux ARM cross compilation:
 


### PR DESCRIPTION
Adds missing `g++` for macOS. This is needed by Qt:
```bash
Configuring qt...
Creating qmake...
gmake[1]: Entering directory '/bitcoin/depends/work/build/arm64-apple-darwin/qt/5.15.14-4bca24c8f89/qtbase/qmake'
gmake[1]: g++: No such file or directory
gmake[1]: *** [Makefile:250: main.o] Error 127
```

`xz-utils` was also missing (but generally already installed), and is needed for the `.tar.xz` tarballs.

Remove `bsdmainutils`, as this is only needed by the main build system (for tests), and isn't needed to complete a depends build.