### PR TITLE
sync: improve CCoinsViewCache ReallocateCache - 2nd try

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -317,10 +317,15 @@ void CCoinsViewCache::ReallocateCache()
 {
     // Cache should be empty when we're calling this.
     assert(cacheCoins.size() == 0);
+    auto current_bucket_count = cacheCoins.bucket_count();
     cacheCoins.~CCoinsMap();
     m_cache_coins_memory_resource.~CCoinsMapMemoryResource();
     ::new (&m_cache_coins_memory_resource) CCoinsMapMemoryResource{};
     ::new (&cacheCoins) CCoinsMap{0, SaltedOutpointHasher{/*deterministic=*/m_deterministic}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
+
+    // After a flush all the cacheCoins's memory has now been freed. It is likely that the map gets full again so flush is necessary, and it will
+    // happen around the same memory usage. So we can already reserve the bucket array to the previous size, reducing the number of rehashes needed.
+    cacheCoins.reserve(current_bucket_count);
 }
 
 void CCoinsViewCache::SanityCheck() const

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -250,14 +250,16 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
     return true;
 }
 
-bool CCoinsViewCache::Flush() {
+bool CCoinsViewCache::Flush(bool reallocate_cache) {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock, /*erase=*/true);
     if (fOk) {
         if (!cacheCoins.empty()) {
             /* BatchWrite must erase all cacheCoins elements when erase=true. */
             throw std::logic_error("Not all cached coins were erased");
         }
-        ReallocateCache();
+        if (reallocate_cache) {
+            ReallocateCache();
+        }
     }
     cachedCoinsUsage = 0;
     return fOk;

--- a/src/coins.h
+++ b/src/coins.h
@@ -304,7 +304,8 @@ public:
     /**
      * Push the modifications applied to this cache to its base and wipe local state.
      * Failure to call this method or Sync() before destruction will cause the changes
-     * to be forgotten.
+     * to be forgotten. By default, this forces a reallocation of the cache map at the
+     * end but this can be skipped by passing false.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
     bool Flush(bool reallocate_cache = true);

--- a/src/coins.h
+++ b/src/coins.h
@@ -307,7 +307,7 @@ public:
      * to be forgotten.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
-    bool Flush();
+    bool Flush(bool reallocate_cache = true);
 
     /**
      * Push the modifications applied to this cache to its base while retaining

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -76,7 +76,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 assert(expected_code_path);
             },
             [&] {
-                (void)coins_view_cache.Flush();
+                (void)coins_view_cache.Flush(fuzzed_data_provider.ConsumeBool());
             },
             [&] {
                 (void)coins_view_cache.Sync();

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -402,7 +402,8 @@ FUZZ_TARGET(coinscache_sim)
                 // Apply to simulation data.
                 flush();
                 // Apply to real caches.
-                caches.back()->Flush();
+                // When the parameter is true this also covers ReallocateCache().
+                caches.back()->Flush(provider.ConsumeBool());
             },
 
             [&]() { // Sync.
@@ -410,14 +411,6 @@ FUZZ_TARGET(coinscache_sim)
                 flush();
                 // Apply to real caches.
                 caches.back()->Sync();
-            },
-
-            [&]() { // Flush + ReallocateCache.
-                // Apply to simulation data.
-                flush();
-                // Apply to real caches.
-                caches.back()->Flush();
-                caches.back()->ReallocateCache();
             },
 
             [&]() { // GetCacheSize

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3054,7 +3054,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
-        bool flushed = view.Flush();
+        bool flushed = view.Flush(/*reallocate_cache=*/false);
         assert(flushed);
     }
     LogPrint(BCLog::BENCH, "- Disconnect block: %.2fms\n",
@@ -3192,7 +3192,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(time_connect_total),
                  Ticks<MillisecondsDouble>(time_connect_total) / num_blocks_total);
-        bool flushed = view.Flush();
+        bool flushed = view.Flush(/*reallocate_cache=*/false);
         assert(flushed);
     }
     const auto time_4{SteadyClock::now()};
@@ -4913,7 +4913,7 @@ bool Chainstate::ReplayBlocks()
     }
 
     cache.SetBestBlock(pindexNew->GetBlockHash());
-    cache.Flush();
+    cache.Flush(/*reallocate_cache=*/false);
     m_chainman.GetNotifications().progress(bilingual_str{}, 100, false);
     return true;
 }


### PR DESCRIPTION
Rebased and reopened #28945

Original description:

> TL;DR: this change improves sync time on my PC by ~6%.
> 
> While syncing when the CCoinsViewCache gets full it is flushed to disk and then memory is freed. Depending on available cache size, this happens several times. This PR removes the unnecessary reallocations for temporary CCoinsViewCache and reserves the cacheCoins's bucket array to its previous size.
> 
> I benchmarked the change on an AMD Ryzen 9 7950X with this command:
> 
> ```shell
> hyperfine \
> --show-output --parameter-list commit b5a271334ca81a6adcb1c608d85c83621a9eae47,ceeb71816512642e92a110b2cf5d2549d090fe78 \
> --setup 'git checkout {commit} && make -j$(nproc) src/bitcoind' \
> --prepare 'sync; sudo /sbin/sysctl vm.drop_caches=3' \
> -M 3 './src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000'
> ```
> 
> Where [b5a2713](https://github.com/bitcoin/bitcoin/commit/b5a271334ca81a6adcb1c608d85c83621a9eae47) is mergebase, and [ceeb718](https://github.com/bitcoin/bitcoin/commit/ceeb71816512642e92a110b2cf5d2549d090fe78) this PR.
> 
> Which runs `./src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000` 3 times and compares both commits, giving this result:
> 
> ```
> Benchmark 1: ./src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (commit = b5a271334ca81a6adcb1c608d85c83621a9eae47)
>   Time (mean ± σ):     2815.648 s ± 70.720 s    [User: 2639.959 s, System: 640.051 s]
>   Range (min … max):   2736.616 s … 2872.964 s    3 runs
> 
> Benchmark 2: ./src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (commit = ceeb71816512642e92a110b2cf5d2549d090fe78)
>   Time (mean ± σ):     2661.520 s ± 23.205 s    [User: 2473.010 s, System: 624.040 s]
>   Range (min … max):   2635.816 s … 2680.926 s    3 runs
> 
> Summary
>   ./src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (commit = ceeb71816512642e92a110b2cf5d2549d090fe78) ran
>     1.06 ± 0.03 times faster than ./src/bitcoind -dbcache=500 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (commit = b5a271334ca81a6adcb1c608d85c83621a9eae47)
> ```