### PR TITLE
Introduce waitFeesChanged() mining interface

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -7,6 +7,7 @@
 
 #include <node/types.h>
 #include <uint256.h>
+#include <util/time.h>
 
 #include <memory>
 #include <optional>
@@ -38,6 +39,19 @@ public:
 
     //! Returns the hash for the tip of this chain
     virtual std::optional<uint256> getTipHash() = 0;
+
+    /**
+     * Waits for fees in the next block to rise, a new tip or the timeout.
+     *
+     * @param[in] timeout how long to wait for a fee increase
+     * @param[in] tip block hash that the most recent template builds on
+     * @param[in] fee_delta currently ignored: how much total fees in the next block should rise.
+     * @param[in,out] fees_before currently ignored: fees for the most recent template
+     * @param[out] tip_changed whether a new tip arrived during the wait
+     *
+     * @returns true if fees increased, false if a new tip arrives or the timeout occurs
+     */
+    virtual bool waitFeesChanged(MillisecondsDouble timeout, uint256 tip, CAmount fee_delta, CAmount& fees_before, bool& tip_changed) = 0;
 
    /**
      * Construct a new block template


### PR DESCRIPTION
This adds `waitFeesChanged()` to the `Mining` interface.

The Stratum v2 protocol allows pushing out templates as fees in the mempool increase. This interface lets us know when it's time to do so.

Without Cluster Mempool however the implementation is "fake", instead returning every time a transaction is added to the mempool. So for now I'm keeping this draft. It's here to provide a complete and stable Mining interface for https://github.com/bitcoin/bitcoin/pull/30437 to build on.

Unlike the entire `Mining` interface so far, this is not a refactor. It adds new functionality.

The current implementation is very similiar to how longpolling in `getblocktemplate` works, which checks `getTransactionsUpdated` every 10 seconds.

However once Cluster Mempool is added it will be cheap enough to frequently generate a block template, check if the fees have gone up enough and then return. That would cause a behaviour change if `getblocktemplate` were to use `waitFeesChanged()`, which is why this PR does not touch the longpolling code.

TODO:
- [ ] try with (draft) cluster mempool branch