### PR TITLE
util: Catch translation string errors at compile time

### DIFF
--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -101,7 +101,6 @@ FUZZ_TARGET(string)
     (void)TrimString(random_string_1, random_string_2);
     (void)UrlDecode(random_string_1);
     (void)ContainsNoNUL(random_string_1);
-    (void)_(random_string_1.c_str());
     try {
         throw scriptnum_error{random_string_1};
     } catch (const std::runtime_error&) {

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Copyright (c) 2019-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -67,13 +67,19 @@ bilingual_str format(const bilingual_str& fmt, const Args&... args)
 /** Translate a message to the native language of the user. */
 const extern std::function<std::string(const char*)> G_TRANSLATION_FUN;
 
+struct ConstevalStringLiteral {
+    const char* const lit;
+    consteval ConstevalStringLiteral(const char* str) : lit{str} {}
+    consteval ConstevalStringLiteral(std::nullptr_t) = delete;
+};
+
 /**
  * Translation function.
  * If no translation function is set, simply return the input.
  */
-inline bilingual_str _(const char* psz)
+inline bilingual_str _(ConstevalStringLiteral str)
 {
-    return bilingual_str{psz, G_TRANSLATION_FUN ? (G_TRANSLATION_FUN)(psz) : psz};
+    return bilingual_str{str.lit, G_TRANSLATION_FUN ? (G_TRANSLATION_FUN)(str.lit) : str.lit};
 }
 
 #endif // BITCOIN_UTIL_TRANSLATION_H


### PR DESCRIPTION
The translation helper function `_()` has many problems. For example, the following compiles:

```cpp
auto ptr{"wrong"};
_(ptr);
_(nullptr);
_(0);
_(NULL);
```

However, it is wrong, because none of the arguments passed to the function can be picked up by the translation tooling for transifex.

Fix all issues by enforcing only real string literals can be passed to the function.