### PR TITLE
guix: bump time-machine to f0bb724211872cd6158fce6162e0b8c73efed126

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=dc4842797bfdc5f9f3f5f725bf189c2b68bd6b5a \
+                      --commit=f0bb724211872cd6158fce6162e0b8c73efed126 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
Includes:
LLVM 18.1.x (#30201)
GCC 13.x (#29881)

git-minimal 2.41.0 -> 2.45.1
Kernel Headers 6.1.80 -> 6.1.92
moreutils 0.68 -> 0.69

Commits like https://git.savannah.gnu.org/cgit/guix.git/commit/?id=7b0f145802f0c2c785014293d748721678fef824, which should improve the bootstrap situation (#30042). This can somewhat be visualised by comparing the (simplified) dependencies of guix itself, between the two time-machines.

Master:
![master_2](https://github.com/bitcoin/bitcoin/assets/863730/714402a2-345e-43c7-974b-5112d03d44c2)

PR:
![pr](https://github.com/bitcoin/bitcoin/assets/863730/7079a155-e013-4d59-9ea1-21a64d71e2d8)

Note that in the case of this PR, we are better off, no-longer having to build a number of tex packages, ruby, cairo, graphics libs, openssl 1.x etc.