### PR TITLE
validation: Improve, document and test logic for chains building on invalid blocks

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -123,7 +123,11 @@ enum BlockStatus : uint32_t {
     BLOCK_HAVE_MASK          =   BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO,
 
     BLOCK_FAILED_VALID       =   32, //!< stage after last reached validness failed
-    BLOCK_FAILED_CHILD       =   64, //!< descends from failed block
+
+    //! Descends from failed block. As failed blocks are encountered, this flag is set on a best-effort basis.
+    //! It's set consistently for all blocks only during startup. Therefore, code should not rely on it being
+    //! set for each descendant of a failed block.
+    BLOCK_FAILED_CHILD       =   64,
     BLOCK_FAILED_MASK        =   BLOCK_FAILED_VALID | BLOCK_FAILED_CHILD,
 
     BLOCK_OPT_WITNESS        =   128, //!< block data in blk*.dat was received with a witness-enforcing client

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2045,6 +2045,11 @@ void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
         m_chainman.m_best_invalid = pindexNew;
     }
     if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindexNew->nHeight) == pindexNew) {
+        CBlockIndex *index_walk{m_chainman.m_best_header};
+        while (index_walk != pindexNew) {
+                index_walk->nStatus |= BLOCK_FAILED_CHILD;
+                index_walk = index_walk->pprev;
+        }
         // Setting m_best_header to the tip here is merely an educated guess. There could be other
         // indexes with more work in the block header tree. Finding these would require walking
         // through the entire block tree or introducing best-possible header tracking (see PR #12138)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2045,6 +2045,9 @@ void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
         m_chainman.m_best_invalid = pindexNew;
     }
     if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindexNew->nHeight) == pindexNew) {
+        // Setting m_best_header to the tip here is merely an educated guess. There could be other
+        // indexes with more work in the block header tree. Finding these would require walking
+        // through the entire block tree or introducing best-possible header tracking (see PR #12138)
         m_chainman.m_best_header = m_chain.Tip();
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4481,6 +4481,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         if (state.IsInvalid() && state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             m_blockman.m_dirty_blockindex.insert(pindex);
+            m_failed_blocks.insert(pindex);
         }
         LogError("%s: %s\n", __func__, state.ToString());
         return false;

--- a/src/validation.h
+++ b/src/validation.h
@@ -1046,10 +1046,11 @@ public:
 
     /**
      * In order to efficiently track invalidity of headers, we keep the set of
-     * blocks which we tried to connect and found to be invalid here (ie which
-     * were set to BLOCK_FAILED_VALID since the last restart). We can then
+     * blocks which were found to be invalid while connecting or accepting do disk
+     * (ie which were set to BLOCK_FAILED_VALID since the last restart). We can then
      * walk this set and check if a new header is a descendant of something in
-     * this set, preventing us from having to walk m_block_index when we try
+     * this set, preventing us from accepting headers building on invalid blocks into
+     * our blockindex and from having to walk m_block_index when we try
      * to connect a bad block and fail.
      *
      * While this is more complicated than marking everything which descends

--- a/src/validation.h
+++ b/src/validation.h
@@ -1065,7 +1065,17 @@ public:
      */
     std::set<CBlockIndex*> m_failed_blocks;
 
-    /** Best header we've seen so far (used for getheaders queries' starting points). */
+    /**
+     * Best header we've seen so far for a block that is not known to be invalid.
+     * Should not be relied upon in critical parts of the code, because it is
+     * determined on a best-effort basis andd can be off in certain situations
+     * with invalid blocks and/or invalidateblock/reconsiderblock where we'd need
+     * to walk through the entire block index to compute the correct value, but
+     * currently don't for performance reasons.
+     *
+     * Used for example for getheaders queries' starting points and reporting
+     * (rpc, gui).
+     */
     CBlockIndex* m_best_header GUARDED_BY(::cs_main){nullptr};
 
     //! The total number of bytes available for us to use across all in-memory

--- a/test/functional/p2p_invalid_chain.py
+++ b/test/functional/p2p_invalid_chain.py
@@ -75,7 +75,7 @@ class InvalidChainTest (BitcoinTestFramework):
         block_time += 1
         block3 = create_block(block2a.sha256, create_coinbase(start_height + 3), block_time)
         block3.solve()
-        node.submitheader(block3.serialize().hex())  # No error, we accept more headers building on a block we have marked as invalid.
+        assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(block3.serialize().hex()))
 
         self.log.info("Test chain with an invalid block (found invalid before acceptance)")
         # Create invalid block (too large)

--- a/test/functional/p2p_invalid_chain.py
+++ b/test/functional/p2p_invalid_chain.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test how invalid blocks will influence chain behavior, in particular
+   the acceptance of future blocks and / or headers building on an invalid chain
+   For simplicity, submitheader / submitblock rpcs will be used in this test. The
+   behavior will be the same if blocks / headers are received through the p2p network.
+"""
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
+from test_framework.script import CScript
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class InvalidChainTest (BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        tip = int(node.getbestblockhash(), 16)
+        start_height = self.nodes[0].getblockcount()
+
+        self.log.info("Test chain with an invalid block (found invalid during connect)")
+        # Create invalid block (too high coinbase)
+        block_time = node.getblock(node.getbestblockhash())['time'] + 1
+        invalid_block = create_block(tip, create_coinbase(start_height + 1, nValue=100), block_time)
+        invalid_block.solve()
+        # Submit the valid header of the invalid block and a header that builds on it
+        node.submitheader(invalid_block.serialize().hex())
+        block_time += 1
+        block2a = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2a.solve()
+        node.submitheader(block2a.serialize().hex())
+        # Submit the invalid block
+        assert_equal(node.submitblock(invalid_block.serialize().hex()), "bad-cb-amount")
+        # Submit a block building directly on the invalid block
+        block_time += 1
+        block2b = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2b.solve()
+        assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(block2b.serialize().hex()))
+        # Submit a block building indirectly on the invalid block
+        block_time += 1
+        block3 = create_block(block2a.sha256, create_coinbase(start_height + 3), block_time)
+        block3.solve()
+        assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(block3.serialize().hex()))
+
+        self.log.info("Test chain with an invalid block (found invalid during acceptance)")
+        # Create invalid block (bad coinbase height)
+        block_time += 1
+        invalid_block = create_block(tip, create_coinbase(start_height + 100), block_time)
+        invalid_block.solve()
+        # Submit the valid header of the invalid block and a header that builds on it
+        node.submitheader(invalid_block.serialize().hex())
+        block_time += 1
+        block2a = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2a.solve()
+        node.submitheader(block2a.serialize().hex())
+        # Submit the invalid block
+        assert_equal(node.submitblock(invalid_block.serialize().hex()), "bad-cb-height")
+        # Submit a block building directly on the invalid block
+        block_time += 1
+        block2b = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2b.solve()
+        assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(block2b.serialize().hex()))
+        # Submit a block building indirectly on the invalid block
+        block_time += 1
+        block3 = create_block(block2a.sha256, create_coinbase(start_height + 3), block_time)
+        block3.solve()
+        node.submitheader(block3.serialize().hex())  # No error, we accept more headers building on a block we have marked as invalid.
+
+        self.log.info("Test chain with an invalid block (found invalid before acceptance)")
+        # Create invalid block (too large)
+        block_time += 1
+        invalid_block = create_block(tip, create_coinbase(start_height + 1, extra_output_script=CScript([b'\x00' * 1000000])), block_time)
+        invalid_block.solve()
+        # Submit the valid header of the invalid block and a header that builds on it
+        node.submitheader(invalid_block.serialize().hex())
+        block_time += 1
+        block2a = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2a.solve()
+        node.submitheader(block2a.serialize().hex())
+        # Submit a block building directly on the invalid block
+        block_time += 1
+        block2b = create_block(invalid_block.sha256, create_coinbase(start_height + 2), block_time)
+        block2b.solve()
+        node.submitheader(block2b.serialize().hex())  # No error, we don't mark the block permanently as invalid.
+        # Submit a block building indirectly on the invalid block
+        assert_equal(node.submitblock(invalid_block.serialize().hex()), "bad-blk-length")
+        block_time += 1
+        block3 = create_block(block2a.sha256, create_coinbase(start_height + 3), block_time)
+        block3.solve()
+        node.submitheader(block3.serialize().hex())  # No error, we don't mark the block permanently as invalid.
+
+
+if __name__ == '__main__':
+    InvalidChainTest(__file__).main()

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -89,7 +89,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         tips = n0.getchaintips()
         assert_equal(len(tips), 3)
         assert_equal(tips[0]['height'], start_height + 2)
-        assert_equal(tips[0]['status'], 'headers-only')  # bug: chain should be marked as invalid instead of headers-only
+        assert_equal(tips[0]['status'], 'invalid')
 
         self.log.info("Check getchaintips behavior after restart")
         self.restart_node(0)

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -10,8 +10,13 @@
 - verify that getchaintips now returns two chain tips.
 """
 
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+
 
 class GetChainTipsTest (BitcoinTestFramework):
     def set_test_params(self):
@@ -56,6 +61,43 @@ class GetChainTipsTest (BitcoinTestFramework):
         tips[1]['branchlen'] = 0
         tips[1]['status'] = 'active'
         assert_equal (tips[1], shortTip)
+
+        self.log.info("Test getchaintips behavior with invalid blocks")
+        self.disconnect_nodes(0, 1)
+        n0 = self.nodes[0]
+        tip = int(n0.getbestblockhash(), 16)
+        start_height = self.nodes[0].getblockcount()
+        # Create invalid block (too high coinbase)
+        block_time = n0.getblock(n0.getbestblockhash())['time'] + 1
+        invalid_block = create_block(tip, create_coinbase(start_height+1, nValue=100), block_time)
+        invalid_block.solve()
+
+        block_time += 1
+        block2 = create_block(invalid_block.sha256, create_coinbase(2), block_time, version=4)
+        block2.solve()
+
+        self.log.info("Submit headers-only chain")
+        n0.submitheader(invalid_block.serialize().hex())
+        n0.submitheader(block2.serialize().hex())
+        tips = n0.getchaintips()
+        assert_equal(len(tips), 3)
+        assert_equal(tips[0]['height'], start_height + 2)
+        assert_equal(tips[0]['status'], 'headers-only')
+
+        self.log.info("Submit invalid block that invalidates the headers-only chain")
+        n0.submitblock(invalid_block.serialize().hex())
+        tips = n0.getchaintips()
+        assert_equal(len(tips), 3)
+        assert_equal(tips[0]['height'], start_height + 2)
+        assert_equal(tips[0]['status'], 'headers-only')  # bug: chain should be marked as invalid instead of headers-only
+
+        self.log.info("Check getchaintips behavior after restart")
+        self.restart_node(0)
+        tips = n0.getchaintips()
+        assert_equal(len(tips), 3)
+        assert_equal(tips[0]['height'], start_height + 2)
+        assert_equal(tips[0]['status'], 'invalid')
+
 
 if __name__ == '__main__':
     GetChainTipsTest(__file__).main()

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -23,44 +23,45 @@ class GetChainTipsTest (BitcoinTestFramework):
         self.num_nodes = 4
 
     def run_test(self):
+        self.log.info("Test getchaintips behavior with two chains of different length")
         tips = self.nodes[0].getchaintips()
         assert_equal(len(tips), 1)
         assert_equal(tips[0]['branchlen'], 0)
         assert_equal(tips[0]['height'], 200)
         assert_equal(tips[0]['status'], 'active')
 
-        # Split the network and build two chains of different lengths.
+        self.log.info("Split the network and build two chains of different lengths.")
         self.split_network()
         self.generate(self.nodes[0], 10, sync_fun=lambda: self.sync_all(self.nodes[:2]))
         self.generate(self.nodes[2], 20, sync_fun=lambda: self.sync_all(self.nodes[2:]))
 
-        tips = self.nodes[1].getchaintips ()
-        assert_equal (len (tips), 1)
+        tips = self.nodes[1].getchaintips()
+        assert_equal(len(tips), 1)
         shortTip = tips[0]
-        assert_equal (shortTip['branchlen'], 0)
-        assert_equal (shortTip['height'], 210)
-        assert_equal (tips[0]['status'], 'active')
+        assert_equal(shortTip['branchlen'], 0)
+        assert_equal(shortTip['height'], 210)
+        assert_equal(tips[0]['status'], 'active')
 
-        tips = self.nodes[3].getchaintips ()
-        assert_equal (len (tips), 1)
+        tips = self.nodes[3].getchaintips()
+        assert_equal(len(tips), 1)
         longTip = tips[0]
-        assert_equal (longTip['branchlen'], 0)
-        assert_equal (longTip['height'], 220)
-        assert_equal (tips[0]['status'], 'active')
+        assert_equal(longTip['branchlen'], 0)
+        assert_equal(longTip['height'], 220)
+        assert_equal(tips[0]['status'], 'active')
 
-        # Join the network halves and check that we now have two tips
+        self.log.info("Join the network halves and check that we now have two tips")
         # (at least at the nodes that previously had the short chain).
-        self.join_network ()
+        self.join_network()
 
-        tips = self.nodes[0].getchaintips ()
-        assert_equal (len (tips), 2)
-        assert_equal (tips[0], longTip)
+        tips = self.nodes[0].getchaintips()
+        assert_equal(len(tips), 2)
+        assert_equal(tips[0], longTip)
 
-        assert_equal (tips[1]['branchlen'], 10)
-        assert_equal (tips[1]['status'], 'valid-fork')
+        assert_equal(tips[1]['branchlen'], 10)
+        assert_equal(tips[1]['status'], 'valid-fork')
         tips[1]['branchlen'] = 0
         tips[1]['status'] = 'active'
-        assert_equal (tips[1], shortTip)
+        assert_equal(tips[1], shortTip)
 
         self.log.info("Test getchaintips behavior with invalid blocks")
         self.disconnect_nodes(0, 1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -262,6 +262,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_block.py --v2transport',
     'p2p_invalid_tx.py --v1transport',
     'p2p_invalid_tx.py --v2transport',
+    'p2p_invalid_chain.py',
     'p2p_v2_transport.py',
     'p2p_v2_encrypted.py',
     'p2p_v2_misbehaving.py',


### PR DESCRIPTION
Some improvements with respect to invalid blocks and blocks building on them:

1.) The fields `m_best_header` (best header of a chain that is not known to be invalid, irrespective on whether we have the full block or not) and `BLOCK_FAILED_CHILD` (BlockStatus saying that  a header descends from an invalid block) are populated on a best-effort basis and can sometimes be off. This is not too bad because critical consensus code doesn't rely on either of these, but it is kind of brittle, especially because this is not clearly documented. Document these limitations to prevent future bugs.
In order to solve these issues completely, it would be necessary to add more places in which we walk over the entire block index (computationally expensive), and/or introduce a header-tip tracking similar to #12138. This PR attempts neither of these, but I'd be interested in opinions whether we should.

2.) The `getchaintips` RPC can fail to recognize chains building on invalid blocks (#8050) as invalid. Add a test for this and fix it for most cases (a comprehensive fix would require one of the larger changes listed above).

3.) Behavior for chains building on invalid blocks depends on the point in validation at which the block was found to be invalid (which in turn depends on what's wrong with the block):
* During the initial context-free `CheckBlock()` we never mark the block as permanently invalid [(rationale)](https://github.com/bitcoin/bitcoin/blob/62f7f59ff495fbcbfc10c25e97bb0dc032647abf/src/validation.cpp#L4449-L4453)
* If the contextual checks in `AcceptBlock()` fail, we mark the block as permanently invalid (`BLOCK_FAILED_VALID`) and don't save it to disk (but we still have the header!). We won't accept headers building directly on it, but will accept headers building indirectly (i.e. with other headers in between), which is not consistent.
* During `ConnectBlock()` we mark the block as permanently invalid and won't accept any more headers building on it, directly or indirectly.

Add test coverage for this behavior and change it such that for blocks found invalid during `AcceptBlock()`, we won't accept indirect headers that build on them either.