### PR TITLE
Fix lint-spelling warnings

### DIFF
--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -97,7 +97,7 @@ class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
 
 - *libbitcoin_consensus* should only depend on *libbitcoin_crypto*, and all other libraries besides *libbitcoin_crypto* should be allowed to depend on it.
 
-- *libbitcoin_util* should be a standalone dependency that any library can depend on, and it should not depend on other libraries except *libbitcoin_crypto*. It provides basic utilities that fill in gaps in the C++ standard library and provide lightweight abstractions over platform-specific features. Since the util library is distributed with the kernel and is usable by kernel applications, it shouldn't contain functions that external code shouldn't call, like higher level code targetted at the node or wallet. (*libbitcoin_common* is a better place for higher level code, or code that is meant to be used by internal applications only.)
+- *libbitcoin_util* should be a standalone dependency that any library can depend on, and it should not depend on other libraries except *libbitcoin_crypto*. It provides basic utilities that fill in gaps in the C++ standard library and provide lightweight abstractions over platform-specific features. Since the util library is distributed with the kernel and is usable by kernel applications, it shouldn't contain functions that external code shouldn't call, like higher level code targeted at the node or wallet. (*libbitcoin_common* is a better place for higher level code, or code that is meant to be used by internal applications only.)
 
 - *libbitcoin_common* is a home for miscellaneous shared code used by different Bitcoin Core applications. It should not depend on anything other than *libbitcoin_util*, *libbitcoin_consensus*, and *libbitcoin_crypto*.
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -492,7 +492,7 @@ make cov
 # unit and functional tests.
 ```
 
-Additional LCOV options can be specified using `LCOV_OPTS`, but may be dependant
+Additional LCOV options can be specified using `LCOV_OPTS`, but may be dependent
 on the version of LCOV. For example, when using LCOV `2.x`, branch coverage can be
 enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`, when configuring.
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -442,7 +442,7 @@ void OptionsDialog::updateProxyValidationState()
     QValidatedLineEdit *otherProxyWidget = (pUiProxyIp == ui->proxyIpTor) ? ui->proxyIp : ui->proxyIpTor;
     if (pUiProxyIp->isValid() && (!ui->proxyPort->isEnabled() || ui->proxyPort->text().toInt() > 0) && (!ui->proxyPortTor->isEnabled() || ui->proxyPortTor->text().toInt() > 0))
     {
-        setOkButtonState(otherProxyWidget->isValid()); //only enable ok button if both proxys are valid
+        setOkButtonState(otherProxyWidget->isValid()); //only enable ok button if both proxies are valid
         clearStatusLabel();
     }
     else

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -383,7 +383,7 @@ bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event*
         return false;
     }
     if (occurred != nullptr) {
-        // We simulate the requested event as occured when ConsumeBool()
+        // We simulate the requested event as occurred when ConsumeBool()
         // returns false. This avoids simulating endless waiting if the
         // FuzzedDataProvider runs out of data.
         *occurred = m_fuzzed_data_provider.ConsumeBool() ? 0 : requested;
@@ -395,7 +395,7 @@ bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& even
 {
     for (auto& [sock, events] : events_per_sock) {
         (void)sock;
-        // We simulate the requested event as occured when ConsumeBool()
+        // We simulate the requested event as occurred when ConsumeBool()
         // returns false. This avoids simulating endless waiting if the
         // FuzzedDataProvider runs out of data.
         events.occurred = m_fuzzed_data_provider.ConsumeBool() ? 0 : events.requested;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2127,7 +2127,7 @@ ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, cons
  * Note that we may set state.reason to NOT_STANDARD for extra soft-fork flags in flags, block-checking
  * callers should probably reset it to CONSENSUS in such cases.
  *
- * Non-static (and re-declared) in src/test/txvalidationcache_tests.cpp
+ * Non-static (and redeclared) in src/test/txvalidationcache_tests.cpp
  */
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -848,7 +848,7 @@ def test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, rbf_node, 
     # less than (original fee + incrementalrelayfee)
     assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, tx["txid"], {"fee_rate": 2.8})
 
-    # You can fee bump as long as the new fee set from fee_rate is atleast (original fee + incrementalrelayfee)
+    # You can fee bump as long as the new fee set from fee_rate is at least (original fee + incrementalrelayfee)
     rbf_node.bumpfee(tx["txid"], {"fee_rate": 3})
     self.clear_mempool()
 

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -1,4 +1,5 @@
 afile
+amountIn
 asend
 ba
 blockin
@@ -7,8 +8,10 @@ cachable
 clen
 crypted
 debbugs
+deques
 fo
 fpr
+hashIn
 hights
 inflight
 invokable
@@ -17,6 +20,7 @@ lief
 mor
 nd
 nin
+outIn
 requestor
 ser
 siz
@@ -24,5 +28,6 @@ stap
 unparseable
 unser
 useable
+viewIn
 warmup
 wit


### PR DESCRIPTION
These warnings were often polluting the CI output, e.g. https://github.com/bitcoin/bitcoin/pull/30499/checks?check_run_id=27745036545

> ./test/lint/lint-spelling.py

before the change:
```
doc/design/libraries.md:100: targetted ==> targeted
doc/developer-notes.md:495: dependant ==> dependent
src/bench/sign_transaction.cpp:49: hashIn ==> hashing, hash in
src/bitcoin-chainstate.cpp:213: hashIn ==> hashing, hash in
src/bitcoin-chainstate.cpp:213: hashIn ==> hashing, hash in
src/coins.cpp:24: viewIn ==> viewing, view in
src/coins.cpp:24: viewIn ==> viewing, view in
src/coins.cpp:29: viewIn ==> viewing, view in
src/coins.cpp:29: viewIn ==> viewing, view in
src/coins.h:44: outIn ==> outing, out in
src/coins.h:44: outIn ==> outing, out in
src/coins.h:45: outIn ==> outing, out in
src/coins.h:45: outIn ==> outing, out in
src/coins.h:215: viewIn ==> viewing, view in
src/coins.h:220: viewIn ==> viewing, view in
src/primitives/transaction.h:37: hashIn ==> hashing, hash in
src/primitives/transaction.h:37: hashIn ==> hashing, hash in
src/protocol.cpp:51: hashIn ==> hashing, hash in
src/protocol.cpp:51: hashIn ==> hashing, hash in
src/protocol.h:497: hashIn ==> hashing, hash in
src/qt/forms/optionsdialog.ui:344: incomin ==> incoming
src/qt/optionsdialog.cpp:445: proxys ==> proxies
src/rpc/mining.cpp:987: hashIn ==> hashing, hash in
src/rpc/mining.cpp:987: hashIn ==> hashing, hash in
src/script/interpreter.h:298: amountIn ==> amounting, amount in
src/script/interpreter.h:298: amountIn ==> amounting, amount in
src/script/interpreter.h:299: amountIn ==> amounting, amount in
src/script/interpreter.h:299: amountIn ==> amounting, amount in
src/script/sigcache.h:70: amountIn ==> amounting, amount in
src/script/sigcache.h:70: amountIn ==> amounting, amount in
src/signet.cpp:144: amountIn ==> amounting, amount in
src/test/fuzz/util/net.cpp:386: occured ==> occurred
src/test/fuzz/util/net.cpp:398: occured ==> occurred
src/util/vecdeque.h:79: deques ==> dequeues
src/util/vecdeque.h:160: deques ==> dequeues
src/util/vecdeque.h:184: deques ==> dequeues
src/util/vecdeque.h:194: deques ==> dequeues
src/validation.cpp:2130: re-declared ==> redeclared
src/validation.h:348: outIn ==> outing, out in
src/validation.h:349: outIn ==> outing, out in
test/functional/wallet_bumpfee.py:851: atleast ==> at least
```
