### PR TITLE
Permit Combiner to strip bip32_deriv information

### DIFF
--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -39,8 +39,10 @@ Generally, each of the above (excluding Creator and Extractor) will simply
 add more and more data to a particular PSBT, until all inputs are fully signed.
 In a naive workflow, they all have to operate sequentially, passing the PSBT
 from one to the next, until the Extractor can convert it to a real transaction.
-In order to permit parallel operation, **Combiners** can be employed which merge
-metadata from different PSBTs for the same unsigned transaction.
+In order to permit parallel operation, **Combiners** can be employed which
+merge metadata from different PSBTs for the same unsigned transaction. They can
+also optionally remove bip32 derivation information from all inputs and outputs
+to increase privacy.
 
 The names above in bold are the names of the roles defined in BIP174. They're
 useful in understanding the underlying steps, but in practice, software and

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -69,6 +69,19 @@ bool PartiallySignedTransaction::AddOutput(const CTxOut& txout, const PSBTOutput
     return true;
 }
 
+void PartiallySignedTransaction::StripDerivationPaths()
+{
+    // Loop over the inputs and strip m_tap_bip32_paths
+    for (unsigned int i = 0; i < inputs.size(); ++i) {
+        inputs[i].hd_keypaths.clear();
+    }
+
+    // Loop over the outputs and strip m_tap_bip32_paths
+    for (unsigned int i = 0; i < outputs.size(); ++i) {
+        outputs[i].hd_keypaths.clear();
+    }
+}
+
 bool PartiallySignedTransaction::GetInputUTXO(CTxOut& utxo, int input_index) const
 {
     const PSBTInput& input = inputs[input_index];

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1136,6 +1136,7 @@ struct PartiallySignedTransaction
     bool AddInput(const CTxIn& txin, PSBTInput& psbtin);
     bool AddOutput(const CTxOut& txout, const PSBTOutput& psbtout);
     PartiallySignedTransaction() = default;
+    void StripDerivationPaths();
     explicit PartiallySignedTransaction(const CMutableTransaction& tx);
     /**
      * Finds the UTXO for a given input index

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -178,6 +178,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createpsbt", 2, "locktime" },
     { "createpsbt", 3, "replaceable" },
     { "combinepsbt", 0, "txs"},
+    { "combinepsbt", 1, "stripderivs"},
     { "joinpsbts", 0, "txs"},
     { "finalizepsbt", 1, "extract"},
     { "converttopsbt", 1, "permitsigdata"},


### PR DESCRIPTION
Closes: #30294

Looking for approach (N)ACK.

Previously setting the `bip32derivs` flag to false with the `walletprocesspsbt` RPC correctly does not include `bip32_derivs` for inputs in the PSBT, but does include `bip32_derivs` for outputs.

User may want to actively strip all bip32 derivation paths from a PSBT for privacy reasons however. It may make sense to do this after signing your inputs and outputs during a manual coinjoin as demonstrated in the [BIP174 example](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#manual-coinjoin-workflow).

To me, this makes more sense to include in the [`Combiner`](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#combiner) PSBT role. It's then separated from signing done by the `Signers`. 

Therefore add functionality to `combinepsbt` permitting stripping of **all** `bip32_derivation` paths found in all provided psbts' inputs and outputs.

As this RPC can be called with a single PSBT, it can be used to strip derivation paths from a PSBT with any number of participants.
