### PR TITLE
logging: Replace LogError and LogWarning with LogAlert

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -724,7 +724,7 @@ General Bitcoin Core
 Logging
 -------
 
-The macros `LogInfo`, `LogDebug`, `LogTrace`, `LogWarning` and `LogError` are available for
+The macros `LogDebug`, `LogInfo`, `LogAlert`, and `LogTrace` are available for
 logging messages. They should be used as follows:
 
 - `LogDebug(BCLog::CATEGORY, fmt, params...)` is what you want
@@ -742,14 +742,8 @@ logging messages. They should be used as follows:
   attacker to fill up storage. Note that `LogPrintf(fmt, params...)` is
   a deprecated alias for `LogInfo`.
 
-- `LogError(fmt, params...)` should be used in place of `LogInfo` for
-  severe problems that require the node (or a subsystem) to shut down
-  entirely (e.g., insufficient storage space).
-
-- `LogWarning(fmt, params...)` should be used in place of `LogInfo` for
-  severe problems that the node admin should address, but are not
-  severe enough to warrant shutting down the node (e.g., system time
-  appears to be wrong, unknown soft fork appears to have activated).
+- `LogAlert(fmt, params...)` should be used in place of `LogInfo` for
+  potentially severe issues that the node admin should address.
 
 - `LogTrace(BCLog::CATEGORY, fmt, params...)` should be used in place of
   `LogDebug` for log messages that would be unusable on a production

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -42,7 +42,7 @@ bool SerializeDB(Stream& stream, const Data& data)
         hashwriter << Params().MessageStart() << data;
         stream << hashwriter.GetHash();
     } catch (const std::exception& e) {
-        LogError("%s: Serialize or I/O error - %s\n", __func__, e.what());
+        LogAlert("%s: Serialize or I/O error - %s\n", __func__, e.what());
         return false;
     }
 
@@ -63,7 +63,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (fileout.IsNull()) {
         fileout.fclose();
         remove(pathTmp);
-        LogError("%s: Failed to open file %s\n", __func__, fs::PathToString(pathTmp));
+        LogAlert("%s: Failed to open file %s\n", __func__, fs::PathToString(pathTmp));
         return false;
     }
 
@@ -76,7 +76,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     if (!FileCommit(fileout.Get())) {
         fileout.fclose();
         remove(pathTmp);
-        LogError("%s: Failed to flush file %s\n", __func__, fs::PathToString(pathTmp));
+        LogAlert("%s: Failed to flush file %s\n", __func__, fs::PathToString(pathTmp));
         return false;
     }
     fileout.fclose();
@@ -84,7 +84,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     // replace existing file, if any, with new file
     if (!RenameOver(pathTmp, path)) {
         remove(pathTmp);
-        LogError("%s: Rename-into-place failed\n", __func__);
+        LogAlert("%s: Rename-into-place failed\n", __func__);
         return false;
     }
 
@@ -142,7 +142,7 @@ bool CBanDB::Write(const banmap_t& banSet)
     }
 
     for (const auto& err : errors) {
-        LogError("%s\n", err);
+        LogAlert("%s\n", err);
     }
     return false;
 }

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -29,13 +29,13 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
 static void LogPrintLevelWithThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=1", "-debug=net"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", "test"); });
 }
 
 static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", "test"); });
 }
 
 static void LogPrintWithCategory(benchmark::Bench& bench)

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -361,7 +361,7 @@ static bool ExecuteBackedWrapper(Func func, const std::vector<std::function<void
         for (const auto& f : err_callbacks) {
             f();
         }
-        LogError("Error reading from database: %s\n", e.what());
+        LogAlert("Error reading from database: %s\n", e.what());
         // Starting the shutdown sequence and returning false to the caller would be
         // interpreted as 'entry not found' (as opposed to unable to read data), and
         // could lead to invalid interpretation. Just exit immediately, as we can't

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -82,17 +82,17 @@ bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
 {
     FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
     if (!file) {
-        LogError("%s: failed to open file %d\n", __func__, pos.nFile);
+        LogAlert("%s: failed to open file %d\n", __func__, pos.nFile);
         return false;
     }
     if (finalize && !TruncateFile(file, pos.nPos)) {
         fclose(file);
-        LogError("%s: failed to truncate file %d\n", __func__, pos.nFile);
+        LogAlert("%s: failed to truncate file %d\n", __func__, pos.nFile);
         return false;
     }
     if (!FileCommit(file)) {
         fclose(file);
-        LogError("%s: failed to commit file %d\n", __func__, pos.nFile);
+        LogAlert("%s: failed to commit file %d\n", __func__, pos.nFile);
         return false;
     }
     DirectoryCommit(m_dir);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -415,10 +415,10 @@ static void libevent_log_cb(int severity, const char *msg)
         level = BCLog::Level::Info;
         break;
     case EVENT_LOG_WARN:
-        level = BCLog::Level::Warning;
+        level = BCLog::Level::Alert;
         break;
     default: // EVENT_LOG_ERR and others are mapped to error
-        level = BCLog::Level::Error;
+        level = BCLog::Level::Alert;
         break;
     }
     LogPrintLevel(BCLog::LIBEVENT, level, "%s\n", msg);

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -148,7 +148,7 @@ bool Session::Listen(Connection& conn)
         conn.sock = StreamAccept();
         return true;
     } catch (const std::runtime_error& e) {
-        LogPrintLevel(BCLog::I2P, BCLog::Level::Error, "Couldn't listen: %s\n", e.what());
+        LogPrintLevel(BCLog::I2P, BCLog::Level::Alert, "Couldn't listen: %s\n", e.what());
         CheckControlSock();
     }
     return false;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -237,7 +237,7 @@ bool BaseIndex::Commit()
         }
     }
     if (!ok) {
-        LogError("%s: Failed to commit latest %s state\n", __func__, GetName());
+        LogAlert("%s: Failed to commit latest %s state\n", __func__, GetName());
         return false;
     }
     return true;

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -138,7 +138,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                LogError("%s: previous block header not found; expected %s\n",
+                LogAlert("%s: previous block header not found; expected %s\n",
                              __func__, expected_block_hash.ToString());
                 return false;
             }
@@ -246,14 +246,14 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
     for (int height = start_height; height <= stop_height; ++height) {
         if (!db_it.GetKey(key) || key.height != height) {
-            LogError("%s: unexpected key in %s: expected (%c, %d)\n",
+            LogAlert("%s: unexpected key in %s: expected (%c, %d)\n",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
             return false;
         }
 
         std::pair<uint256, DBVal> value;
         if (!db_it.GetValue(value)) {
-            LogError("%s: unable to read value in %s at key (%c, %d)\n",
+            LogAlert("%s: unable to read value in %s at key (%c, %d)\n",
                          __func__, index_name, DB_BLOCK_HEIGHT, height);
             return false;
         }
@@ -288,7 +288,7 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
             CBlock block;
 
             if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, *iter_tip)) {
-                LogError("%s: Failed to read block %s from disk\n",
+                LogAlert("%s: Failed to read block %s from disk\n",
                              __func__, iter_tip->GetBlockHash().ToString());
                 return false;
             }
@@ -357,7 +357,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
         // exist. Any other errors indicate database corruption or a disk
         // failure, and starting the index would cause further corruption.
         if (m_db->Exists(DB_MUHASH)) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
+            LogAlert("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -366,7 +366,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
     if (block) {
         DBVal entry;
         if (!LookUpOne(*m_db, *block, entry)) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
+            LogAlert("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -374,7 +374,7 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
         uint256 out;
         m_muhash.Finalize(out);
         if (entry.muhash != out) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
+            LogAlert("%s: Cannot read current %s state; index may be corrupted\n",
                          __func__, GetName());
             return false;
         }
@@ -429,7 +429,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                LogError("%s: previous block header not found; expected %s\n",
+                LogAlert("%s: previous block header not found; expected %s\n",
                              __func__, expected_block_hash.ToString());
                 return false;
             }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -81,23 +81,23 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
 
     AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
-        LogError("%s: OpenBlockFile failed\n", __func__);
+        LogAlert("%s: OpenBlockFile failed\n", __func__);
         return false;
     }
     CBlockHeader header;
     try {
         file >> header;
         if (fseek(file.Get(), postx.nTxOffset, SEEK_CUR)) {
-            LogError("%s: fseek(...) failed\n", __func__);
+            LogAlert("%s: fseek(...) failed\n", __func__);
             return false;
         }
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
-        LogError("%s: Deserialize or I/O error - %s\n", __func__, e.what());
+        LogAlert("%s: Deserialize or I/O error - %s\n", __func__, e.what());
         return false;
     }
     if (tx->GetHash() != tx_hash) {
-        LogError("%s: txid mismatch\n", __func__);
+        LogAlert("%s: txid mismatch\n", __func__);
         return false;
     }
     block_hash = header.GetHash();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -408,7 +408,7 @@ static void HandleSIGHUP(int)
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
 {
     if (!(*Assert(g_shutdown))()) {
-        LogError("Failed to send shutdown signal on Ctrl-C\n");
+        LogAlert("Failed to send shutdown signal on Ctrl-C\n");
         return false;
     }
     Sleep(INFINITE);
@@ -840,7 +840,7 @@ std::set<BlockFilterType> g_enabled_filter_types;
     // Since logging may itself allocate memory, set the handler directly
     // to terminate first.
     std::set_new_handler(std::terminate);
-    LogError("Out of memory. Terminating.\n");
+    LogAlert("Out of memory. Terminating.\n");
 
     // The log was successful, terminate now.
     std::terminate();
@@ -1168,9 +1168,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     scheduler.scheduleEvery([&args, &node]{
         constexpr uint64_t min_disk_space = 50 << 20; // 50 MB
         if (!CheckDiskSpace(args.GetBlocksDirPath(), min_disk_space)) {
-            LogError("Shutting down due to lack of disk space!\n");
+            LogAlert("Shutting down due to lack of disk space!\n");
             if (!(*Assert(node.shutdown))()) {
-                LogError("Failed to send shutdown signal after disk space check\n");
+                LogAlert("Failed to send shutdown signal after disk space check\n");
             }
         }
     }, std::chrono::minutes{5});
@@ -1576,7 +1576,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             try {
                 return f();
             } catch (const std::exception& e) {
-                LogError("%s\n", e.what());
+                LogAlert("%s\n", e.what());
                 return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error opening block database"));
             }
         };
@@ -1584,7 +1584,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             uiInterface.InitMessage(_("Verifying blocks…").translated);
             if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
-                LogWarning("Warning: pruned datadir may not have more than %d blocks; only checking available blocks\n",
+                LogAlert("Warning: pruned datadir may not have more than %d blocks; only checking available blocks\n",
                                   MIN_BLOCKS_TO_KEEP);
             }
             std::tie(status, error) = catch_exceptions([&]{ return VerifyLoadedChainstate(chainman, options);});
@@ -1608,10 +1608,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 if (fRet) {
                     do_reindex = true;
                     if (!Assert(node.shutdown)->reset()) {
-                        LogError("Internal error: failed to reset shutdown signal.\n");
+                        LogAlert("Internal error: failed to reset shutdown signal.\n");
                     }
                 } else {
-                    LogError("Aborted block database rebuild. Exiting.\n");
+                    LogAlert("Aborted block database rebuild. Exiting.\n");
                     return false;
                 }
             } else {
@@ -1747,7 +1747,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
             LogPrintf("Stopping after block import\n");
             if (!(*Assert(node.shutdown))()) {
-                LogError("Failed to send shutdown signal after finishing block import\n");
+                LogAlert("Failed to send shutdown signal after finishing block import\n");
             }
             return;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1584,7 +1584,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             uiInterface.InitMessage(_("Verifying blocks…").translated);
             if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
-                LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
+                LogWarning("Warning: pruned datadir may not have more than %d blocks; only checking available blocks\n",
                                   MIN_BLOCKS_TO_KEEP);
             }
             std::tie(status, error) = catch_exceptions([&]{ return VerifyLoadedChainstate(chainman, options);});

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -134,7 +134,7 @@ static bool ComputeUTXOStats(CCoinsView* view, CCoinsStats& stats, T hash_obj, c
             outputs[key.n] = std::move(coin);
             stats.coins_count++;
         } else {
-            LogError("%s: unable to read value\n", __func__);
+            LogAlert("%s: unable to read value\n", __func__);
             return false;
         }
         pcursor->Next();

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -129,7 +129,7 @@ bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
 
 bool BCLog::Logger::WillLogCategoryLevel(BCLog::LogFlags category, BCLog::Level level) const
 {
-    // Log messages at Info, Warning and Error level unconditionally, so that
+    // Log messages at Info and Alert levels unconditionally, so that
     // important troubleshooting information doesn't get lost.
     if (level >= BCLog::Level::Info) return true;
 
@@ -221,6 +221,8 @@ std::string BCLog::Logger::LogLevelToStr(BCLog::Level level)
         return "debug";
     case BCLog::Level::Info:
         return "info";
+    case BCLog::Level::Alert:
+        return "alert";
     case BCLog::Level::Warning:
         return "warning";
     case BCLog::Level::Error:
@@ -244,6 +246,8 @@ static std::optional<BCLog::Level> GetLogLevel(const std::string& level_str)
         return BCLog::Level::Debug;
     } else if (level_str == "info") {
         return BCLog::Level::Info;
+    } else if (level_str == "alert") {
+        return BCLog::Level::Alert;
     } else if (level_str == "warning") {
         return BCLog::Level::Warning;
     } else if (level_str == "error") {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -223,10 +223,6 @@ std::string BCLog::Logger::LogLevelToStr(BCLog::Level level)
         return "info";
     case BCLog::Level::Alert:
         return "alert";
-    case BCLog::Level::Warning:
-        return "warning";
-    case BCLog::Level::Error:
-        return "error";
     }
     assert(false);
 }
@@ -248,10 +244,6 @@ static std::optional<BCLog::Level> GetLogLevel(const std::string& level_str)
         return BCLog::Level::Info;
     } else if (level_str == "alert") {
         return BCLog::Level::Alert;
-    } else if (level_str == "warning") {
-        return BCLog::Level::Warning;
-    } else if (level_str == "error") {
-        return BCLog::Level::Error;
     } else {
         return std::nullopt;
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -75,6 +75,7 @@ namespace BCLog {
         Trace = 0, // High-volume or detailed logging for development/debugging
         Debug,     // Reasonably noisy logging, but still usable in production
         Info,      // Default
+        Alert,
         Warning,
         Error,
     };
@@ -237,6 +238,7 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
 
 // Log unconditionally.
 #define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, __VA_ARGS__)
+#define LogAlert(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Alert, __VA_ARGS__)
 #define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, __VA_ARGS__)
 #define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, __VA_ARGS__)
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -76,8 +76,6 @@ namespace BCLog {
         Debug,     // Reasonably noisy logging, but still usable in production
         Info,      // Default
         Alert,
-        Warning,
-        Error,
     };
     constexpr auto DEFAULT_LOG_LEVEL{Level::Debug};
 
@@ -239,8 +237,6 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
 // Log unconditionally.
 #define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, __VA_ARGS__)
 #define LogAlert(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Alert, __VA_ARGS__)
-#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, __VA_ARGS__)
-#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, __VA_ARGS__)
 
 // Deprecated unconditional logging.
 #define LogPrintf(...) LogInfo(__VA_ARGS__)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -378,7 +378,7 @@ static CAddress GetBindAddress(const Sock& sock)
     if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
         addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
     } else {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Warning: getsockname failed\n");
     }
     return addr_bind;
 }
@@ -1713,7 +1713,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     }
 
     if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr)) {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Warning: Unknown socket family\n");
     } else {
         addr = CAddress{MaybeFlipIPv6toCJDNS(addr), NODE_NONE};
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -378,7 +378,7 @@ static CAddress GetBindAddress(const Sock& sock)
     if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
         addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
     } else {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Warning: getsockname failed\n");
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "Warning: getsockname failed\n");
     }
     return addr_bind;
 }
@@ -583,7 +583,7 @@ void CNode::SetAddrLocal(const CService& addrLocalIn) {
     AssertLockNotHeld(m_addr_local_mutex);
     LOCK(m_addr_local_mutex);
     if (addrLocal.IsValid()) {
-        LogError("Addr local already set for node: %i. Refusing to change from %s to %s\n", id, addrLocal.ToStringAddrPort(), addrLocalIn.ToStringAddrPort());
+        LogAlert("Addr local already set for node: %i. Refusing to change from %s to %s\n", id, addrLocal.ToStringAddrPort(), addrLocalIn.ToStringAddrPort());
     } else {
         addrLocal = addrLocalIn;
     }
@@ -1713,7 +1713,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     }
 
     if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr)) {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Warning: Unknown socket family\n");
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "Warning: Unknown socket family\n");
     } else {
         addr = CAddress{MaybeFlipIPv6toCJDNS(addr), NODE_NONE};
     }
@@ -3029,14 +3029,14 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
     {
         strError = strprintf(Untranslated("Bind address family for %s not supported"), addrBind.ToStringAddrPort());
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", strError.original);
         return false;
     }
 
     std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
     if (!sock) {
         strError = strprintf(Untranslated("Couldn't open socket for incoming connections (socket returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", strError.original);
         return false;
     }
 
@@ -3071,7 +3071,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
             strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), PACKAGE_NAME);
         else
             strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", strError.original);
         return false;
     }
     LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
@@ -3080,7 +3080,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
     {
         strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "%s\n", strError.original);
         return false;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2463,7 +2463,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
             if (WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.IsBlockPruned(*pindex))) {
                 LogPrint(BCLog::NET, "Block was pruned before it could be read, disconnect peer=%s\n", pfrom.GetId());
             } else {
-                LogError("Cannot load block from disk, disconnect peer=%d\n", pfrom.GetId());
+                LogAlert("Cannot load block from disk, disconnect peer=%d\n", pfrom.GetId());
             }
             pfrom.fDisconnect = true;
             return;
@@ -2477,7 +2477,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
             if (WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.IsBlockPruned(*pindex))) {
                 LogPrint(BCLog::NET, "Block was pruned before it could be read, disconnect peer=%s\n", pfrom.GetId());
             } else {
-                LogError("Cannot load block from disk, disconnect peer=%d\n", pfrom.GetId());
+                LogAlert("Cannot load block from disk, disconnect peer=%d\n", pfrom.GetId());
             }
             pfrom.fDisconnect = true;
             return;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -364,7 +364,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
         IntrRecvError recvr;
         LogPrint(BCLog::NET, "SOCKS5 connecting %s\n", strDest);
         if (strDest.size() > 255) {
-            LogError("Hostname too long\n");
+            LogAlert("Hostname too long\n");
             return false;
         }
         // Construct the version identifier/method selection message
@@ -385,7 +385,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             return false;
         }
         if (pchRet1[0] != SOCKSVersion::SOCKS5) {
-            LogError("Proxy failed to initialize\n");
+            LogAlert("Proxy failed to initialize\n");
             return false;
         }
         if (pchRet1[1] == SOCKS5Method::USER_PASS && auth) {
@@ -393,7 +393,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             std::vector<uint8_t> vAuth;
             vAuth.push_back(0x01); // Current (and only) version of user/pass subnegotiation
             if (auth->username.size() > 255 || auth->password.size() > 255) {
-                LogError("Proxy username or password too long\n");
+                LogAlert("Proxy username or password too long\n");
                 return false;
             }
             vAuth.push_back(auth->username.size());
@@ -404,17 +404,17 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             LogPrint(BCLog::PROXY, "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
             uint8_t pchRetA[2];
             if (InterruptibleRecv(pchRetA, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
-                LogError("Error reading proxy authentication response\n");
+                LogAlert("Error reading proxy authentication response\n");
                 return false;
             }
             if (pchRetA[0] != 0x01 || pchRetA[1] != 0x00) {
-                LogError("Proxy authentication unsuccessful\n");
+                LogAlert("Proxy authentication unsuccessful\n");
                 return false;
             }
         } else if (pchRet1[1] == SOCKS5Method::NOAUTH) {
             // Perform no authentication
         } else {
-            LogError("Proxy requested wrong authentication method %02x\n", pchRet1[1]);
+            LogAlert("Proxy requested wrong authentication method %02x\n", pchRet1[1]);
             return false;
         }
         std::vector<uint8_t> vSocks5;
@@ -435,12 +435,12 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
                  * error message. */
                 return false;
             } else {
-                LogError("Error while reading proxy response\n");
+                LogAlert("Error while reading proxy response\n");
                 return false;
             }
         }
         if (pchRet2[0] != SOCKSVersion::SOCKS5) {
-            LogError("Proxy failed to accept request\n");
+            LogAlert("Proxy failed to accept request\n");
             return false;
         }
         if (pchRet2[1] != SOCKS5Reply::SUCCEEDED) {
@@ -449,7 +449,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             return false;
         }
         if (pchRet2[2] != 0x00) { // Reserved field must be 0
-            LogError("Error: malformed proxy response\n");
+            LogAlert("Error: malformed proxy response\n");
             return false;
         }
         uint8_t pchRet3[256];
@@ -459,7 +459,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
         case SOCKS5Atyp::DOMAINNAME: {
             recvr = InterruptibleRecv(pchRet3, 1, g_socks5_recv_timeout, sock);
             if (recvr != IntrRecvError::OK) {
-                LogError("Error reading from proxy\n");
+                LogAlert("Error reading from proxy\n");
                 return false;
             }
             int nRecv = pchRet3[0];
@@ -467,22 +467,22 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             break;
         }
         default: {
-            LogError("Error: malformed proxy response\n");
+            LogAlert("Error: malformed proxy response\n");
             return false;
         }
         }
         if (recvr != IntrRecvError::OK) {
-            LogError("Error reading from proxy\n");
+            LogAlert("Error reading from proxy\n");
             return false;
         }
         if (InterruptibleRecv(pchRet3, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
-            LogError("Error reading from proxy\n");
+            LogAlert("Error reading from proxy\n");
             return false;
         }
         LogPrint(BCLog::NET, "SOCKS5 connected %s\n", strDest);
         return true;
     } catch (const std::runtime_error& e) {
-        LogError("Error during SOCKS5 proxy handshake: %s\n", e.what());
+        LogAlert("Error during SOCKS5 proxy handshake: %s\n", e.what());
         return false;
     }
 }
@@ -613,7 +613,7 @@ std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connecti
 {
     auto sock = CreateSock(dest.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
     if (!sock) {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "Cannot create a socket for connecting to %s\n", dest.ToStringAddrPort());
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "Cannot create a socket for connecting to %s\n", dest.ToStringAddrPort());
         return {};
     }
 
@@ -641,7 +641,7 @@ std::unique_ptr<Sock> Proxy::Connect() const
 #ifdef HAVE_SOCKADDR_UN
     auto sock = CreateSock(AF_UNIX, SOCK_STREAM, 0);
     if (!sock) {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "Cannot create a socket for connecting to %s\n", m_unix_socket_path);
+        LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "Cannot create a socket for connecting to %s\n", m_unix_socket_path);
         return {};
     }
 

--- a/src/node/abort.cpp
+++ b/src/node/abort.cpp
@@ -21,7 +21,7 @@ void AbortNode(util::SignalInterrupt* shutdown, std::atomic<int>& exit_status, c
     InitError(_("A fatal internal error occurred, see debug.log for details: ") + message);
     exit_status.store(EXIT_FAILURE);
     if (shutdown && !(*shutdown)()) {
-        LogError("Failed to send shutdown signal\n");
+        LogAlert("Failed to send shutdown signal\n");
     };
 }
 } // namespace node

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -908,7 +908,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // untrimmed.
         if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
             LogPrintLevel(BCLog::BLOCKSTORAGE, BCLog::Level::Warning,
-                          "Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
+                          "Warning: Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
                           last_blockfile, finalize_undo, nFile);
         }
         // No undo data yet in the new file, so reset our undo-height tracking.

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -131,13 +131,13 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
                 pindexNew->nTx            = diskindex.nTx;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams)) {
-                    LogError("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
+                    LogAlert("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
                     return false;
                 }
 
                 pcursor->Next();
             } else {
-                LogError("%s: failed to read value\n", __func__);
+                LogAlert("%s: failed to read value\n", __func__);
                 return false;
             }
         } else {
@@ -433,7 +433,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
     for (CBlockIndex* pindex : vSortedByHeight) {
         if (m_interrupt) return false;
         if (previous_index && pindex->nHeight > previous_index->nHeight + 1) {
-            LogError("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
+            LogAlert("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
             return false;
         }
         previous_index = pindex;
@@ -673,7 +673,7 @@ bool BlockManager::UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos
     // Open history file to append
     AutoFile fileout{OpenUndoFile(pos)};
     if (fileout.IsNull()) {
-        LogError("%s: OpenUndoFile failed\n", __func__);
+        LogAlert("%s: OpenUndoFile failed\n", __func__);
         return false;
     }
 
@@ -684,7 +684,7 @@ bool BlockManager::UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos
     // Write undo data
     long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0) {
-        LogError("%s: ftell failed\n", __func__);
+        LogAlert("%s: ftell failed\n", __func__);
         return false;
     }
     pos.nPos = (unsigned int)fileOutPos;
@@ -706,7 +706,7 @@ bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex& in
     // Open history file to read
     AutoFile filein{OpenUndoFile(pos, true)};
     if (filein.IsNull()) {
-        LogError("%s: OpenUndoFile failed for %s\n", __func__, pos.ToString());
+        LogAlert("%s: OpenUndoFile failed for %s\n", __func__, pos.ToString());
         return false;
     }
 
@@ -718,13 +718,13 @@ bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex& in
         verifier >> blockundo;
         filein >> hashChecksum;
     } catch (const std::exception& e) {
-        LogError("%s: Deserialize or I/O error - %s at %s\n", __func__, e.what(), pos.ToString());
+        LogAlert("%s: Deserialize or I/O error - %s at %s\n", __func__, e.what(), pos.ToString());
         return false;
     }
 
     // Verify checksum
     if (hashChecksum != verifier.GetHash()) {
-        LogError("%s: Checksum mismatch at %s\n", __func__, pos.ToString());
+        LogAlert("%s: Checksum mismatch at %s\n", __func__, pos.ToString());
         return false;
     }
 
@@ -907,7 +907,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // a reindex. A flush error might also leave some of the data files
         // untrimmed.
         if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
-            LogPrintLevel(BCLog::BLOCKSTORAGE, BCLog::Level::Warning,
+            LogPrintLevel(BCLog::BLOCKSTORAGE, BCLog::Level::Alert,
                           "Warning: Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
                           last_blockfile, finalize_undo, nFile);
         }
@@ -981,7 +981,7 @@ bool BlockManager::WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const
     // Open history file to append
     AutoFile fileout{OpenBlockFile(pos)};
     if (fileout.IsNull()) {
-        LogError("%s: OpenBlockFile failed\n", __func__);
+        LogAlert("%s: OpenBlockFile failed\n", __func__);
         return false;
     }
 
@@ -992,7 +992,7 @@ bool BlockManager::WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const
     // Write block
     long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0) {
-        LogError("%s: ftell failed\n", __func__);
+        LogAlert("%s: ftell failed\n", __func__);
         return false;
     }
     pos.nPos = (unsigned int)fileOutPos;
@@ -1011,7 +1011,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     if (block.GetUndoPos().IsNull()) {
         FlatFilePos _pos;
         if (!FindUndoPos(state, block.nFile, _pos, ::GetSerializeSize(blockundo) + 40)) {
-            LogError("%s: FindUndoPos failed\n", __func__);
+            LogAlert("%s: FindUndoPos failed\n", __func__);
             return false;
         }
         if (!UndoWriteToDisk(blockundo, _pos, block.pprev->GetBlockHash())) {
@@ -1029,7 +1029,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
             // fact it is. Note though, that a failed flush might leave the data
             // file untrimmed.
             if (!FlushUndoFile(_pos.nFile, true)) {
-                LogPrintLevel(BCLog::BLOCKSTORAGE, BCLog::Level::Warning, "Failed to flush undo file %05i\n", _pos.nFile);
+                LogPrintLevel(BCLog::BLOCKSTORAGE, BCLog::Level::Alert, "Failed to flush undo file %05i\n", _pos.nFile);
             }
         } else if (_pos.nFile == cursor.file_num && block.nHeight > cursor.undo_height) {
             cursor.undo_height = block.nHeight;
@@ -1050,7 +1050,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
     // Open history file to read
     AutoFile filein{OpenBlockFile(pos, true)};
     if (filein.IsNull()) {
-        LogError("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
+        LogAlert("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
         return false;
     }
 
@@ -1058,19 +1058,19 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
     try {
         filein >> TX_WITH_WITNESS(block);
     } catch (const std::exception& e) {
-        LogError("%s: Deserialize or I/O error - %s at %s\n", __func__, e.what(), pos.ToString());
+        LogAlert("%s: Deserialize or I/O error - %s at %s\n", __func__, e.what(), pos.ToString());
         return false;
     }
 
     // Check the header
     if (!CheckProofOfWork(block.GetHash(), block.nBits, GetConsensus())) {
-        LogError("%s: Errors in block header at %s\n", __func__, pos.ToString());
+        LogAlert("%s: Errors in block header at %s\n", __func__, pos.ToString());
         return false;
     }
 
     // Signet only: check block solution
     if (GetConsensus().signet_blocks && !CheckSignetBlockSolution(block, GetConsensus())) {
-        LogError("%s: Errors in block solution at %s\n", __func__, pos.ToString());
+        LogAlert("%s: Errors in block solution at %s\n", __func__, pos.ToString());
         return false;
     }
 
@@ -1085,7 +1085,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex& index) co
         return false;
     }
     if (block.GetHash() != index.GetBlockHash()) {
-        LogError("%s: GetHash() doesn't match index for %s at %s\n", __func__, index.ToString(), block_pos.ToString());
+        LogAlert("%s: GetHash() doesn't match index for %s at %s\n", __func__, index.ToString(), block_pos.ToString());
         return false;
     }
     return true;
@@ -1097,13 +1097,13 @@ bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatF
     // If nPos is less than 8 the pos is null and we don't have the block data
     // Return early to prevent undefined behavior of unsigned int underflow
     if (hpos.nPos < 8) {
-        LogError("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
+        LogAlert("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
         return false;
     }
     hpos.nPos -= 8; // Seek back 8 bytes for meta header
     AutoFile filein{OpenBlockFile(hpos, true)};
     if (filein.IsNull()) {
-        LogError("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
+        LogAlert("%s: OpenBlockFile failed for %s\n", __func__, pos.ToString());
         return false;
     }
 
@@ -1114,14 +1114,14 @@ bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatF
         filein >> blk_start >> blk_size;
 
         if (blk_start != GetParams().MessageStart()) {
-            LogError("%s: Block magic mismatch for %s: %s versus expected %s\n", __func__, pos.ToString(),
+            LogAlert("%s: Block magic mismatch for %s: %s versus expected %s\n", __func__, pos.ToString(),
                          HexStr(blk_start),
                          HexStr(GetParams().MessageStart()));
             return false;
         }
 
         if (blk_size > MAX_SIZE) {
-            LogError("%s: Block data is larger than maximum deserialization size for %s: %s versus %s\n", __func__, pos.ToString(),
+            LogAlert("%s: Block data is larger than maximum deserialization size for %s: %s versus %s\n", __func__, pos.ToString(),
                          blk_size, MAX_SIZE);
             return false;
         }
@@ -1129,7 +1129,7 @@ bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatF
         block.resize(blk_size); // Zeroing of memory is intentional here
         filein.read(MakeWritableByteSpan(block));
     } catch (const std::exception& e) {
-        LogError("%s: Read from block file failed: %s for %s\n", __func__, e.what(), pos.ToString());
+        LogAlert("%s: Read from block file failed: %s for %s\n", __func__, e.what(), pos.ToString());
         return false;
     }
 
@@ -1144,7 +1144,7 @@ FlatFilePos BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight)
     nBlockSize += static_cast<unsigned int>(BLOCK_SERIALIZATION_HEADER_SIZE);
     FlatFilePos blockPos{FindNextBlockPos(nBlockSize, nHeight, block.GetBlockTime())};
     if (blockPos.IsNull()) {
-        LogError("%s: FindNextBlockPos failed\n", __func__);
+        LogAlert("%s: FindNextBlockPos failed\n", __func__);
         return FlatFilePos();
     }
     if (!WriteBlockToDisk(block, blockPos)) {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -131,7 +131,7 @@ public:
     void startShutdown() override
     {
         if (!(*Assert(Assert(m_context)->shutdown))()) {
-            LogError("Failed to send shutdown signal\n");
+            LogAlert("Failed to send shutdown signal\n");
         }
         // Stop RPC for clean shutdown if any of waitfor* commands is executed.
         if (args().GetBoolArg("-server", false)) {

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -53,7 +53,7 @@ kernel::InterruptResult KernelNotifications::blockTip(SynchronizationState state
     uiInterface.NotifyBlockTip(state, &index);
     if (m_stop_at_height && index.nHeight >= m_stop_at_height) {
         if (!m_shutdown()) {
-            LogError("Failed to send shutdown signal after reaching stop height\n");
+            LogAlert("Failed to send shutdown signal after reaching stop height\n");
         }
         return kernel::Interrupted{};
     }

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -60,7 +60,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
         "take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` "
         "RPC methods to get more info."
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
-    LogWarning("Warning: %s\n", msg.original);
+    LogAlert("Warning: %s\n", msg.original);
     m_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
     return true;
 }

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -60,7 +60,7 @@ bool TimeOffsets::WarnIfOutOfSync() const
         "take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` "
         "RPC methods to get more info."
     ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
-    LogWarning("%s\n", msg.original);
+    LogWarning("Warning: %s\n", msg.original);
     m_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
     return true;
 }

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -28,11 +28,11 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
     switch (style) {
     case CClientUIInterface::MSG_ERROR:
         strCaption = "Error: ";
-        if (!fSecure) LogError("%s\n", message.original);
+        if (!fSecure) LogError("%s%s\n", strCaption, message.original);
         break;
     case CClientUIInterface::MSG_WARNING:
         strCaption = "Warning: ";
-        if (!fSecure) LogWarning("%s\n", message.original);
+        if (!fSecure) LogWarning("%s%s\n", strCaption, message.original);
         break;
     case CClientUIInterface::MSG_INFORMATION:
         strCaption = "Information: ";

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -28,11 +28,11 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
     switch (style) {
     case CClientUIInterface::MSG_ERROR:
         strCaption = "Error: ";
-        if (!fSecure) LogError("%s%s\n", strCaption, message.original);
+        if (!fSecure) LogAlert("%s%s\n", strCaption, message.original);
         break;
     case CClientUIInterface::MSG_WARNING:
         strCaption = "Warning: ";
-        if (!fSecure) LogWarning("%s%s\n", strCaption, message.original);
+        if (!fSecure) LogAlert("%s%s\n", strCaption, message.original);
         break;
     case CClientUIInterface::MSG_INFORMATION:
         strCaption = "Information: ";

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -57,7 +57,7 @@ static const int NUM_OS_RANDOM_BYTES = 32;
 
 [[noreturn]] void RandFailure()
 {
-    LogError("Failed to read randomness, aborting\n");
+    LogAlert("Failed to read randomness, aborting\n");
     std::abort();
 }
 

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -158,7 +158,7 @@ bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
 bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
-        LogError("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid\n", MAX_SCRIPT_ELEMENT_SIZE);
+        LogAlert("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid\n", MAX_SCRIPT_ELEMENT_SIZE);
         return false;
     }
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -115,8 +115,8 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacrosDeprecated, LogSetup)
     LogPrintLevel(BCLog::NET, BCLog::Level::Trace, "foo4: %s\n", "bar4"); // not logged
     LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "foo7: %s\n", "bar7");
     LogPrintLevel(BCLog::NET, BCLog::Level::Info, "foo8: %s\n", "bar8");
-    LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "foo9: %s\n", "bar9");
-    LogPrintLevel(BCLog::NET, BCLog::Level::Error, "foo10: %s\n", "bar10");
+    LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "foo9: %s\n", "bar9");
+    LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "foo10: %s\n", "bar10");
     LogPrintfCategory(BCLog::VALIDATION, "foo11: %s\n", "bar11");
     std::ifstream file{tmp_log_path};
     std::vector<std::string> log_lines;
@@ -128,8 +128,8 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacrosDeprecated, LogSetup)
         "[net] foo6: bar6",
         "[net] foo7: bar7",
         "[net:info] foo8: bar8",
-        "[net:warning] foo9: bar9",
-        "[net:error] foo10: bar10",
+        "[net:alert] foo9: bar9",
+        "[net:alert] foo10: bar10",
         "[validation:info] foo11: bar11",
     };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
@@ -140,8 +140,8 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
     LogTrace(BCLog::NET, "foo6: %s\n", "bar6"); // not logged
     LogDebug(BCLog::NET, "foo7: %s\n", "bar7");
     LogInfo("foo8: %s\n", "bar8");
-    LogWarning("foo9: %s\n", "bar9");
-    LogError("foo10: %s\n", "bar10");
+    LogAlert("foo9: %s\n", "bar9");
+    LogAlert("foo10: %s\n", "bar10");
     std::ifstream file{tmp_log_path};
     std::vector<std::string> log_lines;
     for (std::string log; std::getline(file, log);) {
@@ -150,8 +150,8 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
     std::vector<std::string> expected = {
         "[net] foo7: bar7",
         "foo8: bar8",
-        "[warning] foo9: bar9",
-        "[error] foo10: bar10",
+        "[alert] foo9: bar9",
+        "[alert] foo10: bar10",
     };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -196,20 +196,20 @@ BOOST_FIXTURE_TEST_CASE(logging_SeverityLevels, LogSetup)
     // Global log level
     LogPrintLevel(BCLog::HTTP, BCLog::Level::Info, "foo1: %s\n", "bar1");
     LogPrintLevel(BCLog::MEMPOOL, BCLog::Level::Trace, "foo2: %s. This log level is lower than the global one.\n", "bar2");
-    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Warning, "foo3: %s\n", "bar3");
-    LogPrintLevel(BCLog::RPC, BCLog::Level::Error, "foo4: %s\n", "bar4");
+    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Alert, "foo3: %s\n", "bar3");
+    LogPrintLevel(BCLog::RPC, BCLog::Level::Alert, "foo4: %s\n", "bar4");
 
     // Category-specific log level
-    LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "foo5: %s\n", "bar5");
+    LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "foo5: %s\n", "bar5");
     LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "foo6: %s. This log level is the same as the global one but lower than the category-specific one, which takes precedence. \n", "bar6");
-    LogPrintLevel(BCLog::NET, BCLog::Level::Error, "foo7: %s\n", "bar7");
+    LogPrintLevel(BCLog::NET, BCLog::Level::Alert, "foo7: %s\n", "bar7");
 
     std::vector<std::string> expected = {
         "[http:info] foo1: bar1",
-        "[validation:warning] foo3: bar3",
-        "[rpc:error] foo4: bar4",
-        "[net:warning] foo5: bar5",
-        "[net:error] foo7: bar7",
+        "[validation:alert] foo3: bar3",
+        "[rpc:alert] foo4: bar4",
+        "[net:alert] foo5: bar5",
+        "[net:alert] foo7: bar7",
     };
     std::ifstream file{tmp_log_path};
     std::vector<std::string> log_lines;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -100,7 +100,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
         std::vector<uint256> old_heads = GetHeadBlocks();
         if (old_heads.size() == 2) {
             if (old_heads[0] != hashBlock) {
-                LogPrintLevel(BCLog::COINDB, BCLog::Level::Error, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
+                LogPrintLevel(BCLog::COINDB, BCLog::Level::Alert, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
             }
             assert(old_heads[0] == hashBlock);
             old_tip = old_heads[1];

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -277,7 +277,7 @@ CTxMemPool::setEntries CTxMemPool::AssumeCalculateMemPoolAncestors(
 {
     auto result{CalculateMemPoolAncestors(entry, limits, fSearchForParents)};
     if (!Assume(result)) {
-        LogPrintLevel(BCLog::MEMPOOL, BCLog::Level::Error, "%s: CalculateMemPoolAncestors failed unexpectedly, continuing with empty ancestor set (%s)\n",
+        LogPrintLevel(BCLog::MEMPOOL, BCLog::Level::Alert, "%s: CalculateMemPoolAncestors failed unexpectedly, continuing with empty ancestor set (%s)\n",
                       calling_fn_name, util::ErrorString(result).original);
     }
     return std::move(result).value_or(CTxMemPool::setEntries{});

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -564,7 +564,7 @@ public:
      * Same as CalculateMemPoolAncestors, but always returns a (non-optional) setEntries.
      * Should only be used when it is assumed CalculateMemPoolAncestors would not fail. If
      * CalculateMemPoolAncestors does unexpectedly fail, an empty setEntries is returned and the
-     * error is logged to BCLog::MEMPOOL with level BCLog::Level::Error. In debug builds, failure
+     * error is logged to BCLog::MEMPOOL with level BCLog::Level::Alert. In debug builds, failure
      * of CalculateMemPoolAncestors will lead to shutdown due to assertion failure.
      *
      * @param[in]   calling_fn_name     Name of calling function so we can properly log the call site

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -68,7 +68,7 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
     }
     auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
     if (!lock->TryLock()) {
-        LogError("Error while attempting to lock directory %s: %s\n", fs::PathToString(directory), lock->GetReason());
+        LogAlert("Error while attempting to lock directory %s: %s\n", fs::PathToString(directory), lock->GetReason());
         return LockResult::ErrorLock;
     }
     if (!probe_only) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2267,12 +2267,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
 
     CBlockUndo blockUndo;
     if (!m_blockman.UndoReadFromDisk(blockUndo, *pindex)) {
-        LogError("DisconnectBlock(): failure reading undo data\n");
+        LogAlert("DisconnectBlock(): failure reading undo data\n");
         return DISCONNECT_FAILED;
     }
 
     if (blockUndo.vtxundo.size() + 1 != block.vtx.size()) {
-        LogError("DisconnectBlock(): block and undo data inconsistent\n");
+        LogAlert("DisconnectBlock(): block and undo data inconsistent\n");
         return DISCONNECT_FAILED;
     }
 
@@ -2311,7 +2311,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         if (i > 0) { // not coinbases
             CTxUndo &txundo = blockUndo.vtxundo[i-1];
             if (txundo.vprevout.size() != tx.vin.size()) {
-                LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
+                LogAlert("DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
             for (unsigned int j = tx.vin.size(); j > 0;) {
@@ -2435,7 +2435,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // problems.
             return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
         }
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
+        LogAlert("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -2622,7 +2622,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
                             tx_state.GetRejectReason(), tx_state.GetDebugMessage());
-                LogError("%s: Consensus::CheckTxInputs: %s, %s\n", __func__, tx.GetHash().ToString(), state.ToString());
+                LogAlert("%s: Consensus::CheckTxInputs: %s, %s\n", __func__, tx.GetHash().ToString(), state.ToString());
                 return false;
             }
             nFees += txfee;
@@ -2664,7 +2664,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
                               tx_state.GetRejectReason(), tx_state.GetDebugMessage());
-                LogError("ConnectBlock(): CheckInputScripts on %s failed with %s\n",
+                LogAlert("ConnectBlock(): CheckInputScripts on %s failed with %s\n",
                     tx.GetHash().ToString(), state.ToString());
                 return false;
             }
@@ -2868,7 +2868,7 @@ bool Chainstate::FlushStateToDisk(
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Warning, "%s: Warning: Failed to flush block file.\n", __func__);
+                    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Alert, "%s: Warning: Failed to flush block file.\n", __func__);
                 }
             }
 
@@ -3035,7 +3035,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
     if (!m_blockman.ReadBlockFromDisk(block, *pindexDelete)) {
-        LogError("DisconnectTip(): Failed to read block\n");
+        LogAlert("DisconnectTip(): Failed to read block\n");
         return false;
     }
     // Apply the block atomically to the chain state.
@@ -3044,7 +3044,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
-            LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
+            LogAlert("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
         bool flushed = view.Flush();
@@ -3170,7 +3170,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            LogAlert("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
             return false;
         }
         time_3 = SteadyClock::now();
@@ -3842,7 +3842,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     auto prev_tx_sum = [](CBlockIndex& block) { return block.nTx + (block.pprev ? block.pprev->nChainTx : 0); };
     if (!Assume(pindexNew->nChainTx == 0 || pindexNew->nChainTx == prev_tx_sum(*pindexNew) ||
                 pindexNew == GetSnapshotBaseBlock())) {
-        LogWarning("Internal bug detected: block %d has unexpected nChainTx %i that should be %i (%s %s). Please report this issue here: %s\n",
+        LogAlert("Internal bug detected: block %d has unexpected nChainTx %i that should be %i (%s %s). Please report this issue here: %s\n",
             pindexNew->nHeight, pindexNew->nChainTx, prev_tx_sum(*pindexNew), PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT);
         pindexNew->nChainTx = 0;
     }
@@ -3870,7 +3870,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             // assumeutxo snapshot block if assumeutxo snapshot metadata has an
             // incorrect hardcoded AssumeutxoData::nChainTx value.
             if (!Assume(pindex->nChainTx == 0 || pindex->nChainTx == prev_tx_sum(*pindex))) {
-                LogWarning("Internal bug detected: block %d has unexpected nChainTx %i that should be %i (%s %s). Please report this issue here: %s\n",
+                LogAlert("Internal bug detected: block %d has unexpected nChainTx %i that should be %i (%s %s). Please report this issue here: %s\n",
                    pindex->nHeight, pindex->nChainTx, prev_tx_sum(*pindex), PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT);
             }
             pindex->nChainTx = prev_tx_sum(*pindex);
@@ -4474,7 +4474,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             pindex->nStatus |= BLOCK_FAILED_VALID;
             m_blockman.m_dirty_blockindex.insert(pindex);
         }
-        LogError("%s: %s\n", __func__, state.ToString());
+        LogAlert("%s: %s\n", __func__, state.ToString());
         return false;
     }
 
@@ -4544,7 +4544,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
             if (m_options.signals) {
                 m_options.signals->BlockChecked(*block, state);
             }
-            LogError("%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
+            LogAlert("%s: AcceptBlock FAILED (%s)\n", __func__, state.ToString());
             return false;
         }
     }
@@ -4553,14 +4553,14 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
     if (!ActiveChainstate().ActivateBestChain(state, block)) {
-        LogError("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
+        LogAlert("%s: ActivateBestChain failed (%s)\n", __func__, state.ToString());
         return false;
     }
 
     Chainstate* bg_chain{WITH_LOCK(cs_main, return BackgroundSyncInProgress() ? m_ibd_chainstate.get() : nullptr)};
     BlockValidationState bg_state;
     if (bg_chain && !bg_chain->ActivateBestChain(bg_state, block)) {
-        LogError("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
+        LogAlert("%s: [background] ActivateBestChain failed (%s)\n", __func__, bg_state.ToString());
         return false;
      }
 
@@ -4600,15 +4600,15 @@ bool TestBlockValidity(BlockValidationState& state,
 
     // NOTE: CheckBlockHeader is called by CheckBlock
     if (!ContextualCheckBlockHeader(block, state, chainstate.m_blockman, chainstate.m_chainman, pindexPrev)) {
-        LogError("%s: Consensus::ContextualCheckBlockHeader: %s\n", __func__, state.ToString());
+        LogAlert("%s: Consensus::ContextualCheckBlockHeader: %s\n", __func__, state.ToString());
         return false;
     }
     if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot)) {
-        LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
+        LogAlert("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
     }
     if (!ContextualCheckBlock(block, state, chainstate.m_chainman, pindexPrev)) {
-        LogError("%s: Consensus::ContextualCheckBlock: %s\n", __func__, state.ToString());
+        LogAlert("%s: Consensus::ContextualCheckBlock: %s\n", __func__, state.ToString());
         return false;
     }
     if (!chainstate.ConnectBlock(block, state, &indexDummy, viewNew, true)) {
@@ -4814,7 +4814,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     // TODO: merge with ConnectBlock
     CBlock block;
     if (!m_blockman.ReadBlockFromDisk(block, *pindex)) {
-        LogError("ReplayBlock(): ReadBlockFromDisk failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+        LogAlert("ReplayBlock(): ReadBlockFromDisk failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
         return false;
     }
 
@@ -4840,7 +4840,7 @@ bool Chainstate::ReplayBlocks()
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
     if (hashHeads.empty()) return true; // We're already in a consistent state.
     if (hashHeads.size() != 2) {
-        LogError("ReplayBlocks(): unknown inconsistent state\n");
+        LogAlert("ReplayBlocks(): unknown inconsistent state\n");
         return false;
     }
 
@@ -4852,14 +4852,14 @@ bool Chainstate::ReplayBlocks()
     const CBlockIndex* pindexFork = nullptr; // Latest block common to both the old and the new tip.
 
     if (m_blockman.m_block_index.count(hashHeads[0]) == 0) {
-        LogError("ReplayBlocks(): reorganization to unknown block requested\n");
+        LogAlert("ReplayBlocks(): reorganization to unknown block requested\n");
         return false;
     }
     pindexNew = &(m_blockman.m_block_index[hashHeads[0]]);
 
     if (!hashHeads[1].IsNull()) { // The old tip is allowed to be 0, indicating it's the first flush.
         if (m_blockman.m_block_index.count(hashHeads[1]) == 0) {
-            LogError("ReplayBlocks(): reorganization from unknown block requested\n");
+            LogAlert("ReplayBlocks(): reorganization from unknown block requested\n");
             return false;
         }
         pindexOld = &(m_blockman.m_block_index[hashHeads[1]]);
@@ -4872,13 +4872,13 @@ bool Chainstate::ReplayBlocks()
         if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
             CBlock block;
             if (!m_blockman.ReadBlockFromDisk(block, *pindexOld)) {
-                LogError("RollbackBlock(): ReadBlockFromDisk() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                LogAlert("RollbackBlock(): ReadBlockFromDisk() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;
             }
             LogPrintf("Rolling back %s (%i)\n", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
             DisconnectResult res = DisconnectBlock(block, pindexOld, cache);
             if (res == DISCONNECT_FAILED) {
-                LogError("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
+                LogAlert("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;
             }
             // If DISCONNECT_UNCLEAN is returned, it means a non-existing UTXO was deleted, or an existing UTXO was
@@ -4985,13 +4985,13 @@ bool Chainstate::LoadGenesisBlock()
         const CBlock& block = params.GenesisBlock();
         FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, 0)};
         if (blockPos.IsNull()) {
-            LogError("%s: writing genesis block to disk failed\n", __func__);
+            LogAlert("%s: writing genesis block to disk failed\n", __func__);
             return false;
         }
         CBlockIndex* pindex = m_blockman.AddToBlockIndex(block, m_chainman.m_best_header);
         m_chainman.ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        LogError("%s: failed to write genesis block: %s\n", __func__, e.what());
+        LogAlert("%s: failed to write genesis block: %s\n", __func__, e.what());
         return false;
     }
 
@@ -5542,7 +5542,7 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pin
         return 0.0;
 
     if (!Assume(pindex->nChainTx > 0)) {
-        LogWarning("Internal bug detected: block %d has unset nChainTx (%s %s). Please report this issue here: %s\n",
+        LogAlert("Internal bug detected: block %d has unset nChainTx (%s %s). Please report this issue here: %s\n",
                    pindex->nHeight, PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT);
         return 0.0;
     }
@@ -6071,8 +6071,8 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
             PACKAGE_NAME, snapshot_tip_height, snapshot_base_height, snapshot_base_height, PACKAGE_BUGREPORT
         );
 
-        LogError("[snapshot] !!! %s\n", user_error.original);
-        LogError("[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
+        LogAlert("[snapshot] !!! %s\n", user_error.original);
+        LogAlert("[snapshot] deleting snapshot, reverting to validated chain, and stopping node\n");
 
         m_active_chainstate = m_ibd_chainstate.get();
         m_snapshot_chainstate->m_disabled = true;
@@ -6425,7 +6425,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
-        LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
+        LogAlert("[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
         GetNotifications().fatalError(strprintf(_(
             "Rename of '%s' -> '%s' failed. "

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2868,7 +2868,7 @@ bool Chainstate::FlushStateToDisk(
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Warning, "%s: Failed to flush block file.\n", __func__);
+                    LogPrintLevel(BCLog::VALIDATION, BCLog::Level::Warning, "%s: Warning: Failed to flush block file.\n", __func__);
                 }
             }
 

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -22,6 +22,7 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
     'LogConnectFailure,1',
     'LogError,0',
     'LogWarning,0',
+    'LogAlert,0',
     'LogInfo,0',
     'LogDebug,1',
     'LogTrace,1',

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -20,8 +20,6 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
     'fprintf,1',
     'tfm::format,1',  # Assuming tfm::::format(std::ostream&, ...
     'LogConnectFailure,1',
-    'LogError,0',
-    'LogWarning,0',
     'LogAlert,0',
     'LogInfo,0',
     'LogDebug,1',


### PR DESCRIPTION
Replace `LogError` and `LogWarning` with `LogAlert` to make it easier to choose the correct logging levels to use and avoid log spam. 

This PR implements an idea ajtowns came up with in [#30347 (comment)](https://github.com/bitcoin/bitcoin/pull/30347#discussion_r1659096893) and it reduces the decision tree for chosing log levels to:

```mermaid
flowchart TD
    start-->|No|dbg
    start{{Is this critical information?}}-->|Yes|crit

    dbg-->|No|logtrace(Trace + Category)
    dbg{{Is this moderate volume?}}-->|Yes|logdebug(Debug + Category)

    crit{{Is there a problem?}}-->|No|loginfo(Info)
    crit-->|Yes|logfatal(Alert)
```