### PR TITLE
net: Log accepted connection after m_nodes.push_back; Fix intermittent test issue

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1810,13 +1810,11 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
                              });
     pnode->AddRef();
     m_msgproc->InitializeNode(*pnode, nLocalServices);
-
-    LogPrint(BCLog::NET, "connection from %s accepted\n", addr.ToStringAddrPort());
-
     {
         LOCK(m_nodes_mutex);
         m_nodes.push_back(pnode);
     }
+    LogDebug(BCLog::NET, "connection from %s accepted\n", addr.ToStringAddrPort());
 
     // We received a new connection, harvest entropy from the time (and our peer count)
     RandAddEvent((uint32_t)id);

--- a/test/functional/p2p_v2_misbehaving.py
+++ b/test/functional/p2p_v2_misbehaving.py
@@ -140,7 +140,8 @@ class EncryptedP2PMisbehaving(BitcoinTestFramework):
         node0.setmocktime(int(time.time()))
         self.log.info('Sending first 4 bytes of ellswift which match network magic')
         self.log.info('If a response is received, assertion failure would happen in our custom data_received() function')
-        peer1 = node0.add_p2p_connection(MisbehavingV2Peer(TestType.EARLY_KEY_RESPONSE), wait_for_verack=False, send_version=False, supports_v2_p2p=True, wait_for_v2_handshake=False)
+        with node0.wait_for_new_peer():
+            peer1 = node0.add_p2p_connection(MisbehavingV2Peer(TestType.EARLY_KEY_RESPONSE), wait_for_verack=False, send_version=False, supports_v2_p2p=True, wait_for_v2_handshake=False)
         peer1.send_raw_message(MAGIC_BYTES['regtest'])
         self.log.info('Sending remaining ellswift and garbage which are different from V1_PREFIX. Since a response is')
         self.log.info('expected now, our custom data_received() function wouldn\'t result in assertion failure')


### PR DESCRIPTION
Fix the two issues reported in https://github.com/bitcoin/bitcoin/pull/30468/files#r1688444784:

* Delay a debug log line for consistency.
* Fix an intermittent test issue.

They are completely separate fixes, but both `net` related.