### PR TITLE
depends: bump libmultiprocess for CMake fixes

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=8da797c5f1644df1bffd84d10c1ae9836dc70d60
+$(package)_version=8b8a4766ce0a1892b9e8a5eb73dc39821005e520
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=030f4d393d2ac9deba98d2e1973e22fc439ffc009d5f8ae3225c90639f86beb0
+$(package)_sha256_hash=475c0dc2357a2ff30e9a164e4c16dc8a6597a57c9193d646fa9cbf0a55c45d78
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds


### PR DESCRIPTION
Broken out of #30454 . Bumped [even further](https://github.com/bitcoin/bitcoin/pull/30454/commits/4883197abc63aedbc395f37f6d2aded5db5270aa#r1684802528) after https://github.com/chaincodelabs/libmultiprocess/pull/98 was merged upstream.

hebasto Presumably this approach works now with the CMake branch?