### PR TITLE
refactor: Use designated initializer in test/util/net.cpp

### DIFF
--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -118,20 +118,20 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
     candidates.reserve(n_candidates);
     for (int id = 0; id < n_candidates; ++id) {
         candidates.push_back({
-            /*id=*/id,
-            /*m_connected=*/std::chrono::seconds{random_context.randrange(100)},
-            /*m_min_ping_time=*/std::chrono::microseconds{random_context.randrange(100)},
-            /*m_last_block_time=*/std::chrono::seconds{random_context.randrange(100)},
-            /*m_last_tx_time=*/std::chrono::seconds{random_context.randrange(100)},
-            /*fRelevantServices=*/random_context.randbool(),
-            /*m_relay_txs=*/random_context.randbool(),
-            /*fBloomFilter=*/random_context.randbool(),
-            /*nKeyedNetGroup=*/random_context.randrange(100u),
-            /*prefer_evict=*/random_context.randbool(),
-            /*m_is_local=*/random_context.randbool(),
-            /*m_network=*/ALL_NETWORKS[random_context.randrange(ALL_NETWORKS.size())],
-            /*m_noban=*/false,
-            /*m_conn_type=*/ConnectionType::INBOUND,
+            .id=id,
+            .m_connected=std::chrono::seconds{random_context.randrange(100)},
+            .m_min_ping_time=std::chrono::microseconds{random_context.randrange(100)},
+            .m_last_block_time=std::chrono::seconds{random_context.randrange(100)},
+            .m_last_tx_time=std::chrono::seconds{random_context.randrange(100)},
+            .fRelevantServices=random_context.randbool(),
+            .m_relay_txs=random_context.randbool(),
+            .fBloomFilter=random_context.randbool(),
+            .nKeyedNetGroup=random_context.randrange(100u),
+            .prefer_evict=random_context.randbool(),
+            .m_is_local=random_context.randbool(),
+            .m_network=ALL_NETWORKS[random_context.randrange(ALL_NETWORKS.size())],
+            .m_noban=false,
+            .m_conn_type=ConnectionType::INBOUND,
         });
     }
     return candidates;


### PR DESCRIPTION
Block was recently touched (e2d1f84858485650ff743753ffa5c679f210a992) and the codebase recently switched to C++20 which allows this to improve robustness.

Follow-up suggested in https://github.com/bitcoin/bitcoin/pull/29625#discussion_r1664818014