### PR TITLE
ci: Clear unused /msan/llvm-project

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -65,6 +65,10 @@ if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
     -S /msan/llvm-project/runtimes
 
   ninja -C /msan/cxx_build/ "-j$( nproc )"  # Use nproc, because MAKEJOBS is the default in docker image builds
+
+  # Clear no longer needed source folder
+  du -sh /msan/llvm-project
+  rm -rf /msan/llvm-project
 fi
 
 if [[ "${RUN_TIDY}" == "true" ]]; then


### PR DESCRIPTION
Could help to fix the `no space left on device` that are sometimes seen.