### PR TITLE
depends: Amend handling flags environment variables

### DIFF
--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -28,8 +28,8 @@ endef
 
 define add_host_flags_func
 ifeq ($(filter $(origin $1),undefined default),)
-$(host_arch)_$(host_os)_$1 =
-$(host_arch)_$(host_os)_$(release_type)_$1 = $($1)
+$(host_arch)_$(host_os)_$1 = $($1)
+$(host_arch)_$(host_os)_$(release_type)_$1 =
 else
 $(host_arch)_$(host_os)_$1 += $($(host_os)_$1)
 $(host_arch)_$(host_os)_$(release_type)_$1 += $($(host_os)_$(release_type)_$1)


### PR DESCRIPTION
The `{C,CXX,CPP,LD}FLAGS` are build type-agnostic. Therefore, if any of them is specified, it should be assigned to a non-type-specific variable.

This PR is split from https://github.com/bitcoin/bitcoin/pull/30454. It is required because CMake distinguishes [build type-specific variables](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html). For instance, CMake [assumes](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html) that `CXXFLAGS` affects the content of the `CMAKE_CXX_FLAGS` variable. However, without this change, the `CMAKE_CXX_FLAGS_RELEASE` or `CMAKE_CXX_FLAGS_DEBUG` will be affected instead.

No behaviour change for packages in depends:
- on the master branch @ efbf4e71ce8e3cd49ccdfb5e55e14fa4b338453c
```
$ make -C depends print-libevent_cxxflags CXXFLAGS="-std=c++20 -O0 -Wall" 2>&1 | grep libevent
libevent_cxxflags= -std=c++20 -O0 -Wall
$ make -C depends print-libevent_cxxflags CXXFLAGS="-std=c++20 -O0 -Wall" DEBUG=1 2>&1 | grep libevent
libevent_cxxflags= -std=c++20 -O0 -Wall
```
- with this PR:
```
$ make -C depends print-libevent_cxxflags CXXFLAGS="-std=c++20 -O0 -Wall" 2>&1 | grep libevent
libevent_cxxflags=-std=c++20 -O0 -Wall 
$ make -C depends print-libevent_cxxflags CXXFLAGS="-std=c++20 -O0 -Wall" DEBUG=1 2>&1 | grep libevent
libevent_cxxflags=-std=c++20 -O0 -Wall
```
Also there is zero diff for the generated `share/config.site` file.