### PR TITLE
Enable clang-tidy checks for self-assignment

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -6,6 +6,7 @@ bugprone-move-forwarding-reference,
 bugprone-string-constructor,
 bugprone-use-after-move,
 bugprone-lambda-function-name,
+bugprone-unhandled-self-assignment,
 misc-unused-using-decls,
 misc-no-recursion,
 modernize-use-default-member-init,
@@ -23,8 +24,10 @@ readability-const-return-type,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '
+HeaderFilterRegex: '.'
 WarningsAsErrors: '*'
 CheckOptions:
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
    value: false
-HeaderFilterRegex: '.'
+ - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+   value: false

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -43,8 +43,10 @@ public:
 
     base_uint& operator=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
+        if (this != &b) {
+            for (int i = 0; i < WIDTH; i++)
+                pn[i] = b.pn[i];
+        }
         return *this;
     }
 

--- a/src/key.h
+++ b/src/key.h
@@ -75,13 +75,15 @@ public:
 
     CKey& operator=(const CKey& other)
     {
-        if (other.keydata) {
-            MakeKeyData();
-            *keydata = *other.keydata;
-        } else {
-            ClearKeyData();
+        if (this != &other) {
+            if (other.keydata) {
+                MakeKeyData();
+                *keydata = *other.keydata;
+            } else {
+                ClearKeyData();
+            }
+            fCompressed = other.fCompressed;
         }
-        fCompressed = other.fCompressed;
         return *this;
     }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1508,8 +1508,10 @@ struct Tracker
     Tracker(Tracker&& t) noexcept : origin(t.origin), copies(t.copies) {}
     Tracker& operator=(const Tracker& t) noexcept
     {
-        origin = t.origin;
-        copies = t.copies + 1;
+        if (this != &t) {
+            origin = t.origin;
+            copies = t.copies + 1;
+        }
         return *this;
     }
 };


### PR DESCRIPTION
See comment here: https://github.com/bitcoin/bitcoin/pull/30161#issuecomment-2148229582

Our code failed these checks in three places, which have been fixed up here. Though these appear to have been harmless, adding the check avoids the copy in the self-assignment case so there should be no downside.

~Additionally, minisketch failed the check as well. See https://github.com/sipa/minisketch/pull/87~
Edit: Done

After fixing up the violations, turn on the aggressive clang-tidy check.

Note for reviewers: `git diff -w` makes this trivial to review.