### PR TITLE
Always show 100% verification progress when done

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4712,6 +4712,8 @@ VerifyDBResult CVerifyDB::VerifyDB(
         }
     }
 
+    LogPrintf("Verification progress: 100%%\n");
+
     LogPrintf("Verification: No coin database inconsistencies in last %i blocks (%i transactions)\n", block_count, nGoodTransactions);
 
     if (skipped_l3_checks) {


### PR DESCRIPTION
External software/scripts may monitor Bitcoin Core's verification progress in debug.log.
Now these have to scan for "No coin database inconsistencies" to see if the verification progress has finished. It's cleaner to always show 100% when the verification progress has finished (without encountering any problems). If I remember correctly this was the case in older versions of Bitcoin Core.

NOW:

```
2024-06-16T09:12:03Z Verification progress: 0%
2024-06-16T09:12:55Z Verification progress: 16%
2024-06-16T09:13:11Z Verification progress: 33%
2024-06-16T09:13:19Z Verification progress: 50%
2024-06-16T09:13:23Z Verification progress: 66%
2024-06-16T09:13:25Z Verification progress: 83%
2024-06-16T09:13:27Z Verification progress: 99%
2024-06-16T09:13:27Z Verification: No coin database inconsistencies in last 6 blocks (39935 transactions)
```

NEW:

```
2024-06-16T09:12:03Z Verification progress: 0%
2024-06-16T09:12:55Z Verification progress: 16%
2024-06-16T09:13:11Z Verification progress: 33%
2024-06-16T09:13:19Z Verification progress: 50%
2024-06-16T09:13:23Z Verification progress: 66%
2024-06-16T09:13:25Z Verification progress: 83%
2024-06-16T09:13:27Z Verification progress: 99%
2024-06-16T09:13:27Z Verification progress: 100%
2024-06-16T09:13:27Z Verification: No coin database inconsistencies in last 6 blocks (39935 transactions)
```
