### PR TITLE
test: bump mocktime only after node has received and sent bytes

### DIFF
--- a/test/functional/p2p_v2_misbehaving.py
+++ b/test/functional/p2p_v2_misbehaving.py
@@ -147,11 +147,11 @@ class EncryptedP2PMisbehaving(BitcoinTestFramework):
         peer1.v2_state.can_data_be_received = True
         self.wait_until(lambda: peer1.v2_state.ellswift_ours)
         peer1.send_raw_message(peer1.v2_state.ellswift_ours[4:] + peer1.v2_state.sent_garbage)
-        node0.bumpmocktime(3)
         # Ensure that the bytes sent after 4 bytes network magic are actually received.
         self.wait_until(lambda: node0.getpeerinfo()[-1]["bytesrecv"] > 4)
+        self.wait_until(lambda: node0.getpeerinfo()[-1]["bytessent"] > 0)
         with node0.assert_debug_log(['V2 handshake timeout peer=0']):
-            node0.bumpmocktime(1)  # `InactivityCheck()` triggers now
+            node0.bumpmocktime(4)  # `InactivityCheck()` triggers now
             peer1.wait_for_disconnect(timeout=1)
         self.log.info('successful disconnection since modified ellswift was sent as response')
 


### PR DESCRIPTION
Fixes an intermittent failure for `p2p_v2_misbehaving.py` reported in https://github.com/bitcoin/bitcoin/pull/30420#discussion_r1680462164.

A [different error message](https://github.com/bitcoin/bitcoin/blob/262260ce1e919613ba60194a5861b0b0a51dfe01/src/net.cpp#L1970) `"socket no message in first %i seconds"` will be displayed if `m_last_send=0` or if `m_last_recv is 0`.  Fix this by:
1. mocktime bump is done after all the bytes are received. (`m_last_recv is not 0 now`)
2. wait until bytes are sent by `TestNode`/`bitcoind` (`m_last_send is not 0 now`)


See https://cirrus-ci.com/task/5359619151757312?logs=ci#L3935 for an example failure (I wasn't able to reproduce the intermittent failure locally but I think the fix is logical)