### PR TITLE
test: raise an error in `_bulk_tx_` when `target_vsize` is too low

### DIFF
--- a/test/functional/feature_framework_miniwallet.py
+++ b/test/functional/feature_framework_miniwallet.py
@@ -29,8 +29,11 @@ class FeatureFrameworkMiniWalletTest(BitcoinTestFramework):
             utxo = wallet.get_utxo(mark_as_spent=False)
             for target_vsize in [250, 500, 1250, 2500, 5000, 12500, 25000, 50000, 1000000,
                                  248, 501, 1085, 3343, 5805, 12289, 25509, 55855,  999998]:
-                tx = wallet.create_self_transfer(utxo_to_spend=utxo, target_vsize=target_vsize)["tx"]
-                assert_equal(tx.get_vsize(), target_vsize)
+                tx = wallet.create_self_transfer(utxo_to_spend=utxo, target_vsize=target_vsize)
+                assert_equal(tx['tx'].get_vsize(), target_vsize)
+                child_tx = wallet.create_self_transfer_multi(utxos_to_spend=[tx["new_utxo"]], target_vsize=target_vsize)
+                assert_equal(child_tx['tx'].get_vsize(), target_vsize)
+
 
     def test_wallet_tagging(self):
         """Verify that tagged wallet instances are able to send funds."""

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -121,6 +121,9 @@ class MiniWallet:
         """Pad a transaction with extra outputs until it reaches a target vsize.
         returns the tx
         """
+        if target_vsize < tx.get_vsize():
+            raise RuntimeError(f"target_vsize {target_vsize} is less than transaction virtual size {tx.get_vsize()}")
+
         tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN])))
         # determine number of needed padding bytes
         dummy_vbytes = target_vsize - tx.get_vsize()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -378,7 +378,8 @@ class MiniWallet:
         if target_vsize and not fee:  # respect fee_rate if target vsize is passed
             fee = get_fee(target_vsize, fee_rate)
         send_value = utxo_to_spend["value"] - (fee or (fee_rate * vsize / 1000))
-
+        if send_value <= 0:
+            raise RuntimeError(f"UTXO value {utxo_to_spend['value']} is too small to cover fees {(fee or (fee_rate * vsize / 1000))}")
         # create tx
         tx = self.create_self_transfer_multi(
             utxos_to_spend=[utxo_to_spend],


### PR DESCRIPTION
This is a simple test PR that does two things:

1. Raise an exception in `_bulk_tx_` when `target_vsize` is too low, i.e., below the tx vsize.
2. Addresses some review comments from https://github.com/bitcoin/bitcoin/pull/30162, which are:
   - Raise an error if the output value is less than or equal to zero in `create_self_transfer`.
	This prevents creating transactions with a value of 0 or less.
   - Add a test to verify that `create_self_transfer_multi` also respects the passed `target_vsize`.
