### PR TITLE
test, refactor: Fix MSVC warning C4101 "unreferenced local variable"

### DIFF
--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -20,7 +20,7 @@
         try { \
             (stmt); \
             assert(0 && "No exception caught"); \
-        } catch (excMatch & e) { \
+        } catch (excMatch&) { \
         } catch (...) { \
             assert(0 && "Wrong exception caught"); \
         } \

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -21,16 +21,16 @@
             (stmt); \
             assert(0 && "No exception caught"); \
         } catch (excMatch & e) { \
-	} catch (...) { \
-	    assert(0 && "Wrong exception caught"); \
-	} \
+        } catch (...) { \
+            assert(0 && "Wrong exception caught"); \
+        } \
     }
 #define BOOST_CHECK_NO_THROW(stmt) { \
         try { \
             (stmt); \
-	} catch (...) { \
-	    assert(0); \
-	} \
+        } catch (...) { \
+            assert(0); \
+        } \
     }
 
 void univalue_constructor()


### PR DESCRIPTION
This PR is split from https://github.com/bitcoin/bitcoin/pull/30454 and addresses MSVC warning [C4101](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4101) "unreferenced local variable". The current MSVC build system in the master branch skips building univalue tests, so it is not affected.

No behaviour changes.