### PR TITLE
optimization: Switch CTxMemPool::CalculateDescendants from set to vector to reduce transaction hash calculations

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -544,13 +544,12 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
     std::vector<txiter> stage{entryit};
     while (!stage.empty()) {
         txiter it = stage.back();
-        setDescendants.insert(it);
         stage.pop_back();
 
         const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
         for (const CTxMemPoolEntry& child : children) {
             txiter childiter = mapTx.iterator_to(child);
-            if (!setDescendants.count(childiter)) {
+            if (setDescendants.insert(childiter).second) {
                 stage.emplace_back(childiter);
             }
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -537,20 +537,16 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // can save time by not iterating over those entries.
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
 {
-    if (!setDescendants.insert(entryit).second) {
-        return;
-    }
-
-    std::vector<txiter> stage{entryit};
-    while (!stage.empty()) {
-        txiter it = stage.back();
-        stage.pop_back();
-
-        const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
-        for (const CTxMemPoolEntry& child : children) {
-            txiter childiter = mapTx.iterator_to(child);
-            if (setDescendants.insert(childiter).second) {
-                stage.emplace_back(childiter);
+    if (setDescendants.insert(entryit).second) {
+        std::vector<txiter> stage{entryit};
+        while (!stage.empty()) {
+            const auto& children = stage.back()->GetMemPoolChildrenConst();
+            stage.pop_back();
+            for (const auto& child : children) {
+                const auto childiter = mapTx.iterator_to(child);
+                if (setDescendants.insert(childiter).second) {
+                    stage.emplace_back(childiter);
+                }
             }
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -541,22 +541,17 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
         return;
     }
 
-    setEntries stage;
-    stage.insert(entryit);
-
-    // Traverse down the children of entry, only adding children that are not
-    // accounted for in setDescendants already (because those children have either
-    // already been walked, or will be walked in this iteration).
+    std::vector<txiter> stage{entryit};
     while (!stage.empty()) {
-        txiter it = *stage.begin();
+        txiter it = stage.back();
         setDescendants.insert(it);
-        stage.erase(it);
+        stage.pop_back();
 
         const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
         for (const CTxMemPoolEntry& child : children) {
             txiter childiter = mapTx.iterator_to(child);
             if (!setDescendants.count(childiter)) {
-                stage.insert(childiter);
+                stage.emplace_back(childiter);
             }
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -537,10 +537,13 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // can save time by not iterating over those entries.
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
 {
-    setEntries stage;
-    if (setDescendants.count(entryit) == 0) {
-        stage.insert(entryit);
+    if (!setDescendants.insert(entryit).second) {
+        return;
     }
+
+    setEntries stage;
+    stage.insert(entryit);
+
     // Traverse down the children of entry, only adding children that are not
     // accounted for in setDescendants already (because those children have either
     // already been walked, or will be walked in this iteration).


### PR DESCRIPTION
Profiling `BlockAssemblerAddPackageTxns` indicated excessive hash recalculations:
<img src="https://github.com/bitcoin/bitcoin/assets/1841944/e1687162-30b5-47b6-83b3-d234cd156395">

The original implementation used a set to manage the stack of transactions for a depth-first traversal of its child transactions. However, since we're already filtering via `setDescendants` before adding them to `stage`, duplicates cannot exist anyway. Therefore, we can change it to a simple vector, providing efficient push and pop operations, eliminating the need for redundant duplicate checks and hash calculations.

Benchmarking `BlockAssemblerAddPackageTxns` locally an on CI reveals a significant speed increase - please validate it on your machine!

> ./src/bench/bench_bitcoin --filter='BlockAssemblerAddPackageTxns' --min-time=1000

before:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|      377,256,875.00 |                2.65 |    0.2% |      4.15 | `BlockAssemblerAddPackageTxns`

after:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|      275,087,833.00 |                3.64 |    0.1% |      3.02 | `BlockAssemblerAddPackageTxns`