### PR TITLE
wallet, logging: Replace WalletLogPrintf() with LogInfo()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.
     steps:
       - name: Determine fetch depth
-        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 1000))" >> "$GITHUB_ENV"
       - &ANNOTATION_PR_NUMBER
         name: Annotate with pull request number
         # This annotation is machine-readable and can be used to assign a check

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -792,8 +792,7 @@ While `LogInfo`, `LogWarning` and `LogError` messages should be rare,
 in case there are circumstances where they are not, those messages
 are automatically rate-limited to prevent potential disk-filling
 attacks. For the cases where this protection is undesirable,
-rate-limiting can be avoided with the `util::log::NO_RATE_LIMIT` tag, eg
-`LogInfo(util::log::NO_RATE_LIMIT, "UpdateTip: new best=%s ...",...)`.
+rate-limiting can be avoided with the `ratelimit = false` log option.
 
 ## General C++
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -75,10 +75,9 @@ bool BCLog::Logger::StartLogging()
     // dump buffered messages from before we opened the log
     m_buffering = false;
     if (m_buffer_lines_discarded > 0) {
-        LogPrint_({
+        LogPrint_({.level = Level::Info, .ratelimit = false}, {
             .category = BCLog::ALL,
             .level = Level::Info,
-            .should_ratelimit = false,
             .source_loc = SourceLocation{__func__},
             .message = strprintf("Early logging buffer overflowed, %d log lines discarded.", m_buffer_lines_discarded),
         });
@@ -430,14 +429,14 @@ std::string BCLog::Logger::Format(const util::log::Entry& entry) const
     return result;
 }
 
-void BCLog::Logger::LogPrint(util::log::Entry entry)
+void BCLog::Logger::LogPrint(const util::log::Options& options, util::log::Entry entry)
 {
     STDLOCK(m_cs);
-    return LogPrint_(std::move(entry));
+    return LogPrint_(options, std::move(entry));
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void BCLog::Logger::LogPrint_(util::log::Entry entry)
+void BCLog::Logger::LogPrint_(const util::log::Options& options, util::log::Entry entry)
 {
     if (m_buffering) {
         {
@@ -460,14 +459,14 @@ void BCLog::Logger::LogPrint_(util::log::Entry entry)
 
     std::string str_prefixed{Format(entry)};
     bool ratelimit{false};
-    if (entry.should_ratelimit && m_limiter) {
+    if (options.ratelimit && m_limiter) {
         auto status{m_limiter->Consume(entry.source_loc, str_prefixed)};
         if (status == LogRateLimiter::Status::NEWLY_SUPPRESSED) {
             // NOLINTNEXTLINE(misc-no-recursion)
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, // with ratelimit=false, this cannot lead to infinite recursion
+            {
                 .category = LogFlags::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = false, // with should_ratelimit=false, this cannot lead to infinite recursion
                 .source_loc = SourceLocation{__func__},
                 .message = strprintf(
                     "Excessive logging detected from %s:%d (%s): >%d bytes logged during "
@@ -540,10 +539,9 @@ void BCLog::Logger::ShrinkDebugFile()
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
             // LogWarning, except with m_cs held
-            LogPrint_({
+            LogPrint_({.level = Level::Warning, .ratelimit = false}, {
                 .category = BCLog::ALL,
                 .level = Level::Warning,
-                .should_ratelimit = true,
                 .source_loc = SourceLocation{__func__},
                 .message = "Failed to shrink debug log file: fseek(...) failed",
             });
@@ -620,8 +618,8 @@ bool util::log::hooks::ShouldLog(Category category, Level level)
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(Entry entry)
+void util::log::hooks::Log(const Options& options, Entry entry)
 {
     BCLog::Logger& logger{LogInstance()};
-    logger.LogPrint(std::move(entry));
+    logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -612,14 +612,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::hooks::ShouldLog(Category category, Level level)
+bool util::log::hooks::ShouldLog(Logger* log, Category category, Level level)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
 }
 
-void util::log::hooks::Log(const Options& options, Entry entry)
+void util::log::hooks::Log(Logger* log, const Options& options, Entry entry)
 {
-    BCLog::Logger& logger{LogInstance()};
+    auto& logger{log ? *static_cast<BCLog::Logger*>(log) : LogInstance()};
     logger.LogPrint(options, std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -574,7 +574,7 @@ void BCLog::LogRateLimiter::Reset()
     }
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
-        LogWarning(util::log::NO_RATE_LIMIT,
+        LOG_EMIT((.level = Level::Warning, .ratelimit = false),
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));
@@ -614,20 +614,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::ShouldDebugLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Debug);
-}
-
-bool util::log::ShouldTraceLog(Category category)
-{
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Trace);
-}
-
-void util::log::Log(util::log::Entry entry)
+bool util::log::hooks::ShouldLog(Category category, Level level)
 {
     BCLog::Logger& logger{LogInstance()};
-    if (logger.Enabled()) {
-        logger.LogPrint(std::move(entry));
-    }
+    return logger.Enabled() && logger.WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+}
+
+void util::log::hooks::Log(Entry entry)
+{
+    BCLog::Logger& logger{LogInstance()};
+    logger.LogPrint(std::move(entry));
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -349,7 +349,9 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 {
     if (category == LogFlags::NONE) category = LogFlags::ALL;
 
-    const bool has_category{m_always_print_category_level || category != LogFlags::ALL};
+    // Only log categories at debug level and below so users cannot use category
+    // filters at higher levels and miss important messages.
+    const bool has_category{level <= Level::Debug && (m_always_print_category_level || category != LogFlags::ALL)};
 
     // If there is no category, Info is implied
     if (!has_category && level == Level::Info) return {};

--- a/src/logging.h
+++ b/src/logging.h
@@ -160,7 +160,7 @@ namespace BCLog {
         std::list<std::function<void(const std::string&)>> m_print_callbacks GUARDED_BY(m_cs){};
 
         /** Send an entry to the log output (internal) */
-        void LogPrint_(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+        void LogPrint_(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
 
         std::string GetLogPrefix(LogFlags category, Level level) const;
 
@@ -178,7 +178,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send an entry to the log output */
-        void LogPrint(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+        void LogPrint(const util::log::Options& options, util::log::Entry entry) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs)

--- a/src/logging.h
+++ b/src/logging.h
@@ -127,7 +127,7 @@ namespace BCLog {
         bool SuppressionsActive() const { return m_suppression_active; }
     };
 
-    class Logger
+    class Logger : public util::log::Logger
     {
     private:
         mutable StdMutex m_cs; // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -228,6 +228,43 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 
+//! Example of a custom log context that includes a counter value in logged
+//! messages. Custom log contexts allow different areas of the codebase to
+//! attach information to log messages (like request ids or filenames) while
+//! still using standard logging macros.
+struct CountingLogContext {
+    static constexpr bool log_context{true};
+    util::log::Category category{BCLog::VALIDATION};
+    util::log::Logger* logger{nullptr};
+    int counter{0};
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+    {
+        return tfm::format("Custom #%d %s", ++counter, tfm::format(fmt, args...));
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(logging_CustomContext, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Debug);
+    CountingLogContext log;
+    LogTrace(log, "foo0: %s", "bar0"); // not logged
+    LogDebug(log, "foo1: %s", "bar1");
+    LogInfo(log, "foo2: %s", "bar2");
+    LogWarning(log, "foo3: %s", "bar3");
+    LogError(log, "foo4: %s", "bar4");
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[validation] Custom #1 foo1: bar1",
+        "Custom #2 foo2: bar2",
+        "[warning] Custom #3 foo3: bar3",
+        "[error] Custom #4 foo4: bar4",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -105,6 +105,35 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test logging to local logger.
+BOOST_AUTO_TEST_CASE(logging_local_logger)
+{
+    BCLog::Logger logger;
+    logger.m_log_timestamps = false;
+    logger.EnableCategory(BCLog::LogFlags::ALL);
+    logger.SetLogLevel(BCLog::Level::Trace);
+    BOOST_REQUIRE(logger.StartLogging());
+
+    std::vector<std::string> messages;
+    logger.PushBackCallback([&](const std::string& s) { messages.push_back(s); });
+
+    util::log::Context log{BCLog::NET, &logger};
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
+    constexpr auto expected{std::to_array({
+        "[error] error arg\n",
+        "[warning] warning arg\n",
+        "info arg\n",
+        "[net] debug arg\n",
+        "[net:trace] trace arg\n",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(messages.begin(), messages.end(), expected.begin(), expected.end());
+}
+
 //! Test calls to log macros with all possible types of arguments: with and
 //! without categories and with and without format arguments to make sure
 //! varargs are handled correctly.
@@ -150,6 +179,19 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
     LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
 
+    // Test logging with context object.
+    util::log::Context log{BCLog::TOR, &LogInstance()};
+    LogError(log, "error");
+    LogWarning(log, "warning");
+    LogInfo(log, "info");
+    LogDebug(log, "debug");
+    LogTrace(log, "trace");
+    LogError(log, "error %s", "arg");
+    LogWarning(log, "warning %s", "arg");
+    LogInfo(log, "info %s", "arg");
+    LogDebug(log, "debug %s", "arg");
+    LogTrace(log, "trace %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -170,6 +212,18 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
         "options info arg",
         "[net] options debug",
         "[net] options debug arg",
+
+        "[error] error",
+        "[warning] warning",
+        "info",
+        "[tor] debug",
+        "[tor:trace] trace",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+        "[tor] debug arg",
+        "[tor:trace] trace arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
 
     std::vector<Case> cases = {
         {"foo1: bar1", BCLog::NET, BCLog::Level::Debug, "[net] ", SourceLocation{__func__}},
-        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "[net:info] ", SourceLocation{__func__}},
+        {"foo2: bar2", BCLog::NET, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo3: bar3", BCLog::ALL, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},
         {"foo4: bar4", BCLog::ALL, BCLog::Level::Info, "", SourceLocation{__func__}},
         {"foo5: bar5", BCLog::NONE, BCLog::Level::Debug, "[debug] ", SourceLocation{__func__}},

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using util::log::Level;
 using util::SplitString;
 using util::TrimString;
 
@@ -139,6 +140,16 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
     LogDebug(BCLog::NET, "debug %s", "arg");
     LogTrace(BCLog::NET, "trace %s", "arg");
 
+    LOG_EMIT((.level = Level::Info), "options info");
+    LOG_EMIT((.level = Level::Info), "options info %s", "arg");
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info"); // Not allowed because category is forbidden!
+    // LOG_EMIT((.level = Level::Info), BCLog::NET, "options info %s", "arg"); // Not allowed because category is forbidden!
+
+    // LOG_EMIT((.level = Level::Debug), "options debug"); // Not allowed because category is required!
+    // LOG_EMIT((.level = Level::Debug), "options debug %s", "arg"); // Not allowed because category is required!
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug");
+    LOG_EMIT((.level = Level::Debug), BCLog::NET, "options debug %s", "arg");
+
     const auto log_lines{ReadDebugLogLines()};
     constexpr auto expected{std::to_array({
         "[error] error",
@@ -154,6 +165,11 @@ BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
 
         "[net] debug arg",
         "[net:trace] trace arg",
+
+        "options info",
+        "options info arg",
+        "[net] options debug",
+        "[net] options debug arg",
     })};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -419,7 +435,7 @@ void LogFromLocation(Location location, const std::string& message) {
         LogDebug(BCLog::LogFlags::HTTP, "%s\n", message);
         return;
     case Location::INFO_NOLIMIT:
-        LogInfo(util::log::NO_RATE_LIMIT, "%s\n", message);
+        LOG_EMIT((.level = Level::Info, .ratelimit = false), "%s\n", message);
         return;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -463,4 +463,30 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
+{
+    for (bool enable_logger : {true, false}) {
+        LogInstance().DisconnectTestLogger();
+        if (enable_logger) {
+            BOOST_REQUIRE(LogInstance().StartLogging());
+        } else {
+            LogInstance().DisableLogging();
+        }
+        BOOST_REQUIRE_EQUAL(enable_logger, LogInstance().Enabled());
+
+        // Info or higher should always evaluate the arguments.
+        int counter = 0;
+        LogError("error (%s)", ++counter);
+        LogWarning("warning (%s)", ++counter);
+        LogInfo("info (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 3);
+
+        // Debug/Trace should skip argument evaluation when category is disabled.
+        counter = 0;
+        LogDebug(BCLog::NET, "debug (%s)", ++counter);
+        LogTrace(BCLog::NET, "trace (%s)", ++counter);
+        BOOST_CHECK_EQUAL(counter, 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -14,6 +14,7 @@
 #include <util/fs_helpers.h>
 #include <util/string.h>
 
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -103,6 +104,60 @@ struct LogSetup : public BasicTestingSetup {
     }
 };
 
+//! Test calls to log macros with all possible types of arguments: with and
+//! without categories and with and without format arguments to make sure
+//! varargs are handled correctly.
+//! Include commented out calls for combinations of macro arguments which are
+//! prohibited, for easy manual testing to confirm these calls produce readable
+//! compile errors.
+BOOST_FIXTURE_TEST_CASE(logging_macro_args, LogSetup)
+{
+    LogInstance().EnableCategory(BCLog::LogFlags::ALL);
+    LogInstance().SetLogLevel(BCLog::Level::Trace);
+
+    // Test logging with no context.
+    LogError("error");
+    LogWarning("warning");
+    LogInfo("info");
+    // LogDebug("debug"); // Not allowed because category is required!
+    // LogTrace("trace"); // Not allowed because category is required!
+    LogError("error %s", "arg");
+    LogWarning("warning %s", "arg");
+    LogInfo("info %s", "arg");
+    // LogDebug("debug %s", "arg"); // Not allowed because category is required!
+    // LogTrace("trace %s", "arg"); // Not allowed because category is required!
+
+    // Test logging with category constant arguments.
+    // LogError(BCLog::NET, "error"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug");
+    LogTrace(BCLog::NET, "trace");
+    // LogError(BCLog::NET, "error %s", "arg"); // Not allowed because category is forbidden!
+    // LogWarning(BCLog::NET, "warning %s", "arg"); // Not allowed because category is forbidden!
+    // LogInfo(BCLog::NET, "info %s", "arg"); // Not allowed because category is forbidden!
+    LogDebug(BCLog::NET, "debug %s", "arg");
+    LogTrace(BCLog::NET, "trace %s", "arg");
+
+    const auto log_lines{ReadDebugLogLines()};
+    constexpr auto expected{std::to_array({
+        "[error] error",
+        "[warning] warning",
+        "info",
+
+        "[error] error arg",
+        "[warning] warning arg",
+        "info arg",
+
+        "[net] debug",
+        "[net:trace] trace",
+
+        "[net] debug arg",
+        "[net:trace] trace arg",
+    })};
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
@@ -137,24 +192,6 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
         LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
-    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
-}
-
-BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
-{
-    LogInstance().EnableCategory(BCLog::NET);
-    LogTrace(BCLog::NET, "foo6: %s", "bar6"); // not logged
-    LogDebug(BCLog::NET, "foo7: %s", "bar7");
-    LogInfo("foo8: %s", "bar8");
-    LogWarning("foo9: %s", "bar9");
-    LogError("foo10: %s", "bar10");
-    std::vector<std::string> log_lines{ReadDebugLogLines()};
-    std::vector<std::string> expected = {
-        "[net] foo7: bar7",
-        "foo8: bar8",
-        "[warning] foo9: bar9",
-        "[error] foo10: bar10",
-    };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -489,4 +489,20 @@ BOOST_FIXTURE_TEST_CASE(logging_arg_evaluation, LogSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(log_accept_category, LogSetup)
+{
+    using namespace util::log;
+    BCLog::Logger& logger{LogInstance()};
+
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::ALL, Level::Info));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::NET, Level::Warning));
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::VALIDATION, Level::Error));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::LEVELDB, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::ALL, Level::Trace));
+
+    logger.EnableCategory(BCLog::TXPACKAGES);
+    BOOST_CHECK(logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Debug));
+    BOOST_CHECK(!logger.WillLogCategoryLevel(BCLog::TXPACKAGES, Level::Trace));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -205,7 +205,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
         expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
-        LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
+        LogInstance().LogPrint({.level = level}, {.category = category, .level = level, .source_loc = std::move(loc), .message = msg});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -88,7 +88,6 @@ enum class Level {
 struct Entry {
     Category category;
     Level level;
-    bool should_ratelimit{false}; //!< Hint for consumers if this entry should be ratelimited
     SystemClock::time_point timestamp{SystemClock::now()};
     std::chrono::seconds mocktime{GetMockTime()};
     std::string thread_name{util::ThreadGetInternalName()};
@@ -140,7 +139,7 @@ namespace hooks {
 bool ShouldLog(Category category, Level level);
 
 /// Send message to be logged.
-void Log(Entry entry);
+void Log(const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
@@ -179,10 +178,9 @@ Context GetContext(Category category)
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(Entry{
+    hooks::Log(options, Entry{
         .category = context.category,
         .level = options.level,
-        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
         .message = context.Format(fmt, args...)});
 }

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -7,6 +7,7 @@
 
 // This header works in tandem with `logging/categories.h`
 // to expose the complete logging interface.
+#include <attributes.h>
 #include <logging/categories.h> // IWYU pragma: export
 #include <tinyformat.h>
 #include <util/check.h>
@@ -17,6 +18,39 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <type_traits>
+
+/// Logging macros which output log messages at the specified levels. They
+/// accept printf-style format strings and arguments. The debug and trace macros
+/// also require an initial BCLog::LogFlags category argument.
+/// See the "Logging" section of /doc/developer-notes.md for more details.
+#define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
+#define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
+#define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
+#define LogDebug(...) LOG_EMIT((.level = util::log::Level::Debug), __VA_ARGS__)
+#define LogTrace(...) LOG_EMIT((.level = util::log::Level::Trace), __VA_ARGS__)
+
+/// Low-level logging macro called with an initial options argument. Meant to be
+/// called internally, and in special cases to override default behaviors.
+// NOLINTBEGIN(bugprone-lambda-function-name)
+// Allow __func__ to be used in any context without warnings:
+#define LOG_EMIT(options, ...)                                                                     \
+    do {                                                                                           \
+        constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
+        auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
+        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+            util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
+        } else if constexpr (_options.evaluate_when_disabled) {                                    \
+            [](auto&&...) {}(__VA_ARGS__);                                                         \
+        }                                                                                          \
+    } while (0)
+// NOLINTEND(bugprone-lambda-function-name)
+
+/// Return the first argument from a variadic macro argument list.
+#define PP_FIRST_ARG(arg, ...) arg
+
+/// Expand parenthesized macro arguments `(a, b)` into `a, b`.
+#define PP_EXPAND_ARGS(...) __VA_ARGS__
 
 /// Like std::source_location, but allowing to override the function name.
 class SourceLocation
@@ -43,12 +77,6 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
-//! Structure and constant for tagging not to rate limit.
-struct NoRateLimitTag {
-    explicit NoRateLimitTag() = default;
-};
-inline constexpr NoRateLimitTag NO_RATE_LIMIT{};
-
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -68,45 +96,120 @@ struct Entry {
     std::string message;
 };
 
-/// Return whether messages with specified category should be debug logged.
-/// Applications using the logging library need to provide this.
-bool ShouldDebugLog(Category category);
+/// Options that can be passed to log macros using designated initializers (e.g.
+/// `.ratelimit = true`). Add new options here when introducing new logging
+/// behaviors.
+struct Options {
+    Level level;
 
-/// Return whether messages with specified category should be trace logged.
-/// Applications using the logging library need to provide this.
-bool ShouldTraceLog(Category category);
+    // Info and higher log messages are logged by default, so ratelimit them.
+    // Users enabling logging at Debug and lower levels are assumed to be
+    // developers or power users who are aware that -debug may cause excessive
+    // disk usage due to logging.
+    bool ratelimit{level >= Level::Info};
 
-/** Send message to be logged. Applications using the logging library need to provide this. */
-void Log(Entry entry);
+    // Always evaluate format arguments at Info and higher levels because logs
+    // at these levels are rarely disabled, so it's safer to evaluate unused
+    // arguments than risk unintended side effects when logging is disabled.
+    bool evaluate_when_disabled{level >= Level::Info};
+};
 
-template <typename... Args>
-inline void LogPrintFormatInternal_(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    std::string log_msg;
-    try {
-        log_msg = tfm::format(fmt, args...);
-    } catch (tinyformat::format_error& fmterr) {
-        log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+/// Object representing context of log messages. Holds a logging category and
+/// implements log formatting.
+struct Context {
+    Category category;
+
+    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
+    {
+        std::string log_msg;
+        try {
+            log_msg = tfm::format(fmt, args...);
+        } catch (tinyformat::format_error& fmterr) {
+            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+        }
+        return log_msg;
     }
-    util::log::Log(util::log::Entry{
-        .category = flag,
-        .level = level,
-        .should_ratelimit = should_ratelimit,
+};
+
+/// External hooks that logging backends need to implement.
+namespace hooks {
+/// Return whether messages with specified category and level should be logged.
+bool ShouldLog(Category category, Level level);
+
+/// Send message to be logged.
+void Log(Entry entry);
+} // namespace hooks
+
+/// Internal functions used to help implement logging macros.
+namespace detail {
+/// Internal helper to get Context from the first macro argument. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <Options options>
+Context GetContext(std::string_view fmt)
+{
+    // Trigger compile error if caller does not pass a category constant as the
+    // first argument to a logging call, unless the level is Info or higher.
+    // There is no technical reason category arguments must be required, but
+    // categories are useful for finding and filtering relevant messages when
+    // debugging, so we want to encourage them.
+    static_assert(options.level >= Level::Info, "Missing required category argument for Debug/Trace logging call. Category can only be omitted for Info/Warning/Error calls.");
+    return Context{};
+}
+template <Options options>
+Context GetContext(Category category)
+{
+    // Trigger compile error if caller tries to pass a category constant as a
+    // first argument to a logging call at Info level or higher. There is no
+    // technical reason why all logging calls could not accept category
+    // arguments, but for various reasons, such as (1) not wanting to allow
+    // users to filter by category at high priority levels, and (2) wanting to
+    // incentivize developers to use lower log levels to avoid log spam, passing
+    // category constants at higher levels is forbidden.
+    static_assert(options.level < Level::Info, "Cannot pass category argument to Info/Warning/Error logging call. Please switch to Debug/Trace call, or drop the category argument!");
+    return Context{category};
+}
+
+/// Internal helper to construct log entry and emit log message. Overloaded to
+/// detect case where first macro argument is a string literal instead of a
+/// category.
+template <typename Context, typename... Args>
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    hooks::Log(Entry{
+        .category = context.category,
+        .level = options.level,
+        .should_ratelimit = options.ratelimit,
         .source_loc = std::move(source_loc),
-        .message = std::move(log_msg)});
+        .message = context.Format(fmt, args...)});
+}
+template <typename Context, typename ContextArg, typename... Args>
+requires (!std::is_convertible_v<ContextArg, std::string_view>)
+void Emit(Options options, SourceLocation&& source_loc, Context&& context, ContextArg&&, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    Emit(std::move(options), std::move(source_loc), context, fmt, args...);
 }
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+template<Level level>
+bool ShouldLog(Category category)
 {
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/true, fmt, args...);
+    constexpr util::log::Options options{level};
+    static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
+    return util::log::hooks::ShouldLog(category, options.level);
 }
+} // namespace detail
 
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::log::NoRateLimitTag, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/false, fmt, args...);
-}
+/// Functions to detect when logging is enabled. Note: functions for detecting
+/// if logging is enabled at info/warning/error levels are intentionally not
+/// provided, because these logs are rarely disabled, so allowing code to
+/// condition on them could lead to bugs when they are disabled.
+///@{
+inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
+inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+///@}
 } // namespace util::log
 
 namespace BCLog {
@@ -114,33 +217,5 @@ namespace BCLog {
 using Level = util::log::Level;
 } // namespace BCLog
 
-// Allow __func__ to be used in any context without warnings:
-// NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define detail_LogWithSrcLoc(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
-
-// Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
-// Be conservative when using functions that unconditionally log to debug.log!
-// It should not be the case that an inbound peer can fill up a user's storage
-// with debug.log entries.
-#define LogInfo(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
-#define LogWarning(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
-#define LogError(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
-
-// Use a macro instead of a function for conditional logging to prevent
-// evaluating arguments when logging for the category is not enabled.
-
-// Log by prefixing the output with the passed category name and severity level. This logs conditionally if
-// the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
-// developers or power users who are aware that -debug may cause excessive disk usage due to logging.
-#define detail_LogIfCategoryAndLevelEnabled(category, shouldlog, level, ...)                  \
-    do {                                                                                      \
-        if (shouldlog(category)) {                                                            \
-            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__); \
-        }                                                                                     \
-    } while (0)
-
-// Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldDebugLog, util::log::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldTraceLog, util::log::Level::Trace, __VA_ARGS__)
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -25,7 +25,38 @@
 /// printf-style format string and arguments. For Debug and Trace macros,
 /// if a context parameter is not provided, a BCLog::LogFlags category argument
 /// must be provided instead.
-/// See the "Logging" section of /doc/developer-notes.md for more details.
+///
+/// - LogError(), LogWarning(), and LogInfo() are all enabled by default, so
+///   they should be called infrequently, in cases where they will not spam the
+///   log and take up disk space.
+///
+/// - LogDebug() is enabled when debug logging is enabled, and should be used to
+///   show messages that can help users troubleshoot issues.
+///
+/// - LogTrace() is enabled when both debug logging AND tracing are enabled, and
+///   should be used for fine-grained traces that will be helpful to developers.
+///
+/// For more information about log levels, see the -debug and -loglevel
+/// documentation, or the "Logging" section of /doc/developer-notes.md.
+///
+/// `LogDebug` and `LogTrace` macros require an initial category argument unless
+/// given a log source (which provides it). That enables Debug and Trace
+/// messages to be filtered by category. Higher levels do not take a category
+/// (but may be passed a log source):
+///
+///   LogDebug(BCLog::TXRECONCILIATION, "Forget txreconciliation state of peer=%d", peer_id);
+///   LogInfo("Important information, no category.");
+///
+/// Context arguments can also be passed to control log output (see class definition).
+///
+///   const util::log::Context m_log{BCLog::TXRECONCILIATION};
+///   ...
+///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
+///
+/// If severity level is Info or higher, rate limiting is applied to mitigate
+/// disk filling attacks. Users enabling logging at Debug and lower levels are
+/// assumed to be developers or power users who are aware that -debug may cause
+/// excessive disk usage due to logging.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
 #define LogInfo(...) LOG_EMIT((.level = util::log::Level::Info), __VA_ARGS__)
@@ -82,6 +113,10 @@ using Category = uint64_t;
 /** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
 class Logger{};
 
+/// Log level constants. Most code will not need to use these directly and can
+/// use LogTrace, LogDebug, LogInfo, LogWarning, and LogError macros defined
+/// below. See macro definitions below or "Logging" section in
+/// developer-notes.md for more detailed information.
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -53,6 +53,10 @@
 ///   ...
 ///   LogDebug(m_log, "Forget txreconciliation state of peer=%d", peer_id);
 ///
+/// Using context objects also provides the flexibility to add extra information
+/// and custom formatting to log messages, or to divert log messages to a local
+/// logger instead of the global logging instance.
+///
 /// If severity level is Info or higher, rate limiting is applied to mitigate
 /// disk filling attacks. Users enabling logging at Debug and lower levels are
 /// assumed to be developers or power users who are aware that -debug may cause
@@ -157,6 +161,7 @@ struct Options {
 /// optional log pointer which can be used by the application's log handler to
 /// determine where to log to, and a Format hook to control message formatting.
 struct Context {
+    static constexpr bool log_context{true};
     Category category;
     Logger* logger;
 
@@ -189,7 +194,8 @@ namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
 /// detect case where first macro argument is a string literal and context has
 /// been omitted.
-template <Options options>
+template <Options options, typename Context>
+requires (Context::log_context)
 Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -20,9 +20,11 @@
 #include <string_view>
 #include <type_traits>
 
-/// Logging macros which output log messages at the specified levels. They
-/// accept printf-style format strings and arguments. The debug and trace macros
-/// also require an initial BCLog::LogFlags category argument.
+/// Logging macros which output log messages at the specified levels. The
+/// macros accept an optional log context parameter followed by a
+/// printf-style format string and arguments. For Debug and Trace macros,
+/// if a context parameter is not provided, a BCLog::LogFlags category argument
+/// must be provided instead.
 /// See the "Logging" section of /doc/developer-notes.md for more details.
 #define LogError(...) LOG_EMIT((.level = util::log::Level::Error), __VA_ARGS__)
 #define LogWarning(...) LOG_EMIT((.level = util::log::Level::Warning), __VA_ARGS__)
@@ -38,7 +40,7 @@
     do {                                                                                           \
         constexpr util::log::Options _options{PP_EXPAND_ARGS options};                             \
         auto&& _context{util::log::detail::GetContext<_options>(PP_FIRST_ARG(__VA_ARGS__))};       \
-        if (util::log::hooks::ShouldLog(_context.category, _options.level)) {                      \
+        if (util::log::hooks::ShouldLog(_context.logger, _context.category, _options.level)) {     \
             util::log::detail::Emit(_options, SourceLocation{__func__}, _context, __VA_ARGS__);    \
         } else if constexpr (_options.evaluate_when_disabled) {                                    \
             [](auto&&...) {}(__VA_ARGS__);                                                         \
@@ -77,6 +79,9 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
+/** Base class inherited by log consumers. Opaque like category, used for basic type-checking. */
+class Logger{};
+
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -113,12 +118,14 @@ struct Options {
     bool evaluate_when_disabled{level >= Level::Info};
 };
 
-/// Object representing context of log messages. Holds a logging category and
-/// implements log formatting.
+/// Object representing context of log messages. Holds a logging category, an
+/// optional log pointer which can be used by the application's log handler to
+/// determine where to log to, and a Format hook to control message formatting.
 struct Context {
     Category category;
+    Logger* logger;
 
-    explicit Context(Category category = BCLog::LogFlags::ALL) : category{category} {}
+    explicit Context(Category category = BCLog::LogFlags::ALL, Logger* logger = nullptr) : category{category}, logger{logger} {}
 
     template <typename... Args>
     std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
@@ -136,17 +143,19 @@ struct Context {
 /// External hooks that logging backends need to implement.
 namespace hooks {
 /// Return whether messages with specified category and level should be logged.
-bool ShouldLog(Category category, Level level);
+bool ShouldLog(Logger* logger, Category category, Level level);
 
 /// Send message to be logged.
-void Log(const Options& options, Entry entry);
+void Log(Logger* logger, const Options& options, Entry entry);
 } // namespace hooks
 
 /// Internal functions used to help implement logging macros.
 namespace detail {
 /// Internal helper to get Context from the first macro argument. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
+template <Options options>
+Context& GetContext(Context& context LIFETIMEBOUND) { return context; }
 template <Options options>
 Context GetContext(std::string_view fmt)
 {
@@ -173,12 +182,12 @@ Context GetContext(Category category)
 }
 
 /// Internal helper to construct log entry and emit log message. Overloaded to
-/// detect case where first macro argument is a string literal instead of a
-/// category.
+/// detect case where first macro argument is a string literal and context has
+/// been omitted.
 template <typename Context, typename... Args>
 void Emit(Options options, SourceLocation&& source_loc, Context&& context, ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    hooks::Log(options, Entry{
+    hooks::Log(context.logger, options, Entry{
         .category = context.category,
         .level = options.level,
         .source_loc = std::move(source_loc),
@@ -192,11 +201,11 @@ void Emit(Options options, SourceLocation&& source_loc, Context&& context, Conte
 }
 
 template<Level level>
-bool ShouldLog(Category category)
+bool ShouldLog(const Context& context)
 {
     constexpr util::log::Options options{level};
     static_assert(!options.evaluate_when_disabled); // Disallow conditioning on log levels that should be evaluated even when disabled.
-    return util::log::hooks::ShouldLog(category, options.level);
+    return util::log::hooks::ShouldLog(context.logger, context.category, options.level);
 }
 } // namespace detail
 
@@ -205,8 +214,8 @@ bool ShouldLog(Category category)
 /// provided, because these logs are rarely disabled, so allowing code to
 /// condition on them could lead to bugs when they are disabled.
 ///@{
-inline bool ShouldDebugLog(Category category) { return detail::ShouldLog<Level::Debug>(category); }
-inline bool ShouldTraceLog(Category category) { return detail::ShouldLog<Level::Trace>(category); }
+inline bool ShouldDebugLog(const auto&... args) { return detail::ShouldLog<Level::Debug>(Context{args...}); }
+inline bool ShouldTraceLog(const auto&... args) { return detail::ShouldLog<Level::Trace>(Context{args...}); }
 ///@}
 } // namespace util::log
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2865,8 +2865,9 @@ static void UpdateTipLog(
 
     AssertLockHeld(::cs_main);
 
-    // Disable rate limiting as this may log frequently during IBD.
-    LogInfo(util::log::NO_RATE_LIMIT, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Disable rate limiting so this source location may log during IBD.
+    LOG_EMIT((.level = util::log::Level::Info, .ratelimit = false),
+                   "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -114,7 +114,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
 // deleter here.
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
-    wallet->WalletLogPrintf("Releasing wallet\n");
+    LogInfo(wallet->Log(), "Releasing wallet\n");
     wallet->Close();
     delete wallet;
 }

--- a/src/wallet/logging.h
+++ b/src/wallet/logging.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_LOGGING_H
+#define BITCOIN_WALLET_LOGGING_H
+
+#include <logging.h>
+
+#include <string>
+
+namespace wallet {
+/** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
+class WalletLogContext : public util::log::Context
+{
+    std::string m_display_name;
+
+public:
+    WalletLogContext(std::string display_name) : m_display_name{std::move(display_name)} {}
+
+    template <typename... Args>
+    std::string Format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) const
+    {
+        return "[" + m_display_name + "] " + Context::Format(fmt, args...);
+    }
+};
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_LOGGING_H

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -141,6 +141,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                   std::list<COutputEntry>& listSent, CAmount& nFee,
                   bool include_change)
 {
+    const auto& log{wallet.Log()};
     nFee = 0;
     listReceived.clear();
     listSent.clear();
@@ -175,7 +176,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
         if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
         {
-            wallet.WalletLogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
+            LogInfo(log, "CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
                                     wtx.GetHash().ToString());
             address = CNoDestination();
         }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -294,7 +294,7 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = EncodeDestination(ScriptHash(redeemScript));
-        LogInfo(m_log, "%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
+        LogWarning(m_log, "%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -20,6 +20,7 @@
 #include <util/string.h>
 #include <util/time.h>
 #include <util/translation.h>
+#include <wallet/logging.h>
 
 #include <optional>
 
@@ -293,7 +294,7 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = EncodeDestination(ScriptHash(redeemScript));
-        WalletLogPrintf("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
+        LogInfo(m_log, "%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
 
@@ -1120,7 +1121,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     if (IsMine(script)) {
         int32_t index = m_map_script_pub_keys[script];
         if (index >= m_wallet_descriptor.next_index) {
-            WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
+            LogInfo(m_log, "%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
             auto out_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CScript> scripts_temp;
             while (index >= m_wallet_descriptor.next_index) {
@@ -1134,7 +1135,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
             }
         }
         if (!TopUp()) {
-            WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
+            LogInfo(m_log, "%s: Topping up keypool failed (locked wallet)\n", __func__);
         }
     }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -20,6 +20,7 @@
 #include <util/string.h>
 #include <util/time.h>
 #include <util/translation.h>
+#include <wallet/logging.h>
 
 #include <optional>
 
@@ -293,7 +294,7 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = EncodeDestination(ScriptHash(redeemScript));
-        WalletLogPrintf("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
+        LogInfo(m_log, "%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
 
@@ -1152,7 +1153,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     if (IsMine(script)) {
         int32_t index = m_map_script_pub_keys[script];
         if (index >= m_wallet_descriptor.GetNext()) {
-            WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
+            LogInfo(m_log, "%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
             auto out_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CScript> scripts_temp;
             while (index >= m_wallet_descriptor.GetNext()) {
@@ -1166,7 +1167,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
             }
         }
         if (!TopUp()) {
-            WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
+            LogInfo(m_log, "%s: Topping up keypool failed (locked wallet)\n", __func__);
         }
     }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -33,8 +33,9 @@
 enum class OutputType;
 
 namespace wallet {
-struct MigrationData;
 class ScriptPubKeyMan;
+class WalletLogContext;
+struct MigrationData;
 
 // Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
 // It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
@@ -46,6 +47,7 @@ class WalletStorage
 public:
     virtual ~WalletStorage() = default;
     virtual std::string LogName() const = 0;
+    virtual const WalletLogContext& Log() const = 0;
     virtual WalletDatabase& GetDatabase() const = 0;
     virtual bool IsWalletFlagSet(uint64_t) const = 0;
     virtual void UnsetBlankWalletFlag(WalletBatch&) = 0;
@@ -81,10 +83,11 @@ struct WalletDestination
 class ScriptPubKeyMan
 {
 protected:
+    const WalletLogContext& m_log;
     WalletStorage& m_storage;
 
 public:
-    explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
+    explicit ScriptPubKeyMan(WalletStorage& storage) : m_log{storage.Log()}, m_storage(storage) {}
     virtual ~ScriptPubKeyMan() = default;
     virtual util::Result<CTxDestination> GetNewDestination(const OutputType type) { return util::Error{Untranslated("Not supported")}; }
     virtual bool IsMine(const CScript& script) const { return false; }
@@ -145,13 +148,6 @@ public:
 
     /** Returns a set of all the scriptPubKeys that this ScriptPubKeyMan watches */
     virtual std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const { return {}; };
-
-    /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
-    {
-        LogInfo("[%s] %s", m_storage.LogName(), tfm::format(wallet_fmt, params...));
-    };
 
     /** Keypool has new keys */
     btcsignals::signal<void ()> NotifyCanGetAddressesChanged;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -33,8 +33,9 @@
 enum class OutputType;
 
 namespace wallet {
-struct MigrationData;
 class ScriptPubKeyMan;
+class WalletLogContext;
+struct MigrationData;
 
 // Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
 // It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
@@ -46,6 +47,7 @@ class WalletStorage
 public:
     virtual ~WalletStorage() = default;
     virtual std::string LogName() const = 0;
+    virtual const WalletLogContext& Log() const = 0;
     virtual WalletDatabase& GetDatabase() const = 0;
     virtual bool IsWalletFlagSet(uint64_t) const = 0;
     virtual void UnsetBlankWalletFlag(WalletBatch&) = 0;
@@ -79,10 +81,11 @@ struct WalletDestination
 class ScriptPubKeyMan
 {
 protected:
+    const WalletLogContext& m_log;
     WalletStorage& m_storage;
 
 public:
-    explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
+    explicit ScriptPubKeyMan(WalletStorage& storage) : m_log{storage.Log()}, m_storage(storage) {}
     virtual ~ScriptPubKeyMan() = default;
     virtual util::Result<CTxDestination> GetNewDestination(const OutputType type) { return util::Error{Untranslated("Not supported")}; }
     virtual bool IsMine(const CScript& script) const { return false; }
@@ -143,13 +146,6 @@ public:
 
     /** Returns a set of all the scriptPubKeys that this ScriptPubKeyMan watches */
     virtual std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const { return {}; };
-
-    /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
-    {
-        LogInfo("[%s] %s", m_storage.LogName(), tfm::format(wallet_fmt, params...));
-    };
 
     /** Keypool has new keys */
     btcsignals::signal<void ()> NotifyCanGetAddressesChanged;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1063,6 +1063,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         const CCoinControl& coin_control,
         bool sign) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    const auto& log{wallet.Log()};
     AssertLockHeld(wallet.cs_wallet);
 
     FastRandomContext rng_fast;
@@ -1432,8 +1433,8 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // accidental reuse.
     reservedest.KeepDestination();
 
-    wallet.WalletLogPrintf("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
-    wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+    LogInfo(log, "Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
+    LogInfo(log, "Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
               current_fee, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,
               (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) > 0.0 ? 100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) : 0.0,
@@ -1451,6 +1452,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
         const CCoinControl& coin_control,
         bool sign)
 {
+    const auto& log{wallet.Log()};
     if (vecSend.empty()) {
         return util::Error{_("Transaction must have at least one recipient")};
     }
@@ -1490,7 +1492,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
                txr_grouped.has_value() ? txr_grouped->fee : 0,
                txr_grouped.has_value() && txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
         if (txr_grouped) {
-            wallet.WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n",
+            LogInfo(log, "Fee non-grouped = %lld, grouped = %lld, using %s\n",
                 txr_ungrouped.fee, txr_grouped->fee, use_aps ? "grouped" : "non-grouped");
             if (use_aps) return txr_grouped;
         }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1064,6 +1064,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         const CCoinControl& coin_control,
         bool sign) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    const auto& log{wallet.Log()};
     AssertLockHeld(wallet.cs_wallet);
 
     FastRandomContext rng_fast;
@@ -1433,8 +1434,8 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // accidental reuse.
     reservedest.KeepDestination();
 
-    wallet.WalletLogPrintf("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
-    wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u, Source: %s\n",
+    LogInfo(log, "Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
+    LogInfo(log, "Fee Calculation: Fee:%d Bytes:%u, Source: %s\n",
                            current_fee, nBytes, StringForFeeReason(min_fee_rate.fee_reason));
     return CreatedTransactionResult(tx, current_fee, change_pos, min_fee_rate.fee_reason);
 }
@@ -1446,6 +1447,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
         const CCoinControl& coin_control,
         bool sign)
 {
+    const auto& log{wallet.Log()};
     if (vecSend.empty()) {
         return util::Error{_("Transaction must have at least one recipient")};
     }
@@ -1485,7 +1487,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
                txr_grouped.has_value() ? txr_grouped->fee : 0,
                txr_grouped.has_value() && txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
         if (txr_grouped) {
-            wallet.WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n",
+            LogInfo(log, "Fee non-grouped = %lld, grouped = %lld, using %s\n",
                 txr_ungrouped.fee, txr_grouped->fee, use_aps ? "grouped" : "non-grouped");
             if (use_aps) return txr_grouped;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2499,11 +2499,11 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
 
     const std::string& encoded_dest = EncodeDestination(address);
     if (new_purpose && !batch.WritePurpose(encoded_dest, PurposeToString(*new_purpose))) {
-        LogInfo(m_log, "Error: fail to write address book 'purpose' entry\n");
+        LogError(m_log, "Error: fail to write address book 'purpose' entry\n");
         return false;
     }
     if (!batch.WriteName(encoded_dest, strName)) {
-        LogInfo(m_log, "Error: fail to write address book 'name' entry\n");
+        LogError(m_log, "Error: fail to write address book 'name' entry\n");
         return false;
     }
 
@@ -2541,19 +2541,19 @@ bool CWallet::DelAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
         }
         // Delete data rows associated with this address
         if (!batch.EraseAddressData(address)) {
-            LogInfo(m_log, "Error: cannot erase address book entry data\n");
+            LogError(m_log, "Error: cannot erase address book entry data\n");
             return false;
         }
 
         // Delete purpose entry
         if (!batch.ErasePurpose(dest)) {
-            LogInfo(m_log, "Error: cannot erase address book entry purpose\n");
+            LogError(m_log, "Error: cannot erase address book entry purpose\n");
             return false;
         }
 
         // Delete name entry
         if (!batch.EraseName(dest)) {
-            LogInfo(m_log, "Error: cannot erase address book entry name\n");
+            LogError(m_log, "Error: cannot erase address book entry name\n");
             return false;
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -239,7 +239,7 @@ static std::set<std::string> g_unloading_wallet_set GUARDED_BY(g_wallet_release_
 static void FlushAndDeleteWallet(CWallet* wallet)
 {
     const std::string name = wallet->GetName();
-    wallet->WalletLogPrintf("Releasing wallet %s..\n", name);
+    LogInfo(wallet->Log(), "Releasing wallet\n");
     delete wallet;
     // Wallet is now released, notify WaitForDeleteWallet, if any.
     {
@@ -645,7 +645,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
                 if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, master_key)) {
                     return false;
                 }
-                WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+                LogInfo(m_log, "Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
                 WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, master_key);
                 if (fWasLocked)
@@ -837,7 +837,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (!EncryptMasterKey(strWalletPassphrase, plain_master_key, master_key)) {
         return false;
     }
-    WalletLogPrintf("Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+    LogInfo(m_log, "Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
     {
         LOCK2(m_relock_mutex, cs_wallet);
@@ -992,7 +992,7 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
 
     bool success = true;
     if (!batch.WriteTx(wtx)) {
-        WalletLogPrintf("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
+        LogInfo(m_log, "%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
         success = false;
     }
 
@@ -1121,7 +1121,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     if (fInsertedNew || fUpdated) {
         status = fInsertedNew ? (fUpdated ? "new, update" : "new") : "update";
     }
-    WalletLogPrintf("AddToWallet %s %s %s", hash.ToString(), status, TxStateString(state));
+    LogInfo(m_log, "AddToWallet %s %s %s", hash.ToString(), status, TxStateString(state));
 
     // Write to disk
     if (fInsertedNew || fUpdated)
@@ -1213,7 +1213,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
-                        WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        LogInfo(m_log, "Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
                         MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
                     }
                     range.first++;
@@ -1832,7 +1832,7 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     int start_height = 0;
     uint256 start_block;
     bool start = chain().findFirstBlockWithTimeAndHeight(startTime - TIMESTAMP_WINDOW, 0, FoundBlock().hash(start_block).height(start_height));
-    WalletLogPrintf("%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
+    LogInfo(m_log, "%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
 
     if (start) {
         // TODO: this should take into account failure by ScanResult::USER_ABORT
@@ -1881,7 +1881,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     std::unique_ptr<FastWalletRescanFilter> fast_rescan_filter;
     if (chain().hasBlockFilterIndex(BlockFilterType::BASIC)) fast_rescan_filter = std::make_unique<FastWalletRescanFilter>(*this);
 
-    WalletLogPrintf("Rescan started from block %s... (%s)\n", start_block.ToString(),
+    LogInfo(m_log, "Rescan started from block %s... (%s)\n", start_block.ToString(),
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
@@ -1905,7 +1905,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;
         if (next_interval) {
             current_time = reserver.now();
-            WalletLogPrintf("Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
+            LogInfo(m_log, "Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
         }
 
         bool fetch_block{true};
@@ -1958,7 +1958,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                 result.last_scanned_height = block_height;
 
                 if (!loc.IsNull()) {
-                    WalletLogPrintf("Saving scan progress %d.\n", block_height);
+                    LogInfo(m_log, "Saving scan progress %d.\n", block_height);
                     WalletBatch batch(GetDatabase());
                     batch.WriteBestBlock(loc);
                 }
@@ -2001,18 +2001,18 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         }
     }
     if (!max_height) {
-        WalletLogPrintf("Scanning current mempool transactions.\n");
+        LogInfo(m_log, "Scanning current mempool transactions.\n");
         WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
     }
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 100); // hide progress dialog in GUI
     if (fAbortRescan) {
-        WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
+        LogInfo(m_log, "Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else if (chain().shutdownRequested()) {
-        WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
+        LogInfo(m_log, "Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else {
-        WalletLogPrintf("Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
+        LogInfo(m_log, "Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
     }
     return result;
 }
@@ -2045,7 +2045,7 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
         what = "for private broadcast without adding to the mempool";
         break;
     }
-    WalletLogPrintf("Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
+    LogInfo(m_log, "Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
     // We must set TxStateInMempool here. Even though it will also be set later by the
     // entered-mempool callback, if we did not there would be a race where a
     // user could call sendmoney in a loop and hit spurious out of funds errors
@@ -2145,7 +2145,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
     } // cs_wallet
 
     if (submitted_tx_count > 0) {
-        WalletLogPrintf("%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
+        LogInfo(m_log, "%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
     }
 }
 
@@ -2327,7 +2327,7 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
 {
     LOCK(cs_wallet);
-    WalletLogPrintf("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
+    LogInfo(m_log, "CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
@@ -2358,7 +2358,7 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
 
     std::string err_string;
     if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
-        WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
+        LogInfo(m_log, "CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
         // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
     }
 }
@@ -2499,11 +2499,11 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
 
     const std::string& encoded_dest = EncodeDestination(address);
     if (new_purpose && !batch.WritePurpose(encoded_dest, PurposeToString(*new_purpose))) {
-        WalletLogPrintf("Error: fail to write address book 'purpose' entry\n");
+        LogInfo(m_log, "Error: fail to write address book 'purpose' entry\n");
         return false;
     }
     if (!batch.WriteName(encoded_dest, strName)) {
-        WalletLogPrintf("Error: fail to write address book 'name' entry\n");
+        LogInfo(m_log, "Error: fail to write address book 'name' entry\n");
         return false;
     }
 
@@ -2536,24 +2536,24 @@ bool CWallet::DelAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
         // NOTE: This isn't a problem for sending addresses because they don't have any data that needs to be kept.
         // When adding new address data, it should be considered here whether to retain or delete it.
         if (IsMine(address)) {
-            WalletLogPrintf("%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
+            LogInfo(m_log, "%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
             return false;
         }
         // Delete data rows associated with this address
         if (!batch.EraseAddressData(address)) {
-            WalletLogPrintf("Error: cannot erase address book entry data\n");
+            LogInfo(m_log, "Error: cannot erase address book entry data\n");
             return false;
         }
 
         // Delete purpose entry
         if (!batch.ErasePurpose(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry purpose\n");
+            LogInfo(m_log, "Error: cannot erase address book entry purpose\n");
             return false;
         }
 
         // Delete name entry
         if (!batch.EraseName(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry name\n");
+            LogInfo(m_log, "Error: cannot erase address book entry name\n");
             return false;
         }
 
@@ -2855,7 +2855,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx, bool rescanning_old
                 nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
             }
         } else {
-            WalletLogPrintf("%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
+            LogInfo(m_log, "%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
         }
     }
     return nTimeSmart;
@@ -3101,6 +3101,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // TODO: Can't use std::make_shared because we need a custom deleter but
     // should be possible to use std::allocate_shared.
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
+    const auto& log{walletInstance->Log()};
 
     if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
         return nullptr;
@@ -3134,7 +3135,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
         }
     }
 
-    walletInstance->WalletLogPrintf("Wallet completed creation in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(log, "Wallet completed creation in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
@@ -3154,6 +3155,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 
     const auto start{SteadyClock::now()};
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
+    const auto& log{walletInstance->Log()};
 
     if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
         return nullptr;
@@ -3175,7 +3177,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
         }
     }
 
-    walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(log, "Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
@@ -3193,6 +3195,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 
 bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
 {
+    const auto& log{walletInstance->Log()};
     LOCK(walletInstance->cs_wallet);
     // allow setting the chain if it hasn't been set already but prevent changing it
     assert(!walletInstance->m_chain || walletInstance->m_chain == &chain);
@@ -3288,7 +3291,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
 
         chain.initMessage(_("Rescanning…"));
-        walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
+        LogInfo(log, "Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
 
         {
             WalletRescanReserver reserver(*walletInstance);
@@ -3717,7 +3720,7 @@ void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool intern
     // Legacy wallets have only one ScriptPubKeyManager and it's active for all output and change types.
     Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
-    WalletLogPrintf("Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+    LogInfo(m_log, "Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
     auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
     auto& spk_mans_other = internal ? m_external_spk_managers : m_internal_spk_managers;
     auto spk_man = m_spk_managers.at(id).get();
@@ -3735,7 +3738,7 @@ void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool intern
 {
     auto spk_man = GetScriptPubKeyMan(type, internal);
     if (spk_man != nullptr && spk_man->GetID() == id) {
-        WalletLogPrintf("Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+        LogInfo(m_log, "Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
         WalletBatch batch(GetDatabase());
         if (!batch.EraseActiveScriptPubKeyMan(static_cast<uint8_t>(type), internal)) {
             throw std::runtime_error(std::string(__func__) + ": erasing active ScriptPubKeyMan id failed");
@@ -3790,7 +3793,7 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
 
     auto spk_man = GetDescriptorScriptPubKeyMan(desc);
     if (spk_man) {
-        WalletLogPrintf("Update existing descriptor: %s\n", desc.descriptor->ToString());
+        LogInfo(m_log, "Update existing descriptor: %s\n", desc.descriptor->ToString());
         if (auto spkm_res = spk_man->UpdateWalletDescriptor(desc, signing_provider); !spkm_res) {
             return util::Error{util::ErrorString(spkm_res)};
         }
@@ -3834,7 +3837,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
 {
     AssertLockHeld(cs_wallet);
 
-    WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
+    LogInfo(m_log, "Migrating wallet storage database from BerkeleyDB to SQLite.\n");
 
     if (m_database->Format() == "sqlite") {
         error = _("Error: This wallet already uses SQLite");
@@ -4151,6 +4154,7 @@ static std::string MigrationPrefixName(CWallet& wallet)
 
 bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    const auto& log{wallet.Log()};
     AssertLockHeld(wallet.cs_wallet);
 
     // Get all of the descriptors from the legacy wallet
@@ -4176,7 +4180,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
         }
         if (data->watch_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
+            LogInfo(log, "Making a new watchonly wallet containing the watched scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4215,7 +4219,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
         }
         if (data->solvable_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
+            LogInfo(log, "Making a new watchonly wallet containing the unwatched solvable scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4261,7 +4265,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             error = util::ErrorString(res_migration);
             return false;
         }
-        wallet.WalletLogPrintf("Wallet migration complete.\n");
+        LogInfo(log, "Wallet migration complete.\n");
         return true;
     });
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2514,11 +2514,11 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
 
     const std::string& encoded_dest = EncodeDestination(address);
     if (new_purpose && !batch.WritePurpose(encoded_dest, PurposeToString(*new_purpose))) {
-        LogInfo(m_log, "Error: fail to write address book 'purpose' entry\n");
+        LogError(m_log, "Error: fail to write address book 'purpose' entry\n");
         return false;
     }
     if (!batch.WriteName(encoded_dest, strName)) {
-        LogInfo(m_log, "Error: fail to write address book 'name' entry\n");
+        LogError(m_log, "Error: fail to write address book 'name' entry\n");
         return false;
     }
 
@@ -2556,19 +2556,19 @@ bool CWallet::DelAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
         }
         // Delete data rows associated with this address
         if (!batch.EraseAddressData(address)) {
-            LogInfo(m_log, "Error: cannot erase address book entry data\n");
+            LogError(m_log, "Error: cannot erase address book entry data\n");
             return false;
         }
 
         // Delete purpose entry
         if (!batch.ErasePurpose(dest)) {
-            LogInfo(m_log, "Error: cannot erase address book entry purpose\n");
+            LogError(m_log, "Error: cannot erase address book entry purpose\n");
             return false;
         }
 
         // Delete name entry
         if (!batch.EraseName(dest)) {
-            LogInfo(m_log, "Error: cannot erase address book entry name\n");
+            LogError(m_log, "Error: cannot erase address book entry name\n");
             return false;
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -248,7 +248,7 @@ static std::set<std::string> g_unloading_wallet_set GUARDED_BY(g_wallet_release_
 static void FlushAndDeleteWallet(CWallet* wallet)
 {
     const std::string name = wallet->GetName();
-    wallet->WalletLogPrintf("Releasing wallet %s..\n", name);
+    LogInfo(wallet->Log(), "Releasing wallet\n");
     delete wallet;
     // Wallet is now released, notify WaitForDeleteWallet, if any.
     {
@@ -663,7 +663,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
                 if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, master_key)) {
                     return false;
                 }
-                WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+                LogInfo(m_log, "Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
                 WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, master_key);
                 if (fWasLocked)
@@ -861,7 +861,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (!EncryptMasterKey(strWalletPassphrase, plain_master_key, master_key)) {
         return false;
     }
-    WalletLogPrintf("Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+    LogInfo(m_log, "Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
     {
         LOCK2(m_relock_mutex, cs_wallet);
@@ -1016,7 +1016,7 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
 
     bool success = true;
     if (!batch.WriteTx(wtx)) {
-        WalletLogPrintf("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
+        LogInfo(m_log, "%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
         success = false;
     }
 
@@ -1130,7 +1130,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     if (fInsertedNew || fUpdated) {
         status = fInsertedNew ? (fUpdated ? "new, update" : "new") : "update";
     }
-    WalletLogPrintf("AddToWallet %s %s %s", hash.ToString(), status, TxStateString(state));
+    LogInfo(m_log, "AddToWallet %s %s %s", hash.ToString(), status, TxStateString(state));
 
     // Write to disk
     if (fInsertedNew || fUpdated)
@@ -1220,7 +1220,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
-                        WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        LogInfo(m_log, "Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
                         MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
                     }
                     range.first++;
@@ -1839,7 +1839,7 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     int start_height = 0;
     uint256 start_block;
     bool start = chain().findFirstBlockWithTimeAndHeight(startTime - TIMESTAMP_WINDOW, 0, FoundBlock().hash(start_block).height(start_height));
-    WalletLogPrintf("%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
+    LogInfo(m_log, "%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
 
     if (start) {
         // TODO: this should take into account failure by ScanResult::USER_ABORT
@@ -1888,7 +1888,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     std::unique_ptr<FastWalletRescanFilter> fast_rescan_filter;
     if (chain().hasBlockFilterIndex(BlockFilterType::BASIC)) fast_rescan_filter = std::make_unique<FastWalletRescanFilter>(*this);
 
-    WalletLogPrintf("Rescan started from block %s... (%s)\n", start_block.ToString(),
+    LogInfo(m_log, "Rescan started from block %s... (%s)\n", start_block.ToString(),
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
@@ -1912,7 +1912,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;
         if (next_interval) {
             current_time = reserver.now();
-            WalletLogPrintf("Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
+            LogInfo(m_log, "Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
         }
 
         bool fetch_block{true};
@@ -1965,7 +1965,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                 result.last_scanned_height = block_height;
 
                 if (!loc.IsNull()) {
-                    WalletLogPrintf("Saving scan progress %d.\n", block_height);
+                    LogInfo(m_log, "Saving scan progress %d.\n", block_height);
                     WalletBatch batch(GetDatabase());
                     batch.WriteBestBlock(loc);
                 }
@@ -2008,18 +2008,18 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         }
     }
     if (!max_height) {
-        WalletLogPrintf("Scanning current mempool transactions.\n");
+        LogInfo(m_log, "Scanning current mempool transactions.\n");
         WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
     }
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 100); // hide progress dialog in GUI
     if (fAbortRescan) {
-        WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
+        LogInfo(m_log, "Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else if (chain().shutdownRequested()) {
-        WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
+        LogInfo(m_log, "Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else {
-        WalletLogPrintf("Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
+        LogInfo(m_log, "Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
     }
     return result;
 }
@@ -2052,7 +2052,7 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
         what = "for private broadcast without adding to the mempool";
         break;
     }
-    WalletLogPrintf("Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
+    LogInfo(m_log, "Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
     // We must set TxStateInMempool here. Even though it will also be set later by the
     // entered-mempool callback, if we did not there would be a race where a
     // user could call sendmoney in a loop and hit spurious out of funds errors
@@ -2152,7 +2152,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
     } // cs_wallet
 
     if (submitted_tx_count > 0) {
-        WalletLogPrintf("%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
+        LogInfo(m_log, "%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
     }
 }
 
@@ -2341,7 +2341,7 @@ void CWallet::CommitTransaction(
 )
 {
     LOCK(cs_wallet);
-    WalletLogPrintf("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
+    LogInfo(m_log, "CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
@@ -2373,7 +2373,7 @@ void CWallet::CommitTransaction(
 
     std::string err_string;
     if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
-        WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
+        LogInfo(m_log, "CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
         // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
     }
 }
@@ -2514,11 +2514,11 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
 
     const std::string& encoded_dest = EncodeDestination(address);
     if (new_purpose && !batch.WritePurpose(encoded_dest, PurposeToString(*new_purpose))) {
-        WalletLogPrintf("Error: fail to write address book 'purpose' entry\n");
+        LogInfo(m_log, "Error: fail to write address book 'purpose' entry\n");
         return false;
     }
     if (!batch.WriteName(encoded_dest, strName)) {
-        WalletLogPrintf("Error: fail to write address book 'name' entry\n");
+        LogInfo(m_log, "Error: fail to write address book 'name' entry\n");
         return false;
     }
 
@@ -2551,24 +2551,24 @@ bool CWallet::DelAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
         // NOTE: This isn't a problem for sending addresses because they don't have any data that needs to be kept.
         // When adding new address data, it should be considered here whether to retain or delete it.
         if (IsMine(address)) {
-            WalletLogPrintf("%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
+            LogInfo(m_log, "%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
             return false;
         }
         // Delete data rows associated with this address
         if (!batch.EraseAddressData(address)) {
-            WalletLogPrintf("Error: cannot erase address book entry data\n");
+            LogInfo(m_log, "Error: cannot erase address book entry data\n");
             return false;
         }
 
         // Delete purpose entry
         if (!batch.ErasePurpose(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry purpose\n");
+            LogInfo(m_log, "Error: cannot erase address book entry purpose\n");
             return false;
         }
 
         // Delete name entry
         if (!batch.EraseName(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry name\n");
+            LogInfo(m_log, "Error: cannot erase address book entry name\n");
             return false;
         }
 
@@ -2870,7 +2870,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx, bool rescanning_old
                 nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
             }
         } else {
-            WalletLogPrintf("%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
+            LogInfo(m_log, "%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
         }
     }
     return nTimeSmart;
@@ -3116,6 +3116,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // TODO: Can't use std::make_shared because we need a custom deleter but
     // should be possible to use std::allocate_shared.
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
+    const auto& log{walletInstance->Log()};
 
     if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
         return nullptr;
@@ -3149,7 +3150,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
         }
     }
 
-    walletInstance->WalletLogPrintf("Wallet completed creation in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(log, "Wallet completed creation in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
@@ -3169,6 +3170,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 
     const auto start{SteadyClock::now()};
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
+    const auto& log{walletInstance->Log()};
 
     if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
         return nullptr;
@@ -3190,7 +3192,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
         }
     }
 
-    walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    LogInfo(log, "Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
@@ -3208,6 +3210,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 
 bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
 {
+    const auto& log{walletInstance->Log()};
     LOCK(walletInstance->cs_wallet);
     // allow setting the chain if it hasn't been set already but prevent changing it
     assert(!walletInstance->m_chain || walletInstance->m_chain == &chain);
@@ -3303,7 +3306,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
 
         chain.initMessage(_("Rescanning…"));
-        walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
+        LogInfo(log, "Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
 
         {
             WalletRescanReserver reserver(*walletInstance);
@@ -3732,7 +3735,7 @@ void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool intern
     // Legacy wallets have only one ScriptPubKeyManager and it's active for all output and change types.
     Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
-    WalletLogPrintf("Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+    LogInfo(m_log, "Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
     auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
     auto& spk_mans_other = internal ? m_external_spk_managers : m_internal_spk_managers;
     auto spk_man = m_spk_managers.at(id).get();
@@ -3750,7 +3753,7 @@ void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool intern
 {
     auto spk_man = GetScriptPubKeyMan(type, internal);
     if (spk_man != nullptr && spk_man->GetID() == id) {
-        WalletLogPrintf("Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+        LogInfo(m_log, "Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
         WalletBatch batch(GetDatabase());
         if (!batch.EraseActiveScriptPubKeyMan(static_cast<uint8_t>(type), internal)) {
             throw std::runtime_error(std::string(__func__) + ": erasing active ScriptPubKeyMan id failed");
@@ -3805,7 +3808,7 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
 
     auto spk_man = GetDescriptorScriptPubKeyMan(desc);
     if (spk_man) {
-        WalletLogPrintf("Update existing descriptor: %s\n", desc.descriptor->ToString());
+        LogInfo(m_log, "Update existing descriptor: %s\n", desc.descriptor->ToString());
         if (auto spkm_res = spk_man->UpdateWalletDescriptor(desc, signing_provider); !spkm_res) {
             return util::Error{util::ErrorString(spkm_res)};
         }
@@ -3855,7 +3858,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
 {
     AssertLockHeld(cs_wallet);
 
-    WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
+    LogInfo(m_log, "Migrating wallet storage database from BerkeleyDB to SQLite.\n");
 
     if (m_database->Format() == "sqlite") {
         error = _("Error: This wallet already uses SQLite");
@@ -4169,6 +4172,7 @@ static std::string MigrationPrefixName(CWallet& wallet)
 
 bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    const auto& log{wallet.Log()};
     AssertLockHeld(wallet.cs_wallet);
 
     // Get all of the descriptors from the legacy wallet
@@ -4194,7 +4198,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
         }
         if (data->watch_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
+            LogInfo(log, "Making a new watchonly wallet containing the watched scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4234,7 +4238,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
         }
         if (data->solvable_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
+            LogInfo(log, "Making a new watchonly wallet containing the unwatched solvable scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4281,7 +4285,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             error = util::ErrorString(res_migration);
             return false;
         }
-        wallet.WalletLogPrintf("Wallet migration complete.\n");
+        LogInfo(log, "Wallet migration complete.\n");
         return true;
     });
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -32,6 +32,7 @@
 #include <util/ui_change_type.h>
 #include <wallet/crypter.h>
 #include <wallet/db.h>
+#include <wallet/logging.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/transaction.h>
 #include <wallet/types.h>
@@ -393,6 +394,9 @@ private:
     /** Wallet name: relative directory name or "" for default wallet. */
     std::string m_name;
 
+    /** Custom log context which adds the wallet name to all log messages */
+    WalletLogContext m_log;
+
     /** Internal database handle. */
     std::unique_ptr<WalletDatabase> m_database;
 
@@ -475,6 +479,7 @@ public:
     CWallet(interfaces::Chain* chain, const std::string& name, std::unique_ptr<WalletDatabase> database)
         : m_chain(chain),
           m_name(name),
+          m_log{LogName()},
           m_database(std::move(database))
     {
     }
@@ -931,20 +936,14 @@ public:
         std::string name{GetName()};
         return name.empty() ? _("default wallet") : name;
     };
-
-    /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
-    {
-        LogInfo("[%s] %s", LogName(), tfm::format(wallet_fmt, params...));
-    };
+    const WalletLogContext& Log() const override { return m_log; }
 
     void LogStats() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
         AssertLockHeld(cs_wallet);
-        WalletLogPrintf("setKeyPool.size() = %u\n",      GetKeyPoolSize());
-        WalletLogPrintf("mapWallet.size() = %u\n",       mapWallet.size());
-        WalletLogPrintf("m_address_book.size() = %u\n",  m_address_book.size());
+        LogInfo(m_log, "setKeyPool.size() = %u\n",      GetKeyPoolSize());
+        LogInfo(m_log, "mapWallet.size() = %u\n",       mapWallet.size());
+        LogInfo(m_log, "m_address_book.size() = %u\n",  m_address_book.size());
     };
 
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -33,6 +33,7 @@
 #include <util/ui_change_type.h>
 #include <wallet/crypter.h>
 #include <wallet/db.h>
+#include <wallet/logging.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/transaction.h>
 #include <wallet/types.h>
@@ -394,6 +395,9 @@ private:
     /** Wallet name: relative directory name or "" for default wallet. */
     std::string m_name;
 
+    /** Custom log context which adds the wallet name to all log messages */
+    WalletLogContext m_log;
+
     /** Internal database handle. */
     std::unique_ptr<WalletDatabase> m_database;
 
@@ -476,6 +480,7 @@ public:
     CWallet(interfaces::Chain* chain, const std::string& name, std::unique_ptr<WalletDatabase> database)
         : m_chain(chain),
           m_name(name),
+          m_log{LogName()},
           m_database(std::move(database))
     {
     }
@@ -941,20 +946,14 @@ public:
         std::string name{GetName()};
         return name.empty() ? _("default wallet") : name;
     };
-
-    /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
-    {
-        LogInfo("[%s] %s", LogName(), tfm::format(wallet_fmt, params...));
-    };
+    const WalletLogContext& Log() const override { return m_log; }
 
     void LogStats() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
         AssertLockHeld(cs_wallet);
-        WalletLogPrintf("setKeyPool.size() = %u\n",      GetKeyPoolSize());
-        WalletLogPrintf("mapWallet.size() = %u\n",       mapWallet.size());
-        WalletLogPrintf("m_address_book.size() = %u\n",  m_address_book.size());
+        LogInfo(m_log, "setKeyPool.size() = %u\n",      GetKeyPoolSize());
+        LogInfo(m_log, "mapWallet.size() = %u\n",       mapWallet.size());
+        LogInfo(m_log, "m_address_book.size() = %u\n",  m_address_book.size());
     };
 
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -441,7 +441,7 @@ static DBErrors LoadWalletFlags(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIV
     uint64_t flags;
     if (batch.Read(DBKeys::FLAGS, flags)) {
         if (!pwallet->LoadWalletFlags(flags)) {
-            LogInfo(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
+            LogError(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
             return DBErrors::TOO_NEW;
         }
         // All wallets must be descriptor wallets unless opened with a bdb_ro db
@@ -470,7 +470,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
     Assume(!prefix.empty());
     std::unique_ptr<DatabaseCursor> cursor = batch.GetNewPrefixCursor(prefix);
     if (!cursor) {
-        LogInfo(log, "Error getting database cursor for '%s' records\n", key);
+        LogError(log, "Error getting database cursor for '%s' records\n", key);
         result.m_result = DBErrors::CORRUPT;
         return result;
     }
@@ -480,7 +480,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         if (status == DatabaseCursor::Status::DONE) {
             break;
         } else if (status == DatabaseCursor::Status::FAIL) {
-            LogInfo(log, "Error reading next '%s' record for wallet database\n", key);
+            LogError(log, "Error reading next '%s' record for wallet database\n", key);
             result.m_result = DBErrors::CORRUPT;
             return result;
         }
@@ -490,7 +490,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         std::string error;
         DBErrors record_res = load_func(pwallet, ssKey, ssValue, error);
         if (record_res != DBErrors::LOAD_OK) {
-            LogInfo(log, "%s\n", error);
+            LogError(log, "%s\n", error);
         }
         result.m_result = std::max(result.m_result, record_res);
         ++result.m_records;
@@ -542,7 +542,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
     // Make sure descriptor wallets don't have any legacy records
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         if (HasLegacyRecords(*pwallet, batch)) {
-            LogInfo(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
+            LogError(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
             return DBErrors::UNEXPECTED_LEGACY_ENTRY;
         }
 
@@ -950,7 +950,7 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
         value >> purpose_str;
         std::optional<AddressPurpose> purpose{PurposeFromString(purpose_str)};
         if (!purpose) {
-            LogInfo(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
+            LogWarning(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
         }
         pwallet->m_address_book[DecodeDestination(strAddress)].purpose = purpose;
         return DBErrors::LOAD_OK;
@@ -1124,7 +1124,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
 #ifndef ENABLE_EXTERNAL_SIGNER
         if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-            LogInfo(log, "Error: External signer wallet being loaded without external signer support compiled\n");
+            LogError(log, "Error: External signer wallet being loaded without external signer support compiled\n");
             return DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED;
         }
 #endif

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -436,11 +436,12 @@ bool LoadHDChain(CWallet* pwallet, DataStream& ssValue, std::string& strErr)
 
 static DBErrors LoadWalletFlags(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     uint64_t flags;
     if (batch.Read(DBKeys::FLAGS, flags)) {
         if (!pwallet->LoadWalletFlags(flags)) {
-            pwallet->WalletLogPrintf("Error reading wallet database: Unknown non-tolerable wallet flags found\n");
+            LogInfo(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
             return DBErrors::TOO_NEW;
         }
         // All wallets must be descriptor wallets unless opened with a bdb_ro db
@@ -465,10 +466,11 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
     DataStream ssKey;
     DataStream ssValue{};
 
+    const auto& log{Assert(pwallet)->Log()};
     Assume(!prefix.empty());
     std::unique_ptr<DatabaseCursor> cursor = batch.GetNewPrefixCursor(prefix);
     if (!cursor) {
-        pwallet->WalletLogPrintf("Error getting database cursor for '%s' records\n", key);
+        LogInfo(log, "Error getting database cursor for '%s' records\n", key);
         result.m_result = DBErrors::CORRUPT;
         return result;
     }
@@ -478,7 +480,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         if (status == DatabaseCursor::Status::DONE) {
             break;
         } else if (status == DatabaseCursor::Status::FAIL) {
-            pwallet->WalletLogPrintf("Error reading next '%s' record for wallet database\n", key);
+            LogInfo(log, "Error reading next '%s' record for wallet database\n", key);
             result.m_result = DBErrors::CORRUPT;
             return result;
         }
@@ -488,7 +490,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         std::string error;
         DBErrors record_res = load_func(pwallet, ssKey, ssValue, error);
         if (record_res != DBErrors::LOAD_OK) {
-            pwallet->WalletLogPrintf("%s\n", error);
+            LogInfo(log, "%s\n", error);
         }
         result.m_result = std::max(result.m_result, record_res);
         ++result.m_records;
@@ -533,13 +535,14 @@ bool HasLegacyRecords(CWallet& wallet, DatabaseBatch& batch)
 
 static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
     // Make sure descriptor wallets don't have any legacy records
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         if (HasLegacyRecords(*pwallet, batch)) {
-            pwallet->WalletLogPrintf("Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
+            LogInfo(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
             return DBErrors::UNEXPECTED_LEGACY_ENTRY;
         }
 
@@ -667,7 +670,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
                 }
             }
         } else {
-            pwallet->WalletLogPrintf("Inactive HD Chains found but no Legacy ScriptPubKeyMan\n");
+            LogInfo(log, "Inactive HD Chains found but no Legacy ScriptPubKeyMan\n");
             result = DBErrors::CORRUPT;
         }
     }
@@ -731,7 +734,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
 
     if (result <= DBErrors::NONCRITICAL_ERROR) {
         // Only do logging and time first key update if there were no critical errors
-        pwallet->WalletLogPrintf("Legacy Wallet Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total.\n",
+        LogInfo(log, "Legacy Wallet Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total.\n",
                key_res.m_records, ckey_res.m_records, keymeta_res.m_records, key_res.m_records + ckey_res.m_records);
     }
 
@@ -748,6 +751,7 @@ static DataStream PrefixStream(const Args&... args)
 
 static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
 
     // Load descriptor record
@@ -912,7 +916,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
     if (desc_res.m_result <= DBErrors::NONCRITICAL_ERROR) {
         // Only log if there are no critical errors
-        pwallet->WalletLogPrintf("Descriptors: %u, Descriptor Keys: %u plaintext, %u encrypted, %u total.\n",
+        LogInfo(log, "Descriptors: %u, Descriptor Keys: %u plaintext, %u encrypted, %u total.\n",
                desc_res.m_records, num_keys, num_ckeys, num_keys + num_ckeys);
     }
 
@@ -921,6 +925,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
 static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
@@ -938,14 +943,14 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
 
     // Load purpose record
     LoadResult purpose_res = LoadRecords(pwallet, batch, DBKeys::PURPOSE,
-        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        [&] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
         std::string strAddress;
         key >> strAddress;
         std::string purpose_str;
         value >> purpose_str;
         std::optional<AddressPurpose> purpose{PurposeFromString(purpose_str)};
         if (!purpose) {
-            pwallet->WalletLogPrintf("Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
+            LogInfo(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
         }
         pwallet->m_address_book[DecodeDestination(strAddress)].purpose = purpose;
         return DBErrors::LOAD_OK;
@@ -1104,12 +1109,13 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     DBErrors result = DBErrors::LOAD_OK;
     bool any_unordered = false;
 
+    const auto& log{pwallet->Log()};
     LOCK(pwallet->cs_wallet);
 
     // Last client version to open this wallet
     int last_client = CLIENT_VERSION;
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
-    if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
+    if (has_last_client) LogInfo(log, "Last client version = %d\n", last_client);
 
     try {
         // Load wallet flags, so they are known when processing other records.
@@ -1118,7 +1124,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
 #ifndef ENABLE_EXTERNAL_SIGNER
         if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-            pwallet->WalletLogPrintf("Error: External signer wallet being loaded without external signer support compiled\n");
+            LogInfo(log, "Error: External signer wallet being loaded without external signer support compiled\n");
             return DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED;
         }
 #endif
@@ -1149,7 +1155,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         // Any uncaught exceptions will be caught here and treated as critical.
         // Catch std::runtime_error specifically as many functions throw these and they at least have some message that
         // we can log
-        pwallet->WalletLogPrintf("%s\n", e.what());
+        LogInfo(log, "%s\n", e.what());
         result = DBErrors::CORRUPT;
     } catch (...) {
         // All other exceptions are still problematic, but we can't log them
@@ -1180,10 +1186,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Although wallets without private keys should not have *ckey records, we should double check that.
     // Removing the mkey records is only safe if there are no *ckey records.
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && pwallet->HasEncryptionKeys() && !pwallet->HaveCryptedKeys()) {
-        pwallet->WalletLogPrintf("Detected extraneous encryption keys in this wallet without private keys. Removing extraneous encryption keys.\n");
+        LogInfo(log, "Detected extraneous encryption keys in this wallet without private keys. Removing extraneous encryption keys.\n");
         for (const auto& [id, _] : pwallet->mapMasterKeys) {
             if (!EraseMasterKey(id)) {
-                pwallet->WalletLogPrintf("Error: Unable to remove extraneous encryption key '%u'. Wallet corrupt.\n", id);
+                LogInfo(log, "Error: Unable to remove extraneous encryption key '%u'. Wallet corrupt.\n", id);
                 return DBErrors::CORRUPT;
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -446,7 +446,7 @@ static DBErrors LoadWalletFlags(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIV
     uint64_t flags;
     if (batch.Read(DBKeys::FLAGS, flags)) {
         if (!pwallet->LoadWalletFlags(flags)) {
-            LogInfo(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
+            LogError(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
             return DBErrors::TOO_NEW;
         }
         // All wallets must be descriptor wallets unless opened with a bdb_ro db
@@ -475,7 +475,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
     Assume(!prefix.empty());
     std::unique_ptr<DatabaseCursor> cursor = batch.GetNewPrefixCursor(prefix);
     if (!cursor) {
-        LogInfo(log, "Error getting database cursor for '%s' records\n", key);
+        LogError(log, "Error getting database cursor for '%s' records\n", key);
         result.m_result = DBErrors::CORRUPT;
         return result;
     }
@@ -485,7 +485,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         if (status == DatabaseCursor::Status::DONE) {
             break;
         } else if (status == DatabaseCursor::Status::FAIL) {
-            LogInfo(log, "Error reading next '%s' record for wallet database\n", key);
+            LogError(log, "Error reading next '%s' record for wallet database\n", key);
             result.m_result = DBErrors::CORRUPT;
             return result;
         }
@@ -495,7 +495,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         std::string error;
         DBErrors record_res = load_func(pwallet, ssKey, ssValue, error);
         if (record_res != DBErrors::LOAD_OK) {
-            LogInfo(log, "%s\n", error);
+            LogError(log, "%s\n", error);
         }
         result.m_result = std::max(result.m_result, record_res);
         ++result.m_records;
@@ -547,7 +547,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
     // Make sure descriptor wallets don't have any legacy records
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         if (HasLegacyRecords(*pwallet, batch)) {
-            LogInfo(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
+            LogError(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
             return DBErrors::UNEXPECTED_LEGACY_ENTRY;
         }
 
@@ -955,7 +955,7 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
         value >> purpose_str;
         std::optional<AddressPurpose> purpose{PurposeFromString(purpose_str)};
         if (!purpose) {
-            LogInfo(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
+            LogWarning(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
         }
         pwallet->m_address_book[DecodeDestination(strAddress)].purpose = purpose;
         return DBErrors::LOAD_OK;
@@ -1156,7 +1156,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
 #ifndef ENABLE_EXTERNAL_SIGNER
         if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-            LogInfo(log, "Error: External signer wallet being loaded without external signer support compiled\n");
+            LogError(log, "Error: External signer wallet being loaded without external signer support compiled\n");
             return DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED;
         }
 #endif

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -441,11 +441,12 @@ bool LoadHDChain(CWallet* pwallet, DataStream& ssValue, std::string& strErr)
 
 static DBErrors LoadWalletFlags(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     uint64_t flags;
     if (batch.Read(DBKeys::FLAGS, flags)) {
         if (!pwallet->LoadWalletFlags(flags)) {
-            pwallet->WalletLogPrintf("Error reading wallet database: Unknown non-tolerable wallet flags found\n");
+            LogInfo(log, "Error reading wallet database: Unknown non-tolerable wallet flags found\n");
             return DBErrors::TOO_NEW;
         }
         // All wallets must be descriptor wallets unless opened with a bdb_ro db
@@ -470,10 +471,11 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
     DataStream ssKey;
     DataStream ssValue{};
 
+    const auto& log{Assert(pwallet)->Log()};
     Assume(!prefix.empty());
     std::unique_ptr<DatabaseCursor> cursor = batch.GetNewPrefixCursor(prefix);
     if (!cursor) {
-        pwallet->WalletLogPrintf("Error getting database cursor for '%s' records\n", key);
+        LogInfo(log, "Error getting database cursor for '%s' records\n", key);
         result.m_result = DBErrors::CORRUPT;
         return result;
     }
@@ -483,7 +485,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         if (status == DatabaseCursor::Status::DONE) {
             break;
         } else if (status == DatabaseCursor::Status::FAIL) {
-            pwallet->WalletLogPrintf("Error reading next '%s' record for wallet database\n", key);
+            LogInfo(log, "Error reading next '%s' record for wallet database\n", key);
             result.m_result = DBErrors::CORRUPT;
             return result;
         }
@@ -493,7 +495,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
         std::string error;
         DBErrors record_res = load_func(pwallet, ssKey, ssValue, error);
         if (record_res != DBErrors::LOAD_OK) {
-            pwallet->WalletLogPrintf("%s\n", error);
+            LogInfo(log, "%s\n", error);
         }
         result.m_result = std::max(result.m_result, record_res);
         ++result.m_records;
@@ -538,13 +540,14 @@ bool HasLegacyRecords(CWallet& wallet, DatabaseBatch& batch)
 
 static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
     // Make sure descriptor wallets don't have any legacy records
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         if (HasLegacyRecords(*pwallet, batch)) {
-            pwallet->WalletLogPrintf("Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
+            LogInfo(log, "Error: Unexpected legacy entry found in descriptor wallet %s. The wallet might have been tampered with or created with malicious intent.\n", pwallet->GetName());
             return DBErrors::UNEXPECTED_LEGACY_ENTRY;
         }
 
@@ -672,7 +675,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
                 }
             }
         } else {
-            pwallet->WalletLogPrintf("Inactive HD chains found but no LegacyDataSPKM\n");
+            LogInfo(log, "Inactive HD chains found but no LegacyDataSPKM\n");
             result = DBErrors::CORRUPT;
         }
     }
@@ -736,7 +739,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
 
     if (result <= DBErrors::NONCRITICAL_ERROR) {
         // Only do logging and time first key update if there were no critical errors
-        pwallet->WalletLogPrintf("Legacy Wallet Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total.\n",
+        LogInfo(log, "Legacy Wallet Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total.\n",
                key_res.m_records, ckey_res.m_records, keymeta_res.m_records, key_res.m_records + ckey_res.m_records);
     }
 
@@ -753,6 +756,7 @@ static DataStream PrefixStream(const Args&... args)
 
 static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
 
     // Load descriptor record
@@ -917,7 +921,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
     if (desc_res.m_result <= DBErrors::NONCRITICAL_ERROR) {
         // Only log if there are no critical errors
-        pwallet->WalletLogPrintf("Descriptors: %u, Descriptor Keys: %u plaintext, %u encrypted, %u total.\n",
+        LogInfo(log, "Descriptors: %u, Descriptor Keys: %u plaintext, %u encrypted, %u total.\n",
                desc_res.m_records, num_keys, num_ckeys, num_keys + num_ckeys);
     }
 
@@ -926,6 +930,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
 static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
+    const auto& log{pwallet->Log()};
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
@@ -943,14 +948,14 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
 
     // Load purpose record
     LoadResult purpose_res = LoadRecords(pwallet, batch, DBKeys::PURPOSE,
-        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        [&] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
         std::string strAddress;
         key >> strAddress;
         std::string purpose_str;
         value >> purpose_str;
         std::optional<AddressPurpose> purpose{PurposeFromString(purpose_str)};
         if (!purpose) {
-            pwallet->WalletLogPrintf("Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
+            LogInfo(log, "Warning: nonstandard purpose string '%s' for address '%s'\n", purpose_str, strAddress);
         }
         pwallet->m_address_book[DecodeDestination(strAddress)].purpose = purpose;
         return DBErrors::LOAD_OK;
@@ -1136,12 +1141,13 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     DBErrors result = DBErrors::LOAD_OK;
     bool any_unordered = false;
 
+    const auto& log{pwallet->Log()};
     LOCK(pwallet->cs_wallet);
 
     // Last client version to open this wallet
     int last_client = CLIENT_VERSION;
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
-    if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
+    if (has_last_client) LogInfo(log, "Last client version = %d\n", last_client);
 
     try {
         // Load wallet flags, so they are known when processing other records.
@@ -1150,7 +1156,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
 #ifndef ENABLE_EXTERNAL_SIGNER
         if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-            pwallet->WalletLogPrintf("Error: External signer wallet being loaded without external signer support compiled\n");
+            LogInfo(log, "Error: External signer wallet being loaded without external signer support compiled\n");
             return DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED;
         }
 #endif
@@ -1181,7 +1187,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         // Any uncaught exceptions will be caught here and treated as critical.
         // Catch std::runtime_error specifically as many functions throw these and they at least have some message that
         // we can log
-        pwallet->WalletLogPrintf("%s\n", e.what());
+        LogInfo(log, "%s\n", e.what());
         result = DBErrors::CORRUPT;
     } catch (...) {
         // All other exceptions are still problematic, but we can't log them
@@ -1212,10 +1218,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Although wallets without private keys should not have *ckey records, we should double check that.
     // Removing the mkey records is only safe if there are no *ckey records.
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && pwallet->HasEncryptionKeys() && !pwallet->HaveCryptedKeys()) {
-        pwallet->WalletLogPrintf("Detected extraneous encryption keys in this wallet without private keys. Removing extraneous encryption keys.\n");
+        LogInfo(log, "Detected extraneous encryption keys in this wallet without private keys. Removing extraneous encryption keys.\n");
         for (const auto& [id, _] : pwallet->mapMasterKeys) {
             if (!EraseMasterKey(id)) {
-                pwallet->WalletLogPrintf("Error: Unable to remove extraneous encryption key '%u'. Wallet corrupt.\n", id);
+                LogInfo(log, "Error: Unable to remove extraneous encryption key '%u'. Wallet corrupt.\n", id);
                 return DBErrors::CORRUPT;
             }
         }

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -20,7 +20,7 @@ namespace WalletTool {
 // deleter here.
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
-    wallet->WalletLogPrintf("Releasing wallet\n");
+    LogInfo(wallet->Log(), "Releasing wallet\n");
     wallet->Close();
     delete wallet;
 }


### PR DESCRIPTION
Make new logging macros `LogDebug()`, `LogTrace()`, `LogInfo()`, `LogWarning()`, and `LogError()` compatible with wallet code and drop custom `WalletLogPrintf()` function. The new logging macros introduced in #28318 weren't previously useful in wallet code because wallet code prefixes most log messages with the wallet names to be be able to distinguish log output from multiple wallets. Fix this by introducing a new `WalletLogContext` class inheriting from `util::log::Context` which can include the wallet name in log messages.

This change makes `-logsourcelocations` usable with wallet code because it logs actual source locations instead of the `WalletLogPrintf()` location.

---

<!-- begin based-on -->
**This is based on #34778 + #29256.** The non-base commits are:

- [`b45c6256226` wallet, logging: Replace WalletLogPrintf() with LogInfo()](https://github.com/bitcoin/bitcoin/pull/30343/commits/b45c62562261405e9c6c6986214bfd654a1f154a)
- [`1003d69de35` wallet, logging: Switch LogInfo to LogWarning/LogError](https://github.com/bitcoin/bitcoin/pull/30343/commits/1003d69de35ae96639c6906286687c11bbaf1a66)<!-- end -->