### PR TITLE
depends: bump boost to 1.87.0 and use new CMake buildsystem

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,10 +1,32 @@
+
 package=boost
-$(package)_version=1.81.0
-$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
-$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.gz
-$(package)_sha256_hash=205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6
+$(package)_version=1.87.0
+$(package)_download_path=https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
+$(package)_file_name=boost-$($(package)_version)-cmake.tar.gz
+$(package)_sha256_hash=78fbf579e3caf0f47517d3fb4d9301852c3154bfecdc5eeebd9b2b0292366f5b
+$(package)_build_subdir=build
+
+# This compiles a few libs unnecessarily because test doesn't have
+# header-only build/install options
+
+#install_name_tool is unused, so set it to the `true` binary so that CMake thinks it exists
+define $(package)_set_vars
+  $(package)_config_opts=-DBOOST_INCLUDE_LIBRARIES="multi_index;signals2;test" -DBOOST_INSTALL_LAYOUT=system
+  $(package)_config_opts_darwin=-DCMAKE_INSTALL_NAME_TOOL=true
+endef
+
+define $(package)_config_cmds
+  $($(package)_cmake) -S .. -B .
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
 
 define $(package)_stage_cmds
-  mkdir -p $($(package)_staging_prefix_dir)/include && \
-  cp -r boost $($(package)_staging_prefix_dir)/include
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf lib/libboost*
 endef


### PR DESCRIPTION
Marked as draft because this is much more relevant after we've switched to CMake.

This has a few advantages over the old method of simply copying headers:
- Installs proper cmake files which can be picked up by our buildsystem
- Only installs necessary headers, not all of boost

The only drawback is that it builds a few libs that we end up throwing away. date_time and test can both be optionally used header-only (which we do), but boost's CMake buildsystem doesn't expose an option to skip building them.