### PR TITLE
#27307 follow-up: update mempool conflict tests + docs

### DIFF
--- a/doc/release-notes-27307.md
+++ b/doc/release-notes-27307.md
@@ -1,0 +1,8 @@
+Wallet
+---
+
+The wallet now detects when wallet transactions conflict with the mempool. Mempool
+conflicting transactions can be seen in the `"mempoolconflicts"` field of
+`gettransaction`. The inputs of mempool conflicted transactions can now be respent
+without manually abandoning the transactions when the parent transaction is dropped
+from the mempool, which can cause wallet balances to appear higher.

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -415,13 +415,13 @@ static std::vector<RPCResult> TransactionDescriptionString()
            {RPCResult::Type::NUM_TIME, "blocktime", /*optional=*/true, "The block time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
            {RPCResult::Type::STR_HEX, "wtxid", "The hash of serialized transaction, including witness data."},
-           {RPCResult::Type::ARR, "walletconflicts", "Conflicting transaction ids.",
+           {RPCResult::Type::ARR, "walletconflicts", "Confirmed transactions that have been detected by the wallet to conflict with this transaction.",
            {
                {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
            }},
            {RPCResult::Type::STR_HEX, "replaced_by_txid", /*optional=*/true, "Only if 'category' is 'send'. The txid if this tx was replaced."},
            {RPCResult::Type::STR_HEX, "replaces_txid", /*optional=*/true, "Only if 'category' is 'send'. The txid if this tx replaces another."},
-           {RPCResult::Type::ARR, "mempoolconflicts", "Transactions that directly conflict with either this transaction or an ancestor transaction",
+           {RPCResult::Type::ARR, "mempoolconflicts", "Transactions in the mempool that directly conflict with either this transaction or an ancestor transaction",
            {
                {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
            }},

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -9,7 +9,6 @@ Test that wallet correctly tracks transactions that have been conflicted by bloc
 
 from decimal import Decimal
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
         assert_equal,
@@ -37,7 +36,6 @@ class TxConflicts(BitcoinTestFramework):
         """
 
         self.test_block_conflicts()
-        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 7, self.nodes[2].getnewaddress())
         self.test_mempool_conflict()
         self.test_mempool_and_block_conflicts()
         self.test_descendants_with_mempool_conflicts()


### PR DESCRIPTION
#27307 follow-up:
- updates description of `mempoolconflicts` and `walletconflicts` in `gettransaction`
- adds release notes for 27307
- removes unnecessary line from `wallet_conflicts.py`