### PR TITLE
qa: Functional test improvements

### DIFF
--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -24,4 +24,4 @@ class CreateCache(BitcoinTestFramework):
         pass
 
 if __name__ == '__main__':
-    CreateCache().main()
+    CreateCache(__file__).main()

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -225,4 +225,4 @@ class ExampleTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ExampleTest().main()
+    ExampleTest(__file__).main()

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -42,4 +42,4 @@ class AbortNodeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AbortNodeTest().main()
+    AbortNodeTest(__file__).main()

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -160,4 +160,4 @@ class AddrmanTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    AddrmanTest().main()
+    AddrmanTest(__file__).main()

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -141,4 +141,4 @@ class AnchorsTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    AnchorsTest().main()
+    AnchorsTest(__file__).main()

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -30,7 +30,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 DEFAULT_ASMAP_FILENAME = 'ip_asn.map' # defined in src/init.cpp
-ASMAP = '../../src/test/data/asmap.raw' # path to unit test skeleton asmap
+ASMAP = 'src/test/data/asmap.raw' # path to unit test skeleton asmap
 VERSION = 'fec61fa21a9f46f3b17bdcd660d7f4cd90b966aad3aec593c99b35f0aca15853'
 
 def expected_messages(filename):
@@ -133,7 +133,8 @@ class AsmapTest(BitcoinTestFramework):
         self.node = self.nodes[0]
         self.datadir = self.node.chain_path
         self.default_asmap = os.path.join(self.datadir, DEFAULT_ASMAP_FILENAME)
-        self.asmap_raw = os.path.join(os.path.dirname(os.path.realpath(__file__)), ASMAP)
+        base_dir = self.config["environment"]["SRCDIR"]
+        self.asmap_raw = os.path.join(base_dir, ASMAP)
 
         self.test_without_asmap_arg()
         self.test_asmap_with_absolute_path()

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -146,4 +146,4 @@ class AsmapTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AsmapTest().main()
+    AsmapTest(__file__).main()

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -555,4 +555,4 @@ class Block:
     chain_tx: int
 
 if __name__ == '__main__':
-    AssumeutxoTest().main()
+    AssumeutxoTest(__file__).main()

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -172,4 +172,4 @@ class AssumeValidTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AssumeValidTest().main()
+    AssumeValidTest(__file__).main()

--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -88,4 +88,4 @@ class BindExtraTest(BitcoinTestFramework):
             assert_equal(binds, set(expected_services))
 
 if __name__ == '__main__':
-    BindExtraTest().main()
+    BindExtraTest(__file__).main()

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -75,4 +75,4 @@ class BindPortDiscoverTest(BitcoinTestFramework):
         assert found_addr1
 
 if __name__ == '__main__':
-    BindPortDiscoverTest().main()
+    BindPortDiscoverTest(__file__).main()

--- a/test/functional/feature_bind_port_externalip.py
+++ b/test/functional/feature_bind_port_externalip.py
@@ -72,4 +72,4 @@ class BindPortExternalIPTest(BitcoinTestFramework):
             assert found
 
 if __name__ == '__main__':
-    BindPortExternalIPTest().main()
+    BindPortExternalIPTest(__file__).main()

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -412,4 +412,4 @@ class BIP68Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP68Test().main()
+    BIP68Test(__file__).main()

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1434,4 +1434,4 @@ class FullBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FullBlockTest().main()
+    FullBlockTest(__file__).main()

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -35,4 +35,4 @@ class BlocksdirTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlocksdirTest().main()
+    BlocksdirTest(__file__).main()

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -195,4 +195,4 @@ class BIP65Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP65Test().main()
+    BIP65Test(__file__).main()

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -324,4 +324,4 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CoinStatsIndexTest().main()
+    CoinStatsIndexTest(__file__).main()

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -431,4 +431,4 @@ class ConfArgsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ConfArgsTest().main()
+    ConfArgsTest(__file__).main()

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -482,4 +482,4 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP68_112_113Test().main()
+    BIP68_112_113Test(__file__).main()

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -286,4 +286,4 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ChainstateWriteCrashTest().main()
+    ChainstateWriteCrashTest(__file__).main()

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -148,4 +148,4 @@ class BIP66Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP66Test().main()
+    BIP66Test(__file__).main()

--- a/test/functional/feature_dirsymlinks.py
+++ b/test/functional/feature_dirsymlinks.py
@@ -38,4 +38,4 @@ class SymlinkTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    SymlinkTest().main()
+    SymlinkTest(__file__).main()

--- a/test/functional/feature_discover.py
+++ b/test/functional/feature_discover.py
@@ -72,4 +72,4 @@ class DiscoverTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DiscoverTest().main()
+    DiscoverTest(__file__).main()

--- a/test/functional/feature_fastprune.py
+++ b/test/functional/feature_fastprune.py
@@ -26,4 +26,4 @@ class FeatureFastpruneTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeatureFastpruneTest().main()
+    FeatureFastpruneTest(__file__).main()

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -439,4 +439,4 @@ class EstimateFeeTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    EstimateFeeTest().main()
+    EstimateFeeTest(__file__).main()

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -54,4 +54,4 @@ class FilelockTest(BitcoinTestFramework):
                 check_wallet_filelock(True)
 
 if __name__ == '__main__':
-    FilelockTest().main()
+    FilelockTest(__file__).main()

--- a/test/functional/feature_framework_miniwallet.py
+++ b/test/functional/feature_framework_miniwallet.py
@@ -46,4 +46,4 @@ class FeatureFrameworkMiniWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeatureFrameworkMiniWalletTest().main()
+    FeatureFrameworkMiniWalletTest(__file__).main()

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -59,4 +59,4 @@ class HelpTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HelpTest().main()
+    HelpTest(__file__).main()

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -83,4 +83,4 @@ class IncludeConfTest(BitcoinTestFramework):
         assert subversion.endswith("main; relative; relative2)/")
 
 if __name__ == '__main__':
-    IncludeConfTest().main()
+    IncludeConfTest(__file__).main()

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -155,4 +155,4 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeatureIndexPruneTest().main()
+    FeatureIndexPruneTest(__file__).main()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -149,4 +149,4 @@ class InitStressTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InitStressTest().main()
+    InitStressTest(__file__).main()

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -80,4 +80,4 @@ class LoadblockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    LoadblockTest().main()
+    LoadblockTest(__file__).main()

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -101,4 +101,4 @@ class LoggingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    LoggingTest().main()
+    LoggingTest(__file__).main()

--- a/test/functional/feature_maxtipage.py
+++ b/test/functional/feature_maxtipage.py
@@ -62,4 +62,4 @@ class MaxTipAgeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MaxTipAgeTest().main()
+    MaxTipAgeTest(__file__).main()

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -206,4 +206,4 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(extra_args=["-maxuploadtarget=abc"], expected_msg="Error: Unable to parse -maxuploadtarget: 'abc'")
 
 if __name__ == '__main__':
-    MaxUploadTest().main()
+    MaxUploadTest(__file__).main()

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -115,4 +115,4 @@ class MinimumChainWorkTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MinimumChainWorkTest().main()
+    MinimumChainWorkTest(__file__).main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -194,4 +194,4 @@ class NotificationsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NotificationsTest().main()
+    NotificationsTest(__file__).main()

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -154,4 +154,4 @@ class NULLDUMMYTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NULLDUMMYTest().main()
+    NULLDUMMYTest(__file__).main()

--- a/test/functional/feature_posix_fs_permissions.py
+++ b/test/functional/feature_posix_fs_permissions.py
@@ -40,4 +40,4 @@ class PosixFsPermissionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PosixFsPermissionsTest().main()
+    PosixFsPermissionsTest(__file__).main()

--- a/test/functional/feature_presegwit_node_upgrade.py
+++ b/test/functional/feature_presegwit_node_upgrade.py
@@ -54,4 +54,4 @@ class SegwitUpgradeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegwitUpgradeTest().main()
+    SegwitUpgradeTest(__file__).main()

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -457,4 +457,4 @@ class ProxyTest(BitcoinTestFramework):
             os.unlink(socket_path)
 
 if __name__ == '__main__':
-    ProxyTest().main()
+    ProxyTest(__file__).main()

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -513,4 +513,4 @@ class PruneTest(BitcoinTestFramework):
         assert_equal(pruneheight, new_pruneheight)
 
 if __name__ == '__main__':
-    PruneTest().main()
+    PruneTest(__file__).main()

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -727,4 +727,4 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert conflicting_tx['txid'] in self.nodes[0].getrawmempool()
 
 if __name__ == '__main__':
-    ReplaceByFeeTest().main()
+    ReplaceByFeeTest(__file__).main()

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -103,4 +103,4 @@ class ReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ReindexTest().main()
+    ReindexTest(__file__).main()

--- a/test/functional/feature_reindex_readonly.py
+++ b/test/functional/feature_reindex_readonly.py
@@ -87,4 +87,4 @@ class BlockstoreReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockstoreReindexTest().main()
+    BlockstoreReindexTest(__file__).main()

--- a/test/functional/feature_remove_pruned_files_on_startup.py
+++ b/test/functional/feature_remove_pruned_files_on_startup.py
@@ -52,4 +52,4 @@ class FeatureRemovePrunedFilesOnStartupTest(BitcoinTestFramework):
         assert not os.path.exists(rev1)
 
 if __name__ == '__main__':
-    FeatureRemovePrunedFilesOnStartupTest().main()
+    FeatureRemovePrunedFilesOnStartupTest(__file__).main()

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -657,4 +657,4 @@ class SegWitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegWitTest().main()
+    SegWitTest(__file__).main()

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -88,4 +88,4 @@ class SettingsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SettingsTest().main()
+    SettingsTest(__file__).main()

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -32,4 +32,4 @@ class ShutdownTest(BitcoinTestFramework):
         self.stop_node(0, wait=1000)
 
 if __name__ == '__main__':
-    ShutdownTest().main()
+    ShutdownTest(__file__).main()

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -82,4 +82,4 @@ class SignetBasicTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignetBasicTest().main()
+    SignetBasicTest(__file__).main()

--- a/test/functional/feature_startupnotify.py
+++ b/test/functional/feature_startupnotify.py
@@ -39,4 +39,4 @@ class StartupNotifyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    StartupNotifyTest().main()
+    StartupNotifyTest(__file__).main()

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1766,4 +1766,4 @@ class TaprootTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TaprootTest().main()
+    TaprootTest(__file__).main()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -37,4 +37,4 @@ class UacommentTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UacommentTest().main()
+    UacommentTest(__file__).main()

--- a/test/functional/feature_unsupported_utxo_db.py
+++ b/test/functional/feature_unsupported_utxo_db.py
@@ -58,4 +58,4 @@ class UnsupportedUtxoDbTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    UnsupportedUtxoDbTest().main()
+    UnsupportedUtxoDbTest(__file__).main()

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -75,4 +75,4 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UTXOSetHashTest().main()
+    UTXOSetHashTest(__file__).main()

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -100,4 +100,4 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.wait_until(lambda: self.versionbits_in_alert_file())
 
 if __name__ == '__main__':
-    VersionBitsWarningTest().main()
+    VersionBitsWarningTest(__file__).main()

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -383,4 +383,4 @@ class TestBitcoinCli(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TestBitcoinCli().main()
+    TestBitcoinCli(__file__).main()

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -106,4 +106,4 @@ class HTTPBasicsTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HTTPBasicsTest ().main ()
+    HTTPBasicsTest(__file__).main()

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -436,4 +436,4 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(resp.read().decode('utf-8').rstrip(), f"Invalid hash: {INVALID_PARAM}")
 
 if __name__ == '__main__':
-    RESTTest().main()
+    RESTTest(__file__).main()

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -246,4 +246,4 @@ class RPCInterfaceTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RPCInterfaceTest().main()
+    RPCInterfaceTest(__file__).main()

--- a/test/functional/interface_usdt_coinselection.py
+++ b/test/functional/interface_usdt_coinselection.py
@@ -231,4 +231,4 @@ class CoinSelectionTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CoinSelectionTracepointTest().main()
+    CoinSelectionTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -322,4 +322,4 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolTracepointTest().main()
+    MempoolTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -168,4 +168,4 @@ class NetTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetTracepointTest().main()
+    NetTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -407,4 +407,4 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UTXOCacheTracepointTest().main()
+    UTXOCacheTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -131,4 +131,4 @@ class ValidationTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ValidationTracepointTest().main()
+    ValidationTracepointTest(__file__).main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -597,4 +597,4 @@ class ZMQTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ZMQTest().main()
+    ZMQTest(__file__).main()

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -409,4 +409,4 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         )
 
 if __name__ == '__main__':
-    MempoolAcceptanceTest().main()
+    MempoolAcceptanceTest(__file__).main()

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -125,4 +125,4 @@ class MempoolWtxidTest(BitcoinTestFramework):
         assert_equal(node.getmempoolinfo()["unbroadcastcount"], 0)
 
 if __name__ == '__main__':
-    MempoolWtxidTest().main()
+    MempoolWtxidTest(__file__).main()

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -78,4 +78,4 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolCompatibilityTest().main()
+    MempoolCompatibilityTest(__file__).main()

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -88,4 +88,4 @@ class DataCarrierTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DataCarrierTest().main()
+    DataCarrierTest(__file__).main()

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -110,4 +110,4 @@ class DustRelayFeeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DustRelayFeeTest().main()
+    DustRelayFeeTest(__file__).main()

--- a/test/functional/mempool_expiry.py
+++ b/test/functional/mempool_expiry.py
@@ -114,4 +114,4 @@ class MempoolExpiryTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolExpiryTest().main()
+    MempoolExpiryTest(__file__).main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -342,4 +342,4 @@ class MempoolLimitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolLimitTest().main()
+    MempoolLimitTest(__file__).main()

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -343,4 +343,4 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolPackageLimitsTest().main()
+    MempoolPackageLimitsTest(__file__).main()

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -77,4 +77,4 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolPackagesTest().main()
+    MempoolPackagesTest(__file__).main()

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -596,4 +596,4 @@ class PackageRBFTest(BitcoinTestFramework):
         assert child_result["txid"] not in mempool_info
 
 if __name__ == "__main__":
-    PackageRBFTest().main()
+    PackageRBFTest(__file__).main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -298,4 +298,4 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.sync_blocks()
 
 if __name__ == '__main__':
-    MempoolPackagesTest().main()
+    MempoolPackagesTest(__file__).main()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -263,4 +263,4 @@ class MempoolPersistTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolPersistTest().main()
+    MempoolPersistTest(__file__).main()

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -194,4 +194,4 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolCoinbaseTest().main()
+    MempoolCoinbaseTest(__file__).main()

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -55,4 +55,4 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolCoinbaseTest().main()
+    MempoolCoinbaseTest(__file__).main()

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -196,4 +196,4 @@ class BytesPerSigOpTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BytesPerSigOpTest().main()
+    BytesPerSigOpTest(__file__).main()

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -57,4 +57,4 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolSpendCoinbaseTest().main()
+    MempoolSpendCoinbaseTest(__file__).main()

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -644,4 +644,4 @@ class MempoolTRUC(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolTRUC().main()
+    MempoolTRUC(__file__).main()

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -109,4 +109,4 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolUnbroadcastTest().main()
+    MempoolUnbroadcastTest(__file__).main()

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -103,4 +103,4 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolUpdateFromBlockTest().main()
+    MempoolUpdateFromBlockTest(__file__).main()

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -325,4 +325,4 @@ class MiningTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MiningTest().main()
+    MiningTest(__file__).main()

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -73,4 +73,4 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         assert not thr.is_alive()
 
 if __name__ == '__main__':
-    GetBlockTemplateLPTest().main()
+    GetBlockTemplateLPTest(__file__).main()

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -305,4 +305,4 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         assert template != new_template
 
 if __name__ == '__main__':
-    PrioritiseTransactionTest().main()
+    PrioritiseTransactionTest(__file__).main()

--- a/test/functional/p2p_1p1c_network.py
+++ b/test/functional/p2p_1p1c_network.py
@@ -163,4 +163,4 @@ class PackageRelayTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PackageRelayTest().main()
+    PackageRelayTest(__file__).main()

--- a/test/functional/p2p_add_connections.py
+++ b/test/functional/p2p_add_connections.py
@@ -107,4 +107,4 @@ class P2PAddConnections(BitcoinTestFramework):
         assert_equal(feeler_conn.last_message["version"].relay, 0)
 
 if __name__ == '__main__':
-    P2PAddConnections().main()
+    P2PAddConnections(__file__).main()

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -441,4 +441,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_addrfetch.py
+++ b/test/functional/p2p_addrfetch.py
@@ -83,4 +83,4 @@ class P2PAddrFetch(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PAddrFetch().main()
+    P2PAddrFetch(__file__).main()

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -110,4 +110,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_block_sync.py
+++ b/test/functional/p2p_block_sync.py
@@ -34,4 +34,4 @@ class BlockSyncTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockSyncTest().main()
+    BlockSyncTest(__file__).main()

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -282,4 +282,4 @@ def compute_last_header(prev_header, hashes):
 
 
 if __name__ == '__main__':
-    CompactFiltersTest().main()
+    CompactFiltersTest(__file__).main()

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -125,4 +125,4 @@ class P2PBlocksOnly(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PBlocksOnly().main()
+    P2PBlocksOnly(__file__).main()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -965,4 +965,4 @@ class CompactBlocksTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CompactBlocksTest().main()
+    CompactBlocksTest(__file__).main()

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -127,4 +127,4 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         p2p_conn_blocksonly.wait_until(lambda: test_for_cmpctblock(block2))
 
 if __name__ == '__main__':
-    P2PCompactBlocksBlocksOnly().main()
+    P2PCompactBlocksBlocksOnly(__file__).main()

--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -97,4 +97,4 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CompactBlocksConnectionTest().main()
+    CompactBlocksConnectionTest(__file__).main()

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -147,4 +147,4 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
 
 if __name__ == '__main__':
-    DisconnectBanTest().main()
+    DisconnectBanTest(__file__).main()

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -126,4 +126,4 @@ class P2PDNSSeeds(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PDNSSeeds().main()
+    P2PDNSSeeds(__file__).main()

--- a/test/functional/p2p_dos_header_tree.py
+++ b/test/functional/p2p_dos_header_tree.py
@@ -85,4 +85,4 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RejectLowDifficultyHeadersTest().main()
+    RejectLowDifficultyHeadersTest(__file__).main()

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -124,4 +124,4 @@ class P2PEvict(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PEvict().main()
+    P2PEvict(__file__).main()

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -132,4 +132,4 @@ class FeeFilterTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeeFilterTest().main()
+    FeeFilterTest(__file__).main()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -252,4 +252,4 @@ class FilterTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FilterTest().main()
+    FilterTest(__file__).main()

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -130,4 +130,4 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PFingerprintTest().main()
+    P2PFingerprintTest(__file__).main()

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -119,4 +119,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -46,4 +46,4 @@ class GetdataTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    GetdataTest().main()
+    GetdataTest(__file__).main()

--- a/test/functional/p2p_handshake.py
+++ b/test/functional/p2p_handshake.py
@@ -97,4 +97,4 @@ class P2PHandshakeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PHandshakeTest().main()
+    P2PHandshakeTest(__file__).main()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -162,4 +162,4 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RejectLowDifficultyHeadersTest().main()
+    RejectLowDifficultyHeadersTest(__file__).main()

--- a/test/functional/p2p_i2p_ports.py
+++ b/test/functional/p2p_i2p_ports.py
@@ -32,4 +32,4 @@ class I2PPorts(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    I2PPorts().main()
+    I2PPorts(__file__).main()

--- a/test/functional/p2p_i2p_sessions.py
+++ b/test/functional/p2p_i2p_sessions.py
@@ -33,4 +33,4 @@ class I2PSessions(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    I2PSessions().main()
+    I2PSessions(__file__).main()

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -162,4 +162,4 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PIBDStallingTest().main()
+    P2PIBDStallingTest(__file__).main()

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -86,4 +86,4 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             peer_txer.send_and_ping(msg_tx(tx))
 
 if __name__ == '__main__':
-    P2PIBDTxRelayTest().main()
+    P2PIBDTxRelayTest(__file__).main()

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -96,5 +96,5 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.log.info("Success!")
 
 if __name__ == '__main__':
-    HeadersSyncTest().main()
+    HeadersSyncTest(__file__).main()
 

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -138,4 +138,4 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidBlockRequestTest().main()
+    InvalidBlockRequestTest(__file__).main()

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -39,4 +39,4 @@ class InvalidLocatorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidLocatorTest().main()
+    InvalidLocatorTest(__file__).main()

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -356,4 +356,4 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidMessagesTest().main()
+    InvalidMessagesTest(__file__).main()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -224,4 +224,4 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidTxRequestTest().main()
+    InvalidTxRequestTest(__file__).main()

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -178,4 +178,4 @@ class P2PLeakTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PLeakTest().main()
+    P2PLeakTest(__file__).main()

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -104,4 +104,4 @@ class P2PLeakTxTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PLeakTxTest().main()
+    P2PLeakTxTest(__file__).main()

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -69,4 +69,4 @@ class MessageCaptureTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MessageCaptureTest().main()
+    MessageCaptureTest(__file__).main()

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -112,4 +112,4 @@ class MutatedBlocksTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MutatedBlocksTest().main()
+    MutatedBlocksTest(__file__).main()

--- a/test/functional/p2p_net_deadlock.py
+++ b/test/functional/p2p_net_deadlock.py
@@ -34,4 +34,4 @@ class NetDeadlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetDeadlockTest().main()
+    NetDeadlockTest(__file__).main()

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -45,4 +45,4 @@ class P2PNoBloomFilterMessages(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PNoBloomFilterMessages().main()
+    P2PNoBloomFilterMessages(__file__).main()

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -172,4 +172,4 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.test_avoid_requesting_historical_blocks()
 
 if __name__ == '__main__':
-    NodeNetworkLimitedTest().main()
+    NodeNetworkLimitedTest(__file__).main()

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -412,4 +412,4 @@ class PackageRelayTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PackageRelayTest().main()
+    PackageRelayTest(__file__).main()

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -585,4 +585,4 @@ class OrphanHandlingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    OrphanHandlingTest().main()
+    OrphanHandlingTest(__file__).main()

--- a/test/functional/p2p_outbound_eviction.py
+++ b/test/functional/p2p_outbound_eviction.py
@@ -250,4 +250,4 @@ class P2POutEvict(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2POutEvict().main()
+    P2POutEvict(__file__).main()

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -147,4 +147,4 @@ class P2PPermissionsTests(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PPermissionsTests().main()
+    P2PPermissionsTests(__file__).main()

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -117,4 +117,4 @@ class PingPongTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PingPongTest().main()
+    PingPongTest(__file__).main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -2067,4 +2067,4 @@ class SegWitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegWitTest().main()
+    SegWitTest(__file__).main()

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -568,4 +568,4 @@ class SendHeadersTest(BitcoinTestFramework):
         assert "getdata" not in inv_node.last_message
 
 if __name__ == '__main__':
-    SendHeadersTest().main()
+    SendHeadersTest(__file__).main()

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -232,4 +232,4 @@ class SendTxRcnclTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SendTxRcnclTest().main()
+    SendTxRcnclTest(__file__).main()

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -109,4 +109,4 @@ class TimeoutsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TimeoutsTest().main()
+    TimeoutsTest(__file__).main()

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -306,4 +306,4 @@ class TxDownloadTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxDownloadTest().main()
+    TxDownloadTest(__file__).main()

--- a/test/functional/p2p_tx_privacy.py
+++ b/test/functional/p2p_tx_privacy.py
@@ -74,4 +74,4 @@ class TxPrivacyTest(BitcoinTestFramework):
         spy.wait_for_inv_match(CInv(MSG_WTX, tx2.calc_sha256(True)))
 
 if __name__ == '__main__':
-    TxPrivacyTest().main()
+    TxPrivacyTest(__file__).main()

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -296,4 +296,4 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.log.info("Successfully synced nodes 1 and 0")
 
 if __name__ == '__main__':
-    AcceptBlockTest().main()
+    AcceptBlockTest(__file__).main()

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -131,4 +131,4 @@ class P2PEncrypted(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PEncrypted().main()
+    P2PEncrypted(__file__).main()

--- a/test/functional/p2p_v2_misbehaving.py
+++ b/test/functional/p2p_v2_misbehaving.py
@@ -185,4 +185,4 @@ class EncryptedP2PMisbehaving(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    EncryptedP2PMisbehaving().main()
+    EncryptedP2PMisbehaving(__file__).main()

--- a/test/functional/p2p_v2_transport.py
+++ b/test/functional/p2p_v2_transport.py
@@ -168,4 +168,4 @@ class V2TransportTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    V2TransportTest().main()
+    V2TransportTest(__file__).main()

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -124,4 +124,4 @@ class RPCBindTest(BitcoinTestFramework):
         assert_raises_rpc_error(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], self.non_loopback_ip, self.defaultport)
 
 if __name__ == '__main__':
-    RPCBindTest().main()
+    RPCBindTest(__file__).main()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -635,4 +635,4 @@ class BlockchainTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockchainTest().main()
+    BlockchainTest(__file__).main()

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -257,4 +257,4 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RpcCreateMultiSigTest().main()
+    RpcCreateMultiSigTest(__file__).main()

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -289,4 +289,4 @@ class DecodeScriptTest(BitcoinTestFramework):
         self.decodescript_miniscript()
 
 if __name__ == '__main__':
-    DecodeScriptTest().main()
+    DecodeScriptTest(__file__).main()

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -26,4 +26,4 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         self.log.info("No tested deprecated RPC methods")
 
 if __name__ == '__main__':
-    DeprecatedRpcTest().main()
+    DeprecatedRpcTest(__file__).main()

--- a/test/functional/rpc_deriveaddresses.py
+++ b/test/functional/rpc_deriveaddresses.py
@@ -61,4 +61,4 @@ class DeriveaddressesTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, "Descriptor does not have a corresponding address", self.nodes[0].deriveaddresses, bare_multisig_descriptor)
 
 if __name__ == '__main__':
-    DeriveaddressesTest().main()
+    DeriveaddressesTest(__file__).main()

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -58,4 +58,4 @@ class DumptxoutsetTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DumptxoutsetTest().main()
+    DumptxoutsetTest(__file__).main()

--- a/test/functional/rpc_estimatefee.py
+++ b/test/functional/rpc_estimatefee.py
@@ -52,4 +52,4 @@ class EstimateFeeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    EstimateFeeTest().main()
+    EstimateFeeTest(__file__).main()

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -126,4 +126,4 @@ class RPCGenerateTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    RPCGenerateTest().main()
+    RPCGenerateTest(__file__).main()

--- a/test/functional/rpc_getblockfilter.py
+++ b/test/functional/rpc_getblockfilter.py
@@ -61,4 +61,4 @@ class GetBlockFilterTest(BitcoinTestFramework):
                                     self.nodes[0].getblockfilter, genesis_hash, filter_type)
 
 if __name__ == '__main__':
-    GetBlockFilterTest().main()
+    GetBlockFilterTest(__file__).main()

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -154,4 +154,4 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    GetBlockFromPeerTest().main()
+    GetBlockFromPeerTest(__file__).main()

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -183,4 +183,4 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(tip_stats["utxo_size_inc_actual"], 300)
 
 if __name__ == '__main__':
-    GetblockstatsTest().main()
+    GetblockstatsTest(__file__).main()

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -58,4 +58,4 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (tips[1], shortTip)
 
 if __name__ == '__main__':
-    GetChainTipsTest ().main ()
+    GetChainTipsTest(__file__).main()

--- a/test/functional/rpc_getdescriptorinfo.py
+++ b/test/functional/rpc_getdescriptorinfo.py
@@ -63,4 +63,4 @@ class DescriptorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DescriptorTest().main()
+    DescriptorTest(__file__).main()

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -132,4 +132,4 @@ class HelpRpcTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HelpRpcTest().main()
+    HelpRpcTest(__file__).main()

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -119,4 +119,4 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidAddressErrorMessageTest().main()
+    InvalidAddressErrorMessageTest(__file__).main()

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -90,4 +90,4 @@ class InvalidateTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidateTest().main()
+    InvalidateTest(__file__).main()

--- a/test/functional/rpc_mempool_info.py
+++ b/test/functional/rpc_mempool_info.py
@@ -96,4 +96,4 @@ class RPCMempoolInfoTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RPCMempoolInfoTest().main()
+    RPCMempoolInfoTest(__file__).main()

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -102,4 +102,4 @@ class RpcMiscTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RpcMiscTest().main()
+    RpcMiscTest(__file__).main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -35,4 +35,4 @@ class NamedArgumentTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Parameter arg1 specified twice both as positional and named argument", node.echo, 0, None, 2, arg1=1)
 
 if __name__ == '__main__':
-    NamedArgumentTest().main()
+    NamedArgumentTest(__file__).main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -574,4 +574,4 @@ class NetTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetTest().main()
+    NetTest(__file__).main()

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -489,4 +489,4 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(node.getrawmempool(), [chained_txns_burn[0]["txid"]])
 
 if __name__ == "__main__":
-    RPCPackagesTest().main()
+    RPCPackagesTest(__file__).main()

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -109,4 +109,4 @@ class PreciousTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getbestblockhash(), hashH)
 
 if __name__ == '__main__':
-    PreciousTest().main()
+    PreciousTest(__file__).main()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -985,4 +985,4 @@ class PSBTTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PSBTTest().main()
+    PSBTTest(__file__).main()

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -612,4 +612,4 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RawTransactionsTest().main()
+    RawTransactionsTest(__file__).main()

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -136,4 +136,4 @@ class ScanblocksTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ScanblocksTest().main()
+    ScanblocksTest(__file__).main()

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -131,4 +131,4 @@ class ScantxoutsetTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ScantxoutsetTest().main()
+    ScantxoutsetTest(__file__).main()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -75,4 +75,4 @@ class SetBanTests(BitcoinTestFramework):
         assert_equal(banned['ban_duration'], 1234)
 
 if __name__ == '__main__':
-    SetBanTests().main()
+    SetBanTests(__file__).main()

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -77,4 +77,4 @@ class RPCSignerTest(BitcoinTestFramework):
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':
-    RPCSignerTest().main()
+    RPCSignerTest(__file__).main()

--- a/test/functional/rpc_signmessagewithprivkey.py
+++ b/test/functional/rpc_signmessagewithprivkey.py
@@ -60,4 +60,4 @@ class SignMessagesWithPrivTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignMessagesWithPrivTest().main()
+    SignMessagesWithPrivTest(__file__).main()

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -143,4 +143,4 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignRawTransactionWithKeyTest().main()
+    SignRawTransactionWithKeyTest(__file__).main()

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -104,4 +104,4 @@ class MerkleBlockTest(BitcoinTestFramework):
         # verify that the proofs are invalid
 
 if __name__ == '__main__':
-    MerkleBlockTest().main()
+    MerkleBlockTest(__file__).main()

--- a/test/functional/rpc_uptime.py
+++ b/test/functional/rpc_uptime.py
@@ -32,4 +32,4 @@ class UptimeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UptimeTest().main()
+    UptimeTest(__file__).main()

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -156,4 +156,4 @@ class HTTPBasicsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HTTPBasicsTest().main()
+    HTTPBasicsTest(__file__).main()

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -200,4 +200,4 @@ class ValidateAddressMainTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ValidateAddressMainTest().main()
+    ValidateAddressMainTest(__file__).main()

--- a/test/functional/rpc_whitelist.py
+++ b/test/functional/rpc_whitelist.py
@@ -93,4 +93,4 @@ class RPCWhitelistTest(BitcoinTestFramework):
         assert_equal(200, rpccall(self.nodes[0], self.strange_users[4], "getblockcount").status)
 
 if __name__ == "__main__":
-    RPCWhitelistTest().main()
+    RPCWhitelistTest(__file__).main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -103,7 +103,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
         self.supports_cli = True
         self.bind_to_localhost_only = True
-        self.parse_args()
+        self.parse_args(test_file)
         self.default_wallet_name = "default_wallet" if self.options.descriptors else ""
         self.wallet_data_filename = "wallet.dat"
         # Optional list of wallet names that can be set in set_test_params to
@@ -155,14 +155,14 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             exit_code = self.shutdown()
             sys.exit(exit_code)
 
-    def parse_args(self):
+    def parse_args(self, test_file):
         previous_releases_path = os.getenv("PREVIOUS_RELEASES_DIR") or os.getcwd() + "/releases"
         parser = argparse.ArgumentParser(usage="%(prog)s [options]")
         parser.add_argument("--nocleanup", dest="nocleanup", default=False, action="store_true",
                             help="Leave bitcoinds and test.* datadir on exit or error")
         parser.add_argument("--noshutdown", dest="noshutdown", default=False, action="store_true",
                             help="Don't stop bitcoinds after the test execution")
-        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../cache"),
+        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(test_file) + "/../cache"),
                             help="Directory for caching pregenerated datadirs (default: %(default)s)")
         parser.add_argument("--tmpdir", dest="tmpdir", help="Root directory for datadirs (must not exist)")
         parser.add_argument("-l", "--loglevel", dest="loglevel", default="INFO",
@@ -177,7 +177,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         parser.add_argument("--coveragedir", dest="coveragedir",
                             help="Write tested RPC commands into this directory")
         parser.add_argument("--configfile", dest="configfile",
-                            default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../config.ini"),
+                            default=os.path.abspath(os.path.dirname(test_file) + "/../config.ini"),
                             help="Location of the test framework config file (default: %(default)s)")
         parser.add_argument("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
                             help="Attach a python debugger if test fails")

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -92,7 +92,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     This class also contains various public and private helper methods."""
 
-    def __init__(self) -> None:
+    def __init__(self, test_file) -> None:
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
         self.chain: str = 'regtest'
         self.setup_clean_chain: bool = False

--- a/test/functional/tool_signet_miner.py
+++ b/test/functional/tool_signet_miner.py
@@ -62,4 +62,4 @@ class SignetMinerTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    SignetMinerTest().main()
+    SignetMinerTest(__file__).main()

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -563,4 +563,4 @@ class ToolWalletTest(BitcoinTestFramework):
         self.test_dump_very_large_records()
 
 if __name__ == '__main__':
-    ToolWalletTest().main()
+    ToolWalletTest(__file__).main()

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -241,4 +241,4 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_equal(newbalance, balance - Decimal("20"))
 
 if __name__ == '__main__':
-    AbandonConflictTest().main()
+    AbandonConflictTest(__file__).main()

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -387,4 +387,4 @@ class AddressTypeTest(BitcoinTestFramework):
             assert_raises_rpc_error(-8, "Legacy wallets cannot provide bech32m addresses", self.nodes[0].getrawchangeaddress, "bech32m")
 
 if __name__ == '__main__':
-    AddressTypeTest().main()
+    AddressTypeTest(__file__).main()

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -164,4 +164,4 @@ class AssumeutxoTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AssumeutxoTest().main()
+    AssumeutxoTest(__file__).main()

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -177,4 +177,4 @@ class AddressInputTypeGrouping(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddressInputTypeGrouping().main()
+    AddressInputTypeGrouping(__file__).main()

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -381,4 +381,4 @@ class AvoidReuseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AvoidReuseTest().main()
+    AvoidReuseTest(__file__).main()

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -244,4 +244,4 @@ class WalletBackupTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletBackupTest().main()
+    WalletBackupTest(__file__).main()

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -400,4 +400,4 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                 assert_equal(info, addr_info)
 
 if __name__ == '__main__':
-    BackwardsCompatibilityTest().main()
+    BackwardsCompatibilityTest(__file__).main()

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -339,4 +339,4 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(tx_info['lastprocessedblock']['hash'], prev_hash)
 
 if __name__ == '__main__':
-    WalletTest().main()
+    WalletTest(__file__).main()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -818,4 +818,4 @@ class WalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletTest().main()
+    WalletTest(__file__).main()

--- a/test/functional/wallet_blank.py
+++ b/test/functional/wallet_blank.py
@@ -160,4 +160,4 @@ class WalletBlankTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletBlankTest().main()
+    WalletBlankTest(__file__).main()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -854,4 +854,4 @@ def test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, rbf_node, 
 
 
 if __name__ == "__main__":
-    BumpFeeTest().main()
+    BumpFeeTest(__file__).main()

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -105,4 +105,4 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         self.assert_change_pos(w1, tx, 0)
 
 if __name__ == '__main__':
-    WalletChangeAddressTest().main()
+    WalletChangeAddressTest(__file__).main()

--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -60,4 +60,4 @@ class CoinbaseCategoryTest(BitcoinTestFramework):
         self.assert_category("orphan", address, txid, 100)
 
 if __name__ == '__main__':
-    CoinbaseCategoryTest().main()
+    CoinbaseCategoryTest(__file__).main()

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -423,4 +423,4 @@ class TxConflicts(BitcoinTestFramework):
         carol.unloadwallet()
 
 if __name__ == '__main__':
-    TxConflicts().main()
+    TxConflicts(__file__).main()

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -129,4 +129,4 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CreateTxWalletTest().main()
+    CreateTxWalletTest(__file__).main()

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -190,4 +190,4 @@ class CreateWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CreateWalletTest().main()
+    CreateWalletTest(__file__).main()

--- a/test/functional/wallet_createwalletdescriptor.py
+++ b/test/functional/wallet_createwalletdescriptor.py
@@ -120,4 +120,4 @@ class WalletCreateDescriptorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletCreateDescriptorTest().main()
+    WalletCreateDescriptorTest(__file__).main()

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -62,4 +62,4 @@ class WalletCrossChain(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletCrossChain().main()
+    WalletCrossChain(__file__).main()

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -282,4 +282,4 @@ class WalletDescriptorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletDescriptorTest().main ()
+    WalletDescriptorTest(__file__).main()

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -28,4 +28,4 @@ class DisableWalletTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DisableWalletTest().main()
+    DisableWalletTest(__file__).main()

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -223,4 +223,4 @@ class WalletDumpTest(BitcoinTestFramework):
         w3.dumpwallet(self.nodes[0].datadir_path / "w3.dump")
 
 if __name__ == '__main__':
-    WalletDumpTest().main()
+    WalletDumpTest(__file__).main()

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -102,4 +102,4 @@ class WalletEncryptionTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletEncryptionTest().main()
+    WalletEncryptionTest(__file__).main()

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -32,4 +32,4 @@ class WalletRBFTest(BitcoinTestFramework):
         assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendmany("", {self.nodes[0].getnewaddress(): 1}))
 
 if __name__ == '__main__':
-    WalletRBFTest().main()
+    WalletRBFTest(__file__).main()

--- a/test/functional/wallet_fast_rescan.py
+++ b/test/functional/wallet_fast_rescan.py
@@ -99,4 +99,4 @@ class WalletFastRescanTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletFastRescanTest().main()
+    WalletFastRescanTest(__file__).main()

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -1523,4 +1523,4 @@ class RawTransactionsTest(BitcoinTestFramework):
         wallet.unloadwallet()
 
 if __name__ == '__main__':
-    RawTransactionsTest().main()
+    RawTransactionsTest(__file__).main()

--- a/test/functional/wallet_gethdkeys.py
+++ b/test/functional/wallet_gethdkeys.py
@@ -182,4 +182,4 @@ class WalletGetHDKeyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletGetHDKeyTest().main()
+    WalletGetHDKeyTest(__file__).main()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -182,4 +182,4 @@ class WalletGroupTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletGroupTest().main()
+    WalletGroupTest(__file__).main()

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -280,4 +280,4 @@ class WalletHDTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletHDTest().main()
+    WalletHDTest(__file__).main()

--- a/test/functional/wallet_implicitsegwit.py
+++ b/test/functional/wallet_implicitsegwit.py
@@ -65,4 +65,4 @@ class ImplicitSegwitTest(BitcoinTestFramework):
         check_implicit_transactions(implicit_keys, self.nodes[0])
 
 if __name__ == '__main__':
-    ImplicitSegwitTest().main()
+    ImplicitSegwitTest(__file__).main()

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -338,4 +338,4 @@ class ImportRescanTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ImportRescanTest().main()
+    ImportRescanTest(__file__).main()

--- a/test/functional/wallet_import_with_label.py
+++ b/test/functional/wallet_import_with_label.py
@@ -125,4 +125,4 @@ class ImportWithLabel(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ImportWithLabel().main()
+    ImportWithLabel(__file__).main()

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -709,4 +709,4 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(temp_wallet.getbalance(), encrypted_wallet.getbalance())
 
 if __name__ == '__main__':
-    ImportDescriptorsTest().main()
+    ImportDescriptorsTest(__file__).main()

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -898,4 +898,4 @@ class ImportMultiTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ImportMultiTest().main()
+    ImportMultiTest(__file__).main()

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -143,4 +143,4 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ImportPrunedFundsTest().main()
+    ImportPrunedFundsTest(__file__).main()

--- a/test/functional/wallet_inactive_hdchains.py
+++ b/test/functional/wallet_inactive_hdchains.py
@@ -146,4 +146,4 @@ class InactiveHDChainsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InactiveHDChainsTest().main()
+    InactiveHDChainsTest(__file__).main()

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -223,4 +223,4 @@ class KeyPoolTest(BitcoinTestFramework):
             assert_raises_rpc_error(-4, msg, w2.keypoolrefill, 100)
 
 if __name__ == '__main__':
-    KeyPoolTest().main()
+    KeyPoolTest(__file__).main()

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -98,4 +98,4 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    KeypoolRestoreTest().main()
+    KeypoolRestoreTest(__file__).main()

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -256,4 +256,4 @@ def change_label(node, address, old_label, new_label):
     new_label.verify(node)
 
 if __name__ == '__main__':
-    WalletLabelsTest().main()
+    WalletLabelsTest(__file__).main()

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -136,4 +136,4 @@ class ListDescriptorsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListDescriptorsTest().main()
+    ListDescriptorsTest(__file__).main()

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -263,4 +263,4 @@ class ReceivedByTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ReceivedByTest().main()
+    ReceivedByTest(__file__).main()

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -505,4 +505,4 @@ class ListSinceBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListSinceBlockTest().main()
+    ListSinceBlockTest(__file__).main()

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -330,4 +330,4 @@ class ListTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListTransactionsTest().main()
+    ListTransactionsTest(__file__).main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -1032,4 +1032,4 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_blank()
 
 if __name__ == '__main__':
-    WalletMigrationTest().main()
+    WalletMigrationTest(__file__).main()

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -401,4 +401,4 @@ class WalletMiniscriptTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletMiniscriptTest().main()
+    WalletMiniscriptTest(__file__).main()

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -154,4 +154,4 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletMultisigDescriptorPSBTTest().main()
+    WalletMultisigDescriptorPSBTTest(__file__).main()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -423,4 +423,4 @@ class MultiWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MultiWalletTest().main()
+    MultiWalletTest(__file__).main()

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -73,4 +73,4 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    OrphanedBlockRewardTest().main()
+    OrphanedBlockRewardTest(__file__).main()

--- a/test/functional/wallet_pruning.py
+++ b/test/functional/wallet_pruning.py
@@ -155,4 +155,4 @@ class WalletPruningTest(BitcoinTestFramework):
         self.test_wallet_import_pruned_with_missing_blocks(wallet_birthheight_1)
 
 if __name__ == '__main__':
-    WalletPruningTest().main()
+    WalletPruningTest(__file__).main()

--- a/test/functional/wallet_reindex.py
+++ b/test/functional/wallet_reindex.py
@@ -105,4 +105,4 @@ class WalletReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletReindexTest().main()
+    WalletReindexTest(__file__).main()

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -101,4 +101,4 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         assert conflicting["blockhash"] != conflicted_after_reorg["blockhash"]
 
 if __name__ == '__main__':
-    ReorgsRestoreTest().main()
+    ReorgsRestoreTest(__file__).main()

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -80,4 +80,4 @@ class WalletRescanUnconfirmed(BitcoinTestFramework):
         assert_equal(w1.gettransaction(tx_child_unconfirmed_sweep["txid"])["confirmations"], 0)
 
 if __name__ == '__main__':
-    WalletRescanUnconfirmed().main()
+    WalletRescanUnconfirmed(__file__).main()

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -149,4 +149,4 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ResendWalletTransactionsTest().main()
+    ResendWalletTransactionsTest(__file__).main()

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -612,4 +612,4 @@ class WalletSendTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletSendTest().main()
+    WalletSendTest(__file__).main()

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -531,4 +531,4 @@ class SendallTest(BitcoinTestFramework):
         self.sendall_fails_with_transaction_too_large()
 
 if __name__ == '__main__':
-    SendallTest().main()
+    SendallTest(__file__).main()

--- a/test/functional/wallet_sendmany.py
+++ b/test/functional/wallet_sendmany.py
@@ -40,4 +40,4 @@ class SendmanyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SendmanyTest().main()
+    SendmanyTest(__file__).main()

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -263,4 +263,4 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "GetExternalSigner: More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, descriptors=True, external_signer=True)
 
 if __name__ == '__main__':
-    WalletSignerTest().main()
+    WalletSignerTest(__file__).main()

--- a/test/functional/wallet_signmessagewithaddress.py
+++ b/test/functional/wallet_signmessagewithaddress.py
@@ -45,4 +45,4 @@ class SignMessagesWithAddressTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignMessagesWithAddressTest().main()
+    SignMessagesWithAddressTest(__file__).main()

--- a/test/functional/wallet_signrawtransactionwithwallet.py
+++ b/test/functional/wallet_signrawtransactionwithwallet.py
@@ -310,4 +310,4 @@ class SignRawTransactionWithWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignRawTransactionWithWalletTest().main()
+    SignRawTransactionWithWalletTest(__file__).main()

--- a/test/functional/wallet_simulaterawtx.py
+++ b/test/functional/wallet_simulaterawtx.py
@@ -129,4 +129,4 @@ class SimulateTxTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "One or more transaction inputs are missing or have been spent already", w2.simulaterawtransaction, [tx1, tx2])
 
 if __name__ == '__main__':
-    SimulateTxTest().main()
+    SimulateTxTest(__file__).main()

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -505,4 +505,4 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.test_external_input_unconfirmed_low()
 
 if __name__ == '__main__':
-    UnconfirmedInputTest().main()
+    UnconfirmedInputTest(__file__).main()

--- a/test/functional/wallet_startup.py
+++ b/test/functional/wallet_startup.py
@@ -58,4 +58,4 @@ class WalletStartupTest(BitcoinTestFramework):
         assert_equal(set(self.nodes[0].listwallets()), set(('w2', 'w3')))
 
 if __name__ == '__main__':
-    WalletStartupTest().main()
+    WalletStartupTest(__file__).main()

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -507,4 +507,4 @@ class WalletTaprootTest(BitcoinTestFramework):
         )
 
 if __name__ == '__main__':
-    WalletTaprootTest().main()
+    WalletTaprootTest(__file__).main()

--- a/test/functional/wallet_timelock.py
+++ b/test/functional/wallet_timelock.py
@@ -50,4 +50,4 @@ class WalletLocktimeTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletLocktimeTest().main()
+    WalletLocktimeTest(__file__).main()

--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -223,4 +223,4 @@ class TransactionTimeRescanTest(BitcoinTestFramework):
             assert_equal(encrypted_wallet.getbalance(), temp_wallet.getbalance())
 
 if __name__ == '__main__':
-    TransactionTimeRescanTest().main()
+    TransactionTimeRescanTest(__file__).main()

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -149,4 +149,4 @@ class TxnMallTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnMallTest(__file__).main()

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -138,4 +138,4 @@ class TxnMallTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnMallTest(__file__).main()

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -360,4 +360,4 @@ class UpgradeWalletTest(BitcoinTestFramework):
             self.test_upgradewallet(disabled_wallet, previous_version=169900, expected_version=169900)
 
 if __name__ == '__main__':
-    UpgradeWalletTest().main()
+    UpgradeWalletTest(__file__).main()

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -111,4 +111,4 @@ class CreateWalletWatchonlyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CreateWalletWatchonlyTest().main()
+    CreateWalletWatchonlyTest(__file__).main()


### PR DESCRIPTION
This PR includes changes split from https://github.com/bitcoin/bitcoin/pull/30454. They improve the functional test framework, allowing users to [run individual functional tests](https://github.com/hebasto/bitcoin/issues/146) from the build directory in the new CMake-based build system.

This functionality is not available for out-of-source builds using the current Autotools-based build system, which always requires write permissions for the source directory. Nevertheless, this PR can be tested as suggested in https://github.com/bitcoin/bitcoin/pull/30463#issuecomment-2232618421:
1. Make an out-of-source build:
```
$ ./autogen.sh
$ mkdir ../build && cd ../build
$ ../bitcoin/configure
$ make
```
2. Create a symlink in the build directory to a functional test:
```
$ ln --symbolic ../../../bitcoin/test/functional/wallet_disable.py ./test/functional/
```
3. Run this symlink:
```
$ ./test/functional/wallet_disable.py
```
The last command fails on the master branch:
```
Traceback (most recent call last):
  File "/home/hebasto/git/build/./test/functional/wallet_disable.py", line 31, in <module>
    DisableWalletTest().main()
    ^^^^^^^^^^^^^^^^^^^
  File "/home/hebasto/git/bitcoin/test/functional/test_framework/test_framework.py", line 106, in __init__
    self.parse_args()
  File "/home/hebasto/git/bitcoin/test/functional/test_framework/test_framework.py", line 210, in parse_args
    config.read_file(open(self.options.configfile))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/hebasto/git/bitcoin/test/config.ini'

```
and succeeds with this PR.