### PR TITLE
fuzz: Use std::span in FuzzBufferType

### DIFF
--- a/src/test/fuzz/bitset.cpp
+++ b/src/test/fuzz/bitset.cpp
@@ -12,8 +12,8 @@
 
 namespace {
 
-/** Pop the first byte from a Span<const uint8_t>, and return it. */
-uint8_t ReadByte(Span<const uint8_t>& buffer)
+/** Pop the first byte from a byte-span, and return it. */
+uint8_t ReadByte(FuzzBufferType& buffer)
 {
     if (buffer.empty()) return 0;
     uint8_t ret = buffer.front();
@@ -23,7 +23,7 @@ uint8_t ReadByte(Span<const uint8_t>& buffer)
 
 /** Perform a simulation fuzz test on BitSet type S. */
 template<typename S>
-void TestType(Span<const uint8_t> buffer)
+void TestType(FuzzBufferType buffer)
 {
     /** This fuzz test's design is based on the assumption that the actual bits stored in the
      *  bitsets and their simulations do not matter for the purpose of detecting edge cases, thus

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -5,10 +5,9 @@
 #ifndef BITCOIN_TEST_FUZZ_FUZZ_H
 #define BITCOIN_TEST_FUZZ_FUZZ_H
 
-#include <span.h>
-
 #include <cstdint>
 #include <functional>
+#include <span>
 #include <string_view>
 
 /**
@@ -23,7 +22,7 @@
 #define LIMITED_WHILE(condition, limit) \
     for (unsigned _count{limit}; (condition) && _count; --_count)
 
-using FuzzBufferType = Span<const uint8_t>;
+using FuzzBufferType = std::span<const uint8_t>;
 
 using TypeTestOneInput = std::function<void(FuzzBufferType)>;
 struct FuzzTargetOptions {


### PR DESCRIPTION
The use of `Span` is problematic, because it lacks methods such as `rbegin`, leading to compile failures when used:

```
error: no member named 'rbegin' in 'Span<const unsigned char>'
```

One could fix `Span`, but it seems better to use `std::span`, given that `Span` will be removed anyway in the long term.