### PR TITLE
build: Bump clang minimum supported version to 16

### DIFF
--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -7,9 +7,9 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
-export CI_IMAGE_NAME_TAG="docker.io/ubuntu:22.04"
-# Use minimum supported python3.9 (or best-effort 3.10) and clang-15, see doc/dependencies.md
-export PACKAGES="python3-zmq clang-15 llvm-15 libc++abi-15-dev libc++-15-dev"
-export DEP_OPTS="NO_WALLET=1 CC=clang-15 CXX='clang++-15 -stdlib=libc++'"
+export CI_IMAGE_NAME_TAG="docker.io/debian:bullseye"
+# Use minimum supported python3.9 and clang-16, see doc/dependencies.md
+export PACKAGES="python3-zmq clang-16 llvm-16 libc++abi-16-dev libc++-16-dev"
+export DEP_OPTS="NO_WALLET=1 CC=clang-16 CXX='clang++-16 -stdlib=libc++'"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-reduce-exports --enable-experimental-util-chainstate --with-experimental-kernel-lib --enable-shared"

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -8,7 +8,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 | --- | --- |
 | [Autoconf](https://www.gnu.org/software/autoconf/) | [2.69](https://github.com/bitcoin/bitcoin/pull/17769) |
 | [Automake](https://www.gnu.org/software/automake/) | [1.13](https://github.com/bitcoin/bitcoin/pull/18290) |
-| [Clang](https://clang.llvm.org) | [15.0](https://github.com/bitcoin/bitcoin/pull/29165) |
+| [Clang](https://clang.llvm.org) | [16.0](https://github.com/bitcoin/bitcoin/pull/30263) |
 | [GCC](https://gcc.gnu.org) | [11.1](https://github.com/bitcoin/bitcoin/pull/29091) |
 | [Python](https://www.python.org) (scripts, tests) | [3.9](https://github.com/bitcoin/bitcoin/pull/28211) |
 | [systemtap](https://sourceware.org/systemtap/) ([tracing](tracing.md))| N/A |

--- a/doc/release-notes-29091-29165.md
+++ b/doc/release-notes-29091-29165.md
@@ -1,5 +1,5 @@
 Build
 -----
 
-GCC 11.1 or later, or Clang 15+ or later,
+GCC 11.1 or later, or Clang 16.0 or later,
 are now required to compile Bitcoin Core.

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -131,7 +131,7 @@ public:
      */
     void WriteReply(int nStatus, std::string_view reply = "")
     {
-        WriteReply(nStatus, std::as_bytes(std::span{reply.data(), reply.size()}));
+        WriteReply(nStatus, std::as_bytes(std::span{reply}));
     }
     void WriteReply(int nStatus, std::span<const std::byte> reply);
 };

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -72,8 +72,8 @@ auto& FuzzTargets()
 
 void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, FuzzTargetOptions opts)
 {
-    const auto it_ins{FuzzTargets().try_emplace(name, FuzzTarget /* temporary can be dropped after clang-16 */ {std::move(target), std::move(opts)})};
-    Assert(it_ins.second);
+    const auto [it, ins]{FuzzTargets().try_emplace(name, FuzzTarget /* temporary can be dropped after Apple-Clang-16 ? */ {std::move(target), std::move(opts)})};
+    Assert(ins);
 }
 
 static std::string_view g_fuzz_target;


### PR DESCRIPTION
Most supported operating systems ship with clang-16 (or later), so bump the minimum to that and allow new code to drop workarounds for previous clang bugs.

For reference:
* https://packages.debian.org/bookworm/clang-16
* https://packages.ubuntu.com/noble/clang (clang-18)
* CentOS-like 8/9 Stream: All Clang versions from 16 to 17
* FreeBSD 12/13: All Clang versions from 16 to 18
* OpenSuse Tumbleweed ships with https://software.opensuse.org/package/clang (`clang18`); No idea about OpenSuse Leap

On operating systems where the clang version is not shipped by default, the user would have to use GCC, or install clang in a different way. For example:

* https://packages.debian.org/bookworm/g++ (g++-12)
* https://packages.ubuntu.com/jammy/g++ (g++-11)
* https://apt.llvm.org/, or nix, or guix, or compile clang from source, ...

**Ubuntu 22.04 LTS does not ship with clang-16**, so one of the above workarounds is needed there.

macOS 13 is unaffected, and the previous minimum requirement of Xcode15.0 remains, see also https://github.com/bitcoin/bitcoin/blame/b1ba1b178f501daa1afdd91f9efec34e5ec1e294/.github/workflows/ci.yml#L93. For macOS 11 (Big Sur) and 12 (Monterey) you need to install a more recent version of llvm, this remains unchanged as well, see https://github.com/bitcoin/bitcoin/blame/b1ba1b178f501daa1afdd91f9efec34e5ec1e294/doc/build-osx.md#L54.