### PR TITLE
[WIP] p2p: send not_found msgs for unknown, pruned or unwilling to share blocks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3908,6 +3908,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         {
             LOCK(cs_main);
             CNodeState* state = State(pfrom.GetId());
+            // TODO: increase priority when 'sendnotfound' is sent..
             state->fPreferredDownload = (!pfrom.IsInboundConn() || pfrom.HasPermission(NetPermissionFlags::NoBan)) && !pfrom.IsAddrFetchConn() && CanServeBlocks(*peer);
             m_num_preferred_download_peers += state->fPreferredDownload;
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3937,6 +3937,12 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     if (pfrom.nVersion == 0) {
         // Must have a version message before anything else
         LogPrint(BCLog::NET, "non-version message before version handshake. Message \"%s\" from peer=%d\n", SanitizeString(msg_type), pfrom.GetId());
+        // TODO: Should disconnect if a negotiation message is received prior to the version message?
+        //  This is because the remote peer could be expecting certain behavior and it will not happen
+        if (msg_type == NetMsgType::SENDNOTFOUND) {
+            LogPrint(BCLog::NET, "Disconnecting peer=%d for sending a feature negotiation message '%s' before the version msg\n", pfrom.GetId(), SanitizeString(msg_type));
+            pfrom.fDisconnect = true;
+        }
         return;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1886,6 +1886,9 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
             if (queue.pindex)
                 stats.vHeightInFlight.push_back(queue.pindex->nHeight);
         }
+        for (const auto& missing : state->m_missing_blocks) {
+            stats.missing_blocks.emplace_back(missing.hash);
+        }
     }
 
     PeerRef peer = GetPeerRef(nodeid);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -38,6 +38,7 @@ struct CNodeStateStats {
     int m_starting_height = -1;
     std::chrono::microseconds m_ping_wait;
     std::vector<int> vHeightInFlight;
+    std::vector<uint256> missing_blocks;
     bool m_relay_txs;
     CAmount m_fee_filter_received;
     uint64_t m_addr_processed = 0;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -149,6 +149,11 @@ inline constexpr const char* PING{"ping"};
  */
 inline constexpr const char* PONG{"pong"};
 /**
+ * The sendnotfound message signals support for sending NOTFOUND messages for
+ * unknown or pruned blocks.
+ */
+inline constexpr const char* SENDNOTFOUND{"sendnotfound"};
+/**
  * The notfound message is a reply to a getdata message which requested an
  * object the receiving node does not have available for relay.
  * @since protocol version 70001.
@@ -285,6 +290,7 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::MEMPOOL,
     NetMsgType::PING,
     NetMsgType::PONG,
+    NetMsgType::SENDNOTFOUND,
     NetMsgType::NOTFOUND,
     NetMsgType::FILTERLOAD,
     NetMsgType::FILTERADD,

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -161,6 +161,10 @@ static RPCHelpMan getpeerinfo()
                     {
                         {RPCResult::Type::NUM, "n", "The heights of blocks we're currently asking from this peer"},
                     }},
+                    {RPCResult::Type::ARR, "missing_blocks", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "block_hash", "The hashes of blocks this peer told us to not have"},
+                    }},
                     {RPCResult::Type::BOOL, "addr_relay_enabled", "Whether we participate in address relay with this peer"},
                     {RPCResult::Type::NUM, "addr_processed", "The total number of addresses processed, excluding those dropped due to rate limiting"},
                     {RPCResult::Type::NUM, "addr_rate_limited", "The total number of addresses dropped due to rate limiting"},
@@ -267,6 +271,11 @@ static RPCHelpMan getpeerinfo()
             heights.push_back(height);
         }
         obj.pushKV("inflight", std::move(heights));
+        UniValue missing_blocks(UniValue::VARR);
+        for (const auto& hash : statestats.missing_blocks) {
+            missing_blocks.push_back(hash.GetHex());
+        }
+        obj.pushKV("missing_blocks", std::move(missing_blocks));
         obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
         obj.pushKV("addr_processed", statestats.m_addr_processed);
         obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);

--- a/test/functional/p2p_notfound_block.py
+++ b/test/functional/p2p_notfound_block.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test notfound block responses
+"""
+
+from collections import defaultdict
+
+from test_framework.messages import (
+    CInv,
+    msg_getdata,
+    msg_sendnotfound,
+    MSG_BLOCK,
+    MSG_FILTERED_BLOCK,
+    MSG_WITNESS_FLAG,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    P2P_SERVICES
+)
+from test_framework.protocol import (
+    NODE_NETWORK_LIMITED_MIN_BLOCKS
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class NotFoundConnTracker(P2PInterface):
+    def __init__(self):
+        super().__init__()
+        self.not_found_received_map = defaultdict(int)
+        self.blocks_received_map = defaultdict(int)
+
+    def send_version(self):
+        if self.on_connection_send_msg:
+            self.send_message(self.on_connection_send_msg)
+            self.on_connection_send_msg = None  # Never used again
+            # Activate 'notfound' block response
+            self.send_message(msg_sendnotfound())
+
+    def on_inv(self, message):
+        pass  # ignore inv messages
+
+    def on_notfound(self, message):
+        for inv in message.vec:
+            self.not_found_received_map[inv.hash] += 1
+
+    def on_block(self, message):
+        message.block.calc_sha256()
+        self.blocks_received_map[message.block.sha256] += 1
+
+class NotFoundBlockTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [["-blocksonly"], ["-prune=1", "-fastprune"]]
+
+    def test_feature_negotiation(self):
+        # Initial feature negotiation phase.
+        #    a) send SENDNOTFOUND before version. -> output: disconnect.
+        #    b) send SENDNOTFOUND after verack. -> output: disconnect.
+        #    c) send SENDNOTFOUND in-between version-verack -> output: connected.
+        node0 = self.nodes[0]
+        self.disconnect_nodes(1, 0)  # isolate node0
+
+        self.log.info("Check disconnection when negotiating 'sendnotfound' before version")
+        conn = node0.add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        with node0.assert_debug_log(["Disconnecting peer=1 for sending a feature negotiation message 'sendnotfound' before the version msg"]):
+            conn.send_message(msg_sendnotfound())
+            conn.wait_for_disconnect()
+
+        self.log.info("Check disconnection when negotiating 'sendnotfound' after verack")
+        conn = node0.add_p2p_connection(P2PInterface())
+        with node0.assert_debug_log(["'sendnotfound' received after verack from peer=2; disconnecting"]):
+            conn.send_message(msg_sendnotfound())
+            conn.wait_for_disconnect()
+
+        self.log.info("Check connection succeed when negotiating 'sendnotfound' in-between version-verack handshake")
+        conn = node0.add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        conn.peer_connect_send_version(P2P_SERVICES)
+        conn.send_version()
+        conn.send_message(msg_sendnotfound())
+        conn.wait_for_verack()
+        conn.sync_with_ping()
+
+        # Ensure message was successfully processed
+        info = node0.getpeerinfo()
+        assert_equal(len(info), 1)
+        assert info[0]['bytessent_per_msg']['sendnotfound'] > 0
+
+        self.connect_nodes(1, 0)  # re-establish connection
+
+    def send_getdata_and_wait_for_notfound(self, node, block_to_request, block_request_type=MSG_BLOCK):
+        conn = node.add_p2p_connection(NotFoundConnTracker())
+        block_hash = int(block_to_request, 16)
+        conn.send_message(msg_getdata([CInv(t=block_request_type, h=block_hash)]))
+        self.wait_until(lambda: conn.not_found_received_map[block_hash] == 1 or conn.blocks_received_map[block_hash] == 1)
+        assert conn.blocks_received_map.get(block_hash) == 0, " Received block that shouldn't have been sent"
+
+    def test_getdata_response(self):
+        # Test 'notfound' for getdata inv requests.
+        #    a) send getdata with a random hash. -> response: should receive a notfound.
+        #    b) send getdata with a hash of a block from a fork (older than 30 * 24 * 60 * 60). --> response: should receive a not found.
+        #    c) send getdata to a prune node for a block deeper than NODE_NETWORK_LIMITED --> response: should receive a not found.
+        #    d) send getdata to a prune node for a pruned block --> response: should receive a not found.
+        #    e) send getdata (msg_witness type) for a block that is not on disk - need to manually erase it --> response: should receive a not found.
+        #    f) send getdata (msg_merkleblock) for a peer that does not have TxRelay enabled -> response: should receive a not found
+        self.log.info("Test 'notfound' for getdata block requests..")
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+
+        #######################################################################################################
+        self.log.info("(a) Test getdata inv with unknown block hash")
+        self.send_getdata_and_wait_for_notfound(node0, block_to_request=b"1")
+
+        #######################################################################################################
+        self.log.info("(b) Test getdata inv with a hash of a block from a fork (older than 30 * 24 * 60 * 60)")
+
+        # Disconnect nodes to create two chains
+        self.disconnect_nodes(1, 0)
+        self.generate(node0, 101, sync_fun=self.no_op)
+        self.generate(node1, 20, sync_fun=self.no_op)
+        # And obtain fork block hash
+        block_to_request = node1.getbestblockhash()
+
+        # Advance time up to the point where the node stops providing blocks from forks
+        node_time = node0.getblockheader(node0.getbestblockhash())['time'] + (30 * 24 * 60 * 60) + 1
+        for node in [node0, node1]:
+            node.setmocktime(node_time)
+
+        # Sync-up nodes
+        self.connect_nodes(1, 0)
+        self.generate(node0, 1)
+
+        # Request old fork block and expect 'notfound'
+        self.send_getdata_and_wait_for_notfound(node0, block_to_request)
+
+        #######################################################################################################
+        self.log.info("(c) Test send getdata to a prune node for a block deeper than the NODE_NETWORK_LIMITED threshold")
+        self.generate(node1, NODE_NETWORK_LIMITED_MIN_BLOCKS - node1.getblockcount() + 5)
+        self.send_getdata_and_wait_for_notfound(node1, node1.getblockhash(height=1))
+
+        #######################################################################################################
+        self.log.info("(d) Test send getdata to a prune node for a pruned block")
+        self.generate(node1, NODE_NETWORK_LIMITED_MIN_BLOCKS)
+        last_pruned_block_height = node1.pruneblockchain(NODE_NETWORK_LIMITED_MIN_BLOCKS)
+        assert last_pruned_block_height > 1  # ensure the node pruned the first block
+        self.send_getdata_and_wait_for_notfound(node1, node1.getblockhash(height=1))
+
+        #######################################################################################################
+        self.log.info("(d) Test getdata for a block that is not on disk")
+
+        # Perturb first block on disk
+        with open(node0.chain_path / 'blocks/blk00000.dat', "wb") as bf:
+            bf.seek(150)
+            bf.write(b"1" * 400)
+
+        self.send_getdata_and_wait_for_notfound(node0, node0.getblockhash(height=1))
+        self.send_getdata_and_wait_for_notfound(node0, node0.getblockhash(height=1), block_request_type=MSG_BLOCK | MSG_WITNESS_FLAG)
+
+        #######################################################################################################
+        self.log.info("(e) Test getdata (merkleblock) for a peer that does not have TxRelay enabled")
+        self.send_getdata_and_wait_for_notfound(node0, node0.getbestblockhash(), block_request_type=MSG_FILTERED_BLOCK)
+
+
+    def run_test(self):
+        self.test_feature_negotiation()
+        self.test_getdata_response()
+
+
+if __name__ == '__main__':
+    NotFoundBlockTest().main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -173,6 +173,7 @@ class NetTest(BitcoinTestFramework):
                 "timeoffset": 0,
                 "transport_protocol_type": "v1" if not self.options.v2transport else "v2",
                 "version": 0,
+                "missing_blocks": []
             },
         )
         no_version_peer.peer_disconnect()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1443,6 +1443,21 @@ class msg_mempool:
     def __repr__(self):
         return "msg_mempool()"
 
+class msg_sendnotfound:
+    __slots__ = ()
+    msgtype = b"sendnotfound"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendnotfound()"
 
 class msg_notfound:
     __slots__ = ("vec", )

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -63,6 +63,7 @@ from test_framework.messages import (
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendnotfound,
     msg_sendtxrcncl,
     msg_tx,
     MSG_TX,
@@ -134,6 +135,7 @@ MESSAGEMAP = {
     b"inv": msg_inv,
     b"mempool": msg_mempool,
     b"merkleblock": msg_merkleblock,
+    b"sendnotfound": msg_sendnotfound,
     b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
@@ -541,6 +543,7 @@ class P2PInterface(P2PConnection):
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
     def on_sendtxrcncl(self, message): pass
+    def on_sendnotfound(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass
 

--- a/test/functional/test_framework/protocol.py
+++ b/test/functional/test_framework/protocol.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+# Minimum blocks required to signal NODE_NETWORK_LIMITED.
+# Prune nodes will not provide blocks deeper than this threshold.
+NODE_NETWORK_LIMITED_MIN_BLOCKS = 288

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'wallet_address_types.py --legacy-wallet',
     'wallet_address_types.py --descriptors',
     'p2p_orphan_handling.py',
+    'p2p_notfound_block.py',
     'wallet_basic.py --legacy-wallet',
     'wallet_basic.py --descriptors',
     'feature_maxtipage.py',


### PR DESCRIPTION
The 'not_found' message, introduced in protocol version 70001 (Bitcoin Core 0.8.0 - Feb 2013), serves as a response to a 'getdata' message when the receiving node does not have the requested data available for relay. Thus far, this has only been applied to transactions. This PR proposes extending its use to blocks as well.

Currently, when the remote peer does not have the requested block data, it ignores the 'getdata' inventory block request. This lack of response causes the requesting node to wait (and stall if the request was for an IBD block) for 10 minutes until the request timeout is triggered. As a result, the local node abruptly disconnects the peer due to perceived unresponsiveness in order to download the block from another source, even though the peer handled the message accordantly and may still be relaying other headers, blocks, and transactions properly.

This behavior is suboptimal for well-behaving nodes. Therefore, this PR proposes sending 'not_found' messages for blocks the remote peer does not know about or no longer stores, allowing the local node to promptly request them from another peer. Doing so will help prevent network synchronization stalling scenarios, allow us to shorten idle wait times (by reducing the block request timeout for peers supporting this feature), and ensure well-behaving peers remain connected.

Pending tasks:
1. Write detailed commits description.
2. Expand PR description
    1. Describe feature negotiation message. Annotate all considered options.
    2. Describe 'not_found' handler behavior for blocks closer to the tip vs historical ones.
3. Create BIP for the new feature negotiation message.
4. Think about increasing the peer's block download priority when it signals support for the feature.
5. Think about disconnecting the peer when a known feature negotiation message is received prior to the version message.
6. Complete TODOs in the code.