### PR TITLE
rpc: Use CHECK_NONFATAL over Assert

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -801,14 +801,14 @@ std::optional<int> GetPruneHeight(const BlockManager& blockman, const CChain& ch
     // If the chain tip is pruned, everything is pruned.
     if (!((chain_tip->nStatus & BLOCK_HAVE_MASK) == BLOCK_HAVE_MASK)) return chain_tip->nHeight;
 
-    const auto& first_unpruned{*Assert(blockman.GetFirstBlock(*chain_tip, /*status_mask=*/BLOCK_HAVE_MASK, first_block))};
+    const auto& first_unpruned{*CHECK_NONFATAL(blockman.GetFirstBlock(*chain_tip, /*status_mask=*/BLOCK_HAVE_MASK, first_block))};
     if (&first_unpruned == first_block) {
         // All blocks between first_block and chain_tip have data, so nothing is pruned.
         return std::nullopt;
     }
 
     // Block before the first unpruned block is the last pruned block.
-    return Assert(first_unpruned.pprev)->nHeight;
+    return CHECK_NONFATAL(first_unpruned.pprev)->nHeight;
 }
 
 static RPCHelpMan pruneblockchain()

--- a/test/lint/lint-assertions.py
+++ b/test/lint/lint-assertions.py
@@ -27,8 +27,9 @@ def main():
     # checks should be used over assert. See: src/util/check.h
     # src/rpc/server.cpp is excluded from this check since it's mostly meta-code.
     exit_code = git_grep([
-        "-nE",
-        r"\<(A|a)ss(ume|ert) *\(.*\);",
+        "--line-number",
+        "--extended-regexp",
+        r"\<(A|a)ss(ume|ert)\(",
         "--",
         "src/rpc/",
         "src/wallet/rpc*",
@@ -38,8 +39,9 @@ def main():
     # The `BOOST_ASSERT` macro requires to `#include boost/assert.hpp`,
     # which is an unnecessary Boost dependency.
     exit_code |= git_grep([
-        "-E",
-        r"BOOST_ASSERT *\(.*\);",
+        "--line-number",
+        "--extended-regexp",
+        r"BOOST_ASSERT\(",
         "--",
         "*.cpp",
         "*.h",


### PR DESCRIPTION
Any RPC method should not abort the whole node when an internal logic error happens.

Fix it by just aborting this single RPC method call when an error happens.

Also, fix the linter to find the fixed cases.