### PR TITLE
depends: update doc in Qt pwd patch

### DIFF
--- a/depends/patches/qt/dont_hardcode_pwd.patch
+++ b/depends/patches/qt/dont_hardcode_pwd.patch
@@ -1,13 +1,13 @@
-commit 0e953866fc4672486e29e1ba6d83b4207e7b2f0b
-Author: fanquake <fanquake@gmail.com>
-Date:   Tue Aug 18 15:09:06 2020 +0800
+Do not assume FHS in scripts
 
-    Don't hardcode pwd path
+On systems that do not follow the Filesystem Hierarchy Standard, such as
+guix, the hardcoded `/bin/pwd` will fail to be found so that the script
+will fail.
 
-    Let a man use his builtins if he wants to! Also, removes the unnecessary
-    assumption that pwd lives under /bin/pwd.
+Use `pwd`, instead, so that the command can be found through the normal
+path search mechanism.
 
-    See #15581.
+See https://github.com/qt/qtbase/commit/3388de698bfb9bbc456c08f03e83bf3e749df35c.
 
 diff --git a/qtbase/configure b/qtbase/configure
 index 08b49a8d..faea5b55 100755


### PR DESCRIPTION
Now that upstream has gotten around to fixing this. We don't need any more of the patch, and it likely wont apply to our version of Qt in any case. See: https://github.com/qt/qtbase/commit/3388de698bfb9bbc456c08f03e83bf3e749df35c.