### PR TITLE
macOS: rewrite some docs & swap `mmacosx-version-min` for `mmacos-version-min`

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -56,30 +56,22 @@ The `sha256sum` should be `c0c2e7bb92c1fee0c4e9f3a485e4530786732d6c6dd9e9f418c28
 
 ## Deterministic macOS App Notes
 
-macOS Applications are created in Linux using a recent LLVM.
+macOS Applications are created on Linux using a recent LLVM.
 
-Apple uses `clang` extensively for development and has upstreamed the necessary
-functionality so that a vanilla clang can take advantage. It supports the use of `-F`,
-`-target`, `-mmacosx-version-min`, and `-isysroot`, which are all necessary when
-building for macOS.
+All builds must target an Apple SDK. These SDKs are free to download, but not redistributable.
+See the SDK Extraction notes above for how to obtain it.
 
-To complicate things further, all builds must target an Apple SDK. These SDKs are free to
-download, but not redistributable. See the SDK Extraction notes above for how to obtain it.
+The Guix build process has been designed to avoid including the SDK's files in Guix's outputs.
+All interim tarballs are fully deterministic and may be freely redistributed.
 
-The Guix process builds 2 sets of files: Linux tools, then Apple binaries which are
-created using these tools. The build process has been designed to avoid including the
-SDK's files in Guix's outputs. All interim tarballs are fully deterministic and may be freely
-redistributed.
-
-As of OS X 10.9 Mavericks, using an Apple-blessed key to sign binaries is a requirement in
-order to satisfy the new Gatekeeper requirements. Because this private key cannot be
-shared, we'll have to be a bit creative in order for the build process to remain somewhat
-deterministic. Here's how it works:
+Using an Apple-blessed key to sign binaries is a requirement to produce (distributable) macOS
+binaries. Because this private key cannot be shared, we'll have to be a bit creative in order
+for the build process to remain somewhat deterministic. Here's how it works:
 
 - Builders use Guix to create an unsigned release. This outputs an unsigned ZIP which
-  users may choose to bless and run. It also outputs an unsigned app structure in the form
-  of a tarball.
+  users may choose to bless, self-codesign, and run. It also outputs an unsigned app structure
+  in the form of a tarball.
 - The Apple keyholder uses this unsigned app to create a detached signature, using the
-  script that is also included there. Detached signatures are available from this [repository](https://github.com/bitcoin-core/bitcoin-detached-sigs).
-- Builders feed the unsigned app + detached signature back into Guix. It uses the
-  pre-built tools to recombine the pieces into a deterministic ZIP.
+  included script. Detached signatures are available from this [repository](https://github.com/bitcoin-core/bitcoin-detached-sigs).
+- Builders feed the unsigned app + detached signature back into Guix, which combines the
+  pieces into a deterministic ZIP.

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -65,8 +65,8 @@ darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
                -iwithsysroot/usr/include/c++/v1 \
                -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
 
-darwin_CFLAGS=-pipe -std=$(C_STANDARD) -mmacosx-version-min=$(OSX_MIN_VERSION)
-darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD) -mmacosx-version-min=$(OSX_MIN_VERSION)
+darwin_CFLAGS=-pipe -std=$(C_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION)
+darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION)
 darwin_LDFLAGS=-Wl,-platform_version,macos,$(OSX_MIN_VERSION),$(OSX_SDK_VERSION)
 
 ifneq ($(build_os),darwin)


### PR DESCRIPTION
Whilst `-mmacosx-version-min` and `-mmacos-version-min` remain aliases for each other, the later is preferred,
and I assume the former will be removed at some point in the future; see: https://github.com/llvm/llvm-project/pull/95374.

Somewhat of a followup to #21778. Rewrite some of the mac deploy docs.