### PR TITLE
lint: Use consistent out-of-tree build for python and test_runner

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2018-2022 The Bitcoin Core developers
+# Copyright (c) 2018-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
 
-export PATH=$PWD/ci/retry:$PATH
+export CI_RETRY_EXE="/ci_retry --"
 
 ${CI_RETRY_EXE} apt-get update
 # Lint dependencies:

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -8,6 +8,8 @@ export LC_ALL=C
 
 export CI_RETRY_EXE="/ci_retry --"
 
+pushd "/"
+
 ${CI_RETRY_EXE} apt-get update
 # Lint dependencies:
 # - automake pkg-config libtool (for lint_includes_build_config)
@@ -28,7 +30,7 @@ if [ ! -d "${PYTHON_PATH}/bin" ]; then
     libbz2-dev libreadline-dev libsqlite3-dev curl llvm \
     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
     clang
-  env CC=clang python-build "$(cat "./.python-version")" "${PYTHON_PATH}"
+  env CC=clang python-build "$(cat "/.python-version")" "${PYTHON_PATH}"
 fi
 export PATH="${PYTHON_PATH}/bin:${PATH}"
 command -v python3
@@ -38,7 +40,7 @@ export LINT_RUNNER_PATH="/lint_test_runner"
 if [ ! -d "${LINT_RUNNER_PATH}" ]; then
   ${CI_RETRY_EXE} apt-get install -y cargo
   (
-    cd ./test/lint/test_runner || exit 1
+    cd "/test/lint/test_runner" || exit 1
     cargo build
     mkdir -p "${LINT_RUNNER_PATH}"
     mv target/debug/test_runner "${LINT_RUNNER_PATH}"
@@ -62,3 +64,5 @@ MLC_VERSION=v0.18.0
 MLC_BIN=mlc-x86_64-linux
 curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc
+
+popd || exit

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -9,6 +9,7 @@ FROM debian:bookworm
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 
+COPY ./ci/retry/retry /ci_retry
 COPY ./.python-version /.python-version
 COPY ./ci/lint/container-entrypoint.sh /entrypoint.sh
 COPY ./ci/lint/04_install.sh /install.sh

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Copyright (c) 2019-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C.UTF-8
 
-set -o errexit; source ./ci/test/00_setup_env.sh
+cp "./ci/retry/retry" "/ci_retry"
 set -o errexit; source ./ci/lint/04_install.sh
 set -o errexit
 ./ci/lint/06_script.sh

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+# Only used in .cirrus.yml. Refer to test/lint/README.md on how to run locally.
+
 cp "./ci/retry/retry" "/ci_retry"
 set -o errexit; source ./ci/lint/04_install.sh
 set -o errexit

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -9,6 +9,9 @@ export LC_ALL=C.UTF-8
 # Only used in .cirrus.yml. Refer to test/lint/README.md on how to run locally.
 
 cp "./ci/retry/retry" "/ci_retry"
+cp "./.python-version" "/.python-version"
+mkdir --parents "/test/lint"
+cp --recursive "./test/lint/test_runner" "/test/lint/"
 set -o errexit; source ./ci/lint/04_install.sh
 set -o errexit
 ./ci/lint/06_script.sh


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/30496

Seems odd to sometimes do an out-of-tree build (via `./ci/lint_imagefile`, see `test/lint/README.md`) and sometimes not (via Cirrus CI, see `./ci/lint_run_all.sh`).

Fix it by doing an out-of-tree build consistently in the same location.

Also, fix `$CI_RETRY_EXE`, while touching this.