### PR TITLE
kernel: remove mempool_persist

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -950,7 +950,6 @@ libbitcoinkernel_la_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/disconnected_transactions.cpp \
-  kernel/mempool_persist.cpp \
   kernel/mempool_removal_reason.cpp \
   logging.cpp \
   node/blockstorage.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -192,7 +192,6 @@ BITCOIN_CORE_H = \
   kernel/mempool_entry.h \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \
-  kernel/mempool_persist.h \
   kernel/mempool_removal_reason.h \
   kernel/messagestartchars.h \
   kernel/notifications_interface.h \
@@ -228,6 +227,7 @@ BITCOIN_CORE_H = \
   node/interface_ui.h \
   node/kernel_notifications.h \
   node/mempool_args.h \
+  node/mempool_persist.h \
   node/mempool_persist_args.h \
   node/miner.h \
   node/mini_miner.h \
@@ -413,7 +413,6 @@ libbitcoin_node_a_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/disconnected_transactions.cpp \
-  kernel/mempool_persist.cpp \
   kernel/mempool_removal_reason.cpp \
   mapport.cpp \
   net.cpp \
@@ -435,6 +434,7 @@ libbitcoin_node_a_SOURCES = \
   node/interfaces.cpp \
   node/kernel_notifications.cpp \
   node/mempool_args.cpp \
+  node/mempool_persist.cpp \
   node/mempool_persist_args.cpp \
   node/miner.cpp \
   node/mini_miner.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,7 +8,6 @@
 #include <init.h>
 
 #include <kernel/checks.h>
-#include <kernel/mempool_persist.h>
 #include <kernel/validation_cache_sizes.h>
 
 #include <addrman.h>
@@ -51,6 +50,7 @@
 #include <node/interface_ui.h>
 #include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
+#include <node/mempool_persist.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
 #include <node/peerman_args.h>
@@ -119,8 +119,6 @@
 using common::AmountErrMsg;
 using common::InvalidPortErrMsg;
 using common::ResolveErrMsg;
-using kernel::DumpMempool;
-using kernel::LoadMempool;
 using kernel::ValidationCacheSizes;
 
 using node::ApplyArgsManOptions;
@@ -130,6 +128,8 @@ using node::CalculateCacheSizes;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINTPRIORITY;
 using node::DEFAULT_STOPATHEIGHT;
+using node::DumpMempool;
+using node::LoadMempool;
 using node::KernelNotifications;
 using node::LoadChainstate;
 using node::MempoolPath;

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kernel/mempool_persist.h>
+#include <node/mempool_persist.h>
 
 #include <clientversion.h>
 #include <consensus/amount.h>
@@ -33,7 +33,7 @@
 
 using fsbridge::FopenFn;
 
-namespace kernel {
+namespace node {
 
 static const uint64_t MEMPOOL_DUMP_VERSION_NO_XOR_KEY{1};
 static const uint64_t MEMPOOL_DUMP_VERSION{2};
@@ -218,4 +218,4 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
     return true;
 }
 
-} // namespace kernel
+} // namespace node

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_MEMPOOL_PERSIST_H
-#define BITCOIN_KERNEL_MEMPOOL_PERSIST_H
+#ifndef BITCOIN_NODE_MEMPOOL_PERSIST_H
+#define BITCOIN_NODE_MEMPOOL_PERSIST_H
 
 #include <util/fs.h>
 
 class Chainstate;
 class CTxMemPool;
 
-namespace kernel {
+namespace node {
 
 /** Dump the mempool to a file. */
 bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path,
@@ -28,7 +28,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path,
                  Chainstate& active_chainstate,
                  ImportMempoolOptions&& opts);
 
-} // namespace kernel
+} // namespace node
 
 
-#endif // BITCOIN_KERNEL_MEMPOOL_PERSIST_H
+#endif // BITCOIN_NODE_MEMPOOL_PERSIST_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -5,7 +5,7 @@
 
 #include <rpc/blockchain.h>
 
-#include <kernel/mempool_persist.h>
+#include <node/mempool_persist.h>
 
 #include <chainparams.h>
 #include <core_io.h>
@@ -27,7 +27,7 @@
 
 #include <utility>
 
-using kernel::DumpMempool;
+using node::DumpMempool;
 
 using node::DEFAULT_MAX_BURN_AMOUNT;
 using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
@@ -759,13 +759,13 @@ static RPCHelpMan importmempool()
             const UniValue& use_current_time{request.params[1]["use_current_time"]};
             const UniValue& apply_fee_delta{request.params[1]["apply_fee_delta_priority"]};
             const UniValue& apply_unbroadcast{request.params[1]["apply_unbroadcast_set"]};
-            kernel::ImportMempoolOptions opts{
+            node::ImportMempoolOptions opts{
                 .use_current_time = use_current_time.isNull() ? true : use_current_time.get_bool(),
                 .apply_fee_delta_priority = apply_fee_delta.isNull() ? false : apply_fee_delta.get_bool(),
                 .apply_unbroadcast_set = apply_unbroadcast.isNull() ? false : apply_unbroadcast.get_bool(),
             };
 
-            if (!kernel::LoadMempool(mempool, load_path, chainstate, std::move(opts))) {
+            if (!node::LoadMempool(mempool, load_path, chainstate, std::move(opts))) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Unable to import mempool file, see debug.log for details.");
             }
 

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kernel/mempool_persist.h>
+#include <node/mempool_persist.h>
 
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
@@ -21,8 +21,8 @@
 #include <cstdint>
 #include <vector>
 
-using kernel::DumpMempool;
-using kernel::LoadMempool;
+using node::DumpMempool;
+using node::LoadMempool;
 
 using node::MempoolPath;
 


### PR DESCRIPTION
DumpMempool/LoadMempool are not necessary for the kernel.

Noticed while working on instantiated logging.

I suppose these could have been left in on purpose, but I'm assuming it was probably just an oversight.