### PR TITLE
Fix MSVC warning C4273 "inconsistent dll linkage"

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -58,7 +58,9 @@
 #include <sys/auxv.h>
 #endif
 
+#ifndef _MSC_VER
 extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
+#endif
 
 namespace {
 


### PR DESCRIPTION
Broken out of https://github.com/bitcoin/bitcoin/pull/30454.

When using CMake, the user can select the MSVC runtime library to be:
1) Statically-linked (with the corresponding `x64-windows-static` vcpkg triplet) or
2) Dynamically-linked (with the corresponding `x64-windows` vcpkg triplet)

In the latter case, the compiler emits the [C4273](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4273) warning.

As the "Necessary on some platforms" comment does not apply to MSVC, skip the declaration for MSVC.

The MSVC build system in the master branch supports the statically-linked runtime only: https://github.com/bitcoin/bitcoin/blob/ed739d14b58b5e772a65b85bb421703963b06852/build_msvc/common.init.vcxproj.in#L65