### PR TITLE
refactor: performance-for-range-copy in psbt.h

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -237,7 +237,7 @@ struct PSBTInput
 
         if (final_script_sig.empty() && final_script_witness.IsNull()) {
             // Write any partial signatures
-            for (auto sig_pair : partial_sigs) {
+            for (const auto& sig_pair : partial_sigs) {
                 SerializeToVector(s, CompactSizeWriter(PSBT_IN_PARTIAL_SIG), Span{sig_pair.second.first});
                 s << sig_pair.second.second;
             }


### PR DESCRIPTION
A copy of the partial signatures is not required before serializing them.

For reference, this was found by switching the codebase to `std::span` (not sure why it wasn't found with `Span` though):

```
./psbt.h:240:23: error: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy,-warnings-as-errors]
  240 |             for (auto sig_pair : partial_sigs) {
      |                       ^
      |                  const  &