### PR TITLE
refactor: remove unused `CKey::Negate` method

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -166,12 +166,6 @@ void CKey::MakeNewKey(bool fCompressedIn) {
     fCompressed = fCompressedIn;
 }
 
-bool CKey::Negate()
-{
-    assert(keydata);
-    return secp256k1_ec_seckey_negate(secp256k1_context_sign, keydata->data());
-}
-
 CPrivKey CKey::GetPrivKey() const {
     assert(keydata);
     CPrivKey seckey;

--- a/src/key.h
+++ b/src/key.h
@@ -124,9 +124,6 @@ public:
     //! Generate a new private key using a cryptographic PRNG.
     void MakeNewKey(bool fCompressed);
 
-    //! Negate private key
-    bool Negate();
-
     /**
      * Convert the private key to a CPrivKey (serialized OpenSSL private key data).
      * This is expensive.

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -78,16 +78,6 @@ FUZZ_TARGET(key, .init = initialize_key)
         assert(copied_key == key);
     }
 
-    {
-        CKey negated_key = key;
-        negated_key.Negate();
-        assert(negated_key.IsValid());
-        assert(!(negated_key == key));
-
-        negated_key.Negate();
-        assert(negated_key == key);
-    }
-
     const uint256 random_uint256 = Hash(buffer);
 
     {

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -201,37 +201,6 @@ BOOST_AUTO_TEST_CASE(key_signature_tests)
     BOOST_CHECK(found_small);
 }
 
-BOOST_AUTO_TEST_CASE(key_key_negation)
-{
-    // create a dummy hash for signature comparison
-    unsigned char rnd[8];
-    std::string str = "Bitcoin key verification\n";
-    GetRandBytes(rnd);
-    uint256 hash{Hash(str, rnd)};
-
-    // import the static test key
-    CKey key = DecodeSecret(strSecret1C);
-
-    // create a signature
-    std::vector<unsigned char> vch_sig;
-    std::vector<unsigned char> vch_sig_cmp;
-    key.Sign(hash, vch_sig);
-
-    // negate the key twice
-    BOOST_CHECK(key.GetPubKey().data()[0] == 0x03);
-    key.Negate();
-    // after the first negation, the signature must be different
-    key.Sign(hash, vch_sig_cmp);
-    BOOST_CHECK(vch_sig_cmp != vch_sig);
-    BOOST_CHECK(key.GetPubKey().data()[0] == 0x02);
-    key.Negate();
-    // after the second negation, we should have the original key and thus the
-    // same signature
-    key.Sign(hash, vch_sig_cmp);
-    BOOST_CHECK(vch_sig_cmp == vch_sig);
-    BOOST_CHECK(key.GetPubKey().data()[0] == 0x03);
-}
-
 static CPubKey UnserializePubkey(const std::vector<uint8_t>& data)
 {
     DataStream stream{};


### PR DESCRIPTION
This method was introduced as a pre-requirement for the v2 transport protocol back then (see PR #14047, commit 463921bb), when it was still BIP151. With the replacement BIP324, this is not needed anymore, and it's also unlikely that for any other proposal we'd ever need to negate private keys at this abstraction level. I'd argue that this operation is usually something that should happen within a secp256k1 module (like e.g. done in MuSig2, Silent Payments...).

(If there is really demand in the future, it's also trivial to reintroduce the method.)