### PR TITLE
remove truc_policy from libbitcoin_common_a_SOURCES

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -707,7 +707,6 @@ libbitcoin_common_a_SOURCES = \
   outputtype.cpp \
   policy/feerate.cpp \
   policy/policy.cpp \
-  policy/truc_policy.cpp \
   protocol.cpp \
   psbt.cpp \
   rpc/external_signer.cpp \


### PR DESCRIPTION
Hebasto pointed out that it doesn't need to be there since it's in `libbitcoin_node_a_SOURCES`