### PR TITLE
benchmark: Improve SipHash_32b accuracy to avoid potential optimization issues

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -192,10 +192,16 @@ static void SHA512(benchmark::Bench& bench)
 
 static void SipHash_32b(benchmark::Bench& bench)
 {
-    uint256 x;
-    uint64_t k1 = 0;
+    FastRandomContext rng{/*fDeterministic=*/true};
+    auto k0{rng.rand64()}, k1{rng.rand64()};
+    auto val{rng.rand256()};
+    auto i{0U};
     bench.run([&] {
-        *((uint64_t*)x.begin()) = SipHashUint256(0, ++k1, x);
+        ankerl::nanobench::doNotOptimizeAway(SipHashUint256(k0, k1, val));
+        ++k0;
+        ++k1;
+        ++i;
+        val.data()[i % uint256::size()] ^= i & 0xFF;
     });
 }
 


### PR DESCRIPTION
This PR stems from the discussions in https://github.com/bitcoin/bitcoin/pull/30317#discussion_r1649187336

The previous benchmark for `SipHash` was slightly less accurate in representing real-world usage and allowed for potential compiler optimizations that could invalidate the benchmark.
This change aims to ensure the benchmark produces more realistic results.

By modifying the initial values and only incrementing the bytes of `val`, the benchmark should reflects a more typical usage patterns - and prevent the compiler from optimizing away the calculations.

-------

On my M1 processor the benchmark's speed changed significantly (but the CI seems to produce the same result as before):

> cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCH=ON && cmake --build build -j10 &&
./build/src/bench/bench_bitcoin --filter=SipHash_32b --min-time=1000

Before:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               35.15 |       28,445,856.66 |    0.2% |      1.10 | `SipHash_32b`

After (note that only the benchmark changed):
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               22.05 |       45,350,886.64 |    0.3% |      1.10 | `SipHash_32b`
