### PR TITLE
kernel: Only setup kernel context globals once

### DIFF
--- a/src/kernel/context.cpp
+++ b/src/kernel/context.cpp
@@ -8,15 +8,18 @@
 #include <logging.h>
 #include <random.h>
 
+#include <mutex>
 #include <string>
-
 
 namespace kernel {
 Context::Context()
 {
-    std::string sha256_algo = SHA256AutoDetect();
-    LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
-    RandomInit();
+    static std::once_flag globals_initialized{};
+    std::call_once(globals_initialized, []() {
+        std::string sha256_algo = SHA256AutoDetect();
+        LogInfo("Using the '%s' SHA256 implementation\n", sha256_algo);
+        RandomInit();
+    });
 }
 
 


### PR DESCRIPTION
The globals setup by the function calls when creating a new kernel context only need to be setup once. Calling them multiple times may be wasteful and has no apparent benefit.

Besides kernel users potentially creating multiple contexts, this change may also be useful for tests creating multiple setups.