### PR TITLE
init: change shutdown order of load block thread and scheduler

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -296,10 +296,11 @@ void Shutdown(NodeContext& node)
 
     StopTorControl();
 
-    // After everything has been shut down, but before things get flushed, stop the
-    // scheduler and load block thread.
-    if (node.scheduler) node.scheduler->stop();
     if (node.chainman && node.chainman->m_thread_load.joinable()) node.chainman->m_thread_load.join();
+    // After everything has been shut down, but before things get flushed, stop the
+    // the scheduler. After this point, SyncWithValidationInterfaceQueue() should not be called anymore
+    // as this would prevent the shutdown from completing.
+    if (node.scheduler) node.scheduler->stop();
 
     // After the threads that potentially access these pointers have been stopped,
     // destruct and reset all to nullptr.


### PR DESCRIPTION
This avoids situations during a reindex, in which the shutdown doesn't finish since `LimitValidationInterfaceQueue()` is called by the load block thread when the scheduler is already stopped, in which case it would block indefinitely. This can lead to intermittent failures in `feature_reindex.py` (#30424), which I could locally reproduce with 
```diff
diff --git a/src/validation.cpp b/src/validation.cpp
index 74f0e4975c..be1706fdaf 100644
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3446,6 +3446,7 @@ static void LimitValidationInterfaceQueue(ValidationSignals& signals) LOCKS_EXCL
     AssertLockNotHeld(cs_main);
 
     if (signals.CallbacksPending() > 10) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
         signals.SyncWithValidationInterfaceQueue();
     }
 }
```
It has also been reported by users running `reindex-chainstate` (#23234).

I thought for a bit about potential downsides of changing this order, but couldn't find any.

Fixes #30424
Fixes #23234
