### PR TITLE
test: addrman: tried 3 times and never a success so `isTerrible=true`

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -448,10 +448,21 @@ BOOST_AUTO_TEST_CASE(getaddr_unfiltered)
     CNetAddr source = ResolveIP("250.1.2.1");
     BOOST_CHECK(addrman->Add({addr1, addr2}, source));
 
-    // Filtered GetAddr should only return addr1
+    // Set time on this addr so isTerrible = false
+    CAddress addr3 = CAddress(ResolveService("250.251.2.3", 9998), NODE_NONE);
+    addr3.nTime = Now<NodeSeconds>();
+    addrman->Good(addr3, /*time=*/Now<NodeSeconds>());
+    BOOST_CHECK(addrman->Add({addr3}, source));
+    // The time is set, but after ADDRMAN_RETRIES unsuccessful attempts not
+    // retried in the last minute, this addr should be isTerrible = true
+    for (size_t i = 0; i < 3; ++i) {
+        addrman->Attempt(addr3, /*fCountFailure=*/true, /*time=*/Now<NodeSeconds>() - 61s);
+    }
+
+    // GetAddr filtered by quality (i.e. not IsTerrible) should only return addr1
     BOOST_CHECK_EQUAL(addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt).size(), 1U);
-    // Unfiltered GetAddr should return addr1 and addr2
-    BOOST_CHECK_EQUAL(addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false).size(), 2U);
+    // Unfiltered GetAddr should return all addrs
+    BOOST_CHECK_EQUAL(addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false).size(), 3U);
 }
 
 BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy)


### PR DESCRIPTION
This PR adds test coverage for the following verification:
```cpp
if (TicksSinceEpoch<std::chrono::seconds>(m_last_success) == 0 && nAttempts >= ADDRMAN_RETRIES) { // tried N times and never a success
    return true;
}
```

If we've tried an address for 3 or more times and were unsuccessful, this address should be pointed out as "terrible".

-------

You can test this by applying:
```diff
diff --git a/src/addrman.cpp b/src/addrman.cpp
index 054a9bee32..93a9521b59 100644
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -81,7 +81,7 @@ bool AddrInfo::IsTerrible(NodeSeconds now) const
     }
 
     if (TicksSinceEpoch<std::chrono::seconds>(m_last_success) == 0 && nAttempts >= ADDRMAN_RETRIES) { // tried N times and never a success
-        return true;
+        return false;
     }
```