### PR TITLE
doc: add release note for 29091 and 29165

### DIFF
--- a/doc/release-notes-29091-29165.md
+++ b/doc/release-notes-29091-29165.md
@@ -1,0 +1,5 @@
+Build
+-----
+
+GCC 11.1 or later, or Clang 15+ or later,
+are now required to compile Bitcoin Core.


### PR DESCRIPTION
GCC 11.x or Clang 15.x are now required to compile Bitcoin Core.