### PR TITLE
fuzz: fix key size in `crypter`

### DIFF
--- a/src/wallet/test/fuzz/crypter.cpp
+++ b/src/wallet/test/fuzz/crypter.cpp
@@ -27,36 +27,36 @@ FUZZ_TARGET(crypter, .init = initialize_crypter)
     // These values are regularly updated within `CallOneOf`
     std::vector<unsigned char> cipher_text_ed;
     CKeyingMaterial plain_text_ed;
-    const std::vector<unsigned char> random_key = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    const std::vector<unsigned char> random_key = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
 
     LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10000)
     {
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const std::string random_string = fuzzed_data_provider.ConsumeRandomLengthString();
+                const std::string random_string = fuzzed_data_provider.ConsumeRandomLengthString(100);
                 SecureString secure_string(random_string.begin(), random_string.end());
 
                 const unsigned int derivation_method = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<unsigned int>();
 
                 // Limiting the value of nRounds since it is otherwise uselessly expensive and causes a timeout when fuzzing.
                 crypt.SetKeyFromPassphrase(/*strKeyData=*/secure_string,
-                                           /*chSalt=*/ConsumeRandomLengthByteVector(fuzzed_data_provider),
+                                           /*chSalt=*/ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_SALT_SIZE),
                                            /*nRounds=*/fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 25000),
                                            /*nDerivationMethod=*/derivation_method);
             },
             [&] {
-                const std::vector<unsigned char> random_vector = ConsumeFixedLengthByteVector(fuzzed_data_provider, 32);
+                const std::vector<unsigned char> random_vector = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
                 const CKeyingMaterial new_key(random_vector.begin(), random_vector.end());
-                const std::vector<unsigned char>& new_IV = ConsumeFixedLengthByteVector(fuzzed_data_provider, 16);
+                const std::vector<unsigned char>& new_IV = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_IV_SIZE);
                 crypt.SetKey(new_key, new_IV);
             },
             [&] {
-                const std::vector<unsigned char> random_vector = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                const std::vector<unsigned char> random_vector = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
                 plain_text_ed = CKeyingMaterial(random_vector.begin(), random_vector.end());
             },
             [&] {
-                cipher_text_ed = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                cipher_text_ed = ConsumeRandomLengthByteVector(fuzzed_data_provider, 64);
             },
             [&] {
                 (void)crypt.Encrypt(plain_text_ed, cipher_text_ed);
@@ -82,7 +82,7 @@ FUZZ_TARGET(crypter, .init = initialize_crypter)
                 }
                 const CPubKey pub_key = *random_pub_key;
                 const CKeyingMaterial master_key(random_key.begin(), random_key.end());
-                const std::vector<unsigned char> crypted_secret = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                const std::vector<unsigned char> crypted_secret = ConsumeRandomLengthByteVector(fuzzed_data_provider, 64);
                 CKey key;
                 DecryptKey(master_key, crypted_secret, pub_key, key);
             });


### PR DESCRIPTION
Fixes #30251

This PR:
1. Limits `cipher_text_ed` and `random_string` (`SecureString`) size.
2. Replace `ConsumeRandomLengthByteVector` for keys to `ConsumeFixedLengthByteVector` with `WALLET_CRYPTO_KEY_SIZE`.
3. Replace `ConsumeRandomLengthByteVector` for `chSalt` to `ConsumeFixedLengthByteVector` with `WALLET_CRYPTO_SALT_SIZE`.