### PR TITLE
validation: Check if mempool exists before size check in ActivateSnapshot

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5681,7 +5681,8 @@ util::Result<void> ChainstateManager::ActivateSnapshot(
             return util::Error{strprintf(_("The base block header (%s) is part of an invalid chain."), base_blockhash.ToString())};
         }
 
-        if (Assert(m_active_chainstate->GetMempool())->size() > 0) {
+        auto mempool{m_active_chainstate->GetMempool()};
+        if (mempool && mempool->size() > 0) {
             return util::Error{_("Can't activate a snapshot when mempool not empty.")};
         }
     }


### PR DESCRIPTION
The mempool is an optional component of the chainstate manager, so don't assume its presence and instead check if it is there first.