### PR TITLE
test: Add missing --v1transport to feature_proxy.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2022 The Bitcoin Core developers
+# Copyright (c) 2014-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Run regression test suite.
@@ -221,7 +221,7 @@ BASE_SCRIPTS = [
     'interface_usdt_validation.py',
     'rpc_users.py',
     'rpc_whitelist.py',
-    'feature_proxy.py',
+    'feature_proxy.py --v1transport',
     'wallet_signrawtransactionwithwallet.py --legacy-wallet',
     'wallet_signrawtransactionwithwallet.py --descriptors',
     'rpc_signrawtransactionwithkey.py',


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/29871

V2 is enabled via:

```
ci/test/00_setup_env_i686_multiprocess.sh:15:export TEST_RUNNER_EXTRA="--v2transport"
```

However, that seems premature, given that the test fails intermittently (or reproducibly) on some machines:

```
$ while test/functional/feature_proxy.py --v2transport --valgrind  ; do true ; done 
2024-07-25T10:09:50.233000Z TestFramework (INFO): PRNG seed is: 4706088440128402104
2024-07-25T10:09:50.234000Z TestFramework (INFO): Initializing test directory /tmp/bitcoin_func_test__c5c1wwl
2024-07-25T10:10:16.428000Z TestFramework (ERROR): Assertion failed

AssertionError: not(bytearray(b'node.noumenon') == b'fc00:1:2:3:4:5:6:7')
```

Fix it by temporarily disabling it.

In the future, the test can be fixed and this can be enabled again.