### PR TITLE
feefrac: add support for evaluating at given size

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
+#include <compare>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -212,13 +213,8 @@ public:
     friend inline base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
     friend inline base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
     friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
-    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
-    friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
-    friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
-    friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }
-    friend inline bool operator<=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <= 0; }
+    friend inline std::strong_ordering operator<=>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <=> 0; }
     friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
-    friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
 
     /** Hex encoding of the number (with the most significant digits first). */
     std::string GetHex() const;

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -17,26 +17,43 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac empty{0, 0};
     FeeFrac zero_fee{0, 1}; // zero-fee allowed
 
-    BOOST_CHECK_EQUAL(zero_fee.EvaluateFee(0), 0);
-    BOOST_CHECK_EQUAL(zero_fee.EvaluateFee(1), 0);
-    BOOST_CHECK_EQUAL(zero_fee.EvaluateFee(1000000), 0);
-    BOOST_CHECK_EQUAL(zero_fee.EvaluateFee(0x7fffffff), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeDown(0), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeDown(1), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeDown(1000000), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeDown(0x7fffffff), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeUp(0), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeUp(1), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeUp(1000000), 0);
+    BOOST_CHECK_EQUAL(zero_fee.EvaluateFeeUp(0x7fffffff), 0);
 
-    BOOST_CHECK_EQUAL(p1.EvaluateFee(0), 0);
-    BOOST_CHECK_EQUAL(p1.EvaluateFee(1), 10);
-    BOOST_CHECK_EQUAL(p1.EvaluateFee(100000000), 1000000000);
-    BOOST_CHECK_EQUAL(p1.EvaluateFee(0x7fffffff), int64_t(0x7fffffff) * 10);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeDown(0), 0);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeDown(1), 10);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeDown(100000000), 1000000000);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeDown(0x7fffffff), int64_t(0x7fffffff) * 10);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeUp(0), 0);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeUp(1), 10);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeUp(100000000), 1000000000);
+    BOOST_CHECK_EQUAL(p1.EvaluateFeeUp(0x7fffffff), int64_t(0x7fffffff) * 10);
 
     FeeFrac neg{-1001, 100};
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(0), 0);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(1), -11);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(2), -21);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(3), -31);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(100), -1001);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(101), -1012);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(100000000), -1001000000);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(100000001), -1001000011);
-    BOOST_CHECK_EQUAL(neg.EvaluateFee(0x7fffffff), -21496311307);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(0), 0);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(1), -11);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(2), -21);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(3), -31);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(100), -1001);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(101), -1012);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(100000000), -1001000000);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(100000001), -1001000011);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeDown(0x7fffffff), -21496311307);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(0), 0);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(1), -10);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(2), -20);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(3), -30);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(100), -1001);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(101), -1011);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(100000000), -1001000000);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(100000001), -1001000010);
+    BOOST_CHECK_EQUAL(neg.EvaluateFeeUp(0x7fffffff), -21496311306);
 
     BOOST_CHECK(empty == FeeFrac{}); // same as no-args
 
@@ -88,15 +105,22 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     BOOST_CHECK(oversized_1 << oversized_2);
     BOOST_CHECK(oversized_1 != oversized_2);
 
-    BOOST_CHECK_EQUAL(oversized_1.EvaluateFee(0), 0);
-    BOOST_CHECK_EQUAL(oversized_1.EvaluateFee(1), 1152921);
-    BOOST_CHECK_EQUAL(oversized_1.EvaluateFee(2), 2305843);
-    BOOST_CHECK_EQUAL(oversized_1.EvaluateFee(1548031267), 1784758530396540);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeDown(0), 0);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeDown(1), 1152921);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeDown(2), 2305843);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeDown(1548031267), 1784758530396540);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeUp(0), 0);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeUp(1), 1152922);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeUp(2), 2305843);
+    BOOST_CHECK_EQUAL(oversized_1.EvaluateFeeUp(1548031267), 1784758530396541);
 
-    // Test cases on the threshold where FeeFrac::EvaluateFee start using Mul/Div.
-    BOOST_CHECK_EQUAL(FeeFrac(0x1ffffffff, 123456789).EvaluateFee(98765432), 6871947728);
-    BOOST_CHECK_EQUAL(FeeFrac(0x200000000, 123456789).EvaluateFee(98765432), 6871947729);
-    BOOST_CHECK_EQUAL(FeeFrac(0x200000001, 123456789).EvaluateFee(98765432), 6871947730);
+    // Test cases on the threshold where FeeFrac::Evaluate start using Mul/Div.
+    BOOST_CHECK_EQUAL(FeeFrac(0x1ffffffff, 123456789).EvaluateFeeDown(98765432), 6871947728);
+    BOOST_CHECK_EQUAL(FeeFrac(0x200000000, 123456789).EvaluateFeeDown(98765432), 6871947729);
+    BOOST_CHECK_EQUAL(FeeFrac(0x200000001, 123456789).EvaluateFeeDown(98765432), 6871947730);
+    BOOST_CHECK_EQUAL(FeeFrac(0x1ffffffff, 123456789).EvaluateFeeUp(98765432), 6871947729);
+    BOOST_CHECK_EQUAL(FeeFrac(0x200000000, 123456789).EvaluateFeeUp(98765432), 6871947730);
+    BOOST_CHECK_EQUAL(FeeFrac(0x200000001, 123456789).EvaluateFeeUp(98765432), 6871947731);
 
     // Tests paths that use double arithmetic
     FeeFrac busted{(static_cast<int64_t>(INT32_MAX)) + 1, INT32_MAX};
@@ -108,12 +132,18 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     BOOST_CHECK(max_fee <= max_fee);
     BOOST_CHECK(max_fee >= max_fee);
 
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(1), 977888);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(2), 1955777);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(3), 2933666);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(1256796054), 1229006664189047);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFee(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(0), 0);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 977888);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 1955777);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 2933666);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 1229006664189047);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(0), 0);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 977889);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 1955778);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 2933667);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 1229006664189048);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 2100000000000000);
 
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);

--- a/src/test/fuzz/feefrac.cpp
+++ b/src/test/fuzz/feefrac.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <arith_uint256.h>
 #include <util/feefrac.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -13,43 +14,22 @@
 
 namespace {
 
-/** Compute a * b, represented in 4x32 bits, highest limb first. */
-std::array<uint32_t, 4> Mul128(uint64_t a, uint64_t b)
+/** The maximum absolute value of an int64_t, as an arith_uint256 (2^63). */
+const auto MAX_ABS_INT64 = arith_uint256{1} << 63;
+
+/** Construct an arith_uint256 whose value equals abs(x). */
+arith_uint256 Abs256(int64_t x)
 {
-    std::array<uint32_t, 4> ret{0, 0, 0, 0};
-
-    /** Perform ret += v << (32 * pos), at 128-bit precision. */
-    auto add_fn = [&](uint64_t v, int pos) {
-        uint64_t accum{0};
-        for (int i = 0; i + pos < 4; ++i) {
-            // Add current value at limb pos in ret.
-            accum += ret[3 - pos - i];
-            // Add low or high half of v.
-            if (i == 0) accum += v & 0xffffffff;
-            if (i == 1) accum += v >> 32;
-            // Store lower half of result in limb pos in ret.
-            ret[3 - pos - i] = accum & 0xffffffff;
-            // Leave carry in accum.
-            accum >>= 32;
-        }
-        // Make sure no overflow.
-        assert(accum == 0);
-    };
-
-    // Multiply the 4 individual limbs (schoolbook multiply, with base 2^32).
-    add_fn((a & 0xffffffff) * (b & 0xffffffff), 0);
-    add_fn((a >> 32) * (b & 0xffffffff), 1);
-    add_fn((a & 0xffffffff) * (b >> 32), 1);
-    add_fn((a >> 32) * (b >> 32), 2);
-    return ret;
-}
-
-/* comparison helper for std::array */
-std::strong_ordering compare_arrays(const std::array<uint32_t, 4>& a, const std::array<uint32_t, 4>& b) {
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (a[i] != b[i]) return a[i] <=> b[i];
+    if (x >= 0) {
+        // For positive numbers, pass through the value.
+        return arith_uint256{static_cast<uint64_t>(x)};
+    } else if (x > std::numeric_limits<int64_t>::min()) {
+        // For negative numbers, negate first.
+        return arith_uint256{static_cast<uint64_t>(-x)};
+    } else {
+        // Special case for x == -2^63 (for which -x results in integer overflow).
+        return MAX_ABS_INT64;
     }
-    return std::strong_ordering::equal;
 }
 
 std::strong_ordering MulCompare(int64_t a1, int64_t a2, int64_t b1, int64_t b2)
@@ -59,23 +39,14 @@ std::strong_ordering MulCompare(int64_t a1, int64_t a2, int64_t b1, int64_t b2)
     int sign_b = (b1 == 0 ? 0 : b1 < 0 ? -1 : 1) * (b2 == 0 ? 0 : b2 < 0 ? -1 : 1);
     if (sign_a != sign_b) return sign_a <=> sign_b;
 
-    // Compute absolute values.
-    uint64_t abs_a1 = static_cast<uint64_t>(a1), abs_a2 = static_cast<uint64_t>(a2);
-    uint64_t abs_b1 = static_cast<uint64_t>(b1), abs_b2 = static_cast<uint64_t>(b2);
-    // Use (~x + 1) instead of the equivalent (-x) to silence the linter; mod 2^64 behavior is
-    // intentional here.
-    if (a1 < 0) abs_a1 = ~abs_a1 + 1;
-    if (a2 < 0) abs_a2 = ~abs_a2 + 1;
-    if (b1 < 0) abs_b1 = ~abs_b1 + 1;
-    if (b2 < 0) abs_b2 = ~abs_b2 + 1;
+    // Compute absolute values of products.
+    auto mul_abs_a = Abs256(a1) * Abs256(a2), mul_abs_b = Abs256(b1) * Abs256(b2);
 
     // Compute products of absolute values.
-    auto mul_abs_a = Mul128(abs_a1, abs_a2);
-    auto mul_abs_b = Mul128(abs_b1, abs_b2);
     if (sign_a < 0) {
-        return compare_arrays(mul_abs_b, mul_abs_a);
+        return mul_abs_b <=> mul_abs_a;
     } else {
-        return compare_arrays(mul_abs_a, mul_abs_b);
+        return mul_abs_a <=> mul_abs_b;
     }
 }
 

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -37,23 +37,21 @@
  */
 struct FeeFrac
 {
-    /** Fallback version for Mul (see below).
-     *
-     * Separate to permit testing on platforms where it isn't actually needed.
-     */
+    /** Helper function for 32*64 signed multiplication, returning an unspecified but totally
+     *  ordered type. This is a fallback version, separate so it can be tested on platforms where
+     *  it isn't actually needed. */
     static inline std::pair<int64_t, uint32_t> MulFallback(int64_t a, int32_t b) noexcept
     {
-        // Otherwise, emulate 96-bit multiplication using two 64-bit multiplies.
         int64_t low = int64_t{static_cast<uint32_t>(a)} * b;
         int64_t high = (a >> 32) * b;
         return {high + (low >> 32), static_cast<uint32_t>(low)};
     }
 
-    // Compute a * b, returning an unspecified but totally ordered type.
 #ifdef __SIZEOF_INT128__
+    /** Helper function for 32*64 signed multiplication, returning an unspecified but totally
+     *  ordered type. This is a version relying on __int128. */
     static inline __int128 Mul(int64_t a, int32_t b) noexcept
     {
-        // If __int128 is available, use 128-bit wide multiply.
         return __int128{a} * b;
     }
 #else


### PR DESCRIPTION
The `FeeFrac` type represents a fraction, intended to be used for sats/vbyte or sats/WU. This PR adds functionality to evaluate that feerate for a given size, in order to obtain the fee it corresponds with (rounding down, or rounding up).

The motivation here is being able to do accurate feerate evaluations in cluster mempool block building heuristics (where rounding down is needed), but in principle this makes it possible to use `FeeFrac` as a more accurate replacement for `CFeeRate` (where for feerate estimation rounding up is desirable). Because of this, both rounding modes are implemented.

Unit tests are included for known-correct values, plus a fuzz test that verifies the result using `arith_uint256`.