### PR TITLE
Use `WITH_LOCK` in `Warnings::Set`

### DIFF
--- a/src/node/warnings.cpp
+++ b/src/node/warnings.cpp
@@ -28,8 +28,7 @@ Warnings::Warnings()
 }
 bool Warnings::Set(warning_type id, bilingual_str message)
 {
-    LOCK(m_mutex);
-    const auto& [_, inserted]{m_warnings.insert({id, std::move(message)})};
+    const auto& [_, inserted]{WITH_LOCK(m_mutex, return m_warnings.insert({id, std::move(message)}))};
     if (inserted) uiInterface.NotifyAlertChanged();
     return inserted;
 }


### PR DESCRIPTION
The scope of the lock should be limited to just guarding m_warnings as anything listening on `NotifyAlertChanged` may execute code that requires the lock as well.

Fixes #30400 