### PR TITLE
[26.x] upnp: fix build with miniupnpc 2.2.8

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,6 +61,7 @@ Notable changes
 - #29747: depends: fix mingw-w64 Qt DEBUG=1 build
 - #29985: depends: Fix build of Qt for 32-bit platforms with recent glibc
 - #30151: depends: Fetch miniupnpc sources from an alternative website
+- #30283: upnp: fix build with miniupnpc 2.2.8
 
 ### Misc
 
@@ -76,6 +77,7 @@ Thanks to everyone who directly contributed to this release:
 
 - Antoine Poinsot
 - Ava Chow
+- Cory Fields
 - dergoegge
 - fanquake
 - glozow

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -163,8 +163,11 @@ static bool ProcessUpnp()
     struct UPNPUrls urls;
     struct IGDdatas data;
     int r;
-
+#if MINIUPNPC_API_VERSION <= 17
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#endif
     if (r == 1)
     {
         if (fDiscover) {


### PR DESCRIPTION
Backports https://github.com/bitcoin/bitcoin/pull/30283 to the 26.x branch.