### PR TITLE
fuzz: Deglobalize signature cache in sigcache test

### DIFF
--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -2,36 +2,33 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
-#include <key.h>
+#include <consensus/amount.h>
+#include <primitives/transaction.h>
 #include <pubkey.h>
+#include <script/interpreter.h>
 #include <script/sigcache.h>
+#include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
 
-#include <cstdint>
+#include <cstddef>
 #include <optional>
-#include <string>
 #include <vector>
-
-namespace {
-const BasicTestingSetup* g_setup;
-SignatureCache* g_signature_cache;
-} // namespace
 
 void initialize_script_sigcache()
 {
     static const auto testing_setup = MakeNoLogFileContext<>();
-    static SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};
-    g_setup = testing_setup.get();
-    g_signature_cache = &signature_cache;
 }
 
 FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const auto max_sigcache_bytes{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, DEFAULT_SIGNATURE_CACHE_BYTES)};
+    SignatureCache signature_cache{max_sigcache_bytes};
 
     const std::optional<CMutableTransaction> mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
     const CTransaction tx{mutable_transaction ? *mutable_transaction : CMutableTransaction{}};
@@ -39,7 +36,7 @@ FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
     const CAmount amount = ConsumeMoney(fuzzed_data_provider);
     const bool store = fuzzed_data_provider.ConsumeBool();
     PrecomputedTransactionData tx_data;
-    CachingTransactionSignatureChecker caching_transaction_signature_checker{mutable_transaction ? &tx : nullptr, n_in, amount, store, *g_signature_cache, tx_data};
+    CachingTransactionSignatureChecker caching_transaction_signature_checker{mutable_transaction ? &tx : nullptr, n_in, amount, store, signature_cache, tx_data};
     if (fuzzed_data_provider.ConsumeBool()) {
         const auto random_bytes = fuzzed_data_provider.ConsumeBytes<unsigned char>(64);
         const XOnlyPubKey pub_key(ConsumeUInt256(fuzzed_data_provider));


### PR DESCRIPTION
The body of the fuzz test should ideally be a pure function. If data is persisted in the cache over many iterations, and there is a crash, reproducing it from the input might be difficult. Solve this by getting rid of the global state. This is a follow-up from #30425.