### PR TITLE
doc: external-signer, example 'createwallet' RPC call requires eight argument

### DIFF
--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -37,7 +37,7 @@ The master key fingerprint is used to identify a device.
 Create a wallet, this automatically imports the public keys:
 
 ```sh
-$ bitcoin-cli createwallet "hww" true true "" true true true
+$ bitcoin-cli -named createwallet wallet_name="hww" disable_private_keys=true passphrase="" descriptors=true external_signer=true
 ```
 
 ### Verify an address


### PR DESCRIPTION
The eight argument 'true' is necessary to invoke the external signer upon creating the wallet. The parameter defaults to 'false' otherwise.