### PR TITLE
depends: Fix CMake-generated `libzmq.pc` file

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -12,6 +12,7 @@ $(package)_patches += openbsd_kqueue_headers.patch
 $(package)_patches += cmake_minimum.patch
 $(package)_patches += cacheline_undefined.patch
 $(package)_patches += no_librt.patch
+$(package)_patches += fix_mingw_link.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DWITH_DOCS=OFF -DWITH_LIBSODIUM=OFF
@@ -30,7 +31,8 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch && \
   patch -p1 < $($(package)_patch_dir)/openbsd_kqueue_headers.patch && \
   patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch && \
-  patch -p1 < $($(package)_patch_dir)/no_librt.patch
+  patch -p1 < $($(package)_patch_dir)/no_librt.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_mingw_link.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/zeromq/fix_mingw_link.patch
+++ b/depends/patches/zeromq/fix_mingw_link.patch
@@ -1,0 +1,31 @@
+Fix CMake-generated `libzmq.pc` file
+
+This change mirrors the Autotools-based build system behavior for
+cross-compiling for Windows with static linking.
+
+See https://github.com/zeromq/libzmq/pull/4706.
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03462271..0315e606 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -546,12 +546,18 @@ if(ZMQ_HAVE_WINDOWS)
+   # Cannot use check_library_exists because the symbol is always declared as char(*)(void)
+   set(CMAKE_REQUIRED_LIBRARIES "ws2_32.lib")
+   check_cxx_symbol_exists(WSAStartup "winsock2.h" HAVE_WS2_32)
++  if(HAVE_WS2_32)
++    set(pkg_config_libs_private "${pkg_config_libs_private} -lws2_32")
++  endif()
+ 
+   set(CMAKE_REQUIRED_LIBRARIES "rpcrt4.lib")
+   check_cxx_symbol_exists(UuidCreateSequential "rpc.h" HAVE_RPCRT4)
+ 
+   set(CMAKE_REQUIRED_LIBRARIES "iphlpapi.lib")
+   check_cxx_symbol_exists(GetAdaptersAddresses "winsock2.h;iphlpapi.h" HAVE_IPHLAPI)
++  if(HAVE_IPHLAPI)
++    set(pkg_config_libs_private "${pkg_config_libs_private} -liphlpapi")
++  endif()
+   check_cxx_symbol_exists(if_nametoindex "iphlpapi.h" HAVE_IF_NAMETOINDEX)
+ 
+   set(CMAKE_REQUIRED_LIBRARIES "")


### PR DESCRIPTION
This is a backport of: https://github.com/zeromq/libzmq/pull/4706.

Similar to https://github.com/bitcoin/bitcoin/pull/30488.

Addresses https://github.com/bitcoin/bitcoin/pull/29723#issuecomment-2239864170:
> Looking at the mingw .pc generated by this PR:
> 
> ```
> Libs: -L${libdir} -lzmq
> Libs.private:
> Requires.private:
> ```
> 
> It looks like we'll need to take [zeromq/libzmq#4706](https://github.com/zeromq/libzmq/pull/4706) as well for CMake. That can be done as a follow-up though, as it's not yet merged upstream.

