### PR TITLE
Fee Estimation: change `estimatesmartfee` default mode to `economical`

### DIFF
--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -36,7 +36,7 @@ static RPCHelpMan estimatesmartfee()
         "in BIP 141 (witness data is discounted).\n",
         {
             {"conf_target", RPCArg::Type::NUM, RPCArg::Optional::NO, "Confirmation target in blocks (1 - 1008)"},
-            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"conservative"}, "The fee estimate mode.\n"
+            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"economical"}, "The fee estimate mode.\n"
             "Whether to return a more conservative estimate which also satisfies\n"
             "a longer history. A conservative estimate potentially returns a\n"
             "higher feerate and is more likely to be sufficient for the desired\n"
@@ -71,13 +71,13 @@ static RPCHelpMan estimatesmartfee()
             CHECK_NONFATAL(mempool.m_opts.signals)->SyncWithValidationInterfaceQueue();
             unsigned int max_target = fee_estimator.HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
             unsigned int conf_target = ParseConfirmTarget(request.params[0], max_target);
-            bool conservative = true;
+            bool conservative = false;
             if (!request.params[1].isNull()) {
                 FeeEstimateMode fee_mode;
                 if (!FeeModeFromString(request.params[1].get_str(), fee_mode)) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, InvalidEstimateModeErrorMessage());
                 }
-                if (fee_mode == FeeEstimateMode::ECONOMICAL) conservative = false;
+                if (fee_mode == FeeEstimateMode::CONSERVATIVE) conservative = true;
             }
 
             UniValue result(UniValue::VOBJ);


### PR DESCRIPTION
Fixes #30009

This PR changes the `estimatesmartfee` default mode to `economical`. 

This was also suggested on IRC https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2024-04-26#1021609

- `conservative` mode: This is the `estimatesmartfee` RPC mode which considers a longer history of blocks. It potentially returns a higher fee rate and is more likely to be sufficient for the desired target, but it is not as responsive to short-term drops in the prevailing fee market.
- `economical` mode: This is the `estimatesmartfee` RPC mode where estimates are potentially lower and more responsive to short-term drops in the prevailing fee market.


Since users are likely to use the default mode, this change will reduce overestimation for many users. The conservative mode remains available for those who wish to opt-in.

For an in-depth analysis of how significantly the `conservative` mode overestimates, see 
https://delvingbitcoin.org/t/bitcoind-policy-estimator-modes-analysis/964.