### PR TITLE
fuzz: Limit parse_univalue input length

### DIFF
--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -77,7 +77,7 @@ FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
     }
     try {
         FlatSigningProvider provider;
-        (void)EvalDescriptorStringOrObject(univalue, provider);
+        if (buffer.size() < 10'000) (void)EvalDescriptorStringOrObject(univalue, provider);
     } catch (const UniValue&) {
     } catch (const std::runtime_error&) {
     }


### PR DESCRIPTION
The new limit should be more than enough, and hopefully avoids fuzz input bloat, such as `parse_univalue/0426365704e09ddd704a058cc2add1cbf104c1a9`. C.f. https://cirrus-ci.com/task/6178647134961664?logs=ci#L3805

```
Run parse_univalue with args ['/ci_container_base/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/fuzz', '-runs=1', PosixPath('/ci_container_base/ci/scratch/qa-assets/fuzz_seed_corpus/parse_univalue')]INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 572704560
INFO: Loaded 1 modules   (623498 inline 8-bit counters): 623498 [0x561cba23a518, 0x561cba2d28a2), 
INFO: Loaded 1 PC tables (623498 PCs): 623498 [0x561cba2d28a8,0x561cbac56148), 
INFO:     3224 files found in /ci_container_base/ci/scratch/qa-assets/fuzz_seed_corpus/parse_univalue
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1048576 bytes
INFO: seed corpus: files: 3224 min: 1b max: 1050370b total: 25114084b rss: 112Mb
#1024	pulse  cov: 10458 ft: 33444 corp: 906/32Kb exec/s: 341 rss: 154Mb
#2048	pulse  cov: 12081 ft: 55461 corp: 1668/192Kb exec/s: 227 rss: 228Mb
Slowest unit: 15 s:
artifact_prefix='./'; Test unit written to ./slow-unit-9df6997f2f4726843e82b3dfde46862599904d56
Slowest unit: 309 s:
artifact_prefix='./'; Test unit written to ./slow-unit-0426365704e09ddd704a058cc2add1cbf104c1a9
#3226	INITED cov: 12246 ft: 66944 corp: 2358/3510Kb exec/s: 6 rss: 1610Mb
#3226	DONE   cov: 12246 ft: 66944 corp: 2358/3510Kb lim: 282379 exec/s: 6 rss: 1610Mb
Done 3226 runs in 477 second(s)