### PR TITLE
policy: enable full-rbf by default

### DIFF
--- a/doc/release-notes-30493.md
+++ b/doc/release-notes-30493.md
@@ -1,0 +1,4 @@
+Full Replace-By-Fee
+===================
+
+`mempoolfullrbf=1` is now set by default.

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -22,7 +22,7 @@ static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{5};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 /** Whether to fall back to legacy V1 serialization when writing mempool.dat */
 static constexpr bool DEFAULT_PERSIST_V1_DAT{false};
 /** Default for -acceptnonstdtxn */

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -26,15 +26,18 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 2
+        # both nodes disable full-rbf to test BIP125 signaling
         self.extra_args = [
             [
+                "-mempoolfullrbf=0",
                 "-limitancestorcount=50",
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",
                 "-limitdescendantsize=101",
             ],
-            # second node has default mempool parameters
+            # second node has default mempool parameters, besides mempoolfullrbf being disabled
             [
+                "-mempoolfullrbf=0",
             ],
         ]
         self.supports_cli = False

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -54,6 +54,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             '-txindex','-permitbaremultisig=0',
+            '-mempoolfullrbf=0',
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -162,7 +162,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
 
 
-    @cleanup(extra_args=None)
+    @cleanup(extra_args=["-mempoolfullrbf=0"])
     def test_truc_bip125(self):
         node = self.nodes[0]
         self.log.info("Test TRUC transactions that don't signal BIP125 are replaceable")

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -119,6 +119,9 @@ class P2PPermissionsTests(BitcoinTestFramework):
 
         self.log.debug("Check that node[1] will not send an invalid tx to node[0]")
         tx.vout[0].nValue += 1
+        # add dust to cause policy rejection but no disconnection
+        tx.vout.append(tx.vout[0])
+        tx.vout[-1].nValue = 0
         txid = tx.rehash()
         # Send the transaction twice. The first time, it'll be rejected by ATMP because it conflicts
         # with a mempool transaction. The second time, it'll be in the m_recent_rejects filter.
@@ -126,7 +129,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
             [tx],
             self.nodes[1],
             success=False,
-            reject_reason='{} (wtxid={}) from peer=0 was not accepted: txn-mempool-conflict'.format(txid, tx.getwtxid())
+            reject_reason='{} (wtxid={}) from peer=0 was not accepted: dust'.format(txid, tx.getwtxid())
         )
 
         p2p_rebroadcast_wallet.send_txs_and_test(


### PR DESCRIPTION
This pull request enables full rbf (mempool policy) by default. #28132 was closed recently with this [comment](https://github.com/bitcoin/bitcoin/pull/28132#issuecomment-2225369634).

---

Rationale:

- Full RBF config option was added in July 2022: https://github.com/bitcoin/bitcoin/pull/25353

- It is used regularly: https://mempool.space/rbf#fullrbf

- Most mining pools are using it: https://github.com/bitcoin/bitcoin/pull/28132#issuecomment-2059120917