### PR TITLE
refactor: Add explicit cast to expected_last_page to silence fuzz ISan

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -551,7 +551,7 @@ void BerkeleyRODatabase::Open()
     // }
 
     // Check the last page number
-    uint32_t expected_last_page = (size / page_size) - 1;
+    uint32_t expected_last_page{uint32_t((size / page_size) - 1)};
     if (outer_meta.last_page != expected_last_page) {
         throw std::runtime_error("Last page number could not fit in file");
     }


### PR DESCRIPTION
Fixes #30247

I don't think this implicit cast can lead to any bugs, so make it explicit to silence the fuzz integer sanitizer.

Can be tested with:

```
FUZZ=wallet_bdb_parser UBSAN_OPTIONS="suppressions=$(pwd)/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1" ./src/test/fuzz/fuzz /tmp/1376869be72eebcc87fe737020add634b1a29533
```

After downloading the raw fuzz input from https://github.com/bitcoin-core/qa-assets/blob/24c507b3ea6263e6b121fb8dced01123065c44c2/fuzz_seed_corpus/wallet_bdb_parser/1376869be72eebcc87fe737020add634b1a29533