### PR TITLE
lint: Ignore files ignored by git in the Markdown Link Checker

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -58,7 +58,7 @@ curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
-MLC_VERSION=v0.16.3
+MLC_VERSION=v0.18.0
 MLC_BIN=mlc-x86_64-linux
 curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -420,11 +420,6 @@ fn lint_markdown() -> LintResult {
         Ok(output) if output.status.success() => Ok(()),
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            let filtered_stderr: String = stderr // Filter out this annoying trailing line
-                .lines()
-                .filter(|&line| line != "The following links could not be resolved:")
-                .collect::<Vec<&str>>()
-                .join("\n");
             Err(format!(
                 r#"
 One or more markdown links are broken.
@@ -434,7 +429,7 @@ Relative links are preferred (but not required) as jumping to file works nativel
 Markdown link errors found:
 {}
                 "#,
-                filtered_stderr
+                stderr
             ))
         }
         Err(e) if e.kind() == ErrorKind::NotFound => {

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -410,6 +410,7 @@ fn lint_markdown() -> LintResult {
         "--offline",
         "--ignore-path",
         md_ignore_path_str.as_str(),
+        "--gitignore",
         "--root-dir",
         ".",
     ])


### PR DESCRIPTION
Updating to MLC v0.18.0 includes a new feature which will ignore all files ignored by git: `mlc --gitignore`.

This helps avoid false-positives flagged by this linter in non-project files, such as a developer might expect to have in their working directory (e.g. guix-builds, python venvs, etc.)