### PR TITLE
test: p2p: check that connecting to ourself leads to disconnect

### DIFF
--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -17,6 +17,7 @@ from test_framework.messages import (
     NODE_WITNESS,
 )
 from test_framework.p2p import P2PInterface
+from test_framework.util import p2p_port
 
 
 # Desirable service flags for outbound non-pruned and pruned peers. Note that
@@ -87,6 +88,12 @@ class P2PHandshakeTest(BitcoinTestFramework):
         self.log.info("Check that feeler connections get disconnected immediately")
         with node.assert_debug_log([f"feeler connection completed"]):
             self.add_outbound_connection(node, "feeler", NODE_NONE, wait_for_disconnect=True)
+
+        self.log.info("Check that connecting to ourself leads to immediate disconnect")
+        with node.assert_debug_log(["connected to self", "disconnecting"]):
+            node_listen_addr = f"127.0.0.1:{p2p_port(0)}"
+            node.addconnection(node_listen_addr, "outbound-full-relay", self.options.v2transport)
+        self.wait_until(lambda: len(node.getpeerinfo()) == 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This small PR adds test coverage for the scenario of connecting to ourself, leading to an immediate disconnect:
https://github.com/bitcoin/bitcoin/blob/2f6dca4d1c01ee47275a4292f128d714736837a1/src/net_processing.cpp#L3729-L3735

This logic has been first introduced by Satoshi in October 2009, together with a couple of other changes and a version bump to "v0.1.6 BETA" (see commit cc0b4c3b62367a2aebe5fc1f4d0ed4b97e9c2ac9).