### PR TITLE
kernel, logging: Pass Logger instances to kernel objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.
     steps:
       - name: Determine fetch depth
-        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 1000))" >> "$GITHUB_ENV"
       - &ANNOTATION_PR_NUMBER
         name: Annotate with pull request number
         # This annotation is machine-readable and can be used to assign a check

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -789,8 +789,7 @@ While `LogInfo`, `LogWarning` and `LogError` messages should be rare,
 in case there are circumstances where they are not, those messages
 are automatically rate-limited to prevent potential disk-filling
 attacks. For the cases where this protection is undesirable,
-rate-limiting can be avoided with the `util::log::NO_RATE_LIMIT` tag, eg
-`LogInfo(util::log::NO_RATE_LIMIT, "UpdateTip: new best=%s ...",...)`.
+rate-limiting can be avoided with the `ratelimit = false` log option.
 
 ## General C++
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -792,8 +792,7 @@ While `LogInfo`, `LogWarning` and `LogError` messages should be rare,
 in case there are circumstances where they are not, those messages
 are automatically rate-limited to prevent potential disk-filling
 attacks. For the cases where this protection is undesirable,
-rate-limiting can be avoided with the `util::log::NO_RATE_LIMIT` tag, eg
-`LogInfo(util::log::NO_RATE_LIMIT, "UpdateTip: new best=%s ...",...)`.
+rate-limiting can be avoided with the `ratelimit = false` log option.
 
 ## General C++
 

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 #include <crypto/sha256.h>
+#include <logging.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <util/fs.h>
@@ -62,6 +63,7 @@ static std::vector<std::string> parseTestSetupArgs(const ArgsManager& argsman)
 
 int main(int argc, char** argv)
 {
+    BCLog::Logger logger;
     ArgsManager argsman;
     SetupBenchArgs(argsman);
     SHA256AutoDetect();

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -166,12 +166,12 @@ int main(int argc, char* argv[])
         .always_print_category_levels = true,
     };
 
-    logging_set_options(logging_options);
-
     Logger logger{std::make_unique<KernelLog>()};
+    logging_set_options(logger, logging_options);
 
     ContextOptions options{};
     ChainParams params{has_regtest_flag ? ChainType::REGTEST : ChainType::MAINNET};
+    options.SetLogger(logger);
     options.SetChainParams(params);
 
     options.SetNotifications(std::make_shared<TestKernelNotifications>());

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -16,6 +16,7 @@
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <interfaces/rpc.h>
+#include <logging.h>
 #include <netbase.h>
 #include <policy/feerate.h>
 #include <rpc/client.h>
@@ -1669,6 +1670,7 @@ static int CommandLineRPC(int argc, char *argv[])
 
 MAIN_FUNCTION
 {
+    BCLog::Logger logger;
     SetupEnvironment();
     if (!SetupNetworking()) {
         tfm::format(std::cerr, "Error: Initializing networking failed\n");

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -15,6 +15,7 @@
 #include <consensus/consensus.h>
 #include <core_io.h>
 #include <key_io.h>
+#include <logging.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -857,6 +858,7 @@ static int CommandLineRawTx(int argc, char* argv[])
 
 MAIN_FUNCTION
 {
+    BCLog::Logger logger;
     SetupEnvironment();
 
     try {

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -14,6 +14,7 @@
 #include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>
+#include <logging.h>
 #include <streams.h>
 #include <univalue.h>
 #include <util/exception.h>
@@ -212,6 +213,7 @@ static int GetChainParams(const std::vector<std::string>& args, std::string& str
 MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
+    BCLog::Logger logger;
     SetupEnvironment();
 
     try {

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -14,6 +14,7 @@
 #include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>
+#include <logging.h>
 #include <streams.h>
 #include <util/exception.h>
 #include <util/strencodings.h>
@@ -165,6 +166,7 @@ static int NetMagic(const std::vector<std::string>& args, std::string& strPrint)
 MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
+    BCLog::Logger logger;
     SetupEnvironment();
 
     try {

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -96,6 +96,8 @@ MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
 
+    BCLog::Logger logger;
+
     int exit_status;
     std::unique_ptr<interfaces::Init> init = interfaces::MakeWalletInit(argc, argv, exit_status);
     if (!init) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -15,8 +15,8 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
-#include <kernel/context.h>
 #include <logging.h>
+#include <kernel/context.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <node/warnings.h>
@@ -262,6 +262,9 @@ static bool AppInit(NodeContext& node)
 /// \anchor main
 MAIN_FUNCTION
 {
+    // Intentionally leaked! See BCLog::g_logger description for rationale.
+    new BCLog::Logger;
+
     NodeContext node;
     int exit_status;
     std::unique_ptr<interfaces::Init> init = interfaces::MakeNodeInit(node, argc, argv, exit_status);

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -214,7 +214,8 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
 
     // Check for possible mutations early now that we have a seemingly good block
     IsBlockMutatedFn check_mutated{m_check_block_mutated_mock ? m_check_block_mutated_mock : IsBlockMutated};
-    if (check_mutated(/*block=*/block, /*check_witness_root=*/segwit_active)) {
+    auto* logger = pool ? pool->m_log.logger : nullptr;
+    if (check_mutated(logger, /*block=*/block, /*check_witness_root=*/segwit_active)) {
         return READ_STATUS_FAILED; // Possible Short ID collision
     }
 

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -215,7 +215,8 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
 
     // Check for possible mutations early now that we have a seemingly good block
     IsBlockMutatedFn check_mutated{m_check_block_mutated_mock ? m_check_block_mutated_mock : IsBlockMutated};
-    if (check_mutated(/*block=*/block, /*check_witness_root=*/segwit_active)) {
+    auto* logger = pool ? pool->m_log.logger : nullptr;
+    if (check_mutated(logger, /*block=*/block, /*check_witness_root=*/segwit_active)) {
         return READ_STATUS_FAILED; // Possible Short ID collision
     }
 

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -7,6 +7,7 @@
 
 #include <crypto/siphash.h>
 #include <primitives/block.h>
+#include <util/log.h>
 
 #include <functional>
 
@@ -139,7 +140,7 @@ public:
     CBlockHeader header;
 
     // Can be overridden for testing
-    using IsBlockMutatedFn = std::function<bool(const CBlock&, bool)>;
+    using IsBlockMutatedFn = std::function<bool(util::log::Logger*, const CBlock&, bool)>;
     IsBlockMutatedFn m_check_block_mutated_mock{nullptr};
 
     explicit PartiallyDownloadedBlock(CTxMemPool* poolIn) : pool(poolIn) {}

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -34,6 +34,8 @@
 #include <optional>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
 
 bool DestroyDB(const std::string& path_str)
@@ -48,8 +50,8 @@ static void HandleError(const util::log::Context& log, const leveldb::Status& st
     if (status.ok())
         return;
     const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
-    LogError("%s", errmsg);
-    LogInfo("You can use -debug=leveldb to get more complete diagnostic messages");
+    LogError(log, "%s", errmsg);
+    LogInfo(log, "You can use -debug=leveldb to get more complete diagnostic messages");
     throw dbwrapper_error(errmsg);
 }
 
@@ -105,7 +107,7 @@ public:
 
                 assert(p <= limit);
                 base[std::min(bufsize - 1, (int)(p - base))] = '\0';
-                LogDebug(BCLog::LEVELDB, "%s\n", util::RemoveSuffixView(base, "\n"));
+                LogDebug(m_log, "%s\n", util::RemoveSuffixView(base, "\n"));
                 if (base != buffer) {
                     delete[] base;
                 }
@@ -135,7 +137,7 @@ static void SetMaxOpenFiles(const util::log::Context& log, leveldb::Options *opt
         options->max_open_files = 64;
     }
 #endif
-    LogDebug(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
+    LogDebug(log, "LevelDB using max_open_files=%d (default=%d)\n",
              options->max_open_files, default_open_files);
 }
 
@@ -241,14 +243,14 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
     }
     if (!params.memory_only) {
         if (params.wipe_data) {
-            LogInfo("Wiping LevelDB in %s", fs::PathToString(params.path));
+            LogInfo(m_log, "Wiping LevelDB in %s", fs::PathToString(params.path));
             leveldb::Status result = leveldb::DestroyDB(fs::PathToString(params.path), DBContext().options);
             HandleError(m_log, result);
         }
         if (!params.testing_env) {
             TryCreateDirectories(params.path);
         }
-        LogInfo("Opening LevelDB in %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Opening LevelDB in %s", fs::PathToString(params.path));
     }
     // PathToString() return value is safe to pass to leveldb open function,
     // because on POSIX leveldb passes the byte string directly to ::open(), and
@@ -256,12 +258,12 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
     // (see env_posix.cc and env_windows.cc).
     leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
     HandleError(m_log, status);
-    LogInfo("Opened LevelDB successfully");
+    LogInfo(m_log, "Opened LevelDB successfully");
 
     if (params.options.force_compact) {
-        LogInfo("Starting database compaction of %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Starting database compaction of %s", fs::PathToString(params.path));
         CompactFull();
-        LogInfo("Finished database compaction of %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Finished database compaction of %s", fs::PathToString(params.path));
     }
 
     if (!Read(OBFUSCATION_KEY, m_obfuscation) && params.obfuscate && IsEmpty()) {
@@ -270,9 +272,9 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
         assert(!m_obfuscation); // Make sure the key is written without obfuscation.
         Write(OBFUSCATION_KEY, obfuscation);
         m_obfuscation = obfuscation;
-        LogInfo("Wrote new obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
+        LogInfo(m_log, "Wrote new obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
     }
-    LogInfo("Using obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
+    LogInfo(m_log, "Using obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
 }
 
 CDBWrapper::~CDBWrapper()
@@ -300,7 +302,7 @@ void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     HandleError(m_log, status);
     if (log_memory) {
         double mem_after{DynamicMemoryUsage() / double(1_MiB)};
-        LogDebug(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
+        LogDebug(m_log, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
                  m_name, mem_before, mem_after);
     }
 }
@@ -317,7 +319,7 @@ size_t CDBWrapper::DynamicMemoryUsage() const
 {
     std::optional<size_t> parsed;
     if (auto memory{GetProperty("leveldb.approximate-memory-usage")}; !memory || !(parsed = ToIntegral<size_t>(*memory))) {
-        LogDebug(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
+        LogDebug(m_log, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
     return parsed.value();
@@ -331,7 +333,7 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     if (!status.ok()) {
         if (status.IsNotFound())
             return std::nullopt;
-        LogError("LevelDB read failure: %s", status.ToString());
+        LogError(m_log, "LevelDB read failure: %s", status.ToString());
         HandleError(m_log, status);
     }
     return strValue;
@@ -346,7 +348,7 @@ bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
     if (!status.ok()) {
         if (status.IsNotFound())
             return false;
-        LogError("LevelDB read failure: %s", status.ToString());
+        LogError(m_log, "LevelDB read failure: %s", status.ToString());
         HandleError(m_log, status);
     }
     return true;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -43,7 +43,7 @@ bool DestroyDB(const std::string& path_str)
 
 /** Handle database error by throwing dbwrapper_error exception.
  */
-static void HandleError(const leveldb::Status& status)
+static void HandleError(const util::log::Context& log, const leveldb::Status& status)
 {
     if (status.ok())
         return;
@@ -54,11 +54,14 @@ static void HandleError(const leveldb::Status& status)
 }
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
+private:
+    const util::log::Context m_log;
 public:
+    CBitcoinLevelDBLogger(const util::log::Context& log) : m_log{log} {}
     // This code is adapted from posix_logger.h, which is why it is using vsprintf.
     // Please do not do this in normal code
     void Logv(const char * format, va_list ap) override {
-            if (!util::log::ShouldDebugLog(BCLog::LEVELDB)) {
+            if (!util::log::ShouldDebugLog(m_log)) {
                 return;
             }
             char buffer[500];
@@ -111,7 +114,7 @@ public:
     }
 };
 
-static void SetMaxOpenFiles(leveldb::Options *options) {
+static void SetMaxOpenFiles(const util::log::Context& log, leveldb::Options *options) {
     // On most platforms the default setting of max_open_files (which is 1000)
     // is optimal. On Windows using a large file count is OK because the handles
     // do not interfere with select() loops. On 64-bit Unix hosts this value is
@@ -136,20 +139,21 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
              options->max_open_files, default_open_files);
 }
 
-static leveldb::Options GetOptions(size_t nCacheSize, bool bloom_filter)
+static leveldb::Options GetOptions(const util::log::Context& log, size_t nCacheSize, bool bloom_filter)
 {
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = bloom_filter ? leveldb::NewBloomFilterPolicy(10) : nullptr;
     options.compression = leveldb::kNoCompression;
-    options.info_log = new CBitcoinLevelDBLogger();
+    options.info_log = new CBitcoinLevelDBLogger(log);
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
         // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
         // on corruption in later versions.
         options.paranoid_checks = true;
     }
-    SetMaxOpenFiles(&options);
+    options.max_file_size = std::max(options.max_file_size, DBWRAPPER_MAX_FILE_SIZE);
+    SetMaxOpenFiles(log, &options);
     return options;
 }
 
@@ -217,15 +221,15 @@ struct LevelDBContext {
     leveldb::DB* pdb;
 };
 
-CDBWrapper::CDBWrapper(const DBParams& params)
-    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
+CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
+    : m_log{BCLog::LEVELDB, &logger}, m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;
     DBContext().iteroptions.verify_checksums = true;
     DBContext().iteroptions.fill_cache = false;
     DBContext().syncoptions.sync = true;
-    DBContext().options = GetOptions(params.cache_bytes, params.bloom_filter);
+    DBContext().options = GetOptions(m_log, params.cache_bytes, params.bloom_filter);
     DBContext().options.create_if_missing = true;
     DBContext().options.max_file_size = params.max_file_size;
     assert(!(params.testing_env && params.memory_only));
@@ -239,7 +243,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
         if (params.wipe_data) {
             LogInfo("Wiping LevelDB in %s", fs::PathToString(params.path));
             leveldb::Status result = leveldb::DestroyDB(fs::PathToString(params.path), DBContext().options);
-            HandleError(result);
+            HandleError(m_log, result);
         }
         if (!params.testing_env) {
             TryCreateDirectories(params.path);
@@ -251,7 +255,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     // on Windows it converts from UTF-8 to UTF-16 before calling ::CreateFileW
     // (see env_posix.cc and env_windows.cc).
     leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
-    HandleError(status);
+    HandleError(m_log, status);
     LogInfo("Opened LevelDB successfully");
 
     if (params.options.force_compact) {
@@ -287,13 +291,13 @@ CDBWrapper::~CDBWrapper()
 
 void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
-    const bool log_memory = util::log::ShouldDebugLog(BCLog::LEVELDB);
+    const bool log_memory{util::log::ShouldDebugLog(m_log)};
     double mem_before = 0;
     if (log_memory) {
         mem_before = DynamicMemoryUsage() / double(1_MiB);
     }
     leveldb::Status status = DBContext().pdb->Write(fSync ? DBContext().syncoptions : DBContext().writeoptions, &batch.m_impl_batch->batch);
-    HandleError(status);
+    HandleError(m_log, status);
     if (log_memory) {
         double mem_after{DynamicMemoryUsage() / double(1_MiB)};
         LogDebug(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
@@ -328,7 +332,7 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
         if (status.IsNotFound())
             return std::nullopt;
         LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        HandleError(m_log, status);
     }
     return strValue;
 }
@@ -343,7 +347,7 @@ bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
         if (status.IsNotFound())
             return false;
         LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        HandleError(m_log, status);
     }
     return true;
 }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -34,6 +34,8 @@
 #include <optional>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
 
 bool DestroyDB(const std::string& path_str)
@@ -48,8 +50,8 @@ static void HandleError(const util::log::Context& log, const leveldb::Status& st
     if (status.ok())
         return;
     const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
-    LogError("%s", errmsg);
-    LogInfo("You can use -debug=leveldb to get more complete diagnostic messages");
+    LogError(log, "%s", errmsg);
+    LogInfo(log, "You can use -debug=leveldb to get more complete diagnostic messages");
     throw dbwrapper_error(errmsg);
 }
 
@@ -105,7 +107,7 @@ public:
 
                 assert(p <= limit);
                 base[std::min(bufsize - 1, (int)(p - base))] = '\0';
-                LogDebug(BCLog::LEVELDB, "%s\n", util::RemoveSuffixView(base, "\n"));
+                LogDebug(m_log, "%s\n", util::RemoveSuffixView(base, "\n"));
                 if (base != buffer) {
                     delete[] base;
                 }
@@ -135,7 +137,7 @@ static void SetMaxOpenFiles(const util::log::Context& log, leveldb::Options *opt
         options->max_open_files = 64;
     }
 #endif
-    LogDebug(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
+    LogDebug(log, "LevelDB using max_open_files=%d (default=%d)\n",
              options->max_open_files, default_open_files);
 }
 
@@ -167,7 +169,6 @@ bool CDBWrapper::HasKeyStartingWith(const fs::path& path, uint8_t prefix)
     options.paranoid_checks = true;
     // Avoid creating or rotating LevelDB's LOG files during this probe.
     options.info_log = &logger;
-
     leveldb::DB* raw_db;
     HandleError(log, leveldb::DB::Open(options, fs::PathToString(path), &raw_db));
     const std::unique_ptr<leveldb::DB> db{raw_db};
@@ -266,14 +267,14 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
     }
     if (!params.memory_only) {
         if (params.wipe_data) {
-            LogInfo("Wiping LevelDB in %s", fs::PathToString(params.path));
+            LogInfo(m_log, "Wiping LevelDB in %s", fs::PathToString(params.path));
             leveldb::Status result = leveldb::DestroyDB(fs::PathToString(params.path), DBContext().options);
             HandleError(m_log, result);
         }
         if (!params.testing_env) {
             TryCreateDirectories(params.path);
         }
-        LogInfo("Opening LevelDB in %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Opening LevelDB in %s", fs::PathToString(params.path));
     }
     // PathToString() return value is safe to pass to leveldb open function,
     // because on POSIX leveldb passes the byte string directly to ::open(), and
@@ -281,12 +282,12 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
     // (see env_posix.cc and env_windows.cc).
     leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
     HandleError(m_log, status);
-    LogInfo("Opened LevelDB successfully");
+    LogInfo(m_log, "Opened LevelDB successfully");
 
     if (params.options.force_compact) {
-        LogInfo("Starting database compaction of %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Starting database compaction of %s", fs::PathToString(params.path));
         CompactFull();
-        LogInfo("Finished database compaction of %s", fs::PathToString(params.path));
+        LogInfo(m_log, "Finished database compaction of %s", fs::PathToString(params.path));
     }
 
     if (!Read(OBFUSCATION_KEY, m_obfuscation) && params.obfuscate && IsEmpty()) {
@@ -295,9 +296,9 @@ CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
         assert(!m_obfuscation); // Make sure the key is written without obfuscation.
         Write(OBFUSCATION_KEY, obfuscation);
         m_obfuscation = obfuscation;
-        LogInfo("Wrote new obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
+        LogInfo(m_log, "Wrote new obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
     }
-    LogInfo("Using obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
+    LogInfo(m_log, "Using obfuscation key for %s: %s", fs::PathToString(params.path), m_obfuscation.HexKey());
 }
 
 CDBWrapper::~CDBWrapper()
@@ -325,7 +326,7 @@ void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     HandleError(m_log, status);
     if (log_memory) {
         double mem_after{DynamicMemoryUsage() / double(1_MiB)};
-        LogDebug(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
+        LogDebug(m_log, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
                  m_name, mem_before, mem_after);
     }
 }
@@ -342,7 +343,7 @@ size_t CDBWrapper::DynamicMemoryUsage() const
 {
     std::optional<size_t> parsed;
     if (auto memory{GetProperty("leveldb.approximate-memory-usage")}; !memory || !(parsed = ToIntegral<size_t>(*memory))) {
-        LogDebug(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
+        LogDebug(m_log, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
     return parsed.value();
@@ -356,7 +357,7 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     if (!status.ok()) {
         if (status.IsNotFound())
             return std::nullopt;
-        LogError("LevelDB read failure: %s", status.ToString());
+        LogError(m_log, "LevelDB read failure: %s", status.ToString());
         HandleError(m_log, status);
     }
     return strValue;
@@ -371,7 +372,7 @@ bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
     if (!status.ok()) {
         if (status.IsNotFound())
             return false;
-        LogError("LevelDB read failure: %s", status.ToString());
+        LogError(m_log, "LevelDB read failure: %s", status.ToString());
         HandleError(m_log, status);
     }
     return true;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -43,7 +43,7 @@ bool DestroyDB(const std::string& path_str)
 
 /** Handle database error by throwing dbwrapper_error exception.
  */
-static void HandleError(const leveldb::Status& status)
+static void HandleError(const util::log::Context& log, const leveldb::Status& status)
 {
     if (status.ok())
         return;
@@ -54,11 +54,14 @@ static void HandleError(const leveldb::Status& status)
 }
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
+private:
+    const util::log::Context m_log;
 public:
+    CBitcoinLevelDBLogger(const util::log::Context& log) : m_log{log} {}
     // This code is adapted from posix_logger.h, which is why it is using vsprintf.
     // Please do not do this in normal code
     void Logv(const char * format, va_list ap) override {
-            if (!util::log::ShouldDebugLog(BCLog::LEVELDB)) {
+            if (!util::log::ShouldDebugLog(m_log)) {
                 return;
             }
             char buffer[500];
@@ -111,7 +114,7 @@ public:
     }
 };
 
-static void SetMaxOpenFiles(leveldb::Options *options) {
+static void SetMaxOpenFiles(const util::log::Context& log, leveldb::Options *options) {
     // On most platforms the default setting of max_open_files (which is 1000)
     // is optimal. On Windows using a large file count is OK because the handles
     // do not interfere with select() loops. On 64-bit Unix hosts this value is
@@ -136,20 +139,21 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
              options->max_open_files, default_open_files);
 }
 
-static leveldb::Options GetOptions(size_t nCacheSize, bool bloom_filter)
+static leveldb::Options GetOptions(const util::log::Context& log, size_t nCacheSize, bool bloom_filter)
 {
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = bloom_filter ? leveldb::NewBloomFilterPolicy(10) : nullptr;
     options.compression = leveldb::kNoCompression;
-    options.info_log = new CBitcoinLevelDBLogger();
+    options.info_log = new CBitcoinLevelDBLogger(log);
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
         // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
         // on corruption in later versions.
         options.paranoid_checks = true;
     }
-    SetMaxOpenFiles(&options);
+    options.max_file_size = std::max(options.max_file_size, DBWRAPPER_MAX_FILE_SIZE);
+    SetMaxOpenFiles(log, &options);
     return options;
 }
 
@@ -157,14 +161,15 @@ bool CDBWrapper::HasKeyStartingWith(const fs::path& path, uint8_t prefix)
 {
     if (!fs::exists(path / "CURRENT")) return false;
 
-    CBitcoinLevelDBLogger logger;
+    const util::log::Context log{BCLog::LEVELDB};
+    CBitcoinLevelDBLogger logger{log};
     leveldb::Options options;
     options.paranoid_checks = true;
     // Avoid creating or rotating LevelDB's LOG files during this probe.
     options.info_log = &logger;
 
     leveldb::DB* raw_db;
-    HandleError(leveldb::DB::Open(options, fs::PathToString(path), &raw_db));
+    HandleError(log, leveldb::DB::Open(options, fs::PathToString(path), &raw_db));
     const std::unique_ptr<leveldb::DB> db{raw_db};
 
     leveldb::ReadOptions iteroptions;
@@ -173,7 +178,7 @@ bool CDBWrapper::HasKeyStartingWith(const fs::path& path, uint8_t prefix)
     const std::unique_ptr<leveldb::Iterator> it{db->NewIterator(iteroptions)};
     const leveldb::Slice prefix_slice{reinterpret_cast<const char*>(&prefix), sizeof(prefix)};
     it->Seek(prefix_slice);
-    HandleError(it->status());
+    HandleError(log, it->status());
     return it->Valid() && it->key().starts_with(prefix_slice);
 }
 
@@ -241,15 +246,15 @@ struct LevelDBContext {
     leveldb::DB* pdb;
 };
 
-CDBWrapper::CDBWrapper(const DBParams& params)
-    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
+CDBWrapper::CDBWrapper(util::log::Logger& logger, const DBParams& params)
+    : m_log{BCLog::LEVELDB, &logger}, m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;
     DBContext().iteroptions.verify_checksums = true;
     DBContext().iteroptions.fill_cache = false;
     DBContext().syncoptions.sync = true;
-    DBContext().options = GetOptions(params.cache_bytes, params.bloom_filter);
+    DBContext().options = GetOptions(m_log, params.cache_bytes, params.bloom_filter);
     DBContext().options.create_if_missing = true;
     DBContext().options.max_file_size = params.max_file_size;
     assert(!(params.testing_env && params.memory_only));
@@ -263,7 +268,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
         if (params.wipe_data) {
             LogInfo("Wiping LevelDB in %s", fs::PathToString(params.path));
             leveldb::Status result = leveldb::DestroyDB(fs::PathToString(params.path), DBContext().options);
-            HandleError(result);
+            HandleError(m_log, result);
         }
         if (!params.testing_env) {
             TryCreateDirectories(params.path);
@@ -275,7 +280,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     // on Windows it converts from UTF-8 to UTF-16 before calling ::CreateFileW
     // (see env_posix.cc and env_windows.cc).
     leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
-    HandleError(status);
+    HandleError(m_log, status);
     LogInfo("Opened LevelDB successfully");
 
     if (params.options.force_compact) {
@@ -311,13 +316,13 @@ CDBWrapper::~CDBWrapper()
 
 void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
-    const bool log_memory = util::log::ShouldDebugLog(BCLog::LEVELDB);
+    const bool log_memory{util::log::ShouldDebugLog(m_log)};
     double mem_before = 0;
     if (log_memory) {
         mem_before = DynamicMemoryUsage() / double(1_MiB);
     }
     leveldb::Status status = DBContext().pdb->Write(fSync ? DBContext().syncoptions : DBContext().writeoptions, &batch.m_impl_batch->batch);
-    HandleError(status);
+    HandleError(m_log, status);
     if (log_memory) {
         double mem_after{DynamicMemoryUsage() / double(1_MiB)};
         LogDebug(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
@@ -352,7 +357,7 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
         if (status.IsNotFound())
             return std::nullopt;
         LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        HandleError(m_log, status);
     }
     return strValue;
 }
@@ -367,7 +372,7 @@ bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
         if (status.IsNotFound())
             return false;
         LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        HandleError(m_log, status);
     }
     return true;
 }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -12,6 +12,7 @@
 #include <util/byte_units.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/obfuscation.h>
 
 #include <cstddef>
@@ -191,6 +192,10 @@ struct LevelDBContext;
 class CDBWrapper
 {
     friend const Obfuscation& dbwrapper_private::GetObfuscation(const CDBWrapper&);
+protected:
+    //! log object
+    util::log::Context m_log;
+
 private:
     //! holds all leveldb-specific fields of this class
     std::unique_ptr<LevelDBContext> m_db_context;
@@ -210,7 +215,7 @@ private:
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 
 public:
-    CDBWrapper(const DBParams& params);
+    CDBWrapper(util::log::Logger& logger, const DBParams& params);
     ~CDBWrapper();
 
     CDBWrapper(const CDBWrapper&) = delete;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -10,6 +10,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
 #include <kernel/types.h>
+#include <logging.h>
 #include <node/abort.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
@@ -22,7 +23,6 @@
 #include <undo.h>
 #include <util/check.h>
 #include <util/fs.h>
-#include <util/log.h>
 #include <util/string.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
@@ -66,7 +66,7 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
 }
 
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
-    CDBWrapper{DBParams{
+    CDBWrapper{LogInstance(), DBParams{
         .path = path,
         .cache_bytes = n_cache_size,
         .memory_only = f_memory,

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -155,6 +155,11 @@ public:
     /// not block and immediately returns false.
     bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
 
+    //! Non-blocking shutdown signal.
+    //!
+    //! Useful for initiating shutdown of multiple indexes in parallel before
+    //! calling Stop() to block for completion. Purely an optimization; Stop()
+    //! can be called directly instead.
     void Interrupt();
 
     /// Initializes the sync state and registers the instance to the

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -156,6 +156,11 @@ public:
     /// not block and immediately returns false.
     bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
 
+    //! Non-blocking shutdown signal.
+    //!
+    //! Useful for initiating shutdown of multiple indexes in parallel before
+    //! calling Stop() to block for completion. Purely an optimization; Stop()
+    //! can be called directly instead.
     void Interrupt();
 
     /// Initializes the sync state and registers the instance to the

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1373,7 +1373,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     // The coinsdb is opened at a later point on LoadChainstate.
     Assert(!node.chainman); // Was reset above
     try {
-        node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
+        node.chainman = std::make_unique<ChainstateManager>(LogInstance(), *Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
         return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1383,7 +1383,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     // The coinsdb is opened at a later point on LoadChainstate.
     Assert(!node.chainman); // Was reset above
     try {
-        node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
+        node.chainman = std::make_unique<ChainstateManager>(LogInstance(), *Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
         return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -64,9 +64,15 @@ using util::ImmediateTaskRunner;
 // library aren't required to export this symbol
 extern const TranslateFn G_TRANSLATION_FUN{nullptr};
 
-static const kernel::Context btck_context_static{};
-
 namespace {
+
+// Log instance for kernel applications that don't create any logging
+// connections and don't have any logging.
+static BCLog::Logger& GlobalLogger()
+{
+    static BCLog::Logger g_logger;
+    return g_logger;
+}
 
 bool is_valid_flag_combination(script_verify_flags flags)
 {
@@ -234,10 +240,7 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
 }
 
 struct LoggingConnection {
-    // Reference to global log instance. This could be replaced with a
-    // per-connection instance (#30342) to give clients more granular control
-    // over logging.
-    BCLog::Logger& m_logger{LogInstance()};
+    BCLog::Logger m_logger;
     std::unique_ptr<std::list<std::function<void(const std::string&)>>::iterator> m_connection;
     void* m_user_data;
     std::function<void(void* user_data)> m_deleter;
@@ -382,7 +385,7 @@ struct ContextOptions {
 class Context
 {
 public:
-    BCLog::Logger* m_logger;
+    BCLog::Logger& m_logger;
 
     std::unique_ptr<kernel::Context> m_context;
 
@@ -397,18 +400,16 @@ public:
     std::shared_ptr<KernelValidationInterface> m_validation_interface;
 
     Context(const ContextOptions* options, bool& sane)
-        : m_logger{options && options->m_logger ? options->m_logger : nullptr},
+        : m_logger{*(options && options->m_logger ? options->m_logger : &GlobalLogger())},
           m_context{std::make_unique<kernel::Context>()},
           m_interrupt{std::make_unique<util::SignalInterrupt>()}
     {
-        if (!m_logger) {
-            // For efficiency, disable logging globally instead of writing log
-            // messages to temporary buffer if no log callbacks are connected.
-            if (BCLog::Logger& logger{LogInstance()}; logger.NumConnections() == 0 && logger.Enabled()) {
-                logger.DisableLogging();
-            }
-        } else if (!m_logger->StartLogging()) {
-            throw std::runtime_error("Failed to start logging");
+        if (m_logger.NumConnections() > 0) {
+            if (!m_logger.StartLogging()) throw std::runtime_error("Failed to start logging");
+        } else if (m_logger.Enabled()) {
+            // For efficiency, disable logging instead of writing log messages
+            // to temporary buffer if no log callbacks are connected.
+            m_logger.DisableLogging();
         }
 
         if (options) {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -234,6 +234,10 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
 }
 
 struct LoggingConnection {
+    // Reference to global log instance. This could be replaced with a
+    // per-connection instance (#30342) to give clients more granular control
+    // over logging.
+    BCLog::Logger& m_logger{LogInstance()};
     std::unique_ptr<std::list<std::function<void(const std::string&)>>::iterator> m_connection;
     void* m_user_data;
     std::function<void(void* user_data)> m_deleter;
@@ -242,18 +246,7 @@ struct LoggingConnection {
     {
         LOCK(cs_main);
 
-        auto connection{LogInstance().PushBackCallback([callback, user_data](const std::string& str) { callback(user_data, str.c_str(), str.length()); })};
-
-        // Only start logging if we just added the connection.
-        if (LogInstance().NumConnections() == 1 && !LogInstance().StartLogging()) {
-            LogError("Logger start failed.");
-            LogInstance().DeleteCallback(connection);
-            if (user_data && user_data_destroy_callback) {
-                user_data_destroy_callback(user_data);
-            }
-            throw std::runtime_error("Failed to start logging");
-        }
-
+        auto connection{m_logger.PushBackCallback([callback, user_data](const std::string& str) { callback(user_data, str.c_str(), str.length()); })};
         m_connection = std::make_unique<std::list<std::function<void(const std::string&)>>::iterator>(connection);
         m_user_data = user_data;
         m_deleter = user_data_destroy_callback;
@@ -265,15 +258,7 @@ struct LoggingConnection {
     {
         LOCK(cs_main);
         LogDebug(BCLog::KERNEL, "Logger disconnecting.");
-
-        // Switch back to buffering by calling DisconnectTestLogger if the
-        // connection that we are about to remove is the last one.
-        if (LogInstance().NumConnections() == 1) {
-            LogInstance().DisconnectTestLogger();
-        } else {
-            LogInstance().DeleteCallback(*m_connection);
-        }
-
+        m_logger.DeleteCallback(*m_connection);
         m_connection.reset();
         if (m_user_data && m_deleter) {
             m_deleter(m_user_data);
@@ -388,6 +373,7 @@ protected:
 
 struct ContextOptions {
     mutable Mutex m_mutex;
+    BCLog::Logger* m_logger GUARDED_BY(m_mutex) {nullptr};
     std::unique_ptr<const CChainParams> m_chainparams GUARDED_BY(m_mutex);
     std::shared_ptr<KernelNotifications> m_notifications GUARDED_BY(m_mutex);
     std::shared_ptr<KernelValidationInterface> m_validation_interface GUARDED_BY(m_mutex);
@@ -396,6 +382,8 @@ struct ContextOptions {
 class Context
 {
 public:
+    BCLog::Logger* m_logger;
+
     std::unique_ptr<kernel::Context> m_context;
 
     std::shared_ptr<KernelNotifications> m_notifications;
@@ -409,9 +397,20 @@ public:
     std::shared_ptr<KernelValidationInterface> m_validation_interface;
 
     Context(const ContextOptions* options, bool& sane)
-        : m_context{std::make_unique<kernel::Context>()},
+        : m_logger{options && options->m_logger ? options->m_logger : nullptr},
+          m_context{std::make_unique<kernel::Context>()},
           m_interrupt{std::make_unique<util::SignalInterrupt>()}
     {
+        if (!m_logger) {
+            // For efficiency, disable logging globally instead of writing log
+            // messages to temporary buffer if no log callbacks are connected.
+            if (BCLog::Logger& logger{LogInstance()}; logger.NumConnections() == 0 && logger.Enabled()) {
+                logger.DisableLogging();
+            }
+        } else if (!m_logger->StartLogging()) {
+            throw std::runtime_error("Failed to start logging");
+        }
+
         if (options) {
             LOCK(options->m_mutex);
             if (options->m_chainparams) {
@@ -752,39 +751,38 @@ void btck_txid_destroy(btck_Txid* txid)
     delete txid;
 }
 
-void btck_logging_set_options(const btck_LoggingOptions options)
+void btck_logging_set_options(btck_LoggingConnection* logger, const btck_LoggingOptions options)
 {
+    BCLog::Logger& log{btck_LoggingConnection::get(logger).m_logger};
     LOCK(cs_main);
-    LogInstance().m_log_timestamps = options.log_timestamps;
-    LogInstance().m_log_time_micros = options.log_time_micros;
-    LogInstance().m_log_threadnames = options.log_threadnames;
-    LogInstance().m_log_sourcelocations = options.log_sourcelocations;
-    LogInstance().m_always_print_category_level = options.always_print_category_levels;
+    log.m_log_timestamps = options.log_timestamps;
+    log.m_log_time_micros = options.log_time_micros;
+    log.m_log_threadnames = options.log_threadnames;
+    log.m_log_sourcelocations = options.log_sourcelocations;
+    log.m_always_print_category_level = options.always_print_category_levels;
 }
 
-void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level)
+void btck_logging_set_level_category(btck_LoggingConnection* logger, btck_LogCategory category, btck_LogLevel level)
 {
+    BCLog::Logger& log{btck_LoggingConnection::get(logger).m_logger};
     LOCK(cs_main);
     if (category == btck_LogCategory_ALL) {
-        LogInstance().SetLogLevel(get_bclog_level(level));
+        log.SetLogLevel(get_bclog_level(level));
     }
 
-    LogInstance().AddCategoryLogLevel(get_bclog_flag(category), get_bclog_level(level));
+    log.AddCategoryLogLevel(get_bclog_flag(category), get_bclog_level(level));
 }
 
-void btck_logging_enable_category(btck_LogCategory category)
+void btck_logging_enable_category(btck_LoggingConnection* logger, btck_LogCategory category)
 {
-    LogInstance().EnableCategory(get_bclog_flag(category));
+    BCLog::Logger& log{btck_LoggingConnection::get(logger).m_logger};
+    log.EnableCategory(get_bclog_flag(category));
 }
 
-void btck_logging_disable_category(btck_LogCategory category)
+void btck_logging_disable_category(btck_LoggingConnection* logger, btck_LogCategory category)
 {
-    LogInstance().DisableCategory(get_bclog_flag(category));
-}
-
-void btck_logging_disable()
-{
-    LogInstance().DisableLogging();
+    BCLog::Logger& log{btck_LoggingConnection::get(logger).m_logger};
+    log.DisableCategory(get_bclog_flag(category));
 }
 
 btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
@@ -851,6 +849,12 @@ void btck_chain_parameters_destroy(btck_ChainParameters* chain_parameters)
 btck_ContextOptions* btck_context_options_create()
 {
     return btck_ContextOptions::create();
+}
+
+void btck_context_options_set_logger(btck_ContextOptions* options, btck_LoggingConnection* logger)
+{
+    LOCK(btck_ContextOptions::get(options).m_mutex);
+    btck_ContextOptions::get(options).m_logger = &btck_LoggingConnection::get(logger).m_logger;
 }
 
 void btck_context_options_set_chainparams(btck_ContextOptions* options, const btck_ChainParameters* chain_parameters)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1078,7 +1078,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
     std::unique_ptr<ChainstateManager> chainman;
     try {
         LOCK(opts.m_mutex);
-        chainman = std::make_unique<ChainstateManager>(*opts.m_context->m_interrupt, opts.m_chainman_options, opts.m_blockman_options);
+        chainman = std::make_unique<ChainstateManager>(LogInstance(), *opts.m_context->m_interrupt, opts.m_chainman_options, opts.m_blockman_options);
     } catch (const std::exception& e) {
         LogError("Failed to create chainstate manager: %s", e.what());
         return nullptr;

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -66,9 +66,15 @@ using util::ImmediateTaskRunner;
 // library aren't required to export this symbol
 extern const TranslateFn G_TRANSLATION_FUN{nullptr};
 
-static const kernel::Context btck_context_static{};
-
 namespace {
+
+// Log instance for kernel applications that don't create any logging
+// connections and don't have any logging.
+static BCLog::Logger& GlobalLogger()
+{
+    static BCLog::Logger g_logger;
+    return g_logger;
+}
 
 bool is_valid_flag_combination(script_verify_flags flags)
 {
@@ -236,10 +242,7 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
 }
 
 struct LoggingConnection {
-    // Reference to global log instance. This could be replaced with a
-    // per-connection instance (#30342) to give clients more granular control
-    // over logging.
-    BCLog::Logger& m_logger{LogInstance()};
+    BCLog::Logger m_logger;
     std::unique_ptr<std::list<std::function<void(const std::string&)>>::iterator> m_connection;
     void* m_user_data;
     std::function<void(void* user_data)> m_deleter;
@@ -384,7 +387,7 @@ struct ContextOptions {
 class Context
 {
 public:
-    BCLog::Logger* m_logger;
+    BCLog::Logger& m_logger;
 
     std::unique_ptr<kernel::Context> m_context;
 
@@ -399,18 +402,16 @@ public:
     std::shared_ptr<KernelValidationInterface> m_validation_interface;
 
     Context(const ContextOptions* options, bool& sane)
-        : m_logger{options && options->m_logger ? options->m_logger : nullptr},
+        : m_logger{*(options && options->m_logger ? options->m_logger : &GlobalLogger())},
           m_context{std::make_unique<kernel::Context>()},
           m_interrupt{std::make_unique<util::SignalInterrupt>()}
     {
-        if (!m_logger) {
-            // For efficiency, disable logging globally instead of writing log
-            // messages to temporary buffer if no log callbacks are connected.
-            if (BCLog::Logger& logger{LogInstance()}; logger.NumConnections() == 0 && logger.Enabled()) {
-                logger.DisableLogging();
-            }
-        } else if (!m_logger->StartLogging()) {
-            throw std::runtime_error("Failed to start logging");
+        if (m_logger.NumConnections() > 0) {
+            if (!m_logger.StartLogging()) throw std::runtime_error("Failed to start logging");
+        } else if (m_logger.Enabled()) {
+            // For efficiency, disable logging instead of writing log messages
+            // to temporary buffer if no log callbacks are connected.
+            m_logger.DisableLogging();
         }
 
         if (options) {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1095,7 +1095,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
     std::unique_ptr<ChainstateManager> chainman;
     try {
         LOCK(opts.m_mutex);
-        chainman = std::make_unique<ChainstateManager>(*opts.m_context->m_interrupt, opts.m_chainman_options, opts.m_blockman_options);
+        chainman = std::make_unique<ChainstateManager>(LogInstance(), *opts.m_context->m_interrupt, opts.m_chainman_options, opts.m_blockman_options);
     } catch (const std::exception& e) {
         LogError("Failed to create chainstate manager: %s", e.what());
         return nullptr;

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -145,14 +145,6 @@ typedef struct btck_TransactionOutput btck_TransactionOutput;
 
 /**
  * Opaque data structure for holding a logging connection.
- *
- * The logging connection can be used to manually stop logging.
- *
- * Messages that were logged before a connection is created are buffered in a
- * 1MB buffer. Logging can alternatively be permanently disabled by calling
- * @ref btck_logging_disable. Functions changing the logging settings are
- * global and change the settings for all existing btck_LoggingConnection
- * instances.
  */
 typedef struct btck_LoggingConnection btck_LoggingConnection;
 
@@ -865,31 +857,23 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
 ///@{
 
 /**
- * @brief This disables the global internal logger. No log messages will be
- * buffered internally anymore once this is called and the buffer is cleared.
- * This function should only be called once and is not thread or re-entry safe.
- * Log messages will be buffered until this function is called, or a logging
- * connection is created. This must not be called while a logging connection
- * already exists.
- */
-BITCOINKERNEL_API void btck_logging_disable();
-
-/**
- * @brief Set some options for the global internal logger. This changes global
+ * @brief Set some options for the logger. Currently, this changes global
  * settings and will override settings for all existing @ref
  * btck_LoggingConnection instances.
  *
+ * @param[in] logger  Non-null.
  * @param[in] options Sets formatting options of the log messages.
  */
-BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
+BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingConnection* logger, btck_LoggingOptions options) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Set the log level of the global internal logger. This does not
+ * @brief Set the log level of the logger. This does not
  * enable the selected categories. Use @ref btck_logging_enable_category to
- * start logging from a specific, or all categories. This changes a global
+ * start logging from a specific, or all categories. Currently, this changes a global
  * setting and will override settings for all existing
  * @ref btck_LoggingConnection instances.
  *
+ * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, sets both the global fallback log level
  *                     used by all categories that don't have a specific level set, and also
  *                     sets the log level for messages logged with the btck_LogCategory_ALL category itself.
@@ -898,30 +882,38 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
 
  * @param[in] level    Log level at which the log category is set.
  */
-BITCOINKERNEL_API void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level);
+BITCOINKERNEL_API void btck_logging_set_level_category(btck_LoggingConnection* logger, btck_LogCategory category, btck_LogLevel level) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Enable a specific log category for the global internal logger. This
+ * @brief Enable a specific log category for the logger. Currently, this
  * changes a global setting and will override settings for all existing @ref
  * btck_LoggingConnection instances.
  *
+ * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be enabled.
  */
-BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
+BITCOINKERNEL_API void btck_logging_enable_category(btck_LoggingConnection* logger, btck_LogCategory category) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Disable a specific log category for the global internal logger. This
+ * @brief Disable a specific log category for the logger. Currently, this
  * changes a global setting and will override settings for all existing @ref
  * btck_LoggingConnection instances.
  *
+ * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be disabled.
  */
-BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
+BITCOINKERNEL_API void btck_logging_disable_category(btck_LoggingConnection* logger, btck_LogCategory category) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Start logging messages through the provided callback. Log messages
- * produced before this function is first called are buffered and on calling this
- * function are logged immediately.
+ * @brief Register logging callback that can receive log messages and return new
+ * @ref btck_LoggingConnection instance representing a log stream. The returned
+ * handle can be passed to functions like @ref btck_logging_set_options to set
+ * log options and @ref btck_context_options_set_logger to receive log messages
+ * generated in a particular context.
+ *
+ * Currently, most log state is global, so log options applied to other streams
+ * may effect this stream, and if there are multiple contexts, log messages from
+ * other contexts may be received. These behaviors can be improved internally.
  *
  * @param[in] log_callback               Non-null, function through which messages will be logged.
  * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
@@ -1003,6 +995,16 @@ BITCOINKERNEL_API void btck_chain_parameters_destroy(btck_ChainParameters* chain
  * Creates an empty context options.
  */
 BITCOINKERNEL_API btck_ContextOptions* BITCOINKERNEL_WARN_UNUSED_RESULT btck_context_options_create();
+
+/**
+ * @brief Sets log instance for the kernel context to use.
+ *
+ * @param[in] context_options  Non-null, previously created by @ref btck_context_options_create.
+ * @param[in] logger           Is set to the context options.
+ */
+BITCOINKERNEL_API void btck_context_options_set_logger(
+    btck_ContextOptions* context_options,
+    btck_LoggingConnection* logger) BITCOINKERNEL_ARG_NONNULL(1, 2);
 
 /**
  * @brief Sets the chain params for the context options. The context created

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -864,9 +864,7 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
 ///@{
 
 /**
- * @brief Set some options for the logger. Currently, this changes global
- * settings and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Set some options for the logger.
  *
  * @param[in] logger  Non-null.
  * @param[in] options Sets formatting options of the log messages.
@@ -876,9 +874,7 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingConnection* logger, 
 /**
  * @brief Set the log level of the logger. This does not
  * enable the selected categories. Use @ref btck_logging_enable_category to
- * start logging from a specific, or all categories. Currently, this changes a global
- * setting and will override settings for all existing
- * @ref btck_LoggingConnection instances.
+ * start logging from a specific, or all categories.
  *
  * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, sets both the global fallback log level
@@ -892,9 +888,7 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingConnection* logger, 
 BITCOINKERNEL_API void btck_logging_set_level_category(btck_LoggingConnection* logger, btck_LogCategory category, btck_LogLevel level) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Enable a specific log category for the logger. Currently, this
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Enable a specific log category for the logger.
  *
  * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be enabled.
@@ -902,9 +896,7 @@ BITCOINKERNEL_API void btck_logging_set_level_category(btck_LoggingConnection* l
 BITCOINKERNEL_API void btck_logging_enable_category(btck_LoggingConnection* logger, btck_LogCategory category) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Disable a specific log category for the logger. Currently, this
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Disable a specific log category for the logger.
  *
  * @param[in] logger   Non-null.
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be disabled.
@@ -917,10 +909,6 @@ BITCOINKERNEL_API void btck_logging_disable_category(btck_LoggingConnection* log
  * handle can be passed to functions like @ref btck_logging_set_options to set
  * log options and @ref btck_context_options_set_logger to receive log messages
  * generated in a particular context.
- *
- * Currently, most log state is global, so log options applied to other streams
- * may effect this stream, and if there are multiple contexts, log messages from
- * other contexts may be received. These behaviors can be improved internally.
  *
  * @param[in] log_callback               Non-null, function through which messages will be logged.
  * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -865,38 +865,13 @@ public:
     }
 };
 
-inline void logging_disable()
-{
-    btck_logging_disable();
-}
-
-inline void logging_set_options(const btck_LoggingOptions& logging_options)
-{
-    btck_logging_set_options(logging_options);
-}
-
-inline void logging_set_level_category(LogCategory category, LogLevel level)
-{
-    btck_logging_set_level_category(static_cast<btck_LogCategory>(category), static_cast<btck_LogLevel>(level));
-}
-
-inline void logging_enable_category(LogCategory category)
-{
-    btck_logging_enable_category(static_cast<btck_LogCategory>(category));
-}
-
-inline void logging_disable_category(LogCategory category)
-{
-    btck_logging_disable_category(static_cast<btck_LogCategory>(category));
-}
-
 template <typename T>
 concept Log = requires(T a, std::string_view message) {
     { a.LogMessage(message) } -> std::same_as<void>;
 };
 
 template <Log T>
-class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
+class Logger : public UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
 {
 public:
     Logger(std::unique_ptr<T> log)
@@ -907,6 +882,30 @@ public:
     {
     }
 };
+
+template <Log T>
+void logging_set_options(Logger<T>& logger, const btck_LoggingOptions& logging_options)
+{
+    btck_logging_set_options(logger.get(), logging_options);
+}
+
+template <Log T>
+void logging_set_level_category(Logger<T>& logger, LogCategory category, LogLevel level)
+{
+    btck_logging_set_level_category(logger.get(), static_cast<btck_LogCategory>(category), static_cast<btck_LogLevel>(level));
+}
+
+template <Log T>
+void logging_enable_category(Logger<T>& logger, LogCategory category)
+{
+    btck_logging_enable_category(logger.get(), static_cast<btck_LogCategory>(category));
+}
+
+template <Log T>
+void logging_disable_category(Logger<T>& logger, LogCategory category)
+{
+    btck_logging_disable_category(logger.get(), static_cast<btck_LogCategory>(category));
+}
 
 class BlockTreeEntry : public View<btck_BlockTreeEntry>
 {
@@ -1072,6 +1071,12 @@ class ContextOptions : public UniqueHandle<btck_ContextOptions, btck_context_opt
 {
 public:
     ContextOptions() : UniqueHandle{btck_context_options_create()} {}
+
+    template <Log T>
+    void SetLogger(Logger<T>& logger)
+    {
+        btck_context_options_set_logger(get(), logger.get());
+    }
 
     void SetChainParams(ChainParams& chain_params)
     {

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -8,6 +8,7 @@
 
 #include <policy/feerate.h>
 #include <policy/policy.h>
+#include <util/log.h>
 #include <util/time.h>
 
 #include <cstdint>
@@ -56,6 +57,7 @@ struct MemPoolOptions {
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};
     MemPoolLimits limits{};
 
+    util::log::Logger* logger{nullptr};
     ValidationSignals* signals{nullptr};
 };
 } // namespace kernel

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -23,8 +23,9 @@ using util::RemovePrefixView;
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 constexpr auto MAX_USER_SETABLE_SEVERITY_LEVEL{BCLog::Level::Info};
 
-BCLog::Logger& LogInstance()
-{
+bool fLogIPs = DEFAULT_LOGIPS;
+
+namespace BCLog {
 /**
  * NOTE: the logger instances is leaked on exit. This is ugly, but will be
  * cleaned up by the OS/libc. Defining a logger as a global object doesn't work
@@ -40,15 +41,27 @@ BCLog::Logger& LogInstance()
  * This method of initialization was originally introduced in
  * ee3374234c60aba2cc4c5cd5cac1c0aefc2d817c.
  */
-    static BCLog::Logger* g_logger{new BCLog::Logger()};
-    return *g_logger;
-}
-
-bool fLogIPs = DEFAULT_LOGIPS;
+Logger* g_logger{nullptr};
+} // namespace BCLog
 
 static int FileWriteStr(std::string_view str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
+}
+
+BCLog::Logger& LogInstance()
+{
+    return *Assert(BCLog::g_logger);
+}
+
+BCLog::Logger::Logger()
+{
+    if (!g_logger) g_logger = this;
+}
+
+BCLog::Logger::~Logger()
+{
+    if (g_logger == this) g_logger = nullptr;
 }
 
 bool BCLog::Logger::StartLogging()

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -75,10 +75,9 @@ bool BCLog::Logger::StartLogging()
     // dump buffered messages from before we opened the log
     m_buffering = false;
     if (m_buffer_lines_discarded > 0) {
-        LogPrint_({
+        LogPrint_({.level = Level::Info, .ratelimit = false}, {
             .category = BCLog::ALL,
             .level = Level::Info,
-            .should_ratelimit = false,
             .source_loc = SourceLocation{__func__},
             .message = strprintf("Early logging buffer overflowed, %d log lines discarded.", m_buffer_lines_discarded),
         });
@@ -430,14 +429,14 @@ std::string BCLog::Logger::Format(const util::log::Entry& entry) const
     return result;
 }
 
-void BCLog::Logger::LogPrint(util::log::Entry entry)
+void BCLog::Logger::LogPrint(const util::log::Options& options, util::log::Entry entry)
 {
     STDLOCK(m_cs);
-    return LogPrint_(std::move(entry));
+    return LogPrint_(options, std::move(entry));
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void BCLog::Logger::LogPrint_(util::log::Entry entry)
+void BCLog::Logger::LogPrint_(const util::log::Options& options, util::log::Entry entry)
 {
     if (m_buffering) {
         {
@@ -460,14 +459,14 @@ void BCLog::Logger::LogPrint_(util::log::Entry entry)
 
     std::string str_prefixed{Format(entry)};
     bool ratelimit{false};
-    if (entry.should_ratelimit && m_limiter) {
+    if (options.ratelimit && m_limiter) {
         auto status{m_limiter->Consume(entry.source_loc, str_prefixed)};
         if (status == LogRateLimiter::Status::NEWLY_SUPPRESSED) {
             // NOLINTNEXTLINE(misc-no-recursion)
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, // with ratelimit=false, this cannot lead to infinite recursion
+            {
                 .category = LogFlags::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = false, // with should_ratelimit=false, this cannot lead to infinite recursion
                 .source_loc = SourceLocation{__func__},
                 .message = strprintf(
                     "Excessive logging detected from %s:%d (%s): >%d bytes logged during "
@@ -540,10 +539,9 @@ void BCLog::Logger::ShrinkDebugFile()
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
             // LogWarning, except with m_cs held
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, {
                 .category = BCLog::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = true,
                 .source_loc = SourceLocation{__func__},
                 .message = "Failed to shrink debug log file: fseek(...) failed",
             });
@@ -620,8 +618,8 @@ bool util::log::hooks::ShouldLog(Category category, Level level)
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(Entry entry)
+void util::log::hooks::Log(const Options& options, Entry entry)
 {
     BCLog::Logger& logger{LogInstance()};
-    logger.LogPrint(std::move(entry));
+    logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -352,7 +352,9 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 {
     if (category == LogFlags::NONE) category = LogFlags::ALL;
 
-    const bool has_category{m_always_print_category_level || category != LogFlags::ALL};
+    // Only log categories at debug level and below so users cannot use category
+    // filters at higher levels and miss important messages.
+    const bool has_category{level <= Level::Debug && (m_always_print_category_level || category != LogFlags::ALL)};
 
     // If there is no category, Info is implied
     if (!has_category && level == Level::Info) return {};

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -616,14 +616,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::hooks::ShouldLog(Category category, Level level)
+bool util::log::hooks::ShouldLog(Logger* log, Category category, Level level)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(const Options& options, Entry entry)
+void util::log::hooks::Log(Logger* log, const Options& options, Entry entry)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -612,14 +612,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::hooks::ShouldLog(Category category, Level level)
+bool util::log::hooks::ShouldLog(Logger* log, Category category, Level level)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(const Options& options, Entry entry)
+void util::log::hooks::Log(Logger* log, const Options& options, Entry entry)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -574,7 +574,7 @@ void BCLog::LogRateLimiter::Reset()
     }
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
-        LogWarning(util::log::NO_RATE_LIMIT,
+        LOG_EMIT((.level = Level::Warning, .ratelimit = false),
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));
@@ -614,20 +614,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::ShouldDebugLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Debug);
-}
-
-bool util::log::ShouldTraceLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Trace);
-}
-
-void util::log::Log(util::log::Entry entry)
+bool util::log::hooks::ShouldLog(Category category, Level level)
 {
     BCLog::Logger& logger{LogInstance()};
-    if (logger.Enabled()) {
-        logger.LogPrint(std::move(entry));
-    }
+    return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+}
+
+void util::log::hooks::Log(Entry entry)
+{
+    BCLog::Logger& logger{LogInstance()};
+    logger.LogPrint(std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -75,10 +75,9 @@ bool BCLog::Logger::StartLogging()
     // dump buffered messages from before we opened the log
     m_buffering = false;
     if (m_buffer_lines_discarded > 0) {
-        LogPrint_({
+        LogPrint_({.level = Level::Info, .ratelimit = false}, {
             .category = BCLog::ALL,
             .level = Level::Info,
-            .should_ratelimit = false,
             .source_loc = SourceLocation{__func__},
             .message = strprintf("Early logging buffer overflowed, %d log lines discarded.", m_buffer_lines_discarded),
         });
@@ -433,14 +432,14 @@ std::string BCLog::Logger::Format(const util::log::Entry& entry) const
     return result;
 }
 
-void BCLog::Logger::LogPrint(util::log::Entry entry)
+void BCLog::Logger::LogPrint(const util::log::Options& options, util::log::Entry entry)
 {
     STDLOCK(m_cs);
-    return LogPrint_(std::move(entry));
+    return LogPrint_(options, std::move(entry));
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void BCLog::Logger::LogPrint_(util::log::Entry entry)
+void BCLog::Logger::LogPrint_(const util::log::Options& options, util::log::Entry entry)
 {
     if (m_buffering) {
         {
@@ -463,14 +462,14 @@ void BCLog::Logger::LogPrint_(util::log::Entry entry)
 
     std::string str_prefixed{Format(entry)};
     bool ratelimit{false};
-    if (entry.should_ratelimit && m_limiter) {
+    if (options.ratelimit && m_limiter) {
         auto status{m_limiter->Consume(entry.source_loc, str_prefixed)};
         if (status == LogRateLimiter::Status::NEWLY_SUPPRESSED) {
             // NOLINTNEXTLINE(misc-no-recursion)
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, // with ratelimit=false, this cannot lead to infinite recursion
+            {
                 .category = LogFlags::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = false, // with should_ratelimit=false, this cannot lead to infinite recursion
                 .source_loc = SourceLocation{__func__},
                 .message = strprintf(
                     "Excessive logging detected from %s:%d (%s): >%d bytes logged during "
@@ -543,10 +542,9 @@ void BCLog::Logger::ShrinkDebugFile()
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
             // LogWarning, except with m_cs held
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, {
                 .category = BCLog::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = true,
                 .source_loc = SourceLocation{__func__},
                 .message = "Failed to shrink debug log file: fseek(...) failed",
             });
@@ -624,8 +622,8 @@ bool util::log::hooks::ShouldLog(Category category, Level level)
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(Entry entry)
+void util::log::hooks::Log(const Options& options, Entry entry)
 {
     BCLog::Logger& logger{LogInstance()};
-    logger.LogPrint(std::move(entry));
+    logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -577,7 +577,7 @@ void BCLog::LogRateLimiter::Reset()
     }
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
-        LogWarning(util::log::NO_RATE_LIMIT,
+        LOG_EMIT((.level = Level::Warning, .ratelimit = false),
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));
@@ -618,20 +618,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::ShouldDebugLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Debug);
-}
-
-bool util::log::ShouldTraceLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Trace);
-}
-
-void util::log::Log(util::log::Entry entry)
+bool util::log::hooks::ShouldLog(Category category, Level level)
 {
     BCLog::Logger& logger{LogInstance()};
-    if (logger.Enabled()) {
-        logger.LogPrint(std::move(entry));
-    }
+    return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+}
+
+void util::log::hooks::Log(Entry entry)
+{
+    BCLog::Logger& logger{LogInstance()};
+    logger.LogPrint(std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -349,7 +349,9 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 {
     if (category == LogFlags::NONE) category = LogFlags::ALL;
 
-    const bool has_category{m_always_print_category_level || category != LogFlags::ALL};
+    // Only log categories at debug level and below so users cannot use category
+    // filters at higher levels and miss important messages.
+    const bool has_category{level <= Level::Debug && (m_always_print_category_level || category != LogFlags::ALL)};
 
     // If there is no category, Info is implied
     if (!has_category && level == Level::Info) return {};

--- a/src/logging.h
+++ b/src/logging.h
@@ -160,7 +160,7 @@ namespace BCLog {
         std::list<std::function<void(const std::string&)>> m_print_callbacks GUARDED_BY(m_cs){};
 
         /** Send an entry to the log output (internal) */
-        void LogPrint_(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+        void LogPrint_(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
 
         std::string GetLogPrefix(LogFlags category, Level level) const;
 
@@ -178,7 +178,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send an entry to the log output */
-        void LogPrint(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+        void LogPrint(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs)

--- a/src/logging.h
+++ b/src/logging.h
@@ -127,7 +127,7 @@ namespace BCLog {
         bool SuppressionsActive() const { return m_suppression_active; }
     };
 
-    class Logger
+    class Logger : public util::log::Logger
     {
     private:
         mutable StdMutex m_cs; // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected

--- a/src/logging.h
+++ b/src/logging.h
@@ -177,6 +177,9 @@ namespace BCLog {
         fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};
 
+        Logger();
+        ~Logger();
+
         /** Send an entry to the log output */
         void LogPrint(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4891,7 +4891,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const CBlockIndex* prev_block{WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock))};
 
         // Check for possible mutation if it connects to something we know so we can check for DEPLOYMENT_SEGWIT being active
-        if (prev_block && IsBlockMutated(/*block=*/*pblock,
+        if (prev_block && IsBlockMutated(&LogInstance(), /*block=*/*pblock,
                            /*check_witness_root=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
             LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", peer.m_id);
             Misbehaving(peer, "mutated block");

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5107,7 +5107,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const CBlockIndex* prev_block{WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock))};
 
         // Check for possible mutation if it connects to something we know so we can check for DEPLOYMENT_SEGWIT being active
-        if (prev_block && IsBlockMutated(/*block=*/*pblock,
+        if (prev_block && IsBlockMutated(&LogInstance(), /*block=*/*pblock,
                            /*check_witness_root=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
             LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", peer.m_id);
             Misbehaving(peer, "mutated block");

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -54,6 +54,8 @@
 #include <system_error>
 #include <unordered_map>
 
+#define LOG_REQUIRE_CONTEXT true
+
 namespace kernel {
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
 static constexpr uint8_t DB_BLOCK_INDEX{'b'};
@@ -146,13 +148,13 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
                 pindexNew->nTx            = diskindex.nTx;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams)) {
-                    LogError("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
+                    LogError(m_log, "%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
                     return false;
                 }
 
                 pcursor->Next();
             } else {
-                LogError("%s: failed to read value\n", __func__);
+                LogError(m_log, "%s: failed to read value\n", __func__);
                 return false;
             }
         } else {
@@ -325,7 +327,7 @@ void BlockManager::FindFilesToPruneManual(
         setFilesToPrune.insert(fileNumber);
         count++;
     }
-    LogInfo("[%s] Prune (Manual): prune_height=%d removed %d blk/rev pairs",
+    LogInfo(m_log, "[%s] Prune (Manual): prune_height=%d removed %d blk/rev pairs",
         chain.GetRole(), last_block_can_prune, count);
 }
 
@@ -404,7 +406,8 @@ void BlockManager::FindFilesToPrune(
         }
     }
 
-    LogDebug(BCLog::PRUNE, "[%s] target=%dMiB actual=%dMiB diff=%dMiB min_height=%d max_prune_height=%d removed %d blk/rev pairs\n",
+    const util::log::Context log_prune{BCLog::PRUNE, m_log.logger};
+    LogDebug(log_prune, "[%s] target=%dMiB actual=%dMiB diff=%dMiB min_height=%d max_prune_height=%d removed %d blk/rev pairs\n",
              chain.GetRole(), target / 1_MiB, nCurrentUsage / 1_MiB,
              (int64_t(target) - int64_t(nCurrentUsage)) / int64_t(1_MiB),
              min_block_to_prune, last_block_can_prune, count);
@@ -458,7 +461,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
         // to disk, we must bootstrap the value for assumedvalid chainstates
         // from the hardcoded assumeutxo chainparams.
         base->m_chain_tx_count = au_data.m_chain_tx_count;
-        LogInfo("[snapshot] set m_chain_tx_count=%d for %s", au_data.m_chain_tx_count, snapshot_blockhash->ToString());
+        LogInfo(m_log, "[snapshot] set m_chain_tx_count=%d for %s", au_data.m_chain_tx_count, snapshot_blockhash->ToString());
     } else {
         // If this isn't called with a snapshot blockhash, make sure the cached snapshot height
         // is null. This is relevant during snapshot completion, when the blockman may be loaded
@@ -477,7 +480,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
     for (CBlockIndex* pindex : vSortedByHeight) {
         if (m_interrupt) return false;
         if (previous_index && pindex->nHeight > previous_index->nHeight + 1) {
-            LogError("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
+            LogError(m_log, "%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
             return false;
         }
         previous_index = pindex;
@@ -556,11 +559,11 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     // Load block file info
     m_block_tree_db->ReadLastBlockFile(max_blockfile_num);
     m_blockfile_info.resize(max_blockfile_num + 1);
-    LogInfo("Loading block index db: last block file = %i", max_blockfile_num);
+    LogInfo(m_log, "Loading block index db: last block file = %i", max_blockfile_num);
     for (int nFile = 0; nFile <= max_blockfile_num; nFile++) {
         m_block_tree_db->ReadBlockFileInfo(nFile, m_blockfile_info[nFile]);
     }
-    LogInfo("Loading block index db: last block file info: %s", m_blockfile_info[max_blockfile_num].ToString());
+    LogInfo(m_log, "Loading block index db: last block file info: %s", m_blockfile_info[max_blockfile_num].ToString());
     for (int nFile = max_blockfile_num + 1; true; nFile++) {
         CBlockFileInfo info;
         if (m_block_tree_db->ReadBlockFileInfo(nFile, info)) {
@@ -571,7 +574,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     }
 
     // Check presence of blk files
-    LogInfo("Checking all blk files are present...");
+    LogInfo(m_log, "Checking all blk files are present...");
     std::set<int> setBlkDataFiles;
     for (const auto& [_, block_index] : m_block_index) {
         if (block_index.nStatus & BLOCK_HAVE_DATA) {
@@ -596,7 +599,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     // Check whether we have ever pruned block & undo files
     m_block_tree_db->ReadFlag("prunedblockfiles", m_have_pruned);
     if (m_have_pruned) {
-        LogInfo("Loading block index db: Block files have previously been pruned");
+        LogInfo(m_log, "Loading block index db: Block files have previously been pruned");
     }
 
     // Check whether we need to continue reindexing
@@ -677,7 +680,7 @@ void BlockManager::CleanupBlockRevFiles() const
     // Glob all blk?????.dat and rev?????.dat files from the blocks directory.
     // Remove the rev files immediately and insert the blk file paths into an
     // ordered map keyed by block file index.
-    LogInfo("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune");
+    LogInfo(m_log, "Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune");
     for (fs::directory_iterator it(m_opts.blocks_dir); it != fs::directory_iterator(); it++) {
         const std::string path = fs::PathToString(it->path().filename());
         if (fs::is_regular_file(*it) &&
@@ -719,7 +722,7 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
     // Open history file to read
     AutoFile file{OpenUndoFile(pos, true)};
     if (file.IsNull()) {
-        LogError("OpenUndoFile failed for %s while reading block undo", pos.ToString());
+        LogError(m_log, "OpenUndoFile failed for %s while reading block undo", pos.ToString());
         return false;
     }
     BufferedReader filein{std::move(file)};
@@ -736,11 +739,11 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
 
         // Verify checksum
         if (hashChecksum != verifier.GetHash()) {
-            LogError("Checksum mismatch at %s while reading block undo", pos.ToString());
+            LogError(m_log, "Checksum mismatch at %s while reading block undo", pos.ToString());
             return false;
         }
     } catch (const std::exception& e) {
-        LogError("Deserialize or I/O error - %s at %s while reading block undo", e.what(), pos.ToString());
+        LogError(m_log, "Deserialize or I/O error - %s at %s while reading block undo", e.what(), pos.ToString());
         return false;
     }
 
@@ -826,7 +829,7 @@ void BlockManager::UnlinkPrunedFiles(const std::set<int>& setFilesToPrune) const
         const bool removed_blockfile{fs::remove(m_block_file_seq.FileName(pos), ec)};
         const bool removed_undofile{fs::remove(m_undo_file_seq.FileName(pos), ec)};
         if (removed_blockfile || removed_undofile) {
-            LogDebug(BCLog::BLOCKSTORAGE, "Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
+            LogDebug(m_log, "Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
         }
     }
 }
@@ -857,7 +860,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         assert(chain_type == BlockfileType::ASSUMED);
         const auto new_cursor = BlockfileCursor{this->MaxBlockfileNum() + 1};
         m_blockfile_cursors[chain_type] = new_cursor;
-        LogDebug(BCLog::BLOCKSTORAGE, "[%s] initializing blockfile cursor to %s\n", chain_type, new_cursor);
+        LogDebug(m_log, "[%s] initializing blockfile cursor to %s\n", chain_type, new_cursor);
     }
     const int last_blockfile = m_blockfile_cursors[chain_type]->file_num;
 
@@ -900,7 +903,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
     pos.nPos = m_blockfile_info[nFile].nSize;
 
     if (nFile != last_blockfile) {
-        LogDebug(BCLog::BLOCKSTORAGE, "Leaving block file %i: %s (onto %i) (height %i)\n",
+        LogDebug(m_log, "Leaving block file %i: %s (onto %i) (height %i)\n",
                  last_blockfile, m_blockfile_info[last_blockfile].ToString(), nFile, nHeight);
 
         // Do not propagate the return code. The flush concerns a previous block
@@ -911,7 +914,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // a reindex. A flush error might also leave some of the data files
         // untrimmed.
         if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
-            LogWarning(
+            LogWarning(m_log,
                           "Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
                           last_blockfile, finalize_undo, nFile);
         }
@@ -989,14 +992,14 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         FlatFilePos pos;
         const auto blockundo_size{static_cast<uint32_t>(GetSerializeSize(blockundo))};
         if (!FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD)) {
-            LogError("FindUndoPos failed for %s while writing block undo", pos.ToString());
+            LogError(m_log, "FindUndoPos failed for %s while writing block undo", pos.ToString());
             return false;
         }
 
         // Open history file to append
         AutoFile file{OpenUndoFile(pos)};
         if (file.IsNull()) {
-            LogError("OpenUndoFile failed for %s while writing block undo", pos.ToString());
+            LogError(m_log, "OpenUndoFile failed for %s while writing block undo", pos.ToString());
             return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
         }
         {
@@ -1017,7 +1020,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
 
         // Make sure that the file is closed before we call `FlushUndoFile`.
         if (file.fclose() != 0) {
-            LogError("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
+            LogError(m_log, "Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
             return FatalError(m_opts.notifications, state, _("Failed to close block undo file."));
         }
 
@@ -1033,7 +1036,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
             // fact it is. Note though, that a failed flush might leave the data
             // file untrimmed.
             if (!FlushUndoFile(pos.nFile, true)) {
-                LogWarning("Failed to flush undo file %05i\n", pos.nFile);
+                LogWarning(m_log, "Failed to flush undo file %05i\n", pos.nFile);
             }
         } else if (pos.nFile == cursor.file_num && block.nHeight > cursor.undo_height) {
             cursor.undo_height = block.nHeight;
@@ -1061,7 +1064,7 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
         // Read block
         SpanReader{*block_data} >> TX_WITH_WITNESS(block);
     } catch (const std::exception& e) {
-        LogError("Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
+        LogError(m_log, "Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
         return false;
     }
 
@@ -1069,18 +1072,18 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
 
     // Check the header
     if (!CheckProofOfWork(block_hash, block.nBits, GetConsensus())) {
-        LogError("Errors in block header at %s while reading block", pos.ToString());
+        LogError(m_log, "Errors in block header at %s while reading block", pos.ToString());
         return false;
     }
 
     // Signet only: check block solution
     if (GetConsensus().signet_blocks && !CheckSignetBlockSolution(block, GetConsensus())) {
-        LogError("Errors in block solution at %s while reading block", pos.ToString());
+        LogError(m_log, "Errors in block solution at %s while reading block", pos.ToString());
         return false;
     }
 
     if (expected_hash && block_hash != *expected_hash) {
-        LogError("GetHash() doesn't match index at %s while reading block (%s != %s)",
+        LogError(m_log, "GetHash() doesn't match index at %s while reading block (%s != %s)",
                  pos.ToString(), block_hash.ToString(), expected_hash->ToString());
         return false;
     }
@@ -1100,12 +1103,12 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         // If nPos is less than STORAGE_HEADER_BYTES, we can't read the header that precedes the block data
         // This would cause an unsigned integer underflow when trying to position the file cursor
         // This can happen after pruning or default constructed positions
-        LogError("Failed for %s while reading raw block storage header", pos.ToString());
+        LogError(m_log, "Failed for %s while reading raw block storage header", pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
     AutoFile filein{OpenBlockFile({pos.nFile, pos.nPos - STORAGE_HEADER_BYTES}, /*fReadOnly=*/true)};
     if (filein.IsNull()) {
-        LogError("OpenBlockFile failed for %s while reading raw block", pos.ToString());
+        LogError(m_log, "OpenBlockFile failed for %s while reading raw block", pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
 
@@ -1116,13 +1119,13 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         filein >> blk_start >> blk_size;
 
         if (blk_start != GetParams().MessageStart()) {
-            LogError("Block magic mismatch for %s: %s versus expected %s while reading raw block",
+            LogError(m_log, "Block magic mismatch for %s: %s versus expected %s while reading raw block",
                 pos.ToString(), HexStr(blk_start), HexStr(GetParams().MessageStart()));
             return util::Unexpected{ReadRawError::IO};
         }
 
         if (blk_size > MAX_SIZE) {
-            LogError("Block data is larger than maximum deserialization size for %s: %s versus %s while reading raw block",
+            LogError(m_log, "Block data is larger than maximum deserialization size for %s: %s versus %s while reading raw block",
                 pos.ToString(), blk_size, MAX_SIZE);
             return util::Unexpected{ReadRawError::IO};
         }
@@ -1140,7 +1143,7 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         filein.read(data);
         return data;
     } catch (const std::exception& e) {
-        LogError("Read from block file failed: %s for %s while reading raw block", e.what(), pos.ToString());
+        LogError(m_log, "Read from block file failed: %s for %s while reading raw block", e.what(), pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
 }
@@ -1151,12 +1154,12 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
     const unsigned int block_size{static_cast<unsigned int>(GetSerializeSize(TX_WITH_WITNESS(block)))};
     FlatFilePos pos{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
     if (pos.IsNull()) {
-        LogError("FindNextBlockPos failed for %s while writing block", pos.ToString());
+        LogError(m_log, "FindNextBlockPos failed for %s while writing block", pos.ToString());
         return FlatFilePos();
     }
     AutoFile file{OpenBlockFile(pos, /*fReadOnly=*/false)};
     if (file.IsNull()) {
-        LogError("OpenBlockFile failed for %s while writing block", pos.ToString());
+        LogError(m_log, "OpenBlockFile failed for %s while writing block", pos.ToString());
         m_opts.notifications.fatalError(_("Failed to write block."));
         return FlatFilePos();
     }
@@ -1171,7 +1174,7 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
     }
 
     if (file.fclose() != 0) {
-        LogError("Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
+        LogError(m_log, "Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
         m_opts.notifications.fatalError(_("Failed to close file when writing block."));
         return FlatFilePos();
     }
@@ -1232,7 +1235,7 @@ static auto InitBlocksdirXorKey(const util::log::Context& log, const BlockManage
                       HexStr(obfuscation), fs::PathToString(xor_key_path)),
         };
     }
-    LogInfo("Using obfuscation key for blocksdir *.dat files (%s): '%s'\n", fs::PathToString(opts.blocks_dir), HexStr(obfuscation));
+    LogInfo(log, "Using obfuscation key for blocksdir *.dat files (%s): '%s'\n", fs::PathToString(opts.blocks_dir), HexStr(obfuscation));
     return Obfuscation{obfuscation};
 }
 
@@ -1277,6 +1280,7 @@ public:
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths)
 {
     ImportingNow imp{chainman.m_blockman.m_importing};
+    const util::log::Context& log{chainman.m_blockman.m_log};
 
     // -reindex
     if (!chainman.m_blockman.m_blockfiles_indexed) {
@@ -1295,16 +1299,16 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
             if (file.IsNull()) {
                 break; // This error is logged in OpenBlockFile
             }
-            LogInfo("Reindexing block file blk%05u.dat (%d%% complete)...", (unsigned int)nFile, nFile * 100 / total_files);
+            LogInfo(log, "Reindexing block file blk%05u.dat (%d%% complete)...", (unsigned int)nFile, nFile * 100 / total_files);
             chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
             if (chainman.m_interrupt) {
-                LogInfo("Interrupt requested. Exit reindexing.");
+                LogInfo(log, "Interrupt requested. Exit reindexing.");
                 return;
             }
         }
         WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
         chainman.m_blockman.m_blockfiles_indexed = true;
-        LogInfo("Reindexing finished");
+        LogInfo(log, "Reindexing finished");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
         (void)chainman.LoadGenesisBlock();
     }
@@ -1313,14 +1317,14 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
     for (const fs::path& path : import_paths) {
         AutoFile file{fsbridge::fopen(path, "rb")};
         if (!file.IsNull()) {
-            LogInfo("Importing blocks file %s...", fs::PathToString(path));
+            LogInfo(log, "Importing blocks file %s...", fs::PathToString(path));
             chainman.LoadExternalBlockFile(file);
             if (chainman.m_interrupt) {
-                LogInfo("Interrupt requested. Exit block importing.");
+                LogInfo(log, "Interrupt requested. Exit block importing.");
                 return;
             }
         } else {
-            LogWarning("Could not open blocks file %s", fs::PathToString(path));
+            LogWarning(log, "Could not open blocks file %s", fs::PathToString(path));
         }
     }
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1179,7 +1179,7 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
     return pos;
 }
 
-static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
+static auto InitBlocksdirXorKey(const util::log::Context& log, const BlockManager::Options& opts)
 {
     // Bytes are serialized without length indicator, so this is also the exact
     // size of the XOR-key file.
@@ -1236,15 +1236,16 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
     return Obfuscation{obfuscation};
 }
 
-BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
-    : m_prune_mode{opts.prune_target > 0},
-      m_obfuscation{InitBlocksdirXorKey(opts)},
+BlockManager::BlockManager(util::log::Logger& logger, const util::SignalInterrupt& interrupt, Options opts)
+    : m_log{BCLog::BLOCKSTORAGE, &logger},
+      m_interrupt{interrupt},
+      m_prune_mode{opts.prune_target > 0},
+      m_obfuscation{InitBlocksdirXorKey(m_log, opts)},
       m_opts{std::move(opts)},
       m_block_file_seq{FlatFileSeq{m_opts.blocks_dir, "blk", m_opts.fast_prune ? 0x4000 /* 16kB */ : BLOCKFILE_CHUNK_SIZE}},
-      m_undo_file_seq{FlatFileSeq{m_opts.blocks_dir, "rev", UNDOFILE_CHUNK_SIZE}},
-      m_interrupt{interrupt}
+      m_undo_file_seq{FlatFileSeq{m_opts.blocks_dir, "rev", UNDOFILE_CHUNK_SIZE}}
 {
-    m_block_tree_db = std::make_unique<BlockTreeDB>(m_opts.block_tree_db_params);
+    m_block_tree_db = std::make_unique<BlockTreeDB>(logger, m_opts.block_tree_db_params);
 
     if (m_opts.block_tree_db_params.wipe_data) {
         m_block_tree_db->WriteReindexing(true);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -24,6 +24,7 @@
 #include <util/expected.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/log.h>
 #include <util/obfuscation.h>
 
 #include <algorithm>
@@ -197,6 +198,10 @@ class BlockManager
     friend Chainstate;
     friend ChainstateManager;
 
+public:
+    const util::log::Context m_log;
+    const util::SignalInterrupt& m_interrupt;
+
 private:
     const CChainParams& GetParams() const { return m_opts.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_opts.chainparams.GetConsensus(); }
@@ -319,9 +324,8 @@ public:
     using Options = kernel::BlockManagerOpts;
     using ReadRawBlockResult = util::Expected<std::vector<std::byte>, ReadRawError>;
 
-    explicit BlockManager(const util::SignalInterrupt& interrupt, Options opts);
+    explicit BlockManager(util::log::Logger& logger, const util::SignalInterrupt& interrupt, Options opts);
 
-    const util::SignalInterrupt& m_interrupt;
     std::atomic<bool> m_importing{false};
 
     /**

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -26,6 +26,8 @@
 #include <cassert>
 #include <vector>
 
+#define LOG_REQUIRE_CONTEXT true
+
 using kernel::CacheSizes;
 
 namespace node {
@@ -35,6 +37,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
+    const util::log::Context& log{chainman.m_log};
     if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
@@ -84,7 +87,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // block tree into BlockIndex()!
 
     for (const auto& chainstate : chainman.m_chainstates) {
-        LogInfo("Initializing chainstate %s", chainstate->ToString());
+        LogInfo(log, "Initializing chainstate %s", chainstate->ToString());
 
         try {
             chainstate->InitCoinsDB(
@@ -92,7 +95,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
                 /*in_memory=*/options.coins_db_in_memory,
                 /*should_wipe=*/options.wipe_chainstate_db);
         } catch (dbwrapper_error& err) {
-            LogError("%s\n", err.what());
+            LogError(chainman.m_log, "%s\n", err.what());
             return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
         }
 
@@ -151,19 +154,20 @@ static ChainstateLoadResult CompleteChainstateInitialization(
 ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
                                     const ChainstateLoadOptions& options)
 {
+    const util::log::Context& log{chainman.m_log};
     if (!chainman.AssumedValidBlock().IsNull()) {
-        LogInfo("Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
+        LogInfo(log, "Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
     } else {
-        LogInfo("Validating signatures for all blocks.");
+        LogInfo(log, "Validating signatures for all blocks.");
     }
-    LogInfo("Setting nMinimumChainWork=%s", chainman.MinimumChainWork().GetHex());
+    LogInfo(log, "Setting nMinimumChainWork=%s", chainman.MinimumChainWork().GetHex());
     if (chainman.MinimumChainWork() < UintToArith256(chainman.GetConsensus().nMinimumChainWork)) {
-        LogWarning("nMinimumChainWork set below default value of %s", chainman.GetConsensus().nMinimumChainWork.GetHex());
+        LogWarning(log, "nMinimumChainWork set below default value of %s", chainman.GetConsensus().nMinimumChainWork.GetHex());
     }
     if (chainman.m_blockman.GetPruneTarget() == BlockManager::PRUNE_TARGET_MANUAL) {
-        LogInfo("Block pruning enabled. Use RPC call pruneblockchain(height) to manually prune block and undo files.");
+        LogInfo(log, "Block pruning enabled. Use RPC call pruneblockchain(height) to manually prune block and undo files.");
     } else if (chainman.m_blockman.GetPruneTarget()) {
-        LogInfo("Prune configured to target %u MiB on disk for block and undo files.",
+        LogInfo(log, "Prune configured to target %u MiB on disk for block and undo files.",
                 chainman.m_blockman.GetPruneTarget() / 1_MiB);
     }
 
@@ -181,7 +185,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     if (assumeutxo_cs && options.wipe_chainstate_db) {
         // Reset chainstate target to network tip instead of snapshot block.
         validated_cs.SetTargetBlock(nullptr);
-        LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
+        LogInfo(log, "[snapshot] deleting snapshot chainstate due to reindexing");
         if (!chainman.DeleteChainstate(*assumeutxo_cs)) {
             return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
         }
@@ -208,7 +212,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     if (snapshot_completion == SnapshotCompletionResult::SKIPPED) {
         // do nothing; expected case
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
-        LogInfo("[snapshot] cleaning up unneeded background chainstate, then reinitializing");
+        LogInfo(log, "[snapshot] cleaning up unneeded background chainstate, then reinitializing");
         if (!chainman.ValidatedSnapshotCleanup(validated_cs, *assumeutxo_cs)) {
             return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Background chainstate cleanup failed unexpectedly.")};
         }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -14,6 +14,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
+#include <logging.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
@@ -479,6 +480,9 @@ static void SetupUIArgs(ArgsManager& argsman)
 
 int GuiMain(int argc, char* argv[])
 {
+    // Intentionally leaked! See BCLog::g_logger description for rationale.
+    new BCLog::Logger;
+
     std::unique_ptr<interfaces::Init> init = interfaces::MakeGuiInit(argc, argv);
 
     SetupEnvironment();

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -6,6 +6,7 @@
 
 #include <interfaces/init.h>
 #include <interfaces/node.h>
+#include <logging.h>
 #include <qt/bitcoin.h>
 #include <qt/guiconstants.h>
 #include <qt/test/apptests.h>
@@ -35,6 +36,7 @@ const std::function<std::string()> G_TEST_GET_FULL_NAME{};
 // This is all you need to run all the tests
 int main(int argc, char* argv[])
 {
+    BCLog::Logger logger;
     // Initialize persistent globals with the testing setup state for sanity.
     // E.g. -datadir in gArgs is set to a temp directory dummy value (instead
     // of defaulting to the default datadir), or globalChainParams is set to

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -24,6 +24,7 @@
 #include <index/coinstatsindex.h>
 #include <interfaces/mining.h>
 #include <kernel/coinstats.h>
+#include <logging.h>
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
@@ -3234,6 +3235,7 @@ UniValue CreateRolledBackUTXOSnapshot(
     };
 
     std::unique_ptr<CCoinsViewDB> temp_db = std::make_unique<CCoinsViewDB>(
+        LogInstance(),
         std::move(db_params),
         CoinsViewOptions{}
     );

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -24,6 +24,7 @@
 #include <index/coinstatsindex.h>
 #include <interfaces/mining.h>
 #include <kernel/coinstats.h>
+#include <logging.h>
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
@@ -3239,6 +3240,7 @@ UniValue CreateRolledBackUTXOSnapshot(
     };
 
     std::unique_ptr<CCoinsViewDB> temp_db = std::make_unique<CCoinsViewDB>(
+        LogInstance(),
         std::move(db_params),
         CoinsViewOptions{}
     );

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-SignatureCache::SignatureCache(const size_t max_size_bytes)
+SignatureCache::SignatureCache(util::log::Logger& logger, const size_t max_size_bytes)
 {
     uint256 nonce = GetRandHash();
     // We want the nonce to be 64 bytes long to force the hasher to process

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#define LOG_REQUIRE_CONTEXT true
+
 SignatureCache::SignatureCache(util::log::Logger& logger, const size_t max_size_bytes)
 {
     uint256 nonce = GetRandHash();
@@ -32,7 +34,8 @@ SignatureCache::SignatureCache(util::log::Logger& logger, const size_t max_size_
     m_salted_hasher_schnorr.Write(PADDING_SCHNORR, 32);
 
     const auto [num_elems, approx_size_bytes] = setValid.setup_bytes(max_size_bytes);
-    LogInfo("Using %zu MiB out of %zu MiB requested for signature cache, able to store %zu elements",
+    const util::log::Context log{BCLog::VALIDATION, &logger};
+    LogInfo(log, "Using %zu MiB out of %zu MiB requested for signature cache, able to store %zu elements",
               approx_size_bytes >> 20, max_size_bytes >> 20, num_elems);
 }
 

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -15,7 +15,6 @@
 // See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
 #include <util/byte_units.h> // IWYU pragma: keep
 #include <util/hasher.h>
-
 #include <cstddef>
 #include <shared_mutex>
 #include <span>
@@ -24,6 +23,9 @@
 class CPubKey;
 class CTransaction;
 class XOnlyPubKey;
+namespace util::log {
+class Logger;
+} // namespace util::log
 
 // DoS prevention: limit cache size to 32MiB (over 1000000 entries on 64-bit
 // systems). Due to how we count cache size, actual memory usage is slightly
@@ -49,7 +51,7 @@ private:
     std::shared_mutex cs_sigcache;
 
 public:
-    SignatureCache(size_t max_size_bytes);
+    SignatureCache(util::log::Logger& logger, size_t max_size_bytes);
 
     SignatureCache(const SignatureCache&) = delete;
     SignatureCache& operator=(const SignatureCache&) = delete;

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <test/data/blockfilters.json.h>
 #include <test/util/common.h>
+#include <test/util/setup_common.h>
 
 #include <blockfilter.h>
 #include <core_io.h>
@@ -16,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(blockfilter_tests)
+BOOST_FIXTURE_TEST_SUITE(blockfilter_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(gcsfilter_test)
 {

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
             .cache_bytes = 0,
         },
     };
-    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+    BlockManager blockman{m_logger, *Assert(m_node.shutdown_signal), blockman_opts};
     // simulate adding a genesis block normally
     LOCK(::cs_main);
     BOOST_CHECK_EQUAL(blockman.WriteBlock(params->GenesisBlock(), 0).nPos, STORAGE_HEADER_BYTES);
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
             .cache_bytes = 0,
         },
     };
-    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+    BlockManager blockman{m_logger, *Assert(m_node.shutdown_signal), blockman_opts};
 
     // Test blocks with no transactions, not even a coinbase
     CBlock block1;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -298,7 +298,7 @@ BOOST_FIXTURE_TEST_SUITE(coins_tests_dbbase, BasicTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 {
-    CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db_base{m_logger, {.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     SimulationTest(&db_base, true);
 }
 
@@ -1050,7 +1050,7 @@ void TestFlushBehavior(
 BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
 {
     // Create two in-memory caches atop a leveldb view.
-    CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB base{m_logger, {.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(&base));
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(caches.back().get()));
@@ -1070,7 +1070,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     const Coin coin{MakeCoin()};
     const uint256 block_hash{m_rng.rand256()};
 
-    CCoinsViewDB base{{.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+    CCoinsViewDB base{m_logger, {.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
     CCoinsViewCache cache{&base};
 
     cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -291,7 +291,7 @@ BOOST_FIXTURE_TEST_SUITE(coins_tests_dbbase, BasicTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 {
-    CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db_base{m_logger, {.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     SimulationTest(&db_base, true);
 }
 
@@ -1043,7 +1043,7 @@ void TestFlushBehavior(
 BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
 {
     // Create two in-memory caches atop a leveldb view.
-    CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB base{m_logger, {.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(&base));
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(caches.back().get()));
@@ -1063,7 +1063,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     const Coin coin{MakeCoin()};
     const uint256 block_hash{m_rng.rand256()};
 
-    CCoinsViewDB base{{.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+    CCoinsViewDB base{m_logger, {.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
     CCoinsViewCache cache{&base};
 
     cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -7,6 +7,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
+#include <test/util/setup_common.h>
 #include <txdb.h>
 #include <uint256.h>
 #include <util/byte_units.h>
@@ -98,12 +99,12 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 
 } // namespace
 
-BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
+BOOST_FIXTURE_TEST_SUITE(coinsviewoverlay_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -131,7 +132,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -150,7 +151,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     // Add all inputs as spent already in cache
@@ -172,7 +173,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
@@ -194,7 +195,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
     CMutableTransaction coinbase;
     coinbase.vin.emplace_back();
     block.vtx.push_back(MakeTransactionRef(coinbase));
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     Coin coin{};
     coin.out.nValue = 1;
@@ -219,7 +220,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
 BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 
@@ -251,7 +252,7 @@ BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -272,13 +273,13 @@ BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests_noworkers)
+BOOST_FIXTURE_TEST_SUITE(coinsviewoverlay_tests_noworkers, BasicTestingSetup)
 
 // Test that disabled input fetching falls back to normal cache lookups via base->PeekCoin.
 BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
@@ -291,7 +292,7 @@ BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 BOOST_AUTO_TEST_CASE(fetch_interrupted_thread_pool_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -7,6 +7,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
+#include <test/util/setup_common.h>
 #include <txdb.h>
 #include <uint256.h>
 #include <util/byte_units.h>
@@ -99,12 +100,12 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 
 } // namespace
 
-BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
+BOOST_FIXTURE_TEST_SUITE(coinsviewoverlay_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -132,7 +133,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -151,7 +152,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     // Add all inputs as spent already in cache
@@ -173,7 +174,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
@@ -195,7 +196,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
     CMutableTransaction coinbase;
     coinbase.vin.emplace_back();
     block.vtx.push_back(MakeTransactionRef(coinbase));
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     Coin coin{};
     coin.out.nValue = 1;
@@ -220,7 +221,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
 BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 
@@ -252,7 +253,7 @@ BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -273,13 +274,13 @@ BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests_noworkers)
+BOOST_FIXTURE_TEST_SUITE(coinsviewoverlay_tests_noworkers, BasicTestingSetup)
 
 // Test that disabled input fetching falls back to normal cache lookups via base->PeekCoin.
 BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
@@ -292,7 +293,7 @@ BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 BOOST_AUTO_TEST_CASE(fetch_interrupted_thread_pool_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{m_logger, {.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 
         // Write values
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .wipe_data = true, .obfuscate = obfuscate}};
+            CDBWrapper dbw{m_logger, {.path = path, .cache_bytes = CACHE_SIZE, .wipe_data = true, .obfuscate = obfuscate}};
             BOOST_CHECK_EQUAL(obfuscate, !dbw.IsEmpty());
 
             // Ensure that we're doing real obfuscation when obfuscate=true
@@ -48,13 +48,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 
         // Verify that the obfuscation key is never obfuscated
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = false}};
+            CDBWrapper dbw{m_logger, {.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = false}};
             BOOST_CHECK_EQUAL(obfuscation, dbwrapper_private::GetObfuscation(dbw));
         }
 
         // Read back the values
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = obfuscate}};
+            CDBWrapper dbw{m_logger, {.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = obfuscate}};
 
             // Ensure obfuscation is read back correctly
             BOOST_CHECK_EQUAL(obfuscation, dbwrapper_private::GetObfuscation(dbw));
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_1_obfuscate_true" : "dbwrapper_1_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = false, .wipe_data = true, .obfuscate = obfuscate});
+        CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB, .memory_only = false, .wipe_data = true, .obfuscate = obfuscate});
 
         uint256 res;
         uint32_t res_uint_32;
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_batch_obfuscate_true" : "dbwrapper_batch_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
+        CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
 
         uint8_t key{'i'};
         uint256 in = m_rng.rand256();
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_iterator_obfuscate_true" : "dbwrapper_iterator_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
+        CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
 
         // The two keys are intentionally chosen for ordering
         uint8_t key{'j'};
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     fs::create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
+    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(m_logger, DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
     uint8_t key{'k'};
     uint256 in = m_rng.rand256();
     uint256 res;
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     dbw.reset();
 
     // Now, set up another wrapper that wants to obfuscate the same directory
-    CDBWrapper odbw({.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = true});
+    CDBWrapper odbw(m_logger, {.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = true});
 
     // Check that the key/val we wrote with unobfuscated wrapper exists and
     // is readable.
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     fs::create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
+    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(m_logger, DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
     uint8_t key{'k'};
     uint256 in = m_rng.rand256();
     uint256 res;
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     dbw.reset();
 
     // Simulate a -reindex by wiping the existing data store
-    CDBWrapper odbw({.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = true, .obfuscate = true});
+    CDBWrapper odbw(m_logger, {.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = true, .obfuscate = true});
 
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
     fs::path ph = m_args.GetDataDirBase() / "iterator_ordering";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
+    CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
         uint32_t value = x*x;
@@ -405,7 +405,7 @@ struct StringContentsSerializer {
 BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     fs::path ph = m_args.GetDataDirBase() / "iterator_string_ordering";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
+    CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
     for (int x = 0; x < 10; ++x) {
         for (int y = 0; y < 10; ++y) {
             std::string key{ToString(x)};
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(unicodepath)
     // the ANSI CreateDirectoryA call and the code page isn't UTF8.
     // It will succeed if created with CreateDirectoryW.
     fs::path ph = m_args.GetDataDirBase() / "test_runner_₿_🏃_20191128_104644";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB});
+    CDBWrapper dbw(m_logger, {.path = ph, .cache_bytes = 1_MiB});
 
     fs::path lockPath = ph / "LOCK";
     BOOST_CHECK(fs::exists(lockPath));

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -17,7 +17,7 @@ using kernel::CBlockFileInfo;
 
 namespace {
 
-const BasicTestingSetup* g_setup;
+BasicTestingSetup* g_setup;
 
 // Hardcoded block hash and nBits to make sure the blocks we store pass the pow check.
 uint256 g_block_hash;
@@ -49,7 +49,7 @@ CBlockHeader ConsumeBlockHeader(FuzzedDataProvider& provider)
 
 void init_block_index()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(ChainType::MAIN);
+    static const auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>(ChainType::MAIN);
     g_setup = testing_setup.get();
     g_block_hash = Params().GenesisBlock().GetHash();
 }
@@ -57,7 +57,7 @@ void init_block_index()
 FUZZ_TARGET(block_index, .init = init_block_index)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    auto block_index = kernel::BlockTreeDB(DBParams{
+    auto block_index = kernel::BlockTreeDB(g_setup->m_logger, DBParams{
         .path = "", // Memory only.
         .cache_bytes = 1_MiB,
         .memory_only = true,

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -425,11 +425,17 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_coins_view);
 }
 
+static void cleanup_coins_view()
+{
+    // Stop worker threads before logger is destroyed because they log when exiting.
+    g_thread_pool->Stop();
+}
+
 // Creates a CoinsViewOverlay and a MutationGuardCoinsViewCache as the base.
 // This allows us to exercise all methods on a CoinsViewOverlay, while also
 // ensuring that nothing can mutate the underlying cache until Flush or Sync is
 // called.
-FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view, .cleanup = cleanup_coins_view)
 {
     SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedTxidHasher
     StartPoolIfNeeded();
@@ -441,7 +447,7 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }
 
-FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view, .cleanup = cleanup_coins_view)
 {
     SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedTxidHasher
     StartPoolIfNeeded();

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 namespace {
+BasicTestingSetup* g_setup;
 const Coin EMPTY_COIN{};
 
 bool operator==(const Coin& a, const Coin& b)
@@ -135,7 +136,8 @@ CBlock BuildRandomBlock(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& vi
 
 void initialize_coins_view()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>();
+    static const auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>();
+    g_setup = testing_setup.get();
 }
 
 void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView* backend_coins_view)
@@ -418,7 +420,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
         .cache_bytes = 1_MiB,
         .memory_only = true,
     };
-    CCoinsViewDB backend_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewDB backend_coins_view{g_setup->m_logger, std::move(db_params), CoinsViewOptions{}};
     CCoinsViewCache coins_view_cache{&backend_coins_view, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_coins_view);
 }
@@ -449,7 +451,7 @@ FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view)
         .cache_bytes = 1_MiB,
         .memory_only = true,
     };
-    CCoinsViewDB backend_base_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewDB backend_base_coins_view{g_setup->m_logger, std::move(db_params), CoinsViewOptions{}};
     CCoinsViewCache backend_cache{&backend_base_coins_view, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
     CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 
 namespace {
+BasicTestingSetup* g_setup;
 /**
  * MutationGuardCoinsViewCache asserts that nothing mutates cacheCoins until
  * BatchWrite is called. It keeps a snapshot of the cacheCoins state, which it
@@ -128,7 +129,8 @@ CBlock BuildRandomBlock(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& vi
 
 void initialize_coins_view()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>();
+    static const auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>();
+    g_setup = testing_setup.get();
 }
 
 void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView* backend_coins_view)
@@ -411,7 +413,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
         .cache_bytes = 1_MiB,
         .memory_only = true,
     };
-    CCoinsViewDB backend_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewDB backend_coins_view{g_setup->m_logger, std::move(db_params), CoinsViewOptions{}};
     CCoinsViewCache coins_view_cache{&backend_coins_view, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_coins_view);
 }
@@ -442,7 +444,7 @@ FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view)
         .cache_bytes = 1_MiB,
         .memory_only = true,
     };
-    CCoinsViewDB backend_base_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewDB backend_base_coins_view{g_setup->m_logger, std::move(db_params), CoinsViewOptions{}};
     CCoinsViewCache backend_cache{&backend_base_coins_view, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
     CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -418,11 +418,17 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_coins_view);
 }
 
+static void cleanup_coins_view()
+{
+    // Stop worker threads before logger is destroyed because they log when exiting.
+    g_thread_pool->Stop();
+}
+
 // Creates a CoinsViewOverlay and a MutationGuardCoinsViewCache as the base.
 // This allows us to exercise all methods on a CoinsViewOverlay, while also
 // ensuring that nothing can mutate the underlying cache until Flush or Sync is
 // called.
-FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view, .cleanup = cleanup_coins_view)
 {
     SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedCoinsCacheHasher
     StartPoolIfNeeded();
@@ -434,7 +440,7 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }
 
-FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view, .cleanup = cleanup_coins_view)
 {
     SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedCoinsCacheHasher
     StartPoolIfNeeded();

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -213,9 +213,15 @@ void StartPoolIfNeeded()
     if (!g_thread_pool->WorkersCount()) g_thread_pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
 }
 
+static void cleanup_coinscache_sim()
+{
+    // Stop worker threads before logger is destroyed because they log when exiting.
+    g_thread_pool->Stop();
+}
+
 } // namespace
 
-FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; })
+FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }, .cleanup = cleanup_coinscache_sim)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     StartPoolIfNeeded();

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -36,6 +36,13 @@
 #include <vector>
 
 namespace {
+BasicTestingSetup* g_setup;
+
+void initialize()
+{
+    static const auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>();
+    g_setup = testing_setup.get();
+}
 
 /**
  * A leveldb::Env that wraps a memenv and captures scheduled background
@@ -209,7 +216,7 @@ void TestDbWrapper(FuzzedDataProvider& provider,
     const bool obfuscate{provider.ConsumeBool()};
 
     const auto make_db{[&](DBOptions options = {}) {
-        return std::make_unique<CDBWrapper>(ConsumeDBParams(provider, testing_env, obfuscate, options));
+        return std::make_unique<CDBWrapper>(g_setup->m_logger, ConsumeDBParams(provider, testing_env, obfuscate, options));
     }};
     std::unique_ptr<CDBWrapper> dbw{make_db()};
 
@@ -333,7 +340,7 @@ void TestDbWrapper(FuzzedDataProvider& provider,
 
 } // namespace
 
-FUZZ_TARGET(dbwrapper, .init = [] { static auto setup{MakeNoLogFileContext<>()}; })
+FUZZ_TARGET(dbwrapper, .init = initialize)
 {
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
 
@@ -346,7 +353,7 @@ FUZZ_TARGET(dbwrapper, .init = [] { static auto setup{MakeNoLogFileContext<>()};
         /*allow_force_compact=*/false);
 }
 
-FUZZ_TARGET(dbwrapper_threaded, .init = [] { static auto setup{MakeNoLogFileContext<>()}; })
+FUZZ_TARGET(dbwrapper_threaded, .init = initialize)
 {
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
 
@@ -358,7 +365,7 @@ FUZZ_TARGET(dbwrapper_threaded, .init = [] { static auto setup{MakeNoLogFileCont
         /*allow_force_compact=*/true);
 }
 
-FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLogFileContext<>()}; })
+FUZZ_TARGET(dbwrapper_concurrent_reads, .init = initialize)
 {
     StartReadPoolIfNeeded();
     SeedRandomStateForTest(SeedRand::ZEROS);
@@ -368,7 +375,7 @@ FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLog
     const auto memenv{std::unique_ptr<leveldb::Env>{leveldb::NewMemEnv(leveldb::Env::Default())}};
     DeterministicEnv det_env{memenv.get()};
 
-    CDBWrapper db{ConsumeDBParams(provider, &det_env, /*obfuscate=*/provider.ConsumeBool())};
+    CDBWrapper db{g_setup->m_logger, ConsumeDBParams(provider, &det_env, /*obfuscate=*/provider.ConsumeBool())};
 
     // Seed the DB. Drain work after small batches so we don't deadlock on a
     // scheduled compaction.

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -365,7 +365,13 @@ FUZZ_TARGET(dbwrapper_threaded, .init = initialize)
         /*allow_force_compact=*/true);
 }
 
-FUZZ_TARGET(dbwrapper_concurrent_reads, .init = initialize)
+static void cleanup_concurrent_reads()
+{
+    // Stop worker threads before logger is destroyed because they log when exiting.
+    g_read_pool.Stop();
+}
+
+FUZZ_TARGET(dbwrapper_concurrent_reads, .init = initialize, .cleanup = cleanup_concurrent_reads)
 {
     StartReadPoolIfNeeded();
     SeedRandomStateForTest(SeedRand::ZEROS);

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,6 +4,7 @@
 
 #include <test/fuzz/fuzz.h>
 
+#include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/fuzz/util/check_globals.h>
@@ -80,6 +81,25 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 static std::string_view g_fuzz_target;
 static const TypeTestOneInput* g_test_one_input{nullptr};
 
+class FuzzTestSetup
+{
+public:
+    FuzzTestSetup(const FuzzTargetOptions& options) : m_options{options}
+    {
+        if (m_options.init) m_options.init();
+    }
+    ~FuzzTestSetup()
+    {
+        if (m_options.cleanup) m_options.cleanup();
+    }
+    const FuzzTargetOptions& m_options;
+};
+
+static void test_setup(const FuzzTargetOptions& options)
+{
+    static FuzzTestSetup setup{options};
+}
+
 static void test_one_input(FuzzBufferType buffer)
 {
     CheckGlobals check{};
@@ -92,6 +112,9 @@ const std::function<std::string()> G_TEST_GET_FULL_NAME{[]{
 
 static void initialize()
 {
+    // Initialize logger first because RNG startup uses it.
+    static BCLog::Logger g_logger;
+
     CheckGlobals check{};
     // By default, make the RNG deterministic with a fixed seed. This will affect all
     // randomness during the fuzz test, except:
@@ -162,7 +185,7 @@ static void initialize()
     }
     Assert(!g_test_one_input);
     g_test_one_input = &it->second.test_one_input;
-    it->second.opts.init();
+    test_setup(it->second.opts);
 
     ResetCoverageCounters();
 }

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -26,7 +26,8 @@ using FuzzBufferType = std::span<const uint8_t>;
 
 using TypeTestOneInput = std::function<void(FuzzBufferType)>;
 struct FuzzTargetOptions {
-    std::function<void()> init{[] {}};
+    std::function<void()> init{};
+    std::function<void()> cleanup{};
     bool hidden{false};
 };
 

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -35,10 +35,12 @@
 
 namespace {
 
+TestingSetup* g_setup;
 std::deque<COutPoint> g_available_coins;
 void initialize_miner()
 {
-    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    static const auto testing_setup = MakeNoLogFileContext<TestingSetup>();
+    g_setup = testing_setup.get();
     for (uint32_t i = 0; i < uint32_t{100}; ++i) {
         g_available_coins.emplace_back(Txid::FromUint256(uint256::ZERO), i);
     }
@@ -51,7 +53,7 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     bilingual_str error;
-    CTxMemPool pool{CTxMemPool::Options{}, error};
+    CTxMemPool pool{CTxMemPool::Options{.logger = &g_setup->m_logger}, error};
     Assert(error.empty());
     std::vector<COutPoint> outpoints;
     std::deque<COutPoint> available_coins = g_available_coins;

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -39,7 +39,7 @@ void initialize_pdb()
 
 PartiallyDownloadedBlock::IsBlockMutatedFn FuzzedIsBlockMutated(bool result)
 {
-    return [result](const CBlock& block, bool) {
+    return [result](util::log::Logger*, const CBlock& block, bool) {
         return result;
     };
 }

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -18,9 +18,14 @@
 #include <optional>
 #include <vector>
 
+namespace {
+BasicTestingSetup* g_setup;
+} // namespace
+
 void initialize_script_sigcache()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>();
+    static const auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>();
+    g_setup = testing_setup.get();
 }
 
 FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
@@ -29,7 +34,7 @@ FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
     const auto max_sigcache_bytes{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, DEFAULT_SIGNATURE_CACHE_BYTES)};
-    SignatureCache signature_cache{max_sigcache_bytes};
+    SignatureCache signature_cache{g_setup->m_logger, max_sigcache_bytes};
 
     const std::optional<CMutableTransaction> mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
     const CTransaction tx{mutable_transaction ? *mutable_transaction : CMutableTransaction{}};

--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -58,7 +58,13 @@ static void setup_threadpool_test()
     LogInstance().DisableLogging();
 }
 
-FUZZ_TARGET(threadpool, .init = setup_threadpool_test)
+static void cleanup_threadpool_test()
+{
+    // Stop worker threads before logger is destroyed because they log when exiting.
+    g_pool.Stop();
+}
+
+FUZZ_TARGET(threadpool, .init = setup_threadpool_test, .cleanup = cleanup_threadpool_test)
 {
     // Because LibAFL calls fork() after calling the init setup function,
     // the child processes end up having one thread active and no workers.

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -625,20 +625,19 @@ BOOST_AUTO_TEST_CASE(logging_tests)
         .always_print_category_levels = true,
     };
 
-    logging_set_options(logging_options);
-    logging_set_level_category(LogCategory::BENCH, LogLevel::TRACE_LEVEL);
-    logging_disable_category(LogCategory::BENCH);
-    logging_enable_category(LogCategory::VALIDATION);
-    logging_disable_category(LogCategory::VALIDATION);
-
-    // Check that connecting, connecting another, and then disconnecting and connecting a logger again works.
-    {
-        logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
-        logging_enable_category(LogCategory::KERNEL);
-        Logger logger{std::make_unique<TestLog>()};
-        Logger logger_2{std::make_unique<TestLog>()};
-    }
     Logger logger{std::make_unique<TestLog>()};
+    logging_set_options(logger, logging_options);
+    logging_set_level_category(logger, LogCategory::BENCH, LogLevel::TRACE_LEVEL);
+    logging_disable_category(logger, LogCategory::BENCH);
+    logging_enable_category(logger, LogCategory::VALIDATION);
+    logging_disable_category(logger, LogCategory::VALIDATION);
+
+    // Check that setting options on a different logger works.
+    {
+        Logger logger_2{std::make_unique<TestLog>()};
+        logging_set_level_category(logger_2, LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
+        logging_enable_category(logger_2, LogCategory::KERNEL);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(btck_chainparams_tests)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -98,6 +98,10 @@ public:
     }
 };
 
+struct KernelTestFixture {
+    Logger<TestLog> m_logger{std::make_unique<TestLog>()};
+};
+
 struct TestDirectory {
     fs::path m_directory;
     TestDirectory(std::string directory_name)
@@ -389,6 +393,8 @@ void CheckRange(const RangeType& range, size_t expected_size)
     BOOST_CHECK(it2 == it + 1);
 }
 
+BOOST_FIXTURE_TEST_SUITE(test_kernel, KernelTestFixture)
+
 BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 {
     auto tx_data{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};
@@ -652,12 +658,11 @@ BOOST_AUTO_TEST_CASE(logging_tests)
         .always_print_category_levels = true,
     };
 
-    Logger logger{std::make_unique<TestLog>()};
-    logging_set_options(logger, logging_options);
-    logging_set_level_category(logger, LogCategory::BENCH, LogLevel::TRACE_LEVEL);
-    logging_disable_category(logger, LogCategory::BENCH);
-    logging_enable_category(logger, LogCategory::VALIDATION);
-    logging_disable_category(logger, LogCategory::VALIDATION);
+    logging_set_options(m_logger, logging_options);
+    logging_set_level_category(m_logger, LogCategory::BENCH, LogLevel::TRACE_LEVEL);
+    logging_disable_category(m_logger, LogCategory::BENCH);
+    logging_enable_category(m_logger, LogCategory::VALIDATION);
+    logging_disable_category(m_logger, LogCategory::VALIDATION);
 
     // Check that setting options on a different logger works.
     {
@@ -764,7 +769,6 @@ Context create_context(std::shared_ptr<TestKernelNotifications> notifications, C
 
 BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 {
-    Logger logger{std::make_unique<TestLog>()};
     auto test_directory{TestDirectory{"chainman_test_bitcoin_kernel"}};
 
     { // test with default context
@@ -1409,3 +1413,5 @@ BOOST_AUTO_TEST_CASE(btck_transaction_check_tests)
         "ffffffff00ffffffff000100000000000000000000000000000000000000000000000000000000"
         "00000000000000ffffffff010000000000000000015100000000");
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -99,6 +99,10 @@ public:
     }
 };
 
+struct KernelTestFixture {
+    Logger<TestLog> m_logger{std::make_unique<TestLog>()};
+};
+
 struct TestDirectory {
     fs::path m_directory;
     TestDirectory(std::string directory_name)
@@ -390,6 +394,8 @@ void CheckRange(const RangeType& range, size_t expected_size)
     BOOST_CHECK(it2 == it + 1);
 }
 
+BOOST_FIXTURE_TEST_SUITE(test_kernel, KernelTestFixture)
+
 BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 {
     auto tx_data{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};
@@ -653,12 +659,11 @@ BOOST_AUTO_TEST_CASE(logging_tests)
         .always_print_category_levels = true,
     };
 
-    Logger logger{std::make_unique<TestLog>()};
-    logging_set_options(logger, logging_options);
-    logging_set_level_category(logger, LogCategory::BENCH, LogLevel::TRACE_LEVEL);
-    logging_disable_category(logger, LogCategory::BENCH);
-    logging_enable_category(logger, LogCategory::VALIDATION);
-    logging_disable_category(logger, LogCategory::VALIDATION);
+    logging_set_options(m_logger, logging_options);
+    logging_set_level_category(m_logger, LogCategory::BENCH, LogLevel::TRACE_LEVEL);
+    logging_disable_category(m_logger, LogCategory::BENCH);
+    logging_enable_category(m_logger, LogCategory::VALIDATION);
+    logging_disable_category(m_logger, LogCategory::VALIDATION);
 
     // Check that setting options on a different logger works.
     {
@@ -771,7 +776,6 @@ Context create_context(std::shared_ptr<TestKernelNotifications> notifications, C
 
 BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 {
-    Logger logger{std::make_unique<TestLog>()};
     auto test_directory{TestDirectory{"chainman_test_bitcoin_kernel"}};
 
     { // test with default context
@@ -1467,3 +1471,5 @@ BOOST_AUTO_TEST_CASE(btck_set_mock_time_tests)
     BOOST_CHECK(ok_state.GetValidationMode() == ValidationMode::VALID);
     BOOST_CHECK(ok_state.GetBlockValidationResult() == BlockValidationResult::UNSET);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -228,6 +228,43 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 
+//! Example of a custom log context that includes a counter value in logged
+//! messages. Custom log contexts allow different areas of the codebase to
+//! attach information to log messages (like request ids or filenames) while
+//! still using standard logging macros.
+struct CountingLogContext {
+    static constexpr bool log_context{true};
+    util::log::Category category{BCLog::VALIDATION};
+    util::log::Logger* logger{nullptr};
+    int counter{0};
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+    {
+        return tfm::format("Custom #%d %s", ++counter, tfm::format(fmt, args...));
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(logging_CustomContext, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Debug);
+    CountingLogContext log;
+    LogTrace(log, "foo0: %s", "bar0"); // not logged
+    LogDebug(log, "foo1: %s", "bar1");
+    LogInfo(log, "foo2: %s", "bar2");
+    LogWarning(log, "foo3: %s", "bar3");
+    LogError(log, "foo4: %s", "bar4");
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[validation] Custom #1 foo1: bar1",
+        "Custom #2 foo2: bar2",
+        "[warning] Custom #3 foo3: bar3",
+        "[error] Custom #4 foo4: bar4",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -105,6 +105,35 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test logging to local logger.
+BOOST_AUTO_TEST_CASE(logging_local_logger)
+{
+    BCLog::Logger logger;
+    logger.m_log_timestamps = false;
+    logger.EnableCategory(BCLog::LogFlags::ALL);
+    logger.SetLogLevel(BCLog::Level::Trace);
+    BOOST_REQUIRE(logger.StartLogging());
+
+    std::vector<std::string> messages;
+    logger.PushBackCallback([&](const std::string& s) { messages.push_back(s); });
+
+    util::log::Context log{BCLog::NET, &logger};
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
+    constexpr auto expected{std::to_array({
+        "[error] error arg\n",
+        "[warning] warning arg\n",
+        "info arg\n",
+        "[net] debug arg\n",
+        "[net:trace] trace arg\n",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(messages.begin(), messages.end(), expected.begin(), expected.end());
+}
+
 //! Test calls to log macros with all possible types of arguments: with and
 //! without categories and with and without format arguments to make sure
 //! varargs are handled correctly.
@@ -150,6 +179,19 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
 
+    // Test logging with context object.
+    util::log::Context log{BCLog::TOR, &LogInstance()};
+    LogError(log, "error");
+    LogWarning(log, "warning");
+    LogInfo(log, "info");
+    LogDebug(log, "debug");
+    LogTrace(log, "trace");
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -170,6 +212,18 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
         "options info arg",
         "[net] options debug",
         "[net] options debug arg",
+
+        "[error] error",
+        "[warning] warning",
+        "info",
+        "[tor] debug",
+        "[tor:trace] trace",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+        "[tor] debug arg",
+        "[tor:trace] trace arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
 
     std::vector<Case> cases = {
         {"foo1: bar1", BCLog::NET, BCLog::Level::Debug, "[net] ", SourceLocation{__func__}},
-        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "[net:info] ", SourceLocation{__func__}},
+        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo3: bar3", BCLog::ALL, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},
         {"foo4: bar4", BCLog::ALL, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo5: bar5", BCLog::NONE, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using util::log::Level;
 using util::SplitString;
 using util::TrimString;
 
@@ -139,6 +140,16 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LogDebug(BCLog::NET, "debug %s", "arg");
     LogTrace(BCLog::NET, "trace %s", "arg");
 
+    LOG_EMIT((.level = Level::Info), "options info");
+    LOG_EMIT((.level = Level::Info), "options info %s", "arg");
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info"); // Not allowed because category is forbidden!
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info %s", "arg"); // Not allowed because category is forbidden!
+
+    // LOG_EMIT((.level = Level::Debug), "options debug"); // Not allowed because category is required!
+    // LOG_EMIT((.level = Level::Debug), "options debug %s", "arg"); // Not allowed because category is required!
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -154,6 +165,11 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
 
         "[net] debug arg",
         "[net:trace] trace arg",
+
+        "options info",
+        "options info arg",
+        "[net] options debug",
+        "[net] options debug arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -426,7 +442,7 @@ void LogFromLocation(Location location, const std::string& message) {
         LogDebug(BCLog::LogFlags::HTTP, "%s\n", message);
         return;
     case Location::INFO_NOLIMIT:
-        LogInfo(util::log::NO_RATE_LIMIT, "%s\n", message);
+        LOG_EMIT((.level = Level::Info, .ratelimit = false), "%s\n", message);
         return;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using util::log::Level;
 using util::SplitString;
 using util::TrimString;
 
@@ -139,6 +140,16 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LogDebug(BCLog::NET, "debug %s", "arg");
     LogTrace(BCLog::NET, "trace %s", "arg");
 
+    LOG_EMIT((.level = Level::Info), "options info");
+    LOG_EMIT((.level = Level::Info), "options info %s", "arg");
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info"); // Not allowed because category is forbidden!
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info %s", "arg"); // Not allowed because category is forbidden!
+
+    // LOG_EMIT((.level = Level::Debug), "options debug"); // Not allowed because category is required!
+    // LOG_EMIT((.level = Level::Debug), "options debug %s", "arg"); // Not allowed because category is required!
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -154,6 +165,11 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
 
         "[net] debug arg",
         "[net:trace] trace arg",
+
+        "options info",
+        "options info arg",
+        "[net] options debug",
+        "[net] options debug arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -419,7 +435,7 @@ void LogFromLocation(Location location, const std::string& message) {
         LogDebug(BCLog::LogFlags::HTTP, "%s\n", message);
         return;
     case Location::INFO_NOLIMIT:
-        LogInfo(util::log::NO_RATE_LIMIT, "%s\n", message);
+        LOG_EMIT((.level = Level::Info, .ratelimit = false), "%s\n", message);
         return;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -463,4 +463,30 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
+{
+    for (bool enable_logger : {true, false}) {
+        LogInstance().DisconnectTestLogger();
+        if (enable_logger) {
+            BOOST_REQUIRE(LogInstance().StartLogging());
+        } else {
+            LogInstance().DisableLogging();
+        }
+        BOOST_REQUIRE_EQUAL(enable_logger, LogInstance().Enabled());
+
+        // Info or higher should always evaluate the arguments.
+        int counter = 0;
+        LogError("error (%s)", ++counter);
+        LogWarning("warning (%s)", ++counter);
+        LogInfo("info (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 3);
+
+        // Debug/Trace should skip argument evaluation when category is disabled.
+        counter = 0;
+        LogDebug(BCLog::NET, "debug (%s)", ++counter);
+        LogTrace(BCLog::NET, "trace (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -470,4 +470,30 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
+{
+    for (bool enable_logger : {true, false}) {
+        LogInstance().DisconnectTestLogger();
+        if (enable_logger) {
+            BOOST_REQUIRE(LogInstance().StartLogging());
+        } else {
+            LogInstance().DisableLogging();
+        }
+        BOOST_REQUIRE_EQUAL(enable_logger, LogInstance().Enabled());
+
+        // Info or higher should always evaluate the arguments.
+        int counter = 0;
+        LogError("error (%s)", ++counter);
+        LogWarning("warning (%s)", ++counter);
+        LogInfo("info (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 3);
+
+        // Debug/Trace should skip argument evaluation when category is disabled.
+        counter = 0;
+        LogDebug(BCLog::NET, "debug (%s)", ++counter);
+        LogTrace(BCLog::NET, "trace (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -14,6 +14,7 @@
 #include <util/fs_helpers.h>
 #include <util/string.h>
 
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -103,6 +104,60 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test calls to log macros with all possible types of arguments: with and
+//! without categories and with and without format arguments to make sure
+//! varargs are handled correctly.
+//! Include commented out calls for combinations of macro arguments which are
+//! prohibited, for easy manual testing to confirm these calls produce readable
+//! compile errors.
+BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Trace);
+
+    // Test logging with no context.
+    LogError("error");
+    LogWarning("warning");
+    LogInfo("info");
+    // LogDebug("debug"); // Not allowed because category is required!
+    // LogTrace("trace"); // Not allowed because category is required!
+    LogError("error %s", "arg");
+    LogWarning("warning %s", "arg");
+    LogInfo("info %s", "arg");
+    // LogDebug("debug %s", "arg"); // Not allowed because category is required!
+    // LogTrace("trace %s", "arg"); // Not allowed because category is required!
+
+    // Test logging with category constant arguments.
+    // LogError(BCLog::NET, "error"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug");
+    LogTrace(BCLog::NET, "trace");
+    // LogError(BCLog::NET, "error %s", "arg"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning %s", "arg"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info %s", "arg"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug %s", "arg");
+    LogTrace(BCLog::NET, "trace %s", "arg");
+
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[error] error",
+        "[warning] warning",
+        "info",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+
+        "[net] debug",
+        "[net:trace] trace",
+
+        "[net] debug arg",
+        "[net:trace] trace arg",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
@@ -137,24 +192,6 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
         LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
-    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
-}
-
-BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
-{
-    LogInstance().EnableCategory(BCLog::NET);
-    LogTrace(BCLog::NET, "foo6: %s", "bar6"); // not logged
-    LogDebug(BCLog::NET, "foo7: %s", "bar7");
-    LogInfo("foo8: %s", "bar8");
-    LogWarning("foo9: %s", "bar9");
-    LogError("foo10: %s", "bar10");
-    std::vector<std::string> log_lines{ReadDebugLogLines()};
-    std::vector<std::string> expected = {
-        "[net] foo7: bar7",
-        "foo8: bar8",
-        "[warning] foo9: bar9",
-        "[error] foo10: bar10",
-    };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -496,4 +496,20 @@ BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(log_accept_category, LogSetup)
+{
+    using namespace util::log;
+    BCLog::Logger& logger{LogInstance()};
+
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::ALL, Level::Info));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::NET, Level::Warning));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::VALIDATION, Level::Error));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::LEVELDB, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::ALL, Level::Trace));
+
+    logger.EnableCategory(BCLog::TXPACKAGES);
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Trace));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -489,4 +489,20 @@ BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(log_accept_category, LogSetup)
+{
+    using namespace util::log;
+    BCLog::Logger& logger{LogInstance()};
+
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::ALL, Level::Info));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::NET, Level::Warning));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::VALIDATION, Level::Error));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::LEVELDB, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::ALL, Level::Trace));
+
+    logger.EnableCategory(BCLog::TXPACKAGES);
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Trace));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -205,7 +205,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
         expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
-        LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
+        LogInstance().LogPrint({.level = level}, {.category = category, .level = level, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -65,7 +65,7 @@ struct MinerTestingSetup : public TestingSetup {
     {
         CCoinsViewMemPool view_mempool{&m_node.chainman->ActiveChainstate().CoinsTip(), tx_mempool};
         CBlockIndex* tip{m_node.chainman->ActiveChain().Tip()};
-        const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(tip, view_mempool, tx)};
+        const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(&m_logger, tip, view_mempool, tx)};
         return lock_points.has_value() && CheckSequenceLocksAtTip(tip, *lock_points);
     }
     CTxMemPool& MakeMempool()

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -4,12 +4,13 @@
 
 #include <sync.h>
 #include <test/util/common.h>
+#include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <stdexcept>
 
-BOOST_AUTO_TEST_SUITE(reverselock_tests)
+BOOST_FIXTURE_TEST_SUITE(reverselock_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(reverselock_basics)
 {

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <random.h>
 #include <scheduler.h>
+#include <test/util/setup_common.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>
@@ -13,7 +14,7 @@
 #include <thread>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(scheduler_tests)
+BOOST_FIXTURE_TEST_SUITE(scheduler_tests, BasicTestingSetup)
 
 static void microTask(CScheduler& s, std::mutex& mutex, int& counter, int delta, std::chrono::steady_clock::time_point rescheduleTime)
 {

--- a/src/test/script_assets_tests.cpp
+++ b/src/test/script_assets_tests.cpp
@@ -11,6 +11,7 @@
 #include <span.h>
 #include <streams.h>
 #include <test/util/json.h>
+#include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
@@ -27,7 +28,7 @@
 
 script_verify_flags ParseScriptFlags(std::string strFlags);
 
-BOOST_AUTO_TEST_SUITE(script_assets_tests)
+BOOST_FIXTURE_TEST_SUITE(script_assets_tests, BasicTestingSetup)
 
 template <typename T>
 CScript ToScript(const T& byte_container)
@@ -150,7 +151,7 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
 {
     // See src/test/fuzz/script_assets_test_minimizer.cpp for information on how to generate
     // the script_assets_test.json file used by this test.
-    SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};
+    SignatureCache signature_cache{m_logger, DEFAULT_SIGNATURE_CACHE_BYTES};
 
     const char* dir = std::getenv("DIR_UNIT_TEST_DATA");
     BOOST_WARN_MESSAGE(dir != nullptr, "Variable DIR_UNIT_TEST_DATA unset, skipping script_assets_test");

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(sign)
     }
     // All of the above should be OK, and the txTos have valid signatures
     // Check to make sure signature verification fails if we use the wrong ScriptSig:
-    SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};
+    SignatureCache signature_cache{m_logger, DEFAULT_SIGNATURE_CACHE_BYTES};
     for (int i = 0; i < 8; i++) {
         PrecomputedTransactionData txdata(txTo[i]);
         for (int j = 0; j < 8; j++)

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <sync.h>
 #include <test/util/common.h>
+#include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -76,7 +77,7 @@ void TestInconsistentLockOrderDetected(MutexType& mutex1, MutexType& mutex2)
 }
 } // namespace
 
-BOOST_AUTO_TEST_SUITE(sync_tests)
+BOOST_FIXTURE_TEST_SUITE(sync_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -6,6 +6,7 @@
 #include <logging.h>
 #include <random.h>
 #include <test/util/common.h>
+#include <test/util/setup_common.h>
 #include <util/string.h>
 #include <util/threadpool.h>
 #include <util/time.h>
@@ -18,12 +19,17 @@
 #include <ranges>
 #include <semaphore>
 
+// Undefine Windows WAIT_TIMEOUT macro (WinError.h) to avoid name collision.
+#ifdef WAIT_TIMEOUT
+#undef WAIT_TIMEOUT
+#endif
+
 // General test values
 int NUM_WORKERS_DEFAULT = 0;
 constexpr char POOL_NAME[] = "test";
 constexpr auto TEST_WAIT_TIMEOUT = 120s;
 
-struct ThreadPoolFixture {
+struct ThreadPoolFixture : public BasicTestingSetup {
     ThreadPoolFixture() {
         NUM_WORKERS_DEFAULT = FastRandomContext().randrange(GetNumCores()) + 1;
         LogInfo("thread pool workers count: %d", NUM_WORKERS_DEFAULT);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
         coins.emplace_back(std::move(coin));
     }
 
-    SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};
+    SignatureCache signature_cache{m_logger, DEFAULT_SIGNATURE_CACHE_BYTES};
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
         std::vector<CScriptCheck> vChecks;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
         coins.emplace_back(std::move(coin));
     }
 
-    SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};
+    SignatureCache signature_cache{m_logger, DEFAULT_SIGNATURE_CACHE_BYTES};
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
         std::vector<CScriptCheck> vChecks;

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -235,7 +235,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
     // the header and the 1-byte tx count.
     const CDiskTxPos legacy_pos{BlockFilePos(*m_node.chainman, 1), 1};
     {
-        CDBWrapper db{DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}};
+        CDBWrapper db{m_logger, DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}};
         db.Write(txindex::LegacyTxKey(legacy_txid), legacy_pos);
     }
 
@@ -265,7 +265,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_locator_upgrade, TestChain100Setup)
         new_hash = Assert(m_node.chainman->ActiveChain().Tip())->GetBlockHash();
     }
     CBlockLocator legacy_locator{{legacy_hash}}, new_locator{{new_hash}};
-    { CDBWrapper{DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}}.Write(uint8_t{'B'}, legacy_locator); }
+    { CDBWrapper{m_logger, DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}}.Write(uint8_t{'B'}, legacy_locator); }
 
     TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_CHECK(TxIndexTest::ReadBestBlock(txindex).vHave == legacy_locator.vHave);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -109,6 +109,8 @@ constexpr inline auto TEST_DIR_PATH_ELEMENT{"test_common bitcoin"}; // Includes 
 /** Random context to get unique temp data dirs. Separate from m_rng, which can be seeded from a const env var */
 static FastRandomContext g_rng_temp_path;
 static const bool g_rng_temp_path_init{[] {
+    // Make sure there is a global logger SeedStartup() can use.
+    BCLog::Logger logger;
     // Must be initialized before any SeedRandomForTest
     Assert(!g_used_g_prng);
     (void)g_rng_temp_path.rand64();
@@ -140,7 +142,7 @@ static void ExitFailure(std::string_view str_err)
 }
 
 BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
-    : m_logger{LogInstance()}, m_args{}
+    : m_args{}
 {
     if (!EnableFuzzDeterminism()) {
         SeedRandomForTest(SeedRand::FIXED_SEED);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -140,7 +140,7 @@ static void ExitFailure(std::string_view str_err)
 }
 
 BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
-    : m_args{}
+    : m_logger{LogInstance()}, m_args{}
 {
     if (!EnableFuzzDeterminism()) {
         SeedRandomForTest(SeedRand::FIXED_SEED);
@@ -325,7 +325,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
                 .wipe_data = m_args.GetBoolArg("-reindex", false),
             },
         };
-        m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+        m_node.chainman = std::make_unique<ChainstateManager>(m_logger, *Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
     m_make_chainman();
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -140,7 +140,7 @@ static void ExitFailure(std::string_view str_err)
 }
 
 BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
-    : m_args{}
+    : m_logger{LogInstance()}, m_args{}
 {
     if (!EnableFuzzDeterminism()) {
         SeedRandomForTest(SeedRand::FIXED_SEED);
@@ -327,7 +327,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
                 .wipe_data = m_args.GetBoolArg("-reindex", false),
             },
         };
-        m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+        m_node.chainman = std::make_unique<ChainstateManager>(m_logger, *Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
     m_make_chainman();
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -9,6 +9,7 @@
 #include <consensus/amount.h>
 #include <kernel/caches.h>
 #include <key.h>
+#include <logging.h>
 #include <node/caches.h>
 #include <node/context.h> // IWYU pragma: export
 #include <primitives/transaction.h>
@@ -56,6 +57,7 @@ struct TestOpts {
  * This just configures logging, data dir and chain parameters.
  */
 struct BasicTestingSetup {
+    BCLog::Logger& m_logger;
     util::SignalInterrupt m_interrupt;
     node::NodeContext m_node; // keep as first member to be destructed last
 

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -57,7 +57,7 @@ struct TestOpts {
  * This just configures logging, data dir and chain parameters.
  */
 struct BasicTestingSetup {
-    BCLog::Logger& m_logger;
+    BCLog::Logger m_logger;
     util::SignalInterrupt m_interrupt;
     node::NodeContext m_node; // keep as first member to be destructed last
 

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -445,7 +445,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.
             m_node.chainman.reset();
-            m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            m_node.chainman = std::make_unique<ChainstateManager>(m_logger, *Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
         }
         return *Assert(m_node.chainman);
     }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -454,7 +454,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.
             m_node.chainman.reset();
-            m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            m_node.chainman = std::make_unique<ChainstateManager>(m_logger, *Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
         }
         return *Assert(m_node.chainman);
     }

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -154,8 +154,8 @@ BOOST_AUTO_TEST_CASE(block_malleation)
 {
     // Test utilities that calls `IsBlockMutated` and then clears the validity
     // cache flags on `CBlock`.
-    auto is_mutated = [](CBlock& block, bool check_witness_root) {
-        bool mutated{IsBlockMutated(block, check_witness_root)};
+    auto is_mutated = [this](CBlock& block, bool check_witness_root) {
+        bool mutated{IsBlockMutated(&m_logger, block, check_witness_root)};
         block.fChecked = false;
         block.m_checked_witness_commitment = false;
         block.m_checked_merkle_root = false;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -25,6 +25,8 @@
 #include <iterator>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 static constexpr uint8_t DB_COIN{'C'};
 static constexpr uint8_t DB_BEST_BLOCK{'B'};
 static constexpr uint8_t DB_HEAD_BLOCKS{'H'};
@@ -65,7 +67,7 @@ CCoinsViewDB::~CCoinsViewDB()
 {
     if (m_compaction.valid()) {
         if (m_compaction.wait_for(std::chrono::seconds{0}) != std::future_status::ready) {
-            LogInfo("Waiting for background chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogInfo(m_log, "Waiting for background chainstate compaction of %s", fs::PathToString(m_db_params.path));
         }
         m_compaction.wait();
     }
@@ -133,14 +135,14 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
         std::vector<uint256> old_heads = GetHeadBlocks();
         if (old_heads.size() == 2) {
             if (old_heads[0] != block_hash) {
-                LogError("The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
+                LogError(m_log, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
             }
             assert(old_heads[0] == block_hash);
             old_tip = old_heads[1];
         }
     }
 
-    if (dirty_count > WARN_FLUSH_COINS_COUNT) LogWarning("Flushing large (%d entries) UTXO set to disk, it may take several minutes", dirty_count);
+    if (dirty_count > WARN_FLUSH_COINS_COUNT) LogWarning(m_log, "Flushing large (%d entries) UTXO set to disk, it may take several minutes", dirty_count);
     LOG_TIME_MILLIS_WITH_CATEGORY(strprintf("write coins cache to disk (%d out of %d cached coins)",
         dirty_count, cursor.GetTotalCount()), BCLog::BENCH);
 
@@ -163,14 +165,14 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
         count++;
         it = cursor.NextAndMaybeErase(*it);
         if (batch.ApproximateSize() > m_options.batch_write_bytes) {
-            LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
+            LogDebug(m_log, "Writing partial batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
 
             m_db->WriteBatch(batch);
             batch.Clear();
             if (m_options.simulate_crash_ratio) {
                 static FastRandomContext rng;
                 if (rng.randrange(m_options.simulate_crash_ratio) == 0) {
-                    LogError("Simulating a crash. Goodbye.");
+                    LogError(m_log, "Simulating a crash. Goodbye.");
                     _Exit(0);
                 }
             }
@@ -181,9 +183,9 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
     batch.Erase(DB_HEAD_BLOCKS);
     batch.Write(DB_BEST_BLOCK, block_hash);
 
-    LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
+    LogDebug(m_log, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
     m_db->WriteBatch(batch);
-    LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs (out of %u) to coin database...", (unsigned int)dirty_count, (unsigned int)count);
+    LogDebug(m_log, "Committed %u changed transaction outputs (out of %u) to coin database...", (unsigned int)dirty_count, (unsigned int)count);
 }
 
 size_t CCoinsViewDB::EstimateSize() const
@@ -205,11 +207,11 @@ std::shared_future<void> CCoinsViewDB::CompactFullAsync()
             util::ThreadRename("utxocompact");
             LOCK(m_db_mutex);
 
-            LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogDebug(m_log, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
             m_db->CompactFull();
-            LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogDebug(m_log, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
         } catch (const std::exception& e) {
-            LogWarning("Failed chainstate compaction (%s)", e.what());
+            LogWarning(m_log, "Failed chainstate compaction (%s)", e.what());
         }
     }).share();
     return m_compaction;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -55,10 +55,11 @@ struct CoinEntry {
 
 } // namespace
 
-CCoinsViewDB::CCoinsViewDB(DBParams db_params, CoinsViewOptions options) :
+CCoinsViewDB::CCoinsViewDB(util::log::Logger& logger, DBParams db_params, CoinsViewOptions options) :
+    m_log{BCLog::COINDB, &logger},
     m_db_params{std::move(db_params)},
     m_options{std::move(options)},
-    m_db{std::make_unique<CDBWrapper>(m_db_params)} { }
+    m_db{std::make_unique<CDBWrapper>(logger, m_db_params)} { }
 
 CCoinsViewDB::~CCoinsViewDB()
 {
@@ -81,7 +82,7 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
         m_db.reset();
         m_db_params.cache_bytes = new_cache_size;
         m_db_params.wipe_data = false;
-        m_db = std::make_unique<CDBWrapper>(m_db_params);
+        m_db = std::make_unique<CDBWrapper>(*Assert(m_log.logger), m_db_params);
     }
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -12,6 +12,7 @@
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <util/fs.h>
+#include <util/log.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -36,6 +37,7 @@ struct CoinsViewOptions {
 class CCoinsViewDB final : public CCoinsView
 {
 protected:
+    const util::log::Context m_log;
     DBParams m_db_params;
     CoinsViewOptions m_options;
     //! Prevents CompactFull() from using m_db while ResizeCache() replaces it.
@@ -43,7 +45,7 @@ protected:
     std::unique_ptr<CDBWrapper> m_db;
     std::shared_future<void> m_compaction;
 public:
-    explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
+    explicit CCoinsViewDB(util::log::Logger& logger, DBParams db_params, CoinsViewOptions options);
     ~CCoinsViewDB() override;
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -174,7 +174,7 @@ static CTxMemPool::Options&& Flatten(CTxMemPool::Options&& opts, bilingual_str& 
 }
 
 CTxMemPool::CTxMemPool(Options opts, bilingual_str& error)
-    : m_opts{Flatten(std::move(opts), error)}
+    : m_opts{Flatten(std::move(opts), error)}, m_log{BCLog::MEMPOOL, m_opts.logger}
 {
     m_txgraph = MakeTxGraph(
         /*max_cluster_count=*/m_opts.limits.cluster_count,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -34,6 +34,8 @@
 #include <string_view>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 TRACEPOINT_SEMAPHORE(mempool, added);
 TRACEPOINT_SEMAPHORE(mempool, removed);
 
@@ -222,7 +224,7 @@ void CTxMemPool::Apply(ChangeSet* changeset)
         addNewTransaction(it);
     }
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after addition(s).");
+        LogDebug(m_log, "Mempool in non-optimal ordering after addition(s).");
     }
 }
 
@@ -381,7 +383,7 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
         assert(TestLockPointValidity(chain, it->GetLockPoints()));
     }
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after reorg.");
+        LogDebug(m_log, "Mempool in non-optimal ordering after reorg.");
     }
 }
 
@@ -426,7 +428,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = true;
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after block.");
+        LogDebug(m_log, "Mempool in non-optimal ordering after block.");
     }
 }
 
@@ -438,7 +440,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
     AssertLockHeld(::cs_main);
     LOCK(cs);
-    LogDebug(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
+    LogDebug(m_log, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     uint64_t checkTotal = 0;
     CAmount check_total_fee{0};
@@ -652,9 +654,9 @@ void CTxMemPool::PrioritiseTransaction(const Txid& hash, const CAmount& nFeeDelt
         }
         if (delta == 0) {
             mapDeltas.erase(hash);
-            LogInfo("PrioritiseTransaction: %s (%sin mempool) delta cleared\n", hash.ToString(), it == mapTx.end() ? "not " : "");
+            LogInfo(m_log, "PrioritiseTransaction: %s (%sin mempool) delta cleared\n", hash.ToString(), it == mapTx.end() ? "not " : "");
         } else {
-            LogInfo("PrioritiseTransaction: %s (%sin mempool) fee += %s, new delta=%s\n",
+            LogInfo(m_log, "PrioritiseTransaction: %s (%sin mempool) fee += %s, new delta=%s\n",
                       hash.ToString(),
                       it == mapTx.end() ? "not " : "",
                       FormatMoney(nFeeDelta),
@@ -795,7 +797,7 @@ void CTxMemPool::RemoveUnbroadcastTx(const Txid& txid, const bool unchecked) {
 
     if (m_unbroadcast_txids.erase(txid))
     {
-        LogDebug(BCLog::MEMPOOL, "Removed %s from set of unbroadcast txns%s", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
+        LogDebug(m_log, "Removed %s from set of unbroadcast txns%s", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
     }
 }
 
@@ -915,7 +917,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
     }
 
     if (maxFeeRateRemoved > CFeeRate(0)) {
-        LogDebug(BCLog::MEMPOOL, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
+        LogDebug(m_log, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
     }
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -34,6 +34,8 @@
 #include <string_view>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 TRACEPOINT_SEMAPHORE(mempool, added);
 TRACEPOINT_SEMAPHORE(mempool, removed);
 
@@ -222,7 +224,7 @@ void CTxMemPool::Apply(ChangeSet* changeset)
         addNewTransaction(it);
     }
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after addition(s).");
+        LogDebug(m_log, "Mempool in non-optimal ordering after addition(s).");
     }
 }
 
@@ -381,7 +383,7 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
         assert(TestLockPointValidity(chain, it->GetLockPoints()));
     }
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after reorg.");
+        LogDebug(m_log, "Mempool in non-optimal ordering after reorg.");
     }
 }
 
@@ -426,7 +428,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = true;
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
-        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after block.");
+        LogDebug(m_log, "Mempool in non-optimal ordering after block.");
     }
 }
 
@@ -438,7 +440,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
     AssertLockHeld(::cs_main);
     LOCK(cs);
-    LogDebug(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
+    LogDebug(m_log, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     uint64_t checkTotal = 0;
     CAmount check_total_fee{0};
@@ -693,9 +695,9 @@ void CTxMemPool::PrioritiseTransaction(const Txid& hash, const CAmount& nFeeDelt
         }
         if (delta == 0) {
             mapDeltas.erase(hash);
-            LogInfo("PrioritiseTransaction: %s (%sin mempool) delta cleared\n", hash.ToString(), it == mapTx.end() ? "not " : "");
+            LogInfo(m_log, "PrioritiseTransaction: %s (%sin mempool) delta cleared\n", hash.ToString(), it == mapTx.end() ? "not " : "");
         } else {
-            LogInfo("PrioritiseTransaction: %s (%sin mempool) fee += %s, new delta=%s\n",
+            LogInfo(m_log, "PrioritiseTransaction: %s (%sin mempool) fee += %s, new delta=%s\n",
                       hash.ToString(),
                       it == mapTx.end() ? "not " : "",
                       FormatMoney(nFeeDelta),
@@ -836,7 +838,7 @@ void CTxMemPool::RemoveUnbroadcastTx(const Txid& txid, const bool unchecked) {
 
     if (m_unbroadcast_txids.erase(txid))
     {
-        LogDebug(BCLog::MEMPOOL, "Removed %s from set of unbroadcast txns%s", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
+        LogDebug(m_log, "Removed %s from set of unbroadcast txns%s", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
     }
 }
 
@@ -956,7 +958,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
     }
 
     if (maxFeeRateRemoved > CFeeRate(0)) {
-        LogDebug(BCLog::MEMPOOL, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
+        LogDebug(m_log, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
     }
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -299,6 +299,7 @@ public:
     using Options = kernel::MemPoolOptions;
 
     const Options m_opts;
+    const util::log::Context m_log;
 
     /** Create a new CTxMemPool.
      * Sanity checks will be off by default for performance, because otherwise

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -88,7 +88,6 @@ enum class Level {
 struct Entry {
     Category category;
     Level level;
-    bool should_ratelimit{false}; //!< Hint for consumers if this entry should be ratelimited
     SystemClock::time_point timestamp{SystemClock::now()};
     std::chrono::seconds mocktime{GetMockTime()};
     std::string thread_name{util::ThreadGetInternalName()};
@@ -140,7 +139,7 @@ namespace hooks {
 bool ShouldLog(Category category, Level level);
 
 /// Send message to be logged.
-void Log(Entry entry);
+void Log(const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
@@ -179,10 +178,9 @@ Context GetContext(Category category)
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(Entry{
+    hooks::Log(options, Entry{
         .category = context.category,
         .level = options.level,
-        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
         .message = context.Format(fmt, args...)});
 }

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -7,6 +7,7 @@
 
 // This header works in tandem with `logging/categories.h`
 // to expose the complete logging interface.
+#include <attributes.h>
 #include <logging/categories.h> // IWYU pragma: export
 #include <tinyformat.h>
 #include <util/check.h>
@@ -17,6 +18,39 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <type_traits>
+
+/// Logging macros which output log messages at the specified levels. They
+/// accept printf-style format strings and arguments. The debug and trace macros
+/// also require an initial BCLog::LogFlags category argument.
+/// See the "Logging" section of /doc/developer-notes.md for more details.
+#define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
+#define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
+#define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
+#define LogDebug(...) LOG_EMIT((.level = util::log::Level::Debug), __VA_ARGS__)
+#define LogTrace(...) LOG_EMIT((.level = util::log::Level::Trace), __VA_ARGS__)
+
+/// Low-level logging macro called with an initial options argument. Meant to be
+/// called internally, and in special cases to override default behaviors.
+// NOLINTBEGIN(bugprone-lambda-function-name)
+// Allow __func__ to be used in any context without warnings:
+#define LOG_EMIT(options, ...)                                                                     \
+    do {                                                                                           \
+        constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
+        auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
+        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+            util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
+        } else if constexpr (_options.evaluate_when_disabled) {                                    \
+            [](auto&&...) {}(__VA_ARGS__);                                                         \
+        }                                                                                          \
+    } while (0)
+// NOLINTEND(bugprone-lambda-function-name)
+
+/// Return the first argument from a variadic macro argument list.
+#define PP_FIRST_ARG(arg, ...) arg
+
+/// Expand parenthesized macro arguments `(a, b)` into `a, b`.
+#define PP_EXPAND_ARGS(...) __VA_ARGS__
 
 /// Like std::source_location, but allowing to override the function name.
 class SourceLocation
@@ -43,12 +77,6 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
-//! Structure and constant for tagging not to rate limit.
-struct NoRateLimitTag {
-    explicit NoRateLimitTag() = default;
-};
-inline constexpr NoRateLimitTag NO_RATE_LIMIT{};
-
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -68,45 +96,120 @@ struct Entry {
     std::string message;
 };
 
-/// Return whether messages with specified category should be debug logged.
-/// Applications using the logging library need to provide this.
-bool ShouldDebugLog(Category category);
+/// Options that can be passed to log macros using designated initializers (e.g.
+/// `.ratelimit = true`). Add new options here when introducing new logging
+/// behaviors.
+struct Options {
+    Level level;
 
-/// Return whether messages with specified category should be trace logged.
-/// Applications using the logging library need to provide this.
-bool ShouldTraceLog(Category category);
+    // Info and higher log messages are logged by default, so ratelimit them.
+    // Users enabling logging at Debug and lower levels are assumed to be
+    // developers or power users who are aware that -debug may cause excessive
+    // disk usage due to logging.
+    bool ratelimit{level >= Level::Info};
 
-/** Send message to be logged. Applications using the logging library need to provide this. */
-void Log(Entry entry);
+    // Always evaluate format arguments at Info and higher levels because logs
+    // at these levels are rarely disabled, so it's safer to evaluate unused
+    // arguments than risk unintended side effects when logging is disabled.
+    bool evaluate_when_disabled{level >= Level::Info};
+};
 
-template <typename... Args>
-inline void LogPrintFormatInternal_(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    std::string log_msg;
-    try {
-        log_msg = tfm::format(fmt, args...);
-    } catch (tinyformat::format_error& fmterr) {
-        log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+/// Object representing context of log messages. Holds a logging category and
+/// implements log formatting.
+struct Context {
+    Category category;
+
+    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
+    {
+        std::string log_msg;
+        try {
+            log_msg = tfm::format(fmt, args...);
+        } catch (tinyformat::format_error& fmterr) {
+            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+        }
+        return log_msg;
     }
-    util::log::Log(util::log::Entry{
-        .category = flag,
-        .level = level,
-        .should_ratelimit = should_ratelimit,
+};
+
+/// External hooks that logging backends need to implement.
+namespace hooks {
+/// Return whether messages with specified category and level should be logged.
+bool ShouldLog(Category category, Level level);
+
+/// Send message to be logged.
+void Log(Entry entry);
+} // namespace hooks
+
+/// Internal functions used to help implement logging macros.
+namespace detail {
+/// Internal helper to get Context from the first macro argument. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <Options options>
+Context GetContext(std::string_view fmt)
+{
+    // Trigger compile error if caller does not pass a category constant as the
+    // first argument to a logging call, unless the level is Info or higher.
+    // There is no technical reason category arguments must be required, but
+    // categories are useful for finding and filtering relevant messages when
+    // debugging, so we want to encourage them.
+    static_assert(options.level >= Level::Info, "Missing required category argument for Debug/Trace logging call. Category can only be omitted for Info/Warning/Error calls.");
+    return Context{};
+}
+template <Options options>
+Context GetContext(Category category)
+{
+    // Trigger compile error if caller tries to pass a category constant as a
+    // first argument to a logging call at Info level or higher. There is no
+    // technical reason why all logging calls could not accept category
+    // arguments, but for various reasons, such as (1) not wanting to allow
+    // users to filter by category at high priority levels, and (2) wanting to
+    // incentivize developers to use lower log levels to avoid log spam, passing
+    // category constants at higher levels is forbidden.
+    static_assert(options.level < Level::Info, "Cannot pass category argument to Info/Warning/Error logging call. Please switch to Debug/Trace call, or drop the category argument!");
+    return Context{category};
+}
+
+/// Internal helper to construct log entry and emit log message. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <typename Context, typename... Args>
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    hooks::Log(Entry{
+        .category = context.category,
+        .level = options.level,
+        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
-        .message = std::move(log_msg)});
+        .message = context.Format(fmt, args...)});
+}
+template <typename Context, typename ContextArg, typename... Args>
+requires (!std::is_convertible_v<ContextArg, std::string_view>)
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ContextArg&&, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    Emit(std::move(options), std::move(source_loc), context, fmt, args...);
 }
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+template<Level level>
+bool ShouldLog(Category category)
 {
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/true, fmt, args...);
+    constexpr util::log::Options options{level};
+    static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
+    return util::log::hooks::ShouldLog(category, options.level);
 }
+} // namespace detail
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::log::NoRateLimitTag, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/false, fmt, args...);
-}
+/// Functions to detect when logging is enabled. Note: functions for detecting
+/// if logging is enabled at info/warning/error levels are intentionally not
+/// provided, because these logs are rarely disabled, so allowing code to
+/// condition on them could lead to bugs when they are disabled.
+///@{
+inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
+inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+///@}
 } // namespace util::log
 
 namespace BCLog {
@@ -114,33 +217,5 @@ namespace BCLog {
 using Level = util::log::Level;
 } // namespace BCLog
 
-// Allow __func__ to be used in any context without warnings:
-// NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define detail_LogWithSrcLoc(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
-
-// Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
-// Be conservative when using functions that unconditionally log to debug.log!
-// It should not be the case that an inbound peer can fill up a user's storage
-// with debug.log entries.
-#define LogInfo(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
-#define LogWarning(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
-#define LogError(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
-
-// Use a macro instead of a function for conditional logging to prevent
-// evaluating arguments when logging for the category is not enabled.
-
-// Log by prefixing the output with the passed category name and severity level. This logs conditionally if
-// the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
-// developers or power users who are aware that -debug may cause excessive disk usage due to logging.
-#define detail_LogIfCategoryAndLevelEnabled(category, shouldlog, level, ...)                  \
-    do {                                                                                      \
-        if (shouldlog(category)) {                                                            \
-            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__); \
-        }                                                                                     \
-    } while (0)
-
-// Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldDebugLog, util::log::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldTraceLog, util::log::Level::Trace, __VA_ARGS__)
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -25,7 +25,38 @@
 /// printf-style format string and arguments. For Debug and Trace macros,
 /// if a context parameter is not provided, a BCLog::LogFlags category argument
 /// must be provided instead.
-/// See the "Logging" section of /doc/developer-notes.md for more details.
+///
+/// - LogError(), LogWarning(), and LogInfo() are all enabled by default, so
+///   they should be called infrequently, in cases where they will not spam the
+///   log and take up disk space.
+///
+/// - LogDebug() is enabled when debug logging is enabled, and should be used to
+///   show messages that can help users troubleshoot issues.
+///
+/// - LogTrace() is enabled when both debug logging AND tracing are enabled, and
+///   should be used for fine-grained traces that will be helpful to developers.
+///
+/// For more information about log levels, see the -debug and -loglevel
+/// documentation, or the "Logging" section of /doc/developer-notes.md.
+///
+/// `LogDebug` and `LogTrace` macros require an initial category argument unless
+/// given a log source (which provides it). That enables Debug and Trace
+/// messages to be filtered by category. Higher levels do not take a category
+/// (but may be passed a log source):
+///
+///   LogDebug(BCLog::TXRECONCILIATION, "Forget txreconciliation state of peer=%d", peer_id);
+///   LogInfo("Important information, no category.");
+///
+/// Context arguments can also be passed to control log output (see class definition).
+///
+///   const util::log::Context m_log{BCLog::TXRECONCILIATION};
+///   ...
+///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
+///
+/// If severity level is Info or higher, rate limiting is applied to mitigate
+/// disk filling attacks. Users enabling logging at Debug and lower levels are
+/// assumed to be developers or power users who are aware that -debug may cause
+/// excessive disk usage due to logging.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
 #define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
@@ -82,6 +113,10 @@ using Category = uint64_t;
 /** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
 class Logger{};
 
+/// Log level constants. Most code will not need to use these directly and can
+/// use LogTrace, LogDebug, LogInfo, LogWarning, and LogError macros defined
+/// below. See macro definitions below or "Logging" section in
+/// developer-notes.md for more detailed information.
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -71,8 +71,12 @@
 /// called internally, and in special cases to override default behaviors.
 // NOLINTBEGIN(bugprone-lambda-function-name)
 // Allow __func__ to be used in any context without warnings:
+constexpr bool LOG_REQUIRE_CONTEXT = false;
 #define LOG_EMIT(options, ...)                                                                     \
     do {                                                                                           \
+        static_assert(!LOG_REQUIRE_CONTEXT ||                                                      \
+            util::log::detail::LogContext<decltype(PP_FIRST_ARG(__VA_ARGS__))>,                    \
+            "Log macro call is missing required context argument");                                \
         constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
         auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
         if (util::log::hooks::ShouldLog(_context.logger, _context.category, _options.level)) {     \
@@ -191,11 +195,15 @@ void Log(Logger* logger, const Options& options, Entry entry);
 
 /// Internal functions used to help implement logging macros.
 namespace detail {
+template <typename T>
+concept LogContext = requires {
+    requires std::remove_reference_t<T>::log_context;
+};
+
 /// Internal helper to get Context from the first macro argument. Overloaded to
 /// detect case where first macro argument is a string literal and context has
 /// been omitted.
-template <Options options, typename Context>
-requires (Context::log_context)
+template <Options options, LogContext Context>
 Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -53,6 +53,10 @@
 ///   ...
 ///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
 ///
+/// Using context objects also provides the flexibility to add extra information
+/// and custom formatting to log messages, or to divert log messages to a local
+/// logger instead of the global logging instance.
+///
 /// If severity level is Info or higher, rate limiting is applied to mitigate
 /// disk filling attacks. Users enabling logging at Debug and lower levels are
 /// assumed to be developers or power users who are aware that -debug may cause
@@ -157,6 +161,7 @@ struct Options {
 /// optional log pointer which can be used by the application's log handler to
 /// determine where to log to, and a Format hook to control message formatting.
 struct Context {
+    static constexpr bool log_context{true};
     Category category;
     Logger* logger;
 
@@ -189,7 +194,8 @@ namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
 /// detect case where first macro argument is a string literal and context has
 /// been omitted.
-template <Options options>
+template <Options options, typename Context>
+requires (Context::log_context)
 Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -20,9 +20,11 @@
 #include <string_view>
 #include <type_traits>
 
-/// Logging macros which output log messages at the specified levels. They
-/// accept printf-style format strings and arguments. The debug and trace macros
-/// also require an initial BCLog::LogFlags category argument.
+/// Logging macros which output log messages at the specified levels. The
+/// macros accept an optional log context parameter followed by a
+/// printf-style format string and arguments. For Debug and Trace macros,
+/// if a context parameter is not provided, a BCLog::LogFlags category argument
+/// must be provided instead.
 /// See the "Logging" section of /doc/developer-notes.md for more details.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
@@ -38,7 +40,7 @@
     do {                                                                                           \
         constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
         auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
-        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+        if (util::log::hooks::ShouldLog(_context.logger, _context.category, _options.level)) {     \
             util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
         } else if constexpr (_options.evaluate_when_disabled) {                                    \
             [](auto&&...) {}(__VA_ARGS__);                                                         \
@@ -77,6 +79,9 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
+/** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
+class Logger{};
+
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -113,12 +118,14 @@ struct Options {
     bool evaluate_when_disabled{level >= Level::Info};
 };
 
-/// Object representing context of log messages. Holds a logging category and
-/// implements log formatting.
+/// Object representing context of log messages. Holds a logging category, an
+/// optional log pointer which can be used by the application's log handler to
+/// determine where to log to, and a Format hook to control message formatting.
 struct Context {
     Category category;
+    Logger* logger;
 
-    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+    explicit Context(Category category = BCLog::LogFlags::ALL, Logger* logger = nullptr) : category{category}, logger{logger} {}
 
     template <typename... Args>
     std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
@@ -136,17 +143,19 @@ struct Context {
 /// External hooks that logging backends need to implement.
 namespace hooks {
 /// Return whether messages with specified category and level should be logged.
-bool ShouldLog(Category category, Level level);
+bool ShouldLog(Logger* logger, Category category, Level level);
 
 /// Send message to be logged.
-void Log(const Options& options, Entry entry);
+void Log(Logger* logger, const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
 namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
+template <Options options>
+Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)
 {
@@ -173,12 +182,12 @@ Context GetContext(Category category)
 }
 
 /// Internal helper to construct log entry and emit log message. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(options, Entry{
+    hooks::Log(context.logger, options, Entry{
         .category = context.category,
         .level = options.level,
         .source_loc = std::move(source_loc),
@@ -192,11 +201,11 @@ void Emit(Options options, SourceLocation&& source_loc, Context&& context, Conte
 }
 
 template<Level level>
-bool ShouldLog(Category category)
+bool ShouldLog(const Context& context)
 {
     constexpr util::log::Options options{level};
     static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
-    return util::log::hooks::ShouldLog(category, options.level);
+    return util::log::hooks::ShouldLog(context.logger, context.category, options.level);
 }
 } // namespace detail
 
@@ -205,8 +214,8 @@ bool ShouldLog(Category category)
 /// provided, because these logs are rarely disabled, so allowing code to
 /// condition on them could lead to bugs when they are disabled.
 ///@{
-inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
-inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+inline bool ShouldDebugLog(const auto&... args) { return detail::ShouldLog<Level::Debug>(Context{args...}); }
+inline bool ShouldTraceLog(const auto&... args) { return detail::ShouldLog<Level::Trace>(Context{args...}); }
 ///@}
 } // namespace util::log
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -78,6 +78,8 @@
 #include <tuple>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
@@ -200,7 +202,7 @@ std::optional<std::vector<int>> CalculatePrevHeights(
                               ? tip.nHeight + 1 // Assume all mempool transaction confirm in the next block.
                               : coin->nHeight;
         } else {
-            LogInfo("ERROR: %s: Missing input %d in transaction \'%s\'\n", __func__, i, tx.GetHash().GetHex());
+            LogInfo(log, "ERROR: %s: Missing input %d in transaction \'%s\'\n", __func__, i, tx.GetHash().GetHex());
             return std::nullopt;
         }
     }
@@ -281,7 +283,7 @@ static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
     AssertLockHeld(pool.cs);
     int expired = pool.Expire(GetTime<std::chrono::seconds>() - pool.m_opts.expiry);
     if (expired != 0) {
-        LogDebug(BCLog::MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
+        LogDebug(pool.m_log, "Expired %i transactions from the memory pool\n", expired);
     }
 
     std::vector<COutPoint> vNoSpendsRemaining;
@@ -1132,7 +1134,8 @@ bool MemPoolAccept::PackageRBFChecks(const std::vector<CTransactionRef>& txns,
                                      "package RBF failed: " + err_tup.value().second, "");
     }
 
-    LogDebug(BCLog::TXPACKAGES, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s), package hash (%s)\n",
+    const util::log::Context log_packages{BCLog::TXPACKAGES, m_pool.m_log.logger};
+    LogDebug(log_packages, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s), package hash (%s)\n",
         txns.front()->GetHash().ToString(), txns.front()->GetWitnessHash().ToString(),
         txns.back()->GetHash().ToString(), txns.back()->GetWitnessHash().ToString(),
         GetPackageHash(txns).ToString());
@@ -1190,7 +1193,7 @@ bool MemPoolAccept::ConsensusScriptChecks(const ATMPArgs& args, Workspace& ws)
     script_verify_flags currentBlockScriptVerifyFlags{GetBlockScriptFlags(*m_active_chainstate.m_chain.Tip(), m_active_chainstate.m_chainman)};
     if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, currentBlockScriptVerifyFlags,
                                         ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache())) {
-        LogError("BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
+        LogError(m_pool.m_log, "BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
         return Assume(false);
     }
 
@@ -1231,7 +1234,7 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                                     feerate.size);
 
         }
-        LogDebug(BCLog::MEMPOOL, "%s\n", log_string);
+        LogDebug(m_pool.m_log, "%s\n", log_string);
         TRACEPOINT(mempool, replaced,
                 it->GetTx().GetHash().data(),
                 it->GetTxSize(),
@@ -1296,7 +1299,7 @@ bool MemPoolAccept::SubmitPackage(const ATMPArgs& args, std::vector<Workspace>& 
                    [](const auto& ws) { return ws.m_ptx->GetWitnessHash(); });
 
     if (!m_subpackage.m_replaced_transactions.empty()) {
-        LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with %u new one(s) for %s additional fees, %d delta bytes\n",
+        LogDebug(m_pool.m_log, "replaced %u mempool transactions with %u new one(s) for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(), workspaces.size(),
                  m_subpackage.m_total_modified_fees - m_subpackage.m_conflicting_fees,
                  m_subpackage.m_total_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
@@ -1430,7 +1433,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransactionInternal(const CTransa
     }
 
     if (!m_subpackage.m_replaced_transactions.empty()) {
-        LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with 1 new transaction for %s additional fees, %d delta bytes\n",
+        LogDebug(m_pool.m_log, "replaced %u mempool transactions with 1 new transaction for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(),
                  ws.m_modified_fees - m_subpackage.m_conflicting_fees,
                  ws.m_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
@@ -1872,7 +1875,7 @@ void CoinsViews::InitCache(int32_t prevoutfetch_threads)
     auto thread_pool{std::make_shared<ThreadPool>("prevout")};
     if (prevoutfetch_threads > 0) {
         thread_pool->Start(prevoutfetch_threads);
-        LogInfo("Block input prevout fetching uses %d additional threads", prevoutfetch_threads);
+        LogInfo(m_log, "Block input prevout fetching uses %d additional threads", prevoutfetch_threads);
     }
     m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview, std::move(thread_pool));
 }
@@ -1970,7 +1973,7 @@ void Chainstate::CheckForkWarningConditions()
     }
 
     if (m_chainman.m_best_invalid && m_chainman.m_best_invalid->nChainWork > m_chain.Tip()->nChainWork + (GetBlockProof(*m_chain.Tip()) * 6)) {
-        LogWarning("Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers.");
+        LogWarning(m_log, "Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers.");
         m_chainman.GetNotifications().warningSet(
             kernel::Warning::LARGE_WORK_INVALID_CHAIN,
             _("Warning: Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers."));
@@ -1991,12 +1994,12 @@ void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
         m_chainman.RecalculateBestHeader();
     }
 
-    LogInfo("%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
+    LogInfo(m_log, "%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
       log(pindexNew->nChainWork.getdouble())/log(2.0), FormatISO8601DateTime(pindexNew->GetBlockTime()));
     CBlockIndex *tip = m_chain.Tip();
     assert (tip);
-    LogInfo("%s: current best=%s height=%d log2_work=%f date=%s", __func__,
+    LogInfo(m_log, "%s: current best=%s height=%d log2_work=%f date=%s", __func__,
       tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble())/log(2.0),
       FormatISO8601DateTime(tip->GetBlockTime()));
     CheckForkWarningConditions();
@@ -2054,7 +2057,8 @@ ValidationCache::ValidationCache(util::log::Logger& logger, const size_t script_
     m_script_execution_cache_hasher.Write(nonce.begin(), 32);
 
     const auto [num_elems, approx_size_bytes] = m_script_execution_cache.setup_bytes(script_execution_cache_bytes);
-    LogInfo("Using %zu MiB out of %zu MiB requested for script execution cache, able to store %zu elements",
+    const util::log::Context log{BCLog::VALIDATION, &logger};
+    LogInfo(log, "Using %zu MiB out of %zu MiB requested for script execution cache, able to store %zu elements",
               approx_size_bytes >> 20, script_execution_cache_bytes >> 20, num_elems);
 }
 
@@ -2202,12 +2206,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
 
     CBlockUndo blockUndo;
     if (!m_blockman.ReadBlockUndo(blockUndo, *pindex)) {
-        LogError("DisconnectBlock(): failure reading undo data\n");
+        LogError(m_log, "DisconnectBlock(): failure reading undo data\n");
         return DISCONNECT_FAILED;
     }
 
     if (blockUndo.vtxundo.size() + 1 != block.vtx.size()) {
-        LogError("DisconnectBlock(): block and undo data inconsistent\n");
+        LogError(m_log, "DisconnectBlock(): block and undo data inconsistent\n");
         return DISCONNECT_FAILED;
     }
 
@@ -2246,7 +2250,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         if (i > 0) { // not coinbases
             CTxUndo &txundo = blockUndo.vtxundo[i-1];
             if (txundo.vprevout.size() != tx.vin.size()) {
-                LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
+                LogError(m_log, "DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
             for (unsigned int j = tx.vin.size(); j > 0;) {
@@ -2317,6 +2321,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     AssertLockHeld(cs_main);
     assert(pindex);
 
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
 
@@ -2343,7 +2348,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // problems.
             return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
         }
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
+        LogError(m_log, "%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -2403,7 +2408,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_1{SteadyClock::now()};
     m_chainman.time_check += time_1 - time_start;
-    LogDebug(BCLog::BENCH, "    - Sanity checks: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Sanity checks: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_1 - time_start),
              Ticks<SecondsDouble>(m_chainman.time_check),
              Ticks<MillisecondsDouble>(m_chainman.time_check) / m_chainman.num_blocks_total);
@@ -2505,7 +2510,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_2{SteadyClock::now()};
     m_chainman.time_forks += time_2 - time_1;
-    LogDebug(BCLog::BENCH, "    - Fork checks: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Fork checks: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_2 - time_1),
              Ticks<SecondsDouble>(m_chainman.time_forks),
              Ticks<MillisecondsDouble>(m_chainman.time_forks) / m_chainman.num_blocks_total);
@@ -2514,10 +2519,10 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     const kernel::ChainstateRole role{GetRole()};
     if (script_check_reason != m_last_script_check_reason_logged && role.validated && !role.historical) {
         if (fScriptChecks) {
-            LogInfo("Enabling script verification at block #%d (%s): %s.",
+            LogInfo(m_log, "Enabling script verification at block #%d (%s): %s.",
                     pindex->nHeight, block_hash.ToString(), script_check_reason);
         } else {
-            LogInfo("Disabling script verification at block #%d (%s).",
+            LogInfo(m_log, "Disabling script verification at block #%d (%s).",
                     pindex->nHeight, block_hash.ToString());
         }
         m_last_script_check_reason_logged = script_check_reason;
@@ -2619,7 +2624,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     }
     const auto time_3{SteadyClock::now()};
     m_chainman.time_connect += time_3 - time_2;
-    LogDebug(BCLog::BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
+    LogDebug(log_bench, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
              Ticks<MillisecondsDouble>(time_3 - time_2), Ticks<MillisecondsDouble>(time_3 - time_2) / block.vtx.size(),
              nInputs <= 1 ? 0 : Ticks<MillisecondsDouble>(time_3 - time_2) / (nInputs - 1),
              Ticks<SecondsDouble>(m_chainman.time_connect),
@@ -2637,12 +2642,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         }
     }
     if (!state.IsValid()) {
-        LogInfo("Block validation error: %s", state.ToString());
+        LogInfo(m_log, "Block validation error: %s", state.ToString());
         return false;
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_verify += time_4 - time_2;
-    LogDebug(BCLog::BENCH, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1,
+    LogDebug(log_bench, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1,
              Ticks<MillisecondsDouble>(time_4 - time_2),
              nInputs <= 1 ? 0 : Ticks<MillisecondsDouble>(time_4 - time_2) / (nInputs - 1),
              Ticks<SecondsDouble>(m_chainman.time_verify),
@@ -2658,7 +2663,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_5{SteadyClock::now()};
     m_chainman.time_undo += time_5 - time_4;
-    LogDebug(BCLog::BENCH, "    - Write undo data: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Write undo data: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_5 - time_4),
              Ticks<SecondsDouble>(m_chainman.time_undo),
              Ticks<MillisecondsDouble>(m_chainman.time_undo) / m_chainman.num_blocks_total);
@@ -2673,7 +2678,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_6{SteadyClock::now()};
     m_chainman.time_index += time_6 - time_5;
-    LogDebug(BCLog::BENCH, "    - Index writing: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Index writing: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_5),
              Ticks<SecondsDouble>(m_chainman.time_index),
              Ticks<MillisecondsDouble>(m_chainman.time_index) / m_chainman.num_blocks_total);
@@ -2709,7 +2714,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
         max_coins_cache_size_bytes + std::max<int64_t>(int64_t(max_mempool_size_bytes) - nMempoolUsage, 0);
 
     if (cacheSize > nTotalSpace) {
-        LogInfo("Cache size (%s) exceeds total space (%s)\n", cacheSize, nTotalSpace);
+        LogInfo(m_log, "Cache size (%s) exceeds total space (%s)\n", cacheSize, nTotalSpace);
         return CoinsCacheSizeState::CRITICAL;
     } else if (cacheSize > LargeCoinsCacheThreshold(nTotalSpace)) {
         return CoinsCacheSizeState::LARGE;
@@ -2724,6 +2729,7 @@ bool Chainstate::FlushStateToDisk(
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
+    const util::log::Context log_prune{BCLog::PRUNE, m_log.logger};
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2752,7 +2758,7 @@ bool Chainstate::FlushStateToDisk(
             }
 
             if (limiting_lock) {
-                LogDebug(BCLog::PRUNE, "%s limited pruning to height %d\n", limiting_lock.value(), last_prune);
+                LogDebug(log_prune, "%s limited pruning to height %d\n", limiting_lock.value(), last_prune);
             }
 
             if (nManualPruneHeight > 0) {
@@ -2788,7 +2794,8 @@ bool Chainstate::FlushStateToDisk(
         bool should_write = (mode == FlushStateMode::FORCE_SYNC) || empty_cache || fPeriodicWrite || fFlushForPrune;
         // Write blocks, block index and best chain related state to disk.
         if (should_write) {
-            LogDebug(BCLog::COINDB, "Writing chainstate to disk: flush mode=%s, prune=%d, large=%d, critical=%d, periodic=%d",
+            const util::log::Context log_coins{BCLog::COINDB, m_log.logger};
+            LogDebug(log_coins, "Writing chainstate to disk: flush mode=%s, prune=%d, large=%d, critical=%d, periodic=%d",
                      FlushStateModeNames[size_t(mode)], fFlushForPrune, fCacheLarge, fCacheCritical, fPeriodicWrite);
 
             // Ensure we can write block index
@@ -2802,7 +2809,7 @@ bool Chainstate::FlushStateToDisk(
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                    LogWarning(m_log, "%s: Failed to flush block file.\n", __func__);
                 }
             }
 
@@ -2855,7 +2862,7 @@ bool Chainstate::FlushStateToDisk(
             try {
                 CoinsDB().CompactFullAsync();
             } catch (const std::exception& e) {
-                LogWarning("Failed to start chainstate compaction (%s)", e.what());
+                LogWarning(m_log, "Failed to start chainstate compaction (%s)", e.what());
             }
         }
     }
@@ -2869,7 +2876,7 @@ void Chainstate::ForceFlushStateToDisk(bool wipe_cache)
 {
     BlockValidationState state;
     if (!this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC)) {
-        LogWarning("Failed to force flush state (%s)", state.ToString());
+        LogWarning(m_log, "Failed to force flush state (%s)", state.ToString());
     }
 }
 
@@ -2878,7 +2885,7 @@ void Chainstate::PruneAndFlush()
     BlockValidationState state;
     m_blockman.m_check_for_pruning = true;
     if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
-        LogWarning("Failed to flush state (%s)", state.ToString());
+        LogWarning(m_log, "Failed to flush state (%s)", state.ToString());
     }
 }
 
@@ -2896,7 +2903,7 @@ static void UpdateTipLog(
 
     // Disable rate limiting so this source location may log during IBD.
     LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
-                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+                   chainman.m_log,"%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    std::log(tip->nChainWork.getdouble()) / std::log(2.0), tip->m_chain_tx_count,
@@ -2959,6 +2966,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
+    const util::log::Context log_prune{BCLog::PRUNE, m_log.logger};
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2966,7 +2975,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlock(block, *pindexDelete)) {
-        LogError("DisconnectTip(): Failed to read block\n");
+        LogError(m_log, "DisconnectTip(): Failed to read block\n");
         return false;
     }
     // Apply the block atomically to the chain state.
@@ -2975,12 +2984,12 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
-            LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
+            LogError(m_log, "DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
         view.Flush(/*reallocate_cache=*/false); // local CCoinsViewCache goes out of scope
     }
-    LogDebug(BCLog::BENCH, "- Disconnect block: %.2fms\n",
+    LogDebug(log_bench, "- Disconnect block: %.2fms\n",
              Ticks<MillisecondsDouble>(SteadyClock::now() - time_start));
 
     {
@@ -2990,7 +2999,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
             if (prune_lock.second.height_first <= max_height_first) continue;
 
             prune_lock.second.height_first = max_height_first;
-            LogDebug(BCLog::PRUNE, "%s prune lock moved back to %d\n", prune_lock.first, max_height_first);
+            LogDebug(log_prune, "%s prune lock moved back to %d\n", prune_lock.first, max_height_first);
         }
     }
 
@@ -3042,6 +3051,7 @@ bool Chainstate::ConnectTip(
 
     assert(pindexNew->pprev == m_chain.Tip());
     // Read block from disk.
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
@@ -3050,14 +3060,14 @@ bool Chainstate::ConnectTip(
         }
         block_to_connect = std::move(pblockNew);
     } else {
-        LogDebug(BCLog::BENCH, "  - Using cached block\n");
+        LogDebug(log_bench, "  - Using cached block\n");
     }
     // Apply the block atomically to the chain state.
     const auto time_2{SteadyClock::now()};
     SteadyClock::time_point time_3;
     // When adding aggregate statistics in the future, keep in mind that
     // num_blocks_total may be zero until the ConnectBlock() call below.
-    LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
+    LogDebug(log_bench, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
         CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
@@ -3069,13 +3079,13 @@ bool Chainstate::ConnectTip(
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            LogError(m_log, "%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
             return false;
         }
         time_3 = SteadyClock::now();
         m_chainman.time_connect_total += time_3 - time_2;
         assert(m_chainman.num_blocks_total > 0);
-        LogDebug(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n",
+        LogDebug(log_bench, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n",
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(m_chainman.time_connect_total),
                  Ticks<MillisecondsDouble>(m_chainman.time_connect_total) / m_chainman.num_blocks_total);
@@ -3083,7 +3093,7 @@ bool Chainstate::ConnectTip(
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_flush += time_4 - time_3;
-    LogDebug(BCLog::BENCH, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_4 - time_3),
              Ticks<SecondsDouble>(m_chainman.time_flush),
              Ticks<MillisecondsDouble>(m_chainman.time_flush) / m_chainman.num_blocks_total);
@@ -3093,7 +3103,7 @@ bool Chainstate::ConnectTip(
     }
     const auto time_5{SteadyClock::now()};
     m_chainman.time_chainstate += time_5 - time_4;
-    LogDebug(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_5 - time_4),
              Ticks<SecondsDouble>(m_chainman.time_chainstate),
              Ticks<MillisecondsDouble>(m_chainman.time_chainstate) / m_chainman.num_blocks_total);
@@ -3110,11 +3120,11 @@ bool Chainstate::ConnectTip(
     const auto time_6{SteadyClock::now()};
     m_chainman.time_post_connect += time_6 - time_5;
     m_chainman.time_total += time_6 - time_1;
-    LogDebug(BCLog::BENCH, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_5),
              Ticks<SecondsDouble>(m_chainman.time_post_connect),
              Ticks<MillisecondsDouble>(m_chainman.time_post_connect) / m_chainman.num_blocks_total);
-    LogDebug(BCLog::BENCH, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_1),
              Ticks<SecondsDouble>(m_chainman.time_total),
              Ticks<MillisecondsDouble>(m_chainman.time_total) / m_chainman.num_blocks_total);
@@ -3310,7 +3320,7 @@ void ChainstateManager::UpdateIBDStatus()
     if (!m_cached_is_ibd.load(std::memory_order_relaxed)) return;
     if (m_blockman.LoadingBlocks()) return;
     if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age)) return;
-    LogInfo("Leaving InitialBlockDownload (latching to false)");
+    LogInfo(m_log, "Leaving InitialBlockDownload (latching to false)");
     m_cached_is_ibd.store(false, std::memory_order_relaxed);
 }
 
@@ -3363,7 +3373,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
-        LogError("%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
+        LogError(m_log, "%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
         return Assume(false);
     }
 
@@ -3798,7 +3808,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     auto prev_tx_sum = [](CBlockIndex& block) { return block.nTx + (block.pprev ? block.pprev->m_chain_tx_count : 0); };
     if (!Assume(pindexNew->m_chain_tx_count == 0 || pindexNew->m_chain_tx_count == prev_tx_sum(*pindexNew) ||
                 std::ranges::any_of(m_chainstates, [&](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->SnapshotBase() == pindexNew; }))) {
-        LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
+        LogWarning(m_log, "Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
             pindexNew->nHeight, pindexNew->m_chain_tx_count, prev_tx_sum(*pindexNew), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
         pindexNew->m_chain_tx_count = 0;
     }
@@ -3826,7 +3836,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             // assumeutxo snapshot block if assumeutxo snapshot metadata has an
             // incorrect hardcoded AssumeutxoData::m_chain_tx_count value.
             if (!Assume(pindex->m_chain_tx_count == 0 || pindex->m_chain_tx_count == prev_tx_sum(*pindex))) {
-                LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
+                LogWarning(m_log, "Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
                    pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
@@ -4050,9 +4060,10 @@ bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus:
 
 bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_witness_root)
 {
+    util::log::Context log{BCLog::VALIDATION, logger};
     BlockValidationState state;
     if (!CheckMerkleRoot(block, state)) {
-        LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
+        LogDebug(log, "Block mutated: %s\n", state.ToString());
         return true;
     }
 
@@ -4072,7 +4083,7 @@ bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_w
     }
 
     if (!CheckWitnessMalleation(block, check_witness_root, state)) {
-        LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
+        LogDebug(log, "Block mutated: %s\n", state.ToString());
         return true;
     }
 
@@ -4221,7 +4232,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             if (ppindex)
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_VALID) {
-                LogDebug(BCLog::VALIDATION, "%s: block %s is marked invalid\n", __func__, hash.ToString());
+                LogDebug(m_log, "%s: block %s is marked invalid\n", __func__, hash.ToString());
                 return state.Invalid(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid",
                                      strprintf("block %s was previously marked invalid", hash.ToString()));
             }
@@ -4229,7 +4240,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         }
 
         if (!CheckBlockHeader(block, state, GetConsensus())) {
-            LogDebug(BCLog::VALIDATION, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
+            LogDebug(m_log, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
 
@@ -4237,21 +4248,21 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         CBlockIndex* pindexPrev = nullptr;
         BlockMap::iterator mi{m_blockman.m_block_index.find(block.hashPrevBlock)};
         if (mi == m_blockman.m_block_index.end()) {
-            LogDebug(BCLog::VALIDATION, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
+            LogDebug(m_log, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_MISSING_PREV, "prev-blk-not-found");
         }
         pindexPrev = &((*mi).second);
         if (pindexPrev->nStatus & BLOCK_FAILED_VALID) {
-            LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
+            LogDebug(m_log, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
         if (!ContextualCheckBlockHeader(block, state, *this, pindexPrev)) {
-            LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
+            LogDebug(m_log, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
     }
     if (!min_pow_checked) {
-        LogDebug(BCLog::VALIDATION, "%s: not adding new block header %s, missing anti-dos proof-of-work validation\n", __func__, hash.ToString());
+        LogDebug(m_log, "%s: not adding new block header %s, missing anti-dos proof-of-work validation\n", __func__, hash.ToString());
         return state.Invalid(BlockValidationResult::BLOCK_HEADER_LOW_WORK, "too-little-chainwork");
     }
     CBlockIndex* pindex{m_blockman.AddToBlockIndex(block, m_best_header)};
@@ -4287,7 +4298,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
             int64_t blocks_left{(NodeClock::now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
             blocks_left = std::max<int64_t>(0, blocks_left);
             const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
-            LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
+            LogInfo(m_log, "Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
         }
     }
     return true;
@@ -4314,7 +4325,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
         int64_t blocks_left{(NodeClock::now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
         blocks_left = std::max<int64_t>(0, blocks_left);
         const double progress{100.0 * height / (height + blocks_left)};
-        LogInfo("Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
+        LogInfo(m_log, "Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
     }
 }
 
@@ -4376,7 +4387,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         if (Assume(state.IsInvalid())) {
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
-        LogError("%s: %s\n", __func__, state.ToString());
+        LogError(m_log, "%s: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -4453,7 +4464,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
             if (m_options.signals) {
                 m_options.signals->BlockChecked(block, state);
             }
-            LogError("%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
+            LogError(m_log, "%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
             return false;
         }
     }
@@ -4462,14 +4473,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
     if (!ActiveChainstate().ActivateBestChain(state, block)) {
-        LogError("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
+        LogError(m_log, "%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
         return false;
     }
 
     Chainstate* bg_chain{WITH_LOCK(cs_main, return HistoricalChainstate())};
     BlockValidationState bg_state;
     if (bg_chain && !bg_chain->ActivateBestChain(bg_state, block)) {
-        LogError("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
+        LogError(m_log, "%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
         return false;
      }
 
@@ -4567,10 +4578,11 @@ BlockValidationState TestBlockValidity(
 /* This function is called from the RPC code for pruneblockchain */
 void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
+    const util::log::Context& log{active_chainstate.m_log};
     BlockValidationState state;
     if (!active_chainstate.FlushStateToDisk(
             state, FlushStateMode::NONE, nManualPruneHeight)) {
-        LogWarning("Failed to flush state after manual prune (%s)", state.ToString());
+        LogWarning(log, "Failed to flush state after manual prune (%s)", state.ToString());
     }
 }
 
@@ -4609,7 +4621,7 @@ bool Chainstate::LoadChainTip()
         target = target->pprev;
     }
 
-    LogInfo("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f",
+    LogInfo(m_log, "Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f",
               tip->GetBlockHash().ToString(),
               m_chain.Height(),
               FormatISO8601DateTime(tip->GetBlockTime()),
@@ -4647,6 +4659,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
+    const util::log::Context& log{chainstate.m_log};
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
         return VerifyDBResult::SUCCESS;
@@ -4657,7 +4670,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
         nCheckDepth = chainstate.m_chain.Height();
     }
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
-    LogInfo("Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
+    LogInfo(log, "Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
     CCoinsViewCache coins(&coinsview);
     CBlockIndex* pindex;
     CBlockIndex* pindexFailure = nullptr;
@@ -4666,7 +4679,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int reportDone = 0;
     bool skipped_no_block_data{false};
     bool skipped_l3_checks{false};
-    LogInfo("Verification progress: 0%%");
+    LogInfo(log, "Verification progress: 0%%");
 
     const bool is_snapshot_cs{chainstate.m_from_snapshot_blockhash};
 
@@ -4674,7 +4687,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(chainstate.m_chain.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
         if (reportDone < percentageDone / 10) {
             // report every 10% step
-            LogInfo("Verification progress: %d%%", percentageDone);
+            LogInfo(log, "Verification progress: %d%%", percentageDone);
             reportDone = percentageDone / 10;
         }
         m_notifications.progress(_("Verifying blocks…"), percentageDone, false);
@@ -4684,19 +4697,19 @@ VerifyDBResult CVerifyDB::VerifyDB(
         if ((chainstate.m_blockman.IsPruneMode() || is_snapshot_cs) && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
             // If pruning or running under an assumeutxo snapshot, only go
             // back as far as we have data.
-            LogInfo("Block verification stopping at height %d (no data). This could be due to pruning or use of an assumeutxo snapshot.", pindex->nHeight);
+            LogInfo(log, "Block verification stopping at height %d (no data). This could be due to pruning or use of an assumeutxo snapshot.", pindex->nHeight);
             skipped_no_block_data = true;
             break;
         }
         CBlock block;
         // check level 0: read from disk
         if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-            LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+            LogError(log, "Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params)) {
-            LogError("Verification error: found bad block at %d, hash=%s (%s)",
+            LogError(log, "Verification error: found bad block at %d, hash=%s (%s)",
                       pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
@@ -4705,7 +4718,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
                 if (!chainstate.m_blockman.ReadBlockUndo(undo, *pindex)) {
-                    LogError("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                    LogError(log, "Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;
                 }
             }
@@ -4718,7 +4731,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                    LogError(log, "Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;
                 }
                 if (res == DISCONNECT_UNCLEAN) {
@@ -4734,11 +4747,11 @@ VerifyDBResult CVerifyDB::VerifyDB(
         if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
     }
     if (pindexFailure) {
-        LogError("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
+        LogError(log, "Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
         return VerifyDBResult::CORRUPTED_BLOCK_DB;
     }
     if (skipped_l3_checks) {
-        LogWarning("Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
+        LogWarning(log, "Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
     }
 
     // store block count as we move pindex at check level >= 4
@@ -4750,27 +4763,27 @@ VerifyDBResult CVerifyDB::VerifyDB(
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(chainstate.m_chain.Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
             if (reportDone < percentageDone / 10) {
                 // report every 10% step
-                LogInfo("Verification progress: %d%%", percentageDone);
+                LogInfo(log, "Verification progress: %d%%", percentageDone);
                 reportDone = percentageDone / 10;
             }
             m_notifications.progress(_("Verifying blocks…"), percentageDone, false);
             pindex = chainstate.m_chain.Next(*pindex);
             CBlock block;
             if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-                LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                LogError(log, "Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
             if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
-                LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
+                LogError(log, "Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
             if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
         }
     }
 
-    LogInfo("Verification: checked last %i blocks at level %i", block_count, nCheckLevel);
+    LogInfo(log, "Verification: checked last %i blocks at level %i", block_count, nCheckLevel);
     if (nCheckLevel >= 3 && !skipped_l3_checks) {
-        LogInfo("Verification: no coin database inconsistencies (%i transactions)", nGoodTransactions);
+        LogInfo(log, "Verification: no coin database inconsistencies (%i transactions)", nGoodTransactions);
     }
 
     if (skipped_l3_checks) {
@@ -4789,7 +4802,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     // TODO: merge with ConnectBlock
     CBlock block;
     if (!m_blockman.ReadBlock(block, *pindex)) {
-        LogError("ReplayBlock(): ReadBlock failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+        LogError(m_log, "ReplayBlock(): ReadBlock failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
         return false;
     }
 
@@ -4815,26 +4828,26 @@ bool Chainstate::ReplayBlocks()
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
     if (hashHeads.empty()) return true; // We're already in a consistent state.
     if (hashHeads.size() != 2) {
-        LogError("ReplayBlocks(): unknown inconsistent state\n");
+        LogError(m_log, "ReplayBlocks(): unknown inconsistent state\n");
         return false;
     }
 
     m_chainman.GetNotifications().progress(_("Replaying blocks…"), 0, false);
-    LogInfo("Replaying blocks");
+    LogInfo(m_log, "Replaying blocks");
 
     const CBlockIndex* pindexOld = nullptr;  // Old tip during the interrupted flush.
     const CBlockIndex* pindexNew;            // New tip during the interrupted flush.
     const CBlockIndex* pindexFork = nullptr; // Latest block common to both the old and the new tip.
 
     if (!m_blockman.m_block_index.contains(hashHeads[0])) {
-        LogError("ReplayBlocks(): reorganization to unknown block requested\n");
+        LogError(m_log, "ReplayBlocks(): reorganization to unknown block requested\n");
         return false;
     }
     pindexNew = &(m_blockman.m_block_index[hashHeads[0]]);
 
     if (!hashHeads[1].IsNull()) { // The old tip is allowed to be 0, indicating it's the first flush.
         if (!m_blockman.m_block_index.contains(hashHeads[1])) {
-            LogError("ReplayBlocks(): reorganization from unknown block requested\n");
+            LogError(m_log, "ReplayBlocks(): reorganization from unknown block requested\n");
             return false;
         }
         pindexOld = &(m_blockman.m_block_index[hashHeads[1]]);
@@ -4845,20 +4858,20 @@ bool Chainstate::ReplayBlocks()
     // Rollback along the old branch.
     const int nForkHeight{pindexFork ? pindexFork->nHeight : 0};
     if (pindexOld != pindexFork) {
-        LogInfo("Rolling back from %s (%i to %i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight, nForkHeight);
+        LogInfo(m_log, "Rolling back from %s (%i to %i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight, nForkHeight);
         while (pindexOld != pindexFork) {
             if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
                 CBlock block;
                 if (!m_blockman.ReadBlock(block, *pindexOld)) {
-                    LogError("RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                    LogError(m_log, "RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                     return false;
                 }
                 if (pindexOld->nHeight % 10'000 == 0) {
-                    LogInfo("Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
+                    LogInfo(m_log, "Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
                 }
                 DisconnectResult res = DisconnectBlock(block, pindexOld, cache);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                    LogError(m_log, "RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                     return false;
                 }
                 // If DISCONNECT_UNCLEAN is returned, it means a non-existing UTXO was deleted, or an existing UTXO was
@@ -4868,22 +4881,22 @@ bool Chainstate::ReplayBlocks()
             }
             pindexOld = pindexOld->pprev;
         }
-        LogInfo("Rolled back to %s", pindexFork->GetBlockHash().ToString());
+        LogInfo(m_log, "Rolled back to %s", pindexFork->GetBlockHash().ToString());
     }
 
     // Roll forward from the forking point to the new tip.
     if (nForkHeight < pindexNew->nHeight) {
-        LogInfo("Rolling forward to %s (%i to %i)", pindexNew->GetBlockHash().ToString(), nForkHeight, pindexNew->nHeight);
+        LogInfo(m_log, "Rolling forward to %s (%i to %i)", pindexNew->GetBlockHash().ToString(), nForkHeight, pindexNew->nHeight);
         for (int nHeight = nForkHeight + 1; nHeight <= pindexNew->nHeight; ++nHeight) {
             const CBlockIndex& pindex{*Assert(pindexNew->GetAncestor(nHeight))};
 
             if (nHeight % 10'000 == 0) {
-                LogInfo("Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);
+                LogInfo(m_log, "Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);
             }
             m_chainman.GetNotifications().progress(_("Replaying blocks…"), (int)((nHeight - nForkHeight) * 100.0 / (pindexNew->nHeight - nForkHeight)), false);
             if (!RollforwardBlock(&pindex, cache)) return false;
         }
-        LogInfo("Rolled forward to %s", pindexNew->GetBlockHash().ToString());
+        LogInfo(m_log, "Rolled forward to %s", pindexNew->GetBlockHash().ToString());
     }
 
     cache.SetBestBlock(pindexNew->GetBlockHash());
@@ -4975,13 +4988,13 @@ bool ChainstateManager::LoadGenesisBlock()
     try {
         FlatFilePos blockPos{m_blockman.WriteBlock(genesis_block, 0)};
         if (blockPos.IsNull()) {
-            LogError("Writing genesis block to disk failed");
+            LogError(m_log, "Writing genesis block to disk failed");
             return false;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
         ReceivedBlockTransactions(genesis_block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        LogError("Failed to write genesis block: %s", e.what());
+        LogError(m_log, "Failed to write genesis block: %s", e.what());
         return false;
     }
 
@@ -4996,6 +5009,7 @@ void ChainstateManager::LoadExternalBlockFile(
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
+    const util::log::Context log_reindex{BCLog::REINDEX, m_log.logger};
     const auto start{SteadyClock::now()};
     const CChainParams& params{GetParams()};
 
@@ -5050,7 +5064,7 @@ void ChainstateManager::LoadExternalBlockFile(
                     LOCK(cs_main);
                     // detect out of order blocks, and store them for later
                     if (hash != params.GetConsensus().hashGenesisBlock && !m_blockman.LookupBlockIndex(header.hashPrevBlock)) {
-                        LogDebug(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
+                        LogDebug(log_reindex, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
                                  header.hashPrevBlock.ToString());
                         if (dbp && blocks_with_unknown_parent) {
                             blocks_with_unknown_parent->emplace(header.hashPrevBlock, *dbp);
@@ -5075,7 +5089,7 @@ void ChainstateManager::LoadExternalBlockFile(
                             break;
                         }
                     } else if (hash != params.GetConsensus().hashGenesisBlock && pindex->nHeight % 1000 == 0) {
-                        LogDebug(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
+                        LogDebug(log_reindex, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
                     }
                 }
 
@@ -5102,7 +5116,7 @@ void ChainstateManager::LoadExternalBlockFile(
                     // called by concurrent network message processing. but, that is not
                     // reliable for the purpose of pruning while importing.
                     if (auto result{ActivateBestChains()}; !result) {
-                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(result).original);
+                        LogDebug(log_reindex, "%s\n", util::ErrorString(result).original);
                         break;
                     }
                 }
@@ -5123,7 +5137,7 @@ void ChainstateManager::LoadExternalBlockFile(
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
                         if (m_blockman.ReadBlock(*pblockrecursive, it->second, {})) {
                             const auto& block_hash{pblockrecursive->GetHash()};
-                            LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
+                            LogDebug(log_reindex, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
                             LOCK(cs_main);
                             BlockValidationState dummy;
                             if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
@@ -5148,13 +5162,13 @@ void ChainstateManager::LoadExternalBlockFile(
                 // the reindex process is not the place to attempt to clean and/or compact the block files. if so desired, a studious node operator
                 // may use knowledge of the fact that the block files are not entirely pristine in order to prepare a set of pristine, and
                 // perhaps ordered, block files for later reindexing.
-                LogDebug(BCLog::REINDEX, "%s: unexpected data at file offset 0x%x - %s. continuing\n", __func__, (nRewind - 1), e.what());
+                LogDebug(log_reindex, "%s: unexpected data at file offset 0x%x - %s. continuing\n", __func__, (nRewind - 1), e.what());
             }
         }
     } catch (const std::runtime_error& e) {
         GetNotifications().fatalError(strprintf(_("System error while loading external block file: %s"), e.what()));
     }
-    LogInfo("Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(m_log, "Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 }
 
 bool ChainstateManager::ShouldCheckBlockIndex() const
@@ -5503,9 +5517,9 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     m_coinsdb_cache_size_bytes = coinsdb_size;
     CoinsDB().ResizeCache(coinsdb_size);
 
-    LogInfo("[%s] resized coinsdb cache to %.1f MiB",
+    LogInfo(m_log, "[%s] resized coinsdb cache to %.1f MiB",
         this->ToString(), coinsdb_size / double(1_MiB));
-    LogInfo("[%s] resized coinstip cache to %.1f MiB",
+    LogInfo(m_log, "[%s] resized coinstip cache to %.1f MiB",
         this->ToString(), coinstip_size / double(1_MiB));
 
     BlockValidationState state;
@@ -5530,7 +5544,7 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
     }
 
     if (pindex->m_chain_tx_count == 0) {
-        LogDebug(BCLog::VALIDATION, "Block %d has unset m_chain_tx_count. Unable to estimate verification progress.\n", pindex->nHeight);
+        LogDebug(m_log, "Block %d has unset m_chain_tx_count. Unable to estimate verification progress.\n", pindex->nHeight);
         return 0.0;
     }
 
@@ -5565,7 +5579,7 @@ double ChainstateManager::GetBackgroundVerificationProgress(const CBlockIndex& p
     auto target_block = HistoricalChainstate()->TargetBlock();
 
     if (pindex.m_chain_tx_count == 0 || target_block->m_chain_tx_count == 0) {
-        LogDebug(BCLog::VALIDATION, "[background validation] Block %d has unset m_chain_tx_count. Unable to estimate verification progress.", pindex.nHeight);
+        LogDebug(m_log, "[background validation] Block %d has unset m_chain_tx_count. Unable to estimate verification progress.", pindex.nHeight);
         return 0.0;
     }
     return static_cast<double>(pindex.m_chain_tx_count) / static_cast<double>(target_block->m_chain_tx_count);
@@ -5579,7 +5593,7 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return *m_chainstates.back();
 }
 
-[[nodiscard]] static bool DeleteCoinsDBFromDisk(const fs::path db_path, bool is_snapshot)
+[[nodiscard]] static bool DeleteCoinsDBFromDisk(const util::log::Context& log, const fs::path db_path, bool is_snapshot)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
@@ -5590,24 +5604,24 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
         try {
             bool existed = fs::remove(base_blockhash_path);
             if (!existed) {
-                LogWarning("[snapshot] snapshot chainstate dir being removed lacks %s file",
+                LogWarning(log, "[snapshot] snapshot chainstate dir being removed lacks %s file",
                           fs::PathToString(node::SNAPSHOT_BLOCKHASH_FILENAME));
             }
         } catch (const fs::filesystem_error& e) {
-            LogWarning("[snapshot] failed to remove file %s: %s\n",
+            LogWarning(log, "[snapshot] failed to remove file %s: %s\n",
                        fs::PathToString(base_blockhash_path), e.code().message());
         }
     }
 
     std::string path_str = fs::PathToString(db_path);
-    LogInfo("Removing leveldb dir at %s\n", path_str);
+    LogInfo(log, "Removing leveldb dir at %s\n", path_str);
 
     // We have to destruct before this call leveldb::DB in order to release the db
     // lock, otherwise `DestroyDB` will fail. See `leveldb::~DBImpl()`.
     const bool destroyed = DestroyDB(path_str);
 
     if (!destroyed) {
-        LogError("leveldb DestroyDB call failed on %s", path_str);
+        LogError(log, "leveldb DestroyDB call failed on %s", path_str);
     }
 
     // Datadir should be removed from filesystem; otherwise initialization may detect
@@ -5718,7 +5732,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
             // DestroyDB() (in DeleteCoinsDBFromDisk()) will fail. See `leveldb::~DBImpl()`.
             // Destructing the chainstate (and so resetting the coinsviews object) does this.
             snapshot_chainstate.reset();
-            bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
+            bool removed = DeleteCoinsDBFromDisk(m_log, *snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
                 GetNotifications().fatalError(strprintf(_("Failed to remove snapshot chainstate dir (%s). "
                     "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
@@ -5753,8 +5767,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     chainstate.PopulateBlockIndexCandidates();
 
-    LogInfo("[snapshot] successfully activated snapshot %s", base_blockhash.ToString());
-    LogInfo("[snapshot] (%.2f MB)",
+    LogInfo(m_log, "[snapshot] successfully activated snapshot %s", base_blockhash.ToString());
+    LogInfo(m_log, "[snapshot] (%.2f MB)",
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
     this->MaybeRebalanceCaches();
@@ -5825,7 +5839,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     const uint64_t coins_count = metadata.m_coins_count;
     uint64_t coins_left = metadata.m_coins_count;
 
-    LogInfo("[snapshot] loading %d coins from snapshot %s", coins_left, base_blockhash.ToString());
+    LogInfo(m_log, "[snapshot] loading %d coins from snapshot %s", coins_left, base_blockhash.ToString());
     int64_t coins_processed{0};
 
     while (coins_left > 0) {
@@ -5861,7 +5875,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 ++coins_processed;
 
                 if (coins_processed % 1000000 == 0) {
-                    LogInfo("[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
+                    LogInfo(m_log, "[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
                         coins_processed,
                         static_cast<float>(coins_processed) * 100 / static_cast<float>(coins_count),
                         coins_cache.DynamicMemoryUsage() / (1000 * 1000));
@@ -5916,7 +5930,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
             coins_count))};
     }
 
-    LogInfo("[snapshot] loaded %d (%.2f MB) coins from snapshot %s",
+    LogInfo(m_log, "[snapshot] loaded %d (%.2f MB) coins from snapshot %s",
         coins_count,
         coins_cache.DynamicMemoryUsage() / (1000 * 1000),
         base_blockhash.ToString());
@@ -5982,7 +5996,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     assert(index == snapshot_start_block);
     index->m_chain_tx_count = au_data.m_chain_tx_count;
 
-    LogInfo("[snapshot] validated snapshot (%.2f MB)",
+    LogInfo(m_log, "[snapshot] validated snapshot (%.2f MB)",
         coins_cache.DynamicMemoryUsage() / (1000 * 1000));
     return {};
 }
@@ -6035,8 +6049,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
             validated_cs.m_chain.Height(),
             validated_cs.m_chain.Height(), CLIENT_BUGREPORT);
 
-        LogError("[snapshot] !!! %s\n", user_error.original);
-        LogError("[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
+        LogError(m_log, "[snapshot] !!! %s\n", user_error.original);
+        LogError(m_log, "[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
 
         // Reset chainstate target to network tip instead of snapshot block.
         validated_cs.SetTargetBlock(nullptr);
@@ -6056,7 +6070,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
     if (!maybe_au_data) {
-        LogWarning("[snapshot] assumeutxo data not found for height "
+        LogWarning(m_log, "[snapshot] assumeutxo data not found for height "
             "(%d) - refusing to validate snapshot", validated_cs.m_chain.Height());
         handle_invalid_snapshot();
         return SnapshotCompletionResult::MISSING_CHAINPARAMS;
@@ -6064,7 +6078,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     const AssumeutxoData& au_data = *maybe_au_data;
     std::optional<CCoinsStats> validated_cs_stats;
-    LogInfo("[snapshot] computing UTXO stats for background chainstate to validate "
+    LogInfo(m_log, "[snapshot] computing UTXO stats for background chainstate to validate "
         "snapshot - this could take a few minutes");
     try {
         validated_cs_stats = ComputeUTXOStats(
@@ -6078,7 +6092,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     // XXX note that this function is slow and will hold cs_main for potentially minutes.
     if (!validated_cs_stats) {
-        LogWarning("[snapshot] failed to generate stats for validation coins db");
+        LogWarning(m_log, "[snapshot] failed to generate stats for validation coins db");
         // While this isn't a problem with the snapshot per se, this condition
         // prevents us from validating the snapshot, so we should shut down and let the
         // user handle the issue manually.
@@ -6093,14 +6107,14 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
     // hash for the snapshot when it's loaded in its chainstate's leveldb. We could then
     // reference that here for an additional check.
     if (AssumeutxoHash{validated_cs_stats->hashSerialized} != au_data.hash_serialized) {
-        LogWarning("[snapshot] hash mismatch: actual=%s, expected=%s",
+        LogWarning(m_log, "[snapshot] hash mismatch: actual=%s, expected=%s",
             validated_cs_stats->hashSerialized.ToString(),
             au_data.hash_serialized.ToString());
         handle_invalid_snapshot();
         return SnapshotCompletionResult::HASH_MISMATCH;
     }
 
-    LogInfo("[snapshot] snapshot beginning at %s has been fully validated",
+    LogInfo(m_log, "[snapshot] snapshot beginning at %s has been fully validated",
         unvalidated_cs.m_from_snapshot_blockhash->ToString());
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
@@ -6127,7 +6141,7 @@ void ChainstateManager::MaybeRebalanceCaches()
         current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
-        LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
+        LogInfo(m_log, "[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
         current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
     } else {
@@ -6194,11 +6208,11 @@ Chainstate* ChainstateManager::LoadAssumeutxoChainstate()
     if (!base_blockhash) {
         return nullptr;
     }
-    LogInfo("[snapshot] detected active snapshot chainstate (%s) - loading",
+    LogInfo(m_log, "[snapshot] detected active snapshot chainstate (%s) - loading",
         fs::PathToString(*path));
 
     auto snapshot_chainstate{std::make_unique<Chainstate>(nullptr, m_blockman, *this, base_blockhash)};
-    LogInfo("[snapshot] switching active chainstate to %s", snapshot_chainstate->ToString());
+    LogInfo(m_log, "[snapshot] switching active chainstate to %s", snapshot_chainstate->ToString());
     return &this->AddChainstate(std::move(snapshot_chainstate));
 }
 
@@ -6245,7 +6259,7 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
     const fs::path invalid_path{db_path + "_INVALID"};
     const std::string db_path_str{fs::PathToString(db_path)};
     const std::string invalid_path_str{fs::PathToString(invalid_path)};
-    LogInfo("[snapshot] renaming snapshot datadir %s to %s", db_path_str, invalid_path_str);
+    LogInfo(m_log, "[snapshot] renaming snapshot datadir %s to %s", db_path_str, invalid_path_str);
 
     // The invalid storage directory is simply moved and not deleted because we may
     // want to do forensics later during issue investigation. The user is instructed
@@ -6253,7 +6267,7 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
     try {
         fs::rename(db_path, invalid_path);
     } catch (const fs::filesystem_error& e) {
-        LogError("While invalidating the coins db: Error renaming file '%s' -> '%s': %s",
+        LogError(m_log, "While invalidating the coins db: Error renaming file '%s' -> '%s': %s",
                  db_path_str, invalid_path_str, e.what());
         return util::Error{strprintf(_(
             "Rename of '%s' -> '%s' failed. "
@@ -6270,8 +6284,8 @@ bool ChainstateManager::DeleteChainstate(Chainstate& chainstate)
     AssertLockHeld(::cs_main);
     assert(!chainstate.m_coins_views);
     const fs::path db_path{chainstate.StoragePath()};
-    if (!DeleteCoinsDBFromDisk(db_path, /*is_snapshot=*/bool{chainstate.m_from_snapshot_blockhash})) {
-        LogError("Deletion of %s failed. Please remove it manually to continue reindexing.",
+    if (!DeleteCoinsDBFromDisk(m_log, db_path, /*is_snapshot=*/bool{chainstate.m_from_snapshot_blockhash})) {
+        LogError(m_log, "Deletion of %s failed. Please remove it manually to continue reindexing.",
                   fs::PathToString(db_path));
         return false;
     }
@@ -6333,14 +6347,14 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
     this->ResetChainstates();
     assert(this->m_chainstates.size() == 0);
 
-    LogInfo("[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
+    LogInfo(m_log, "[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
               fs::PathToString(validated_path));
 
     auto rename_failed_abort = [this](
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
-        LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
+        LogError(m_log, "[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
         GetNotifications().fatalError(strprintf(_(
             "Rename of '%s' -> '%s' failed. "
@@ -6355,7 +6369,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         throw;
     }
 
-    LogInfo("[snapshot] moving snapshot chainstate (%s) to "
+    LogInfo(m_log, "[snapshot] moving snapshot chainstate (%s) to "
               "default chainstate directory (%s)",
               fs::PathToString(assumed_valid_path), fs::PathToString(validated_path));
 
@@ -6366,14 +6380,14 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         throw;
     }
 
-    if (!DeleteCoinsDBFromDisk(delete_path, /*is_snapshot=*/false)) {
+    if (!DeleteCoinsDBFromDisk(m_log, delete_path, /*is_snapshot=*/false)) {
         // No need to FatalError because once the unneeded bg chainstate data is
         // moved, it will not interfere with subsequent initialization.
-        LogWarning("Deletion of %s failed. Please remove it manually, as the "
+        LogWarning(m_log, "Deletion of %s failed. Please remove it manually, as the "
                    "directory is now unnecessary.",
                    fs::PathToString(delete_path));
     } else {
-        LogInfo("[snapshot] deleted background chainstate directory (%s)",
+        LogInfo(m_log, "[snapshot] deleted background chainstate directory (%s)",
                 fs::PathToString(validated_path));
     }
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -187,6 +187,7 @@ namespace {
  * @returns A vector of input heights or nullopt, in case of an error.
  */
 std::optional<std::vector<int>> CalculatePrevHeights(
+    const util::log::Context& log,
     const CBlockIndex& tip,
     const CCoinsView& coins,
     const CTransaction& tx)
@@ -208,13 +209,16 @@ std::optional<std::vector<int>> CalculatePrevHeights(
 } // namespace
 
 std::optional<LockPoints> CalculateLockPointsAtTip(
+    util::log::Logger* logger,
     CBlockIndex* tip,
     const CCoinsView& coins_view,
     const CTransaction& tx)
 {
     assert(tip);
 
-    auto prev_heights{CalculatePrevHeights(*tip, coins_view, tx)};
+    const util::log::Context log{BCLog::VALIDATION, logger};
+
+    auto prev_heights{CalculatePrevHeights(log, *tip, coins_view, tx)};
     if (!prev_heights.has_value()) return std::nullopt;
 
     CBlockIndex next_tip;
@@ -365,7 +369,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
             }
         } else {
             const CCoinsViewMemPool view_mempool{&CoinsTip(), *m_mempool};
-            const std::optional<LockPoints> new_lock_points{CalculateLockPointsAtTip(m_chain.Tip(), view_mempool, tx)};
+            const std::optional<LockPoints> new_lock_points{CalculateLockPointsAtTip(m_log.logger, m_chain.Tip(), view_mempool, tx)};
             if (new_lock_points.has_value() && CheckSequenceLocksAtTip(m_chain.Tip(), *new_lock_points)) {
                 // Now update the mempool entry lockpoints as well.
                 it->UpdateLockPoints(*new_lock_points);
@@ -888,7 +892,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // be mined yet.
     // Pass in m_view which has all of the relevant inputs cached. Note that, since m_view's
     // backend was removed, it no longer pulls coins from the mempool.
-    const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(m_active_chainstate.m_chain.Tip(), m_view, tx)};
+    const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(m_pool.m_log.logger, m_active_chainstate.m_chain.Tip(), m_view, tx)};
     if (!lock_points.has_value() || !CheckSequenceLocksAtTip(m_active_chainstate.m_chain.Tip(), *lock_points)) {
         return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "non-BIP68-final");
     }
@@ -1856,8 +1860,9 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
-CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
-    : m_dbview{std::move(db_params), std::move(options)},
+CoinsViews::CoinsViews(util::log::Logger& logger, DBParams db_params, CoinsViewOptions options)
+    : m_log{BCLog::VALIDATION, &logger},
+      m_dbview{logger, std::move(db_params), std::move(options)},
       m_catcherview(&m_dbview) {}
 
 void CoinsViews::InitCache(int32_t prevoutfetch_threads)
@@ -1878,6 +1883,7 @@ Chainstate::Chainstate(
     ChainstateManager& chainman,
     std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
+      m_log{chainman.m_log},
       m_blockman(blockman),
       m_chainman(chainman),
       m_assumeutxo(from_snapshot_blockhash ? Assumeutxo::UNVALIDATED : Assumeutxo::VALIDATED),
@@ -1928,6 +1934,7 @@ void Chainstate::InitCoinsDB(
     bool should_wipe)
 {
     m_coins_views = std::make_unique<CoinsViews>(
+        *Assert(m_log.logger),
         DBParams{
             .path = StoragePath(),
             .cache_bytes = cache_size_bytes,
@@ -2035,8 +2042,8 @@ std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
     }
 }
 
-ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, const size_t signature_cache_bytes)
-    : m_signature_cache{signature_cache_bytes}
+ValidationCache::ValidationCache(util::log::Logger& logger, const size_t script_execution_cache_bytes, const size_t signature_cache_bytes)
+    : m_signature_cache{logger, signature_cache_bytes}
 {
     // Setup the salted hasher
     uint256 nonce = GetRandHash();
@@ -2892,7 +2899,7 @@ static void UpdateTipLog(
                    "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
-                   log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,
+                   std::log(tip->nChainWork.getdouble()) / std::log(2.0), tip->m_chain_tx_count,
                    FormatISO8601DateTime(tip->GetBlockTime()),
                    background_validation ? chainman.GetBackgroundVerificationProgress(*tip) : chainman.GuessVerificationProgress(tip),
                    coins_tip.DynamicMemoryUsage() / double(1_MiB),
@@ -4041,7 +4048,7 @@ bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus:
                                [&](const auto& header) { return CheckProofOfWork(header.GetHash(), header.nBits, consensusParams); });
 }
 
-bool IsBlockMutated(const CBlock& block, bool check_witness_root)
+bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_witness_root)
 {
     BlockValidationState state;
     if (!CheckMerkleRoot(block, state)) {
@@ -6159,12 +6166,13 @@ static ChainstateManager::Options&& Flatten(ChainstateManager::Options&& opts)
     return std::move(opts);
 }
 
-ChainstateManager::ChainstateManager(const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options)
+ChainstateManager::ChainstateManager(util::log::Logger& logger, const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options)
     : m_script_check_queue{/*batch_size=*/128, std::clamp(options.worker_threads_num, 0, MAX_SCRIPTCHECK_THREADS)},
+      m_log{BCLog::VALIDATION, &logger},
       m_interrupt{interrupt},
       m_options{Flatten(std::move(options))},
-      m_blockman{interrupt, std::move(blockman_options)},
-      m_validation_cache{m_options.script_execution_cache_bytes, m_options.signature_cache_bytes}
+      m_blockman{logger, interrupt, std::move(blockman_options)},
+      m_validation_cache{logger, m_options.script_execution_cache_bytes, m_options.signature_cache_bytes}
 {
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2865,8 +2865,9 @@ static void UpdateTipLog(
 
     AssertLockHeld(::cs_main);
 
-    // Disable rate limiting as this may log frequently during IBD.
-    LogInfo(util::log::NO_RATE_LIMIT, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Disable rate limiting so this source location may log during IBD.
+    LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
+                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2887,8 +2887,9 @@ static void UpdateTipLog(
 
     AssertLockHeld(::cs_main);
 
-    // Disable rate limiting as this may log frequently during IBD.
-    LogInfo(util::log::NO_RATE_LIMIT, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Disable rate limiting so this source location may log during IBD.
+    LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
+                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -187,6 +187,7 @@ namespace {
  * @returns A vector of input heights or nullopt, in case of an error.
  */
 std::optional<std::vector<int>> CalculatePrevHeights(
+    const util::log::Context& log,
     const CBlockIndex& tip,
     const CCoinsView& coins,
     const CTransaction& tx)
@@ -208,13 +209,16 @@ std::optional<std::vector<int>> CalculatePrevHeights(
 } // namespace
 
 std::optional<LockPoints> CalculateLockPointsAtTip(
+    util::log::Logger* logger,
     CBlockIndex* tip,
     const CCoinsView& coins_view,
     const CTransaction& tx)
 {
     assert(tip);
 
-    auto prev_heights{CalculatePrevHeights(*tip, coins_view, tx)};
+    const util::log::Context log{BCLog::VALIDATION, logger};
+
+    auto prev_heights{CalculatePrevHeights(log, *tip, coins_view, tx)};
     if (!prev_heights.has_value()) return std::nullopt;
 
     CBlockIndex next_tip;
@@ -365,7 +369,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
             }
         } else {
             const CCoinsViewMemPool view_mempool{&CoinsTip(), *m_mempool};
-            const std::optional<LockPoints> new_lock_points{CalculateLockPointsAtTip(m_chain.Tip(), view_mempool, tx)};
+            const std::optional<LockPoints> new_lock_points{CalculateLockPointsAtTip(m_log.logger, m_chain.Tip(), view_mempool, tx)};
             if (new_lock_points.has_value() && CheckSequenceLocksAtTip(m_chain.Tip(), *new_lock_points)) {
                 // Now update the mempool entry lockpoints as well.
                 it->UpdateLockPoints(*new_lock_points);
@@ -888,7 +892,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // be mined yet.
     // Pass in m_view which has all of the relevant inputs cached. Note that, since m_view's
     // backend was removed, it no longer pulls coins from the mempool.
-    const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(m_active_chainstate.m_chain.Tip(), m_view, tx)};
+    const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(m_pool.m_log.logger, m_active_chainstate.m_chain.Tip(), m_view, tx)};
     if (!lock_points.has_value() || !CheckSequenceLocksAtTip(m_active_chainstate.m_chain.Tip(), *lock_points)) {
         return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "non-BIP68-final");
     }
@@ -1854,8 +1858,9 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
-CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
-    : m_dbview{std::move(db_params), std::move(options)},
+CoinsViews::CoinsViews(util::log::Logger& logger, DBParams db_params, CoinsViewOptions options)
+    : m_log{BCLog::VALIDATION, &logger},
+      m_dbview{logger, std::move(db_params), std::move(options)},
       m_catcherview(&m_dbview) {}
 
 void CoinsViews::InitCache(int32_t prevoutfetch_threads)
@@ -1876,6 +1881,7 @@ Chainstate::Chainstate(
     ChainstateManager& chainman,
     std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
+      m_log{chainman.m_log},
       m_blockman(blockman),
       m_chainman(chainman),
       m_assumeutxo(from_snapshot_blockhash ? Assumeutxo::UNVALIDATED : Assumeutxo::VALIDATED),
@@ -1926,6 +1932,7 @@ void Chainstate::InitCoinsDB(
     bool should_wipe)
 {
     m_coins_views = std::make_unique<CoinsViews>(
+        *Assert(m_log.logger),
         DBParams{
             .path = StoragePath(),
             .cache_bytes = cache_size_bytes,
@@ -2033,8 +2040,8 @@ std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
     }
 }
 
-ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, const size_t signature_cache_bytes)
-    : m_signature_cache{signature_cache_bytes}
+ValidationCache::ValidationCache(util::log::Logger& logger, const size_t script_execution_cache_bytes, const size_t signature_cache_bytes)
+    : m_signature_cache{logger, signature_cache_bytes}
 {
     // Setup the salted hasher
     uint256 nonce = GetRandHash();
@@ -2890,7 +2897,7 @@ static void UpdateTipLog(
                    "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
-                   log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,
+                   std::log(tip->nChainWork.getdouble()) / std::log(2.0), tip->m_chain_tx_count,
                    FormatISO8601DateTime(tip->GetBlockTime()),
                    background_validation ? chainman.GetBackgroundVerificationProgress(*tip) : chainman.GuessVerificationProgress(tip),
                    coins_tip.DynamicMemoryUsage() / double(1_MiB),
@@ -4039,7 +4046,7 @@ bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus:
                                [&](const auto& header) { return CheckProofOfWork(header.GetHash(), header.nBits, consensusParams); });
 }
 
-bool IsBlockMutated(const CBlock& block, bool check_witness_root)
+bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_witness_root)
 {
     BlockValidationState state;
     if (!CheckMerkleRoot(block, state)) {
@@ -6157,12 +6164,13 @@ static ChainstateManager::Options&& Flatten(ChainstateManager::Options&& opts)
     return std::move(opts);
 }
 
-ChainstateManager::ChainstateManager(const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options)
+ChainstateManager::ChainstateManager(util::log::Logger& logger, const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options)
     : m_script_check_queue{/*batch_size=*/128, std::clamp(options.worker_threads_num, 0, MAX_SCRIPTCHECK_THREADS)},
+      m_log{BCLog::VALIDATION, &logger},
       m_interrupt{interrupt},
       m_options{Flatten(std::move(options))},
-      m_blockman{interrupt, std::move(blockman_options)},
-      m_validation_cache{m_options.script_execution_cache_bytes, m_options.signature_cache_bytes}
+      m_blockman{logger, interrupt, std::move(blockman_options)},
+      m_validation_cache{logger, m_options.script_execution_cache_bytes, m_options.signature_cache_bytes}
 {
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -78,6 +78,8 @@
 #include <tuple>
 #include <utility>
 
+#define LOG_REQUIRE_CONTEXT true
+
 using kernel::CCoinsStats;
 using kernel::ChainstateRole;
 using kernel::CoinStatsHashType;
@@ -200,7 +202,7 @@ std::optional<std::vector<int>> CalculatePrevHeights(
                               ? tip.nHeight + 1 // Assume all mempool transaction confirm in the next block.
                               : coin->nHeight;
         } else {
-            LogInfo("ERROR: %s: Missing input %d in transaction \'%s\'\n", __func__, i, tx.GetHash().GetHex());
+            LogInfo(log, "ERROR: %s: Missing input %d in transaction \'%s\'\n", __func__, i, tx.GetHash().GetHex());
             return std::nullopt;
         }
     }
@@ -281,7 +283,7 @@ static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
     AssertLockHeld(pool.cs);
     int expired = pool.Expire(GetTime<std::chrono::seconds>() - pool.m_opts.expiry);
     if (expired != 0) {
-        LogDebug(BCLog::MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
+        LogDebug(pool.m_log, "Expired %i transactions from the memory pool\n", expired);
     }
 
     std::vector<COutPoint> vNoSpendsRemaining;
@@ -1130,7 +1132,8 @@ bool MemPoolAccept::PackageRBFChecks(const std::vector<CTransactionRef>& txns,
                                      "package RBF failed: " + err_tup.value().second, "");
     }
 
-    LogDebug(BCLog::TXPACKAGES, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s), package hash (%s)\n",
+    const util::log::Context log_packages{BCLog::TXPACKAGES, m_pool.m_log.logger};
+    LogDebug(log_packages, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s), package hash (%s)\n",
         txns.front()->GetHash().ToString(), txns.front()->GetWitnessHash().ToString(),
         txns.back()->GetHash().ToString(), txns.back()->GetWitnessHash().ToString(),
         GetPackageHash(txns).ToString());
@@ -1188,7 +1191,7 @@ bool MemPoolAccept::ConsensusScriptChecks(const ATMPArgs& args, Workspace& ws)
     script_verify_flags currentBlockScriptVerifyFlags{GetBlockScriptFlags(*m_active_chainstate.m_chain.Tip(), m_active_chainstate.m_chainman)};
     if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, currentBlockScriptVerifyFlags,
                                         ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache())) {
-        LogError("BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
+        LogError(m_pool.m_log, "BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
         return Assume(false);
     }
 
@@ -1229,7 +1232,7 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                                     feerate.size);
 
         }
-        LogDebug(BCLog::MEMPOOL, "%s\n", log_string);
+        LogDebug(m_pool.m_log, "%s\n", log_string);
         TRACEPOINT(mempool, replaced,
                 it->GetTx().GetHash().data(),
                 it->GetTxSize(),
@@ -1294,7 +1297,7 @@ bool MemPoolAccept::SubmitPackage(const ATMPArgs& args, std::vector<Workspace>& 
                    [](const auto& ws) { return ws.m_ptx->GetWitnessHash(); });
 
     if (!m_subpackage.m_replaced_transactions.empty()) {
-        LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with %u new one(s) for %s additional fees, %d delta bytes\n",
+        LogDebug(m_pool.m_log, "replaced %u mempool transactions with %u new one(s) for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(), workspaces.size(),
                  m_subpackage.m_total_modified_fees - m_subpackage.m_conflicting_fees,
                  m_subpackage.m_total_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
@@ -1428,7 +1431,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransactionInternal(const CTransa
     }
 
     if (!m_subpackage.m_replaced_transactions.empty()) {
-        LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with 1 new transaction for %s additional fees, %d delta bytes\n",
+        LogDebug(m_pool.m_log, "replaced %u mempool transactions with 1 new transaction for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(),
                  ws.m_modified_fees - m_subpackage.m_conflicting_fees,
                  ws.m_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
@@ -1870,7 +1873,7 @@ void CoinsViews::InitCache(int32_t prevoutfetch_threads)
     auto thread_pool{std::make_shared<ThreadPool>("prevout")};
     if (prevoutfetch_threads > 0) {
         thread_pool->Start(prevoutfetch_threads);
-        LogInfo("Block input prevout fetching uses %d additional threads", prevoutfetch_threads);
+        LogInfo(m_log, "Block input prevout fetching uses %d additional threads", prevoutfetch_threads);
     }
     m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview, std::move(thread_pool));
 }
@@ -1968,7 +1971,7 @@ void Chainstate::CheckForkWarningConditions()
     }
 
     if (m_chainman.m_best_invalid && m_chainman.m_best_invalid->nChainWork > m_chain.Tip()->nChainWork + (GetBlockProof(*m_chain.Tip()) * 6)) {
-        LogWarning("Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers.");
+        LogWarning(m_log, "Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers.");
         m_chainman.GetNotifications().warningSet(
             kernel::Warning::LARGE_WORK_INVALID_CHAIN,
             _("Warning: Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers."));
@@ -1989,12 +1992,12 @@ void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
         m_chainman.RecalculateBestHeader();
     }
 
-    LogInfo("%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
+    LogInfo(m_log, "%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
       log(pindexNew->nChainWork.getdouble())/log(2.0), FormatISO8601DateTime(pindexNew->GetBlockTime()));
     CBlockIndex *tip = m_chain.Tip();
     assert (tip);
-    LogInfo("%s: current best=%s height=%d log2_work=%f date=%s", __func__,
+    LogInfo(m_log, "%s: current best=%s height=%d log2_work=%f date=%s", __func__,
       tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble())/log(2.0),
       FormatISO8601DateTime(tip->GetBlockTime()));
     CheckForkWarningConditions();
@@ -2052,7 +2055,8 @@ ValidationCache::ValidationCache(util::log::Logger& logger, const size_t script_
     m_script_execution_cache_hasher.Write(nonce.begin(), 32);
 
     const auto [num_elems, approx_size_bytes] = m_script_execution_cache.setup_bytes(script_execution_cache_bytes);
-    LogInfo("Using %zu MiB out of %zu MiB requested for script execution cache, able to store %zu elements",
+    const util::log::Context log{BCLog::VALIDATION, &logger};
+    LogInfo(log, "Using %zu MiB out of %zu MiB requested for script execution cache, able to store %zu elements",
               approx_size_bytes >> 20, script_execution_cache_bytes >> 20, num_elems);
 }
 
@@ -2200,12 +2204,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
 
     CBlockUndo blockUndo;
     if (!m_blockman.ReadBlockUndo(blockUndo, *pindex)) {
-        LogError("DisconnectBlock(): failure reading undo data\n");
+        LogError(m_log, "DisconnectBlock(): failure reading undo data\n");
         return DISCONNECT_FAILED;
     }
 
     if (blockUndo.vtxundo.size() + 1 != block.vtx.size()) {
-        LogError("DisconnectBlock(): block and undo data inconsistent\n");
+        LogError(m_log, "DisconnectBlock(): block and undo data inconsistent\n");
         return DISCONNECT_FAILED;
     }
 
@@ -2244,7 +2248,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         if (i > 0) { // not coinbases
             CTxUndo &txundo = blockUndo.vtxundo[i-1];
             if (txundo.vprevout.size() != tx.vin.size()) {
-                LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
+                LogError(m_log, "DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
             for (unsigned int j = tx.vin.size(); j > 0;) {
@@ -2315,6 +2319,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     AssertLockHeld(cs_main);
     assert(pindex);
 
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
 
@@ -2341,7 +2346,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // problems.
             return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
         }
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
+        LogError(m_log, "%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -2401,7 +2406,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_1{SteadyClock::now()};
     m_chainman.time_check += time_1 - time_start;
-    LogDebug(BCLog::BENCH, "    - Sanity checks: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Sanity checks: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_1 - time_start),
              Ticks<SecondsDouble>(m_chainman.time_check),
              Ticks<MillisecondsDouble>(m_chainman.time_check) / m_chainman.num_blocks_total);
@@ -2503,7 +2508,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_2{SteadyClock::now()};
     m_chainman.time_forks += time_2 - time_1;
-    LogDebug(BCLog::BENCH, "    - Fork checks: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Fork checks: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_2 - time_1),
              Ticks<SecondsDouble>(m_chainman.time_forks),
              Ticks<MillisecondsDouble>(m_chainman.time_forks) / m_chainman.num_blocks_total);
@@ -2512,10 +2517,10 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     const kernel::ChainstateRole role{GetRole()};
     if (script_check_reason != m_last_script_check_reason_logged && role.validated && !role.historical) {
         if (fScriptChecks) {
-            LogInfo("Enabling script verification at block #%d (%s): %s.",
+            LogInfo(m_log, "Enabling script verification at block #%d (%s): %s.",
                     pindex->nHeight, block_hash.ToString(), script_check_reason);
         } else {
-            LogInfo("Disabling script verification at block #%d (%s).",
+            LogInfo(m_log, "Disabling script verification at block #%d (%s).",
                     pindex->nHeight, block_hash.ToString());
         }
         m_last_script_check_reason_logged = script_check_reason;
@@ -2617,7 +2622,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     }
     const auto time_3{SteadyClock::now()};
     m_chainman.time_connect += time_3 - time_2;
-    LogDebug(BCLog::BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
+    LogDebug(log_bench, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
              Ticks<MillisecondsDouble>(time_3 - time_2), Ticks<MillisecondsDouble>(time_3 - time_2) / block.vtx.size(),
              nInputs <= 1 ? 0 : Ticks<MillisecondsDouble>(time_3 - time_2) / (nInputs - 1),
              Ticks<SecondsDouble>(m_chainman.time_connect),
@@ -2635,12 +2640,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         }
     }
     if (!state.IsValid()) {
-        LogInfo("Block validation error: %s", state.ToString());
+        LogInfo(m_log, "Block validation error: %s", state.ToString());
         return false;
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_verify += time_4 - time_2;
-    LogDebug(BCLog::BENCH, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1,
+    LogDebug(log_bench, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1,
              Ticks<MillisecondsDouble>(time_4 - time_2),
              nInputs <= 1 ? 0 : Ticks<MillisecondsDouble>(time_4 - time_2) / (nInputs - 1),
              Ticks<SecondsDouble>(m_chainman.time_verify),
@@ -2656,7 +2661,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_5{SteadyClock::now()};
     m_chainman.time_undo += time_5 - time_4;
-    LogDebug(BCLog::BENCH, "    - Write undo data: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Write undo data: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_5 - time_4),
              Ticks<SecondsDouble>(m_chainman.time_undo),
              Ticks<MillisecondsDouble>(m_chainman.time_undo) / m_chainman.num_blocks_total);
@@ -2671,7 +2676,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const auto time_6{SteadyClock::now()};
     m_chainman.time_index += time_6 - time_5;
-    LogDebug(BCLog::BENCH, "    - Index writing: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "    - Index writing: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_5),
              Ticks<SecondsDouble>(m_chainman.time_index),
              Ticks<MillisecondsDouble>(m_chainman.time_index) / m_chainman.num_blocks_total);
@@ -2707,7 +2712,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
         max_coins_cache_size_bytes + std::max<int64_t>(int64_t(max_mempool_size_bytes) - nMempoolUsage, 0);
 
     if (cacheSize > nTotalSpace) {
-        LogInfo("Cache size (%s) exceeds total space (%s)\n", cacheSize, nTotalSpace);
+        LogInfo(m_log, "Cache size (%s) exceeds total space (%s)\n", cacheSize, nTotalSpace);
         return CoinsCacheSizeState::CRITICAL;
     } else if (cacheSize > LargeCoinsCacheThreshold(nTotalSpace)) {
         return CoinsCacheSizeState::LARGE;
@@ -2722,6 +2727,7 @@ bool Chainstate::FlushStateToDisk(
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
+    const util::log::Context log_prune{BCLog::PRUNE, m_log.logger};
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2750,7 +2756,7 @@ bool Chainstate::FlushStateToDisk(
             }
 
             if (limiting_lock) {
-                LogDebug(BCLog::PRUNE, "%s limited pruning to height %d\n", limiting_lock.value(), last_prune);
+                LogDebug(log_prune, "%s limited pruning to height %d\n", limiting_lock.value(), last_prune);
             }
 
             if (nManualPruneHeight > 0) {
@@ -2786,7 +2792,8 @@ bool Chainstate::FlushStateToDisk(
         bool should_write = (mode == FlushStateMode::FORCE_SYNC) || empty_cache || fPeriodicWrite || fFlushForPrune;
         // Write blocks, block index and best chain related state to disk.
         if (should_write) {
-            LogDebug(BCLog::COINDB, "Writing chainstate to disk: flush mode=%s, prune=%d, large=%d, critical=%d, periodic=%d",
+            const util::log::Context log_coins{BCLog::COINDB, m_log.logger};
+            LogDebug(log_coins, "Writing chainstate to disk: flush mode=%s, prune=%d, large=%d, critical=%d, periodic=%d",
                      FlushStateModeNames[size_t(mode)], fFlushForPrune, fCacheLarge, fCacheCritical, fPeriodicWrite);
 
             // Ensure we can write block index
@@ -2800,7 +2807,7 @@ bool Chainstate::FlushStateToDisk(
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                    LogWarning(m_log, "%s: Failed to flush block file.\n", __func__);
                 }
             }
 
@@ -2853,7 +2860,7 @@ bool Chainstate::FlushStateToDisk(
             try {
                 CoinsDB().CompactFullAsync();
             } catch (const std::exception& e) {
-                LogWarning("Failed to start chainstate compaction (%s)", e.what());
+                LogWarning(m_log, "Failed to start chainstate compaction (%s)", e.what());
             }
         }
     }
@@ -2867,7 +2874,7 @@ void Chainstate::ForceFlushStateToDisk(bool wipe_cache)
 {
     BlockValidationState state;
     if (!this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC)) {
-        LogWarning("Failed to force flush state (%s)", state.ToString());
+        LogWarning(m_log, "Failed to force flush state (%s)", state.ToString());
     }
 }
 
@@ -2876,7 +2883,7 @@ void Chainstate::PruneAndFlush()
     BlockValidationState state;
     m_blockman.m_check_for_pruning = true;
     if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
-        LogWarning("Failed to flush state (%s)", state.ToString());
+        LogWarning(m_log, "Failed to flush state (%s)", state.ToString());
     }
 }
 
@@ -2894,7 +2901,7 @@ static void UpdateTipLog(
 
     // Disable rate limiting so this source location may log during IBD.
     LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
-                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+                   chainman.m_log,"%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    std::log(tip->nChainWork.getdouble()) / std::log(2.0), tip->m_chain_tx_count,
@@ -2957,6 +2964,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
+    const util::log::Context log_prune{BCLog::PRUNE, m_log.logger};
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     assert(pindexDelete->pprev);
@@ -2964,7 +2973,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlock(block, *pindexDelete)) {
-        LogError("DisconnectTip(): Failed to read block\n");
+        LogError(m_log, "DisconnectTip(): Failed to read block\n");
         return false;
     }
     // Apply the block atomically to the chain state.
@@ -2973,12 +2982,12 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
-            LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
+            LogError(m_log, "DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
         view.Flush(/*reallocate_cache=*/false); // local CCoinsViewCache goes out of scope
     }
-    LogDebug(BCLog::BENCH, "- Disconnect block: %.2fms\n",
+    LogDebug(log_bench, "- Disconnect block: %.2fms\n",
              Ticks<MillisecondsDouble>(SteadyClock::now() - time_start));
 
     {
@@ -2988,7 +2997,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
             if (prune_lock.second.height_first <= max_height_first) continue;
 
             prune_lock.second.height_first = max_height_first;
-            LogDebug(BCLog::PRUNE, "%s prune lock moved back to %d\n", prune_lock.first, max_height_first);
+            LogDebug(log_prune, "%s prune lock moved back to %d\n", prune_lock.first, max_height_first);
         }
     }
 
@@ -3040,6 +3049,7 @@ bool Chainstate::ConnectTip(
 
     assert(pindexNew->pprev == m_chain.Tip());
     // Read block from disk.
+    const util::log::Context log_bench{BCLog::BENCH, m_log.logger};
     const auto time_1{SteadyClock::now()};
     if (!block_to_connect) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
@@ -3048,14 +3058,14 @@ bool Chainstate::ConnectTip(
         }
         block_to_connect = std::move(pblockNew);
     } else {
-        LogDebug(BCLog::BENCH, "  - Using cached block\n");
+        LogDebug(log_bench, "  - Using cached block\n");
     }
     // Apply the block atomically to the chain state.
     const auto time_2{SteadyClock::now()};
     SteadyClock::time_point time_3;
     // When adding aggregate statistics in the future, keep in mind that
     // num_blocks_total may be zero until the ConnectBlock() call below.
-    LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
+    LogDebug(log_bench, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
         CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
@@ -3067,13 +3077,13 @@ bool Chainstate::ConnectTip(
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            LogError(m_log, "%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
             return false;
         }
         time_3 = SteadyClock::now();
         m_chainman.time_connect_total += time_3 - time_2;
         assert(m_chainman.num_blocks_total > 0);
-        LogDebug(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n",
+        LogDebug(log_bench, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n",
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(m_chainman.time_connect_total),
                  Ticks<MillisecondsDouble>(m_chainman.time_connect_total) / m_chainman.num_blocks_total);
@@ -3081,7 +3091,7 @@ bool Chainstate::ConnectTip(
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_flush += time_4 - time_3;
-    LogDebug(BCLog::BENCH, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_4 - time_3),
              Ticks<SecondsDouble>(m_chainman.time_flush),
              Ticks<MillisecondsDouble>(m_chainman.time_flush) / m_chainman.num_blocks_total);
@@ -3091,7 +3101,7 @@ bool Chainstate::ConnectTip(
     }
     const auto time_5{SteadyClock::now()};
     m_chainman.time_chainstate += time_5 - time_4;
-    LogDebug(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_5 - time_4),
              Ticks<SecondsDouble>(m_chainman.time_chainstate),
              Ticks<MillisecondsDouble>(m_chainman.time_chainstate) / m_chainman.num_blocks_total);
@@ -3108,11 +3118,11 @@ bool Chainstate::ConnectTip(
     const auto time_6{SteadyClock::now()};
     m_chainman.time_post_connect += time_6 - time_5;
     m_chainman.time_total += time_6 - time_1;
-    LogDebug(BCLog::BENCH, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_5),
              Ticks<SecondsDouble>(m_chainman.time_post_connect),
              Ticks<MillisecondsDouble>(m_chainman.time_post_connect) / m_chainman.num_blocks_total);
-    LogDebug(BCLog::BENCH, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n",
+    LogDebug(log_bench, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n",
              Ticks<MillisecondsDouble>(time_6 - time_1),
              Ticks<SecondsDouble>(m_chainman.time_total),
              Ticks<MillisecondsDouble>(m_chainman.time_total) / m_chainman.num_blocks_total);
@@ -3308,7 +3318,7 @@ void ChainstateManager::UpdateIBDStatus()
     if (!m_cached_is_ibd.load(std::memory_order_relaxed)) return;
     if (m_blockman.LoadingBlocks()) return;
     if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age)) return;
-    LogInfo("Leaving InitialBlockDownload (latching to false)");
+    LogInfo(m_log, "Leaving InitialBlockDownload (latching to false)");
     m_cached_is_ibd.store(false, std::memory_order_relaxed);
 }
 
@@ -3361,7 +3371,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.
     if (WITH_LOCK(::cs_main, return m_target_utxohash)) {
-        LogError("%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
+        LogError(m_log, "%s", STR_INTERNAL_BUG("m_target_utxohash is set - this chainstate should not be in operation."));
         return Assume(false);
     }
 
@@ -3796,7 +3806,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     auto prev_tx_sum = [](CBlockIndex& block) { return block.nTx + (block.pprev ? block.pprev->m_chain_tx_count : 0); };
     if (!Assume(pindexNew->m_chain_tx_count == 0 || pindexNew->m_chain_tx_count == prev_tx_sum(*pindexNew) ||
                 std::ranges::any_of(m_chainstates, [&](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->SnapshotBase() == pindexNew; }))) {
-        LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
+        LogWarning(m_log, "Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
             pindexNew->nHeight, pindexNew->m_chain_tx_count, prev_tx_sum(*pindexNew), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
         pindexNew->m_chain_tx_count = 0;
     }
@@ -3824,7 +3834,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             // assumeutxo snapshot block if assumeutxo snapshot metadata has an
             // incorrect hardcoded AssumeutxoData::m_chain_tx_count value.
             if (!Assume(pindex->m_chain_tx_count == 0 || pindex->m_chain_tx_count == prev_tx_sum(*pindex))) {
-                LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
+                LogWarning(m_log, "Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
                    pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
@@ -4048,9 +4058,10 @@ bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus:
 
 bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_witness_root)
 {
+    util::log::Context log{BCLog::VALIDATION, logger};
     BlockValidationState state;
     if (!CheckMerkleRoot(block, state)) {
-        LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
+        LogDebug(log, "Block mutated: %s\n", state.ToString());
         return true;
     }
 
@@ -4070,7 +4081,7 @@ bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_w
     }
 
     if (!CheckWitnessMalleation(block, check_witness_root, state)) {
-        LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
+        LogDebug(log, "Block mutated: %s\n", state.ToString());
         return true;
     }
 
@@ -4219,7 +4230,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             if (ppindex)
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_VALID) {
-                LogDebug(BCLog::VALIDATION, "%s: block %s is marked invalid\n", __func__, hash.ToString());
+                LogDebug(m_log, "%s: block %s is marked invalid\n", __func__, hash.ToString());
                 return state.Invalid(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid",
                                      strprintf("block %s was previously marked invalid", hash.ToString()));
             }
@@ -4227,7 +4238,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         }
 
         if (!CheckBlockHeader(block, state, GetConsensus())) {
-            LogDebug(BCLog::VALIDATION, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
+            LogDebug(m_log, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
 
@@ -4235,21 +4246,21 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         CBlockIndex* pindexPrev = nullptr;
         BlockMap::iterator mi{m_blockman.m_block_index.find(block.hashPrevBlock)};
         if (mi == m_blockman.m_block_index.end()) {
-            LogDebug(BCLog::VALIDATION, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
+            LogDebug(m_log, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_MISSING_PREV, "prev-blk-not-found");
         }
         pindexPrev = &((*mi).second);
         if (pindexPrev->nStatus & BLOCK_FAILED_VALID) {
-            LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
+            LogDebug(m_log, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
         if (!ContextualCheckBlockHeader(block, state, *this, pindexPrev)) {
-            LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
+            LogDebug(m_log, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
     }
     if (!min_pow_checked) {
-        LogDebug(BCLog::VALIDATION, "%s: not adding new block header %s, missing anti-dos proof-of-work validation\n", __func__, hash.ToString());
+        LogDebug(m_log, "%s: not adding new block header %s, missing anti-dos proof-of-work validation\n", __func__, hash.ToString());
         return state.Invalid(BlockValidationResult::BLOCK_HEADER_LOW_WORK, "too-little-chainwork");
     }
     CBlockIndex* pindex{m_blockman.AddToBlockIndex(block, m_best_header)};
@@ -4285,7 +4296,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
             int64_t blocks_left{(NodeClock::now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
             blocks_left = std::max<int64_t>(0, blocks_left);
             const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
-            LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
+            LogInfo(m_log, "Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
         }
     }
     return true;
@@ -4312,7 +4323,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
         int64_t blocks_left{(NodeClock::now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
         blocks_left = std::max<int64_t>(0, blocks_left);
         const double progress{100.0 * height / (height + blocks_left)};
-        LogInfo("Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
+        LogInfo(m_log, "Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
     }
 }
 
@@ -4374,7 +4385,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         if (Assume(state.IsInvalid())) {
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
-        LogError("%s: %s\n", __func__, state.ToString());
+        LogError(m_log, "%s: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -4451,7 +4462,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
             if (m_options.signals) {
                 m_options.signals->BlockChecked(block, state);
             }
-            LogError("%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
+            LogError(m_log, "%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
             return false;
         }
     }
@@ -4460,14 +4471,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
     if (!ActiveChainstate().ActivateBestChain(state, block)) {
-        LogError("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
+        LogError(m_log, "%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
         return false;
     }
 
     Chainstate* bg_chain{WITH_LOCK(cs_main, return HistoricalChainstate())};
     BlockValidationState bg_state;
     if (bg_chain && !bg_chain->ActivateBestChain(bg_state, block)) {
-        LogError("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
+        LogError(m_log, "%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
         return false;
      }
 
@@ -4565,10 +4576,11 @@ BlockValidationState TestBlockValidity(
 /* This function is called from the RPC code for pruneblockchain */
 void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
+    const util::log::Context& log{active_chainstate.m_log};
     BlockValidationState state;
     if (!active_chainstate.FlushStateToDisk(
             state, FlushStateMode::NONE, nManualPruneHeight)) {
-        LogWarning("Failed to flush state after manual prune (%s)", state.ToString());
+        LogWarning(log, "Failed to flush state after manual prune (%s)", state.ToString());
     }
 }
 
@@ -4607,7 +4619,7 @@ bool Chainstate::LoadChainTip()
         target = target->pprev;
     }
 
-    LogInfo("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f",
+    LogInfo(m_log, "Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f",
               tip->GetBlockHash().ToString(),
               m_chain.Height(),
               FormatISO8601DateTime(tip->GetBlockTime()),
@@ -4645,6 +4657,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);
+    const util::log::Context& log{chainstate.m_log};
 
     if (chainstate.m_chain.Tip() == nullptr || chainstate.m_chain.Tip()->pprev == nullptr) {
         return VerifyDBResult::SUCCESS;
@@ -4655,7 +4668,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
         nCheckDepth = chainstate.m_chain.Height();
     }
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
-    LogInfo("Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
+    LogInfo(log, "Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
     CCoinsViewCache coins(&coinsview);
     CBlockIndex* pindex;
     CBlockIndex* pindexFailure = nullptr;
@@ -4664,7 +4677,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     int reportDone = 0;
     bool skipped_no_block_data{false};
     bool skipped_l3_checks{false};
-    LogInfo("Verification progress: 0%%");
+    LogInfo(log, "Verification progress: 0%%");
 
     const bool is_snapshot_cs{chainstate.m_from_snapshot_blockhash};
 
@@ -4672,7 +4685,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(chainstate.m_chain.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
         if (reportDone < percentageDone / 10) {
             // report every 10% step
-            LogInfo("Verification progress: %d%%", percentageDone);
+            LogInfo(log, "Verification progress: %d%%", percentageDone);
             reportDone = percentageDone / 10;
         }
         m_notifications.progress(_("Verifying blocks…"), percentageDone, false);
@@ -4682,19 +4695,19 @@ VerifyDBResult CVerifyDB::VerifyDB(
         if ((chainstate.m_blockman.IsPruneMode() || is_snapshot_cs) && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
             // If pruning or running under an assumeutxo snapshot, only go
             // back as far as we have data.
-            LogInfo("Block verification stopping at height %d (no data). This could be due to pruning or use of an assumeutxo snapshot.", pindex->nHeight);
+            LogInfo(log, "Block verification stopping at height %d (no data). This could be due to pruning or use of an assumeutxo snapshot.", pindex->nHeight);
             skipped_no_block_data = true;
             break;
         }
         CBlock block;
         // check level 0: read from disk
         if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-            LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+            LogError(log, "Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params)) {
-            LogError("Verification error: found bad block at %d, hash=%s (%s)",
+            LogError(log, "Verification error: found bad block at %d, hash=%s (%s)",
                       pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
@@ -4703,7 +4716,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
                 if (!chainstate.m_blockman.ReadBlockUndo(undo, *pindex)) {
-                    LogError("Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                    LogError(log, "Verification error: found bad undo data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;
                 }
             }
@@ -4716,7 +4729,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                    LogError(log, "Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;
                 }
                 if (res == DISCONNECT_UNCLEAN) {
@@ -4732,11 +4745,11 @@ VerifyDBResult CVerifyDB::VerifyDB(
         if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
     }
     if (pindexFailure) {
-        LogError("Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
+        LogError(log, "Verification error: coin database inconsistencies found (last %i blocks, %i good transactions before that)", chainstate.m_chain.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
         return VerifyDBResult::CORRUPTED_BLOCK_DB;
     }
     if (skipped_l3_checks) {
-        LogWarning("Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
+        LogWarning(log, "Skipped verification of level >=3 (insufficient database cache size). Consider increasing -dbcache.");
     }
 
     // store block count as we move pindex at check level >= 4
@@ -4748,27 +4761,27 @@ VerifyDBResult CVerifyDB::VerifyDB(
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(chainstate.m_chain.Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
             if (reportDone < percentageDone / 10) {
                 // report every 10% step
-                LogInfo("Verification progress: %d%%", percentageDone);
+                LogInfo(log, "Verification progress: %d%%", percentageDone);
                 reportDone = percentageDone / 10;
             }
             m_notifications.progress(_("Verifying blocks…"), percentageDone, false);
             pindex = chainstate.m_chain.Next(*pindex);
             CBlock block;
             if (!chainstate.m_blockman.ReadBlock(block, *pindex)) {
-                LogError("Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                LogError(log, "Verification error: ReadBlock failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
             if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
-                LogError("Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
+                LogError(log, "Verification error: found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
                 return VerifyDBResult::CORRUPTED_BLOCK_DB;
             }
             if (chainstate.m_chainman.m_interrupt) return VerifyDBResult::INTERRUPTED;
         }
     }
 
-    LogInfo("Verification: checked last %i blocks at level %i", block_count, nCheckLevel);
+    LogInfo(log, "Verification: checked last %i blocks at level %i", block_count, nCheckLevel);
     if (nCheckLevel >= 3 && !skipped_l3_checks) {
-        LogInfo("Verification: no coin database inconsistencies (%i transactions)", nGoodTransactions);
+        LogInfo(log, "Verification: no coin database inconsistencies (%i transactions)", nGoodTransactions);
     }
 
     if (skipped_l3_checks) {
@@ -4787,7 +4800,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     // TODO: merge with ConnectBlock
     CBlock block;
     if (!m_blockman.ReadBlock(block, *pindex)) {
-        LogError("ReplayBlock(): ReadBlock failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+        LogError(m_log, "ReplayBlock(): ReadBlock failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
         return false;
     }
 
@@ -4813,26 +4826,26 @@ bool Chainstate::ReplayBlocks()
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
     if (hashHeads.empty()) return true; // We're already in a consistent state.
     if (hashHeads.size() != 2) {
-        LogError("ReplayBlocks(): unknown inconsistent state\n");
+        LogError(m_log, "ReplayBlocks(): unknown inconsistent state\n");
         return false;
     }
 
     m_chainman.GetNotifications().progress(_("Replaying blocks…"), 0, false);
-    LogInfo("Replaying blocks");
+    LogInfo(m_log, "Replaying blocks");
 
     const CBlockIndex* pindexOld = nullptr;  // Old tip during the interrupted flush.
     const CBlockIndex* pindexNew;            // New tip during the interrupted flush.
     const CBlockIndex* pindexFork = nullptr; // Latest block common to both the old and the new tip.
 
     if (!m_blockman.m_block_index.contains(hashHeads[0])) {
-        LogError("ReplayBlocks(): reorganization to unknown block requested\n");
+        LogError(m_log, "ReplayBlocks(): reorganization to unknown block requested\n");
         return false;
     }
     pindexNew = &(m_blockman.m_block_index[hashHeads[0]]);
 
     if (!hashHeads[1].IsNull()) { // The old tip is allowed to be 0, indicating it's the first flush.
         if (!m_blockman.m_block_index.contains(hashHeads[1])) {
-            LogError("ReplayBlocks(): reorganization from unknown block requested\n");
+            LogError(m_log, "ReplayBlocks(): reorganization from unknown block requested\n");
             return false;
         }
         pindexOld = &(m_blockman.m_block_index[hashHeads[1]]);
@@ -4843,20 +4856,20 @@ bool Chainstate::ReplayBlocks()
     // Rollback along the old branch.
     const int nForkHeight{pindexFork ? pindexFork->nHeight : 0};
     if (pindexOld != pindexFork) {
-        LogInfo("Rolling back from %s (%i to %i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight, nForkHeight);
+        LogInfo(m_log, "Rolling back from %s (%i to %i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight, nForkHeight);
         while (pindexOld != pindexFork) {
             if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
                 CBlock block;
                 if (!m_blockman.ReadBlock(block, *pindexOld)) {
-                    LogError("RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                    LogError(m_log, "RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                     return false;
                 }
                 if (pindexOld->nHeight % 10'000 == 0) {
-                    LogInfo("Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
+                    LogInfo(m_log, "Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
                 }
                 DisconnectResult res = DisconnectBlock(block, pindexOld, cache);
                 if (res == DISCONNECT_FAILED) {
-                    LogError("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                    LogError(m_log, "RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                     return false;
                 }
                 // If DISCONNECT_UNCLEAN is returned, it means a non-existing UTXO was deleted, or an existing UTXO was
@@ -4866,22 +4879,22 @@ bool Chainstate::ReplayBlocks()
             }
             pindexOld = pindexOld->pprev;
         }
-        LogInfo("Rolled back to %s", pindexFork->GetBlockHash().ToString());
+        LogInfo(m_log, "Rolled back to %s", pindexFork->GetBlockHash().ToString());
     }
 
     // Roll forward from the forking point to the new tip.
     if (nForkHeight < pindexNew->nHeight) {
-        LogInfo("Rolling forward to %s (%i to %i)", pindexNew->GetBlockHash().ToString(), nForkHeight, pindexNew->nHeight);
+        LogInfo(m_log, "Rolling forward to %s (%i to %i)", pindexNew->GetBlockHash().ToString(), nForkHeight, pindexNew->nHeight);
         for (int nHeight = nForkHeight + 1; nHeight <= pindexNew->nHeight; ++nHeight) {
             const CBlockIndex& pindex{*Assert(pindexNew->GetAncestor(nHeight))};
 
             if (nHeight % 10'000 == 0) {
-                LogInfo("Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);
+                LogInfo(m_log, "Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);
             }
             m_chainman.GetNotifications().progress(_("Replaying blocks…"), (int)((nHeight - nForkHeight) * 100.0 / (pindexNew->nHeight - nForkHeight)), false);
             if (!RollforwardBlock(&pindex, cache)) return false;
         }
-        LogInfo("Rolled forward to %s", pindexNew->GetBlockHash().ToString());
+        LogInfo(m_log, "Rolled forward to %s", pindexNew->GetBlockHash().ToString());
     }
 
     cache.SetBestBlock(pindexNew->GetBlockHash());
@@ -4973,13 +4986,13 @@ bool ChainstateManager::LoadGenesisBlock()
     try {
         FlatFilePos blockPos{m_blockman.WriteBlock(genesis_block, 0)};
         if (blockPos.IsNull()) {
-            LogError("Writing genesis block to disk failed");
+            LogError(m_log, "Writing genesis block to disk failed");
             return false;
         }
         CBlockIndex* pindex{m_blockman.AddToBlockIndex(genesis_block, m_best_header)};
         ReceivedBlockTransactions(genesis_block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        LogError("Failed to write genesis block: %s", e.what());
+        LogError(m_log, "Failed to write genesis block: %s", e.what());
         return false;
     }
 
@@ -4994,6 +5007,7 @@ void ChainstateManager::LoadExternalBlockFile(
     // Either both should be specified (-reindex), or neither (-loadblock).
     assert(!dbp == !blocks_with_unknown_parent);
 
+    const util::log::Context log_reindex{BCLog::REINDEX, m_log.logger};
     const auto start{SteadyClock::now()};
     const CChainParams& params{GetParams()};
 
@@ -5048,7 +5062,7 @@ void ChainstateManager::LoadExternalBlockFile(
                     LOCK(cs_main);
                     // detect out of order blocks, and store them for later
                     if (hash != params.GetConsensus().hashGenesisBlock && !m_blockman.LookupBlockIndex(header.hashPrevBlock)) {
-                        LogDebug(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
+                        LogDebug(log_reindex, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
                                  header.hashPrevBlock.ToString());
                         if (dbp && blocks_with_unknown_parent) {
                             blocks_with_unknown_parent->emplace(header.hashPrevBlock, *dbp);
@@ -5073,7 +5087,7 @@ void ChainstateManager::LoadExternalBlockFile(
                             break;
                         }
                     } else if (hash != params.GetConsensus().hashGenesisBlock && pindex->nHeight % 1000 == 0) {
-                        LogDebug(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
+                        LogDebug(log_reindex, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
                     }
                 }
 
@@ -5100,7 +5114,7 @@ void ChainstateManager::LoadExternalBlockFile(
                     // called by concurrent network message processing. but, that is not
                     // reliable for the purpose of pruning while importing.
                     if (auto result{ActivateBestChains()}; !result) {
-                        LogDebug(BCLog::REINDEX, "%s\n", util::ErrorString(result).original);
+                        LogDebug(log_reindex, "%s\n", util::ErrorString(result).original);
                         break;
                     }
                 }
@@ -5121,7 +5135,7 @@ void ChainstateManager::LoadExternalBlockFile(
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
                         if (m_blockman.ReadBlock(*pblockrecursive, it->second, {})) {
                             const auto& block_hash{pblockrecursive->GetHash()};
-                            LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
+                            LogDebug(log_reindex, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
                             LOCK(cs_main);
                             BlockValidationState dummy;
                             if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
@@ -5146,13 +5160,13 @@ void ChainstateManager::LoadExternalBlockFile(
                 // the reindex process is not the place to attempt to clean and/or compact the block files. if so desired, a studious node operator
                 // may use knowledge of the fact that the block files are not entirely pristine in order to prepare a set of pristine, and
                 // perhaps ordered, block files for later reindexing.
-                LogDebug(BCLog::REINDEX, "%s: unexpected data at file offset 0x%x - %s. continuing\n", __func__, (nRewind - 1), e.what());
+                LogDebug(log_reindex, "%s: unexpected data at file offset 0x%x - %s. continuing\n", __func__, (nRewind - 1), e.what());
             }
         }
     } catch (const std::runtime_error& e) {
         GetNotifications().fatalError(strprintf(_("System error while loading external block file: %s"), e.what()));
     }
-    LogInfo("Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(m_log, "Loaded %i blocks from external file in %dms", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 }
 
 bool ChainstateManager::ShouldCheckBlockIndex() const
@@ -5501,9 +5515,9 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     m_coinsdb_cache_size_bytes = coinsdb_size;
     CoinsDB().ResizeCache(coinsdb_size);
 
-    LogInfo("[%s] resized coinsdb cache to %.1f MiB",
+    LogInfo(m_log, "[%s] resized coinsdb cache to %.1f MiB",
         this->ToString(), coinsdb_size / double(1_MiB));
-    LogInfo("[%s] resized coinstip cache to %.1f MiB",
+    LogInfo(m_log, "[%s] resized coinstip cache to %.1f MiB",
         this->ToString(), coinstip_size / double(1_MiB));
 
     BlockValidationState state;
@@ -5528,7 +5542,7 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
     }
 
     if (pindex->m_chain_tx_count == 0) {
-        LogDebug(BCLog::VALIDATION, "Block %d has unset m_chain_tx_count. Unable to estimate verification progress.\n", pindex->nHeight);
+        LogDebug(m_log, "Block %d has unset m_chain_tx_count. Unable to estimate verification progress.\n", pindex->nHeight);
         return 0.0;
     }
 
@@ -5563,7 +5577,7 @@ double ChainstateManager::GetBackgroundVerificationProgress(const CBlockIndex& p
     auto target_block = HistoricalChainstate()->TargetBlock();
 
     if (pindex.m_chain_tx_count == 0 || target_block->m_chain_tx_count == 0) {
-        LogDebug(BCLog::VALIDATION, "[background validation] Block %d has unset m_chain_tx_count. Unable to estimate verification progress.", pindex.nHeight);
+        LogDebug(m_log, "[background validation] Block %d has unset m_chain_tx_count. Unable to estimate verification progress.", pindex.nHeight);
         return 0.0;
     }
     return static_cast<double>(pindex.m_chain_tx_count) / static_cast<double>(target_block->m_chain_tx_count);
@@ -5577,7 +5591,7 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
     return *m_chainstates.back();
 }
 
-[[nodiscard]] static bool DeleteCoinsDBFromDisk(const fs::path db_path, bool is_snapshot)
+[[nodiscard]] static bool DeleteCoinsDBFromDisk(const util::log::Context& log, const fs::path db_path, bool is_snapshot)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
@@ -5588,24 +5602,24 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
         try {
             bool existed = fs::remove(base_blockhash_path);
             if (!existed) {
-                LogWarning("[snapshot] snapshot chainstate dir being removed lacks %s file",
+                LogWarning(log, "[snapshot] snapshot chainstate dir being removed lacks %s file",
                           fs::PathToString(node::SNAPSHOT_BLOCKHASH_FILENAME));
             }
         } catch (const fs::filesystem_error& e) {
-            LogWarning("[snapshot] failed to remove file %s: %s\n",
+            LogWarning(log, "[snapshot] failed to remove file %s: %s\n",
                        fs::PathToString(base_blockhash_path), e.code().message());
         }
     }
 
     std::string path_str = fs::PathToString(db_path);
-    LogInfo("Removing leveldb dir at %s\n", path_str);
+    LogInfo(log, "Removing leveldb dir at %s\n", path_str);
 
     // We have to destruct before this call leveldb::DB in order to release the db
     // lock, otherwise `DestroyDB` will fail. See `leveldb::~DBImpl()`.
     const bool destroyed = DestroyDB(path_str);
 
     if (!destroyed) {
-        LogError("leveldb DestroyDB call failed on %s", path_str);
+        LogError(log, "leveldb DestroyDB call failed on %s", path_str);
     }
 
     // Datadir should be removed from filesystem; otherwise initialization may detect
@@ -5716,7 +5730,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
             // DestroyDB() (in DeleteCoinsDBFromDisk()) will fail. See `leveldb::~DBImpl()`.
             // Destructing the chainstate (and so resetting the coinsviews object) does this.
             snapshot_chainstate.reset();
-            bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
+            bool removed = DeleteCoinsDBFromDisk(m_log, *snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
                 GetNotifications().fatalError(strprintf(_("Failed to remove snapshot chainstate dir (%s). "
                     "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
@@ -5751,8 +5765,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     chainstate.PopulateBlockIndexCandidates();
 
-    LogInfo("[snapshot] successfully activated snapshot %s", base_blockhash.ToString());
-    LogInfo("[snapshot] (%.2f MB)",
+    LogInfo(m_log, "[snapshot] successfully activated snapshot %s", base_blockhash.ToString());
+    LogInfo(m_log, "[snapshot] (%.2f MB)",
               chainstate.CoinsTip().DynamicMemoryUsage() / (1000 * 1000));
 
     this->MaybeRebalanceCaches();
@@ -5823,7 +5837,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     const uint64_t coins_count = metadata.m_coins_count;
     uint64_t coins_left = metadata.m_coins_count;
 
-    LogInfo("[snapshot] loading %d coins from snapshot %s", coins_left, base_blockhash.ToString());
+    LogInfo(m_log, "[snapshot] loading %d coins from snapshot %s", coins_left, base_blockhash.ToString());
     int64_t coins_processed{0};
 
     while (coins_left > 0) {
@@ -5859,7 +5873,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 ++coins_processed;
 
                 if (coins_processed % 1000000 == 0) {
-                    LogInfo("[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
+                    LogInfo(m_log, "[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
                         coins_processed,
                         static_cast<float>(coins_processed) * 100 / static_cast<float>(coins_count),
                         coins_cache.DynamicMemoryUsage() / (1000 * 1000));
@@ -5914,7 +5928,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
             coins_count))};
     }
 
-    LogInfo("[snapshot] loaded %d (%.2f MB) coins from snapshot %s",
+    LogInfo(m_log, "[snapshot] loaded %d (%.2f MB) coins from snapshot %s",
         coins_count,
         coins_cache.DynamicMemoryUsage() / (1000 * 1000),
         base_blockhash.ToString());
@@ -5980,7 +5994,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     assert(index == snapshot_start_block);
     index->m_chain_tx_count = au_data.m_chain_tx_count;
 
-    LogInfo("[snapshot] validated snapshot (%.2f MB)",
+    LogInfo(m_log, "[snapshot] validated snapshot (%.2f MB)",
         coins_cache.DynamicMemoryUsage() / (1000 * 1000));
     return {};
 }
@@ -6033,8 +6047,8 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
             validated_cs.m_chain.Height(),
             validated_cs.m_chain.Height(), CLIENT_BUGREPORT);
 
-        LogError("[snapshot] !!! %s\n", user_error.original);
-        LogError("[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
+        LogError(m_log, "[snapshot] !!! %s\n", user_error.original);
+        LogError(m_log, "[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
 
         // Reset chainstate target to network tip instead of snapshot block.
         validated_cs.SetTargetBlock(nullptr);
@@ -6054,7 +6068,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     const auto& maybe_au_data = m_options.chainparams.AssumeutxoForHeight(validated_cs.m_chain.Height());
     if (!maybe_au_data) {
-        LogWarning("[snapshot] assumeutxo data not found for height "
+        LogWarning(m_log, "[snapshot] assumeutxo data not found for height "
             "(%d) - refusing to validate snapshot", validated_cs.m_chain.Height());
         handle_invalid_snapshot();
         return SnapshotCompletionResult::MISSING_CHAINPARAMS;
@@ -6062,7 +6076,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     const AssumeutxoData& au_data = *maybe_au_data;
     std::optional<CCoinsStats> validated_cs_stats;
-    LogInfo("[snapshot] computing UTXO stats for background chainstate to validate "
+    LogInfo(m_log, "[snapshot] computing UTXO stats for background chainstate to validate "
         "snapshot - this could take a few minutes");
     try {
         validated_cs_stats = ComputeUTXOStats(
@@ -6076,7 +6090,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
 
     // XXX note that this function is slow and will hold cs_main for potentially minutes.
     if (!validated_cs_stats) {
-        LogWarning("[snapshot] failed to generate stats for validation coins db");
+        LogWarning(m_log, "[snapshot] failed to generate stats for validation coins db");
         // While this isn't a problem with the snapshot per se, this condition
         // prevents us from validating the snapshot, so we should shut down and let the
         // user handle the issue manually.
@@ -6091,14 +6105,14 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
     // hash for the snapshot when it's loaded in its chainstate's leveldb. We could then
     // reference that here for an additional check.
     if (AssumeutxoHash{validated_cs_stats->hashSerialized} != au_data.hash_serialized) {
-        LogWarning("[snapshot] hash mismatch: actual=%s, expected=%s",
+        LogWarning(m_log, "[snapshot] hash mismatch: actual=%s, expected=%s",
             validated_cs_stats->hashSerialized.ToString(),
             au_data.hash_serialized.ToString());
         handle_invalid_snapshot();
         return SnapshotCompletionResult::HASH_MISMATCH;
     }
 
-    LogInfo("[snapshot] snapshot beginning at %s has been fully validated",
+    LogInfo(m_log, "[snapshot] snapshot beginning at %s has been fully validated",
         unvalidated_cs.m_from_snapshot_blockhash->ToString());
 
     unvalidated_cs.m_assumeutxo = Assumeutxo::VALIDATED;
@@ -6125,7 +6139,7 @@ void ChainstateManager::MaybeRebalanceCaches()
         current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
-        LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
+        LogInfo(m_log, "[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
         current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
     } else {
@@ -6192,11 +6206,11 @@ Chainstate* ChainstateManager::LoadAssumeutxoChainstate()
     if (!base_blockhash) {
         return nullptr;
     }
-    LogInfo("[snapshot] detected active snapshot chainstate (%s) - loading",
+    LogInfo(m_log, "[snapshot] detected active snapshot chainstate (%s) - loading",
         fs::PathToString(*path));
 
     auto snapshot_chainstate{std::make_unique<Chainstate>(nullptr, m_blockman, *this, base_blockhash)};
-    LogInfo("[snapshot] switching active chainstate to %s", snapshot_chainstate->ToString());
+    LogInfo(m_log, "[snapshot] switching active chainstate to %s", snapshot_chainstate->ToString());
     return &this->AddChainstate(std::move(snapshot_chainstate));
 }
 
@@ -6243,7 +6257,7 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
     const fs::path invalid_path{db_path + "_INVALID"};
     const std::string db_path_str{fs::PathToString(db_path)};
     const std::string invalid_path_str{fs::PathToString(invalid_path)};
-    LogInfo("[snapshot] renaming snapshot datadir %s to %s", db_path_str, invalid_path_str);
+    LogInfo(m_log, "[snapshot] renaming snapshot datadir %s to %s", db_path_str, invalid_path_str);
 
     // The invalid storage directory is simply moved and not deleted because we may
     // want to do forensics later during issue investigation. The user is instructed
@@ -6251,7 +6265,7 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
     try {
         fs::rename(db_path, invalid_path);
     } catch (const fs::filesystem_error& e) {
-        LogError("While invalidating the coins db: Error renaming file '%s' -> '%s': %s",
+        LogError(m_log, "While invalidating the coins db: Error renaming file '%s' -> '%s': %s",
                  db_path_str, invalid_path_str, e.what());
         return util::Error{strprintf(_(
             "Rename of '%s' -> '%s' failed. "
@@ -6268,8 +6282,8 @@ bool ChainstateManager::DeleteChainstate(Chainstate& chainstate)
     AssertLockHeld(::cs_main);
     assert(!chainstate.m_coins_views);
     const fs::path db_path{chainstate.StoragePath()};
-    if (!DeleteCoinsDBFromDisk(db_path, /*is_snapshot=*/bool{chainstate.m_from_snapshot_blockhash})) {
-        LogError("Deletion of %s failed. Please remove it manually to continue reindexing.",
+    if (!DeleteCoinsDBFromDisk(m_log, db_path, /*is_snapshot=*/bool{chainstate.m_from_snapshot_blockhash})) {
+        LogError(m_log, "Deletion of %s failed. Please remove it manually to continue reindexing.",
                   fs::PathToString(db_path));
         return false;
     }
@@ -6331,14 +6345,14 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
     this->ResetChainstates();
     assert(this->m_chainstates.size() == 0);
 
-    LogInfo("[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
+    LogInfo(m_log, "[snapshot] deleting background chainstate directory (now unnecessary) (%s)",
               fs::PathToString(validated_path));
 
     auto rename_failed_abort = [this](
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
-        LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
+        LogError(m_log, "[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
         GetNotifications().fatalError(strprintf(_(
             "Rename of '%s' -> '%s' failed. "
@@ -6353,7 +6367,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         throw;
     }
 
-    LogInfo("[snapshot] moving snapshot chainstate (%s) to "
+    LogInfo(m_log, "[snapshot] moving snapshot chainstate (%s) to "
               "default chainstate directory (%s)",
               fs::PathToString(assumed_valid_path), fs::PathToString(validated_path));
 
@@ -6364,14 +6378,14 @@ bool ChainstateManager::ValidatedSnapshotCleanup(Chainstate& validated_cs, Chain
         throw;
     }
 
-    if (!DeleteCoinsDBFromDisk(delete_path, /*is_snapshot=*/false)) {
+    if (!DeleteCoinsDBFromDisk(m_log, delete_path, /*is_snapshot=*/false)) {
         // No need to FatalError because once the unneeded bg chainstate data is
         // moved, it will not interfere with subsequent initialization.
-        LogWarning("Deletion of %s failed. Please remove it manually, as the "
+        LogWarning(m_log, "Deletion of %s failed. Please remove it manually, as the "
                    "directory is now unnecessary.",
                    fs::PathToString(delete_path));
     } else {
-        LogInfo("[snapshot] deleted background chainstate directory (%s)",
+        LogInfo(m_log, "[snapshot] deleted background chainstate directory (%s)",
                 fs::PathToString(validated_path));
     }
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -33,6 +33,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/log.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -318,6 +319,7 @@ bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& 
  *          calculation, or std::nullopt if there is an error.
  */
 std::optional<LockPoints> CalculateLockPointsAtTip(
+    util::log::Logger* logger,
     CBlockIndex* tip,
     const CCoinsView& coins_view,
     const CTransaction& tx);
@@ -380,7 +382,7 @@ public:
     CuckooCache::cache<uint256, SignatureCacheHasher> m_script_execution_cache;
     SignatureCache m_signature_cache;
 
-    ValidationCache(size_t script_execution_cache_bytes, size_t signature_cache_bytes);
+    ValidationCache(util::log::Logger& logger, size_t script_execution_cache_bytes, size_t signature_cache_bytes);
 
     ValidationCache(const ValidationCache&) = delete;
     ValidationCache& operator=(const ValidationCache&) = delete;
@@ -421,7 +423,7 @@ BlockValidationState TestBlockValidity(
 bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus::Params& consensusParams);
 
 /** Check if a block has been mutated (with respect to its merkle root and witness commitments). */
-bool IsBlockMutated(const CBlock& block, bool check_witness_root);
+bool IsBlockMutated(util::log::Logger* logger, const CBlock& block, bool check_witness_root);
 
 /** Return the sum of the claimed work on a given set of headers. No verification of PoW is done. */
 arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers);
@@ -482,6 +484,8 @@ enum class FlushStateMode: uint8_t {
 class CoinsViews {
 
 public:
+    util::log::Context m_log;
+
     //! The lowest level of the CoinsViews cache hierarchy sits in a leveldb database on disk.
     //! All unspent coins reside in this store.
     CCoinsViewDB m_dbview GUARDED_BY(cs_main);
@@ -503,7 +507,7 @@ public:
     //! state to disk, which should not be done until the health of the database is verified.
     //!
     //! All arguments forwarded onto CCoinsViewDB.
-    CoinsViews(DBParams db_params, CoinsViewOptions options);
+    CoinsViews(util::log::Logger& logger, DBParams db_params, CoinsViewOptions options);
 
     //! Initialize the CCoinsViewCache member.
     void InitCache(int32_t prevoutfetch_threads) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
@@ -576,6 +580,7 @@ protected:
     std::optional<const char*> m_last_script_check_reason_logged GUARDED_BY(::cs_main){};
 
 public:
+    const util::log::Context m_log;
     //! Reference to a BlockManager instance which itself is shared across all
     //! Chainstate instances.
     node::BlockManager& m_blockman;
@@ -1003,7 +1008,7 @@ protected:
 public:
     using Options = kernel::ChainstateManagerOpts;
 
-    explicit ChainstateManager(const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options);
+    explicit ChainstateManager(util::log::Logger& logger, const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options);
 
     //! Function to restart active indexes; set dynamically to avoid a circular
     //! dependency on `base/index.cpp`.
@@ -1036,6 +1041,7 @@ public:
      */
     RecursiveMutex& GetMutex() const LOCK_RETURNED(::cs_main) { return ::cs_main; }
 
+    const util::log::Context m_log;
     const util::SignalInterrupt& m_interrupt;
     const Options m_options;
     //! A single BlockManager instance is shared across each constructed

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -71,7 +71,8 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
     CTxMemPool::Options mempool_opts{
         .incremental_relay_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, 1'000'000)},
         .min_relay_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, 1'000'000)},
-        .dust_relay_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, 1'000'000)}
+        .dust_relay_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, 1'000'000)},
+        .logger = &g_setup->m_logger,
     };
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, error);
     std::unique_ptr<CBlockPolicyEstimator> fee_estimator = std::make_unique<FuzzedBlockPolicyEstimator>(fuzzed_data_provider);


### PR DESCRIPTION
Pass `Logger` instances to `BlockManager`, `CCoinsViewDB`, `CDBWrapper`, `Chainstate`, `ChainstateManager`, `CoinsViews`, and `CTxMemPool` classes so libbitcoinkernel applications and tests have the option to control where log output goes instead of having all output sent to the global logger.

This PR is an alternative to #30338. It is more limited because it only changes kernel code while leaving other parts of the codebase alone. It also takes the opportunity to migrate legacy LogPrint / LogPrintf calls to the new log macros introduced in #28318.

---

<!-- begin based-on -->
**This is based on #34778 + #29256 + #33847.** The non-base commits are:

- [`775344b1f0d` refactor: Pass Logger instances to kernel objects](https://github.com/bitcoin/bitcoin/pull/30342/commits/775344b1f0d10912041752c03ef6cb88d4162e26)
- [`6106a57a2fa` logging: Add LOG_REQUIRE_CONTEXT option](https://github.com/bitcoin/bitcoin/pull/30342/commits/6106a57a2fac578962534ac0d2a7ebd03a3ca44b)
- [`6c1f3aedd01` refactor: Log kernel output to local log instances](https://github.com/bitcoin/bitcoin/pull/30342/commits/6c1f3aedd014ca480aca0a11b9179429182fe823)
- [`dbe85f39723` kernel: Drop global Logger instance](https://github.com/bitcoin/bitcoin/pull/30342/commits/dbe85f39723568b54b02ee9fbce8585a865a6e11)<!-- end -->