### PR TITLE
depends: Cleanup postprocess commands after switching to CMake

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -24,6 +24,3 @@ define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
 
-define $(package)_postprocess_cmds
-  rm -rf share/man
-endef

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -39,7 +39,7 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm bin/event_rpcgen.py && \
+  rm -rf bin && \
   rm include/ev*.h && \
   rm include/event2/*_compat.h
 endef

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -29,3 +29,8 @@ endef
 define $(package)_stage_cmds
   cmake --install . --prefix $($(package)_staging_prefix_dir)
 endef
+
+define $(package)_postprocess_cmds
+  rm -rf bin && \
+  rm -rf share
+endef

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -28,3 +28,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm -rf share
+endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -42,5 +42,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf bin share lib/*.la
+  rm -rf share
 endef


### PR DESCRIPTION
I overlooked this while reviewing https://github.com/bitcoin/bitcoin/pull/29723, https://github.com/bitcoin/bitcoin/pull/29835, and https://github.com/bitcoin/bitcoin/pull/29880.