### PR TITLE
Revert "test: p2p: check that connecting to ourself leads to disconnect"

### DIFF
--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -17,7 +17,6 @@ from test_framework.messages import (
     NODE_WITNESS,
 )
 from test_framework.p2p import P2PInterface
-from test_framework.util import p2p_port
 
 
 # Desirable service flags for outbound non-pruned and pruned peers. Note that
@@ -89,11 +88,9 @@ class P2PHandshakeTest(BitcoinTestFramework):
         with node.assert_debug_log([f"feeler connection completed"]):
             self.add_outbound_connection(node, "feeler", NODE_NONE, wait_for_disconnect=True)
 
-        self.log.info("Check that connecting to ourself leads to immediate disconnect")
-        with node.assert_debug_log(["connected to self", "disconnecting"]):
-            node_listen_addr = f"127.0.0.1:{p2p_port(0)}"
-            node.addconnection(node_listen_addr, "outbound-full-relay", self.options.v2transport)
-        self.wait_until(lambda: len(node.getpeerinfo()) == 0)
+        # TODO: re-add test introduced in commit 5d2fb14bafe4e80c0a482d99e5ebde07c477f000
+        # ("test: p2p: check that connecting to ourself leads to disconnect") once
+        # the race condition causing issue #30368 is fixed
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As suggested in https://github.com/bitcoin/bitcoin/issues/30368#issuecomment-2200786670, this PR reverts the recently  added test  #30362 that causes frequent CI failures. A TODO is added in the functional test file to re-add it later when the race condition is fixed.
