### PR TITLE
doc: use proper doxygen formatting for CTxMemPool::cs

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -366,9 +366,7 @@ public:
      * that are guarded by it.
      *
      * @par Consistency guarantees
-     *
      * By design, it is guaranteed that:
-     *
      * 1. Locking both `cs_main` and `mempool.cs` will give a view of mempool
      *    that is consistent with current chain tip (`ActiveChain()` and
      *    `CoinsTip()`) and is fully populated. Fully populated means that if the
@@ -376,7 +374,6 @@ public:
      *    previously active chain, all the missing transactions will have been
      *    re-added to the mempool and should be present if they meet size and
      *    consistency constraints.
-     *
      * 2. Locking `mempool.cs` without `cs_main` will give a view of a mempool
      *    consistent with some chain that was active since `cs_main` was last
      *    locked, and that is fully populated as described above. It is ok for


### PR DESCRIPTION
Having `@par title` followed by an empty line renders improperly in Doxygen - it results in a paragraph with a title but without a body.

https://www.doxygen.nl/manual/commands.html#cmdpar

This also results in a compiler warning (or error) with Clang 19:

```
./txmempool.h:368:34: error: empty paragraph passed to '@par' command [-Werror,-Wdocumentation]
  368 |      * @par Consistency guarantees
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~^
1 error generated.
```