### PR TITLE
fuzz: Mutate -max_len= during generation phase

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -276,12 +276,14 @@ def generate_corpus(*, fuzz_pool, src_dir, fuzz_bin, corpus_dir, targets):
         target_corpus_dir = corpus_dir / target
         os.makedirs(target_corpus_dir, exist_ok=True)
         use_value_profile = int(random.random() < .3)
+        max_len = 0 if random.random() < .7 else 2**random.randint(6, 12)
         command = [
             fuzz_bin,
             "-rss_limit_mb=8000",
             "-max_total_time=6000",
             "-reload=0",
             f"-use_value_profile={use_value_profile}",
+            f"-max_len={max_len}",
             target_corpus_dir,
         ]
         futures.append(fuzz_pool.submit(job, command, target, t_env))


### PR DESCRIPTION
This revives https://github.com/bitcoin/bitcoin/pull/28178#issuecomment-1927243781, because it helps to find https://github.com/bitcoin/bitcoin/issues/30367, which failed to be found for more than a year on any of the existing fuzz servers.

Locally, I can find the bug with `-max_len=84 -use_value_profile=1` on a single thread on a laptop. The reason is likely that a smaller max_len results in a faster fuzzing speed (iterations). As a side-effect it may also be effective at reducing the size of existing inputs (without losing coverage), but I haven't benchmarked this.