### PR TITLE
build: warn on self-assignment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -411,12 +411,12 @@ AX_CHECK_COMPILE_FLAG([-Wsuggest-override], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wsug
 AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wimplicit-fallthrough"], [], [$CXXFLAG_WERROR])
 AX_CHECK_COMPILE_FLAG([-Wunreachable-code], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunreachable-code"], [], [$CXXFLAG_WERROR])
 AX_CHECK_COMPILE_FLAG([-Wdocumentation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"], [], [$CXXFLAG_WERROR])
+AX_CHECK_COMPILE_FLAG([-Wself-assign], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wself-assign"], [], [$CXXFLAG_WERROR])
 
 dnl Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
 dnl unknown options if any other warning is produced. Test the -Wfoo case, and
 dnl set the -Wno-foo case if it works.
 AX_CHECK_COMPILE_FLAG([-Wunused-parameter], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"], [], [$CXXFLAG_WERROR])
-AX_CHECK_COMPILE_FLAG([-Wself-assign], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"], [], [$CXXFLAG_WERROR])
 
 dnl Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 AX_CHECK_COMPILE_FLAG([-fno-extended-identifiers], [CORE_CXXFLAGS="$CORE_CXXFLAGS -fno-extended-identifiers"], [], [$CXXFLAG_WERROR])

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -43,7 +43,19 @@ FUZZ_TARGET(muhash)
         },
         [&] {
             // Test that dividing a MuHash by itself brings it back to it's initial state
+
+            // See note about clang + self-assignment in test/uint256_tests.cpp
+            #if defined(__clang__)
+            #    pragma clang diagnostic push
+            #    pragma clang diagnostic ignored "-Wself-assign-overloaded"
+            #endif
+
             muhash /= muhash;
+
+            #if defined(__clang__)
+            #    pragma clang diagnostic pop
+            #endif
+
             muhash.Finalize(out);
             out2 = uint256S(initial_state_hash);
         },

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -267,6 +267,22 @@ BOOST_AUTO_TEST_CASE( conversion )
 
 BOOST_AUTO_TEST_CASE( operator_with_self )
 {
+
+/* Clang 16 and earlier detects v -= v and v /= v as self-assignments
+   to 0 and 1 respectively.
+   See: https://github.com/llvm/llvm-project/issues/42469
+   and the fix in commit c5302325b2a62d77cf13dd16cd5c19141862fed0 .
+
+   This makes some sense for arithmetic classes, but could be considered a bug
+   elsewhere. Disable the warning here so that the code can be tested, but the
+   warning should remain on as there will likely always be a better way to
+   express this.
+*/
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
     arith_uint256 v = UintToArith256(uint256S("02"));
     v *= v;
     BOOST_CHECK(v == UintToArith256(uint256S("04")));
@@ -276,6 +292,9 @@ BOOST_AUTO_TEST_CASE( operator_with_self )
     BOOST_CHECK(v == UintToArith256(uint256S("02")));
     v -= v;
     BOOST_CHECK(v == UintToArith256(uint256S("0")));
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(parse)


### PR DESCRIPTION
Belt-and suspenders after #30234. Self-assignment should be safe _and_ discouraged.

We used to opt out of this warning because something deep in our serialization/byteswapping code could self-assign, but that doesn't appear to be the case anymore.