### PR TITLE
fuzz: Fix wallet_bdb_parser 32-bit unhandled fseek error

### DIFF
--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -63,6 +63,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
 #endif
         if (error.original.starts_with("AutoFile::ignore: end of file") ||
             error.original.starts_with("AutoFile::read: end of file") ||
+            error.original.starts_with("AutoFile::seek: ") ||
             error.original == "Not a BDB file" ||
             error.original == "Unexpected page type, should be 9 (BTree Metadata)" ||
             error.original == "Unexpected database flags, should only be 0x20 (subdatabases)" ||


### PR DESCRIPTION
`std::fseek` on 64-bit past the end of the file may work fine (the following read would fail). However, on 32-bit it may fail early.

Fix it, by ignoring the error, treating it similar to a read error.

This was found by OSS-Fuzz.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69414