### PR TITLE
Mining interface followups, reduce cs_main locking, test rpc bug fix

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_INTERFACES_MINING_H
 #define BITCOIN_INTERFACES_MINING_H
 
+#include <memory>
 #include <optional>
 #include <uint256.h>
 

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -67,7 +67,7 @@ public:
      * @param[in] block the block to validate
      * @param[in] check_merkle_root call CheckMerkleRoot()
      * @param[out] state details of why a block failed to validate
-     * @returns false if any of the checks fail
+     * @returns false if it does not build on the current tip, or any of the checks fail
      */
     virtual bool testBlockValidity(const CBlock& block, bool check_merkle_root, BlockValidationState& state) = 0;
 

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -45,6 +45,7 @@ public:
      * @returns a block template
      */
     virtual std::unique_ptr<node::CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool = true) = 0;
+
     /**
      * Processes new block. A valid new block is automatically relayed to peers.
      *
@@ -63,12 +64,12 @@ public:
      * Only works on top of our current best block.
      * Does not check proof-of-work.
      *
-     * @param[out] state details of why a block failed to validate
      * @param[in] block the block to validate
      * @param[in] check_merkle_root call CheckMerkleRoot()
+     * @param[out] state details of why a block failed to validate
      * @returns false if any of the checks fail
      */
-    virtual bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root = true) = 0;
+    virtual bool testBlockValidity(const CBlock& block, bool check_merkle_root, BlockValidationState& state) = 0;
 
     //! Get internal node context. Useful for RPC and testing,
     //! but not accessible across processes.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -870,7 +870,7 @@ public:
         return context()->mempool->GetTransactionsUpdated();
     }
 
-    bool testBlockValidity(BlockValidationState& state, const CBlock& block, bool check_merkle_root) override
+    bool testBlockValidity(const CBlock& block, bool check_merkle_root, BlockValidationState& state) override
     {
         LOCK(::cs_main);
         return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, chainman().ActiveChain().Tip(), /*fCheckPOW=*/false, check_merkle_root);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -872,8 +872,15 @@ public:
 
     bool testBlockValidity(const CBlock& block, bool check_merkle_root, BlockValidationState& state) override
     {
-        LOCK(::cs_main);
-        return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, chainman().ActiveChain().Tip(), /*fCheckPOW=*/false, check_merkle_root);
+        LOCK(cs_main);
+        CBlockIndex* tip{chainman().ActiveChain().Tip()};
+        // Fail if the tip updated before the lock was taken
+        if (block.hashPrevBlock != tip->GetBlockHash()) {
+            state.Error("Block does not connect to current chain tip.");
+            return false;
+        }
+
+        return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, tip, /*fCheckPOW=*/false, check_merkle_root);
     }
 
     std::unique_ptr<CBlockTemplate> createNewBlock(const CScript& script_pub_key, bool use_mempool) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -881,7 +881,6 @@ public:
         BlockAssembler::Options options;
         ApplyArgsManOptions(gArgs, options);
 
-        LOCK(::cs_main);
         return BlockAssembler{chainman().ActiveChainstate(), use_mempool ? context()->mempool.get() : nullptr, options}.CreateNewBlock(script_pub_key);
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -371,8 +371,6 @@ static RPCHelpMan generateblock()
 
     ChainstateManager& chainman = EnsureChainman(node);
     {
-        LOCK(cs_main);
-
         std::unique_ptr<CBlockTemplate> blocktemplate{miner.createNewBlock(coinbase_script, /*use_mempool=*/false)};
         if (!blocktemplate) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
@@ -387,8 +385,6 @@ static RPCHelpMan generateblock()
     RegenerateCommitments(block, chainman);
 
     {
-        LOCK(cs_main);
-
         BlockValidationState state;
         if (!miner.testBlockValidity(block, /*check_merkle_root=*/false, state)) {
             throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("testBlockValidity failed: %s", state.ToString()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -667,9 +667,7 @@ static RPCHelpMan getblocktemplate()
     ChainstateManager& chainman = EnsureChainman(node);
     Mining& miner = EnsureMining(node);
     LOCK(cs_main);
-    std::optional<uint256> maybe_tip{miner.getTipHash()};
-    CHECK_NONFATAL(maybe_tip);
-    uint256 tip{maybe_tip.value()};
+    uint256 tip{CHECK_NONFATAL(miner.getTipHash()).value()};
 
     std::string strMode = "template";
     UniValue lpval = NullUniValue;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -390,7 +390,7 @@ static RPCHelpMan generateblock()
         LOCK(cs_main);
 
         BlockValidationState state;
-        if (!miner.testBlockValidity(state, block, /*check_merkle_root=*/false)) {
+        if (!miner.testBlockValidity(block, /*check_merkle_root=*/false, state)) {
             throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("testBlockValidity failed: %s", state.ToString()));
         }
     }
@@ -713,7 +713,7 @@ static RPCHelpMan getblocktemplate()
                 return "inconclusive-not-best-prevblk";
             }
             BlockValidationState state;
-            miner.testBlockValidity(state, block);
+            miner.testBlockValidity(block, /*check_merkle_root=*/true, state);
             return BIP22ValidationResult(state);
         }
 


### PR DESCRIPTION
Followups from #30200

Fixes:
- `std::unique_ptr` needs `#include <memory>` (noticed while working on #30332, which has fewer includes than its parent PR that I originally tested with)
- Drop lock from createNewBlock that was spuriously added
- Have testBlockValidity hold cs_main instead of caller (also fixes a race condition in test-only code)

Refactor:
- Use CHECK_NONFATAL to avoid single-use symbol (refactor)
- move output argument `state` to the end of `testBlockValidity`, see https://github.com/bitcoin/bitcoin/pull/30200#discussion_r1647987176
