### PR TITLE
cluster mempool: merging & postprocessing of linearizations

### DIFF
--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -169,6 +169,17 @@ void BenchLinearizeNoItersWorstCaseLIMO(ClusterIndex ntx, benchmark::Bench& benc
     });
 }
 
+template<typename SetType>
+void BenchPostLinearizeWorstCase(ClusterIndex ntx, benchmark::Bench& bench)
+{
+    DepGraph<SetType> depgraph = MakeWideGraph<SetType>(ntx);
+    std::vector<ClusterIndex> lin(ntx);
+    bench.run([&] {
+        for (ClusterIndex i = 0; i < ntx; ++i) lin[i] = i;
+        PostLinearize(depgraph, lin);
+    });
+}
+
 } // namespace
 
 static void LinearizePerIter16TxWorstCase(benchmark::Bench& bench) { BenchLinearizePerIterWorstCase<BitSet<16>>(16, bench); }
@@ -192,6 +203,13 @@ static void LinearizeNoIters64TxWorstCaseLIMO(benchmark::Bench& bench) { BenchLi
 static void LinearizeNoIters75TxWorstCaseLIMO(benchmark::Bench& bench) { BenchLinearizeNoItersWorstCaseLIMO<BitSet<75>>(75, bench); }
 static void LinearizeNoIters99TxWorstCaseLIMO(benchmark::Bench& bench) { BenchLinearizeNoItersWorstCaseLIMO<BitSet<99>>(99, bench); }
 
+static void PostLinearize16TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<16>>(16, bench); }
+static void PostLinearize32TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<32>>(32, bench); }
+static void PostLinearize48TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<48>>(48, bench); }
+static void PostLinearize64TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<64>>(64, bench); }
+static void PostLinearize75TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<75>>(75, bench); }
+static void PostLinearize99TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<99>>(99, bench); }
+
 BENCHMARK(LinearizePerIter16TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizePerIter32TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizePerIter48TxWorstCase, benchmark::PriorityLevel::HIGH);
@@ -212,3 +230,10 @@ BENCHMARK(LinearizeNoIters48TxWorstCaseLIMO, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizeNoIters64TxWorstCaseLIMO, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizeNoIters75TxWorstCaseLIMO, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizeNoIters99TxWorstCaseLIMO, benchmark::PriorityLevel::HIGH);
+
+BENCHMARK(PostLinearize16TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(PostLinearize32TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(PostLinearize48TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(PostLinearize64TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(PostLinearize75TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(PostLinearize99TxWorstCase, benchmark::PriorityLevel::HIGH);

--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -180,6 +180,27 @@ void BenchPostLinearizeWorstCase(ClusterIndex ntx, benchmark::Bench& bench)
     });
 }
 
+template<typename SetType>
+void BenchMergeLinearizationsWorstCase(ClusterIndex ntx, benchmark::Bench& bench)
+{
+    DepGraph<SetType> depgraph;
+    for (ClusterIndex i = 0; i < ntx; ++i) {
+        depgraph.AddTransaction({i, 1});
+        if (i) depgraph.AddDependency(0, i);
+    }
+    std::vector<ClusterIndex> lin1;
+    std::vector<ClusterIndex> lin2;
+    lin1.push_back(0);
+    lin2.push_back(0);
+    for (ClusterIndex i = 1; i < ntx; ++i) {
+        lin1.push_back(i);
+        lin2.push_back(ntx - i);
+    }
+    bench.run([&] {
+        MergeLinearizations(depgraph, lin1, lin2);
+    });
+}
+
 } // namespace
 
 static void LinearizePerIter16TxWorstCase(benchmark::Bench& bench) { BenchLinearizePerIterWorstCase<BitSet<16>>(16, bench); }
@@ -210,6 +231,13 @@ static void PostLinearize64TxWorstCase(benchmark::Bench& bench) { BenchPostLinea
 static void PostLinearize75TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<75>>(75, bench); }
 static void PostLinearize99TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<99>>(99, bench); }
 
+static void MergeLinearizations16TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<16>>(16, bench); }
+static void MergeLinearizations32TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<32>>(32, bench); }
+static void MergeLinearizations48TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<48>>(48, bench); }
+static void MergeLinearizations64TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<64>>(64, bench); }
+static void MergeLinearizations75TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<75>>(75, bench); }
+static void MergeLinearizations99TxWorstCase(benchmark::Bench& bench) { BenchMergeLinearizationsWorstCase<BitSet<99>>(99, bench); }
+
 BENCHMARK(LinearizePerIter16TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizePerIter32TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LinearizePerIter48TxWorstCase, benchmark::PriorityLevel::HIGH);
@@ -237,3 +265,10 @@ BENCHMARK(PostLinearize48TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(PostLinearize64TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(PostLinearize75TxWorstCase, benchmark::PriorityLevel::HIGH);
 BENCHMARK(PostLinearize99TxWorstCase, benchmark::PriorityLevel::HIGH);
+
+BENCHMARK(MergeLinearizations16TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MergeLinearizations32TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MergeLinearizations48TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MergeLinearizations64TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MergeLinearizations75TxWorstCase, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MergeLinearizations99TxWorstCase, benchmark::PriorityLevel::HIGH);

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -122,6 +122,8 @@ public:
     auto TxCount() const noexcept { return entries.size(); }
     /** Get the feerate of a given transaction i. Complexity: O(1). */
     const FeeFrac& FeeRate(ClusterIndex i) const noexcept { return entries[i].feerate; }
+    /** Get the mutable feerate of a given transaction i. Complexity: O(1). */
+    FeeFrac& FeeRate(ClusterIndex i) noexcept { return entries[i].feerate; }
     /** Get the ancestors of a given transaction i. Complexity: O(1). */
     const SetType& Ancestors(ClusterIndex i) const noexcept { return entries[i].ancestors; }
     /** Get the descendants of a given transaction i. Complexity: O(1). */
@@ -780,6 +782,207 @@ std::pair<std::vector<ClusterIndex>, bool> Linearize(const DepGraph<SetType>& de
     }
 
     return {std::move(linearization), optimal};
+}
+
+/** Improve a given linearization.
+ *
+ * @param[in]     depgraph       Dependency graph of the cluster being linearized.
+ * @param[in,out] linearization  On input, an existing linearization for depgraph. On output, a
+ *                               potentially better linearization for the same graph.
+ *
+ * Postlinearization guarantees:
+ * - The resulting chunks are connected.
+ * - If the input has a tree shape (either all transactions have at most one child, or all
+ *   transactions have at most one parent), the result is optimal.
+ * - Given a linearization L1 and a leaf transaction T in it. Let L2 be L1 with T moved to the end,
+ *   optionally with its fee increased. Let L3 be the postlinearization of L2. L3 will be at least
+ *   as good as L1. This means that replacing transactions with same-size higher-fee transactions
+ *   will not worsen linearizations through a "drop conflicts, append new transactions,
+ *   postlinearize" process.
+ */
+template<typename SetType>
+void PostLinearize(const DepGraph<SetType>& depgraph, Span<ClusterIndex> linearization)
+{
+    // This algorithm performs a number of passes (currently 2); the even ones operate from back to
+    // front, the odd ones from front to back. Each results in an equal-or-better linearization
+    // than the one started from.
+    // - One pass in either direction guarantees that the resulting chunks are connected.
+    // - Each direction corresponds to one shape of tree being linearized optimally (forward passes
+    //   guarantee this for graphs where each transaction has at most one child; backward passes
+    //   guarantee this for graphs where each transaction has at most one parent).
+    // - Starting with a backward pass guarantees the moved-tree property.
+    //
+    // During an odd (forward) pass, the high-level operation is:
+    // - Start with an empty list of groups L=[].
+    // - For every transaction i in the old linearization, from front to back:
+    //   - Append a new group C=[i], containing just i, to the back of L.
+    //   - While L has at least one group before C, and the group immediately before C has feerate
+    //     lower than C:
+    //     - If C depends on P:
+    //       - Merge P into C, making C the concatenation of P+C, continuing with the combined C.
+    //     - Otherwise:
+    //       - Swap P with C, continuing with the now-moved C.
+    // - The output linearization is the concatenation of the groups in L.
+    //
+    // During even (backward) passes, i iterates from the back to the front of the existing
+    // linearization, and new groups are prepended instead of appended to the list L. To enable
+    // more code reuse, both passes append groups, but during even passes the meanings of
+    // parent/child, and of high/low feerate are reversed, and the final concatenation is reversed
+    // on output.
+    //
+    // In the implementation below, the groups are represented by singly-linked lists (pointing
+    // from the back to the front), which are themselves organized in a singly-linked circular
+    // list (each group pointing to its predecessor, with a special sentinel group at the front
+    // that points back to the last group).
+    //
+    // Information about transaction t is stored in entries[t + 1], while the sentinel is in
+    // entries[0].
+
+    /** Index of the sentinel in the entries array below. */
+    static constexpr ClusterIndex SENTINEL{0};
+    /** Indicator that a group has no previous transaction. */
+    static constexpr ClusterIndex NO_PREV_TX{0};
+
+
+    /** Data structure per transaction entry. */
+    struct TxEntry
+    {
+        /** The index of the previous transaction in this group; NO_PREV_TX if this is the first
+         *  entry of a group. */
+        ClusterIndex prev_tx;
+
+        // The fields below are only used for transactions that are the last one in a group
+        // (referred to as tail transactions below).
+
+        /** Index of the first transaction in this group, possibly itself. */
+        ClusterIndex first_tx;
+        /** Index of the last transaction in the previous group. The first group (the sentinel)
+         *  points back to the last group here, making it a singly-linked circular list. */
+        ClusterIndex prev_group;
+        /** All transactions in the group. Empty for the sentinel. */
+        SetType group;
+        /** All dependencies of the group (descendants in even passes; ancestors in odd ones). */
+        SetType deps;
+        /** The combined fee/size of transactions in the group. Fee is negated in even passes. */
+        FeeFrac feerate;
+    };
+
+    // As an example, consider the state corresponding to the linearization [1,0,3,2], with
+    // groups [1,0,3] and [2], in an odd pass. The linked lists would be:
+    //
+    //                                        +-----+
+    //                                 0<-P-- | 0 S | ---\     Legend:
+    //                                        +-----+    |
+    //                                           ^       |     - digit in box: entries index
+    //             /--------------F---------+    G       |       (note: one more than tx value)
+    //             v                         \   |       |     - S: sentinel group
+    //          +-----+        +-----+        +-----+    |          (empty feerate)
+    //   0<-P-- | 2   | <--P-- | 1   | <--P-- | 4 T |    |     - T: tail transaction, contains
+    //          +-----+        +-----+        +-----+    |          fields beyond prev_tv.
+    //                                           ^       |     - P: prev_tx reference
+    //                                           G       G     - F: first_tx reference
+    //                                           |       |     - G: prev_group reference
+    //                                        +-----+    |
+    //                                 0<-P-- | 3 T | <--/
+    //                                        +-----+
+    //                                         ^   |
+    //                                         \-F-/
+    //
+    // During an even pass, the diagram above would correspond to linearization [2,3,0,1], with
+    // groups [2] and [3,0,1].
+
+    std::vector<TxEntry> entries(linearization.size() + 1);
+
+    // Perform two passes over the linearization.
+    for (int pass = 0; pass < 2; ++pass) {
+        int rev = !(pass & 1);
+        // Construct a sentinel group, identifying the start of the list.
+        entries[SENTINEL].prev_group = SENTINEL;
+        Assume(entries[SENTINEL].feerate.IsEmpty());
+
+        // Iterate over all elements in the existing linearization.
+        for (ClusterIndex i = 0; i < linearization.size(); ++i) {
+            // Even passes are from back to front; odd passes from front to back.
+            ClusterIndex idx = linearization[rev ? linearization.size() - 1 - i : i];
+            // Construct a new group containing just idx. In even passes, the meaning of
+            // parent/child and high/low feerate are swapped.
+            ClusterIndex cur_group = idx + 1;
+            entries[cur_group].group = SetType::Singleton(idx);
+            entries[cur_group].deps = rev ? depgraph.Descendants(idx): depgraph.Ancestors(idx);
+            entries[cur_group].feerate = depgraph.FeeRate(idx);
+            if (rev) entries[cur_group].feerate.fee = -entries[cur_group].feerate.fee;
+            entries[cur_group].prev_tx = NO_PREV_TX; // No previous transaction in group.
+            entries[cur_group].first_tx = cur_group; // Transaction itself is first of group.
+            // Insert the new group at the back of the groups linked list.
+            entries[cur_group].prev_group = entries[SENTINEL].prev_group;
+            entries[SENTINEL].prev_group = cur_group;
+
+            // Start merge/swap cycle.
+            ClusterIndex next_group = SENTINEL; // We inserted at the end, so next group is sentinel.
+            ClusterIndex prev_group = entries[cur_group].prev_group;
+            // Continue as long as the current group has higher feerate than the previous one.
+            while (entries[cur_group].feerate >> entries[prev_group].feerate) {
+                // prev_group/cur_group/next_group refer to (the last transactions of) 3
+                // consecutive entries in groups list.
+                Assume(cur_group == entries[next_group].prev_group);
+                Assume(prev_group == entries[cur_group].prev_group);
+                // The sentinel has empty feerate, which is neither higher or lower than other
+                // feerates. Thus, the while loop we are in here guarantees that cur_group and
+                // prev_group are not the sentinel.
+                Assume(cur_group != SENTINEL);
+                Assume(prev_group != SENTINEL);
+                if (entries[cur_group].deps.Overlaps(entries[prev_group].group)) {
+                    // There is a dependency between cur_group and prev_group; merge prev_group
+                    // into cur_group. The group/deps/feerate fields of prev_group remain unchanged
+                    // but become unused.
+                    entries[cur_group].group |= entries[prev_group].group;
+                    entries[cur_group].deps |= entries[prev_group].deps;
+                    entries[cur_group].feerate += entries[prev_group].feerate;
+                    // Make the first of the current group point to the tail of the previous group.
+                    entries[entries[cur_group].first_tx].prev_tx = prev_group;
+                    // The first of the previous group becomes the first of the newly-merged group.
+                    entries[cur_group].first_tx = entries[prev_group].first_tx;
+                    // The previous group becomes whatever group was before the former one.
+                    prev_group = entries[prev_group].prev_group;
+                    entries[cur_group].prev_group = prev_group;
+                } else {
+                    // There is no dependency between cur_group and prev_group; swap them.
+                    ClusterIndex preprev_group = entries[prev_group].prev_group;
+                    // If PP, P, C, N were the old preprev, prev, cur, next groups, then the new
+                    // layout becomes [PP, C, P, N]. Update prev_groups to reflect that order.
+                    entries[next_group].prev_group = prev_group;
+                    entries[prev_group].prev_group = cur_group;
+                    entries[cur_group].prev_group = preprev_group;
+                    // The current group remains the same, but the groups before/after it have
+                    // changed.
+                    next_group = prev_group;
+                    prev_group = preprev_group;
+                }
+            }
+        }
+
+        // Convert the entries back to linearization (overwriting the existing one).
+        ClusterIndex cur_group = entries[0].prev_group;
+        ClusterIndex done = 0;
+        while (cur_group != SENTINEL) {
+            ClusterIndex cur_tx = cur_group;
+            // Traverse the transactions of cur_group (from back to front), and write them in the
+            // same order during odd passes, and reversed (front to back) in even passes.
+            if (rev) {
+                do {
+                    *(linearization.begin() + (done++)) = cur_tx - 1;
+                    cur_tx = entries[cur_tx].prev_tx;
+                } while (cur_tx != NO_PREV_TX);
+            } else {
+                do {
+                    *(linearization.end() - (++done)) = cur_tx - 1;
+                    cur_tx = entries[cur_tx].prev_tx;
+                } while (cur_tx != NO_PREV_TX);
+            }
+            cur_group = entries[cur_group].prev_group;
+        }
+        Assume(done == linearization.size());
+    }
 }
 
 } // namespace cluster_linearize

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -333,12 +333,12 @@ public:
      *  of the linearization that has a feerate not below subset's.
      *
      * This is a crucial operation in guaranteeing improvements to linearizations. If subset has
-     * a feerate not below GetChunk(0)'s, then moving Intersect(subset) to the front of (what
-     * remains of) the linearization is guaranteed not to make it worse at any point.
+     * a feerate not below GetChunk(0)'s, then moving IntersectPrefixes(subset) to the front of
+     * (what remains of) the linearization is guaranteed not to make it worse at any point.
      *
      * See https://delvingbitcoin.org/t/introduction-to-cluster-linearization/1032 for background.
      */
-    SetInfo<SetType> Intersect(const SetInfo<SetType>& subset) const noexcept
+    SetInfo<SetType> IntersectPrefixes(const SetInfo<SetType>& subset) const noexcept
     {
         Assume(subset.transactions.IsSubsetOf(m_todo));
         SetInfo<SetType> accumulator;
@@ -719,7 +719,7 @@ std::pair<std::vector<ClusterIndex>, bool> Linearize(const DepGraph<SetType>& de
             // sure we don't pick something that makes us unable to reach further diagram points
             // of the old linearization.
             if (old_chunking.NumChunksLeft() > 0) {
-                best = old_chunking.Intersect(best);
+                best = old_chunking.IntersectPrefixes(best);
             }
         }
 

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -929,3 +929,29 @@ FUZZ_TARGET(clusterlin_postlinearize_moved_leaf)
     auto cmp = CompareChunks(new_chunking, old_chunking);
     assert(cmp >= 0);
 }
+
+FUZZ_TARGET(clusterlin_merge)
+{
+    // Construct an arbitrary graph from the fuzz input.
+    SpanReader reader(buffer);
+    DepGraph<TestBitSet> depgraph;
+    try {
+        reader >> Using<DepGraphFormatter>(depgraph);
+    } catch (const std::ios_base::failure&) {}
+
+    // Retrieve two linearizations from the fuzz input.
+    auto lin1 = ReadLinearization(depgraph, reader);
+    auto lin2 = ReadLinearization(depgraph, reader);
+
+    // Merge the two.
+    auto lin_merged = MergeLinearizations(depgraph, lin1, lin2);
+
+    // Compute chunkings and compare.
+    auto chunking1 = ChunkLinearization(depgraph, lin1);
+    auto chunking2 = ChunkLinearization(depgraph, lin2);
+    auto chunking_merged = ChunkLinearization(depgraph, lin_merged);
+    auto cmp1 = CompareChunks(chunking_merged, chunking1);
+    assert(cmp1 >= 0);
+    auto cmp2 = CompareChunks(chunking_merged, chunking2);
+    assert(cmp2 >= 0);
+}

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -560,10 +560,10 @@ FUZZ_TARGET(clusterlin_linearization_chunking)
         }
         assert(combined == todo);
 
-        // Verify the expected properties of LinearizationChunking::Intersect:
-        auto intersect = chunking.Intersect(subset);
+        // Verify the expected properties of LinearizationChunking::IntersectPrefixes:
+        auto intersect = chunking.IntersectPrefixes(subset);
         // - Intersecting again doesn't change the result.
-        assert(chunking.Intersect(intersect) == intersect);
+        assert(chunking.IntersectPrefixes(intersect) == intersect);
         // - The intersection is topological.
         TestBitSet intersect_anc;
         for (auto idx : intersect.transactions) {


### PR DESCRIPTION
Part of cluster mempool: #30289 

Depends on #30126, and was split off from it. #28676 depends on this.

This adds the algorithms for merging & postprocessing linearizations.

The `PostLinearize(depgraph, linearization)` function performs an in-place improvement of `linearization`, using two iterations of the [Linearization post-processing](https://delvingbitcoin.org/t/linearization-post-processing-o-n-2-fancy-chunking/201/8) algorithm. The first running from back to front, the second from front to back.

The `MergeLinearizations(depgraph, linearization1, linearization2)` function computes a new linearization for the provided cluster, given two existing linearizations for that cluster, which is at least as good as both inputs. The algorithm is described at a high level in [merging incomparable linearizations](https://delvingbitcoin.org/t/merging-incomparable-linearizations/209).

For background and references, see [Introduction to cluster linearization](https://delvingbitcoin.org/t/introduction-to-cluster-linearization/1032).