### PR TITLE
fuzz: add I2P harness

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -327,6 +327,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/headerssync.cpp \
  test/fuzz/hex.cpp \
  test/fuzz/http_request.cpp \
+ test/fuzz/i2p.cpp \
  test/fuzz/integer.cpp \
  test/fuzz/key.cpp \
  test/fuzz/key_io.cpp \

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/args.h>
+#include <i2p.h>
+#include <netaddress.h>
+#include <netbase.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
+#include <test/util/setup_common.h>
+#include <util/fs_helpers.h>
+#include <util/threadinterrupt.h>
+
+void initialize_i2p()
+{
+    static const auto testing_setup = MakeNoLogFileContext<>();
+}
+
+FUZZ_TARGET(i2p, .init = initialize_i2p)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
+
+    // Mock CreateSock() to create FuzzedSock.
+    auto CreateSockOrig = CreateSock;
+    CreateSock = [&fuzzed_data_provider](const sa_family_t&) {
+        return std::make_unique<FuzzedSock>(fuzzed_data_provider);
+    };
+
+    const fs::path private_key_path = gArgs.GetDataDirNet() / "fuzzed_i2p_private_key";
+    const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), 7656};
+    const Proxy sam_proxy{addr, false};
+    CThreadInterrupt interrupt;
+
+    i2p::sam::Session session{private_key_path, sam_proxy, &interrupt};
+    i2p::Connection conn;
+
+    if (session.Listen(conn)) {
+        if (session.Accept(conn)) {
+            try {
+                (void)conn.sock->RecvUntilTerminator('\n', 10ms, interrupt, i2p::sam::MAX_MSG_SIZE);
+            } catch (const std::runtime_error&) {
+            }
+        }
+    }
+
+    bool proxy_error;
+
+    if (session.Connect(CService{}, conn, proxy_error)) {
+        try {
+            conn.sock->SendComplete("verack\n", 10ms, interrupt);
+        } catch (const std::runtime_error&) {
+        }
+    }
+
+    fs::remove_all(private_key_path);
+
+    CreateSock = CreateSockOrig;
+}


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bitcoin/issues/28803. This updated harness sets mock time at the beginning of each iteration and deletes the private key file at the end of each iteration. Mock time is used to make the fuzz test more stable, as `GetTime` is called at points in `i2p`. Deleting the private key file ensures that each iteration is independent from the last. Now, a new key is generated in `i2p` every time, so the fuzzer can eventually make progress through the target code.

Re-working this harness also led me and dergoegge to resolve a couple of issues in `FuzzedSock`, which allows for full coverage of the `i2p` code. Those changes can be seen in https://github.com/bitcoin/bitcoin/pull/30211.

The SAM protocol for interacting with I2P requires some specifc inputs so it's best to use a dictionary when running this harness.

<details>
<summary>I2P dict</summary>

```
"HELLO VERSION"
"HELLO REPLY RESULT=OK VERSION="
"HELLO REPLY RESULT=NOVERSION"
"HELLO REPLY RESULT=I2P_ERROR"
"SESSION CREATE"
"SESSION STATUS RESULT=OK DESTINATION="
"SESSION STATUS RESULT=DUPLICATED_ID"
"SESSION STATUS RESULT=DUPLICATED_DEST"
"SESSION STATUS RESULT=INVALID_ID"
"SESSION STATUS RESULT=INVALID_KEY"
"SESSION STATUS RESULT=I2P_ERROR MESSAGE="
"SESSION ADD"
"SESSION REMOVE"
"STREAM CONNECT"
"STREAM STATUS RESULT=OK"
"STREAM STATUS RESULT=INVALID_ID"
"STREAM STATUS RESULT=INVALID_KEY"
"STREAM STATUS RESULT=CANT_REACH_PEER"
"STREAM STATUS RESULT=I2P_ERROR MESSAGE="
"STREAM ACCEPT"
"STREAM FORWARD"
"DATAGRAM SEND"
"RAW SEND"
"DEST GENERATE"
"DEST REPLY PUB= PRIV="
"DEST REPLY RESULT=I2P_ERROR"
"NAMING LOOKUP"
"NAMING REPLY RESULT=OK NAME= VALUE="
"DATAGRAM RECEIVED DESTINATION= SIZE="
"RAW RECEIVED SIZE="
"NAMING REPLY RESULT=INVALID_KEY NAME="
"NAMING REPLY RESULT=KEY_NOT_FOUND NAME="
"MIN"
"MAX"
"STYLE"
"ID"
"SILENT"
"DESTINATION"
"NAME"
"SIGNATURE_TYPE"
"CRYPTO_TYPE"
"SIZE"
"HOST"
"PORT"
"FROM_PORT"
"TRANSIENT"
"STREAM"
"DATAGRAM"
"RAW"
"MASTER"
"true"
"false"
```

</details>

I'll add this dict to qa-assets later on.