### PR TITLE
doc: Mention EOL policy in release notes template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,10 @@
 
 ## Supported Versions
 
-See our website for versions of Bitcoin Core that are currently supported with
-security updates: https://bitcoincore.org/en/lifecycle/#schedule
+Please refer to the Bitcoin Core end-of-life policy to find all versions that
+are currently supported with security updates.  Only the last point release of
+each supported major release version will have the latest security fixes:
+https://bitcoincore.org/en/lifecycle/#schedule
 
 ## Reporting a Vulnerability
 

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -20,6 +20,12 @@ To receive security and update notifications, please subscribe to:
 
   <https://bitcoincore.org/en/list/announcements/join/>
 
+Please refer to the Bitcoin Core end-of-life policy to find all versions that
+are currently supported with security updates.  Only the last point release of
+each supported major release version will have the latest security fixes:
+
+  <https://bitcoincore.org/en/lifecycle/#schedule>
+
 How to Upgrade
 ==============
 


### PR DESCRIPTION
Currently the release notes template does not link to the EOL policy. Not sure if anyone still isn't aware of it, but I guess it can't hurt to link to it from the release notes.