### PR TITLE
fuzz: reduce keypool size in `scriptpubkeyman` target

### DIFF
--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -94,6 +94,7 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         wallet.SetLastBlockProcessed(chainstate.m_chain.Height(), chainstate.m_chain.Tip()->GetBlockHash());
+        wallet.m_keypool_size = 10;
     }
 
     auto wallet_desc{CreateWalletDescriptor(fuzzed_data_provider)};


### PR DESCRIPTION
Fixes #30476

This PR reduces keypool size in scriptpubkeyman fuzz target to avoid spend a lot of time in `TopUp` (which is obviously called by many spkm functions).

For reference:

This PR:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1845055748
INFO: Loaded 1 modules   (1225616 inline 8-bit counters): 1225616 [0x106346fe0, 0x106472370), 
INFO: Loaded 1 PC tables (1225616 PCs): 1225616 [0x106472370,0x107725c70), 
./src/test/fuzz/fuzz: Running 1 inputs 10 time(s) each.
Running: ./qa-assets/fuzz_seed_corpus/scriptpubkeyman/c9b8928cecb1edc192fb2d5816b4b7878cdfcf50
Executed ./qa-assets/fuzz_seed_corpus/scriptpubkeyman/c9b8928cecb1edc192fb2d5816b4b7878cdfcf50 in 250 ms
```

Master:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2004906948
INFO: Loaded 1 modules   (1225603 inline 8-bit counters): 1225603 [0x104196f80, 0x1042c2303), 
INFO: Loaded 1 PC tables (1225603 PCs): 1225603 [0x1042c2308,0x105575b38), 
./src/test/fuzz/fuzz: Running 1 inputs 10 time(s) each.
Running: ./qa-assets/fuzz_seed_corpus/scriptpubkeyman/c9b8928cecb1edc192fb2d5816b4b7878cdfcf50
Executed ./qa-assets/fuzz_seed_corpus/scriptpubkeyman/c9b8928cecb1edc192fb2d5816b4b7878cdfcf50 in 21016 ms
```