### PR TITLE
test: Do not write Python bytecode to source directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -329,7 +329,7 @@ clean-docs:
 
 clean-local: clean-docs
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ fuzz.coverage/ test/tmp/ cache/ $(OSX_APP)
-	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache share/rpcauth/__pycache__
+	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache
 	rm -rf dist/ test/lint/test_runner/target/ test/lint/__pycache__
 
 test-security-check:

--- a/test/util/rpcauth-test.py
+++ b/test/util/rpcauth-test.py
@@ -21,6 +21,7 @@ class TestRPCAuth(unittest.TestCase):
         with open(config_path, encoding="utf8") as config_file:
             config.read_file(config_file)
         sys.path.insert(0, os.path.dirname(config['environment']['RPCAUTH']))
+        sys.dont_write_bytecode = True
         self.rpcauth = importlib.import_module('rpcauth')
 
     def test_generate_salt(self):


### PR DESCRIPTION
This change prevents writing `share/rpcauth/__pycache__/*.pyc`, which is especially useful for out-of-source builds when the source directory is supposed to be read-only.

Also see https://github.com/bitcoin/bitcoin/pull/19385#issuecomment-1078970958.

I believe that performance concerns can be disregarded in this case.