### PR TITLE
depends: Set `CMAKE_SYSTEM_VERSION` for CMake builds

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -191,7 +191,7 @@ ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else
 ifneq ($(host),$(build))
-$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system)
+$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system_name)
 $(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host)
 $(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host)
 endif

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -192,6 +192,7 @@ $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else
 ifneq ($(host),$(build))
 $(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system_name)
+$(1)_cmake += -DCMAKE_SYSTEM_VERSION=$($(host_os)_cmake_system_version)
 $(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host)
 $(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host)
 endif

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -82,3 +82,6 @@ darwin_debug_CFLAGS=-O1 -g
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_cmake_system_name=Darwin
+# Darwin version, which corresponds to OSX_MIN_VERSION.
+# See https://en.wikipedia.org/wiki/Darwin_(operating_system)
+darwin_cmake_system_version=20.1

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -81,4 +81,4 @@ darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 darwin_debug_CFLAGS=-O1 -g
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
-darwin_cmake_system=Darwin
+darwin_cmake_system_name=Darwin

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -28,4 +28,4 @@ x86_64_freebsd_CC=$(default_host_CC) -m64
 x86_64_freebsd_CXX=$(default_host_CXX) -m64
 endif
 
-freebsd_cmake_system=FreeBSD
+freebsd_cmake_system_name=FreeBSD

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -39,4 +39,4 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
-linux_cmake_system=Linux
+linux_cmake_system_name=Linux

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -39,4 +39,7 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
+
 linux_cmake_system_name=Linux
+# Refer to doc/dependencies.md for the minimum required kernel.
+linux_cmake_system_version=3.17.0

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -20,3 +20,5 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 mingw32_cmake_system_name=Windows
+# Windows 7 (NT 6.1).
+mingw32_cmake_system_version=6.1

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -19,4 +19,4 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
-mingw32_cmake_system=Windows
+mingw32_cmake_system_name=Windows

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -36,4 +36,4 @@ x86_64_netbsd_CC=$(default_host_CC) -m64
 x86_64_netbsd_CXX=$(default_host_CXX) -m64
 endif
 
-netbsd_cmake_system=NetBSD
+netbsd_cmake_system_name=NetBSD

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -28,4 +28,4 @@ x86_64_openbsd_CC=$(default_host_CC) -m64
 x86_64_openbsd_CXX=$(default_host_CXX) -m64
 endif
 
-openbsd_cmake_system=OpenBSD
+openbsd_cmake_system_name=OpenBSD


### PR DESCRIPTION
From CMake [docs](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html):
> When the [CMAKE_SYSTEM_NAME](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html#variable:CMAKE_SYSTEM_NAME) variable is set explicitly to enable [cross compiling](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-toolchain) then the value of CMAKE_SYSTEM_VERSION must also be set explicitly to specify the target system version.

This PR is split from https://github.com/bitcoin/bitcoin/pull/30454 and improves the current depends build subsystem.