### PR TITLE
depends: Fix CMake-generated `libevent*.pc` files

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://github.com/libevent/libevent/releases/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 $(package)_patches=cmake_fixups.patch
+$(package)_patches+=fix_mingw_link.patch
 $(package)_build_subdir=build
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
@@ -21,7 +22,8 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch
+  patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_mingw_link.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/fix_mingw_link.patch
+++ b/depends/patches/libevent/fix_mingw_link.patch
@@ -1,0 +1,25 @@
+commit d108099913c5fdbe518f3f4d711f248f8522bd10
+Author: Hennadii Stepanov <32963518+hebasto@users.noreply.github.com>
+Date:   Mon Apr 22 06:39:35 2024 +0100
+
+    build: Add `Iphlpapi` to `Libs.private` in `*.pc` files on Windows
+    
+    It has been required since https://github.com/libevent/libevent/pull/923
+    at least for the `if_nametoindex` call.
+
+    See https://github.com/libevent/libevent/pull/1622.
+
+
+diff --git a/configure.ac b/configure.ac
+index d00e063a..cd1fce37 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -906,7 +906,7 @@ if(WIN32)
+     list(APPEND HDR_PRIVATE WIN32-Code/getopt.h)
+ 
+     set(EVENT__DNS_USE_FTIME_FOR_ID 1)
+-    set(LIB_PLATFORM ws2_32 shell32 advapi32)
++    set(LIB_PLATFORM ws2_32 shell32 advapi32 iphlpapi)
+     add_definitions(
+             -D_CRT_SECURE_NO_WARNINGS
+             -D_CRT_NONSTDC_NO_DEPRECATE)


### PR DESCRIPTION
Broken out of #30454. This is a backport of the merged upstream PR: https://github.com/libevent/libevent/pull/1622.

Note that after #29835 we might end up dropping pkg-config and using the installed CMake files directly, but that depends on whether or not enough distros actually ship those files.

Either way, having fixed up .pc files won't hurt.