### PR TITLE
util: add missing VecDeque include

### DIFF
--- a/src/util/vecdeque.h
+++ b/src/util/vecdeque.h
@@ -9,6 +9,7 @@
 
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 /** Data structure largely mimicking std::deque, but using single preallocated ring buffer.
  *


### PR DESCRIPTION
Noticed when testing `VecDeque` with no other includes.

For libc++, need type_traits for `std::is_trivially_destructible_v`.