### PR TITLE
test: cover more errors for `signrawtransactionwithkey` RPC

### DIFF
--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -126,10 +126,20 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         privkeys = [self.nodes[0].get_deterministic_priv_key().key]
         assert_raises_rpc_error(-8, "'all' is not a valid sighash parameter.", self.nodes[0].signrawtransactionwithkey, tx, privkeys, sighashtype="all")
 
+    def invalid_private_key_and_tx(self):
+        self.log.info("Test signing transaction with an invalid private key")
+        tx = self.nodes[0].createrawtransaction(INPUTS, OUTPUTS)
+        privkeys = ["123"]
+        assert_raises_rpc_error(-5, "Invalid private key", self.nodes[0].signrawtransactionwithkey, tx, privkeys)
+        self.log.info("Test signing transaction with an invalid tx hex")
+        privkeys = [self.nodes[0].get_deterministic_priv_key().key]
+        assert_raises_rpc_error(-22, "TX decode failed. Make sure the tx has at least one input.", self.nodes[0].signrawtransactionwithkey, tx + "00", privkeys)
+
     def run_test(self):
         self.successful_signing_test()
         self.witness_script_test()
         self.invalid_sighashtype_test()
+        self.invalid_private_key_and_tx()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds test coverage for the following errors for the `signrawtransactionwithkey` RPC:

- Invalid private key
- TX decode failed

For reference: https://maflcko.github.io/b-c-cov/total.coverage/src/rpc/rawtransaction.cpp.gcov.html