### PR TITLE
p2p: Lazy init some bloom filters; fuzz version handshake

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -350,6 +350,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/netaddress.cpp \
  test/fuzz/netbase_dns_lookup.cpp \
  test/fuzz/node_eviction.cpp \
+ test/fuzz/p2p_handshake.cpp \
  test/fuzz/p2p_transport_serialization.cpp \
  test/fuzz/package_eval.cpp \
  test/fuzz/parse_hd_keypath.cpp \

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addrman.h>
+#include <consensus/consensus.h>
+#include <net.h>
+#include <net_processing.h>
+#include <node/warnings.h>
+#include <protocol.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
+#include <test/util/mining.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <util/time.h>
+#include <validationinterface.h>
+
+#include <ios>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+const TestingSetup* g_setup;
+
+void initialize()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
+        /*chain_type=*/ChainType::REGTEST);
+    g_setup = testing_setup.get();
+}
+} // namespace
+
+FUZZ_TARGET(p2p_handshake, .init = ::initialize)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    ConnmanTestMsg& connman = static_cast<ConnmanTestMsg&>(*g_setup->m_node.connman);
+    auto& chainman = static_cast<TestChainstateManager&>(*g_setup->m_node.chainman);
+    SetMockTime(1610000000); // any time to successfully reset ibd
+    chainman.ResetIbd();
+
+    node::Warnings warnings{};
+    NetGroupManager netgroupman{{}};
+    AddrMan addrman{netgroupman, /*deterministic=*/true, 0};
+    auto peerman = PeerManager::make(connman, addrman,
+                                     /*banman=*/nullptr, chainman,
+                                     *g_setup->m_node.mempool, warnings,
+                                     PeerManager::Options{
+                                         .reconcile_txs = true,
+                                         .deterministic_rng = true,
+                                     });
+    connman.SetMsgProc(peerman.get());
+
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    std::vector<CNode*> peers;
+    const auto num_peers_to_add = fuzzed_data_provider.ConsumeIntegralInRange(1, 3);
+    for (int i = 0; i < num_peers_to_add; ++i) {
+        peers.push_back(ConsumeNodeAsUniquePtr(fuzzed_data_provider, i).release());
+        connman.AddTestNode(*peers.back());
+        peerman->InitializeNode(
+            *peers.back(),
+            static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()));
+    }
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
+    {
+        CNode& connection = *PickValue(fuzzed_data_provider, peers);
+        if (connection.fDisconnect || connection.fSuccessfullyConnected) {
+            // Skip if the the connection was disconnected or if the version
+            // handshake was already completed.
+            continue;
+        }
+
+        SetMockTime(GetTime() +
+                    fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(
+                        -std::chrono::seconds{10min}.count(), // Allow mocktime to go backwards slightly
+                        std::chrono::seconds{TIMEOUT_INTERVAL}.count()));
+
+        CSerializedNetMsg net_msg;
+        net_msg.m_type = PickValue(fuzzed_data_provider, ALL_NET_MESSAGE_TYPES);
+        net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
+
+        connman.FlushSendBuffer(connection);
+        (void)connman.ReceiveMsgFrom(connection, std::move(net_msg));
+
+        bool more_work{true};
+        while (more_work) {
+            connection.fPauseSend = false;
+
+            try {
+                more_work = connman.ProcessMessagesOnce(connection);
+            } catch (const std::ios_base::failure&) {
+            }
+            peerman->SendMessages(&connection);
+        }
+    }
+
+    g_setup->m_node.connman->StopNodes();
+}

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -34,6 +34,11 @@ class Span;
 struct ConnmanTestMsg : public CConnman {
     using CConnman::CConnman;
 
+    void SetMsgProc(NetEventsInterface* msgproc)
+    {
+        m_msgproc = msgproc;
+    }
+
     void SetPeerConnectTimeout(std::chrono::seconds timeout)
     {
         m_peer_connect_timeout = timeout;

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -162,7 +162,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.log.info("Generate a block")
         last_block = self.generate(self.nodes[0], 1)
         # generate() implicitly syncs blocks, so that peer 1 gets the block before timelock_tx
-        # Otherwise, peer 1 would put the timelock_tx in m_recent_rejects
+        # Otherwise, peer 1 would put the timelock_tx in m_lazy_recent_rejects
 
         self.log.info("The time-locked transaction can now be spent")
         timelock_tx_id = self.nodes[0].sendrawtransaction(timelock_tx)

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -121,7 +121,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         tx.vout[0].nValue += 1
         txid = tx.rehash()
         # Send the transaction twice. The first time, it'll be rejected by ATMP because it conflicts
-        # with a mempool transaction. The second time, it'll be in the m_recent_rejects filter.
+        # with a mempool transaction. The second time, it'll be in the m_lazy_recent_rejects filter.
         p2p_rebroadcast_wallet.send_txs_and_test(
             [tx],
             self.nodes[1],


### PR DESCRIPTION
This adds a fuzzing harness dedicated to the version handshake. To avoid determinism issues, the harness creates necessary components each iteration (addrman, peerman, etc). A harness like this would have easily caught https://bitcoincore.org/en/2024/07/03/disclose-timestamp-overflow/.

As a performance optimization, this PR includes a change to `PeerManager` to lazily initialize various filters (to avoid large unnecessary memory allocations each iteration).