### PR TITLE
contrib: use c++ compiler rather than c compiler for binary checks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -334,14 +334,14 @@ clean-local: clean-docs
 
 test-security-check:
 if TARGET_DARWIN
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_MACHO
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_MACHO
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_MACHO
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_MACHO
 endif
 if TARGET_WINDOWS
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_PE
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_PE
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_PE
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_PE
 endif
 if TARGET_LINUX
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_ELF
-	$(AM_V_at) CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_ELF
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_ELF
+	$(AM_V_at) CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS)' CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_ELF
 endif

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -15,10 +15,10 @@ from utils import determine_wellknown_cmd
 def write_testcode(filename):
     with open(filename, 'w', encoding="utf8") as f:
         f.write('''
-    #include <stdio.h>
+    #include <cstdio>
     int main()
     {
-        printf("the quick brown fox jumps over the lazy god\\n");
+        std::printf("the quick brown fox jumps over the lazy god\\n");
         return 0;
     }
     ''')

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -34,7 +34,7 @@ def env_flags() -> list[str]:
     # See the definitions for ac_link in autoconf's lib/autoconf/c.m4 file for
     # reference.
     flags: list[str] = []
-    for var in ['CFLAGS', 'CPPFLAGS', 'LDFLAGS']:
+    for var in ['CXXFLAGS', 'CPPFLAGS', 'LDFLAGS']:
         flags += filter(None, os.environ.get(var, '').split(' '))
     return flags
 
@@ -52,9 +52,9 @@ def get_arch(cc, source, executable):
 
 class TestSecurityChecks(unittest.TestCase):
     def test_ELF(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CC', 'gcc')
+        cc = determine_wellknown_cmd('CXX', 'g++')
         write_testcode(source)
         arch = get_arch(cc, source, executable)
 
@@ -90,9 +90,9 @@ class TestSecurityChecks(unittest.TestCase):
         clean_files(source, executable)
 
     def test_PE(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1.exe'
-        cc = determine_wellknown_cmd('CC', 'x86_64-w64-mingw32-gcc')
+        cc = determine_wellknown_cmd('CXX', 'x86_64-w64-mingw32-g++')
         write_testcode(source)
 
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--disable-nxcompat','-Wl,--disable-reloc-section','-Wl,--disable-dynamicbase','-Wl,--disable-high-entropy-va','-no-pie','-fno-PIE','-fno-stack-protector']),
@@ -113,9 +113,9 @@ class TestSecurityChecks(unittest.TestCase):
         clean_files(source, executable)
 
     def test_MACHO(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CC', 'clang')
+        cc = determine_wellknown_cmd('CXX', 'clang++')
         write_testcode(source)
         arch = get_arch(cc, source, executable)
 

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -11,7 +11,7 @@ import unittest
 
 from utils import determine_wellknown_cmd
 
-def call_symbol_check(cc: list[str], source, executable, options):
+def call_symbol_check(cxx: list[str], source, executable, options):
     # This should behave the same as AC_TRY_LINK, so arrange well-known flags
     # in the same order as autoconf would.
     #
@@ -21,7 +21,7 @@ def call_symbol_check(cc: list[str], source, executable, options):
     for var in ['CXXFLAGS', 'CPPFLAGS', 'LDFLAGS']:
         env_flags += filter(None, os.environ.get(var, '').split(' '))
 
-    subprocess.run([*cc,source,'-o',executable] + env_flags + options, check=True)
+    subprocess.run([*cxx,source,'-o',executable] + env_flags + options, check=True)
     p = subprocess.run([os.path.join(os.path.dirname(__file__), 'symbol-check.py'), executable], stdout=subprocess.PIPE, text=True)
     os.remove(source)
     os.remove(executable)
@@ -31,7 +31,7 @@ class TestSymbolChecks(unittest.TestCase):
     def test_ELF(self):
         source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CXX', 'g++')
+        cxx = determine_wellknown_cmd('CXX', 'g++')
 
         # -lutil is part of the libc6 package so a safe bet that it's installed
         # it's also out of context enough that it's unlikely to ever become a real dependency
@@ -48,7 +48,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lutil']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lutil']),
                 (1, executable + ': libutil.so.1 is not in ALLOWED_LIBRARIES!\n' +
                     executable + ': failed LIBRARY_DEPENDENCIES'))
 
@@ -66,13 +66,13 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, []),
+        self.assertEqual(call_symbol_check(cxx, source, executable, []),
                 (0, ''))
 
     def test_MACHO(self):
         source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CXX', 'clang++')
+        cxx = determine_wellknown_cmd('CXX', 'clang++')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -86,7 +86,7 @@ class TestSymbolChecks(unittest.TestCase):
 
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lexpat', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lexpat', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
             (1, 'libexpat.1.dylib is not in ALLOWED_LIBRARIES!\n' +
                 f'{executable}: failed DYNAMIC_LIBRARIES MIN_OS SDK'))
 
@@ -103,7 +103,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-framework', 'CoreGraphics', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-framework', 'CoreGraphics', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
                 (1, f'{executable}: failed MIN_OS SDK'))
 
         source = 'test3.cpp'
@@ -116,13 +116,13 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-Wl,-platform_version','-Wl,macos', '-Wl,11.0', '-Wl,11.4']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-Wl,-platform_version','-Wl,macos', '-Wl,11.0', '-Wl,11.4']),
                 (1, f'{executable}: failed SDK'))
 
     def test_PE(self):
         source = 'test1.cpp'
         executable = 'test1.exe'
-        cc = determine_wellknown_cmd('CXX', 'x86_64-w64-mingw32-g++')
+        cxx = determine_wellknown_cmd('CXX', 'x86_64-w64-mingw32-g++')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -135,7 +135,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lpdh', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lpdh', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
             (1, 'pdh.dll is not in ALLOWED_LIBRARIES!\n' +
                  executable + ': failed DYNAMIC_LIBRARIES'))
 
@@ -150,7 +150,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-Wl,--major-subsystem-version', '-Wl,9', '-Wl,--minor-subsystem-version', '-Wl,9']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-Wl,--major-subsystem-version', '-Wl,9', '-Wl,--minor-subsystem-version', '-Wl,9']),
             (1, executable + ': failed SUBSYSTEM_VERSION'))
 
         source = 'test3.cpp'
@@ -166,7 +166,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lole32', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lole32', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
                 (0, ''))
 
 

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -57,11 +57,11 @@ class TestSymbolChecks(unittest.TestCase):
         executable = 'test3'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
-                #include <stdio.h>
+                #include <cstdio>
 
                 int main()
                 {
-                    printf("42");
+                    std::printf("42");
                     return 0;
                 }
         ''')

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -18,7 +18,7 @@ def call_symbol_check(cc: list[str], source, executable, options):
     # See the definitions for ac_link in autoconf's lib/autoconf/c.m4 file for
     # reference.
     env_flags: list[str] = []
-    for var in ['CFLAGS', 'CPPFLAGS', 'LDFLAGS']:
+    for var in ['CXXFLAGS', 'CPPFLAGS', 'LDFLAGS']:
         env_flags += filter(None, os.environ.get(var, '').split(' '))
 
     subprocess.run([*cc,source,'-o',executable] + env_flags + options, check=True)
@@ -29,13 +29,13 @@ def call_symbol_check(cc: list[str], source, executable, options):
 
 class TestSymbolChecks(unittest.TestCase):
     def test_ELF(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CC', 'gcc')
+        cc = determine_wellknown_cmd('CXX', 'g++')
 
         # -lutil is part of the libc6 package so a safe bet that it's installed
         # it's also out of context enough that it's unlikely to ever become a real dependency
-        source = 'test2.c'
+        source = 'test2.cpp'
         executable = 'test2'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -53,7 +53,7 @@ class TestSymbolChecks(unittest.TestCase):
                     executable + ': failed LIBRARY_DEPENDENCIES'))
 
         # finally, check a simple conforming binary
-        source = 'test3.c'
+        source = 'test3.cpp'
         executable = 'test3'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -70,9 +70,9 @@ class TestSymbolChecks(unittest.TestCase):
                 (0, ''))
 
     def test_MACHO(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1'
-        cc = determine_wellknown_cmd('CC', 'clang')
+        cc = determine_wellknown_cmd('CXX', 'clang++')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -90,7 +90,7 @@ class TestSymbolChecks(unittest.TestCase):
             (1, 'libexpat.1.dylib is not in ALLOWED_LIBRARIES!\n' +
                 f'{executable}: failed DYNAMIC_LIBRARIES MIN_OS SDK'))
 
-        source = 'test2.c'
+        source = 'test2.cpp'
         executable = 'test2'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -106,7 +106,7 @@ class TestSymbolChecks(unittest.TestCase):
         self.assertEqual(call_symbol_check(cc, source, executable, ['-framework', 'CoreGraphics', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
                 (1, f'{executable}: failed MIN_OS SDK'))
 
-        source = 'test3.c'
+        source = 'test3.cpp'
         executable = 'test3'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -120,9 +120,9 @@ class TestSymbolChecks(unittest.TestCase):
                 (1, f'{executable}: failed SDK'))
 
     def test_PE(self):
-        source = 'test1.c'
+        source = 'test1.cpp'
         executable = 'test1.exe'
-        cc = determine_wellknown_cmd('CC', 'x86_64-w64-mingw32-gcc')
+        cc = determine_wellknown_cmd('CXX', 'x86_64-w64-mingw32-g++')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -139,7 +139,7 @@ class TestSymbolChecks(unittest.TestCase):
             (1, 'pdh.dll is not in ALLOWED_LIBRARIES!\n' +
                  executable + ': failed DYNAMIC_LIBRARIES'))
 
-        source = 'test2.c'
+        source = 'test2.cpp'
         executable = 'test2.exe'
 
         with open(source, 'w', encoding="utf8") as f:
@@ -153,7 +153,7 @@ class TestSymbolChecks(unittest.TestCase):
         self.assertEqual(call_symbol_check(cc, source, executable, ['-Wl,--major-subsystem-version', '-Wl,9', '-Wl,--minor-subsystem-version', '-Wl,9']),
             (1, executable + ': failed SUBSYSTEM_VERSION'))
 
-        source = 'test3.c'
+        source = 'test3.cpp'
         executable = 'test3.exe'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''


### PR DESCRIPTION
From hebasto's CMake repo. See discussion here: https://github.com/hebasto/bitcoin/pull/252#discussion_r1664657488

Use CXX/CXXFLAGS rather than CC/CFLAGS to test our actual compiler for binary checks rather than the one we only forward to secp256k1.