### PR TITLE
guix: (explicitly) build Linux GCC with `--enable-cet`

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -434,6 +434,7 @@ inspecting signatures in Mach-O binaries.")
                   "--enable-default-ssp=yes",
                   "--enable-default-pie=yes",
                   "--enable-standard-branch-protection=yes",
+                  "--enable-cet=yes",
                   building-on)))
         ((#:phases phases)
           `(modify-phases ,phases


### PR DESCRIPTION
Similar to #29695, and in the same vein of explicitly configuring hardening options in our release toolchain.

See https://gcc.gnu.org/install/configure.html:

>` --enable-cet`

> Enable building target run-time libraries with control-flow instrumentation, see `-fcf-protection option`. When --enable-cet is specified target libraries are configured to add `-fcf-protection` and, if needed, other target specific options to a set of building options.

> `--enable-cet=auto` is default. CET is enabled on Linux/x86 if target binutils supports Intel CET instructions and disabled otherwise. In this case, the target libraries are configured to get additional `-fcf-protection` option.