### PR TITLE
assumeUTXO: snapshot load, update VERSION msg height

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2836,6 +2836,10 @@ static RPCHelpMan loadtxoutset()
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Unable to load UTXO snapshot: %s. (%s)", util::ErrorString(activation_result).original, path.utf8string()));
     }
 
+    // Update peer manager best block
+    const auto& tip = WITH_LOCK(chainman.GetMutex(), return chainman.ActiveTip());
+    node.peerman->SetBestBlock(tip->nHeight, std::chrono::seconds{tip->GetBlockTime()});
+
     UniValue result(UniValue::VOBJ);
     result.pushKV("coins_loaded", metadata.m_coins_count);
     result.pushKV("tip_hash", metadata.m_base_blockhash.ToString());


### PR DESCRIPTION
Due to a missing height update; the node sends its pre-snapshot height to
any peer connecting after the snapshot load but before the node receive
a new tip block.

This does not make any difference for us because we are not using the
`VERSION` msg height field but it does not seem consistent plus other
software might be using the field.