### PR TITLE
build: no-longer allow GCC-10 in C++20 check

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -983,7 +983,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201709L  // Temporary patch on top of upstream to allow g++-10
+#elif __cplusplus < 202002L
 
 #error "This is not a C++20 compiler"
 


### PR DESCRIPTION
Reverts part of fa67f096bdea9db59dd20c470c9e32f3dac5be94, now that we require a minimum of GCC 11.

See also:
https://github.com/bitcoin/bitcoin/pull/28349#issuecomment-1745143612.