### PR TITLE
refactor: Make m_last_notified_header private

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -906,6 +906,11 @@ private:
 
     CBlockIndex* m_best_invalid GUARDED_BY(::cs_main){nullptr};
 
+    /** The last header for which a headerTip notification was issued. */
+    CBlockIndex* m_last_notified_header GUARDED_BY(GetMutex()){nullptr};
+
+    bool NotifyHeaderTip() LOCKS_EXCLUDED(GetMutex());
+
     //! Internal helper for ActivateSnapshot().
     //!
     //! De-serialization of a snapshot that is created with
@@ -1062,9 +1067,6 @@ public:
 
     /** Best header we've seen so far (used for getheaders queries' starting points). */
     CBlockIndex* m_best_header GUARDED_BY(::cs_main){nullptr};
-
-    /** The last header for which a headerTip notification was issued. */
-    CBlockIndex* m_last_notified_header GUARDED_BY(::cs_main){nullptr};
 
     //! The total number of bytes available for us to use across all in-memory
     //! coins caches. This will be split somehow across chainstates.


### PR DESCRIPTION
Seems brittle to expose mutable fields public.

Fix it by making it private.

Fixes https://github.com/bitcoin/bitcoin/pull/30425#discussion_r1677633601