### PR TITLE
Ephemeral Dust

### DIFF
--- a/doc/release-notes-30239.md
+++ b/doc/release-notes-30239.md
@@ -1,0 +1,12 @@
+P2P and network changes
+-----------------------
+
+Ephemeral dust is a new concept that allows a single
+dust output in a transaction, provided the transaction
+is zero fee. In order to spend any unconfirmed outputs
+from this transaction, the spender must also spend
+this dust in addition to any other outputs.
+
+In other words, this type of transaction
+should be created in a transaction package where
+the dust is both created and spent simultaneously.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,6 +252,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/utxo_snapshot.cpp
   node/warnings.cpp
   noui.cpp
+  policy/ephemeral_policy.cpp
   policy/fees.cpp
   policy/fees_args.cpp
   policy/packages.cpp

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(bench_bitcoin
   load_external.cpp
   lockedpool.cpp
   logging.cpp
+  mempool_ephemeral_spends.cpp
   mempool_eviction.cpp
   mempool_stress.cpp
   merkle_root.cpp

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <consensus/amount.h>
+#include <kernel/cs_main.h>
+#include <policy/ephemeral_policy.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <txmempool.h>
+#include <util/check.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+
+static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
+{
+    int64_t nTime{0};
+    unsigned int nHeight{1};
+    uint64_t sequence{0};
+    bool spendsCoinbase{false};
+    unsigned int sigOpCost{4};
+    uint64_t fee{0};
+    LockPoints lp;
+    pool.addUnchecked(CTxMemPoolEntry(
+        tx, fee, nTime, nHeight, sequence,
+        spendsCoinbase, sigOpCost, lp));
+}
+
+static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
+{
+    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+
+    int number_outputs{1000};
+    if (bench.complexityN() > 1) {
+        number_outputs = static_cast<int>(bench.complexityN());
+    }
+
+    // Tx with many outputs
+    CMutableTransaction tx1 = CMutableTransaction();
+    tx1.vin.resize(1);
+    tx1.vout.resize(number_outputs);
+    for (size_t i = 0; i < tx1.vout.size(); i++) {
+        tx1.vout[i].scriptPubKey = CScript();
+        // Each output progressively larger
+        tx1.vout[i].nValue = i * CENT;
+    }
+
+    const auto& parent_txid = tx1.GetHash();
+
+    // Spends all outputs of tx1, other details don't matter
+    CMutableTransaction tx2 = CMutableTransaction();
+    tx2.vin.resize(tx1.vout.size());
+    for (size_t i = 0; i < tx2.vin.size(); i++) {
+        tx2.vin[0].prevout.hash = parent_txid;
+        tx2.vin[0].prevout.n = i;
+    }
+    tx2.vout.resize(1);
+
+    CTxMemPool& pool = *Assert(testing_setup->m_node.mempool);
+    LOCK2(cs_main, pool.cs);
+    // Create transaction references outside the "hot loop"
+    const CTransactionRef tx1_r{MakeTransactionRef(tx1)};
+    const CTransactionRef tx2_r{MakeTransactionRef(tx2)};
+
+    AddTx(tx1_r, pool);
+
+    uint32_t iteration{0};
+
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+
+        CheckEphemeralSpends({tx2_r}, /*dust_relay_rate=*/CFeeRate(iteration * COIN / 10), pool);
+        iteration++;
+    });
+}
+
+BENCHMARK(MempoolCheckEphemeralSpends, benchmark::PriorityLevel::HIGH);

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(bitcoinkernel
   ../node/blockstorage.cpp
   ../node/chainstate.cpp
   ../node/utxo_snapshot.cpp
+  ../policy/ephemeral_policy.cpp
   ../policy/feerate.cpp
   ../policy/packages.cpp
   ../policy/policy.cpp

--- a/src/policy/ephemeral_policy.cpp
+++ b/src/policy/ephemeral_policy.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/ephemeral_policy.h>
+#include <policy/policy.h>
+
+bool HasDust(const CTransactionRef& tx, CFeeRate dust_relay_rate)
+{
+    return std::any_of(tx->vout.cbegin(), tx->vout.cend(), [&](const auto& output) { return IsDust(output, dust_relay_rate); });
+}
+
+bool CheckValidEphemeralTx(const CTransactionRef& tx, CFeeRate dust_relay_rate, CAmount base_fee, CAmount mod_fee, TxValidationState& state)
+{
+    // We never want to give incentives to mine this transaction alone
+    if ((base_fee != 0 || mod_fee != 0) && HasDust(tx, dust_relay_rate)) {
+        return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "dust", "tx with dust output must be 0-fee");
+    }
+
+    return true;
+}
+
+std::optional<Txid> CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, const CTxMemPool& tx_pool)
+{
+    if (!Assume(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}))) {
+        // Bail out of spend checks if caller gave us an invalid package
+        return std::nullopt;
+    }
+
+    std::map<Txid, CTransactionRef> map_txid_ref;
+    for (const auto& tx : package) {
+        map_txid_ref[tx->GetHash()] = tx;
+    }
+
+    for (const auto& tx : package) {
+        Txid txid = tx->GetHash();
+        std::unordered_set<Txid, SaltedTxidHasher> processed_parent_set;
+        std::unordered_set<COutPoint, SaltedOutpointHasher> unspent_parent_dust;
+
+        for (const auto& tx_input : tx->vin) {
+            const Txid& parent_txid{tx_input.prevout.hash};
+            // Skip parents we've already checked dust for
+            if (processed_parent_set.contains(parent_txid)) continue;
+
+            // We look for an in-package or in-mempool dependency
+            CTransactionRef parent_ref = nullptr;
+            if (auto it = map_txid_ref.find(parent_txid); it != map_txid_ref.end()) {
+                parent_ref = it->second;
+            } else {
+                parent_ref = tx_pool.get(parent_txid);
+            }
+
+            // Check for dust on parents
+            if (parent_ref) {
+                for (uint32_t out_index = 0; out_index < parent_ref->vout.size(); out_index++) {
+                    const auto& tx_output = parent_ref->vout[out_index];
+                    if (IsDust(tx_output, dust_relay_rate)) {
+                        unspent_parent_dust.insert(COutPoint(parent_txid, out_index));
+                    }
+                }
+            }
+
+            processed_parent_set.insert(parent_txid);
+        }
+
+        // Now that we have gathered parents' dust, make sure it's spent
+        // by the child
+        for (const auto& tx_input : tx->vin) {
+            unspent_parent_dust.erase(tx_input.prevout);
+        }
+
+        if (!unspent_parent_dust.empty()) {
+            return txid;
+        }
+    }
+
+    return std::nullopt;
+}

--- a/src/policy/ephemeral_policy.h
+++ b/src/policy/ephemeral_policy.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_EPHEMERAL_POLICY_H
+#define BITCOIN_POLICY_EPHEMERAL_POLICY_H
+
+#include <policy/packages.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <txmempool.h>
+
+/** These utility functions ensure that ephemeral dust is safely
+ * created and spent without unduly risking them entering the utxo
+ * set.
+
+ * This is ensured by requiring:
+ * - CheckValidEphemeralTx checks are respected
+ * - The parent has no child (and 0-fee as implied above to disincentivize mining)
+ * - OR the parent transaction has exactly one child, and the dust is spent by that child
+ *
+ * Imagine three transactions:
+ * TxA, 0-fee with two outputs, one non-dust, one dust
+ * TxB, spends TxA's non-dust
+ * TxC, spends TxA's dust
+ *
+ * All the dust is spent if TxA+TxB+TxC is accepted, but the mining template may just pick
+ * up TxA+TxB rather than the three "legal configurations:
+ * 1) None
+ * 2) TxA+TxB+TxC
+ * 3) TxA+TxC
+ * By requiring the child transaction to sweep any dust from the parent txn, we ensure that
+ * there is a single child only, and this child, or the child's descendants,
+ * are the only way to bring fees.
+ */
+
+/** Returns true if transaction contains dust */
+bool HasDust(const CTransactionRef& tx, CFeeRate dust_relay_rate);
+
+/* All the following checks are only called if standardness rules are being applied. */
+
+/** Must be called for each transaction once transaction fees are known.
+ * Does context-less checks about a single transaction.
+ * Returns false if the fee is non-zero and dust exists, populating state. True otherwise.
+ */
+bool CheckValidEphemeralTx(const CTransactionRef& tx, CFeeRate dust_relay_rate, CAmount base_fee, CAmount mod_fee, TxValidationState& state);
+
+/** Must be called for each transaction(package) if any dust is in the package.
+ *  Checks that each transaction's parents have their dust spent by the child,
+ *  where parents are either in the mempool or in the package itself.
+ *  The function returns std::nullopt if all dust is properly spent, or the txid of the violating child spend.
+ */
+std::optional<Txid> CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, const CTxMemPool& tx_pool);
+
+#endif // BITCOIN_POLICY_EPHEMERAL_POLICY_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -77,6 +77,10 @@ static const unsigned int MAX_OP_RETURN_RELAY = 83;
  */
 static constexpr unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT{10000};
 
+/**
+ * Maximum number of ephemeral dust outputs allowed.
+ */
+static constexpr unsigned int MAX_DUST_OUTPUTS_PER_TX{1};
 
 /**
  * Mandatory script verification flags that all new transactions must comply with for

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -813,6 +813,11 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     // Check dust with default relay fee:
     CAmount nDustThreshold = 182 * g_dust.GetFeePerK() / 1000;
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
+
+    // Add dust output to take dust slot, still standard!
+    t.vout.emplace_back(0, t.vout[0].scriptPubKey);
+    CheckIsStandard(t);
+
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
     CheckIsNotStandard(t, "dust");
@@ -968,6 +973,10 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     g_bare_multi = false;
     CheckIsNotStandard(t, "bare-multisig");
     g_bare_multi = DEFAULT_PERMIT_BAREMULTISIG;
+
+    // Add dust output to take dust slot
+    assert(t.vout.size() == 1);
+    t.vout.emplace_back(0, t.vout[0].scriptPubKey);
 
     // Check compressed P2PK outputs dust threshold (must have leading 02 or 03)
     t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG;

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -141,7 +141,7 @@ std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,
     return std::nullopt;
 }
 
-std::vector<uint32_t> GetDustIndexes(const CTransactionRef tx_ref, CFeeRate dust_relay_rate)
+std::vector<uint32_t> GetDustIndexes(const CTransactionRef& tx_ref, CFeeRate dust_relay_rate)
 {
     std::vector<uint32_t> dust_indexes;
     for (size_t i = 0; i < tx_ref->vout.size(); ++i) {

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -141,6 +141,54 @@ std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,
     return std::nullopt;
 }
 
+std::vector<uint32_t> GetDustIndexes(const CTransactionRef tx_ref, CFeeRate dust_relay_rate)
+{
+    std::vector<uint32_t> dust_indexes;
+    for (size_t i = 0; i < tx_ref->vout.size(); ++i) {
+        const auto& output = tx_ref->vout[i];
+        if (IsDust(output, dust_relay_rate)) dust_indexes.push_back(i);
+    }
+
+    return dust_indexes;
+}
+
+void CheckMempoolEphemeralInvariants(const CTxMemPool& tx_pool)
+{
+    LOCK(tx_pool.cs);
+    for (const auto& tx_info : tx_pool.infoAll()) {
+        const auto& entry = *Assert(tx_pool.GetEntry(tx_info.tx->GetHash()));
+
+        std::vector<uint32_t> dust_indexes = GetDustIndexes(tx_info.tx, tx_pool.m_opts.dust_relay_feerate);
+
+        Assert(dust_indexes.size() < 2);
+
+        if (dust_indexes.empty()) continue;
+
+        // Transaction must have no base fee
+        Assert(entry.GetFee() == 0 && entry.GetModifiedFee() == 0);
+
+        // Transaction has single dust; make sure it's swept or will not be mined
+        const auto& children = entry.GetMemPoolChildrenConst();
+
+        // Multiple children should never happen as non-dust-spending child
+        // can get mined as package
+        Assert(children.size() < 2);
+
+        if (children.empty()) {
+            // No children and no fees; modified fees aside won't get mined so it's fine
+            // Happens naturally if child spend is RBF cycled away.
+            continue;
+        }
+
+        // Only-child should be spending the dust
+        const auto& only_child = children.begin()->get().GetTx();
+        COutPoint dust_outpoint{tx_info.tx->GetHash(), dust_indexes[0]};
+        Assert(std::any_of(only_child.vin.begin(), only_child.vin.end(), [&dust_outpoint](const CTxIn& txin) {
+            return txin.prevout == dust_outpoint;
+            }));
+    }
+}
+
 void CheckMempoolTRUCInvariants(const CTxMemPool& tx_pool)
 {
     LOCK(tx_pool.cs);

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -57,7 +57,7 @@ void CheckMempoolEphemeralInvariants(const CTxMemPool& tx_pool);
 /** Return indexes of the transaction's outputs that are considered dust
  * at given dust_relay_rate.
 */
-std::vector<uint32_t> GetDustIndexes(const CTransactionRef tx_ref, CFeeRate dust_relay_rate);
+std::vector<uint32_t> GetDustIndexes(const CTransactionRef& tx_ref, CFeeRate dust_relay_rate);
 
 /** For every transaction in tx_pool, check TRUC invariants:
  * - a TRUC tx's ancestor count must be within TRUC_ANCESTOR_LIMIT

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -47,6 +47,18 @@ std::optional<std::string>  CheckPackageMempoolAcceptResult(const Package& txns,
                                                             bool expect_valid,
                                                             const CTxMemPool* mempool);
 
+/** Check that we never get into a state where an ephemeral dust
+ *  transaction would be mined without the spend of the dust
+ *  also being mined. This assumes standardness checks are being
+ *  enforced.
+*/
+void CheckMempoolEphemeralInvariants(const CTxMemPool& tx_pool);
+
+/** Return indexes of the transaction's outputs that are considered dust
+ * at given dust_relay_rate.
+*/
+std::vector<uint32_t> GetDustIndexes(const CTransactionRef tx_ref, CFeeRate dust_relay_rate);
+
 /** For every transaction in tx_pool, check TRUC invariants:
  * - a TRUC tx's ancestor count must be within TRUC_ANCESTOR_LIMIT
  * - a TRUC tx's descendant count must be within TRUC_DESCENDANT_LIMIT

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -71,8 +71,38 @@ class DustRelayFeeTest(BitcoinTestFramework):
         # finally send the transaction to avoid running out of MiniWallet UTXOs
         self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_good_hex)
 
+    def test_dustrelay(self):
+        self.log.info("Test that small outputs are acceptable when dust relay rate is set to 0 that would otherwise trigger ephemeral dust rules")
+
+        self.restart_node(0, extra_args=["-dustrelayfee=0"])
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Double dust, both unspent, with fees. Would have failed individual checks.
+        # Dust is 1 satoshi create_self_transfer_multi disallows 0
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=1000, amount_per_output=1, num_outputs=2)
+        dust_txid = self.nodes[0].sendrawtransaction(hexstring=dusty_tx["hex"], maxfeerate=0)
+
+        assert_equal(self.nodes[0].getrawmempool(), [dust_txid])
+
+        # Spends one dust along with fee input, leave other dust unspent to check ephemeral dust checks aren't being enforced
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[self.wallet.get_utxo(), dusty_tx["new_utxos"][0]])
+        sweep_txid = self.nodes[0].sendrawtransaction(sweep_tx["hex"])
+
+        mempool_entries = self.nodes[0].getrawmempool()
+        assert dust_txid in mempool_entries
+        assert sweep_txid in mempool_entries
+        assert_equal(len(mempool_entries), 2)
+
+        # Wipe extra arg to reset dust relay
+        self.restart_node(0, extra_args=[])
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
+
+        self.test_dustrelay()
 
         # prepare output scripts of each standard type
         _, uncompressed_pubkey = generate_keypair(compressed=False)

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from decimal import Decimal
+
+from test_framework.messages import (
+    COIN,
+    CTxOut,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mempool_util import assert_mempool_contents
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    MiniWallet,
+)
+
+class EphemeralDustTest(BitcoinTestFramework):
+    def set_test_params(self):
+        # Mempools should match via 1P1C p2p relay
+        self.num_nodes = 2
+
+        # Don't test trickling logic
+        self.noban_tx_relay = True
+
+    def add_output_to_create_multi_result(self, result, output_value=0):
+        """ Add output without changing absolute tx fee
+        """
+        assert len(result["tx"].vout) > 0
+        assert result["tx"].vout[0].nValue >= output_value
+        result["tx"].vout.append(CTxOut(output_value, result["tx"].vout[0].scriptPubKey))
+        # Take value from first output
+        result["tx"].vout[0].nValue -= output_value
+        result["new_utxos"][0]["value"] = Decimal(result["tx"].vout[0].nValue) / COIN
+        new_txid = result["tx"].rehash()
+        result["txid"]  = new_txid
+        result["wtxid"] = result["tx"].getwtxid()
+        result["hex"] = result["tx"].serialize().hex()
+        for new_utxo in result["new_utxos"]:
+            new_utxo["txid"] = new_txid
+            new_utxo["wtxid"] = result["tx"].getwtxid()
+
+        result["new_utxos"].append({"txid": new_txid, "vout": len(result["tx"].vout) - 1, "value": Decimal(output_value) / COIN, "height": 0, "coinbase": False, "confirmations": 0})
+
+    def run_test(self):
+
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+
+        self.test_normal_dust()
+        self.test_sponsor_cycle()
+        self.test_node_restart()
+        self.test_fee_having_parent()
+        self.test_multidust()
+        self.test_nonzero_dust()
+        self.test_non_truc()
+        self.test_unspent_ephemeral()
+        self.test_reorgs()
+        self.test_free_relay()
+
+    def test_normal_dust(self):
+        self.log.info("Create 0-value dusty output, show that it works inside truc when spent in package")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        # Test doesn't work because lack of package feerates
+        test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"], sweep_tx["hex"]])
+        assert not test_res[0]["allowed"]
+        assert_equal(test_res[0]["reject-reason"], "min relay fee not met")
+
+        # And doesn't work on its own
+        assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, dusty_tx["hex"])
+
+        # If we add modified fees, it is still not allowed due to dust check
+        self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=COIN)
+        test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"]])
+        assert not test_res[0]["allowed"]
+        assert_equal(test_res[0]["reject-reason"], "dust")
+        # Reset priority
+        self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-COIN)
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {})
+
+        # Package evaluation succeeds
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "success")
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # Entry is denied when non-0-fee, either base or unmodified.
+        # If in-mempool, we're not allowed to prioritise due to detected dust output
+        assert_raises_rpc_error(-8, "Priority is not supported for transactions with dust outputs.", self.nodes[0].prioritisetransaction, dusty_tx["txid"], 0, 1)
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {})
+
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+    def test_node_restart(self):
+        self.log.info("Test that an ephemeral package is rejected on restart due to individual evaluation")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "success")
+        assert_equal(len(self.nodes[0].getrawmempool()), 2)
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # Node restart; doesn't allow allow ephemeral transaction back in due to individual submission
+        # resulting in 0-fee. Supporting re-submission of CPFP packages on restart is desired but not
+        # yet implemented.
+        self.restart_node(0)
+        self.restart_node(1)
+        self.connect_nodes(0, 1)
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+    def test_fee_having_parent(self):
+        self.log.info("Test that a transaction with ephemeral dust may not have non-0 base fee")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        sats_fee = 1
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=sats_fee, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+        assert_equal(int(COIN * dusty_tx["fee"]), sats_fee) # has fees
+        assert_greater_than(dusty_tx["tx"].vout[0].nValue, 330) # main output is not dust
+        assert_equal(dusty_tx["tx"].vout[1].nValue, 0) # added one is dust
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        # When base fee is non-0, we report dust like usual
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "transaction failed")
+        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+
+        # Priority is ignored: rejected even if modified fee is 0
+        self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-sats_fee)
+        self.nodes[1].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-sats_fee)
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "transaction failed")
+        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+
+        # Will not be accepted if base fee is 0 with modified fee of non-0
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=1000)
+        self.nodes[1].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=1000)
+
+        # It's rejected submitted alone
+        test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"]])
+        assert not test_res[0]["allowed"]
+        assert_equal(test_res[0]["reject-reason"], "dust")
+
+        # Or as a package
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "transaction failed")
+        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+    def test_multidust(self):
+        self.log.info("Test that a transaction with multiple ephemeral dusts is not allowed")
+
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "transaction failed")
+        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust")
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+    def test_nonzero_dust(self):
+        self.log.info("Test that a single output of any satoshi amount is allowed, not checking spending")
+
+        # We aren't checking spending, allow it in with no fee
+        self.restart_node(0, extra_args=["-minrelaytxfee=0"])
+        self.restart_node(1, extra_args=["-minrelaytxfee=0"])
+        self.connect_nodes(0, 1)
+
+        # 330 is dust threshold for taproot outputs
+        for value in [1, 329, 330]:
+            assert_equal(self.nodes[0].getrawmempool(), [])
+
+            dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+            self.add_output_to_create_multi_result(dusty_tx, value)
+
+            test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"]])
+            assert test_res[0]["allowed"]
+
+        self.restart_node(0, extra_args=[])
+        self.restart_node(1, extra_args=[])
+        self.connect_nodes(0, 1)
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+    # N.B. If individual minrelay requirement is dropped, this test can be dropped
+    def test_non_truc(self):
+        self.log.info("Test that v2 dust-having transaction is rejected even if spent, because of min relay requirement")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=2)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=2)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "transaction failed")
+        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "min relay fee not met, 0 < 147")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+    def test_unspent_ephemeral(self):
+        self.log.info("Test that spending from a tx with ephemeral outputs is only allowed if dust is spent as well")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx, 329)
+
+        # Valid sweep we will RBF incorrectly by not spending dust as well
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+        self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # Doesn't spend in-mempool dust output from parent
+        unspent_sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=2000, utxos_to_spend=[dusty_tx["new_utxos"][0]], version=3)
+        assert_greater_than(unspent_sweep_tx["fee"], sweep_tx["fee"])
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], unspent_sweep_tx["hex"]])
+        assert_equal(res["tx-results"][unspent_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        assert_raises_rpc_error(-26, f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} did not spend parent's ephemeral dust", self.nodes[0].sendrawtransaction, unspent_sweep_tx["hex"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # Spend works with dust spent
+        sweep_tx_2 = self.wallet.create_self_transfer_multi(fee_per_output=2000, utxos_to_spend=dusty_tx["new_utxos"], version=3)
+        assert sweep_tx["hex"] != sweep_tx_2["hex"]
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx_2["hex"]])
+        assert_equal(res["package_msg"], "success")
+
+        # Re-set and test again with nothing from package in mempool this time
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx, 329)
+
+        # Spend non-dust only
+        unspent_sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[dusty_tx["new_utxos"][0]], version=3)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], unspent_sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "unspent-dust")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Now spend dust only which should work
+        second_coin = self.wallet.get_utxo() # another fee-bringing coin
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[dusty_tx["new_utxos"][1], second_coin], version=3)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "success")
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        self.generate(self.nodes[0], 1)
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+    def test_sponsor_cycle(self):
+        self.log.info("Test that dust txn is not evicted when it becomes childless, but won't be mined")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(
+            fee_per_output=0,
+            version=3
+        )
+
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sponsor_coin = self.wallet.get_utxo()
+
+        # Bring "fee" input that can be double-spend separately
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"] + [sponsor_coin], version=3)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+        assert_equal(res["package_msg"], "success")
+        assert_equal(len(self.nodes[0].getrawmempool()), 2)
+        # sync to make sure unsponsor_tx hits second node's mempool after initial package
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # Now we RBF away the child using the sponsor input only
+        unsponsor_tx = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[sponsor_coin],
+            num_outputs=1,
+            fee_per_output=2000,
+            version=3
+        )
+        self.nodes[0].sendrawtransaction(unsponsor_tx["hex"])
+
+        # Parent is now childless and fee-free, so will not be mined
+        entry_info = self.nodes[0].getmempoolentry(dusty_tx["txid"])
+        assert_equal(entry_info["descendantcount"], 1)
+        assert_equal(entry_info["fees"]["descendant"], Decimal(0))
+
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], unsponsor_tx["tx"]])
+
+        # Dust tx is not mined
+        self.generate(self.nodes[0], 1)
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"]])
+
+        # Create sweep that doesn't spend conflicting sponsor coin
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=3)
+
+        # Can resweep
+        self.nodes[0].sendrawtransaction(sweep_tx["hex"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        self.generate(self.nodes[0], 1)
+        assert_mempool_contents(self, self.nodes[0], expected=[])
+
+    def test_reorgs(self):
+        self.log.info("Test that reorgs breaking the truc topology doesn't cause issues")
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Many shallow re-orgs confuse block gossiping making test less reliable otherwise
+        self.disconnect_nodes(0, 1)
+
+        # Get dusty tx mined, then check that it makes it back into mempool on reorg
+        # due to bypass_limits allowing 0-fee individually
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(dusty_tx)
+        assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, dusty_tx["hex"])
+
+        block_res = self.nodes[0].rpc.generateblock(self.wallet.get_address(), [dusty_tx["hex"]])
+        self.nodes[0].invalidateblock(block_res["hash"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"]], sync=False)
+
+        # Create a sweep that has dust of its own and leaves dusty_tx's dust unspent
+        sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, utxos_to_spend=[dusty_tx["new_utxos"][0]], version=3)
+        self.add_output_to_create_multi_result(sweep_tx)
+        assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, sweep_tx["hex"])
+
+        # Mine the sweep then re-org, the sweep will not make it back in due to spend checks
+        block_res = self.nodes[0].rpc.generateblock(self.wallet.get_address(), [dusty_tx["hex"], sweep_tx["hex"]])
+        self.nodes[0].invalidateblock(block_res["hash"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"]], sync=False)
+
+        # Also should happen if dust is swept
+        sweep_tx_2 = self.wallet.create_self_transfer_multi(fee_per_output=0, utxos_to_spend=dusty_tx["new_utxos"], version=3)
+        self.add_output_to_create_multi_result(sweep_tx_2)
+        assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, sweep_tx_2["hex"])
+
+        reconsider_block_res = self.nodes[0].rpc.generateblock(self.wallet.get_address(), [dusty_tx["hex"], sweep_tx_2["hex"]])
+        self.nodes[0].invalidateblock(reconsider_block_res["hash"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx_2["tx"]], sync=False)
+
+        # TRUC transactions restriction for ephemeral dust disallows further spends of ancestor chains
+        child_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=sweep_tx_2["new_utxos"], version=3)
+        assert_raises_rpc_error(-26, "TRUC-violation", self.nodes[0].sendrawtransaction, child_tx["hex"])
+
+        self.nodes[0].reconsiderblock(reconsider_block_res["hash"])
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        self.log.info("Test that ephemeral dust tx with fees or multi dust don't enter mempool via reorg")
+        multi_dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=3)
+        self.add_output_to_create_multi_result(multi_dusty_tx)
+        self.add_output_to_create_multi_result(multi_dusty_tx)
+
+        block_res = self.nodes[0].rpc.generateblock(self.wallet.get_address(), [multi_dusty_tx["hex"]])
+        self.nodes[0].invalidateblock(block_res["hash"])
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # With fee and one dust
+        dusty_fee_tx = self.wallet.create_self_transfer_multi(fee_per_output=1, version=3)
+        self.add_output_to_create_multi_result(dusty_fee_tx)
+
+        block_res = self.nodes[0].rpc.generateblock(self.wallet.get_address(), [dusty_fee_tx["hex"]])
+        self.nodes[0].invalidateblock(block_res["hash"])
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Re-connect and make sure we have same state still
+        self.connect_nodes(0, 1)
+        self.sync_all()
+
+    # N.B. this extra_args can be removed post cluster mempool
+    def test_free_relay(self):
+        self.log.info("Test that ephemeral dust works in non-TRUC contexts when there's no minrelay requirement")
+
+        # Note: since minrelay is 0, it is not testing 1P1C relay
+        self.restart_node(0, extra_args=["-minrelaytxfee=0"])
+        self.restart_node(1, extra_args=["-minrelaytxfee=0"])
+        self.connect_nodes(0, 1)
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=0, version=2)
+        self.add_output_to_create_multi_result(dusty_tx)
+
+        sweep_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=dusty_tx["new_utxos"], version=2)
+
+        self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
+
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
+
+        # generate coins for next tests
+        self.generate(self.nodes[0], 1)
+        self.wallet.rescan_utxos()
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        self.log.info("Test batched ephemeral dust sweep")
+        dusty_txs = []
+        for _ in range(24):
+            dusty_txs.append(self.wallet.create_self_transfer_multi(fee_per_output=0, version=2))
+            self.add_output_to_create_multi_result(dusty_txs[-1])
+
+        all_parent_utxos = [utxo for tx in dusty_txs for utxo in tx["new_utxos"]]
+
+        # Missing one dust spend from a single parent, child rejected
+        insufficient_sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=25000, utxos_to_spend=all_parent_utxos[:-1], version=2)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs] + [insufficient_sweep_tx["hex"]])
+        assert_equal(res['package_msg'], "transaction failed")
+        assert_equal(res['tx-results'][insufficient_sweep_tx['wtxid']]['error'], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        # Everything got in except for insufficient spend
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs])
+
+        # Next put some parents in mempool, but not others, and test unspent dust again with all parents spent
+        B_coin = self.wallet.get_utxo() # coin to cycle out CPFP
+        sweep_all_but_one_tx = self.wallet.create_self_transfer_multi(fee_per_output=20000, utxos_to_spend=all_parent_utxos[:-2] + [B_coin], version=2)
+        res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs[:-1]] + [sweep_all_but_one_tx["hex"]])
+        assert_equal(res['package_msg'], "success")
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs] + [sweep_all_but_one_tx["tx"]])
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs] + [insufficient_sweep_tx["hex"]])
+        assert_equal(res['package_msg'], "transaction failed")
+        assert_equal(res['tx-results'][insufficient_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs] + [sweep_all_but_one_tx["tx"]])
+
+        # Cycle out the partial sweep to avoid triggering package RBF behavior which limits package to no in-mempool ancestors
+        cancel_sweep = self.wallet.create_self_transfer_multi(fee_per_output=21000, utxos_to_spend=[B_coin], version=2)
+        self.nodes[0].sendrawtransaction(cancel_sweep["hex"])
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs] + [cancel_sweep["tx"]])
+
+        # Sweeps all dust, where all dusty txs are already in-mempool
+        sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=25000, utxos_to_spend=all_parent_utxos, version=2)
+
+        res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs] + [sweep_tx["hex"]])
+        assert_equal(res['package_msg'], "success")
+        assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs] + [sweep_tx["tx"], cancel_sweep["tx"]])
+
+        self.generate(self.nodes[0], 25)
+        self.wallet.rescan_utxos()
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Other topology tests require relaxation of submitpackage topology
+
+        self.restart_node(0, extra_args=[])
+        self.restart_node(1, extra_args=[])
+        self.connect_nodes(0, 1)
+
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+if __name__ == "__main__":
+    EphemeralDustTest(__file__).main()

--- a/test/functional/test_framework/mempool_util.py
+++ b/test/functional/test_framework/mempool_util.py
@@ -21,6 +21,20 @@ from .wallet import (
 
 ORPHAN_TX_EXPIRE_TIME = 1200
 
+def assert_mempool_contents(test_framework, node, expected=None, sync=True):
+    """Assert that all transactions in expected are in the mempool,
+    and no additional ones exist. 'expected' is an array of
+    CTransaction objects
+    """
+    if sync:
+        test_framework.sync_mempools()
+    if not expected:
+        expected = []
+    mempool = node.getrawmempool(verbose=False)
+    assert_equal(len(mempool), len(expected))
+    for tx in expected:
+        assert tx.rehash() in mempool
+
 
 def fill_mempool(test_framework, node, *, tx_sync_fun=None):
     """Fill mempool until eviction.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -400,6 +400,7 @@ BASE_SCRIPTS = [
     'rpc_getdescriptorinfo.py',
     'rpc_mempool_info.py',
     'rpc_help.py',
+    'mempool_ephemeral_dust.py',
     'p2p_handshake.py',
     'p2p_handshake.py --v2transport',
     'feature_dirsymlinks.py',


### PR DESCRIPTION
A replacement for https://github.com/bitcoin/bitcoin/pull/29001

Now that we have 1P1C relay, TRUC transactions and sibling eviction, it makes sense to retarget this feature more narrowly by not introducing a new output type, and simple focusing on the feature of allowing temporary dust in the mempool.

Users of this can immediately use dust outputs as:
1. Single keyed anchor (can be shared by multiple parties)
2. Single unkeyed anchor, ala P2A

Which is useful when the parent transaction cannot have fees for technical or accounting reasons.

What I'm calling "keyed" anchors would be used anytime you don't want a third party to be able to run off with the utxo. As a motivating example, in Ark there is the concept of a "forfeit transaction" which spends a "connector output". The connector output would ideally be 0-value, but you would not want that utxo spend by anyone, because this would cause financial loss for the coordinator of the service: https://arkdev.info/docs/learn/concepts#forfeit-transaction

Note that this specific use-case likely doesn't work as it involves a tree of dust, but the connector idea in general demonstrates how it could be used.

Another related example is connector outputs in BitVM2: https://bitvm.org/bitvm2.html .

Note that non-TRUC usage will be impractical unless the minrelay requirement on individual transactions are dropped in general, which should happen post-cluster mempool.

Lightning Network intends to use this feature post-29.0 if available: https://github.com/lightning/bolts/issues/1171#issuecomment-2373748582 

It's also useful for Ark, ln-symmetry, spacechains, Timeout Trees, and other constructs with large presigned trees or other large-N party smart contracts.