### PR TITLE
Assumeutxo: Sanitize block height in metadata

### DIFF
--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -99,6 +99,9 @@ public:
         }
 
         s >> m_base_blockheight;
+        if (m_base_blockheight > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+            throw std::ios_base::failure("Block height is out of range.");
+        }
         s >> m_base_blockhash;
         s >> m_coins_count;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5639,7 +5639,7 @@ util::Result<void> ChainstateManager::ActivateSnapshot(
         bool in_memory)
 {
     uint256 base_blockhash = metadata.m_base_blockhash;
-    int base_blockheight = metadata.m_base_blockheight;
+    uint32_t base_blockheight = metadata.m_base_blockheight;
 
     if (this->SnapshotBlockhash()) {
         return util::Error{Untranslated("Can't activate a snapshot-based chainstate more than once")};

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -100,12 +100,14 @@ class AssumeutxoTest(BitcoinTestFramework):
         # The height is not used for anything critical currently, so we just
         # confirm the manipulation in the error message
         bogus_height = 1337
+        signed_overflow_height = 3275262676
         for bad_block_hash in [bogus_block_hash, prev_block_hash]:
-            with open(bad_snapshot_path, 'wb') as f:
-                f.write(valid_snapshot_contents[:11] + bogus_height.to_bytes(4, "little") + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[47:])
+            for bad_height in [bogus_height, signed_overflow_height]:
+                with open(bad_snapshot_path, 'wb') as f:
+                    f.write(valid_snapshot_contents[:11] + bad_height.to_bytes(4, "little") + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[47:])
 
-            msg = f"Unable to load UTXO snapshot: assumeutxo block hash in snapshot metadata not recognized (hash: {bad_block_hash}, height: {bogus_height}). The following snapshot heights are available: 110, 200, 299."
-            assert_raises_rpc_error(-32603, msg, node.loadtxoutset, bad_snapshot_path)
+                msg = f"Unable to load UTXO snapshot: assumeutxo block hash in snapshot metadata not recognized (hash: {bad_block_hash}, height: {bad_height}). The following snapshot heights are available: 110, 200, 299."
+                assert_raises_rpc_error(-32603, msg, node.loadtxoutset, bad_snapshot_path)
 
         self.log.info("  - snapshot file with wrong number of coins")
         valid_num_coins = int.from_bytes(valid_snapshot_contents[47:47 + 8], "little")

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -100,14 +100,19 @@ class AssumeutxoTest(BitcoinTestFramework):
         # The height is not used for anything critical currently, so we just
         # confirm the manipulation in the error message
         bogus_height = 1337
-        signed_overflow_height = 3275262676
         for bad_block_hash in [bogus_block_hash, prev_block_hash]:
-            for bad_height in [bogus_height, signed_overflow_height]:
-                with open(bad_snapshot_path, 'wb') as f:
-                    f.write(valid_snapshot_contents[:11] + bad_height.to_bytes(4, "little") + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[47:])
+            with open(bad_snapshot_path, 'wb') as f:
+                f.write(valid_snapshot_contents[:11] + bogus_height.to_bytes(4, "little") + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[47:])
 
-                msg = f"Unable to load UTXO snapshot: assumeutxo block hash in snapshot metadata not recognized (hash: {bad_block_hash}, height: {bad_height}). The following snapshot heights are available: 110, 200, 299."
-                assert_raises_rpc_error(-32603, msg, node.loadtxoutset, bad_snapshot_path)
+            msg = f"Unable to load UTXO snapshot: assumeutxo block hash in snapshot metadata not recognized (hash: {bad_block_hash}, height: {bogus_height}). The following snapshot heights are available: 110, 200, 299."
+            assert_raises_rpc_error(-32603, msg, node.loadtxoutset, bad_snapshot_path)
+
+        self.log.info("  - snapshot file referring to a block that is not in the assumeutxo parameters")
+        signed_overflow_height = 3275262676
+        with open(bad_snapshot_path, 'wb') as f:
+            f.write(valid_snapshot_contents[:11] + signed_overflow_height.to_bytes(4, "little") + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[47:])
+        msg = f"Unable to parse metadata: Block height is out of range."
+        assert_raises_rpc_error(-22, msg, node.loadtxoutset, bad_snapshot_path)
 
         self.log.info("  - snapshot file with wrong number of coins")
         valid_num_coins = int.from_bytes(valid_snapshot_contents[47:47 + 8], "little")


### PR DESCRIPTION
Fixes #30514 which has more context.

The block height in the assumeutxo metadata was implicitly cast to `int` which could cause it to be interpreted as signed.

The first commit shows how to reproduce the error shown in #30514 and how it could be fixed with a minimal change. The second commit adds an explicit sanitizer that will probably be the preferred approach. I can squash the commits but first I would like to hear conceptual feedback since #30514 suggested to remove the block height instead.