### PR TITLE
WIP: Simplify SipHash

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -190,9 +190,19 @@ static void SHA512(benchmark::Bench& bench)
 static void SipHash_32b(benchmark::Bench& bench)
 {
     uint256 x;
-    uint64_t k1 = 0;
+    uint64_t k0 = 0, k1 = 0;
     bench.run([&] {
-        *((uint64_t*)x.begin()) = SipHashUint256(0, ++k1, x);
+        SipHashUint256(++k0, ++k1, x);
+    });
+}
+
+static void SipHash_32b_Extra(benchmark::Bench& bench)
+{
+    uint256 x;
+    uint64_t k0 = 0, k1 = 0;
+    uint32_t extra = 42;
+    bench.run([&] {
+        SipHashUint256Extra(++k0, ++k1, x, ++extra);
     });
 }
 
@@ -270,6 +280,7 @@ BENCHMARK(SHA256_32b_SSE4, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256_32b_AVX2, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256_32b_SHANI, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SipHash_32b, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SipHash_32b_Extra, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_STANDARD, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_SSE4, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_AVX2, benchmark::PriorityLevel::HIGH);

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -6,14 +6,15 @@
 
 #include <bit>
 
-#define SIPROUND do { \
-    v0 += v1; v1 = std::rotl(v1, 13); v1 ^= v0; \
-    v0 = std::rotl(v0, 32); \
-    v2 += v3; v3 = std::rotl(v3, 16); v3 ^= v2; \
-    v0 += v3; v3 = std::rotl(v3, 21); v3 ^= v0; \
-    v2 += v1; v1 = std::rotl(v1, 17); v1 ^= v2; \
-    v2 = std::rotl(v2, 32); \
-} while (0)
+inline static void SipRound(uint64_t (&v)[4])
+{
+    v[0] += v[1]; v[1] = std::rotl(v[1], 13); v[1] ^= v[0];
+    v[0] = std::rotl(v[0], 32);
+    v[2] += v[3]; v[3] = std::rotl(v[3], 16); v[3] ^= v[2];
+    v[0] += v[3]; v[3] = std::rotl(v[3], 21); v[3] ^= v[0];
+    v[2] += v[1]; v[1] = std::rotl(v[1], 17); v[1] ^= v[2];
+    v[2] = std::rotl(v[2], 32);
+}
 
 CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
 {
@@ -27,19 +28,12 @@ CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
 
 CSipHasher& CSipHasher::Write(uint64_t data)
 {
-    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
-
     assert(count % 8 == 0);
 
-    v3 ^= data;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= data;
-
-    v[0] = v0;
-    v[1] = v1;
-    v[2] = v2;
-    v[3] = v3;
+    v[3] ^= data;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= data;
 
     count += 8;
     return *this;
@@ -47,7 +41,6 @@ CSipHasher& CSipHasher::Write(uint64_t data)
 
 CSipHasher& CSipHasher::Write(Span<const unsigned char> data)
 {
-    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
     uint64_t t = tmp;
     uint8_t c = count;
 
@@ -55,19 +48,15 @@ CSipHasher& CSipHasher::Write(Span<const unsigned char> data)
         t |= uint64_t{data.front()} << (8 * (c % 8));
         c++;
         if ((c & 7) == 0) {
-            v3 ^= t;
-            SIPROUND;
-            SIPROUND;
-            v0 ^= t;
+            v[3] ^= t;
+            SipRound(v);
+            SipRound(v);
+            v[0] ^= t;
             t = 0;
         }
         data = data.subspan(1);
     }
 
-    v[0] = v0;
-    v[1] = v1;
-    v[2] = v2;
-    v[3] = v3;
     count = c;
     tmp = t;
 
@@ -76,99 +65,99 @@ CSipHasher& CSipHasher::Write(Span<const unsigned char> data)
 
 uint64_t CSipHasher::Finalize() const
 {
-    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
+    uint64_t v_final[] = {v[0], v[1], v[2], v[3]};
 
-    uint64_t t = tmp | (((uint64_t)count) << 56);
+    uint64_t t = tmp | (((uint64_t) count) << 56);
 
-    v3 ^= t;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= t;
-    v2 ^= 0xFF;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    return v0 ^ v1 ^ v2 ^ v3;
+    v_final[3] ^= t;
+    SipRound(v_final);
+    SipRound(v_final);
+    v_final[0] ^= t;
+    v_final[2] ^= 0xFF;
+    SipRound(v_final);
+    SipRound(v_final);
+    SipRound(v_final);
+    SipRound(v_final);
+    return v_final[0] ^ v_final[1] ^ v_final[2] ^ v_final[3];
 }
 
+/* Specialized implementation for efficiency */
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val)
 {
-    /* Specialized implementation for efficiency */
+    uint64_t v[] = {
+        0x736f6d6570736575ULL ^ k0, 0x646f72616e646f6dULL ^ k1,
+        0x6c7967656e657261ULL ^ k0, 0x7465646279746573ULL ^ k1
+    };
+
     uint64_t d = val.GetUint64(0);
-
-    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
-    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
-    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
-    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
-
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(1);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(2);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(3);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
-    v3 ^= (uint64_t{4}) << 59;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= (uint64_t{4}) << 59;
-    v2 ^= 0xFF;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    return v0 ^ v1 ^ v2 ^ v3;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
+    v[3] ^= (uint64_t{4}) << 59;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= (uint64_t{4}) << 59;
+    v[2] ^= 0xFF;
+    SipRound(v);
+    SipRound(v);
+    SipRound(v);
+    SipRound(v);
+    return v[0] ^ v[1] ^ v[2] ^ v[3];
 }
 
+/* Specialized implementation for efficiency */
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra)
 {
-    /* Specialized implementation for efficiency */
+    uint64_t v[] = {
+        0x736f6d6570736575ULL ^ k0, 0x646f72616e646f6dULL ^ k1,
+        0x6c7967656e657261ULL ^ k0, 0x7465646279746573ULL ^ k1
+    };
+
     uint64_t d = val.GetUint64(0);
-
-    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
-    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
-    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
-    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
-
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(1);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(2);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = val.GetUint64(3);
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
     d = ((uint64_t{36}) << 56) | extra;
-    v3 ^= d;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= d;
-    v2 ^= 0xFF;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    return v0 ^ v1 ^ v2 ^ v3;
+    v[3] ^= d;
+    SipRound(v);
+    SipRound(v);
+    v[0] ^= d;
+    v[2] ^= 0xFF;
+    SipRound(v);
+    SipRound(v);
+    SipRound(v);
+    SipRound(v);
+    return v[0] ^ v[1] ^ v[2] ^ v[3];
 }


### PR DESCRIPTION
WIP, not finished yet.

Profiling `./bitcoind -reindex-chainstate -checkblocks=10000` revealed that hashing is a bottleneck:
<img src="https://github.com/bitcoin/bitcoin/assets/1841944/8fa91d78-a5f0-4f4e-a281-f3ff1548b536">

I tried optimizing it, but the benchmark seemed off, it showed a 10% speedup which didn't replicate on CI - so I unified the bechmark to follow the format of other ones, which seems to have fixed the inconsistent behavior.

I didn't end up optimizing the code (has the exact same speed as before), but if I've already simplified it, I'll push it anyway.