### PR TITLE
lint: Add missing docker.io prefix to ci/lint_imagefile

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -21,7 +21,7 @@ ${CI_RETRY_EXE} apt-get install -y automake pkg-config libtool curl xz-utils git
 PYTHON_PATH="/python_build"
 if [ ! -d "${PYTHON_PATH}/bin" ]; then
   (
-    ${CI_RETRY_EXE} git clone https://github.com/pyenv/pyenv.git
+    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/pyenv/pyenv.git
     cd pyenv/plugins/python-build || exit 1
     ./install.sh
   )

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -4,7 +4,7 @@
 
 # See test/lint/README.md for usage.
 
-FROM debian:bookworm
+FROM docker.io/debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
Currently, the `ci/lint_imagefile` may pick the wrong (non-native) architecture due to the missing prefix.

For example, assuming the user has previously pulled an s390x image:

```
$ podman run --rm 'docker.io/s390x/debian:bookworm' dpkg --print-architecture
exec /usr/bin/dpkg: exec format error
```

Now, `debian:bookworm` will refer to the same image:

```
$ podman run --rm 'debian:bookworm' dpkg --print-architecture
exec /usr/bin/dpkg: exec format error
```

However, `docker.io/debian:bookworm` works fine:

```
 $ podman run --rm 'docker.io/debian:bookworm' dpkg --print-architecture
arm64
```

(Also includes a nit-fix from https://github.com/bitcoin/bitcoin/pull/30499#discussion_r1686470495)