### PR TITLE
release: Update translations for v28.0 soft translation string freeze

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:bitcoin:p:bitcoin:r:qt-translation-027x]
+[o:bitcoin:p:bitcoin:r:qt-translation-028x]
 file_filter = src/qt/locale/bitcoin_<lang>.xlf
 source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -30,6 +30,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for "
 "details and a full list."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"A forked headers-chain with more work than the chain with the snapshot base "
+"block header exists. Please proceed to sync without AssumeUtxo."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot downgrade wallet from version %i to version %i. Wallet version "
 "unchanged."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -87,6 +90,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous "
 "cluster of unconfirmed transactions."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Failed to remove snapshot chainstate dir (%s). Manually remove it before "
+"restarting.\n"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Failed to rename invalid peers.dat file. Please move or delete it and try "
 "again."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -95,6 +101,11 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "File %s already exists. If you are sure this is what you want, move it out "
 "of the way first."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Flushing block file to disk failed. This is likely the result of an I/O "
+"error."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Flushing undo file to disk failed. This is likely the result of an I/O error."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet "
 "forbids connections to IPv4/IPv6"),
@@ -105,6 +116,10 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Invalid or corrupt peers.dat (%s). If you believe this is a bug, please "
 "report it to %s. As a workaround, you can move the file (%s) out of the way "
 "(rename, move, or delete) to have a new one created on the next start."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Maximum transaction weight is less than transaction weight without inputs"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Maximum transaction weight is too low, can not accommodate change output"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "More than one onion bind address is provided. Using %s for the automatically "
 "created Tor onion service."),
@@ -130,9 +145,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not "
 "provided"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Please check that your computer's date and time are correct! If your clock "
-"is wrong, %s will not work properly."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Please contribute if you find %s useful. Visit %s for further information "
 "about the software."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -143,6 +155,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Prune: last wallet synchronisation goes beyond pruned data. You need to -"
 "reindex (download the whole blockchain again in case of pruned node)"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Rename of '%s' -> '%s' failed. Cannot clean up the background chainstate "
+"leveldb directory."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Rename of '%s' -> '%s' failed. You should resolve this by manually moving or "
 "deleting the invalid snapshot directory %s, otherwise you will encounter the "
@@ -155,6 +170,10 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "This may be due to your computer's date and time being set incorrectly. Only "
 "rebuild the block database if you are sure that your computer's date and "
 "time are correct"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"The combination of the pre-selected inputs and the wallet automatic inputs "
+"selection exceeds the transaction maximum weight. Please try sending a "
+"smaller amount or manually consolidating your wallet's UTXOs"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "The inputs size exceeds the maximum weight. Please try sending a smaller "
 "amount or manually consolidating your wallet's UTXOs"),
@@ -236,14 +255,25 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "You need to rebuild the database using -reindex to go back to unpruned "
 "mode.  This will redownload the entire blockchain"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Your computer's date and time appear to be more than %d minutes out of sync "
+"with the network, this may lead to consensus failure. After you've confirmed "
+"your computer's clock, this message should no longer appear when you restart "
+"your node. Without a restart, it should stop showing automatically after "
+"you've connected to a sufficient number of new outbound peers, which may "
+"take some time. You can inspect the `timeoffset` field of the `getpeerinfo` "
+"and `getnetworkinfo` RPC methods to get more info."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "\n"
 "Unable to cleanup failed migration"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "\n"
 "Unable to restore backup of wallet."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"whitebind may only be used for incoming connections (\"out\" was passed)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "%s is set very high!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "-maxmempool must be at least %d MB"),
-QT_TRANSLATE_NOOP("bitcoin-core", "A fatal internal error occurred, see debug.log for details"),
+QT_TRANSLATE_NOOP("bitcoin-core", "A fatal internal error occurred, see debug.log for details: "),
+QT_TRANSLATE_NOOP("bitcoin-core", "Assumeutxo data not found for the given blockhash '%s'."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Block verification was interrupted"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot resolve -%s address: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot set -forcednsseed to true when setting -dnsseed to false."),
@@ -251,6 +281,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Cannot set -peerblockfilters without -blockfi
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot write to data directory '%s'; check permissions."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Config setting for %s only applied on %s network when in [%s] section."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Copyright (C) %i-%i"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Corrupt block found indicating potential hardware failure."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Corrupted block database detected"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Could not find asmap file %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Could not parse asmap file %s"),
@@ -258,6 +289,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Disk space is too low!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Do you want to rebuild the block database now?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Done loading"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Dump file %s does not exist."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Elliptic curve cryptography sanity check failure. %s is shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error committing db txn for wallet transactions removal"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error creating %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error initializing block database"),
@@ -297,10 +329,17 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to write solvable wallet best b
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to write watchonly wallet best block locator record"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: address book copy failed for wallet %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: database transaction cannot be executed for wallet %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to connect best block (%s)."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to disconnect block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to listen on any port. Use -listen=0 if you want this."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to read block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to rescan the wallet during initialization"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to start indexes, shutting down.."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to verify database"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write block."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write to block index database."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write to coin database."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write undo data."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failure removing transaction: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Fee rate (%s) is lower than the minimum fee rate setting (%s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Ignoring duplicate -wallet %s."),
@@ -325,6 +364,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Loading P2P addresses…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading banlist…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading block index…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading wallet…"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Maximum transaction weight must be between %d and %d"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Missing amount"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Missing solving data for estimating transaction size"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Need to specify a port with -whitebind: '%s'"),
@@ -332,6 +372,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "No addresses available"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not enough file descriptors available."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not found pre-selected input %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not solvable pre-selected input %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Only direction was set, no permissions: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune cannot be configured with a negative value."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune mode is incompatible with -txindex."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Pruning blockstore…"),
@@ -345,6 +386,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", "SQLiteDatabase: Unexpected application id. Ex
 QT_TRANSLATE_NOOP("bitcoin-core", "Section [%s] is not recognized."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Settings file could not be read"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Settings file could not be written"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Signer did not echo address"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Signer echoed unexpected address %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Signer returned error: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Signing transaction failed"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Specified -walletdir \"%s\" does not exist"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Specified -walletdir \"%s\" is a relative path"),
@@ -352,10 +396,14 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Specified -walletdir \"%s\" is not a director
 QT_TRANSLATE_NOOP("bitcoin-core", "Specified blocks directory \"%s\" does not exist."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Specified data directory \"%s\" does not exist."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Starting network threads…"),
+QT_TRANSLATE_NOOP("bitcoin-core", "System error while flushing: %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "System error while loading external block file: %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "System error while saving block to disk: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The source code is available from %s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "The specified config file %s does not exist"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The transaction amount is too small to pay the fee"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The wallet will avoid paying less than the minimum relay fee."),
+QT_TRANSLATE_NOOP("bitcoin-core", "There is no ScriptPubKeyManager for this address"),
 QT_TRANSLATE_NOOP("bitcoin-core", "This is experimental software."),
 QT_TRANSLATE_NOOP("bitcoin-core", "This is the minimum transaction fee you pay on every transaction."),
 QT_TRANSLATE_NOOP("bitcoin-core", "This is the transaction fee you will pay if you send a transaction."),
@@ -366,7 +414,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Transaction change output index out of range"
 QT_TRANSLATE_NOOP("bitcoin-core", "Transaction must have at least one recipient"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Transaction needs a change address, but we can't generate it."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Transaction too large"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Unable to allocate memory for -maxsigcachesize: '%s' MiB"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer (bind returned error %s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer. %s is probably already running."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to create the PID file '%s': %s"),
@@ -382,6 +429,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Unknown address type '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown change type '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown network specified in -onlynet: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown new rules activated (versionbit %i)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Unrecognised option \"%s\" provided in -test=<option>."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unsupported global logging level %s=%s. Valid values: %s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unsupported logging category %s=%s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "User Agent comment (%s) contains unsafe characters."),

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -2,34 +2,6 @@
 <context>
     <name>AddressBookPage</name>
     <message>
-        <source>Right-click to edit address or label</source>
-        <translation type="unfinished">انقر بالزر الايمن لتعديل العنوان</translation>
-    </message>
-    <message>
-        <source>Create a new address</source>
-        <translation type="unfinished">أنشئ عنوان جديد</translation>
-    </message>
-    <message>
-        <source>&amp;New</source>
-        <translation type="unfinished">&amp;جديد</translation>
-    </message>
-    <message>
-        <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">‫انسخ العنوان المحدد للحافظة‬</translation>
-    </message>
-    <message>
-        <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;نسخ</translation>
-    </message>
-    <message>
-        <source>C&amp;lose</source>
-        <translation type="unfinished">ا&amp;غلاق</translation>
-    </message>
-    <message>
-        <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">احذف العنوان المحدد من القائمة</translation>
-    </message>
-    <message>
         <source>Enter address or label to search</source>
         <translation type="unfinished">أدخل عنوانا أو مذكرة للبحث</translation>
     </message>
@@ -42,62 +14,10 @@
         <translation type="unfinished">&amp;تصدير</translation>
     </message>
     <message>
-        <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;حذف</translation>
-    </message>
-    <message>
-        <source>Choose the address to send coins to</source>
-        <translation type="unfinished">اختر العنوان الذي ترغب بارسال بتكوين اليه</translation>
-    </message>
-    <message>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished">اختر العنوان الذي ترغب باستلام بتكوين اليه</translation>
     </message>
-    <message>
-        <source>C&amp;hoose</source>
-        <translation type="unfinished">ا&amp;ختر</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">‫هذه عناوين البتكوين الخاصة بك لإرسال المدفوعات. تأكد دائما من القيم المدخلة ومن العنوان المستلم قبل الارسال.‬</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
-Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">هذه عناوين البتكوين الخاصة بك لاستلام المدفوعات. قم بالنقر على زر انشاء عنوان استلام جديد لإنشاء عناوين جديدة.
-التوقيع ممكن باستخدام العناوين القديمة "Legacy" فقط.</translation>
-    </message>
-    <message>
-        <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;نسخ العنوان</translation>
-    </message>
-    <message>
-        <source>Copy &amp;Label</source>
-        <translation type="unfinished">نسخ &amp;المذكرة</translation>
-    </message>
-    <message>
-        <source>&amp;Edit</source>
-        <translation type="unfinished">&amp;تحرير</translation>
-    </message>
-    <message>
-        <source>Export Address List</source>
-        <translation type="unfinished">تصدير قائمة العناوين</translation>
-    </message>
-    <message>
-        <source>Comma separated file</source>
-        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">ملف القيم المفصولة بفاصلة</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">حدث خطأ أثناء محاولة حفظ قائمة العناوين في %1. يرجى معاودة المحاولة. </translation>
-    </message>
-    <message>
-        <source>Exporting Failed</source>
-        <translation type="unfinished">فشل التصدير</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -1637,11 +1557,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
         <translation type="unfinished">‫تفعيل التحكم ب &amp;المعاملات الموقعة جزئيا‬</translation>
-    </message>
-    <message>
-        <source>Whether to show PSBT controls.</source>
-        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">‫خيار عرض التحكم بالمعاملات الموقعة جزئيا.‬</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>

--- a/src/qt/locale/bitcoin_az.ts
+++ b/src/qt/locale/bitcoin_az.ts
@@ -2,6 +2,10 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Ünvanı və ya etiketi redaktə etmək üçün sağ klikləyin</translation>
+    </message>
+    <message>
         <source>Create a new address</source>
         <translation type="unfinished">Yeni ünvan yaradın</translation>
     </message>
@@ -281,43 +285,43 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
         </translation>
     </message>
     </context>
@@ -881,7 +885,7 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
-        <translation type="unfinished">Xərclənməmiş qalığı kilidd'n &amp;çıxarın</translation>
+        <translation type="unfinished">Xərclənməmiş qalığı kiliddən &amp;çıxarın</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -946,7 +950,7 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     </message>
     <message>
         <source>Can't list signers</source>
-        <translation type="unfinished">İmzalaynları göstərmək mümkün deyil</translation>
+        <translation type="unfinished">İmzalayanları göstərmək mümkün deyil</translation>
     </message>
     </context>
 <context>
@@ -954,7 +958,7 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message>
         <source>Load Wallets</source>
         <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
-        <translation type="unfinished">Cüzdanları yükləyin</translation>
+        <translation type="unfinished">Pulqabıları yükləyin</translation>
     </message>
     <message>
         <source>Loading wallets…</source>
@@ -962,6 +966,13 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Pulqabılar yüklənir...</translation>
     </message>
 </context>
+<context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Pulqabını köçür</translation>
+    </message>
+    </context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -974,12 +985,12 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">standart cüzdan</translation>
+        <translation type="unfinished">standart pulqabı</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Cüzdanı açın</translation>
+        <translation type="unfinished">Pulqabını açın</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
@@ -992,7 +1003,7 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message>
         <source>Restore Wallet</source>
         <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
-        <translation type="unfinished">Cüzdanı bərpa et</translation>
+        <translation type="unfinished">Pulqabını bərpa et</translation>
     </message>
     <message>
         <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
@@ -1002,24 +1013,24 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message>
         <source>Restore wallet failed</source>
         <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
-        <translation type="unfinished">Cüzdan bərpa oluna bilmədi</translation>
+        <translation type="unfinished">Pulqabı bərpa oluna bilmədi</translation>
     </message>
     <message>
         <source>Restore wallet warning</source>
         <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
-        <translation type="unfinished">Cüzdanın bərpa olunması xəbərdarlığı</translation>
+        <translation type="unfinished">Pulqabının bərpa olunması xəbərdarlığı</translation>
     </message>
     <message>
         <source>Restore wallet message</source>
         <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
-        <translation type="unfinished">Cüzdanın bərpası ismarıcı</translation>
+        <translation type="unfinished">Pulqabının bərpası ismarıcı</translation>
     </message>
 </context>
 <context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Cüzdanı bağlayın</translation>
+        <translation type="unfinished">Pulqabını bağlayın</translation>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
@@ -1042,7 +1053,7 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Cüzdan yaradın</translation>
+        <translation type="unfinished">Pulqabı yaradın</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1136,30 +1147,30 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
@@ -1457,8 +1468,8 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -1479,8 +1490,8 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_az@latin.ts
+++ b/src/qt/locale/bitcoin_az@latin.ts
@@ -285,43 +285,43 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
         </translation>
     </message>
     </context>
@@ -1140,30 +1140,30 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
@@ -1461,8 +1461,8 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -1483,8 +1483,8 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_be.ts
+++ b/src/qt/locale/bitcoin_be.ts
@@ -83,6 +83,14 @@
         <translation type="unfinished">Адбылася памылка падчас спробы захаваць адрас у %1. Паспрабуйце зноў.</translation>
     </message>
     <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">Адрасы адпраўкі - %1</translation>
+    </message>
+    <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">Адрасы прымання - %1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">Экспартаванне няўдалае</translation>
     </message>
@@ -155,6 +163,10 @@
     <message>
         <source>Wallet encrypted</source>
         <translation type="unfinished">Гаманец зашыфраваны</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Гаманец будзе зашыфраваны</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -1500,7 +1500,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Неизвестно. Синхронизиране на Глави (%1, %2%)...</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Неизвестно. Предварителна синхронизация на хедъри (%1, %2%)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -311,6 +311,12 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">No encaminable</translation>
     </message>
     <message>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <extracomment>Name of Tor network in peer info</extracomment>
+        <translation type="unfinished">Ceba</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Entrant</translation>
@@ -347,36 +353,36 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segons</numerusform>
+            <numerusform>%n segon(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuts</numerusform>
+            <numerusform>%n minuts</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hores</numerusform>
+            <numerusform>%n hores</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dies</numerusform>
+            <numerusform>%n dies</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n setmanes</numerusform>
+            <numerusform>%n setmanes</numerusform>
         </translation>
     </message>
     <message>
@@ -386,8 +392,8 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n any</numerusform>
+            <numerusform>%n anys</numerusform>
         </translation>
     </message>
     </context>
@@ -1136,7 +1142,22 @@ El procés de migració crearà una còpia de seguretat de la cartera abans de m
         <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
         <translation type="unfinished">Restaurant cartera &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
-    </context>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Reestablir cartera ha fallat</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Avís al restaurar la cartera</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Missatge al restaurar la cartera</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1165,6 +1186,14 @@ El procés de migració crearà una còpia de seguretat de la cartera abans de m
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Crear cartera</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Només et queda un pas per a crear la teva nova cartera</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Si us plau, proporciona un nom i, si vols, activa qualsevol opció avançada</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1304,8 +1333,8 @@ Això és ideal per a carteres de mode només lectura.</translation>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB d'espai lliure disponible</numerusform>
+            <numerusform>%n GB d'espai lliure disponibles</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1377,6 +1406,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Aquesta sincronització inicial és molt exigent i pot exposar problemes de maquinari amb l'equip que anteriorment havien passat desapercebuts. Cada vegada que executeu %1, continuarà descarregant des del punt on es va deixar.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Quan feu clic a D'acord, %1 començarà a descarregar i processar la cadena de blocs %4 completa (%2 GB) començant per les primeres transaccions de %3, any de llençament inicial de %4.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1471,7 +1504,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Desconegut. Sincronització de les capçaleres (%1, %2%)...</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconegut. Sincronització de les capçaleres (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1527,6 +1564,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Minimitza en comptes de sortir de l'aplicació quan la finestra es tanca. Quan s'habilita aquesta opció l'aplicació es tancarà només quan se selecciona Surt del menú. </translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Les opcions configurades en aquest diàleg són sobreescrites per la línia de comandes:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Obriu el fitxer de configuració %1 des del directori de treball.</translation>
     </message>
@@ -1559,6 +1600,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">(0 = auto, &lt;0 = deixa tants nuclis lliures)</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Activa el servidor R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Moneder</translation>
     </message>
@@ -1573,6 +1619,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Gasta el canvi sense confirmar</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Activa els controls &amp;PSBT</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -1671,6 +1722,14 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Selecciona la unitat de subdivisió per defecte per a mostrar en la interfície quan s'envien monedes.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL de terceres parts (p. ex. explorador de blocs) que apareix en la pestanya de transaccions com elements del menú contextual. %s en l'URL es reemplaçat pel resum de la transacció. Diferents URL estan separades per una barra vertical |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URL de transaccions de tercers</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Si voleu mostrar les funcions de control de monedes o no.</translation>
     </message>
@@ -1727,6 +1786,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">El fitxer de configuració s'utilitza per a especificar les opcions d'usuari avançades que substitueixen la configuració de la interfície gràfica d'usuari. A més, qualsevol opció de la línia d'ordres substituirà aquest fitxer de configuració.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continua</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1818,6 +1881,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
+    <message>
+        <source>PSBT Operations</source>
+        <translation type="unfinished">Operacions PSBT</translation>
+    </message>
     <message>
         <source>Sign Tx</source>
         <translation type="unfinished">Signa Tx</translation>
@@ -1916,6 +1983,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">La transacció encara necessita una o vàries firmes.</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Cap cartera ha estat carregada.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Però aquesta cartera no pot firmar transaccions.)</translation>
     </message>
@@ -1978,6 +2049,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Igual</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Edat</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2864,6 +2940,11 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
         <translation type="unfinished">Si us plau, revisa la teva proposta de transacció. Es produirà una transacció de Bitcoin amb firma parcial (PSBT) que podeu guardar o copiar i després firmar, per exemple, amb una cartera %1, o amb una cartera física compatible amb PSBT.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Voleu crear aquesta transacció?</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Reviseu la transacció</translation>
@@ -3247,8 +3328,10 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>madura en %n bloc més
+</numerusform>
+            <numerusform>madura en %n blocs més
+</numerusform>
         </translation>
     </message>
     <message>
@@ -3897,6 +3980,23 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">No es pot escriure en el directori de dades "%s". Reviseu-ne els permisos.</translation>
     </message>
     <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">%s especificat molt alt! Tarifes tan grans podrien pagar-se en una única transacció.
+</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">S'ha produït un error en llegir %s. Totes les claus es llegeixen correctament, però les dades de la transacció o les entra des de la llibreta d'adreces podrien faltar o ser incorrectes.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">L'estimació de la quota ha fallat. Fallbackfee està desactivat. Espereu uns quants blocs o activeu %s.</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Import no vàlid per a %s=&lt;amount&gt;: '%s' (cal que sigui com a mínim la comissió de minrelay de %s per evitar que les comissions s'encallin)</translation>
+    </message>
+    <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
         <translation type="unfinished">Configuració per a %s únicament aplicada a  %s de la xarxa quan es troba a la secció [%s].</translation>
     </message>
@@ -4070,12 +4170,24 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Permís P2P no vàlid: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Import no vàlid per a %s=&lt;amount&gt;: «%s» (ha de ser com a mínim %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Import invàlid per a %s=&lt;amount&gt;: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Import invàlid per a -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">S'ha especificat una màscara de xarxa no vàlida a -whitelist: «%s»</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">ha fallat escoltar les connexions entrants (l'escoltament ha retornat l'error %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4164,6 +4276,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">El directori de blocs especificat "%s" no existeix.</translation>
+    </message>
+    <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">El directori de dades especificat «%s» no existeix.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -4148,6 +4148,12 @@ Ověřuji peněženku.</translation>
         <translation type="unfinished">Chyba při načtení %s: Externí podepisovací peněženka se načítá bez zkompilované podpory externího podpisovatele.</translation>
     </message>
     <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">Nastala chyba při čtení souboru %s! Všechny klíče se přečetly správně, ale data o transakcích nebo záznamy v adresáři moho
+u chybět či být nesprávné.
+</translation>
+    </message>
+    <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
         <translation type="unfinished">Chyba: Data adres v peněžence není možné identifikovat jako data patřící k migrovaným peněženkám.</translation>
     </message>
@@ -4728,6 +4734,10 @@ Nelze obnovit zálohu peněženky.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodporovaná logovací kategorie %s=%s.</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <translation type="unfinished">Chyba: Nelze přidat pouze-sledovací tx %s do peněženky pro čtení</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -1187,8 +1187,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB fri plads tilgængelig</numerusform>
+            <numerusform>%n GB fri plads tilgængelig</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1264,6 +1264,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Denne indledningsvise synkronisering er meget krævende, og den kan potentielt afsløre hardwareproblemer med din computer, som du ellers ikke har lagt mærke til. Hver gang, du kører %1, vil den fortsætte med at downloade, hvor den sidst slap.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Når du klikker OK, vil %1 begynde at downloade og bearbejde den fulde %4-blokkæde (%2 GB), startende med de tidligste transaktioner i %3, da %4 først startede.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1396,6 +1400,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished">Antallet af script&amp;verificeringstråde</translation>
+    </message>
+    <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Fuld sti til et %1-kompatibelt script (f.eks. C:\Downloads\hwi.exe eller /Users/you/Downloads/hwi.py). Pas på: malware kan stjæle dine mønter!</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
@@ -3888,6 +3896,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Kan ikke skrive til datamappe '%s'; tjek tilladelser.</translation>
     </message>
     <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">%s er sat meget højt! Gebyrer så store risikeres betalt på en enkelt transaktion.</translation>
+    </message>
+    <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <translation type="unfinished">Kan ikke levere specifikke forbindelser og få adrman til at finde udgående forbindelser på samme tid.</translation>
     </message>
@@ -3896,8 +3908,20 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Fejlindlæsning %s: Ekstern underskriver-tegnebog indlæses uden ekstern underskriverunderstøttelse kompileret</translation>
     </message>
     <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">Fejl under læsning af %s! Alle nøgler blev læst korrekt, men transaktionsdata eller indgange i adressebogen kan mangle eller være ukorrekte.</translation>
+    </message>
+    <message>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
         <translation type="unfinished">Kunne ikke omdøbe ugyldig peers.dat fil. Flyt eller slet den venligst og prøv igen.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">Estimering af gebyr mislykkedes. Tilbagefaldsgebyr er deaktiveret. Vent et par blokke eller aktiver %s.</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Ugyldigt beløb for %s=&lt;beløb&gt;: “%s” (skal være på mindst minrelay-gebyret på %s for at undgå hængende transaktioner)</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -4076,12 +4100,25 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Invalid P2P tilladelse: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Ugyldigt beløb for %s=&lt;beløb&gt;: “%s” (skal være mindst %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Ugyldigt beløb for %s=&lt;beløb&gt;: “%s”</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Ugyldigt beløb for -%s=&lt;beløb&gt;: “%s”</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Ugyldig netmaske angivet i -whitelist: “%s”</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Lytning efter indkommende forbindelser mislykkedes (lytning resultarede i fejl %s)
+</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4182,6 +4219,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Angivet blokmappe “%s” eksisterer ikke.</translation>
+    </message>
+    <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Angivet datamappe “%s” eksisterer ikke.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -366,10 +366,6 @@ Das Signieren ist nur mit Adressen vom Typ 'Legacy' möglich.</translation>
         <translation type="unfinished">%1 T</translation>
     </message>
     <message>
-        <source>%1 h</source>
-        <translation type="unfinished">%1 S</translation>
-    </message>
-    <message>
         <source>%1 m</source>
         <translation type="unfinished">%1 min</translation>
     </message>
@@ -1226,7 +1222,7 @@ Während des Migrationsprozesses wird vor der Migration ein Backup der Wallet er
     </message>
     <message>
         <source>You are one step away from creating your new wallet!</source>
-        <translation type="unfinished">Nur noch einen Schritt entfernt, das neue Wallet zu erstellen!</translation>
+        <translation type="unfinished">Nur noch einen Schritt entfernt um das neue Wallet zu erstellen!</translation>
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
@@ -2169,7 +2165,7 @@ Wenn Sie diese Fehlermeldung erhalten, sollten Sie den Händler bitten, einen BI
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Übertragen</translation>
+        <translation type="unfinished">Gesendet</translation>
     </message>
     <message>
         <source>Received</source>
@@ -2310,7 +2306,7 @@ Wenn Sie diese Fehlermeldung erhalten, sollten Sie den Händler bitten, einen BI
     </message>
     <message>
         <source>Sent</source>
-        <translation type="unfinished">Übertragen</translation>
+        <translation type="unfinished">Gesendet</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
@@ -2685,7 +2681,7 @@ Benutze %3 und %4, um die Fontgröße zu vergrößern bzw. verkleinern.
 Tippe %5 für einen Überblick über verfügbare Befehle.
 Für weitere Informationen über diese Konsole, tippe %6.
 
-%7 ACHTUNG: Es sind Betrüger zu Gange, die Benutzer anweisen, hier Kommandos einzugeben, wodurch sie den Inhalt der Wallet stehlen können. Benutze diese Konsole nicht, ohne die Implikationen eines Kommandos vollständig zu verstehen.%8</translation>
+%7ACHTUNG: Es sind Betrüger zu Gange, die Benutzer anweisen, hier Kommandos einzugeben, wodurch sie den Inhalt der Wallet stehlen können. Benutze diese Konsole nicht, ohne die Implikationen eines Kommandos vollständig zu verstehen.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -3042,7 +3038,7 @@ Hinweis: Da die Gebühr auf Basis der Bytes berechnet wird, führt eine Gebühre
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Eine niedrige Gebühr kann dazu führen das eine Transaktion niemals bestätigt wird (Lesen sie die Anmerkung).</translation>
+        <translation type="unfinished">Eine niedrige Gebühr kann dazu führen das eine Transaktion niemals bestätigt wird (Lesen Sie die Anmerkung).</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
@@ -3124,7 +3120,7 @@ Hinweis: Da die Gebühr auf Basis der Bytes berechnet wird, führt eine Gebühre
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Erzeugt eine teilsignierte Bitcoin Transaktion (PSBT) zur Benutzung mit z.B. einem Offline %1 Wallet, oder einem kompatiblen Hardware Wallet.</translation>
+        <translation type="unfinished">Erzeugt eine teilsignierte Bitcoin Transaktion (PSBT) zur Benutzung mit z.B. einem Offline %1 Wallet oder einem kompatiblen Hardware Wallet.</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>

--- a/src/qt/locale/bitcoin_de_CH.ts
+++ b/src/qt/locale/bitcoin_de_CH.ts
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">&amp;Schließen</translation>
+        <translation type="unfinished">&amp;Schliessen</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -445,6 +445,18 @@ Das Signieren ist nur mit Adressen vom Typ 'Legacy' möglich.</translation>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Neues Wallet erstellen</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimieren</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Senden</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Empfangen</translation>
     </message>
     <message>
         <source>&amp;Options…</source>

--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -283,6 +283,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">άγνωστο</translation>
     </message>
     <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Προεπιλεγμένη γραμματοσειρά συστήματος "%1"</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">Ποσό</translation>
     </message>
@@ -2319,8 +2323,20 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Η συμβολοσειρά αναγνωριστικού περιόδου σύνδεσης BIP324 σε δεκαεξαδική μορφή, εάν υπάρχει.</translation>
     </message>
     <message>
+        <source>Session ID</source>
+        <translation type="unfinished">Αναγνωριστικό περιόδου σύνδεσης</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Έκδοση</translation>
+    </message>
+    <message>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished">Είτε αναμεταδίδουμε συναλλαγές σε αυτόν τον ομότιμο.</translation>
+    </message>
+    <message>
+        <source>Transaction Relay</source>
+        <translation type="unfinished">Αναμετάδοση Συναλλαγής</translation>
     </message>
     <message>
         <source>Starting Block</source>
@@ -2345,6 +2361,36 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Χαρτογραφημένο ως</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Είτε αναμεταδίδουμε διευθύνσεις σε αυτόν τον ομότιμο.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Αναμετάδοση Διεύθυνσης</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Ο συνολικός αριθμός των διευθύνσεων που ελήφθησαν από αυτόν τον ομότιμο και υποβλήθηκαν σε επεξεργασία (εξαιρούνται οι διευθύνσεις που απορρίφθηκαν λόγω περιορισμού ποσοστού).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Ο συνολικός αριθμός των διευθύνσεων που ελήφθησαν από αυτόν τον ομότιμο και απορρίφθηκαν (δεν υποβλήθηκαν σε επεξεργασία) λόγω περιορισμού ποσοστού.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Επεξεργασμένες Διευθύνσεις </translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Περιορισμένου Ποσοστού Διευθύνσεις </translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2379,8 +2425,16 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Κατεύθυνση/Τύπος</translation>
     </message>
     <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Το πρωτόκολλο δικτύου αυτού του ομότιμου συνδέεται μέσω: IPv4, IPv6, Onion, I2P ή CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Υπηρεσίες</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Αναμετάδοση υψηλού εύρους ζώνης BIP152 συμπαγούς μπλοκ: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
@@ -2391,8 +2445,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Χρόνος σύνδεσης</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Ο χρόνος που έχει παρέλθει από τη λήψη ενός νέου μπλοκ που περνούσε τους αρχικούς ελέγχους εγκυρότητας ελήφθη από αυτόν τον ομότιμο.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Τελευταίο Block</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Ο χρόνος που έχει παρέλθει από τη λήψη μιας νέας συναλλαγής που έγινε αποδεκτή στο υπόμνημά μας από αυτόν τον ομότιμο.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2464,8 +2527,56 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Εισερχόμενo: Ξεκίνησε από peer</translation>
     </message>
     <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Πλήρες Εξερχόμενη Αναμετάδοση: προεπιλογή</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Μπλοκ Εξερχόμενης Αναμετάδοσης: δεν αναμεταδίδει συναλλαγές ή διευθύνσεις</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Εγχειρίδιο Εξερχόμενων: προστέθηκε χρησιμοποιώντας RPC %1ή %2/%3επιλογές διαμόρφωσης</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Εξερχόμενων Ελλείψεων: βραχύβια, για δοκιμή διευθύνσεων</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Ανάκτηση Εξερχόμενης Διεύθυνσης: βραχύβια, για την αναζήτηση διευθύνσεων</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">ανίχνευση: ο ομότιμος μπορεί να είναι v1 ή v2</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: πρωτόκολλο μεταφοράς μη κρυπτογραφημένου απλού κειμένου</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: Κρυπτογραφημένο πρωτόκολλο μεταφοράς BIP324</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">επιλέξαμε τον ομότιμο για αναμετάδοση υψηλού εύρους ζώνης</translation>
+    </message>
+    <message>
         <source>the peer selected us for high bandwidth relay</source>
         <translation type="unfinished">ο ομότιμος μας επέλεξε για υψηλής ταχύτητας αναμετάδοση </translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">δεν επιλέχθηκε υψηλού εύρους ζώνη αναμετάδοσης</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2513,6 +2624,23 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished"> 
 Εκτελέστε εντολή χρησιμοποιώντας το πορτοφόλι "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Καλώς ήρθατε στην%1κονσόλα RPC.
+Χρησιμοποιήστε τα πάνω και τα κάτω βέλη για πλοήγηση στο ιστορικό και%2εκκαθάριση της οθόνης.
+Χρησιμοποιήστε%3και%4για να αυξήσετε ή να μειώσετε το μέγεθος της γραμματοσειράς.
+Πληκτρολογήστε%5για επισκόπηση των διαθέσιμων εντολών.
+Για περισσότερες πληροφορίες σχετικά με τη χρήση αυτής της κονσόλας, πληκτρολογήστε%6.
+
+%7ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Οι σκάμερς είναι ενεργοί, λέγοντας στους χρήστες να πληκτρολογούν εντολές εδώ, κλέβοντας το περιεχόμενο του πορτοφολιού τους. Μην χρησιμοποιείτε αυτήν την κονσόλα χωρίς να κατανοήσετε πλήρως τις συνέπειες μιας εντολής.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2645,6 +2773,26 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Αντιγραφή &amp;ποσού</translation>
+    </message>
+    <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Base58 (Παλαιού τύπου)</translation>
+    </message>
+    <message>
+        <source>Not recommended due to higher fees and less protection against typos.</source>
+        <translation type="unfinished">Δεν συνιστάται λόγω υψηλότερων χρεώσεων και μικρότερης προστασίας έναντι τυπογραφικών σφαλμάτων.</translation>
+    </message>
+    <message>
+        <source>Generates an address compatible with older wallets.</source>
+        <translation type="unfinished">Παράγει μια διεύθυνση συμβατή με παλαιότερα πορτοφόλια.</translation>
+    </message>
+    <message>
+        <source>Generates a native segwit address (BIP-173). Some old wallets don't support it.</source>
+        <translation type="unfinished">Δημιουργεί μια εγγενή διεύθυνση segwit (BIP-173). Ορισμένα παλιά πορτοφόλια δεν το υποστηρίζουν.</translation>
+    </message>
+    <message>
+        <source>Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
+        <translation type="unfinished">Το Bech32m (BIP-350) είναι μια αναβάθμιση στο Bech32, η υποστήριξη πορτοφολιού εξακολουθεί να είναι περιορισμένη.</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2926,6 +3074,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Συνδέστε πρώτα τη συσκευή πορτοφολιού σας.</translation>
     </message>
     <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ορίστε τη διαδρομή σεναρίου εξωτερικού υπογράφοντος στις Επιλογές -&gt; Πορτοφόλι</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Δη&amp;μιουργία Ανυπόγραφου</translation>
     </message>
@@ -2949,6 +3102,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
         <translation type="unfinished">Δεν βρέθηκε ο εξωτερικός υπογράφων</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Αποτυχία εξωτερικού υπογράφοντος</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2987,6 +3145,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Θέλετε να δημιουργήσετε αυτήν τη συναλλαγή;</translation>
     </message>
     <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Παρακαλώ, ελέγξτε τη συναλλαγή σας. Μπορείτε να δημιουργήσετε και να στείλετε αυτήν τη συναλλαγή ή να δημιουργήσετε μια μερικώς υπογεγραμμένη συναλλαγή Bitcoin (PSBT), την οποία μπορείτε να αποθηκεύσετε ή να αντιγράψετε και στη συνέχεια να υπογράψετε, π.χ. με ένα πορτοφόλι εκτός σύνδεσης%1ή ένα πορτοφόλι υλικού συμβατό με PSBT.</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Παρακαλούμε, ελέγξτε τη συναλλαγή σας.</translation>
@@ -3003,6 +3166,20 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>Total Amount</source>
         <translation type="unfinished">Συνολικό ποσό</translation>
+    </message>
+    <message>
+        <source>Unsigned Transaction</source>
+        <comment>PSBT copied</comment>
+        <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
+        <translation type="unfinished">Ανυπόγραφη Συναλλαγή</translation>
+    </message>
+    <message>
+        <source>The PSBT has been copied to the clipboard. You can also save it.</source>
+        <translation type="unfinished">Το PSBT αντιγράφηκε στο πρόχειρο. Μπορείτε, επίσης, να το αποθηκεύσετε.</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk</source>
+        <translation type="unfinished">Το PSBT αποθηκεύτηκε στον δίσκο</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3043,8 +3220,8 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -3357,8 +3534,8 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>ωριμάζει σε %n περισσότερα μπλοκ</numerusform>
+            <numerusform>ωριμάζει σε %n περισσότερα κομμάτια</numerusform>
         </translation>
     </message>
     <message>
@@ -3962,6 +4139,18 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Αδύνατη η εγγραφή στον κατάλογο δεδομένων '%s'. Ελέγξτε τα δικαιώματα.</translation>
     </message>
     <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">%s είναι καταχωρημένο πολύ υψηλά! Έξοδα τόσο υψηλά μπορούν να πληρωθούν σε μια ενιαία συναλλαγή.</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">Σφάλμα κατά την ανάγνωση %s! Όλα τα κλειδιά διαβάζονται σωστά, αλλά τα δεδομένα των συναλλαγών ή οι καταχωρίσεις του βιβλίου διευθύνσεων ενδέχεται να λείπουν ή να είναι εσφαλμένα.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">Η αποτίμηση του τέλους απέτυχε. Το Fallbackfee είναι απενεργοποιημένο. Περιμένετε λίγα τετράγωνα ή ενεργοποιήστε το %s.</translation>
+    </message>
+    <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
         <translation type="unfinished">Η ρύθμιση Config για το %s εφαρμόστηκε μόνο στο δίκτυο %s όταν βρίσκεται στην ενότητα [%s].</translation>
     </message>
@@ -4110,6 +4299,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Μη έγκυρη μάσκα δικτύου που καθορίζεται στο -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Η ακρόαση για εισερχόμενες συνδέσεις απέτυχε (ακούστε επιστραμμένο σφάλμα %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">Φόρτωση διευθύνσεων P2P...</translation>
     </message>
@@ -4188,6 +4381,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Δεν υπάρχει κατάλογος καθορισμένων μπλοκ "%s".</translation>
+    </message>
+    <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Ο ορισμένος κατάλογος δεδομένων "%s" δεν υπάρχει.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -55,7 +55,7 @@
     </message>
     <message>
         <location line="-30"/>
-        <location filename="../addressbookpage.cpp" line="+117"/>
+        <location filename="../addressbookpage.cpp" line="+113"/>
         <source>&amp;Delete</source>
         <translation>&amp;Delete</translation>
     </message>
@@ -179,7 +179,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+49"/>
+        <location filename="../askpassphrasedialog.cpp" line="+45"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
+        <location line="+48"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,17 +210,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+0"/>
+        <location line="+18"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+58"/>
+        <location line="+12"/>
+        <location line="+54"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-138"/>
+        <location line="-147"/>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,12 +231,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
+        <location line="+50"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Wallet to be encrypted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -245,7 +256,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+15"/>
         <source>Your wallet is now encrypted. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -257,18 +268,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <message>
         <location line="+6"/>
         <location line="+8"/>
-        <location line="+62"/>
+        <location line="+58"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
+        <location line="-65"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
-        <location line="+62"/>
+        <location line="+58"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,7 +345,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+184"/>
         <source>Runaway exception</source>
         <translation type="unfinished"></translation>
     </message>
@@ -357,7 +368,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+250"/>
+        <location filename="../bitcoingui.cpp" line="+252"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
@@ -417,7 +428,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
+        <location line="+162"/>
         <source>&amp;Minimize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -427,7 +438,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+417"/>
+        <location line="+418"/>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished"></translation>
@@ -533,7 +544,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
+        <location line="+120"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
@@ -553,7 +564,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Tabs toolbar</translation>
     </message>
     <message>
-        <location line="+481"/>
+        <location line="+482"/>
         <source>Syncing Headers (%1%)…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -753,7 +764,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+20"/>
         <source>No wallets available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -817,7 +828,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+117"/>
+        <location line="+118"/>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
@@ -1034,7 +1045,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished">Confirmed</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+69"/>
+        <location filename="../coincontroldialog.cpp" line="+65"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1123,7 +1134,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <location filename="../walletcontroller.cpp" line="+246"/>
+        <location filename="../walletcontroller.cpp" line="+247"/>
         <source>Create Wallet</source>
         <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
         <translation type="unfinished"></translation>
@@ -1228,7 +1239,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../createwalletdialog.cpp" line="+22"/>
+        <location filename="../createwalletdialog.cpp" line="+20"/>
         <source>Create</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1310,7 +1321,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+75"/>
+        <location filename="../intro.cpp" line="+73"/>
         <source>A new data directory will be created.</source>
         <translation>A new data directory will be created.</translation>
     </message>
@@ -1338,7 +1349,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+38"/>
+        <location filename="../utilitydialog.cpp" line="+36"/>
         <source>version</source>
         <translation type="unfinished">version</translation>
     </message>
@@ -1581,7 +1592,7 @@ The migration process will create a backup of the wallet before migrating. This 
     <message>
         <location line="+7"/>
         <location line="+26"/>
-        <location filename="../modaloverlay.cpp" line="+152"/>
+        <location filename="../modaloverlay.cpp" line="+160"/>
         <source>Unknown…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1622,12 +1633,12 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modaloverlay.cpp" line="-121"/>
+        <location filename="../modaloverlay.cpp" line="-126"/>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+127"/>
+        <location line="+132"/>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2059,7 +2070,7 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+152"/>
+        <location filename="../optionsdialog.cpp" line="+153"/>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>&quot;External signing&quot; means using devices such as hardware wallets.</extracomment>
         <translation type="unfinished"></translation>
@@ -2145,7 +2156,7 @@ The migration process will create a backup of the wallet before migrating. This 
 <context>
     <name>OptionsModel</name>
     <message>
-        <location filename="../optionsmodel.cpp" line="+230"/>
+        <location filename="../optionsmodel.cpp" line="+228"/>
         <source>Could not read setting &quot;%1&quot;, %2.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2282,7 +2293,7 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../psbtoperationsdialog.cpp" line="+60"/>
+        <location filename="../psbtoperationsdialog.cpp" line="+64"/>
         <source>Failed to load transaction: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2421,7 +2432,7 @@ The migration process will create a backup of the wallet before migrating. This 
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+149"/>
+        <location filename="../paymentserver.cpp" line="+145"/>
         <source>Payment request error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2545,7 +2556,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+133"/>
+        <location filename="../guiutil.cpp" line="+139"/>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2737,13 +2748,14 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <location line="+2"/>
-        <location filename="../rpcconsole.cpp" line="+1006"/>
+        <location filename="../rpcconsole.cpp" line="+1008"/>
         <source>%1 kB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <location filename="../rpcconsole.cpp" line="+2"/>
+        <location filename="../rpcconsole.cpp" line="+1"/>
+        <location line="+1"/>
         <source>%1 MB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2753,7 +2765,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="-282"/>
+        <location filename="../bitcoin.cpp" line="-287"/>
         <source>Do you want to reset settings to default values, or to abort without making changes?</source>
         <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
         <translation type="unfinished"></translation>
@@ -2765,7 +2777,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+423"/>
+        <location line="+428"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2780,7 +2792,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="-389"/>
+        <location filename="../optionsdialog.cpp" line="-391"/>
         <source>Embedded &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2798,7 +2810,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../qrimagewidget.cpp" line="+30"/>
+        <location filename="../qrimagewidget.cpp" line="+28"/>
         <source>&amp;Save Image…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2876,7 +2888,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <location line="+26"/>
         <location line="+26"/>
         <location line="+26"/>
-        <location filename="../rpcconsole.h" line="+147"/>
+        <location filename="../rpcconsole.h" line="+145"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
@@ -2995,7 +3007,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <location line="+68"/>
-        <location filename="../rpcconsole.cpp" line="+165"/>
+        <location filename="../rpcconsole.cpp" line="+166"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3010,12 +3022,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <source>The BIP324 session ID string in hex, if any.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+26"/>
         <source>Session ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3147,7 +3154,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+49"/>
+        <source>The BIP324 session ID string in hex.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+26"/>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3248,7 +3260,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-203"/>
+        <location filename="../rpcconsole.cpp" line="-204"/>
         <source>In:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3298,7 +3310,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-475"/>
+        <location filename="../rpcconsole.cpp" line="-476"/>
         <source>Inbound: initiated by peer</source>
         <extracomment>Explanatory text for an inbound peer connection.</extracomment>
         <translation type="unfinished"></translation>
@@ -3433,12 +3445,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+230"/>
+        <location line="+231"/>
         <source>Network activity disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+80"/>
         <source>Executing command without any wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3473,7 +3485,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-147"/>
+        <location line="-149"/>
         <source>Welcome to the %1 RPC console.
 Use up and down arrows to navigate history, and %2 to clear screen.
 Use %3 and %4 to increase or decrease the font size.
@@ -3485,7 +3497,7 @@ For more information on using this console, type %6.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
+        <location line="+159"/>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
         <translation type="unfinished"></translation>
@@ -3728,7 +3740,7 @@ For more information on using this console, type %6.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+48"/>
+        <location filename="../receiverequestdialog.cpp" line="+46"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3741,7 +3753,7 @@ For more information on using this console, type %6.
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+32"/>
+        <location filename="../recentrequeststablemodel.cpp" line="+34"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -3813,7 +3825,7 @@ For more information on using this console, type %6.
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+762"/>
+        <location filename="../sendcoinsdialog.cpp" line="+763"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -3995,7 +4007,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-667"/>
+        <location filename="../sendcoinsdialog.cpp" line="-668"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4072,7 +4084,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
+        <location line="+63"/>
         <source>Sign failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4111,7 +4123,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-324"/>
+        <location line="-325"/>
         <source>or</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4184,7 +4196,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+30"/>
         <source>PSBT saved to disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4397,7 +4409,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
     </message>
     <message>
         <location line="+6"/>
-        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <source>You can sign messages/agreements with your legacy (P2PKH) addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4512,27 +4524,25 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+119"/>
+        <location filename="../signverifymessagedialog.cpp" line="+120"/>
         <location line="+99"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-99"/>
-        <location line="+7"/>
-        <location line="+93"/>
-        <location line="+7"/>
+        <location line="+100"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-100"/>
-        <location line="+99"/>
-        <source>The entered address does not refer to a key.</source>
+        <location line="-93"/>
+        <location line="+98"/>
+        <source>The entered address does not refer to a legacy (P2PKH) key. Message signing for SegWit and other non-P2PKH address types is not supported in this version of %1. Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-91"/>
+        <location line="-90"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4557,7 +4567,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
+        <location line="+66"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4578,7 +4588,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-32"/>
+        <location line="-29"/>
         <source>Message verified.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4586,7 +4596,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+177"/>
+        <location filename="../splashscreen.cpp" line="+175"/>
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4607,7 +4617,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+44"/>
+        <location filename="../transactiondesc.cpp" line="+40"/>
         <source>conflicted with a transaction with %1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished"></translation>
@@ -5245,21 +5255,21 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+227"/>
+        <location filename="../walletmodel.cpp" line="+224"/>
         <location line="+13"/>
         <source>Send Coins</source>
         <translation type="unfinished">Send Coins</translation>
     </message>
     <message>
         <location line="+254"/>
-        <location line="+55"/>
-        <location line="+15"/>
+        <location line="+49"/>
+        <location line="+20"/>
         <location line="+5"/>
         <source>Fee bump error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-74"/>
         <source>Increasing transaction fee failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5295,7 +5305,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+17"/>
         <source>Can&apos;t draft transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5306,12 +5316,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+0"/>
-        <source>Copied to clipboard</source>
-        <comment>Fee-bump PSBT saved</comment>
+        <source>Fee-bump PSBT copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+13"/>
         <source>Can&apos;t sign transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5321,12 +5330,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+13"/>
+        <source>Signer error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Can&apos;t display address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+17"/>
         <source>default wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5403,7 +5417,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+7"/>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5463,17 +5477,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+15"/>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+14"/>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+8"/>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5494,11 +5508,6 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+16"/>
-        <source>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5518,7 +5527,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5533,7 +5542,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+16"/>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5623,7 +5632,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+19"/>
         <source>%s is set very high!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5633,12 +5642,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Cannot resolve -%s address: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5658,12 +5662,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-225"/>
+        <location line="-255"/>
         <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+6"/>
+        <source>A forked headers-chain with more work than the chain with the snapshot base block header exists. Please proceed to sync without AssumeUtxo.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5699,6 +5708,12 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+3"/>
+        <source>Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5709,6 +5724,16 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+6"/>
+        <source>Flushing block file to disk failed. This is likely the result of an I/O error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Flushing undo file to disk failed. This is likely the result of an I/O error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5718,7 +5743,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+7"/>
+        <source>Maximum transaction weight is less than transaction weight without inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Maximum transaction weight is too low, can not accommodate change output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5738,7 +5773,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+14"/>
+        <source>Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5781,6 +5826,11 @@ Please try running the latest software version.
     </message>
     <message>
         <location line="+34"/>
+        <source>Your computer&apos;s date and time appear to be more than %d minutes out of sync with the network, this may lead to consensus failure. After you&apos;ve confirmed your computer&apos;s clock, this message should no longer appear when you restart your node. Without a restart, it should stop showing automatically after you&apos;ve connected to a sufficient number of new outbound peers, which may take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` RPC methods to get more info.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>
 Unable to cleanup failed migration</source>
         <translation type="unfinished"></translation>
@@ -5792,7 +5842,22 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+3"/>
+        <source>whitebind may only be used for incoming connections (&quot;out&quot; was passed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>A fatal internal error occurred, see debug.log for details: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Assumeutxo data not found for the given blockhash &apos;%s&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Block verification was interrupted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5804,6 +5869,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Corrupt block found indicating potential hardware failure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5839,6 +5909,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Dump file %s does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Elliptic curve cryptography sanity check failure. %s is shutting down.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6028,7 +6103,22 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Failed to connect best block (%s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to disconnect block.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to read block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6044,6 +6134,26 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Failed to verify database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to write block.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to write to block index database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to write to coin database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to write undo data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6168,6 +6278,11 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Maximum transaction weight must be between %d and %d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Missing amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6199,6 +6314,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Not solvable pre-selected input %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Only direction was set, no permissions: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6258,6 +6378,21 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+3"/>
+        <source>Signer did not echo address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signer echoed unexpected address %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signer returned error: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6293,6 +6428,21 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>System error while flushing: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>System error while loading external block file: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>System error while saving block to disk: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>The source code is available from %s.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6309,6 +6459,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>There is no ScriptPubKeyManager for this address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6359,11 +6514,6 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Transaction too large</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Unable to allocate memory for -maxsigcachesize: &apos;%s&apos; MiB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6443,6 +6593,11 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Unrecognised option &quot;%s&quot; provided in -test=&lt;option&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6462,7 +6617,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-110"/>
+        <location line="-126"/>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6472,7 +6627,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
+        <location line="+126"/>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6492,7 +6647,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-52"/>
         <source>Settings file could not be read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qt/locale/bitcoin_en.xlf
+++ b/src/qt/locale/bitcoin_en.xlf
@@ -45,7 +45,7 @@
       <trans-unit id="_msg11">
         <source xml:space="preserve">&amp;Delete</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">117</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">113</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -53,62 +53,62 @@
     <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
       <trans-unit id="_msg12">
         <source xml:space="preserve">Choose the address to send coins to</source>
-        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
       <trans-unit id="_msg13">
         <source xml:space="preserve">Choose the address to receive coins with</source>
-        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
       <trans-unit id="_msg14">
         <source xml:space="preserve">C&amp;hoose</source>
-        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="_msg15">
         <source xml:space="preserve">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg16">
         <source xml:space="preserve">These are your Bitcoin addresses for receiving payments. Use the &apos;Create new receiving address&apos; button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
       <trans-unit id="_msg17">
         <source xml:space="preserve">&amp;Copy Address</source>
-        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
       <trans-unit id="_msg18">
         <source xml:space="preserve">Copy &amp;Label</source>
-        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
       <trans-unit id="_msg19">
         <source xml:space="preserve">&amp;Edit</source>
-        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
       <trans-unit id="_msg20">
         <source xml:space="preserve">Export Address List</source>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
       <trans-unit id="_msg21">
         <source xml:space="preserve">Comma separated file</source>
-        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
       <trans-unit id="_msg22">
         <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
         <note annotates="source" from="developer">An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</note>
       </trans-unit>
       <trans-unit id="_msg23">
         <source xml:space="preserve">Sending addresses - %1</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
       <trans-unit id="_msg24">
         <source xml:space="preserve">Receiving addresses - %1</source>
-        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
       <trans-unit id="_msg25">
         <source xml:space="preserve">Exporting Failed</source>
-        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -156,122 +156,131 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
       <trans-unit id="_msg34">
         <source xml:space="preserve">Encrypt wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
       <trans-unit id="_msg35">
         <source xml:space="preserve">This operation needs your wallet passphrase to unlock the wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
       <trans-unit id="_msg36">
         <source xml:space="preserve">Unlock wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
       <trans-unit id="_msg37">
         <source xml:space="preserve">Change passphrase</source>
-        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
       <trans-unit id="_msg38">
         <source xml:space="preserve">Confirm wallet encryption</source>
-        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
       <trans-unit id="_msg39">
         <source xml:space="preserve">Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
       <trans-unit id="_msg40">
         <source xml:space="preserve">Are you sure you wish to encrypt your wallet?</source>
-        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
       <trans-unit id="_msg41">
         <source xml:space="preserve">Wallet encrypted</source>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
       </trans-unit>
       <trans-unit id="_msg42">
         <source xml:space="preserve">Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
       <trans-unit id="_msg43">
         <source xml:space="preserve">Enter the old passphrase and new passphrase for the wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="_msg44">
+        <source xml:space="preserve">Continue</source>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg45">
+        <source xml:space="preserve">Back</source>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg46">
         <source xml:space="preserve">Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg45">
-        <source xml:space="preserve">Wallet to be encrypted</source>
-        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg46">
-        <source xml:space="preserve">Your wallet is about to be encrypted. </source>
-        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg47">
-        <source xml:space="preserve">Your wallet is now encrypted. </source>
-        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+        <source xml:space="preserve">Wallet to be encrypted</source>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
       <trans-unit id="_msg48">
-        <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+        <source xml:space="preserve">Your wallet is about to be encrypted. </source>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
       <trans-unit id="_msg49">
-        <source xml:space="preserve">Wallet encryption failed</source>
-        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg50">
-        <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <source xml:space="preserve">Your wallet is now encrypted. </source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg50">
+        <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg51">
-        <source xml:space="preserve">The supplied passphrases do not match.</source>
+        <source xml:space="preserve">Wallet encryption failed</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
       <trans-unit id="_msg52">
-        <source xml:space="preserve">Wallet unlock failed</source>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+        <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
       <trans-unit id="_msg53">
-        <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect.</source>
-        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+        <source xml:space="preserve">The supplied passphrases do not match.</source>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
       <trans-unit id="_msg54">
-        <source xml:space="preserve">The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
-        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+        <source xml:space="preserve">Wallet unlock failed</source>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
       <trans-unit id="_msg55">
-        <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
-        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+        <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect.</source>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
       <trans-unit id="_msg56">
-        <source xml:space="preserve">Passphrase change failed</source>
-        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+        <source xml:space="preserve">The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
       <trans-unit id="_msg57">
-        <source xml:space="preserve">The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
-        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+        <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
       <trans-unit id="_msg58">
+        <source xml:space="preserve">Passphrase change failed</source>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg59">
+        <source xml:space="preserve">The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg60">
         <source xml:space="preserve">Warning: The Caps Lock key is on!</source>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bantablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BanTableModel">
-      <trans-unit id="_msg59">
+      <trans-unit id="_msg61">
         <source xml:space="preserve">IP/Netmask</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg60">
+      <trans-unit id="_msg62">
         <source xml:space="preserve">Banned Until</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
@@ -279,605 +288,605 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../bitcoin.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
-      <trans-unit id="_msg61">
+      <trans-unit id="_msg63">
         <source xml:space="preserve">Settings file %1 might be corrupt or invalid.</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg62">
-        <source xml:space="preserve">Runaway exception</source>
-        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg63">
-        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg64">
-        <source xml:space="preserve">Internal error</source>
-        <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
+        <source xml:space="preserve">Runaway exception</source>
+        <context-group purpose="location"><context context-type="linenumber">459</context></context-group>
       </trans-unit>
       <trans-unit id="_msg65">
+        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <context-group purpose="location"><context context-type="linenumber">460</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg66">
+        <source xml:space="preserve">Internal error</source>
+        <context-group purpose="location"><context context-type="linenumber">469</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg67">
         <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg66">
+      <trans-unit id="_msg68">
         <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
       </trans-unit>
-      <trans-unit id="_msg67">
+      <trans-unit id="_msg69">
         <source xml:space="preserve">A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
       </trans-unit>
-      <trans-unit id="_msg68">
+      <trans-unit id="_msg70">
         <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">626</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">631</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg69">
+      <trans-unit id="_msg71">
         <source xml:space="preserve">%1 didn&apos;t yet exit safely…</source>
-        <context-group purpose="location"><context context-type="linenumber">699</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bitcoingui.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
-      <trans-unit id="_msg70">
-        <source xml:space="preserve">&amp;Overview</source>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg71">
-        <source xml:space="preserve">Show general overview of wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg72">
-        <source xml:space="preserve">&amp;Transactions</source>
-        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+        <source xml:space="preserve">&amp;Overview</source>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
       </trans-unit>
       <trans-unit id="_msg73">
-        <source xml:space="preserve">Browse transaction history</source>
-        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+        <source xml:space="preserve">Show general overview of wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
       <trans-unit id="_msg74">
-        <source xml:space="preserve">E&amp;xit</source>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+        <source xml:space="preserve">&amp;Transactions</source>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
       <trans-unit id="_msg75">
-        <source xml:space="preserve">Quit application</source>
-        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+        <source xml:space="preserve">Browse transaction history</source>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
       <trans-unit id="_msg76">
-        <source xml:space="preserve">&amp;About %1</source>
-        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+        <source xml:space="preserve">E&amp;xit</source>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
       <trans-unit id="_msg77">
-        <source xml:space="preserve">Show information about %1</source>
-        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+        <source xml:space="preserve">Quit application</source>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
       <trans-unit id="_msg78">
-        <source xml:space="preserve">About &amp;Qt</source>
-        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+        <source xml:space="preserve">&amp;About %1</source>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
       </trans-unit>
       <trans-unit id="_msg79">
-        <source xml:space="preserve">Show information about Qt</source>
-        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+        <source xml:space="preserve">Show information about %1</source>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
       <trans-unit id="_msg80">
-        <source xml:space="preserve">Modify configuration options for %1</source>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+        <source xml:space="preserve">About &amp;Qt</source>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
       <trans-unit id="_msg81">
-        <source xml:space="preserve">Create a new wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg82">
-        <source xml:space="preserve">&amp;Minimize</source>
-        <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg83">
-        <source xml:space="preserve">Wallet:</source>
-        <context-group purpose="location"><context context-type="linenumber">589</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg84">
-        <source xml:space="preserve">Network activity disabled.</source>
-        <context-group purpose="location"><context context-type="linenumber">1006</context></context-group>
-        <note annotates="source" from="developer">A substring of the tooltip.</note>
-      </trans-unit>
-      <trans-unit id="_msg85">
-        <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1457</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg86">
-        <source xml:space="preserve">Send coins to a Bitcoin address</source>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg87">
-        <source xml:space="preserve">Backup wallet to another location</source>
-        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg88">
-        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
-        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg89">
-        <source xml:space="preserve">&amp;Send</source>
-        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg90">
-        <source xml:space="preserve">&amp;Receive</source>
-        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg91">
-        <source xml:space="preserve">&amp;Options…</source>
+        <source xml:space="preserve">Show information about Qt</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg92">
-        <source xml:space="preserve">&amp;Encrypt Wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+      <trans-unit id="_msg82">
+        <source xml:space="preserve">Modify configuration options for %1</source>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg93">
-        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      <trans-unit id="_msg83">
+        <source xml:space="preserve">Create a new wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg94">
-        <source xml:space="preserve">&amp;Backup Wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      <trans-unit id="_msg84">
+        <source xml:space="preserve">&amp;Minimize</source>
+        <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg95">
-        <source xml:space="preserve">&amp;Change Passphrase…</source>
-        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      <trans-unit id="_msg85">
+        <source xml:space="preserve">Wallet:</source>
+        <context-group purpose="location"><context context-type="linenumber">590</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg96">
-        <source xml:space="preserve">Sign &amp;message…</source>
-        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      <trans-unit id="_msg86">
+        <source xml:space="preserve">Network activity disabled.</source>
+        <context-group purpose="location"><context context-type="linenumber">1008</context></context-group>
+        <note annotates="source" from="developer">A substring of the tooltip.</note>
       </trans-unit>
-      <trans-unit id="_msg97">
-        <source xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</source>
+      <trans-unit id="_msg87">
+        <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1459</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg88">
+        <source xml:space="preserve">Send coins to a Bitcoin address</source>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg89">
+        <source xml:space="preserve">Backup wallet to another location</source>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg90">
+        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg91">
+        <source xml:space="preserve">&amp;Send</source>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg92">
+        <source xml:space="preserve">&amp;Receive</source>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg93">
+        <source xml:space="preserve">&amp;Options…</source>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg94">
+        <source xml:space="preserve">&amp;Encrypt Wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg95">
+        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg96">
+        <source xml:space="preserve">&amp;Backup Wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg97">
+        <source xml:space="preserve">&amp;Change Passphrase…</source>
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg98">
-        <source xml:space="preserve">&amp;Verify message…</source>
+        <source xml:space="preserve">Sign &amp;message…</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
       <trans-unit id="_msg99">
-        <source xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <source xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</source>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
       <trans-unit id="_msg100">
-        <source xml:space="preserve">&amp;Load PSBT from file…</source>
+        <source xml:space="preserve">&amp;Verify message…</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
       <trans-unit id="_msg101">
-        <source xml:space="preserve">Open &amp;URI…</source>
-        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+        <source xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
       <trans-unit id="_msg102">
-        <source xml:space="preserve">Close Wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+        <source xml:space="preserve">&amp;Load PSBT from file…</source>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
       <trans-unit id="_msg103">
-        <source xml:space="preserve">Create Wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+        <source xml:space="preserve">Open &amp;URI…</source>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
       </trans-unit>
       <trans-unit id="_msg104">
-        <source xml:space="preserve">Close All Wallets…</source>
-        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+        <source xml:space="preserve">Close Wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
       <trans-unit id="_msg105">
-        <source xml:space="preserve">&amp;File</source>
-        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
+        <source xml:space="preserve">Create Wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
       <trans-unit id="_msg106">
-        <source xml:space="preserve">&amp;Settings</source>
-        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
+        <source xml:space="preserve">Close All Wallets…</source>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
       </trans-unit>
       <trans-unit id="_msg107">
-        <source xml:space="preserve">&amp;Help</source>
-        <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
+        <source xml:space="preserve">&amp;File</source>
+        <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
       </trans-unit>
       <trans-unit id="_msg108">
-        <source xml:space="preserve">Tabs toolbar</source>
-        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
+        <source xml:space="preserve">&amp;Settings</source>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
       <trans-unit id="_msg109">
-        <source xml:space="preserve">Syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1050</context></context-group>
+        <source xml:space="preserve">&amp;Help</source>
+        <context-group purpose="location"><context context-type="linenumber">559</context></context-group>
       </trans-unit>
       <trans-unit id="_msg110">
-        <source xml:space="preserve">Synchronizing with network…</source>
-        <context-group purpose="location"><context context-type="linenumber">1108</context></context-group>
+        <source xml:space="preserve">Tabs toolbar</source>
+        <context-group purpose="location"><context context-type="linenumber">570</context></context-group>
       </trans-unit>
       <trans-unit id="_msg111">
-        <source xml:space="preserve">Indexing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1113</context></context-group>
+        <source xml:space="preserve">Syncing Headers (%1%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">1052</context></context-group>
       </trans-unit>
       <trans-unit id="_msg112">
-        <source xml:space="preserve">Processing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1115</context></context-group>
+        <source xml:space="preserve">Synchronizing with network…</source>
+        <context-group purpose="location"><context context-type="linenumber">1110</context></context-group>
       </trans-unit>
       <trans-unit id="_msg113">
-        <source xml:space="preserve">Connecting to peers…</source>
-        <context-group purpose="location"><context context-type="linenumber">1122</context></context-group>
+        <source xml:space="preserve">Indexing blocks on disk…</source>
+        <context-group purpose="location"><context context-type="linenumber">1115</context></context-group>
       </trans-unit>
       <trans-unit id="_msg114">
-        <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
-        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+        <source xml:space="preserve">Processing blocks on disk…</source>
+        <context-group purpose="location"><context context-type="linenumber">1117</context></context-group>
       </trans-unit>
       <trans-unit id="_msg115">
-        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+        <source xml:space="preserve">Connecting to peers…</source>
+        <context-group purpose="location"><context context-type="linenumber">1124</context></context-group>
       </trans-unit>
       <trans-unit id="_msg116">
-        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
-        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+        <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
       <trans-unit id="_msg117">
+        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg118">
+        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg119">
         <source xml:space="preserve">&amp;Command-line options</source>
-        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1131</context></context-group>
-        <trans-unit id="_msg118[0]">
+        <context-group purpose="location"><context context-type="linenumber">1133</context></context-group>
+        <trans-unit id="_msg120[0]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
-        <trans-unit id="_msg118[1]">
+        <trans-unit id="_msg120[1]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg119">
-        <source xml:space="preserve">%1 behind</source>
-        <context-group purpose="location"><context context-type="linenumber">1154</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg120">
-        <source xml:space="preserve">Catching up…</source>
-        <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg121">
-        <source xml:space="preserve">Last received block was generated %1 ago.</source>
-        <context-group purpose="location"><context context-type="linenumber">1178</context></context-group>
+        <source xml:space="preserve">%1 behind</source>
+        <context-group purpose="location"><context context-type="linenumber">1156</context></context-group>
       </trans-unit>
       <trans-unit id="_msg122">
-        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
-        <context-group purpose="location"><context context-type="linenumber">1180</context></context-group>
+        <source xml:space="preserve">Catching up…</source>
+        <context-group purpose="location"><context context-type="linenumber">1161</context></context-group>
       </trans-unit>
       <trans-unit id="_msg123">
-        <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">1220</context></context-group>
+        <source xml:space="preserve">Last received block was generated %1 ago.</source>
+        <context-group purpose="location"><context context-type="linenumber">1180</context></context-group>
       </trans-unit>
       <trans-unit id="_msg124">
-        <source xml:space="preserve">Warning</source>
-        <context-group purpose="location"><context context-type="linenumber">1224</context></context-group>
+        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
+        <context-group purpose="location"><context context-type="linenumber">1182</context></context-group>
       </trans-unit>
       <trans-unit id="_msg125">
-        <source xml:space="preserve">Information</source>
-        <context-group purpose="location"><context context-type="linenumber">1228</context></context-group>
+        <source xml:space="preserve">Error</source>
+        <context-group purpose="location"><context context-type="linenumber">1222</context></context-group>
       </trans-unit>
       <trans-unit id="_msg126">
-        <source xml:space="preserve">Up to date</source>
-        <context-group purpose="location"><context context-type="linenumber">1135</context></context-group>
+        <source xml:space="preserve">Warning</source>
+        <context-group purpose="location"><context context-type="linenumber">1226</context></context-group>
       </trans-unit>
       <trans-unit id="_msg127">
-        <source xml:space="preserve">Ctrl+Q</source>
-        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+        <source xml:space="preserve">Information</source>
+        <context-group purpose="location"><context context-type="linenumber">1230</context></context-group>
       </trans-unit>
       <trans-unit id="_msg128">
-        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+        <source xml:space="preserve">Up to date</source>
+        <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
       </trans-unit>
       <trans-unit id="_msg129">
-        <source xml:space="preserve">Load PSBT from &amp;clipboard…</source>
-        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+        <source xml:space="preserve">Ctrl+Q</source>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
       <trans-unit id="_msg130">
-        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
       <trans-unit id="_msg131">
-        <source xml:space="preserve">Node window</source>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+        <source xml:space="preserve">Load PSBT from &amp;clipboard…</source>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
       <trans-unit id="_msg132">
-        <source xml:space="preserve">Open node debugging and diagnostic console</source>
-        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
       <trans-unit id="_msg133">
-        <source xml:space="preserve">&amp;Sending addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+        <source xml:space="preserve">Node window</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
       <trans-unit id="_msg134">
-        <source xml:space="preserve">&amp;Receiving addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+        <source xml:space="preserve">Open node debugging and diagnostic console</source>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
       <trans-unit id="_msg135">
-        <source xml:space="preserve">Open a bitcoin: URI</source>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+        <source xml:space="preserve">&amp;Sending addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
       <trans-unit id="_msg136">
-        <source xml:space="preserve">Open Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+        <source xml:space="preserve">&amp;Receiving addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
       <trans-unit id="_msg137">
-        <source xml:space="preserve">Open a wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+        <source xml:space="preserve">Open a bitcoin: URI</source>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
       <trans-unit id="_msg138">
-        <source xml:space="preserve">Close wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+        <source xml:space="preserve">Open Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
       <trans-unit id="_msg139">
-        <source xml:space="preserve">Restore Wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
-        <note annotates="source" from="developer">Name of the menu item that restores wallet from a backup file.</note>
+        <source xml:space="preserve">Open a wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
       <trans-unit id="_msg140">
-        <source xml:space="preserve">Restore a wallet from a backup file</source>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-        <note annotates="source" from="developer">Status tip for Restore Wallet menu item</note>
+        <source xml:space="preserve">Close wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
       <trans-unit id="_msg141">
-        <source xml:space="preserve">Close all wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+        <source xml:space="preserve">Restore Wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+        <note annotates="source" from="developer">Name of the menu item that restores wallet from a backup file.</note>
       </trans-unit>
       <trans-unit id="_msg142">
-        <source xml:space="preserve">Migrate Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+        <source xml:space="preserve">Restore a wallet from a backup file</source>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+        <note annotates="source" from="developer">Status tip for Restore Wallet menu item</note>
       </trans-unit>
       <trans-unit id="_msg143">
-        <source xml:space="preserve">Migrate a wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+        <source xml:space="preserve">Close all wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
       </trans-unit>
       <trans-unit id="_msg144">
-        <source xml:space="preserve">Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+        <source xml:space="preserve">Migrate Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
       </trans-unit>
       <trans-unit id="_msg145">
-        <source xml:space="preserve">&amp;Mask values</source>
-        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+        <source xml:space="preserve">Migrate a wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
       </trans-unit>
       <trans-unit id="_msg146">
-        <source xml:space="preserve">Mask the values in the Overview tab</source>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+        <source xml:space="preserve">Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
       <trans-unit id="_msg147">
-        <source xml:space="preserve">default wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
+        <source xml:space="preserve">&amp;Mask values</source>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
       <trans-unit id="_msg148">
-        <source xml:space="preserve">No wallets available</source>
-        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+        <source xml:space="preserve">Mask the values in the Overview tab</source>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
       </trans-unit>
       <trans-unit id="_msg149">
-        <source xml:space="preserve">Wallet Data</source>
-        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
-        <note annotates="source" from="developer">Name of the wallet data file format.</note>
+        <source xml:space="preserve">default wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
       <trans-unit id="_msg150">
-        <source xml:space="preserve">Load Wallet Backup</source>
-        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
-        <note annotates="source" from="developer">The title for Restore Wallet File Windows</note>
+        <source xml:space="preserve">No wallets available</source>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
       </trans-unit>
       <trans-unit id="_msg151">
-        <source xml:space="preserve">Restore Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
-        <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
+        <source xml:space="preserve">Wallet Data</source>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+        <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
       <trans-unit id="_msg152">
-        <source xml:space="preserve">Wallet Name</source>
-        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
-        <note annotates="source" from="developer">Label of the input field where the name of the wallet is entered.</note>
+        <source xml:space="preserve">Load Wallet Backup</source>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+        <note annotates="source" from="developer">The title for Restore Wallet File Windows</note>
       </trans-unit>
       <trans-unit id="_msg153">
-        <source xml:space="preserve">&amp;Window</source>
-        <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
+        <source xml:space="preserve">Restore Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+        <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
       </trans-unit>
       <trans-unit id="_msg154">
-        <source xml:space="preserve">Ctrl+M</source>
-        <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
+        <source xml:space="preserve">Wallet Name</source>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+        <note annotates="source" from="developer">Label of the input field where the name of the wallet is entered.</note>
       </trans-unit>
       <trans-unit id="_msg155">
-        <source xml:space="preserve">Zoom</source>
-        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
+        <source xml:space="preserve">&amp;Window</source>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
       </trans-unit>
       <trans-unit id="_msg156">
-        <source xml:space="preserve">Main Window</source>
-        <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
+        <source xml:space="preserve">Ctrl+M</source>
+        <context-group purpose="location"><context context-type="linenumber">512</context></context-group>
       </trans-unit>
       <trans-unit id="_msg157">
-        <source xml:space="preserve">%1 client</source>
-        <context-group purpose="location"><context context-type="linenumber">817</context></context-group>
+        <source xml:space="preserve">Zoom</source>
+        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
       </trans-unit>
       <trans-unit id="_msg158">
-        <source xml:space="preserve">&amp;Hide</source>
-        <context-group purpose="location"><context context-type="linenumber">885</context></context-group>
+        <source xml:space="preserve">Main Window</source>
+        <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
       </trans-unit>
       <trans-unit id="_msg159">
-        <source xml:space="preserve">S&amp;how</source>
+        <source xml:space="preserve">%1 client</source>
+        <context-group purpose="location"><context context-type="linenumber">818</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg160">
+        <source xml:space="preserve">&amp;Hide</source>
         <context-group purpose="location"><context context-type="linenumber">886</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg161">
+        <source xml:space="preserve">S&amp;how</source>
+        <context-group purpose="location"><context context-type="linenumber">887</context></context-group>
+      </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1003</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1005</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
-        <trans-unit id="_msg160[0]">
+        <trans-unit id="_msg162[0]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
-        <trans-unit id="_msg160[1]">
+        <trans-unit id="_msg162[1]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg161">
+      <trans-unit id="_msg163">
         <source xml:space="preserve">Click for more actions.</source>
-        <context-group purpose="location"><context context-type="linenumber">1013</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1015</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip. &quot;More actions&quot; are available via the context menu.</note>
       </trans-unit>
-      <trans-unit id="_msg162">
+      <trans-unit id="_msg164">
         <source xml:space="preserve">Show Peers tab</source>
-        <context-group purpose="location"><context context-type="linenumber">1030</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1032</context></context-group>
         <note annotates="source" from="developer">A context menu item. The &quot;Peers tab&quot; is an element of the &quot;Node window&quot;.</note>
       </trans-unit>
-      <trans-unit id="_msg163">
+      <trans-unit id="_msg165">
         <source xml:space="preserve">Disable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1038</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1040</context></context-group>
         <note annotates="source" from="developer">A context menu item.</note>
       </trans-unit>
-      <trans-unit id="_msg164">
+      <trans-unit id="_msg166">
         <source xml:space="preserve">Enable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1040</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1042</context></context-group>
         <note annotates="source" from="developer">A context menu item. The network activity was disabled previously.</note>
       </trans-unit>
-      <trans-unit id="_msg165">
-        <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1057</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg166">
-        <source xml:space="preserve">Error creating wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1196</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg167">
-        <source xml:space="preserve">Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <context-group purpose="location"><context context-type="linenumber">1196</context></context-group>
+        <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">1059</context></context-group>
       </trans-unit>
       <trans-unit id="_msg168">
-        <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1221</context></context-group>
+        <source xml:space="preserve">Error creating wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">1198</context></context-group>
       </trans-unit>
       <trans-unit id="_msg169">
-        <source xml:space="preserve">Warning: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1225</context></context-group>
+        <source xml:space="preserve">Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <context-group purpose="location"><context context-type="linenumber">1198</context></context-group>
       </trans-unit>
       <trans-unit id="_msg170">
-        <source xml:space="preserve">Date: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1333</context></context-group>
+        <source xml:space="preserve">Error: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1223</context></context-group>
       </trans-unit>
       <trans-unit id="_msg171">
-        <source xml:space="preserve">Amount: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1334</context></context-group>
+        <source xml:space="preserve">Warning: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1227</context></context-group>
       </trans-unit>
       <trans-unit id="_msg172">
-        <source xml:space="preserve">Wallet: %1
+        <source xml:space="preserve">Date: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg173">
+        <source xml:space="preserve">Amount: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1336</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg173">
-        <source xml:space="preserve">Type: %1
+      <trans-unit id="_msg174">
+        <source xml:space="preserve">Wallet: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg174">
-        <source xml:space="preserve">Label: %1
+      <trans-unit id="_msg175">
+        <source xml:space="preserve">Type: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg175">
-        <source xml:space="preserve">Address: %1
+      <trans-unit id="_msg176">
+        <source xml:space="preserve">Label: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg176">
-        <source xml:space="preserve">Sent transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1343</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg177">
-        <source xml:space="preserve">Incoming transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1343</context></context-group>
+        <source xml:space="preserve">Address: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1344</context></context-group>
       </trans-unit>
       <trans-unit id="_msg178">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1395</context></context-group>
+        <source xml:space="preserve">Sent transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">1345</context></context-group>
       </trans-unit>
       <trans-unit id="_msg179">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1395</context></context-group>
+        <source xml:space="preserve">Incoming transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">1345</context></context-group>
       </trans-unit>
       <trans-unit id="_msg180">
-        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1395</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
       </trans-unit>
       <trans-unit id="_msg181">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1418</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
       </trans-unit>
       <trans-unit id="_msg182">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1426</context></context-group>
+        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
       </trans-unit>
       <trans-unit id="_msg183">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg184">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg185">
         <source xml:space="preserve">Original message:</source>
-        <context-group purpose="location"><context context-type="linenumber">1545</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1547</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
-      <trans-unit id="_msg184">
+      <trans-unit id="_msg186">
         <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
-        <context-group purpose="location"><context context-type="linenumber">1584</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1586</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg185">
+      <trans-unit id="_msg187">
         <source xml:space="preserve">Coin Selection</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg186">
+      <trans-unit id="_msg188">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg187">
+      <trans-unit id="_msg189">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg188">
+      <trans-unit id="_msg190">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg189">
+      <trans-unit id="_msg191">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg190">
+      <trans-unit id="_msg192">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg191">
+      <trans-unit id="_msg193">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg192">
+      <trans-unit id="_msg194">
         <source xml:space="preserve">(un)select all</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg193">
+      <trans-unit id="_msg195">
         <source xml:space="preserve">Tree mode</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg194">
+      <trans-unit id="_msg196">
         <source xml:space="preserve">List mode</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg195">
+      <trans-unit id="_msg197">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg196">
+      <trans-unit id="_msg198">
         <source xml:space="preserve">Received with label</source>
         <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg197">
+      <trans-unit id="_msg199">
         <source xml:space="preserve">Received with address</source>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg198">
+      <trans-unit id="_msg200">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg199">
+      <trans-unit id="_msg201">
         <source xml:space="preserve">Confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg200">
+      <trans-unit id="_msg202">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
       </trans-unit>
@@ -885,293 +894,293 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg201">
-        <source xml:space="preserve">Copy amount</source>
-        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg202">
-        <source xml:space="preserve">&amp;Copy address</source>
-        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg203">
-        <source xml:space="preserve">Copy &amp;label</source>
-        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+        <source xml:space="preserve">Copy amount</source>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
       <trans-unit id="_msg204">
-        <source xml:space="preserve">Copy &amp;amount</source>
-        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+        <source xml:space="preserve">&amp;Copy address</source>
+        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
       <trans-unit id="_msg205">
-        <source xml:space="preserve">Copy transaction &amp;ID and output index</source>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+        <source xml:space="preserve">Copy &amp;label</source>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
       <trans-unit id="_msg206">
-        <source xml:space="preserve">L&amp;ock unspent</source>
-        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+        <source xml:space="preserve">Copy &amp;amount</source>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
       <trans-unit id="_msg207">
-        <source xml:space="preserve">&amp;Unlock unspent</source>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+        <source xml:space="preserve">Copy transaction &amp;ID and output index</source>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="_msg208">
-        <source xml:space="preserve">Copy quantity</source>
-        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <source xml:space="preserve">L&amp;ock unspent</source>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
       <trans-unit id="_msg209">
-        <source xml:space="preserve">Copy fee</source>
-        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <source xml:space="preserve">&amp;Unlock unspent</source>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
       <trans-unit id="_msg210">
-        <source xml:space="preserve">Copy after fee</source>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+        <source xml:space="preserve">Copy quantity</source>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
       <trans-unit id="_msg211">
-        <source xml:space="preserve">Copy bytes</source>
-        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+        <source xml:space="preserve">Copy fee</source>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
       <trans-unit id="_msg212">
-        <source xml:space="preserve">Copy change</source>
-        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+        <source xml:space="preserve">Copy after fee</source>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="_msg213">
-        <source xml:space="preserve">(%1 locked)</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <source xml:space="preserve">Copy bytes</source>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
       <trans-unit id="_msg214">
-        <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
-        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
+        <source xml:space="preserve">Copy change</source>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
       <trans-unit id="_msg215">
-        <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">635</context></context-group>
+        <source xml:space="preserve">(%1 locked)</source>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
       <trans-unit id="_msg216">
-        <source xml:space="preserve">change from %1 (%2)</source>
-        <context-group purpose="location"><context context-type="linenumber">628</context></context-group>
+        <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
+        <context-group purpose="location"><context context-type="linenumber">532</context></context-group>
       </trans-unit>
       <trans-unit id="_msg217">
+        <source xml:space="preserve">(no label)</source>
+        <context-group purpose="location"><context context-type="linenumber">577</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">631</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg218">
+        <source xml:space="preserve">change from %1 (%2)</source>
+        <context-group purpose="location"><context context-type="linenumber">624</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg219">
         <source xml:space="preserve">(change)</source>
-        <context-group purpose="location"><context context-type="linenumber">629</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">625</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletcontroller.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
-      <trans-unit id="_msg218">
+      <trans-unit id="_msg220">
         <source xml:space="preserve">Create Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of creation of a new wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg219">
+      <trans-unit id="_msg221">
         <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</note>
       </trans-unit>
-      <trans-unit id="_msg220">
-        <source xml:space="preserve">Create wallet failed</source>
-        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg221">
-        <source xml:space="preserve">Create wallet warning</source>
-        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg222">
-        <source xml:space="preserve">Can&apos;t list signers</source>
-        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+        <source xml:space="preserve">Create wallet failed</source>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
       <trans-unit id="_msg223">
+        <source xml:space="preserve">Create wallet warning</source>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg224">
+        <source xml:space="preserve">Can&apos;t list signers</source>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg225">
         <source xml:space="preserve">Too many external signers found</source>
-        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="LoadWalletsActivity">
-      <trans-unit id="_msg224">
+      <trans-unit id="_msg226">
         <source xml:space="preserve">Load Wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being loaded.</note>
       </trans-unit>
-      <trans-unit id="_msg225">
+      <trans-unit id="_msg227">
         <source xml:space="preserve">Loading wallets…</source>
-        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="MigrateWalletActivity">
-      <trans-unit id="_msg226">
+      <trans-unit id="_msg228">
         <source xml:space="preserve">Migrate wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg227">
-        <source xml:space="preserve">Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg228">
+      <trans-unit id="_msg229">
+        <source xml:space="preserve">Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg230">
         <source xml:space="preserve">Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
 If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
 If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
 
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the &quot;Restore Wallet&quot; functionality.</source>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg229">
-        <source xml:space="preserve">Migrate Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg230">
-        <source xml:space="preserve">Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
       </trans-unit>
       <trans-unit id="_msg231">
-        <source xml:space="preserve">The wallet &apos;%1&apos; was migrated successfully.</source>
-        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
+        <source xml:space="preserve">Migrate Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">468</context></context-group>
       </trans-unit>
       <trans-unit id="_msg232">
-        <source xml:space="preserve">Watchonly scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
-        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
+        <source xml:space="preserve">Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <context-group purpose="location"><context context-type="linenumber">468</context></context-group>
       </trans-unit>
       <trans-unit id="_msg233">
-        <source xml:space="preserve">Solvable but not watched scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
-        <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
+        <source xml:space="preserve">The wallet &apos;%1&apos; was migrated successfully.</source>
+        <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
       </trans-unit>
       <trans-unit id="_msg234">
-        <source xml:space="preserve">Migration failed</source>
-        <context-group purpose="location"><context context-type="linenumber">492</context></context-group>
+        <source xml:space="preserve">Watchonly scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
+        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
       </trans-unit>
       <trans-unit id="_msg235">
+        <source xml:space="preserve">Solvable but not watched scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
+        <context-group purpose="location"><context context-type="linenumber">479</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg236">
+        <source xml:space="preserve">Migration failed</source>
+        <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg237">
         <source xml:space="preserve">Migration Successful</source>
-        <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
-      <trans-unit id="_msg236">
-        <source xml:space="preserve">Open wallet failed</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg237">
-        <source xml:space="preserve">Open wallet warning</source>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg238">
-        <source xml:space="preserve">default wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+        <source xml:space="preserve">Open wallet failed</source>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
       <trans-unit id="_msg239">
-        <source xml:space="preserve">Open Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
-        <note annotates="source" from="developer">Title of window indicating the progress of opening of a wallet.</note>
+        <source xml:space="preserve">Open wallet warning</source>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
       </trans-unit>
       <trans-unit id="_msg240">
+        <source xml:space="preserve">default wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg241">
+        <source xml:space="preserve">Open Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+        <note annotates="source" from="developer">Title of window indicating the progress of opening of a wallet.</note>
+      </trans-unit>
+      <trans-unit id="_msg242">
         <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="RestoreWalletActivity">
-      <trans-unit id="_msg241">
+      <trans-unit id="_msg243">
         <source xml:space="preserve">Restore Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg242">
+      <trans-unit id="_msg244">
         <source xml:space="preserve">Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg243">
+      <trans-unit id="_msg245">
         <source xml:space="preserve">Restore wallet failed</source>
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet could not be restored.</note>
       </trans-unit>
-      <trans-unit id="_msg244">
+      <trans-unit id="_msg246">
         <source xml:space="preserve">Restore wallet warning</source>
-        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is restored with some warning.</note>
       </trans-unit>
-      <trans-unit id="_msg245">
+      <trans-unit id="_msg247">
         <source xml:space="preserve">Restore wallet message</source>
-        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is successfully restored.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="WalletController">
-      <trans-unit id="_msg246">
+      <trans-unit id="_msg248">
         <source xml:space="preserve">Close wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg247">
-        <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg248">
-        <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+      <trans-unit id="_msg249">
+        <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg249">
-        <source xml:space="preserve">Close all wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg250">
-        <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
+        <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg251">
+        <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg252">
+        <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg251">
+      <trans-unit id="_msg253">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg252">
+      <trans-unit id="_msg254">
         <source xml:space="preserve">You are one step away from creating your new wallet!</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg253">
+      <trans-unit id="_msg255">
         <source xml:space="preserve">Please provide a name and, if desired, enable any advanced options</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg254">
+      <trans-unit id="_msg256">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg255">
+      <trans-unit id="_msg257">
         <source xml:space="preserve">Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg256">
+      <trans-unit id="_msg258">
         <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg257">
+      <trans-unit id="_msg259">
         <source xml:space="preserve">Encrypt Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg258">
+      <trans-unit id="_msg260">
         <source xml:space="preserve">Advanced Options</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg259">
+      <trans-unit id="_msg261">
         <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg260">
+      <trans-unit id="_msg262">
         <source xml:space="preserve">Disable Private Keys</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg261">
+      <trans-unit id="_msg263">
         <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg262">
+      <trans-unit id="_msg264">
         <source xml:space="preserve">Make Blank Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg263">
+      <trans-unit id="_msg265">
         <source xml:space="preserve">Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg264">
+      <trans-unit id="_msg266">
         <source xml:space="preserve">External signer</source>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
@@ -1179,36 +1188,36 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg265">
+      <trans-unit id="_msg267">
         <source xml:space="preserve">Create</source>
-        <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg266">
+      <trans-unit id="_msg268">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
-        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg267">
+      <trans-unit id="_msg269">
         <source xml:space="preserve">Edit Address</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg268">
+      <trans-unit id="_msg270">
         <source xml:space="preserve">&amp;Label</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg269">
+      <trans-unit id="_msg271">
         <source xml:space="preserve">The label associated with this address list entry</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg270">
+      <trans-unit id="_msg272">
         <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg271">
+      <trans-unit id="_msg273">
         <source xml:space="preserve">&amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
@@ -1216,35 +1225,35 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg272">
+      <trans-unit id="_msg274">
         <source xml:space="preserve">New sending address</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg273">
+      <trans-unit id="_msg275">
         <source xml:space="preserve">Edit receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg274">
+      <trans-unit id="_msg276">
         <source xml:space="preserve">Edit sending address</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg275">
+      <trans-unit id="_msg277">
         <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg276">
+      <trans-unit id="_msg278">
         <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg277">
+      <trans-unit id="_msg279">
         <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg278">
+      <trans-unit id="_msg280">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg279">
+      <trans-unit id="_msg281">
         <source xml:space="preserve">New key generation failed.</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
@@ -1252,168 +1261,168 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../intro.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
-      <trans-unit id="_msg280">
-        <source xml:space="preserve">A new data directory will be created.</source>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg281">
-        <source xml:space="preserve">name</source>
-        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg282">
-        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+        <source xml:space="preserve">A new data directory will be created.</source>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
       <trans-unit id="_msg283">
-        <source xml:space="preserve">Path already exists, and is not a directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+        <source xml:space="preserve">name</source>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg284">
+        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg285">
+        <source xml:space="preserve">Path already exists, and is not a directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg286">
         <source xml:space="preserve">Cannot create data directory here.</source>
-        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg285">
+      <trans-unit id="_msg287">
         <source xml:space="preserve">Bitcoin</source>
-        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-        <trans-unit id="_msg286[0]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-        <trans-unit id="_msg286[1]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
-        <trans-unit id="_msg287[0]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-        <trans-unit id="_msg287[1]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
         <trans-unit id="_msg288[0]">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
+          <source xml:space="preserve">%n GB of space available</source>
         </trans-unit>
         <trans-unit id="_msg288[1]">
+          <source xml:space="preserve">%n GB of space available</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+        <trans-unit id="_msg289[0]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+        <trans-unit id="_msg289[1]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+        <trans-unit id="_msg290[0]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+        </trans-unit>
+        <trans-unit id="_msg290[1]">
           <source xml:space="preserve">(%n GB needed for full chain)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg289">
-        <source xml:space="preserve">Choose data directory</source>
-        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg290">
-        <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg291">
+        <source xml:space="preserve">Choose data directory</source>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg292">
+        <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg293">
         <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
         <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
-        <trans-unit id="_msg292[0]">
+        <trans-unit id="_msg294[0]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
-        <trans-unit id="_msg292[1]">
+        <trans-unit id="_msg294[1]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg293">
-        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg294">
-        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg295">
-        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
-        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
       </trans-unit>
       <trans-unit id="_msg296">
+        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg297">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg298">
         <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../utilitydialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
-      <trans-unit id="_msg297">
-        <source xml:space="preserve">version</source>
-        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg298">
-        <source xml:space="preserve">About %1</source>
-        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg299">
+        <source xml:space="preserve">version</source>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg300">
+        <source xml:space="preserve">About %1</source>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg301">
         <source xml:space="preserve">Command-line options</source>
-        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
-      <trans-unit id="_msg300">
+      <trans-unit id="_msg302">
         <source xml:space="preserve">%1 is shutting down…</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg301">
+      <trans-unit id="_msg303">
         <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg302">
+      <trans-unit id="_msg304">
         <source xml:space="preserve">Welcome</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg303">
+      <trans-unit id="_msg305">
         <source xml:space="preserve">Welcome to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg304">
+      <trans-unit id="_msg306">
         <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg305">
+      <trans-unit id="_msg307">
         <source xml:space="preserve">Limit block chain storage to</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg306">
+      <trans-unit id="_msg308">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg307">
+      <trans-unit id="_msg309">
         <source xml:space="preserve"> GB</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg308">
+      <trans-unit id="_msg310">
         <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg309">
+      <trans-unit id="_msg311">
         <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg310">
+      <trans-unit id="_msg312">
         <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg311">
+      <trans-unit id="_msg313">
         <source xml:space="preserve">Use the default data directory</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg312">
+      <trans-unit id="_msg314">
         <source xml:space="preserve">Use a custom data directory:</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
@@ -1421,54 +1430,54 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg313">
+      <trans-unit id="_msg315">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg314">
+      <trans-unit id="_msg316">
         <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg315">
+      <trans-unit id="_msg317">
         <source xml:space="preserve">Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg316">
+      <trans-unit id="_msg318">
         <source xml:space="preserve">Number of blocks left</source>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg317">
+      <trans-unit id="_msg319">
         <source xml:space="preserve">Unknown…</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">152</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg318">
+      <trans-unit id="_msg320">
         <source xml:space="preserve">calculating…</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg319">
+      <trans-unit id="_msg321">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg320">
+      <trans-unit id="_msg322">
         <source xml:space="preserve">Progress</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg321">
+      <trans-unit id="_msg323">
         <source xml:space="preserve">Progress increase per hour</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg322">
+      <trans-unit id="_msg324">
         <source xml:space="preserve">Estimated time left until synced</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg323">
+      <trans-unit id="_msg325">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg324">
+      <trans-unit id="_msg326">
         <source xml:space="preserve">Esc</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
@@ -1476,37 +1485,37 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../modaloverlay.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg325">
-        <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg326">
-        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg327">
+        <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg328">
+        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg329">
         <source xml:space="preserve">Unknown. Pre-syncing Headers (%1, %2%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg328">
+      <trans-unit id="_msg330">
         <source xml:space="preserve">unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
-      <trans-unit id="_msg329">
+      <trans-unit id="_msg331">
         <source xml:space="preserve">Open bitcoin URI</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg330">
+      <trans-unit id="_msg332">
         <source xml:space="preserve">URI:</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg331">
+      <trans-unit id="_msg333">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
         <note annotates="source" from="developer">Tooltip text for button that allows you to paste an address that is in your clipboard.</note>
@@ -1515,302 +1524,302 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg332">
+      <trans-unit id="_msg334">
         <source xml:space="preserve">Options</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg333">
+      <trans-unit id="_msg335">
         <source xml:space="preserve">&amp;Main</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg334">
+      <trans-unit id="_msg336">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg335">
+      <trans-unit id="_msg337">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg336">
+      <trans-unit id="_msg338">
         <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg337">
+      <trans-unit id="_msg339">
         <source xml:space="preserve">Size of &amp;database cache</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg338">
+      <trans-unit id="_msg340">
         <source xml:space="preserve">Number of script &amp;verification threads</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg339">
+      <trans-unit id="_msg341">
         <source xml:space="preserve">Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg340">
+      <trans-unit id="_msg342">
         <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">575</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg341">
+      <trans-unit id="_msg343">
         <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg342">
+      <trans-unit id="_msg344">
         <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg343">
+      <trans-unit id="_msg345">
         <source xml:space="preserve">Font in the Overview tab: </source>
         <context-group purpose="location"><context context-type="linenumber">779</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg344">
+      <trans-unit id="_msg346">
         <source xml:space="preserve">Options set in this dialog are overridden by the command line:</source>
         <context-group purpose="location"><context context-type="linenumber">824</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg345">
+      <trans-unit id="_msg347">
         <source xml:space="preserve">Open the %1 configuration file from the working directory.</source>
         <context-group purpose="location"><context context-type="linenumber">869</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg346">
+      <trans-unit id="_msg348">
         <source xml:space="preserve">Open Configuration File</source>
         <context-group purpose="location"><context context-type="linenumber">872</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg347">
+      <trans-unit id="_msg349">
         <source xml:space="preserve">Reset all client options to default.</source>
         <context-group purpose="location"><context context-type="linenumber">882</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg348">
+      <trans-unit id="_msg350">
         <source xml:space="preserve">&amp;Reset Options</source>
         <context-group purpose="location"><context context-type="linenumber">885</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg349">
+      <trans-unit id="_msg351">
         <source xml:space="preserve">&amp;Network</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg350">
+      <trans-unit id="_msg352">
         <source xml:space="preserve">Prune &amp;block storage to</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg351">
+      <trans-unit id="_msg353">
         <source xml:space="preserve">GB</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg352">
+      <trans-unit id="_msg354">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg353">
+      <trans-unit id="_msg355">
         <source xml:space="preserve">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
       </trans-unit>
-      <trans-unit id="_msg354">
+      <trans-unit id="_msg356">
         <source xml:space="preserve">MiB</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg355">
+      <trans-unit id="_msg357">
         <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
       </trans-unit>
-      <trans-unit id="_msg356">
+      <trans-unit id="_msg358">
         <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg357">
+      <trans-unit id="_msg359">
         <source xml:space="preserve">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that enables the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg358">
+      <trans-unit id="_msg360">
         <source xml:space="preserve">Enable R&amp;PC server</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
         <note annotates="source" from="developer">An Options window setting to enable the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg359">
+      <trans-unit id="_msg361">
         <source xml:space="preserve">W&amp;allet</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg360">
+      <trans-unit id="_msg362">
         <source xml:space="preserve">Whether to set subtract fee from amount as default or not.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg361">
+      <trans-unit id="_msg363">
         <source xml:space="preserve">Subtract &amp;fee from amount by default</source>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
         <note annotates="source" from="developer">An Options window setting to set subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg362">
+      <trans-unit id="_msg364">
         <source xml:space="preserve">Expert</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg363">
+      <trans-unit id="_msg365">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg364">
+      <trans-unit id="_msg366">
         <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg365">
+      <trans-unit id="_msg367">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg366">
+      <trans-unit id="_msg368">
         <source xml:space="preserve">Enable &amp;PSBT controls</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
         <note annotates="source" from="developer">An options window setting to enable PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg367">
+      <trans-unit id="_msg369">
         <source xml:space="preserve">Whether to show PSBT controls.</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
         <note annotates="source" from="developer">Tooltip text for options window setting that enables PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg368">
+      <trans-unit id="_msg370">
         <source xml:space="preserve">External Signer (e.g. hardware wallet)</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg369">
+      <trans-unit id="_msg371">
         <source xml:space="preserve">&amp;External signer script path</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg370">
+      <trans-unit id="_msg372">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg371">
+      <trans-unit id="_msg373">
         <source xml:space="preserve">Map port using &amp;UPnP</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg372">
+      <trans-unit id="_msg374">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg373">
+      <trans-unit id="_msg375">
         <source xml:space="preserve">Map port using NA&amp;T-PMP</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg374">
+      <trans-unit id="_msg376">
         <source xml:space="preserve">Accept connections from outside.</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg375">
+      <trans-unit id="_msg377">
         <source xml:space="preserve">Allow incomin&amp;g connections</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg376">
+      <trans-unit id="_msg378">
         <source xml:space="preserve">Connect to the Bitcoin network through a SOCKS5 proxy.</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg377">
+      <trans-unit id="_msg379">
         <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
         <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg378">
+      <trans-unit id="_msg380">
         <source xml:space="preserve">Proxy &amp;IP:</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg379">
+      <trans-unit id="_msg381">
         <source xml:space="preserve">&amp;Port:</source>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">582</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg380">
+      <trans-unit id="_msg382">
         <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
         <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">607</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg381">
+      <trans-unit id="_msg383">
         <source xml:space="preserve">Used for reaching peers via:</source>
         <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg382">
+      <trans-unit id="_msg384">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg383">
+      <trans-unit id="_msg385">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg384">
+      <trans-unit id="_msg386">
         <source xml:space="preserve">Tor</source>
         <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg385">
+      <trans-unit id="_msg387">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg386">
+      <trans-unit id="_msg388">
         <source xml:space="preserve">Show the icon in the system tray.</source>
         <context-group purpose="location"><context context-type="linenumber">649</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg387">
+      <trans-unit id="_msg389">
         <source xml:space="preserve">&amp;Show tray icon</source>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg388">
+      <trans-unit id="_msg390">
         <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
         <context-group purpose="location"><context context-type="linenumber">662</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg389">
+      <trans-unit id="_msg391">
         <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg390">
+      <trans-unit id="_msg392">
         <source xml:space="preserve">M&amp;inimize on close</source>
         <context-group purpose="location"><context context-type="linenumber">675</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg391">
+      <trans-unit id="_msg393">
         <source xml:space="preserve">&amp;Display</source>
         <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg392">
+      <trans-unit id="_msg394">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg393">
+      <trans-unit id="_msg395">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg394">
+      <trans-unit id="_msg396">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
         <context-group purpose="location"><context context-type="linenumber">728</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg395">
+      <trans-unit id="_msg397">
         <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg396">
+      <trans-unit id="_msg398">
         <source xml:space="preserve">Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
         <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">765</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg397">
+      <trans-unit id="_msg399">
         <source xml:space="preserve">&amp;Third-party transaction URLs</source>
         <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg398">
+      <trans-unit id="_msg400">
         <source xml:space="preserve">Whether to show coin control features or not.</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg399">
+      <trans-unit id="_msg401">
         <source xml:space="preserve">Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
         <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg400">
+      <trans-unit id="_msg402">
         <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <context-group purpose="location"><context context-type="linenumber">541</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg401">
+      <trans-unit id="_msg403">
         <source xml:space="preserve">&amp;OK</source>
         <context-group purpose="location"><context context-type="linenumber">965</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg402">
+      <trans-unit id="_msg404">
         <source xml:space="preserve">&amp;Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
       </trans-unit>
@@ -1818,170 +1827,170 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../optionsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg403">
+      <trans-unit id="_msg405">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg404">
-        <source xml:space="preserve">default</source>
-        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg405">
-        <source xml:space="preserve">none</source>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg406">
-        <source xml:space="preserve">Confirm options reset</source>
-        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
-        <note annotates="source" from="developer">Window title text of pop-up window shown when the user has chosen to reset options.</note>
+        <source xml:space="preserve">default</source>
+        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
       <trans-unit id="_msg407">
-        <source xml:space="preserve">Client restart required to activate changes.</source>
-        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
-        <note annotates="source" from="developer">Text explaining that the settings changed will not come into effect until the client is restarted.</note>
+        <source xml:space="preserve">none</source>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
       <trans-unit id="_msg408">
-        <source xml:space="preserve">Current settings will be backed up at &quot;%1&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
-        <note annotates="source" from="developer">Text explaining to the user that the client&apos;s current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location&apos;s path.</note>
+        <source xml:space="preserve">Confirm options reset</source>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+        <note annotates="source" from="developer">Window title text of pop-up window shown when the user has chosen to reset options.</note>
       </trans-unit>
       <trans-unit id="_msg409">
-        <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
-        <note annotates="source" from="developer">Text asking the user to confirm if they would like to proceed with a client shutdown.</note>
+        <source xml:space="preserve">Client restart required to activate changes.</source>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+        <note annotates="source" from="developer">Text explaining that the settings changed will not come into effect until the client is restarted.</note>
       </trans-unit>
       <trans-unit id="_msg410">
-        <source xml:space="preserve">Configuration options</source>
-        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
-        <note annotates="source" from="developer">Window title text of pop-up box that allows opening up of configuration file.</note>
+        <source xml:space="preserve">Current settings will be backed up at &quot;%1&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+        <note annotates="source" from="developer">Text explaining to the user that the client&apos;s current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location&apos;s path.</note>
       </trans-unit>
       <trans-unit id="_msg411">
-        <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
-        <note annotates="source" from="developer">Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</note>
+        <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+        <note annotates="source" from="developer">Text asking the user to confirm if they would like to proceed with a client shutdown.</note>
       </trans-unit>
       <trans-unit id="_msg412">
-        <source xml:space="preserve">Continue</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <source xml:space="preserve">Configuration options</source>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+        <note annotates="source" from="developer">Window title text of pop-up box that allows opening up of configuration file.</note>
       </trans-unit>
       <trans-unit id="_msg413">
-        <source xml:space="preserve">Cancel</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+        <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+        <note annotates="source" from="developer">Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</note>
       </trans-unit>
       <trans-unit id="_msg414">
-        <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <source xml:space="preserve">Continue</source>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
       <trans-unit id="_msg415">
-        <source xml:space="preserve">The configuration file could not be opened.</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <source xml:space="preserve">Cancel</source>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
       <trans-unit id="_msg416">
-        <source xml:space="preserve">This change would require a client restart.</source>
-        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+        <source xml:space="preserve">Error</source>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
       <trans-unit id="_msg417">
+        <source xml:space="preserve">The configuration file could not be opened.</source>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg418">
+        <source xml:space="preserve">This change would require a client restart.</source>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg419">
         <source xml:space="preserve">The supplied proxy address is invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg418">
+      <trans-unit id="_msg420">
         <source xml:space="preserve">Embedded &quot;%1&quot;</source>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg421">
+        <source xml:space="preserve">Default system font &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg419">
-        <source xml:space="preserve">Default system font &quot;%1&quot;</source>
-        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg420">
+      <trans-unit id="_msg422">
         <source xml:space="preserve">Custom…</source>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../optionsmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsModel">
-      <trans-unit id="_msg421">
+      <trans-unit id="_msg423">
         <source xml:space="preserve">Could not read setting &quot;%1&quot;, %2.</source>
-        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg422">
+      <trans-unit id="_msg424">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg423">
+      <trans-unit id="_msg425">
         <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg424">
+      <trans-unit id="_msg426">
         <source xml:space="preserve">Watch-only:</source>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg425">
+      <trans-unit id="_msg427">
         <source xml:space="preserve">Available:</source>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg426">
+      <trans-unit id="_msg428">
         <source xml:space="preserve">Your current spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg427">
+      <trans-unit id="_msg429">
         <source xml:space="preserve">Pending:</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg428">
+      <trans-unit id="_msg430">
         <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg429">
+      <trans-unit id="_msg431">
         <source xml:space="preserve">Immature:</source>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg430">
+      <trans-unit id="_msg432">
         <source xml:space="preserve">Mined balance that has not yet matured</source>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg431">
+      <trans-unit id="_msg433">
         <source xml:space="preserve">Balances</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg432">
+      <trans-unit id="_msg434">
         <source xml:space="preserve">Total:</source>
         <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg433">
+      <trans-unit id="_msg435">
         <source xml:space="preserve">Your current total balance</source>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg434">
+      <trans-unit id="_msg436">
         <source xml:space="preserve">Your current balance in watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg435">
+      <trans-unit id="_msg437">
         <source xml:space="preserve">Spendable:</source>
         <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg436">
+      <trans-unit id="_msg438">
         <source xml:space="preserve">Recent transactions</source>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg437">
+      <trans-unit id="_msg439">
         <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg438">
+      <trans-unit id="_msg440">
         <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg439">
+      <trans-unit id="_msg441">
         <source xml:space="preserve">Current total balance in watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
@@ -1989,7 +1998,7 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../overviewpage.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg440">
+      <trans-unit id="_msg442">
         <source xml:space="preserve">Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
@@ -1997,27 +2006,27 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg441">
+      <trans-unit id="_msg443">
         <source xml:space="preserve">PSBT Operations</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg442">
+      <trans-unit id="_msg444">
         <source xml:space="preserve">Sign Tx</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg443">
+      <trans-unit id="_msg445">
         <source xml:space="preserve">Broadcast Tx</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg444">
+      <trans-unit id="_msg446">
         <source xml:space="preserve">Copy to Clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg445">
+      <trans-unit id="_msg447">
         <source xml:space="preserve">Save…</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg446">
+      <trans-unit id="_msg448">
         <source xml:space="preserve">Close</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
@@ -2025,203 +2034,203 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg447">
-        <source xml:space="preserve">Failed to load transaction: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg448">
-        <source xml:space="preserve">Failed to sign transaction: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg449">
-        <source xml:space="preserve">Cannot sign inputs while wallet is locked.</source>
-        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+        <source xml:space="preserve">Failed to load transaction: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
       <trans-unit id="_msg450">
-        <source xml:space="preserve">Could not sign any more inputs.</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <source xml:space="preserve">Failed to sign transaction: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="_msg451">
-        <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
+        <source xml:space="preserve">Cannot sign inputs while wallet is locked.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
       <trans-unit id="_msg452">
-        <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+        <source xml:space="preserve">Could not sign any more inputs.</source>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
       <trans-unit id="_msg453">
-        <source xml:space="preserve">Unknown error processing transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+        <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg454">
-        <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+        <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
       <trans-unit id="_msg455">
-        <source xml:space="preserve">Transaction broadcast failed: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+        <source xml:space="preserve">Unknown error processing transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
       <trans-unit id="_msg456">
-        <source xml:space="preserve">PSBT copied to clipboard.</source>
-        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+        <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
       <trans-unit id="_msg457">
-        <source xml:space="preserve">Save Transaction Data</source>
-        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+        <source xml:space="preserve">Transaction broadcast failed: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
       <trans-unit id="_msg458">
-        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
-        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
-        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
+        <source xml:space="preserve">PSBT copied to clipboard.</source>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
       <trans-unit id="_msg459">
-        <source xml:space="preserve">PSBT saved to disk.</source>
-        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+        <source xml:space="preserve">Save Transaction Data</source>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
       <trans-unit id="_msg460">
-        <source xml:space="preserve">Sends %1 to %2</source>
-        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
       <trans-unit id="_msg461">
-        <source xml:space="preserve">own address</source>
-        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+        <source xml:space="preserve">PSBT saved to disk.</source>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
       <trans-unit id="_msg462">
-        <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+        <source xml:space="preserve">Sends %1 to %2</source>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
       <trans-unit id="_msg463">
-        <source xml:space="preserve">Pays transaction fee: </source>
-        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+        <source xml:space="preserve">own address</source>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
       <trans-unit id="_msg464">
-        <source xml:space="preserve">Total Amount</source>
-        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
+        <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
       <trans-unit id="_msg465">
-        <source xml:space="preserve">or</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+        <source xml:space="preserve">Pays transaction fee: </source>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
       <trans-unit id="_msg466">
-        <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+        <source xml:space="preserve">Total Amount</source>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
       <trans-unit id="_msg467">
-        <source xml:space="preserve">Transaction is missing some information about inputs.</source>
-        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+        <source xml:space="preserve">or</source>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
       <trans-unit id="_msg468">
-        <source xml:space="preserve">Transaction still needs signature(s).</source>
-        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+        <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
       <trans-unit id="_msg469">
-        <source xml:space="preserve">(But no wallet is loaded.)</source>
-        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+        <source xml:space="preserve">Transaction is missing some information about inputs.</source>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
       <trans-unit id="_msg470">
-        <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
-        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+        <source xml:space="preserve">Transaction still needs signature(s).</source>
+        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
       <trans-unit id="_msg471">
-        <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
-        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+        <source xml:space="preserve">(But no wallet is loaded.)</source>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
       <trans-unit id="_msg472">
-        <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
-        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+        <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
       <trans-unit id="_msg473">
-        <source xml:space="preserve">Transaction status is unknown.</source>
+        <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg474">
+        <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg475">
+        <source xml:space="preserve">Transaction status is unknown.</source>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../paymentserver.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PaymentServer">
-      <trans-unit id="_msg474">
-        <source xml:space="preserve">Payment request error</source>
-        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg475">
-        <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg476">
-        <source xml:space="preserve">URI handling</source>
-        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+        <source xml:space="preserve">Payment request error</source>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
       <trans-unit id="_msg477">
-        <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+        <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
       <trans-unit id="_msg478">
+        <source xml:space="preserve">URI handling</source>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg479">
+        <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg480">
         <source xml:space="preserve">Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg479">
+      <trans-unit id="_msg481">
         <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg480">
+      <trans-unit id="_msg482">
         <source xml:space="preserve">Payment request file handling</source>
-        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../peertablemodel.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg481">
+      <trans-unit id="_msg483">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the peer&apos;s User Agent string.</note>
       </trans-unit>
-      <trans-unit id="_msg482">
+      <trans-unit id="_msg484">
         <source xml:space="preserve">Ping</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the current latency of the connection with the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg483">
+      <trans-unit id="_msg485">
         <source xml:space="preserve">Peer</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains a unique number used to identify a connection.</note>
       </trans-unit>
-      <trans-unit id="_msg484">
+      <trans-unit id="_msg486">
         <source xml:space="preserve">Age</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</note>
       </trans-unit>
-      <trans-unit id="_msg485">
+      <trans-unit id="_msg487">
         <source xml:space="preserve">Direction</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the direction the peer connection was initiated from.</note>
       </trans-unit>
-      <trans-unit id="_msg486">
+      <trans-unit id="_msg488">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg487">
+      <trans-unit id="_msg489">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have received from the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg488">
+      <trans-unit id="_msg490">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</note>
       </trans-unit>
-      <trans-unit id="_msg489">
+      <trans-unit id="_msg491">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</note>
       </trans-unit>
-      <trans-unit id="_msg490">
+      <trans-unit id="_msg492">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which states the network the peer connected through.</note>
@@ -2230,12 +2239,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg491">
+      <trans-unit id="_msg493">
         <source xml:space="preserve">Inbound</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
         <note annotates="source" from="developer">An Inbound Connection from a Peer.</note>
       </trans-unit>
-      <trans-unit id="_msg492">
+      <trans-unit id="_msg494">
         <source xml:space="preserve">Outbound</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
         <note annotates="source" from="developer">An Outbound Connection to a Peer.</note>
@@ -2244,7 +2253,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg493">
+      <trans-unit id="_msg495">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
@@ -2252,231 +2261,232 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../guiutil.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg494">
-        <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
-        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg495">
-        <source xml:space="preserve">Ctrl+W</source>
-        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg496">
-        <source xml:space="preserve">Unroutable</source>
-        <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
+        <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
       <trans-unit id="_msg497">
+        <source xml:space="preserve">Ctrl+W</source>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg498">
+        <source xml:space="preserve">Unroutable</source>
+        <context-group purpose="location"><context context-type="linenumber">684</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg499">
         <source xml:space="preserve">IPv4</source>
-        <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv4 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg498">
+      <trans-unit id="_msg500">
         <source xml:space="preserve">IPv6</source>
-        <context-group purpose="location"><context context-type="linenumber">682</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv6 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg499">
+      <trans-unit id="_msg501">
         <source xml:space="preserve">Onion</source>
-        <context-group purpose="location"><context context-type="linenumber">684</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">690</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of Tor network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg500">
+      <trans-unit id="_msg502">
         <source xml:space="preserve">I2P</source>
-        <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of I2P network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg501">
+      <trans-unit id="_msg503">
         <source xml:space="preserve">CJDNS</source>
-        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of CJDNS network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg502">
+      <trans-unit id="_msg504">
         <source xml:space="preserve">Inbound</source>
-        <context-group purpose="location"><context context-type="linenumber">702</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">708</context></context-group>
         <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg503">
+      <trans-unit id="_msg505">
         <source xml:space="preserve">Outbound</source>
-        <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
         <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
       </trans-unit>
-      <trans-unit id="_msg504">
+      <trans-unit id="_msg506">
         <source xml:space="preserve">Full Relay</source>
-        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
       </trans-unit>
-      <trans-unit id="_msg505">
+      <trans-unit id="_msg507">
         <source xml:space="preserve">Block Relay</source>
-        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">719</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg506">
+      <trans-unit id="_msg508">
         <source xml:space="preserve">Manual</source>
-        <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">721</context></context-group>
         <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
       </trans-unit>
-      <trans-unit id="_msg507">
+      <trans-unit id="_msg509">
         <source xml:space="preserve">Feeler</source>
-        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">723</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg508">
+      <trans-unit id="_msg510">
         <source xml:space="preserve">Address Fetch</source>
-        <context-group purpose="location"><context context-type="linenumber">719</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">725</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg509">
-        <source xml:space="preserve">%1 d</source>
-        <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg510">
-        <source xml:space="preserve">%1 h</source>
-        <context-group purpose="location"><context context-type="linenumber">732</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg511">
-        <source xml:space="preserve">%1 m</source>
-        <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
+        <source xml:space="preserve">%1 d</source>
+        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">749</context></context-group>
       </trans-unit>
       <trans-unit id="_msg512">
-        <source xml:space="preserve">%1 s</source>
-        <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">746</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">772</context></context-group>
+        <source xml:space="preserve">%1 h</source>
+        <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
       </trans-unit>
       <trans-unit id="_msg513">
-        <source xml:space="preserve">None</source>
-        <context-group purpose="location"><context context-type="linenumber">760</context></context-group>
+        <source xml:space="preserve">%1 m</source>
+        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
       <trans-unit id="_msg514">
-        <source xml:space="preserve">N/A</source>
-        <context-group purpose="location"><context context-type="linenumber">766</context></context-group>
+        <source xml:space="preserve">%1 s</source>
+        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">778</context></context-group>
       </trans-unit>
       <trans-unit id="_msg515">
+        <source xml:space="preserve">None</source>
+        <context-group purpose="location"><context context-type="linenumber">766</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg516">
+        <source xml:space="preserve">N/A</source>
+        <context-group purpose="location"><context context-type="linenumber">772</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg517">
         <source xml:space="preserve">%1 ms</source>
-        <context-group purpose="location"><context context-type="linenumber">767</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">773</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">785</context></context-group>
-        <trans-unit id="_msg516[0]">
-          <source xml:space="preserve">%n second(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg516[1]">
-          <source xml:space="preserve">%n second(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">789</context></context-group>
-        <trans-unit id="_msg517[0]">
-          <source xml:space="preserve">%n minute(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg517[1]">
-          <source xml:space="preserve">%n minute(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">793</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">791</context></context-group>
         <trans-unit id="_msg518[0]">
-          <source xml:space="preserve">%n hour(s)</source>
+          <source xml:space="preserve">%n second(s)</source>
         </trans-unit>
         <trans-unit id="_msg518[1]">
+          <source xml:space="preserve">%n second(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">795</context></context-group>
+        <trans-unit id="_msg519[0]">
+          <source xml:space="preserve">%n minute(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg519[1]">
+          <source xml:space="preserve">%n minute(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">799</context></context-group>
+        <trans-unit id="_msg520[0]">
+          <source xml:space="preserve">%n hour(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg520[1]">
           <source xml:space="preserve">%n hour(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">797</context></context-group>
-        <trans-unit id="_msg519[0]">
+        <context-group purpose="location"><context context-type="linenumber">803</context></context-group>
+        <trans-unit id="_msg521[0]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
-        <trans-unit id="_msg519[1]">
+        <trans-unit id="_msg521[1]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">801</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">807</context></context-group>
-        <trans-unit id="_msg520[0]">
-          <source xml:space="preserve">%n week(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg520[1]">
-          <source xml:space="preserve">%n week(s)</source>
-        </trans-unit>
-      </group>
-      <trans-unit id="_msg521">
-        <source xml:space="preserve">%1 and %2</source>
-        <context-group purpose="location"><context context-type="linenumber">807</context></context-group>
-      </trans-unit>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">807</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">813</context></context-group>
         <trans-unit id="_msg522[0]">
-          <source xml:space="preserve">%n year(s)</source>
+          <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
         <trans-unit id="_msg522[1]">
-          <source xml:space="preserve">%n year(s)</source>
+          <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
       </group>
       <trans-unit id="_msg523">
-        <source xml:space="preserve">%1 B</source>
-        <context-group purpose="location"><context context-type="linenumber">815</context></context-group>
+        <source xml:space="preserve">%1 and %2</source>
+        <context-group purpose="location"><context context-type="linenumber">813</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg524">
-        <source xml:space="preserve">%1 kB</source>
-        <context-group purpose="location"><context context-type="linenumber">817</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1006</context></context-group>
-      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">813</context></context-group>
+        <trans-unit id="_msg524[0]">
+          <source xml:space="preserve">%n year(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg524[1]">
+          <source xml:space="preserve">%n year(s)</source>
+        </trans-unit>
+      </group>
       <trans-unit id="_msg525">
-        <source xml:space="preserve">%1 MB</source>
-        <context-group purpose="location"><context context-type="linenumber">819</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1008</context></context-group>
+        <source xml:space="preserve">%1 B</source>
+        <context-group purpose="location"><context context-type="linenumber">821</context></context-group>
       </trans-unit>
       <trans-unit id="_msg526">
+        <source xml:space="preserve">%1 kB</source>
+        <context-group purpose="location"><context context-type="linenumber">823</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1008</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg527">
+        <source xml:space="preserve">%1 MB</source>
+        <context-group purpose="location"><context context-type="linenumber">825</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1009</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1010</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg528">
         <source xml:space="preserve">%1 GB</source>
-        <context-group purpose="location"><context context-type="linenumber">821</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">827</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
-      <trans-unit id="_msg527">
-        <source xml:space="preserve">&amp;Save Image…</source>
-        <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg528">
-        <source xml:space="preserve">&amp;Copy Image</source>
-        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg529">
-        <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
-        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
+        <source xml:space="preserve">&amp;Save Image…</source>
+        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
       <trans-unit id="_msg530">
-        <source xml:space="preserve">Error encoding URI into QR Code.</source>
-        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+        <source xml:space="preserve">&amp;Copy Image</source>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
       <trans-unit id="_msg531">
-        <source xml:space="preserve">QR code support not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+        <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
       <trans-unit id="_msg532">
-        <source xml:space="preserve">Save QR Code</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+        <source xml:space="preserve">Error encoding URI into QR Code.</source>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
       <trans-unit id="_msg533">
+        <source xml:space="preserve">QR code support not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg534">
+        <source xml:space="preserve">Save QR Code</source>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg535">
         <source xml:space="preserve">PNG Image</source>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
         <note annotates="source" from="developer">Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</note>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg534">
+      <trans-unit id="_msg536">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
@@ -2517,309 +2527,309 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <context-group purpose="location"><context context-type="linenumber">1662</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1688</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1714</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg535">
+      <trans-unit id="_msg537">
         <source xml:space="preserve">Client version</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg536">
+      <trans-unit id="_msg538">
         <source xml:space="preserve">&amp;Information</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg537">
+      <trans-unit id="_msg539">
         <source xml:space="preserve">General</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg538">
+      <trans-unit id="_msg540">
         <source xml:space="preserve">Datadir</source>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg539">
+      <trans-unit id="_msg541">
         <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg540">
+      <trans-unit id="_msg542">
         <source xml:space="preserve">Blocksdir</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg541">
+      <trans-unit id="_msg543">
         <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg542">
+      <trans-unit id="_msg544">
         <source xml:space="preserve">Startup time</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg543">
+      <trans-unit id="_msg545">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg544">
+      <trans-unit id="_msg546">
         <source xml:space="preserve">Name</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg545">
+      <trans-unit id="_msg547">
         <source xml:space="preserve">Number of connections</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg546">
+      <trans-unit id="_msg548">
         <source xml:space="preserve">Block chain</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg547">
+      <trans-unit id="_msg549">
         <source xml:space="preserve">Memory Pool</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg548">
+      <trans-unit id="_msg550">
         <source xml:space="preserve">Current number of transactions</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg549">
+      <trans-unit id="_msg551">
         <source xml:space="preserve">Memory usage</source>
         <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg550">
+      <trans-unit id="_msg552">
         <source xml:space="preserve">Wallet: </source>
         <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg551">
+      <trans-unit id="_msg553">
         <source xml:space="preserve">(none)</source>
         <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg552">
+      <trans-unit id="_msg554">
         <source xml:space="preserve">&amp;Reset</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg553">
+      <trans-unit id="_msg555">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1505</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg554">
+      <trans-unit id="_msg556">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">825</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1482</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg555">
+      <trans-unit id="_msg557">
         <source xml:space="preserve">&amp;Peers</source>
         <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg556">
+      <trans-unit id="_msg558">
         <source xml:space="preserve">Banned peers</source>
         <context-group purpose="location"><context context-type="linenumber">942</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg557">
+      <trans-unit id="_msg559">
         <source xml:space="preserve">Select a peer to view detailed information.</source>
         <context-group purpose="location"><context context-type="linenumber">1010</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1173</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg558">
+      <trans-unit id="_msg560">
         <source xml:space="preserve">The transport layer version: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1090</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg559">
+      <trans-unit id="_msg561">
         <source xml:space="preserve">Transport</source>
         <context-group purpose="location"><context context-type="linenumber">1093</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560">
-        <source xml:space="preserve">The BIP324 session ID string in hex, if any.</source>
-        <context-group purpose="location"><context context-type="linenumber">1116</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg561">
+      <trans-unit id="_msg562">
         <source xml:space="preserve">Session ID</source>
         <context-group purpose="location"><context context-type="linenumber">1119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562">
+      <trans-unit id="_msg563">
         <source xml:space="preserve">Version</source>
         <context-group purpose="location"><context context-type="linenumber">1168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563">
+      <trans-unit id="_msg564">
         <source xml:space="preserve">Whether we relay transactions to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564">
+      <trans-unit id="_msg565">
         <source xml:space="preserve">Transaction Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565">
+      <trans-unit id="_msg566">
         <source xml:space="preserve">Starting Block</source>
         <context-group purpose="location"><context context-type="linenumber">1292</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566">
+      <trans-unit id="_msg567">
         <source xml:space="preserve">Synced Headers</source>
         <context-group purpose="location"><context context-type="linenumber">1315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567">
+      <trans-unit id="_msg568">
         <source xml:space="preserve">Synced Blocks</source>
         <context-group purpose="location"><context context-type="linenumber">1338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568">
+      <trans-unit id="_msg569">
         <source xml:space="preserve">Last Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1413</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569">
+      <trans-unit id="_msg570">
         <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
         <context-group purpose="location"><context context-type="linenumber">1623</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg570">
+      <trans-unit id="_msg571">
         <source xml:space="preserve">Mapped AS</source>
         <context-group purpose="location"><context context-type="linenumber">1626</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg571">
+      <trans-unit id="_msg572">
         <source xml:space="preserve">Whether we relay addresses to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1649</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg572">
+      <trans-unit id="_msg573">
         <source xml:space="preserve">Address Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1652</context></context-group>
         <note annotates="source" from="developer">Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg573">
+      <trans-unit id="_msg574">
         <source xml:space="preserve">The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <context-group purpose="location"><context context-type="linenumber">1675</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg574">
+      <trans-unit id="_msg575">
         <source xml:space="preserve">The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <context-group purpose="location"><context context-type="linenumber">1701</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg575">
+      <trans-unit id="_msg576">
         <source xml:space="preserve">Addresses Processed</source>
         <context-group purpose="location"><context context-type="linenumber">1678</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg576">
+      <trans-unit id="_msg577">
         <source xml:space="preserve">Addresses Rate-Limited</source>
         <context-group purpose="location"><context context-type="linenumber">1704</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg577">
+      <trans-unit id="_msg578">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg578">
+      <trans-unit id="_msg579">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg579">
+      <trans-unit id="_msg580">
         <source xml:space="preserve">Current block height</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg580">
+      <trans-unit id="_msg581">
         <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg581">
+      <trans-unit id="_msg582">
         <source xml:space="preserve">Decrease font size</source>
         <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg582">
+      <trans-unit id="_msg583">
         <source xml:space="preserve">Increase font size</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg583">
+      <trans-unit id="_msg584">
         <source xml:space="preserve">Permissions</source>
         <context-group purpose="location"><context context-type="linenumber">1041</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg584">
+      <trans-unit id="_msg585">
         <source xml:space="preserve">The direction and type of peer connection: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1064</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg585">
+      <trans-unit id="_msg586">
         <source xml:space="preserve">Direction/Type</source>
         <context-group purpose="location"><context context-type="linenumber">1067</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg586">
+      <trans-unit id="_msg587">
+        <source xml:space="preserve">The BIP324 session ID string in hex.</source>
+        <context-group purpose="location"><context context-type="linenumber">1116</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg588">
         <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <context-group purpose="location"><context context-type="linenumber">1142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg587">
+      <trans-unit id="_msg589">
         <source xml:space="preserve">Services</source>
         <context-group purpose="location"><context context-type="linenumber">1214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg588">
+      <trans-unit id="_msg590">
         <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg589">
+      <trans-unit id="_msg591">
         <source xml:space="preserve">High Bandwidth</source>
         <context-group purpose="location"><context context-type="linenumber">1269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg590">
+      <trans-unit id="_msg592">
         <source xml:space="preserve">Connection Time</source>
         <context-group purpose="location"><context context-type="linenumber">1361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg591">
+      <trans-unit id="_msg593">
         <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg592">
+      <trans-unit id="_msg594">
         <source xml:space="preserve">Last Block</source>
         <context-group purpose="location"><context context-type="linenumber">1387</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg593">
+      <trans-unit id="_msg595">
         <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1410</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Last Transaction field in the peer details area.</note>
       </trans-unit>
-      <trans-unit id="_msg594">
+      <trans-unit id="_msg596">
         <source xml:space="preserve">Last Send</source>
         <context-group purpose="location"><context context-type="linenumber">1436</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg595">
+      <trans-unit id="_msg597">
         <source xml:space="preserve">Last Receive</source>
         <context-group purpose="location"><context context-type="linenumber">1459</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg596">
+      <trans-unit id="_msg598">
         <source xml:space="preserve">Ping Time</source>
         <context-group purpose="location"><context context-type="linenumber">1528</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg597">
+      <trans-unit id="_msg599">
         <source xml:space="preserve">The duration of a currently outstanding ping.</source>
         <context-group purpose="location"><context context-type="linenumber">1551</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg598">
+      <trans-unit id="_msg600">
         <source xml:space="preserve">Ping Wait</source>
         <context-group purpose="location"><context context-type="linenumber">1554</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg599">
+      <trans-unit id="_msg601">
         <source xml:space="preserve">Min Ping</source>
         <context-group purpose="location"><context context-type="linenumber">1577</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg600">
+      <trans-unit id="_msg602">
         <source xml:space="preserve">Time Offset</source>
         <context-group purpose="location"><context context-type="linenumber">1600</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg601">
+      <trans-unit id="_msg603">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg602">
+      <trans-unit id="_msg604">
         <source xml:space="preserve">&amp;Open</source>
         <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg603">
+      <trans-unit id="_msg605">
         <source xml:space="preserve">&amp;Console</source>
         <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg604">
+      <trans-unit id="_msg606">
         <source xml:space="preserve">&amp;Network Traffic</source>
         <context-group purpose="location"><context context-type="linenumber">613</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg605">
+      <trans-unit id="_msg607">
         <source xml:space="preserve">Totals</source>
         <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg606">
+      <trans-unit id="_msg608">
         <source xml:space="preserve">Debug log file</source>
         <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg607">
+      <trans-unit id="_msg609">
         <source xml:space="preserve">Clear console</source>
         <context-group purpose="location"><context context-type="linenumber">515</context></context-group>
       </trans-unit>
@@ -2827,158 +2837,158 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../rpcconsole.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg608">
-        <source xml:space="preserve">In:</source>
-        <context-group purpose="location"><context context-type="linenumber">970</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg609">
-        <source xml:space="preserve">Out:</source>
-        <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg610">
-        <source xml:space="preserve">Inbound: initiated by peer</source>
-        <context-group purpose="location"><context context-type="linenumber">496</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
+        <source xml:space="preserve">In:</source>
+        <context-group purpose="location"><context context-type="linenumber">972</context></context-group>
       </trans-unit>
       <trans-unit id="_msg611">
-        <source xml:space="preserve">Outbound Full Relay: default</source>
-        <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
+        <source xml:space="preserve">Out:</source>
+        <context-group purpose="location"><context context-type="linenumber">973</context></context-group>
       </trans-unit>
       <trans-unit id="_msg612">
-        <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
+        <source xml:space="preserve">Inbound: initiated by peer</source>
+        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
       </trans-unit>
       <trans-unit id="_msg613">
-        <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
-        <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
+        <source xml:space="preserve">Outbound Full Relay: default</source>
+        <context-group purpose="location"><context context-type="linenumber">501</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
       </trans-unit>
       <trans-unit id="_msg614">
-        <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">514</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
+        <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">504</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
       <trans-unit id="_msg615">
-        <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">517</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
+        <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
       </trans-unit>
       <trans-unit id="_msg616">
-        <source xml:space="preserve">detecting: peer could be v1 or v2</source>
-        <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for &quot;detecting&quot; transport type.</note>
+        <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">515</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
       </trans-unit>
       <trans-unit id="_msg617">
-        <source xml:space="preserve">v1: unencrypted, plaintext transport protocol</source>
-        <context-group purpose="location"><context context-type="linenumber">524</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for v1 transport type.</note>
+        <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
       </trans-unit>
       <trans-unit id="_msg618">
-        <source xml:space="preserve">v2: BIP324 encrypted transport protocol</source>
-        <context-group purpose="location"><context context-type="linenumber">526</context></context-group>
-        <note annotates="source" from="developer">Explanatory text for v2 transport type.</note>
+        <source xml:space="preserve">detecting: peer could be v1 or v2</source>
+        <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for &quot;detecting&quot; transport type.</note>
       </trans-unit>
       <trans-unit id="_msg619">
-        <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
-        <context-group purpose="location"><context context-type="linenumber">530</context></context-group>
+        <source xml:space="preserve">v1: unencrypted, plaintext transport protocol</source>
+        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for v1 transport type.</note>
       </trans-unit>
       <trans-unit id="_msg620">
-        <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
-        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
+        <source xml:space="preserve">v2: BIP324 encrypted transport protocol</source>
+        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for v2 transport type.</note>
       </trans-unit>
       <trans-unit id="_msg621">
-        <source xml:space="preserve">no high bandwidth relay selected</source>
-        <context-group purpose="location"><context context-type="linenumber">532</context></context-group>
+        <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
+        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
       </trans-unit>
       <trans-unit id="_msg622">
-        <source xml:space="preserve">Ctrl++</source>
-        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
-        <note annotates="source" from="developer">Main shortcut to increase the RPC console font size.</note>
+        <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
+        <context-group purpose="location"><context context-type="linenumber">532</context></context-group>
       </trans-unit>
       <trans-unit id="_msg623">
-        <source xml:space="preserve">Ctrl+=</source>
-        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
-        <note annotates="source" from="developer">Secondary shortcut to increase the RPC console font size.</note>
+        <source xml:space="preserve">no high bandwidth relay selected</source>
+        <context-group purpose="location"><context context-type="linenumber">533</context></context-group>
       </trans-unit>
       <trans-unit id="_msg624">
-        <source xml:space="preserve">Ctrl+-</source>
-        <context-group purpose="location"><context context-type="linenumber">551</context></context-group>
-        <note annotates="source" from="developer">Main shortcut to decrease the RPC console font size.</note>
+        <source xml:space="preserve">Ctrl++</source>
+        <context-group purpose="location"><context context-type="linenumber">546</context></context-group>
+        <note annotates="source" from="developer">Main shortcut to increase the RPC console font size.</note>
       </trans-unit>
       <trans-unit id="_msg625">
-        <source xml:space="preserve">Ctrl+_</source>
-        <context-group purpose="location"><context context-type="linenumber">553</context></context-group>
-        <note annotates="source" from="developer">Secondary shortcut to decrease the RPC console font size.</note>
+        <source xml:space="preserve">Ctrl+=</source>
+        <context-group purpose="location"><context context-type="linenumber">548</context></context-group>
+        <note annotates="source" from="developer">Secondary shortcut to increase the RPC console font size.</note>
       </trans-unit>
       <trans-unit id="_msg626">
-        <source xml:space="preserve">&amp;Copy address</source>
-        <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
-        <note annotates="source" from="developer">Context menu action to copy the address of a peer.</note>
+        <source xml:space="preserve">Ctrl+-</source>
+        <context-group purpose="location"><context context-type="linenumber">552</context></context-group>
+        <note annotates="source" from="developer">Main shortcut to decrease the RPC console font size.</note>
       </trans-unit>
       <trans-unit id="_msg627">
-        <source xml:space="preserve">&amp;Disconnect</source>
-        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+        <source xml:space="preserve">Ctrl+_</source>
+        <context-group purpose="location"><context context-type="linenumber">554</context></context-group>
+        <note annotates="source" from="developer">Secondary shortcut to decrease the RPC console font size.</note>
       </trans-unit>
       <trans-unit id="_msg628">
-        <source xml:space="preserve">1 &amp;hour</source>
-        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
+        <source xml:space="preserve">&amp;Copy address</source>
+        <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
+        <note annotates="source" from="developer">Context menu action to copy the address of a peer.</note>
       </trans-unit>
       <trans-unit id="_msg629">
-        <source xml:space="preserve">1 d&amp;ay</source>
-        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
+        <source xml:space="preserve">&amp;Disconnect</source>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
       </trans-unit>
       <trans-unit id="_msg630">
-        <source xml:space="preserve">1 &amp;week</source>
-        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
+        <source xml:space="preserve">1 &amp;hour</source>
+        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
       </trans-unit>
       <trans-unit id="_msg631">
-        <source xml:space="preserve">1 &amp;year</source>
-        <context-group purpose="location"><context context-type="linenumber">714</context></context-group>
+        <source xml:space="preserve">1 d&amp;ay</source>
+        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
       </trans-unit>
       <trans-unit id="_msg632">
-        <source xml:space="preserve">&amp;Copy IP/Netmask</source>
-        <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
-        <note annotates="source" from="developer">Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer&apos;s IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</note>
+        <source xml:space="preserve">1 &amp;week</source>
+        <context-group purpose="location"><context context-type="linenumber">714</context></context-group>
       </trans-unit>
       <trans-unit id="_msg633">
-        <source xml:space="preserve">&amp;Unban</source>
-        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
+        <source xml:space="preserve">1 &amp;year</source>
+        <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
       </trans-unit>
       <trans-unit id="_msg634">
-        <source xml:space="preserve">Network activity disabled</source>
-        <context-group purpose="location"><context context-type="linenumber">974</context></context-group>
+        <source xml:space="preserve">&amp;Copy IP/Netmask</source>
+        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
+        <note annotates="source" from="developer">Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer&apos;s IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</note>
       </trans-unit>
       <trans-unit id="_msg635">
-        <source xml:space="preserve">Executing command without any wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1053</context></context-group>
+        <source xml:space="preserve">&amp;Unban</source>
+        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
       </trans-unit>
       <trans-unit id="_msg636">
-        <source xml:space="preserve">Ctrl+I</source>
-        <context-group purpose="location"><context context-type="linenumber">1378</context></context-group>
+        <source xml:space="preserve">Network activity disabled</source>
+        <context-group purpose="location"><context context-type="linenumber">976</context></context-group>
       </trans-unit>
       <trans-unit id="_msg637">
-        <source xml:space="preserve">Ctrl+T</source>
-        <context-group purpose="location"><context context-type="linenumber">1379</context></context-group>
+        <source xml:space="preserve">Executing command without any wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">1056</context></context-group>
       </trans-unit>
       <trans-unit id="_msg638">
-        <source xml:space="preserve">Ctrl+N</source>
-        <context-group purpose="location"><context context-type="linenumber">1380</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg639">
-        <source xml:space="preserve">Ctrl+P</source>
+        <source xml:space="preserve">Ctrl+I</source>
         <context-group purpose="location"><context context-type="linenumber">1381</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg639">
+        <source xml:space="preserve">Ctrl+T</source>
+        <context-group purpose="location"><context context-type="linenumber">1382</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg640">
-        <source xml:space="preserve">Node window - [%1]</source>
-        <context-group purpose="location"><context context-type="linenumber">1399</context></context-group>
+        <source xml:space="preserve">Ctrl+N</source>
+        <context-group purpose="location"><context context-type="linenumber">1383</context></context-group>
       </trans-unit>
       <trans-unit id="_msg641">
-        <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1051</context></context-group>
+        <source xml:space="preserve">Ctrl+P</source>
+        <context-group purpose="location"><context context-type="linenumber">1384</context></context-group>
       </trans-unit>
       <trans-unit id="_msg642">
+        <source xml:space="preserve">Node window - [%1]</source>
+        <context-group purpose="location"><context context-type="linenumber">1402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg643">
+        <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">1054</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg644">
         <source xml:space="preserve">Welcome to the %1 RPC console.
 Use up and down arrows to navigate history, and %2 to clear screen.
 Use %3 and %4 to increase or decrease the font size.
@@ -2986,124 +2996,124 @@ Type %5 for an overview of available commands.
 For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
-        <context-group purpose="location"><context context-type="linenumber">904</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">905</context></context-group>
         <note annotates="source" from="developer">RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</note>
       </trans-unit>
-      <trans-unit id="_msg643">
+      <trans-unit id="_msg645">
         <source xml:space="preserve">Executing…</source>
-        <context-group purpose="location"><context context-type="linenumber">1061</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1064</context></context-group>
         <note annotates="source" from="developer">A console message indicating an entered command is currently being executed.</note>
       </trans-unit>
-      <trans-unit id="_msg644">
+      <trans-unit id="_msg646">
         <source xml:space="preserve">(peer: %1)</source>
-        <context-group purpose="location"><context context-type="linenumber">1179</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg645">
+      <trans-unit id="_msg647">
         <source xml:space="preserve">via %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1181</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1184</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../rpcconsole.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg646">
-        <source xml:space="preserve">Yes</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg647">
-        <source xml:space="preserve">No</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg648">
-        <source xml:space="preserve">To</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <source xml:space="preserve">Yes</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
       <trans-unit id="_msg649">
-        <source xml:space="preserve">From</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <source xml:space="preserve">No</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
       <trans-unit id="_msg650">
-        <source xml:space="preserve">Ban for</source>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <source xml:space="preserve">To</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
       <trans-unit id="_msg651">
-        <source xml:space="preserve">Never</source>
-        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+        <source xml:space="preserve">From</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
       <trans-unit id="_msg652">
+        <source xml:space="preserve">Ban for</source>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg653">
+        <source xml:space="preserve">Never</source>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg654">
         <source xml:space="preserve">Unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg653">
+      <trans-unit id="_msg655">
         <source xml:space="preserve">&amp;Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg654">
+      <trans-unit id="_msg656">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg655">
+      <trans-unit id="_msg657">
         <source xml:space="preserve">&amp;Message:</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg656">
+      <trans-unit id="_msg658">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg657">
+      <trans-unit id="_msg659">
         <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg658">
+      <trans-unit id="_msg660">
         <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg659">
+      <trans-unit id="_msg661">
         <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg660">
+      <trans-unit id="_msg662">
         <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg661">
+      <trans-unit id="_msg663">
         <source xml:space="preserve">An optional message that is attached to the payment request and may be displayed to the sender.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg662">
+      <trans-unit id="_msg664">
         <source xml:space="preserve">&amp;Create new receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg663">
+      <trans-unit id="_msg665">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg664">
+      <trans-unit id="_msg666">
         <source xml:space="preserve">Clear</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg665">
+      <trans-unit id="_msg667">
         <source xml:space="preserve">Requested payments history</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg666">
+      <trans-unit id="_msg668">
         <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg667">
+      <trans-unit id="_msg669">
         <source xml:space="preserve">Show</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg668">
+      <trans-unit id="_msg670">
         <source xml:space="preserve">Remove the selected entries from the list</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg669">
+      <trans-unit id="_msg671">
         <source xml:space="preserve">Remove</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
@@ -3111,63 +3121,63 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg670">
+      <trans-unit id="_msg672">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg671">
+      <trans-unit id="_msg673">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg672">
+      <trans-unit id="_msg674">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg673">
+      <trans-unit id="_msg675">
         <source xml:space="preserve">Copy &amp;message</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg674">
+      <trans-unit id="_msg676">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg675">
+      <trans-unit id="_msg677">
         <source xml:space="preserve">Base58 (Legacy)</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg676">
+      <trans-unit id="_msg678">
         <source xml:space="preserve">Not recommended due to higher fees and less protection against typos.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg677">
+      <trans-unit id="_msg679">
         <source xml:space="preserve">Base58 (P2SH-SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg678">
+      <trans-unit id="_msg680">
         <source xml:space="preserve">Generates an address compatible with older wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg679">
+      <trans-unit id="_msg681">
         <source xml:space="preserve">Bech32 (SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg680">
+      <trans-unit id="_msg682">
         <source xml:space="preserve">Generates a native segwit address (BIP-173). Some old wallets don&apos;t support it.</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg681">
+      <trans-unit id="_msg683">
         <source xml:space="preserve">Bech32m (Taproot)</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg682">
+      <trans-unit id="_msg684">
         <source xml:space="preserve">Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg683">
+      <trans-unit id="_msg685">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg684">
+      <trans-unit id="_msg686">
         <source xml:space="preserve">Could not generate new %1 address</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
@@ -3175,51 +3185,51 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg685">
+      <trans-unit id="_msg687">
         <source xml:space="preserve">Request payment to …</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg686">
+      <trans-unit id="_msg688">
         <source xml:space="preserve">Address:</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg687">
+      <trans-unit id="_msg689">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg688">
+      <trans-unit id="_msg690">
         <source xml:space="preserve">Label:</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg689">
+      <trans-unit id="_msg691">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg690">
+      <trans-unit id="_msg692">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg691">
+      <trans-unit id="_msg693">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg692">
+      <trans-unit id="_msg694">
         <source xml:space="preserve">Copy &amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg693">
+      <trans-unit id="_msg695">
         <source xml:space="preserve">&amp;Verify</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg694">
+      <trans-unit id="_msg696">
         <source xml:space="preserve">Verify this address on e.g. a hardware wallet screen</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg695">
+      <trans-unit id="_msg697">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg696">
+      <trans-unit id="_msg698">
         <source xml:space="preserve">Payment information</source>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
@@ -3227,190 +3237,190 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg697">
+      <trans-unit id="_msg699">
         <source xml:space="preserve">Request payment to %1</source>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
-      <trans-unit id="_msg698">
-        <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg699">
-        <source xml:space="preserve">Label</source>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg700">
-        <source xml:space="preserve">Message</source>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+        <source xml:space="preserve">Date</source>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
       <trans-unit id="_msg701">
-        <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <source xml:space="preserve">Label</source>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
       <trans-unit id="_msg702">
-        <source xml:space="preserve">(no message)</source>
-        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+        <source xml:space="preserve">Message</source>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
       <trans-unit id="_msg703">
-        <source xml:space="preserve">(no amount requested)</source>
-        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+        <source xml:space="preserve">(no label)</source>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
       <trans-unit id="_msg704">
+        <source xml:space="preserve">(no message)</source>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg705">
+        <source xml:space="preserve">(no amount requested)</source>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg706">
         <source xml:space="preserve">Requested</source>
-        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg705">
+      <trans-unit id="_msg707">
         <source xml:space="preserve">Send Coins</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">762</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">763</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg706">
+      <trans-unit id="_msg708">
         <source xml:space="preserve">Coin Control Features</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg707">
+      <trans-unit id="_msg709">
         <source xml:space="preserve">automatically selected</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg708">
+      <trans-unit id="_msg710">
         <source xml:space="preserve">Insufficient funds!</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg709">
+      <trans-unit id="_msg711">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg710">
+      <trans-unit id="_msg712">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg711">
+      <trans-unit id="_msg713">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg712">
+      <trans-unit id="_msg714">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg713">
+      <trans-unit id="_msg715">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg714">
+      <trans-unit id="_msg716">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg715">
+      <trans-unit id="_msg717">
         <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg716">
+      <trans-unit id="_msg718">
         <source xml:space="preserve">Custom change address</source>
         <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg717">
+      <trans-unit id="_msg719">
         <source xml:space="preserve">Transaction Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg718">
+      <trans-unit id="_msg720">
         <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg719">
+      <trans-unit id="_msg721">
         <source xml:space="preserve">Warning: Fee estimation is currently not possible.</source>
         <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg720">
+      <trans-unit id="_msg722">
         <source xml:space="preserve">per kilobyte</source>
         <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg721">
+      <trans-unit id="_msg723">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg722">
+      <trans-unit id="_msg724">
         <source xml:space="preserve">Recommended:</source>
         <context-group purpose="location"><context context-type="linenumber">892</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg723">
+      <trans-unit id="_msg725">
         <source xml:space="preserve">Custom:</source>
         <context-group purpose="location"><context context-type="linenumber">922</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg724">
+      <trans-unit id="_msg726">
         <source xml:space="preserve">Send to multiple recipients at once</source>
         <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg725">
+      <trans-unit id="_msg727">
         <source xml:space="preserve">Add &amp;Recipient</source>
         <context-group purpose="location"><context context-type="linenumber">1140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg726">
+      <trans-unit id="_msg728">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">1120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg727">
+      <trans-unit id="_msg729">
         <source xml:space="preserve">Inputs…</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg728">
+      <trans-unit id="_msg730">
         <source xml:space="preserve">Choose…</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg729">
+      <trans-unit id="_msg731">
         <source xml:space="preserve">Hide transaction fee settings</source>
         <context-group purpose="location"><context context-type="linenumber">777</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg730">
+      <trans-unit id="_msg732">
         <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg731">
+      <trans-unit id="_msg733">
         <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg732">
+      <trans-unit id="_msg734">
         <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg733">
+      <trans-unit id="_msg735">
         <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg734">
+      <trans-unit id="_msg736">
         <source xml:space="preserve">Confirmation time target:</source>
         <context-group purpose="location"><context context-type="linenumber">997</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg735">
+      <trans-unit id="_msg737">
         <source xml:space="preserve">Enable Replace-By-Fee</source>
         <context-group purpose="location"><context context-type="linenumber">1055</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg736">
+      <trans-unit id="_msg738">
         <source xml:space="preserve">With Replace-By-Fee (BIP-125) you can increase a transaction&apos;s fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
         <context-group purpose="location"><context context-type="linenumber">1058</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg737">
+      <trans-unit id="_msg739">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">1123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg738">
+      <trans-unit id="_msg740">
         <source xml:space="preserve">Balance:</source>
         <context-group purpose="location"><context context-type="linenumber">1178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg739">
+      <trans-unit id="_msg741">
         <source xml:space="preserve">Confirm the send action</source>
         <context-group purpose="location"><context context-type="linenumber">1094</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg740">
+      <trans-unit id="_msg742">
         <source xml:space="preserve">S&amp;end</source>
         <context-group purpose="location"><context context-type="linenumber">1097</context></context-group>
       </trans-unit>
@@ -3418,300 +3428,300 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg741">
+      <trans-unit id="_msg743">
         <source xml:space="preserve">Copy quantity</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg742">
+      <trans-unit id="_msg744">
         <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg743">
+      <trans-unit id="_msg745">
         <source xml:space="preserve">Copy fee</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg744">
+      <trans-unit id="_msg746">
         <source xml:space="preserve">Copy after fee</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg745">
+      <trans-unit id="_msg747">
         <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg746">
+      <trans-unit id="_msg748">
         <source xml:space="preserve">Copy change</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg747">
+      <trans-unit id="_msg749">
         <source xml:space="preserve">%1 (%2 blocks)</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg748">
+      <trans-unit id="_msg750">
         <source xml:space="preserve">Sign on device</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
         <note annotates="source" from="developer">&quot;device&quot; usually means a hardware wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg749">
+      <trans-unit id="_msg751">
         <source xml:space="preserve">Connect your hardware wallet first.</source>
         <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg750">
+      <trans-unit id="_msg752">
         <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
         <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg751">
+      <trans-unit id="_msg753">
         <source xml:space="preserve">Cr&amp;eate Unsigned</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg752">
+      <trans-unit id="_msg754">
         <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg753">
+      <trans-unit id="_msg755">
         <source xml:space="preserve">%1 to &apos;%2&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg754">
+      <trans-unit id="_msg756">
         <source xml:space="preserve">%1 to %2</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg755">
+      <trans-unit id="_msg757">
         <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg756">
-        <source xml:space="preserve">Sign failed</source>
-        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg757">
-        <source xml:space="preserve">External signer not found</source>
-        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
-      </trans-unit>
       <trans-unit id="_msg758">
-        <source xml:space="preserve">External signer failure</source>
-        <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
+        <source xml:space="preserve">Sign failed</source>
+        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
       <trans-unit id="_msg759">
-        <source xml:space="preserve">Save Transaction Data</source>
-        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+        <source xml:space="preserve">External signer not found</source>
+        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg760">
-        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
-        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
-        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
+        <source xml:space="preserve">External signer failure</source>
+        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg761">
-        <source xml:space="preserve">PSBT saved</source>
-        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
-        <note annotates="source" from="developer">Popup message when a PSBT has been saved to a file</note>
+        <source xml:space="preserve">Save Transaction Data</source>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
       <trans-unit id="_msg762">
-        <source xml:space="preserve">External balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">708</context></context-group>
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
       <trans-unit id="_msg763">
+        <source xml:space="preserve">PSBT saved</source>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+        <note annotates="source" from="developer">Popup message when a PSBT has been saved to a file</note>
+      </trans-unit>
+      <trans-unit id="_msg764">
+        <source xml:space="preserve">External balance:</source>
+        <context-group purpose="location"><context context-type="linenumber">709</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg765">
         <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg764">
+      <trans-unit id="_msg766">
         <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg765">
+      <trans-unit id="_msg767">
         <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</note>
       </trans-unit>
-      <trans-unit id="_msg766">
+      <trans-unit id="_msg768">
         <source xml:space="preserve">%1 from wallet &apos;%2&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg767">
+      <trans-unit id="_msg769">
         <source xml:space="preserve">Do you want to create this transaction?</source>
         <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
         <note annotates="source" from="developer">Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</note>
       </trans-unit>
-      <trans-unit id="_msg768">
+      <trans-unit id="_msg770">
         <source xml:space="preserve">Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</note>
       </trans-unit>
-      <trans-unit id="_msg769">
+      <trans-unit id="_msg771">
         <source xml:space="preserve">Please, review your transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
         <note annotates="source" from="developer">Text to prompt a user to review the details of the transaction they are attempting to send.</note>
       </trans-unit>
-      <trans-unit id="_msg770">
+      <trans-unit id="_msg772">
         <source xml:space="preserve">Transaction fee</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg771">
+      <trans-unit id="_msg773">
         <source xml:space="preserve">%1 kvB</source>
         <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT transaction creation</context></context-group>
         <note annotates="source" from="developer">When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with &quot;virtual size&quot; of the transaction displayed for context</note>
       </trans-unit>
-      <trans-unit id="_msg772">
+      <trans-unit id="_msg774">
         <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
         <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg773">
+      <trans-unit id="_msg775">
         <source xml:space="preserve">Total Amount</source>
         <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg774">
+      <trans-unit id="_msg776">
         <source xml:space="preserve">Unsigned Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT copied</context></context-group>
         <note annotates="source" from="developer">Caption of &quot;PSBT has been copied&quot; messagebox</note>
       </trans-unit>
-      <trans-unit id="_msg775">
+      <trans-unit id="_msg777">
         <source xml:space="preserve">The PSBT has been copied to the clipboard. You can also save it.</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg776">
-        <source xml:space="preserve">PSBT saved to disk</source>
-        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg777">
-        <source xml:space="preserve">Confirm send coins</source>
-        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg778">
-        <source xml:space="preserve">Watch-only balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
+        <source xml:space="preserve">PSBT saved to disk</source>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
       </trans-unit>
       <trans-unit id="_msg779">
-        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
-        <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
+        <source xml:space="preserve">Confirm send coins</source>
+        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
       </trans-unit>
       <trans-unit id="_msg780">
-        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
-        <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
+        <source xml:space="preserve">Watch-only balance:</source>
+        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
       </trans-unit>
       <trans-unit id="_msg781">
-        <source xml:space="preserve">The amount exceeds your balance.</source>
-        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
+        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
+        <context-group purpose="location"><context context-type="linenumber">736</context></context-group>
       </trans-unit>
       <trans-unit id="_msg782">
-        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
-        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
+        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
+        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
       </trans-unit>
       <trans-unit id="_msg783">
-        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
-        <context-group purpose="location"><context context-type="linenumber">747</context></context-group>
+        <source xml:space="preserve">The amount exceeds your balance.</source>
+        <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
       </trans-unit>
       <trans-unit id="_msg784">
-        <source xml:space="preserve">Transaction creation failed!</source>
-        <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
+        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
+        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
       </trans-unit>
       <trans-unit id="_msg785">
-        <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
-        <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
+        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
+        <context-group purpose="location"><context context-type="linenumber">748</context></context-group>
       </trans-unit>
       <trans-unit id="_msg786">
+        <source xml:space="preserve">Transaction creation failed!</source>
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg787">
+        <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
+        <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg788">
         <source xml:space="preserve">%1/kvB</source>
-        <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">868</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">834</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">869</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">882</context></context-group>
-        <trans-unit id="_msg787[0]">
+        <context-group purpose="location"><context context-type="linenumber">883</context></context-group>
+        <trans-unit id="_msg789[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
-        <trans-unit id="_msg787[1]">
+        <trans-unit id="_msg789[1]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg788">
-        <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
-        <context-group purpose="location"><context context-type="linenumber">977</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg789">
-        <source xml:space="preserve">Warning: Unknown change address</source>
-        <context-group purpose="location"><context context-type="linenumber">982</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg790">
-        <source xml:space="preserve">Confirm custom change address</source>
-        <context-group purpose="location"><context context-type="linenumber">985</context></context-group>
+        <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
+        <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
       </trans-unit>
       <trans-unit id="_msg791">
-        <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <context-group purpose="location"><context context-type="linenumber">985</context></context-group>
+        <source xml:space="preserve">Warning: Unknown change address</source>
+        <context-group purpose="location"><context context-type="linenumber">983</context></context-group>
       </trans-unit>
       <trans-unit id="_msg792">
+        <source xml:space="preserve">Confirm custom change address</source>
+        <context-group purpose="location"><context context-type="linenumber">986</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg793">
+        <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <context-group purpose="location"><context context-type="linenumber">986</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg794">
         <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">1006</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1007</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
-      <trans-unit id="_msg793">
+      <trans-unit id="_msg795">
         <source xml:space="preserve">A&amp;mount:</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg794">
+      <trans-unit id="_msg796">
         <source xml:space="preserve">Pay &amp;To:</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg795">
+      <trans-unit id="_msg797">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg796">
+      <trans-unit id="_msg798">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg797">
+      <trans-unit id="_msg799">
         <source xml:space="preserve">The Bitcoin address to send the payment to</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg798">
+      <trans-unit id="_msg800">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg799">
+      <trans-unit id="_msg801">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg800">
+      <trans-unit id="_msg802">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg801">
+      <trans-unit id="_msg803">
         <source xml:space="preserve">Remove this entry</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg802">
+      <trans-unit id="_msg804">
         <source xml:space="preserve">The amount to send in the selected unit</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg803">
+      <trans-unit id="_msg805">
         <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg804">
+      <trans-unit id="_msg806">
         <source xml:space="preserve">S&amp;ubtract fee from amount</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg805">
+      <trans-unit id="_msg807">
         <source xml:space="preserve">Use available balance</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg806">
+      <trans-unit id="_msg808">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg807">
+      <trans-unit id="_msg809">
         <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg808">
+      <trans-unit id="_msg810">
         <source xml:space="preserve">A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
@@ -3719,11 +3729,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendConfirmationDialog">
-      <trans-unit id="_msg809">
+      <trans-unit id="_msg811">
         <source xml:space="preserve">Send</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg810">
+      <trans-unit id="_msg812">
         <source xml:space="preserve">Create Unsigned</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
@@ -3731,105 +3741,105 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg811">
+      <trans-unit id="_msg813">
         <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg812">
+      <trans-unit id="_msg814">
         <source xml:space="preserve">&amp;Sign Message</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg813">
-        <source xml:space="preserve">You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+      <trans-unit id="_msg815">
+        <source xml:space="preserve">You can sign messages/agreements with your legacy (P2PKH) addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg814">
+      <trans-unit id="_msg816">
         <source xml:space="preserve">The Bitcoin address to sign the message with</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg815">
+      <trans-unit id="_msg817">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg816">
+      <trans-unit id="_msg818">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg817">
+      <trans-unit id="_msg819">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg818">
+      <trans-unit id="_msg820">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg819">
+      <trans-unit id="_msg821">
         <source xml:space="preserve">Enter the message you want to sign here</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg820">
+      <trans-unit id="_msg822">
         <source xml:space="preserve">Signature</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg821">
+      <trans-unit id="_msg823">
         <source xml:space="preserve">Copy the current signature to the system clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg822">
+      <trans-unit id="_msg824">
         <source xml:space="preserve">Sign the message to prove you own this Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg823">
+      <trans-unit id="_msg825">
         <source xml:space="preserve">Sign &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg824">
+      <trans-unit id="_msg826">
         <source xml:space="preserve">Reset all sign message fields</source>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg825">
+      <trans-unit id="_msg827">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg826">
+      <trans-unit id="_msg828">
         <source xml:space="preserve">&amp;Verify Message</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg827">
+      <trans-unit id="_msg829">
         <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg828">
+      <trans-unit id="_msg830">
         <source xml:space="preserve">The Bitcoin address the message was signed with</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg829">
+      <trans-unit id="_msg831">
         <source xml:space="preserve">The signed message to verify</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg830">
+      <trans-unit id="_msg832">
         <source xml:space="preserve">The signature given when the message was signed</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg831">
+      <trans-unit id="_msg833">
         <source xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg832">
+      <trans-unit id="_msg834">
         <source xml:space="preserve">Verify &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg833">
+      <trans-unit id="_msg835">
         <source xml:space="preserve">Reset all verify message fields</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg834">
+      <trans-unit id="_msg836">
         <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
@@ -3837,81 +3847,79 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg835">
-        <source xml:space="preserve">The entered address is invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg836">
-        <source xml:space="preserve">Please check the address and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg837">
-        <source xml:space="preserve">The entered address does not refer to a key.</source>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+        <source xml:space="preserve">The entered address is invalid.</source>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
       </trans-unit>
       <trans-unit id="_msg838">
-        <source xml:space="preserve">Wallet unlock was cancelled.</source>
-        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
       </trans-unit>
       <trans-unit id="_msg839">
-        <source xml:space="preserve">No error</source>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <source xml:space="preserve">The entered address does not refer to a legacy (P2PKH) key. Message signing for SegWit and other non-P2PKH address types is not supported in this version of %1. Please check the address and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
       <trans-unit id="_msg840">
-        <source xml:space="preserve">Private key for the entered address is not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
       <trans-unit id="_msg841">
-        <source xml:space="preserve">Message signing failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+        <source xml:space="preserve">No error</source>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
       <trans-unit id="_msg842">
-        <source xml:space="preserve">Message signed.</source>
-        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
       <trans-unit id="_msg843">
-        <source xml:space="preserve">The signature could not be decoded.</source>
-        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+        <source xml:space="preserve">Message signing failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
       <trans-unit id="_msg844">
-        <source xml:space="preserve">Please check the signature and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+        <source xml:space="preserve">Message signed.</source>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
       <trans-unit id="_msg845">
-        <source xml:space="preserve">The signature did not match the message digest.</source>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+        <source xml:space="preserve">The signature could not be decoded.</source>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
       </trans-unit>
       <trans-unit id="_msg846">
-        <source xml:space="preserve">Message verification failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+        <source xml:space="preserve">Please check the signature and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
       <trans-unit id="_msg847">
+        <source xml:space="preserve">The signature did not match the message digest.</source>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg848">
+        <source xml:space="preserve">Message verification failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg849">
         <source xml:space="preserve">Message verified.</source>
-        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../splashscreen.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SplashScreen">
-      <trans-unit id="_msg848">
+      <trans-unit id="_msg850">
         <source xml:space="preserve">(press q to shutdown and continue later)</source>
-        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg849">
+      <trans-unit id="_msg851">
         <source xml:space="preserve">press q to shutdown</source>
-        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
-      <trans-unit id="_msg850">
+      <trans-unit id="_msg852">
         <source xml:space="preserve">kB/s</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
@@ -3919,194 +3927,194 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondesc.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
-      <trans-unit id="_msg851">
+      <trans-unit id="_msg853">
         <source xml:space="preserve">conflicted with a transaction with %1 confirmations</source>
-        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg852">
+      <trans-unit id="_msg854">
         <source xml:space="preserve">0/unconfirmed, in memory pool</source>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg853">
+      <trans-unit id="_msg855">
         <source xml:space="preserve">0/unconfirmed, not in memory pool</source>
-        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg854">
+      <trans-unit id="_msg856">
         <source xml:space="preserve">abandoned</source>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg855">
+      <trans-unit id="_msg857">
         <source xml:space="preserve">%1/unconfirmed</source>
-        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg856">
+      <trans-unit id="_msg858">
         <source xml:space="preserve">%1 confirmations</source>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg857">
-        <source xml:space="preserve">Status</source>
-        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg858">
-        <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg859">
-        <source xml:space="preserve">Source</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <source xml:space="preserve">Status</source>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
       <trans-unit id="_msg860">
-        <source xml:space="preserve">Generated</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <source xml:space="preserve">Date</source>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
       <trans-unit id="_msg861">
-        <source xml:space="preserve">From</source>
-        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+        <source xml:space="preserve">Source</source>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
       <trans-unit id="_msg862">
-        <source xml:space="preserve">unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+        <source xml:space="preserve">Generated</source>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
       <trans-unit id="_msg863">
-        <source xml:space="preserve">To</source>
-        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+        <source xml:space="preserve">From</source>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
       <trans-unit id="_msg864">
-        <source xml:space="preserve">own address</source>
-        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+        <source xml:space="preserve">unknown</source>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
       <trans-unit id="_msg865">
-        <source xml:space="preserve">watch-only</source>
-        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+        <source xml:space="preserve">To</source>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
       <trans-unit id="_msg866">
-        <source xml:space="preserve">label</source>
-        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+        <source xml:space="preserve">own address</source>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
       <trans-unit id="_msg867">
+        <source xml:space="preserve">watch-only</source>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg868">
+        <source xml:space="preserve">label</source>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg869">
         <source xml:space="preserve">Credit</source>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
-        <trans-unit id="_msg868[0]">
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+        <trans-unit id="_msg870[0]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
-        <trans-unit id="_msg868[1]">
+        <trans-unit id="_msg870[1]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg869">
-        <source xml:space="preserve">not accepted</source>
-        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg870">
-        <source xml:space="preserve">Debit</source>
-        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg871">
-        <source xml:space="preserve">Total debit</source>
-        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+        <source xml:space="preserve">not accepted</source>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
       <trans-unit id="_msg872">
-        <source xml:space="preserve">Total credit</source>
-        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+        <source xml:space="preserve">Debit</source>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
       <trans-unit id="_msg873">
-        <source xml:space="preserve">Transaction fee</source>
-        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+        <source xml:space="preserve">Total debit</source>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
       <trans-unit id="_msg874">
-        <source xml:space="preserve">Net amount</source>
-        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+        <source xml:space="preserve">Total credit</source>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
       <trans-unit id="_msg875">
-        <source xml:space="preserve">Message</source>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+        <source xml:space="preserve">Transaction fee</source>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
       <trans-unit id="_msg876">
-        <source xml:space="preserve">Comment</source>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+        <source xml:space="preserve">Net amount</source>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
       <trans-unit id="_msg877">
-        <source xml:space="preserve">Transaction ID</source>
-        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+        <source xml:space="preserve">Message</source>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
       <trans-unit id="_msg878">
-        <source xml:space="preserve">Transaction total size</source>
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+        <source xml:space="preserve">Comment</source>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
       <trans-unit id="_msg879">
-        <source xml:space="preserve">Transaction virtual size</source>
-        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+        <source xml:space="preserve">Transaction ID</source>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
       <trans-unit id="_msg880">
-        <source xml:space="preserve">Output index</source>
-        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+        <source xml:space="preserve">Transaction total size</source>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
       <trans-unit id="_msg881">
-        <source xml:space="preserve">%1 (Certificate was not verified)</source>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+        <source xml:space="preserve">Transaction virtual size</source>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
       <trans-unit id="_msg882">
-        <source xml:space="preserve">Merchant</source>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+        <source xml:space="preserve">Output index</source>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
       <trans-unit id="_msg883">
-        <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+        <source xml:space="preserve">%1 (Certificate was not verified)</source>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
       <trans-unit id="_msg884">
-        <source xml:space="preserve">Debug information</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+        <source xml:space="preserve">Merchant</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
       <trans-unit id="_msg885">
-        <source xml:space="preserve">Transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+        <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
       <trans-unit id="_msg886">
-        <source xml:space="preserve">Inputs</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+        <source xml:space="preserve">Debug information</source>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
       <trans-unit id="_msg887">
-        <source xml:space="preserve">Amount</source>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+        <source xml:space="preserve">Transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
       <trans-unit id="_msg888">
-        <source xml:space="preserve">true</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+        <source xml:space="preserve">Inputs</source>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
       <trans-unit id="_msg889">
+        <source xml:space="preserve">Amount</source>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg890">
+        <source xml:space="preserve">true</source>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg891">
         <source xml:space="preserve">false</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg890">
+      <trans-unit id="_msg892">
         <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
@@ -4114,7 +4122,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg891">
+      <trans-unit id="_msg893">
         <source xml:space="preserve">Details for %1</source>
         <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
       </trans-unit>
@@ -4122,95 +4130,95 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
-      <trans-unit id="_msg892">
+      <trans-unit id="_msg894">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg893">
+      <trans-unit id="_msg895">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg894">
+      <trans-unit id="_msg896">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg895">
+      <trans-unit id="_msg897">
         <source xml:space="preserve">Unconfirmed</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg896">
+      <trans-unit id="_msg898">
         <source xml:space="preserve">Abandoned</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg897">
+      <trans-unit id="_msg899">
         <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg898">
+      <trans-unit id="_msg900">
         <source xml:space="preserve">Confirmed (%1 confirmations)</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg899">
+      <trans-unit id="_msg901">
         <source xml:space="preserve">Conflicted</source>
         <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg900">
+      <trans-unit id="_msg902">
         <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
         <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg901">
+      <trans-unit id="_msg903">
         <source xml:space="preserve">Generated but not accepted</source>
         <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg902">
+      <trans-unit id="_msg904">
         <source xml:space="preserve">Received with</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg903">
+      <trans-unit id="_msg905">
         <source xml:space="preserve">Received from</source>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg904">
+      <trans-unit id="_msg906">
         <source xml:space="preserve">Sent to</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg905">
+      <trans-unit id="_msg907">
         <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg906">
+      <trans-unit id="_msg908">
         <source xml:space="preserve">watch-only</source>
         <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg907">
+      <trans-unit id="_msg909">
         <source xml:space="preserve">(n/a)</source>
         <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg908">
+      <trans-unit id="_msg910">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">629</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg909">
+      <trans-unit id="_msg911">
         <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
         <context-group purpose="location"><context context-type="linenumber">668</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg910">
+      <trans-unit id="_msg912">
         <source xml:space="preserve">Date and time that the transaction was received.</source>
         <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg911">
+      <trans-unit id="_msg913">
         <source xml:space="preserve">Type of transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg912">
+      <trans-unit id="_msg914">
         <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg913">
+      <trans-unit id="_msg915">
         <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">676</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg914">
+      <trans-unit id="_msg916">
         <source xml:space="preserve">Amount removed from or added to balance.</source>
         <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
       </trans-unit>
@@ -4218,162 +4226,162 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactionview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionView">
-      <trans-unit id="_msg915">
+      <trans-unit id="_msg917">
         <source xml:space="preserve">All</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg916">
+      <trans-unit id="_msg918">
         <source xml:space="preserve">Today</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg917">
+      <trans-unit id="_msg919">
         <source xml:space="preserve">This week</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg918">
+      <trans-unit id="_msg920">
         <source xml:space="preserve">This month</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg919">
+      <trans-unit id="_msg921">
         <source xml:space="preserve">Last month</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg920">
+      <trans-unit id="_msg922">
         <source xml:space="preserve">This year</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg921">
+      <trans-unit id="_msg923">
         <source xml:space="preserve">Received with</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg922">
+      <trans-unit id="_msg924">
         <source xml:space="preserve">Sent to</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg923">
+      <trans-unit id="_msg925">
         <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg924">
+      <trans-unit id="_msg926">
         <source xml:space="preserve">Other</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg925">
+      <trans-unit id="_msg927">
         <source xml:space="preserve">Enter address, transaction id, or label to search</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg926">
+      <trans-unit id="_msg928">
         <source xml:space="preserve">Min amount</source>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg927">
+      <trans-unit id="_msg929">
         <source xml:space="preserve">Range…</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg928">
+      <trans-unit id="_msg930">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg929">
+      <trans-unit id="_msg931">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg930">
+      <trans-unit id="_msg932">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg931">
+      <trans-unit id="_msg933">
         <source xml:space="preserve">Copy transaction &amp;ID</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg932">
+      <trans-unit id="_msg934">
         <source xml:space="preserve">Copy &amp;raw transaction</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg933">
+      <trans-unit id="_msg935">
         <source xml:space="preserve">Copy full transaction &amp;details</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg934">
+      <trans-unit id="_msg936">
         <source xml:space="preserve">&amp;Show transaction details</source>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg935">
+      <trans-unit id="_msg937">
         <source xml:space="preserve">Increase transaction &amp;fee</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg936">
+      <trans-unit id="_msg938">
         <source xml:space="preserve">A&amp;bandon transaction</source>
         <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg937">
+      <trans-unit id="_msg939">
         <source xml:space="preserve">&amp;Edit address label</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg938">
+      <trans-unit id="_msg940">
         <source xml:space="preserve">Show in %1</source>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
         <note annotates="source" from="developer">Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</note>
       </trans-unit>
-      <trans-unit id="_msg939">
+      <trans-unit id="_msg941">
         <source xml:space="preserve">Export Transaction History</source>
         <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg940">
+      <trans-unit id="_msg942">
         <source xml:space="preserve">Comma separated file</source>
         <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
-      <trans-unit id="_msg941">
+      <trans-unit id="_msg943">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg942">
+      <trans-unit id="_msg944">
         <source xml:space="preserve">Watch-only</source>
         <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg943">
+      <trans-unit id="_msg945">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg944">
+      <trans-unit id="_msg946">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg945">
+      <trans-unit id="_msg947">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg946">
+      <trans-unit id="_msg948">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg947">
+      <trans-unit id="_msg949">
         <source xml:space="preserve">ID</source>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg948">
+      <trans-unit id="_msg950">
         <source xml:space="preserve">Exporting Failed</source>
         <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg949">
+      <trans-unit id="_msg951">
         <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg950">
+      <trans-unit id="_msg952">
         <source xml:space="preserve">Exporting Successful</source>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg951">
+      <trans-unit id="_msg953">
         <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg952">
+      <trans-unit id="_msg954">
         <source xml:space="preserve">Range:</source>
         <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg953">
+      <trans-unit id="_msg955">
         <source xml:space="preserve">to</source>
         <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
       </trans-unit>
@@ -4381,39 +4389,39 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../walletframe.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletFrame">
-      <trans-unit id="_msg954">
+      <trans-unit id="_msg956">
         <source xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg955">
+      <trans-unit id="_msg957">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg956">
+      <trans-unit id="_msg958">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg957">
+      <trans-unit id="_msg959">
         <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg958">
+      <trans-unit id="_msg960">
         <source xml:space="preserve">Load Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg959">
+      <trans-unit id="_msg961">
         <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg960">
+      <trans-unit id="_msg962">
         <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg961">
+      <trans-unit id="_msg963">
         <source xml:space="preserve">Unable to decode PSBT</source>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
@@ -4421,114 +4429,117 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../walletmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletModel">
-      <trans-unit id="_msg962">
-        <source xml:space="preserve">Send Coins</source>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg963">
-        <source xml:space="preserve">Fee bump error</source>
-        <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">564</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg964">
-        <source xml:space="preserve">Increasing transaction fee failed</source>
-        <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
+        <source xml:space="preserve">Send Coins</source>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
       </trans-unit>
       <trans-unit id="_msg965">
-        <source xml:space="preserve">Do you want to increase the fee?</source>
-        <context-group purpose="location"><context context-type="linenumber">501</context></context-group>
-        <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
+        <source xml:space="preserve">Fee bump error</source>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
       </trans-unit>
       <trans-unit id="_msg966">
-        <source xml:space="preserve">Current fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
+        <source xml:space="preserve">Increasing transaction fee failed</source>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
       </trans-unit>
       <trans-unit id="_msg967">
-        <source xml:space="preserve">Increase:</source>
-        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
+        <source xml:space="preserve">Do you want to increase the fee?</source>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
+        <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
       </trans-unit>
       <trans-unit id="_msg968">
-        <source xml:space="preserve">New fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
+        <source xml:space="preserve">Current fee:</source>
+        <context-group purpose="location"><context context-type="linenumber">502</context></context-group>
       </trans-unit>
       <trans-unit id="_msg969">
-        <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
+        <source xml:space="preserve">Increase:</source>
+        <context-group purpose="location"><context context-type="linenumber">506</context></context-group>
       </trans-unit>
       <trans-unit id="_msg970">
-        <source xml:space="preserve">Confirm fee bump</source>
-        <context-group purpose="location"><context context-type="linenumber">526</context></context-group>
+        <source xml:space="preserve">New fee:</source>
+        <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
       </trans-unit>
       <trans-unit id="_msg971">
-        <source xml:space="preserve">Can&apos;t draft transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
+        <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
       </trans-unit>
       <trans-unit id="_msg972">
-        <source xml:space="preserve">PSBT copied</source>
-        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+        <source xml:space="preserve">Confirm fee bump</source>
+        <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
       </trans-unit>
       <trans-unit id="_msg973">
-        <source xml:space="preserve">Copied to clipboard</source>
-        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
-        <context-group><context context-type="x-gettext-msgctxt">Fee-bump PSBT saved</context></context-group>
+        <source xml:space="preserve">Can&apos;t draft transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
       </trans-unit>
       <trans-unit id="_msg974">
-        <source xml:space="preserve">Can&apos;t sign transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">564</context></context-group>
+        <source xml:space="preserve">PSBT copied</source>
+        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
       <trans-unit id="_msg975">
-        <source xml:space="preserve">Could not commit transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
+        <source xml:space="preserve">Fee-bump PSBT copied to clipboard</source>
+        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
       <trans-unit id="_msg976">
-        <source xml:space="preserve">Can&apos;t display address</source>
-        <context-group purpose="location"><context context-type="linenumber">583</context></context-group>
+        <source xml:space="preserve">Can&apos;t sign transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
       </trans-unit>
       <trans-unit id="_msg977">
+        <source xml:space="preserve">Could not commit transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg978">
+        <source xml:space="preserve">Signer error</source>
+        <context-group purpose="location"><context context-type="linenumber">578</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg979">
+        <source xml:space="preserve">Can&apos;t display address</source>
+        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg980">
         <source xml:space="preserve">default wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">601</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">598</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletView">
-      <trans-unit id="_msg978">
+      <trans-unit id="_msg981">
         <source xml:space="preserve">&amp;Export</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg979">
+      <trans-unit id="_msg982">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg980">
+      <trans-unit id="_msg983">
         <source xml:space="preserve">Backup Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg981">
+      <trans-unit id="_msg984">
         <source xml:space="preserve">Wallet Data</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg982">
+      <trans-unit id="_msg985">
         <source xml:space="preserve">Backup Failed</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg983">
+      <trans-unit id="_msg986">
         <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg984">
+      <trans-unit id="_msg987">
         <source xml:space="preserve">Backup Successful</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg985">
+      <trans-unit id="_msg988">
         <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg986">
+      <trans-unit id="_msg989">
         <source xml:space="preserve">Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
@@ -4536,902 +4547,1015 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../bitcoinstrings.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
-      <trans-unit id="_msg987">
+      <trans-unit id="_msg990">
         <source xml:space="preserve">The %s developers</source>
         <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg988">
+      <trans-unit id="_msg991">
         <source xml:space="preserve">%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
         <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg989">
+      <trans-unit id="_msg992">
         <source xml:space="preserve">%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
         <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg990">
+      <trans-unit id="_msg993">
         <source xml:space="preserve">%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
         <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg991">
+      <trans-unit id="_msg994">
         <source xml:space="preserve">Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg992">
-        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg993">
-        <source xml:space="preserve">Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg994">
-        <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg995">
-        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
       <trans-unit id="_msg996">
-        <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
-        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+        <source xml:space="preserve">Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
       <trans-unit id="_msg997">
-        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+        <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
       <trans-unit id="_msg998">
-        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
       <trans-unit id="_msg999">
-        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+        <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1000">
-        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1001">
-        <source xml:space="preserve">Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
-        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1002">
-        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
-        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1003">
-        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1004">
-        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+        <source xml:space="preserve">Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1005">
-        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1006">
-        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1007">
-        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1008">
-        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
+        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1009">
-        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1010">
-        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1011">
-        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1012">
-        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1013">
-        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1014">
-        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1015">
-        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg1014">
+        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1015">
+        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg1016">
-        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1017">
-        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
+        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1018">
-        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1019">
-        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1020">
-        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1021">
-        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1022">
-        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1023">
-        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
+        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1024">
-        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1025">
-        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1026">
-        <source xml:space="preserve">Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
+        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1027">
-        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1028">
-        <source xml:space="preserve">Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
-        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+        <source xml:space="preserve">Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1029">
-        <source xml:space="preserve">Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1030">
-        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+        <source xml:space="preserve">Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1031">
-        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+        <source xml:space="preserve">Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1032">
-        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1033">
-        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1034">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1035">
-        <source xml:space="preserve">%s is set very high!</source>
-        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1036">
-        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1037">
-        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
+        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1038">
-        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+      <trans-unit id="_msg1034">
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1039">
-        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
-        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1040">
-        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1041">
-        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+      <trans-unit id="_msg1035">
+        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg1036">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1037">
+        <source xml:space="preserve">%s is set very high!</source>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1038">
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1039">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1040">
+        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1041">
+        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg1042">
+        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1043">
         <source xml:space="preserve">%s is set very high! Fees this large could be paid on a single transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1043">
-        <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
-        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg1044">
-        <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
-        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+        <source xml:space="preserve">A forked headers-chain with more work than the chain with the snapshot base block header exists. Please proceed to sync without AssumeUtxo.</source>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1045">
-        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+        <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1046">
-        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+        <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1047">
-        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
-        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1048">
-        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1049">
-        <source xml:space="preserve">Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1050">
-        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1051">
-        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+        <source xml:space="preserve">Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1052">
-        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
-        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+        <source xml:space="preserve">Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
+</source>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1053">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1054">
-        <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
-        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1055">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
-        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+        <source xml:space="preserve">Flushing block file to disk failed. This is likely the result of an I/O error.</source>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1056">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
-        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+        <source xml:space="preserve">Flushing undo file to disk failed. This is likely the result of an I/O error.</source>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1057">
-        <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1058">
-        <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1059">
-        <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
-        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+        <source xml:space="preserve">Maximum transaction weight is less than transaction weight without inputs</source>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1060">
-        <source xml:space="preserve">Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
-        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+        <source xml:space="preserve">Maximum transaction weight is too low, can not accommodate change output</source>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1061">
-        <source xml:space="preserve">UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
-        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+        <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1062">
-        <source xml:space="preserve">Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
-        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1063">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1064">
+        <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1065">
+        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1066">
+        <source xml:space="preserve">The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1067">
+        <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1068">
+        <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1069">
+        <source xml:space="preserve">Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1070">
+        <source xml:space="preserve">UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1071">
+        <source xml:space="preserve">Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1072">
         <source xml:space="preserve">Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1064">
+      <trans-unit id="_msg1073">
         <source xml:space="preserve">Unrecognized descriptor found. Loading wallet %s
 
 The wallet might had been created on a newer version.
 Please try running the latest software version.
 </source>
-        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1065">
-        <source xml:space="preserve">
-Unable to cleanup failed migration</source>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1066">
-        <source xml:space="preserve">
-Unable to restore backup of wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1067">
-        <source xml:space="preserve">Block verification was interrupted</source>
-        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1068">
-        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
-        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1069">
-        <source xml:space="preserve">Copyright (C) %i-%i</source>
-        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1070">
-        <source xml:space="preserve">Corrupted block database detected</source>
-        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1071">
-        <source xml:space="preserve">Could not find asmap file %s</source>
-        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1072">
-        <source xml:space="preserve">Could not parse asmap file %s</source>
-        <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1073">
-        <source xml:space="preserve">Disk space is too low!</source>
-        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1074">
-        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+        <source xml:space="preserve">Your computer&apos;s date and time appear to be more than %d minutes out of sync with the network, this may lead to consensus failure. After you&apos;ve confirmed your computer&apos;s clock, this message should no longer appear when you restart your node. Without a restart, it should stop showing automatically after you&apos;ve connected to a sufficient number of new outbound peers, which may take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` RPC methods to get more info.</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1075">
-        <source xml:space="preserve">Done loading</source>
-        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1076">
-        <source xml:space="preserve">Dump file %s does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1077">
-        <source xml:space="preserve">Error committing db txn for wallet transactions removal</source>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1078">
-        <source xml:space="preserve">Error creating %s</source>
-        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1079">
-        <source xml:space="preserve">Error initializing block database</source>
-        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1080">
-        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
-        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1081">
-        <source xml:space="preserve">Error loading %s</source>
+        <source xml:space="preserve">
+Unable to cleanup failed migration</source>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1082">
-        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
-        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1083">
-        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
-        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1084">
-        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+      <trans-unit id="_msg1076">
+        <source xml:space="preserve">
+Unable to restore backup of wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1085">
-        <source xml:space="preserve">Error loading block database</source>
-        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1086">
-        <source xml:space="preserve">Error opening block database</source>
-        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1087">
-        <source xml:space="preserve">Error reading configuration file: %s</source>
+      <trans-unit id="_msg1077">
+        <source xml:space="preserve">whitebind may only be used for incoming connections (&quot;out&quot; was passed)</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1088">
-        <source xml:space="preserve">Error reading from database, shutting down.</source>
-        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1089">
-        <source xml:space="preserve">Error reading next record from wallet database</source>
-        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1090">
-        <source xml:space="preserve">Error starting db txn for wallet transactions removal</source>
-        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1091">
-        <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
+      <trans-unit id="_msg1078">
+        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details: </source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1092">
-        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
-        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1093">
-        <source xml:space="preserve">Error: Disk space is low for %s</source>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1094">
-        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
-        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1095">
-        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1096">
-        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1097">
-        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1098">
-        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
-        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1099">
-        <source xml:space="preserve">Error: Missing checksum</source>
-        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1100">
-        <source xml:space="preserve">Error: No %s addresses available.</source>
-        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1101">
-        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
-        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1102">
-        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1103">
-        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
-        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1104">
-        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1105">
-        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1106">
-        <source xml:space="preserve">Error: Unable to read all records in the database</source>
-        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1107">
-        <source xml:space="preserve">Error: Unable to read wallet&apos;s best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1108">
-        <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
-        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1109">
-        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1110">
-        <source xml:space="preserve">Error: Unable to write solvable wallet best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1111">
-        <source xml:space="preserve">Error: Unable to write watchonly wallet best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1112">
-        <source xml:space="preserve">Error: address book copy failed for wallet %s</source>
-        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1113">
-        <source xml:space="preserve">Error: database transaction cannot be executed for wallet %s</source>
-        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1114">
-        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1115">
-        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1116">
-        <source xml:space="preserve">Failed to start indexes, shutting down..</source>
-        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1117">
-        <source xml:space="preserve">Failed to verify database</source>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1118">
-        <source xml:space="preserve">Failure removing transaction: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1119">
-        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1120">
-        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1121">
-        <source xml:space="preserve">Importing…</source>
-        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1122">
-        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1123">
-        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
-        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1124">
-        <source xml:space="preserve">Input not found or already spent</source>
-        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1125">
-        <source xml:space="preserve">Insufficient dbcache for block verification</source>
-        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1126">
-        <source xml:space="preserve">Insufficient funds</source>
-        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1127">
-        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1128">
-        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1129">
-        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1130">
-        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1131">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1132">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1133">
-        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1134">
-        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1135">
-        <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1136">
-        <source xml:space="preserve">Invalid pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1137">
-        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1138">
-        <source xml:space="preserve">Loading P2P addresses…</source>
-        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1139">
-        <source xml:space="preserve">Loading banlist…</source>
-        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1140">
-        <source xml:space="preserve">Loading block index…</source>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1141">
-        <source xml:space="preserve">Loading wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1142">
-        <source xml:space="preserve">Missing amount</source>
-        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1143">
-        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1144">
-        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1145">
-        <source xml:space="preserve">No addresses available</source>
-        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1146">
-        <source xml:space="preserve">Not enough file descriptors available.</source>
-        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1147">
-        <source xml:space="preserve">Not found pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1148">
-        <source xml:space="preserve">Not solvable pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1149">
-        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1150">
-        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1151">
-        <source xml:space="preserve">Pruning blockstore…</source>
-        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1152">
-        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1153">
-        <source xml:space="preserve">Replaying blocks…</source>
-        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1154">
-        <source xml:space="preserve">Rescanning…</source>
-        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1155">
-        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1156">
-        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1157">
-        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1158">
-        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1159">
-        <source xml:space="preserve">Section [%s] is not recognized.</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1160">
-        <source xml:space="preserve">Signing transaction failed</source>
-        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1161">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
-        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1162">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
-        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1163">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
-        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1164">
-        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1165">
-        <source xml:space="preserve">Specified data directory &quot;%s&quot; does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1166">
-        <source xml:space="preserve">Starting network threads…</source>
-        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1167">
-        <source xml:space="preserve">The source code is available from %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1168">
-        <source xml:space="preserve">The specified config file %s does not exist</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1169">
-        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
-        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1170">
-        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
-        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1171">
-        <source xml:space="preserve">This is experimental software.</source>
-        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1172">
-        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1173">
-        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1174">
-        <source xml:space="preserve">Transaction %s does not belong to this wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1175">
-        <source xml:space="preserve">Transaction amount too small</source>
-        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1176">
-        <source xml:space="preserve">Transaction amounts must not be negative</source>
-        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1177">
-        <source xml:space="preserve">Transaction change output index out of range</source>
-        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1178">
-        <source xml:space="preserve">Transaction must have at least one recipient</source>
-        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1179">
-        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
-        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1180">
-        <source xml:space="preserve">Transaction too large</source>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1181">
-        <source xml:space="preserve">Unable to allocate memory for -maxsigcachesize: &apos;%s&apos; MiB</source>
-        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1182">
-        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1183">
-        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1184">
-        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1185">
-        <source xml:space="preserve">Unable to find UTXO for external input</source>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1186">
-        <source xml:space="preserve">Unable to generate initial keys</source>
-        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1187">
-        <source xml:space="preserve">Unable to generate keys</source>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1188">
-        <source xml:space="preserve">Unable to open %s for writing</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1189">
-        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1190">
-        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1191">
-        <source xml:space="preserve">Unable to unload the wallet before migrating</source>
-        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1192">
-        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1193">
-        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1194">
-        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1195">
-        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1196">
-        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
-        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1197">
-        <source xml:space="preserve">Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1198">
-        <source xml:space="preserve">Wallet file creation failed: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1199">
-        <source xml:space="preserve">acceptstalefeeestimates is not supported on %s chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1200">
-        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
-        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1201">
-        <source xml:space="preserve">Error: Could not add watchonly tx %s to watchonly wallet</source>
+      <trans-unit id="_msg1079">
+        <source xml:space="preserve">Assumeutxo data not found for the given blockhash &apos;%s&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1202">
-        <source xml:space="preserve">Error: Could not delete watchonly transactions. </source>
+      <trans-unit id="_msg1080">
+        <source xml:space="preserve">Block verification was interrupted</source>
         <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1203">
-        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
-        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+      <trans-unit id="_msg1081">
+        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1204">
-        <source xml:space="preserve">Verifying blocks…</source>
-        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+      <trans-unit id="_msg1082">
+        <source xml:space="preserve">Copyright (C) %i-%i</source>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1205">
-        <source xml:space="preserve">Verifying wallet(s)…</source>
-        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      <trans-unit id="_msg1083">
+        <source xml:space="preserve">Corrupt block found indicating potential hardware failure.</source>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1206">
-        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
-        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      <trans-unit id="_msg1084">
+        <source xml:space="preserve">Corrupted block database detected</source>
+        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1207">
-        <source xml:space="preserve">Settings file could not be read</source>
+      <trans-unit id="_msg1085">
+        <source xml:space="preserve">Could not find asmap file %s</source>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1086">
+        <source xml:space="preserve">Could not parse asmap file %s</source>
+        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1087">
+        <source xml:space="preserve">Disk space is too low!</source>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1088">
+        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1089">
+        <source xml:space="preserve">Done loading</source>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1090">
+        <source xml:space="preserve">Dump file %s does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1091">
+        <source xml:space="preserve">Elliptic curve cryptography sanity check failure. %s is shutting down.</source>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1092">
+        <source xml:space="preserve">Error committing db txn for wallet transactions removal</source>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1093">
+        <source xml:space="preserve">Error creating %s</source>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1094">
+        <source xml:space="preserve">Error initializing block database</source>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1095">
+        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1096">
+        <source xml:space="preserve">Error loading %s</source>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1097">
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1098">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1099">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1100">
+        <source xml:space="preserve">Error loading block database</source>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1101">
+        <source xml:space="preserve">Error opening block database</source>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1102">
+        <source xml:space="preserve">Error reading configuration file: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1103">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1104">
+        <source xml:space="preserve">Error reading next record from wallet database</source>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1105">
+        <source xml:space="preserve">Error starting db txn for wallet transactions removal</source>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1106">
+        <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1107">
+        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1108">
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1109">
+        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1110">
+        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1111">
+        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1112">
+        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1113">
+        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1114">
+        <source xml:space="preserve">Error: Missing checksum</source>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1115">
+        <source xml:space="preserve">Error: No %s addresses available.</source>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1116">
+        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1117">
+        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1118">
+        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1119">
+        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1120">
+        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1121">
+        <source xml:space="preserve">Error: Unable to read all records in the database</source>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1122">
+        <source xml:space="preserve">Error: Unable to read wallet&apos;s best block locator record</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1123">
+        <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1124">
+        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1125">
+        <source xml:space="preserve">Error: Unable to write solvable wallet best block locator record</source>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1126">
+        <source xml:space="preserve">Error: Unable to write watchonly wallet best block locator record</source>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1127">
+        <source xml:space="preserve">Error: address book copy failed for wallet %s</source>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1128">
+        <source xml:space="preserve">Error: database transaction cannot be executed for wallet %s</source>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1129">
+        <source xml:space="preserve">Failed to connect best block (%s).</source>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1130">
+        <source xml:space="preserve">Failed to disconnect block.</source>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1131">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1132">
+        <source xml:space="preserve">Failed to read block.</source>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1133">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1134">
+        <source xml:space="preserve">Failed to start indexes, shutting down..</source>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1135">
+        <source xml:space="preserve">Failed to verify database</source>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1136">
+        <source xml:space="preserve">Failed to write block.</source>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1137">
+        <source xml:space="preserve">Failed to write to block index database.</source>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1138">
+        <source xml:space="preserve">Failed to write to coin database.</source>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1139">
+        <source xml:space="preserve">Failed to write undo data.</source>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1140">
+        <source xml:space="preserve">Failure removing transaction: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1141">
+        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1142">
+        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1143">
+        <source xml:space="preserve">Importing…</source>
         <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1208">
-        <source xml:space="preserve">Settings file could not be written</source>
+      <trans-unit id="_msg1144">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
         <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1145">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1146">
+        <source xml:space="preserve">Input not found or already spent</source>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1147">
+        <source xml:space="preserve">Insufficient dbcache for block verification</source>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1148">
+        <source xml:space="preserve">Insufficient funds</source>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1149">
+        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1150">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1151">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1152">
+        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1153">
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1154">
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1155">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1156">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1157">
+        <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1158">
+        <source xml:space="preserve">Invalid pre-selected input %s</source>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1159">
+        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1160">
+        <source xml:space="preserve">Loading P2P addresses…</source>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1161">
+        <source xml:space="preserve">Loading banlist…</source>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1162">
+        <source xml:space="preserve">Loading block index…</source>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1163">
+        <source xml:space="preserve">Loading wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1164">
+        <source xml:space="preserve">Maximum transaction weight must be between %d and %d</source>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1165">
+        <source xml:space="preserve">Missing amount</source>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1166">
+        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1167">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1168">
+        <source xml:space="preserve">No addresses available</source>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1169">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1170">
+        <source xml:space="preserve">Not found pre-selected input %s</source>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1171">
+        <source xml:space="preserve">Not solvable pre-selected input %s</source>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1172">
+        <source xml:space="preserve">Only direction was set, no permissions: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1173">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1174">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1175">
+        <source xml:space="preserve">Pruning blockstore…</source>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1176">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1177">
+        <source xml:space="preserve">Replaying blocks…</source>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1178">
+        <source xml:space="preserve">Rescanning…</source>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1179">
+        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1180">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1181">
+        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1182">
+        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1183">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1184">
+        <source xml:space="preserve">Signer did not echo address</source>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1185">
+        <source xml:space="preserve">Signer echoed unexpected address %s</source>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1186">
+        <source xml:space="preserve">Signer returned error: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1187">
+        <source xml:space="preserve">Signing transaction failed</source>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1188">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1189">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1190">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1191">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1192">
+        <source xml:space="preserve">Specified data directory &quot;%s&quot; does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1193">
+        <source xml:space="preserve">Starting network threads…</source>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1194">
+        <source xml:space="preserve">System error while flushing: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1195">
+        <source xml:space="preserve">System error while loading external block file: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1196">
+        <source xml:space="preserve">System error while saving block to disk: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1197">
+        <source xml:space="preserve">The source code is available from %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1198">
+        <source xml:space="preserve">The specified config file %s does not exist</source>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1199">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1200">
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1201">
+        <source xml:space="preserve">There is no ScriptPubKeyManager for this address</source>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1202">
+        <source xml:space="preserve">This is experimental software.</source>
+        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1203">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1204">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1205">
+        <source xml:space="preserve">Transaction %s does not belong to this wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1206">
+        <source xml:space="preserve">Transaction amount too small</source>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1207">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1208">
+        <source xml:space="preserve">Transaction change output index out of range</source>
+        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1209">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1210">
+        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1211">
+        <source xml:space="preserve">Transaction too large</source>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1212">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1213">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1214">
+        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1215">
+        <source xml:space="preserve">Unable to find UTXO for external input</source>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1216">
+        <source xml:space="preserve">Unable to generate initial keys</source>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1217">
+        <source xml:space="preserve">Unable to generate keys</source>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1218">
+        <source xml:space="preserve">Unable to open %s for writing</source>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1219">
+        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1220">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1221">
+        <source xml:space="preserve">Unable to unload the wallet before migrating</source>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1222">
+        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1223">
+        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1224">
+        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1225">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1226">
+        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1227">
+        <source xml:space="preserve">Unrecognised option &quot;%s&quot; provided in -test=&lt;option&gt;.</source>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1228">
+        <source xml:space="preserve">Unsupported global logging level %s=%s. Valid values: %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1229">
+        <source xml:space="preserve">Wallet file creation failed: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1230">
+        <source xml:space="preserve">acceptstalefeeestimates is not supported on %s chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1231">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1232">
+        <source xml:space="preserve">Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1233">
+        <source xml:space="preserve">Error: Could not delete watchonly transactions. </source>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1234">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1235">
+        <source xml:space="preserve">Verifying blocks…</source>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1236">
+        <source xml:space="preserve">Verifying wallet(s)…</source>
+        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1237">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1238">
+        <source xml:space="preserve">Settings file could not be read</source>
+        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1239">
+        <source xml:space="preserve">Settings file could not be written</source>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
       </trans-unit>
     </group>
   </body></file>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -258,36 +258,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekundo</numerusform>
+            <numerusform>%n sekundoj</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutoj</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n horo</numerusform>
+            <numerusform>%n horoj</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n tago</numerusform>
+            <numerusform>%n tagoj</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semajno</numerusform>
+            <numerusform>%n semajnoj</numerusform>
         </translation>
     </message>
     <message>
@@ -297,8 +297,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n jaro</numerusform>
+            <numerusform>%n jaroj</numerusform>
         </translation>
     </message>
     </context>
@@ -834,8 +834,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n gigabajto de libera loko disponeble</numerusform>
+            <numerusform>%n gigabajtoj de libera loko disponebla.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -2142,6 +2142,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Signing transaction failed</source>
         <translation type="unfinished">Subskriba transakcio fiaskis</translation>
+    </message>
+    <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">la elektita dosierujo por datumoj "%s" ne ekzistas.</translation>
     </message>
     <message>
         <source>This is experimental software.</source>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -520,7 +520,7 @@ Solo es posible firmar con direcciones de tipo "legacy".</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Firmar mensajes con tus direcciones Bitcoin para probar la propiedad</translation>
+        <translation type="unfinished">Firmar mensajes con tus direcciones de Bitcoin para probar la propiedad</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -1252,7 +1252,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (se requiere para la firma externa)</translation>
     </message>
 </context>
 <context>
@@ -1562,7 +1562,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Dirección IP del proxy (por ejemplo, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">Dirección IP del proxy (p. ej., IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
@@ -1570,7 +1570,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación sólo se cerrará después de seleccionar "Salir" en el menú.</translation>
+        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana esté cerrada. Cuando se activa esta opción, la aplicación solo se cerrará después de seleccionar "Salir" en el menú.</translation>
     </message>
     <message>
         <source>Font in the Overview tab: </source>
@@ -1611,7 +1611,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     <message>
         <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
-        <translation type="unfinished">Tamaño máximo de la caché de la base de datos. Una caché más grande puede contribuir a una sincronización más rápida, después de lo cual el beneficio es menos pronunciado para la mayoría de los casos de uso. Disminuir el tamaño de la caché reducirá el uso de la memoria. La memoria mempool no utilizada se comparte para esta caché.</translation>
+        <translation type="unfinished">Tamaño máximo de la caché de la base de datos. Una caché más grande puede contribuir a una sincronización más rápida, después de lo cual el beneficio es menos pronunciado para la mayoría de los casos de uso. Disminuir el tamaño de la caché reducirá el uso de la memoria. La memoria del mempool no utilizada se comparte para esta caché.</translation>
     </message>
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
@@ -1665,12 +1665,12 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Activar controles &amp;TBPF</translation>
+        <translation type="unfinished">Activar controles de &amp;TBPF</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Establecer si se muestran los controles TBPF</translation>
+        <translation type="unfinished">Establecer si se muestran los controles de TBPF</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -1774,7 +1774,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">URL de terceros (por ejemplo, un explorador de bloques) que aparecen en la pestaña de transacciones como elementos del menú contextual. %s en la URL se sustituye por el hash de la transacción. Las URL múltiples se separan con una barra vertical |.</translation>
+        <translation type="unfinished">URL de terceros (por ejemplo, un explorador de bloques) que aparecen en la pestaña de transacciones como elementos del menú contextual. %s en la URL se sustituye por el hash de la transacción. Las URL múltiples se separan con una barra vertical (|).</translation>
     </message>
     <message>
         <source>&amp;Third-party transaction URLs</source>
@@ -1803,7 +1803,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (requerido para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (se requiere para la firma externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1903,7 +1903,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     </message>
     <message>
         <source>Immature:</source>
-        <translation type="unfinished">Inmadura:</translation>
+        <translation type="unfinished">Inmaduro:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
@@ -1950,7 +1950,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     <name>PSBTOperationsDialog</name>
     <message>
         <source>PSBT Operations</source>
-        <translation type="unfinished">Operaciones TBPF</translation>
+        <translation type="unfinished">Operaciones de TBPF</translation>
     </message>
     <message>
         <source>Sign Tx</source>
@@ -2063,7 +2063,7 @@ El proceso de migración creará una copia de seguridad del monedero antes de mi
     </message>
     <message>
         <source>(But no wallet is loaded.)</source>
-        <translation type="unfinished">(No existe ningún monedero cargado).</translation>
+        <translation type="unfinished">(No hay ningún monedero cargado).</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -2114,7 +2114,7 @@ Si recibes este error, debes solicitar al comerciante que te proporcione un URI 
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Gestión del archivo de solicitud de pago</translation>
+        <translation type="unfinished">Gestión de archivos de solicitud de pago</translation>
     </message>
 </context>
 <context>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -299,6 +299,10 @@ Solo es posible firmar con direcciones de tipo legacy.</translation>
         <translation type="unfinished">desconocido</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">"%1" integrado</translation>
+    </message>
+    <message>
         <source>Default system font "%1"</source>
         <translation type="unfinished">Fuente predeterminada del sistema "%1"</translation>
     </message>
@@ -704,7 +708,7 @@ Solo es posible firmar con direcciones de tipo legacy.</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Ocultar los valores en la pestaña de vista general</translation>
+        <translation type="unfinished">Ocultar los valores en la pestaña "Vista general"</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -1087,11 +1091,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Guiones vigilantes han sido migrados a un monedero con el nombre '%1'.</translation>
+        <translation type="unfinished">Los scripts solo de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Solucionable pero ninguno de los guiones vigilados han sido migrados a un monedero llamados '%1'.</translation>
+        <translation type="unfinished">Los scripts solucionables pero no de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -1565,7 +1569,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Font in the Overview tab: </source>
-        <translation type="unfinished">Fuente en la pestaña Resumen:</translation>
+        <translation type="unfinished">Fuente en la pestaña "Vista general":</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -2646,7 +2650,7 @@ Para obtener más información sobre cómo usar esta consola, escribe %6.
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>From</source>
@@ -3121,7 +3125,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>%1 from wallet '%2'</source>
-        <translation type="unfinished">%1 desde monedero "%2"</translation>
+        <translation type="unfinished">%1 desde billetera "%2"</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
@@ -3194,7 +3198,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">¡Fallo al crear la transacción!</translation>
+        <translation type="unfinished">Fallo al crear la transacción</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
@@ -3510,7 +3514,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>own address</source>
@@ -4342,7 +4346,7 @@ Ir a "Archivo &gt; Abrir billetera" para cargar una.
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <translation type="unfinished">Se encontró una entrada heredada inesperada en la billetera basada en descriptores. Cargando billetera%s
+        <translation type="unfinished">Se encontró una entrada inesperada tipo "legacy" en la billetera basada en descriptores. Cargando billetera%s
 
 Es posible que la billetera haya sido manipulada o creada con malas intenciones.
 </translation>
@@ -4533,7 +4537,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to read wallet's best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de leer el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo leer el registro del mejor localizador de bloques de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to remove watchonly address book data</source>
@@ -4545,16 +4549,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to write solvable wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solucionable.</translation>
     </message>
     <message>
         <source>Error: Unable to write watchonly wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor monedero vigilado del bloque del registro localizador</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: address book copy failed for wallet %s</source>
-        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera 1%s
- </translation>
+        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera %s</translation>
     </message>
     <message>
         <source>Error: database transaction cannot be executed for wallet %s</source>
@@ -4578,7 +4581,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failure removing transaction: %s</source>
-        <translation type="unfinished">Error al eliminar la transacción: 1%s</translation>
+        <translation type="unfinished">Error al eliminar la transacción: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4898,7 +4901,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
-        <translation type="unfinished">Creación errónea del fichero monedero: %s</translation>
+        <translation type="unfinished">Error al crear el archivo de la billetera: %s</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
@@ -4910,11 +4913,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
-        <translation type="unfinished">Error: no pudo agregar tx de solo vigía %s para monedero de solo vigía</translation>
+        <translation type="unfinished">Error: No se pudo agregar la transacción %s a la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: Could not delete watchonly transactions. </source>
-        <translation type="unfinished">Error: no se pudieron eliminar las transacciones de watchonly.</translation>
+        <translation type="unfinished">Error: No se pudieron eliminar las transacciones solo de observación</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Click derecho para editar la dirección o etiqueta</translation>
+        <translation type="unfinished">Hacer clic derecho para editar la dirección o etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -11,11 +11,11 @@
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;Nuevo</translation>
+        <translation type="unfinished">&amp;Nueva</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Copie las direcciones seleccionadas actualmente al portapapeles del sistema</translation>
+        <translation type="unfinished">Copiar la dirección seleccionada actualmente al portapapeles del sistema</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -23,19 +23,19 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">C&amp;errar</translation>
+        <translation type="unfinished">&amp;Cerrar</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Borrar las direcciones seleccionadas recientemente de la lista</translation>
+        <translation type="unfinished">Eliminar la dirección seleccionada de la lista</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Introduzca una dirección o etiqueta que buscar</translation>
+        <translation type="unfinished">Ingresar una dirección o etiqueta para buscar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar los datos en la pestaña actual a un archivo</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -47,32 +47,33 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Escoja la direccion a enviar las monedas</translation>
+        <translation type="unfinished">Elige la dirección a la que se enviarán monedas</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Elige la dirección para recibir monedas</translation>
+        <translation type="unfinished">Elige la dirección con la que se recibirán monedas</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">Escoger</translation>
+        <translation type="unfinished">&amp;Seleccionar</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estas son tus direcciones Bitcoin para realizar pagos. Verifica siempre el monto y la dirección de recepción antes de enviar monedas. </translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para enviar pagos. Revisa siempre el importe y la dirección de recepción antes de enviar monedas.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Estas son tus direcciones de Bitcoin para recibir pagos. Utilice el botón 'Crear nueva dirección de recepción' en la pestaña Recibir para crear nuevas direcciones. La firma solo es posible con direcciones del tipo 'legacy'</translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para recibir pagos. Usa el botón "Crear nueva dirección de recepción" en la pestaña "Recibir" para crear nuevas direcciones.
+Solo es posible firmar con direcciones de tipo legacy.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">Copiar dirección</translation>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar &amp;Etiqueta</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -90,12 +91,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Tuvimos un problema al guardar la dirección en la lista %1. Intenta de Nuevo.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar la lista de direcciones en %1. Inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">Direcciones de envío - %1</translation>
     </message>
     <message>
         <source>Receiving addresses - %1</source>
-        <translation type="unfinished">Recepción de direcciones - %1
-</translation>
+        <translation type="unfinished">Direcciones de recepción - %1</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -106,11 +110,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">Direccion</translation>
+        <translation type="unfinished">Dirección</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -121,11 +125,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">Diálogo contraseña</translation>
+        <translation type="unfinished">Diálogo de frase de contraseña</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">Ingresa frase de contraseña</translation>
+        <translation type="unfinished">Ingresar la frase de contraseña</translation>
     </message>
     <message>
         <source>New passphrase</source>
@@ -133,92 +137,91 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Repetir nueva frase de contraseña</translation>
+        <translation type="unfinished">Repetir la nueva frase de contraseña</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Mostrar frase de contraseña</translation>
+        <translation type="unfinished">Mostrar la frase de contraseña</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Cifrar monedero</translation>
+        <translation type="unfinished">Encriptar billetera</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Esta operación necesita su frase de contraseña de la billetera para desbloquearla.
-</translation>
+        <translation type="unfinished">Esta operación requiere la frase de contraseña de la billetera para desbloquearla.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">Desbloquear monedero</translation>
+        <translation type="unfinished">Desbloquear billetera</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Cambiar frase secreta</translation>
+        <translation type="unfinished">Cambiar frase de contraseña</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">Confirmar cifrado de billetera</translation>
+        <translation type="unfinished">Confirmar el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Atención: Si cifra su monedero y pierde la contraseña, perderá ¡&lt;b&gt;TODOS SUS BITCOINS&lt;/b&gt;!</translation>
+        <translation type="unfinished">Advertencia: Si encriptas la billetera y pierdes tu frase de contraseña, ¡&lt;b&gt;PERDERÁS TODOS TUS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">¿Está seguro que desea cifrar su monedero?</translation>
+        <translation type="unfinished">¿Seguro quieres encriptar la billetera?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Monedero cifrado</translation>
+        <translation type="unfinished">Billetera encriptada</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Ingrese la nueva frase de contraseña para la billetera&lt;br/&gt;. Utilice una frase de cont&lt;b&gt;raseñade diez o más caracteres&lt;/b&gt; aleatorios o och&lt;b&gt;o o más palab&lt;/b&gt;ras.</translation>
+        <translation type="unfinished">Ingresa la nueva frase de contraseña para la billetera. &lt;br/&gt;Usa una frase de contraseña de &lt;b&gt;diez o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Ingrese la frase de contraseña antigua y la nueva frase de contraseña para la billetera</translation>
+        <translation type="unfinished">Ingresa la antigua frase de contraseña y la nueva frase de contraseña para la billetera.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Recuerda que cifrar tu billetera no puede proteger completamente tus bitcoins de ser robados por malware que infecte tu computadora.</translation>
+        <translation type="unfinished">Recuerda que encriptar tu billetera no garantiza la protección total contra el robo de tus bitcoins si la computadora está infectada con malware.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Billetera para ser cifrada</translation>
+        <translation type="unfinished">Billetera para encriptar</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Tu monedero va a ser cifrado</translation>
+        <translation type="unfinished">Tu billetera está a punto de encriptarse.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Tu monedero está ahora cifrado</translation>
+        <translation type="unfinished">Tu billetera ahora está encriptada.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
+        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad anterior que hayas hecho del archivo de la billetera se deberá reemplazar por el nuevo archivo encriptado que generaste. Por motivos de seguridad, las copias de seguridad realizadas anteriormente quedarán obsoletas en cuanto empieces a usar la nueva billetera encriptada.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Ha fallado el cifrado del monedero</translation>
+        <translation type="unfinished">Falló el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">Ha fallado el cifrado del monedero debido a un error interno. El monedero no ha sido cifrado.</translation>
+        <translation type="unfinished">El encriptado de la billetera falló debido a un error interno. La billetera no se encriptó.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">Las contraseñas no coinciden.</translation>
+        <translation type="unfinished">Las frases de contraseña proporcionadas no coinciden.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">Ha fallado el desbloqueo del monedero</translation>
+        <translation type="unfinished">Falló el desbloqueo de la billetera</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">La contraseña introducida para descifrar el monedero es incorrecta.</translation>
+        <translation type="unfinished">La frase de contraseña introducida para el cifrado de la billetera es incorrecta.</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
@@ -226,7 +229,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">Se ha cambiado correctamente la contraseña del monedero.</translation>
+        <translation type="unfinished">La frase de contraseña de la billetera se cambió correctamente.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
@@ -238,7 +241,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Aviso: ¡La tecla de bloqueo de mayúsculas está activada!</translation>
+        <translation type="unfinished">Advertencia: ¡Las mayúsculas están activadas!</translation>
     </message>
 </context>
 <context>
@@ -259,8 +262,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">El archivo de configuración %1 puede estar corrupto o no ser válido.</translation>
     </message>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción fuera de control</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Se ha producido un error garrafal. %1Ya no podrá continuar de manera segura y abandonará.</translation>
+        <translation type="unfinished">Se produjo un error fatal. %1 ya no puede continuar de manera segura y se cerrará.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -268,7 +275,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Un error interno ocurrió. %1 intentará continuar. Este es un error inesperado que puede ser reportado de las formas que se muestran debajo,</translation>
+        <translation type="unfinished">Se produjo un error interno. %1 intentará continuar de manera segura. Este es un error inesperado que se puede reportar como se describe a continuación.</translation>
     </message>
 </context>
 <context>
@@ -281,7 +288,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Un error fatal ha ocurrido. Comprueba que el archivo de configuración soporta escritura, o intenta ejecutar de nuevo el programa con -nosettings</translation>
+        <translation type="unfinished">Se produjo un error fatal. Comprueba que el archivo de configuración soporte escritura o intenta ejecutar el programa con -nosettings.</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
@@ -290,6 +297,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>unknown</source>
         <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">"%1" integrado</translation>
     </message>
     <message>
         <source>Default system font "%1"</source>
@@ -301,11 +312,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Ingresa una dirección de Bitcoin (Ejemplo: %1)</translation>
+        <translation type="unfinished">Ingresar una dirección de Bitcoin (por ejemplo, %1)</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -319,7 +330,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
     <message>
         <source>Full Relay</source>
@@ -329,7 +340,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Block Relay</source>
         <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">Retransmisión de bloque</translation>
+        <translation type="unfinished">Retransmisión de bloques</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -399,7 +410,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation type="unfinished">Mostrar visión general de la billetera</translation>
+        <translation type="unfinished">Muestra una vista general de la billetera</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -407,15 +418,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation type="unfinished">Buscar historial de transacciones</translation>
+        <translation type="unfinished">Explora el historial de transacciones</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;alir</translation>
+        <translation type="unfinished">&amp;Salir</translation>
     </message>
     <message>
         <source>Quit application</source>
-        <translation type="unfinished">Quitar aplicación</translation>
+        <translation type="unfinished">Salir del programa</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;Acerca de %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Mostrar Información sobre %1</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -423,27 +442,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation type="unfinished">Mostrar información acerca de Qt</translation>
+        <translation type="unfinished">Mostrar información sobre Qt</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">Modificar las opciones de configuración para %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Crear monedero nuevo</translation>
+        <translation type="unfinished">Crear una nueva billetera</translation>
     </message>
     <message>
         <source>&amp;Minimize</source>
-        <translation type="unfinished">Minimizar</translation>
+        <translation type="unfinished">&amp;Minimizar</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Actividad de red deshabilitada.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proxy &lt;b&gt;habilitado&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">Enviar monedas a una dirección Bitcoin</translation>
+        <translation type="unfinished">Enviar monedas a una dirección de Bitcoin</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation type="unfinished">Respaldar billetera en otra ubicación</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera en otra ubicación</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">Cambiar frase secreta usada para la encriptación de la billetera</translation>
+        <translation type="unfinished">Cambiar la frase de contraseña utilizada para encriptar la billetera</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -454,28 +490,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Recibir</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opciones…</translation>
+    </message>
+    <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Cifrar monedero</translation>
+        <translation type="unfinished">&amp;Encriptar billetera…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">Encriptar las llaves privadas que pertenecen a tu billetera</translation>
+        <translation type="unfinished">Encriptar las claves privadas que pertenecen a la billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Realizar copia de seguridad de la billetera...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
         <translation type="unfinished">&amp;Cambiar frase de contraseña...</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Firmar &amp;mensaje...</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Firma mensajes con tus direcciones Bitcoin para probar que eres dueño de ellas</translation>
+        <translation type="unfinished">Firmar mensajes con tus direcciones de Bitcoin para demostrar que te pertenecen</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Verificar mensaje...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Verificar mensajes para asegurar que estaban firmados con direcciones Bitcoin especificas</translation>
+        <translation type="unfinished">Verificar mensajes para asegurarte de que estén firmados con direcciones de Bitcoin concretas</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Cargar PSBT desde archivo...</translation>
+        <translation type="unfinished">&amp;Cargar TBPF desde archivo...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -483,15 +535,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Cerrar monedero...</translation>
+        <translation type="unfinished">Cerrar billetera...</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Crear monedero...</translation>
+        <translation type="unfinished">Crear billetera...</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Cerrar todos los monederos...</translation>
+        <translation type="unfinished">Cerrar todas las billeteras...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -503,7 +555,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="unfinished">A&amp;yuda</translation>
+        <translation type="unfinished">&amp;Ayuda</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
@@ -531,30 +583,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Solicitar pagos (genera codigo QR y URL's de Bitcoin)</translation>
+        <translation type="unfinished">Solicitar pagos (genera códigos QR y URI de tipo "bitcoin:")</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Mostrar la lista de direcciones de envío y etiquetas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de envío usadas</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Muestra la lista de direcciones de recepción y etiquetas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de recepción usadas</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">Opciones de línea de comandos</translation>
+        <translation type="unfinished">&amp;Opciones de línea de comandos</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>%n bloque procesado del historial de transacciones.</numerusform>
-            <numerusform>%n bloques procesados del historial de transacciones.</numerusform>
+            <numerusform>Se procesó %n bloque del historial de transacciones.</numerusform>
+            <numerusform>Se procesaron %n bloques del historial de transacciones.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation type="unfinished">%1 detrás</translation>
+        <translation type="unfinished">%1 atrás</translation>
     </message>
     <message>
         <source>Catching up…</source>
@@ -562,11 +614,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished">El último bloque recibido fue generado hace %1 hora(s).</translation>
+        <translation type="unfinished">El último bloque recibido se generó hace %1.</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">Transacciones después de esta no serán visibles todavía.</translation>
+        <translation type="unfinished">Las transacciones posteriores aún no están visibles.</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -578,7 +630,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Up to date</source>
-        <translation type="unfinished">Al día</translation>
+        <translation type="unfinished">Actualizado</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
@@ -586,7 +638,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
-        <translation type="unfinished">Cargar PSBT desde el &amp;portapapeles...</translation>
+        <translation type="unfinished">Cargar TBPF desde el &amp;portapapeles...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -594,11 +646,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Abrir consola de depuración y diagnóstico de nodo</translation>
+        <translation type="unfinished">Abrir la consola de depuración y diagnóstico del nodo</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -606,15 +658,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Direcciones de recepción</translation>
+        <translation type="unfinished">&amp;Direcciones de destino</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Bitcoin: abrir URI</translation>
+        <translation type="unfinished">Abrir un URI de tipo "bitcoin:"</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Abrir una billetera</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cerrar billetera</translation>
     </message>
     <message>
         <source>Restore Wallet…</source>
@@ -628,7 +688,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -639,20 +699,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Migrar una billetera</translation>
     </message>
     <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mostrar el mensaje de ayuda %1 para obtener una lista de las posibles opciones de línea de comandos de Bitcoin</translation>
+    </message>
+    <message>
         <source>&amp;Mask values</source>
         <translation type="unfinished">&amp;Ocultar valores</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Ocultar los valores en la pestaña de vista general</translation>
+        <translation type="unfinished">Ocultar los valores en la pestaña "Vista general"</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">Monederos no disponibles</translation>
+        <translation type="unfinished">No hay billeteras disponibles</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -672,11 +736,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera</translation>
     </message>
     <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ventana</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Acercar</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Ventana principal</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -688,14 +760,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">M&amp;ostrar</translation>
+        <translation type="unfinished">&amp;Mostrar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n conexiones activas con la red Bitcoin</numerusform>
-            <numerusform>%n conexiones activas con la red Bitcoin </numerusform>
+            <numerusform>%n conexión activa con la red de Bitcoin.</numerusform>
+            <numerusform>%n conexiones activas con la red de Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -728,7 +800,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">No se puede crear una nueva billetera, el software se compiló sin soporte sqlite (requerido para billeteras descriptivas)</translation>
+        <translation type="unfinished">No se puede crear una billetera nueva, ya que el software se compiló sin compatibilidad con sqlite (requerida para billeteras basadas en descriptores)</translation>
     </message>
     <message>
         <source>Warning: %1</source>
@@ -761,7 +833,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">Etiqueta: %1
+        <translation type="unfinished">Etiqueta %1
 </translation>
     </message>
     <message>
@@ -784,7 +856,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">La generación de la clave HD está &lt;b&gt; desactivada &lt;/ b&gt;</translation>
+        <translation type="unfinished">La generación de clave HD está &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
@@ -792,11 +864,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">La billetera está encriptada y desbloqueada recientemente</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;desbloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation type="unfinished">La billetera está encriptada y bloqueada recientemente</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;bloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
@@ -807,14 +879,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Unidad en la que se muestran las cantidades. Haga clic para seleccionar otra unidad.</translation>
+        <translation type="unfinished">Unidad en la que se muestran los importes. Haz clic para seleccionar otra unidad.</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">Selección de moneda</translation>
+        <translation type="unfinished">Selección de monedas</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -822,7 +894,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Monto:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -830,7 +902,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Después de tasas:</translation>
+        <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -838,19 +910,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(de)seleccionar todo</translation>
+        <translation type="unfinished">(des)marcar todos</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">Modo de árbol</translation>
+        <translation type="unfinished">Modo árbol</translation>
     </message>
     <message>
         <source>List mode</source>
-        <translation type="unfinished">Modo de lista</translation>
+        <translation type="unfinished">Modo lista</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Received with label</source>
@@ -870,11 +942,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="unfinished">Confirmada</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -894,7 +966,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">B&amp;loquear importe no gastado</translation>
+        <translation type="unfinished">&amp;Bloquear importe no gastado</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
@@ -910,7 +982,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de aplicar donación</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -926,7 +998,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Puede variar en +/- %1 satoshi(s) por entrada.</translation>
+        <translation type="unfinished">Puede variar +/- %1 satoshi(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -934,7 +1006,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">Enviar desde %1 (%2)</translation>
+        <translation type="unfinished">cambio desde %1 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
@@ -943,6 +1015,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
@@ -954,7 +1031,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Advertencia de crear billetera</translation>
+        <translation type="unfinished">Advertencia al crear la billetera</translation>
     </message>
     <message>
         <source>Can't list signers</source>
@@ -970,12 +1047,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Load Wallets</source>
         <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
-        <translation type="unfinished">Cargar monederos</translation>
+        <translation type="unfinished">Cargar billeteras</translation>
     </message>
     <message>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
-        <translation type="unfinished">Cargando monederos...</translation>
+        <translation type="unfinished">Cargando billeteras...</translation>
     </message>
 </context>
 <context>
@@ -986,7 +1063,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Estas seguro de wue deseas migrar la billetera 1 %1 1 ?</translation>
+        <translation type="unfinished">¿Seguro deseas migrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
@@ -995,10 +1072,10 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
         <translation type="unfinished">La migración de la billetera la convertirá en una o más billeteras basadas en descriptores. Será necesario realizar una nueva copia de seguridad de la billetera.
-Si esta billetera contiene scripts solo de lectura, se creará una nueva billetera que los contenga.
-Si esta billetera contiene scripts solucionables pero no de lectura, se creará una nueva billetera diferente que los contenga.
+Si esta billetera contiene scripts solo de observación, se creará una nueva billetera que los contenga.
+Si esta billetera contiene scripts solucionables pero no de observación, se creará una nueva billetera diferente que los contenga.
 
-El proceso de migración creará una copia de seguridad de la billetera antes de migrar. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En el caso de una migración incorrecta, la copia de seguridad puede restaurarse con la funcionalidad "Restore Wallet" (Restaurar billetera).</translation>
+El proceso de migración creará una copia de seguridad de la billetera antes de proceder. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En caso de que la migración falle, se puede restaurar la copia de seguridad con la funcionalidad "Restaurar billetera".</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -1014,11 +1091,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Guiones vigilantes han sido migrados a un monedero con el nombre '%1'.</translation>
+        <translation type="unfinished">Los scripts solo de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Solucionable pero ninguno de los guiones vigilados han sido migrados a un monedero llamados '%1'.</translation>
+        <translation type="unfinished">Los scripts solucionables pero no de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -1032,22 +1109,26 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
 <context>
     <name>OpenWalletActivity</name>
     <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Fallo al abrir billetera</translation>
+    </message>
+    <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Advertencia sobre crear monedero</translation>
+        <translation type="unfinished">Advertencia al abrir billetera</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">Abriendo Monedero &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Abriendo billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
 </context>
 <context>
@@ -1081,35 +1162,43 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
 <context>
     <name>WalletController</name>
     <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cerrar billetera</translation>
+    </message>
+    <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">¿Estás seguro de que deseas cerrar el monedero &lt;i&gt;%1&lt;/i&gt;?</translation>
+        <translation type="unfinished">¿Seguro deseas cerrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Cerrar el monedero durante demasiado tiempo puede causar la resincronización de toda la cadena si la poda es habilitada.</translation>
+        <translation type="unfinished">Cerrar la billetera durante demasiado tiempo puede causar la resincronización de toda la cadena si el podado está habilitado.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">¿Está seguro de que desea cerrar todas las billeteras?</translation>
+        <translation type="unfinished">¿Seguro quieres cerrar todas las billeteras?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>You are one step away from creating your new wallet!</source>
         <translation type="unfinished">Estás a un paso de crear tu nueva billetera.</translation>
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
-        <translation type="unfinished">Escribe un nombre y, si lo deseas, activa las opciones avanzadas.</translation>
+        <translation type="unfinished">Escribe un nombre y, si quieres, activa las opciones avanzadas.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera </translation>
     </message>
     <message>
         <source>Wallet</source>
@@ -1117,7 +1206,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Encriptar la billetera. La billetera será encriptada con una contraseña de tu elección.</translation>
+        <translation type="unfinished">Encriptar la billetera. La billetera se encriptará con una frase de contraseña de tu elección.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Encriptar billetera</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Opciones avanzadas</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Desactivar las claves privadas para esta billetera. Las billeteras con claves privadas desactivadas no tendrán claves privadas y no podrán tener ninguna semilla HD ni claves privadas importadas. Esto es ideal para billeteras solo de observación.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1125,11 +1226,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Crear un monedero vacío. Los monederos vacíos no tienen claves privadas ni scripts. Las claves privadas y direcciones pueden importarse después o también establecer una semilla HD.</translation>
+        <translation type="unfinished">Crea una billetera en blanco. Las billeteras en blanco inicialmente no tienen llaves privadas ni scripts. Las llaves privadas y las direcciones pueden ser importadas o se puede establecer una semilla HD más tarde.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">Crear billetera vacía</translation>
+        <translation type="unfinished">Crear billetera en blanco</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Usa un dispositivo de firma externo, por ejemplo, una billetera de hardware. Configura primero el script del firmante externo en las preferencias de la billetera.</translation>
     </message>
     <message>
         <source>External signer</source>
@@ -1142,7 +1247,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
 </context>
 <context>
@@ -1157,11 +1262,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">La etiqueta asociada con esta entrada de la lista de direcciones</translation>
+        <translation type="unfinished">La etiqueta asociada con esta entrada en la lista de direcciones</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">La dirección asociada con esta entrada de la lista de direcciones. Esta puede ser modificada solo para el envío de direcciones.</translation>
+        <translation type="unfinished">La dirección asociada con esta entrada en la lista de direcciones. Solo se puede modificar para las direcciones de envío.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -1181,22 +1286,30 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">La dirección introducida "%1" no es una dirección Bitcoin válida.</translation>
+        <translation type="unfinished">La dirección ingresada "%1" no es una dirección de Bitcoin válida.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">La dirección "%1" ya existe como dirección de recepción con la etiqueta "%2" y, por lo tanto, no se puede agregar como dirección de envío.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">La dirección ingresada "%1" ya está en la libreta de direcciones con la etiqueta "%2".</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">No se pudo desbloquear el monedero.</translation>
+        <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">Ha fallado la generación de la nueva clave.</translation>
+        <translation type="unfinished">Error al generar clave nueva.</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished">Un nuevo directorio de datos será creado.</translation>
+        <translation type="unfinished">Se creará un nuevo directorio de datos.</translation>
     </message>
     <message>
         <source>name</source>
@@ -1204,15 +1317,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">El directorio ya existe. Agrega %1 si tiene la intención de crear un nuevo directorio aquí.</translation>
+        <translation type="unfinished">El directorio ya existe. Agrega %1 si deseas crear un nuevo directorio aquí.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">La ruta ya existe, y no es un directorio.</translation>
+        <translation type="unfinished">Ruta de acceso existente, pero no es un directorio.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished">No puede crear directorio de datos aquí.</translation>
+        <translation type="unfinished">No se puede crear un directorio de datos aquí.</translation>
     </message>
 </context>
 <context>
@@ -1227,15 +1340,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform>(of %n GB needed)</numerusform>
-            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(de %n GB necesario)</numerusform>
+            <numerusform>(de %n GB necesarios)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform>(%n GB needed for full chain)</numerusform>
-            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB necesario para completar la cadena)</numerusform>
+            <numerusform>(%n GB necesarios para completar la cadena)</numerusform>
         </translation>
     </message>
     <message>
@@ -1243,8 +1356,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Elegir directorio de datos</translation>
     </message>
     <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Se almacenará al menos %1 GB de información en este directorio, que aumentará con el tiempo.</translation>
+    </message>
+    <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Aproximadamente %1 GB de información será almacenada en este directorio.</translation>
+        <translation type="unfinished">Se almacenará aproximadamente %1 GB de información en este directorio.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -1260,27 +1377,35 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">El monedero también se almacenará en este directorio.</translation>
+        <translation type="unfinished">La billetera también se almacenará en este directorio.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Error: Directorio de datos especificado "%1" no puede ser creado.</translation>
+        <translation type="unfinished">Error: No se puede crear el directorio de datos especificado "%1" .</translation>
     </message>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished">Bienvenido</translation>
+        <translation type="unfinished">Te damos la bienvenida</translation>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">Bienvenido a %1.</translation>
+        <translation type="unfinished">Te damos la bienvenida a %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Al ser esta la primera vez que se ejecuta el programa, puedes escoger donde %1 almacenará los datos.</translation>
+        <translation type="unfinished">Como es la primera vez que se ejecuta el programa, puedes elegir dónde %1 almacenará los datos.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">Limitar el almacenamiento de cadena de bloques a</translation>
+        <translation type="unfinished">Limitar el almacenamiento de la cadena de bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Para revertir esta configuración, se debe descargar de nuevo la cadena de bloques completa. Es más rápido descargar la cadena completa y podarla después. Desactiva algunas funciones avanzadas.</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">La sincronización inicial consume muchos recursos y es posible que exponga problemas de hardware en la computadora que anteriormente pasaron desapercibidos. Cada vez que ejecutes %1, seguirá descargando desde el punto en el que quedó.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
@@ -1288,15 +1413,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Si ha elegido limitar el almacenamiento de la cadena de bloques (pruning o poda), los datos históricos todavía se deben descargar y procesar, pero se eliminarán posteriormente para mantener el uso del disco bajo.</translation>
+        <translation type="unfinished">Si elegiste la opción de limitar el almacenamiento de la cadena de bloques (podado), los datos históricos se deben descargar y procesar de igual manera, pero se eliminarán después para disminuir el uso del disco.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">Usar el directorio de datos por defecto</translation>
+        <translation type="unfinished">Usar el directorio de datos predeterminado</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">Usa un directorio de datos personalizado:</translation>
+        <translation type="unfinished">Usar un directorio de datos personalizado:</translation>
     </message>
 </context>
 <context>
@@ -1315,38 +1440,69 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
 </context>
 <context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">No apagues la computadora hasta que desaparezca esta ventana.</translation>
+    </message>
+</context>
+<context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">Desde</translation>
+        <translation type="unfinished">Formulario</translation>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Es posible que las transacciones recientes aún no estén visibles y por lo tanto, el saldo de su monedero podría ser incorrecto. Esta información será correcta una vez que su monedero haya terminado de sincronizarse con la red bitcoin, como se detalla a continuación.</translation>
+        <translation type="unfinished">Es posible que las transacciones recientes aún no sean visibles y, por lo tanto, el saldo de la billetera podría ser incorrecto. Esta información será correcta una vez que la billetera haya terminado de sincronizarse con la red de Bitcoin, como se detalla abajo.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">La red no aceptará si se intenta gastar bitcoins afectados por las transacciones que aún no se muestran.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation type="unfinished">Numero de bloques pendientes</translation>
+        <translation type="unfinished">Número de bloques restantes</translation>
     </message>
     <message>
         <source>Unknown…</source>
         <translation type="unfinished">Desconocido...</translation>
     </message>
     <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Hora del último bloque</translation>
     </message>
     <message>
+        <source>Progress</source>
+        <translation type="unfinished">Progreso</translation>
+    </message>
+    <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Incremento del progreso por hora</translation>
+        <translation type="unfinished">Avance del progreso por hora</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Tiempo estimado restante hasta la sincronización</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 está actualmente sincronizándose. Descargará cabeceras y bloques de nodos semejantes y los validará hasta alcanzar la cabeza de la cadena de bloques.</translation>
+        <translation type="unfinished">%1 se está sincronizando actualmente. Descargará encabezados y bloques de pares, y los validará hasta alcanzar el extremo de la cadena de bloques.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconocido. Sincronizando cabeceras (%1, %2%)…</translation>
+        <translation type="unfinished">Desconocido. Sincronizando encabezados (%1, %2%)…</translation>
     </message>
     <message>
         <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
@@ -1362,7 +1518,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
 </context>
 <context>
@@ -1372,16 +1528,28 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Opciones</translation>
     </message>
     <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;Principal</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">Iniciar automáticamente %1 después de iniciar sesión en el sistema.</translation>
+    </message>
+    <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Iniciar %1 al iniciar el sistema</translation>
+        <translation type="unfinished">&amp;Iniciar %1 al iniciar sesión en el sistema</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Al activar el modo pruning, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+        <translation type="unfinished">Al activar el podado, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Tamaño de la caché de la &amp;base de datos</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Número de hilos de &amp;verificación de scripts</translation>
+        <translation type="unfinished">Número de subprocesos de &amp;verificación de scripts</translation>
     </message>
     <message>
         <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
@@ -1389,15 +1557,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Dirección IP del proxy (ej. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">Dirección IP del proxy (por ejemplo, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Muestra si el proxy SOCKS5 por defecto suministrado se utiliza para llegar a los pares a través de este tipo de red.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimice en lugar de salir de la aplicación cuando la ventana esté cerrada. Cuando esta opción está habilitada, la aplicación se cerrará solo después de seleccionar Salir en el menú.</translation>
+        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación solo se cerrará después de seleccionar "Salir" en el menú.</translation>
     </message>
     <message>
         <source>Font in the Overview tab: </source>
-        <translation type="unfinished">Fuente en la pestaña Resumen:</translation>
+        <translation type="unfinished">Fuente en la pestaña "Vista general":</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -1413,7 +1585,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished">Restablecer todas las opciones del cliente a las predeterminadas.</translation>
+        <translation type="unfinished">Restablecer todas las opciones del cliente a los valores predeterminados.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
@@ -1439,7 +1611,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
-        <translation type="unfinished">Establezca el número de hilos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
+        <translation type="unfinished">Establece el número de subprocesos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
@@ -1448,7 +1620,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
-        <translation type="unfinished">Esto le permite a usted o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
+        <translation type="unfinished">Esto te permite a ti o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
@@ -1457,12 +1629,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished">Billetera</translation>
+        <translation type="unfinished">&amp;Billetera</translation>
     </message>
     <message>
         <source>Whether to set subtract fee from amount as default or not.</source>
         <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">Si se resta la comisión del importe por defecto o no.</translation>
+        <translation type="unfinished">Si se resta o no la comisión del importe por defecto.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1474,8 +1646,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Experto</translation>
     </message>
     <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">Habilitar funciones de &amp;control de monedas</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Si deshabilita el gasto de un cambio no confirmado, el cambio de una transacción no se puede usar hasta que esa transacción tenga al menos una confirmación. Esto también afecta cómo se calcula su saldo.</translation>
+        <translation type="unfinished">Si deshabilitas el gasto del cambio sin confirmar, no se puede usar el cambio de una transacción hasta que esta tenga al menos una confirmación. Esto también afecta cómo se calcula el saldo.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1484,12 +1660,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Activar controles de &amp;PSBT</translation>
+        <translation type="unfinished">Activar controles de &amp;TBPF</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Si se muestran los controles de PSBT.</translation>
+        <translation type="unfinished">Si se muestran los controles de TBPF.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -1501,11 +1677,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona si el router admite UPnP y está activado.</translation>
+        <translation type="unfinished">Abrir automáticamente el puerto del cliente de Bitcoin en el router. Esto funciona solo cuando tu router es compatible con UPnP y está habilitado.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
-        <translation type="unfinished">Mapear el puerto usando &amp;UPnP</translation>
+        <translation type="unfinished">Asignar puerto usando &amp;UPnP</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
@@ -1516,16 +1692,24 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Asignar puerto usando NA&amp;T-PMP</translation>
     </message>
     <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">Aceptar conexiones externas.</translation>
+    </message>
+    <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Permitir conexiones entrantes</translation>
+        <translation type="unfinished">&amp;Permitir conexiones entrantes</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Conectar a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Conectarse a través del proxy SOCKS5 (proxy predeterminado):</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
-        <translation type="unfinished">Dirección &amp;IP del proxy:</translation>
+        <translation type="unfinished">&amp;IP del proxy:</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
@@ -1533,11 +1717,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation type="unfinished">Puerto del servidor proxy (ej. 9050)</translation>
+        <translation type="unfinished">Puerto del proxy (p. ej., 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Utilizado para llegar a los compañeros a través de:</translation>
+        <translation type="unfinished">Usado para conectarse con pares a través de:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1553,35 +1737,35 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">Minimizar la ventana a la bandeja de iconos del sistema.</translation>
+        <translation type="unfinished">Mostrar solo un ícono de bandeja después de minimizar la ventana.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation type="unfinished">&amp;Minimizar a la bandeja en vez de a la barra de tareas</translation>
+        <translation type="unfinished">&amp;Minimizar a la bandeja en vez de la barra de tareas</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">M&amp;inimizar al cerrar</translation>
+        <translation type="unfinished">&amp;Minimizar al cerrar</translation>
     </message>
     <message>
         <source>&amp;Display</source>
-        <translation type="unfinished">&amp;Interfaz</translation>
+        <translation type="unfinished">&amp;Visualización</translation>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation type="unfinished">I&amp;dioma de la interfaz de usuario</translation>
+        <translation type="unfinished">&amp;Idioma de la interfaz de usuario:</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración tendrá efecto después de reiniciar %1.</translation>
+        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración surtirá efecto después de reiniciar %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation type="unfinished">Mostrar las cantidades en la &amp;unidad:</translation>
+        <translation type="unfinished">&amp;Unidad en la que se muestran los importes:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished">Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían monedas.</translation>
+        <translation type="unfinished">Elegir la unidad de subdivisión predeterminada para mostrar en la interfaz y al enviar monedas.</translation>
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
@@ -1593,19 +1777,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Mostrar o no características de control de moneda</translation>
+        <translation type="unfinished">Si se muestran o no las funcionalidades de control de monedas.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Conectarse a la red Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <translation type="unfinished">Usar un proxy SOCKS&amp;5 independiente para comunicarse con pares a través de los servicios onion de Tor:</translation>
-    </message>
-    <message>
-        <source>&amp;OK</source>
-        <translation type="unfinished">&amp;Aceptar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -1614,7 +1794,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1627,12 +1807,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Confirm options reset</source>
         <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
-        <translation type="unfinished">Confirme el restablecimiento de las opciones</translation>
+        <translation type="unfinished">Confirmar restablecimiento de opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
         <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
-        <translation type="unfinished">Reinicio del cliente para activar cambios.</translation>
+        <translation type="unfinished">Es necesario reiniciar el cliente para activar los cambios.</translation>
     </message>
     <message>
         <source>Current settings will be backed up at "%1".</source>
@@ -1642,7 +1822,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
-        <translation type="unfinished">El cliente será cluasurado. Quieres proceder?</translation>
+        <translation type="unfinished">El cliente se cerrará. ¿Quieres continuar?</translation>
     </message>
     <message>
         <source>Configuration options</source>
@@ -1652,7 +1832,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">El archivo de configuración se utiliza para especificar opciones de usuario avanzadas que anulan la configuración de la GUI. Además, cualquier opción de línea de comandos anulará este archivo de configuración.</translation>
+        <translation type="unfinished">El archivo de configuración se usa para especificar opciones avanzadas del usuario, que remplazan la configuración de la GUI. Además, las opciones de la línea de comandos remplazarán este archivo de configuración.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1664,15 +1844,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">El archivo de configuración no se pudo abrir.</translation>
+        <translation type="unfinished">No se pudo abrir el archivo de configuración.</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation type="unfinished">Este cambio requiere reinicio por parte del cliente.</translation>
+        <translation type="unfinished">Estos cambios requieren reiniciar el cliente.</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation type="unfinished">La dirección proxy indicada es inválida.</translation>
+        <translation type="unfinished">La dirección del proxy proporcionada es inválida.</translation>
     </message>
 </context>
 <context>
@@ -1686,11 +1866,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">Desde</translation>
+        <translation type="unfinished">Formulario</translation>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red Bitcoin después de que se haya establecido una conexión, pero este proceso aún no se ha completado.</translation>
+        <translation type="unfinished">La información mostrada puede estar desactualizada. La billetera se sincroniza automáticamente con la red de Bitcoin después de establecer una conexión, pero este proceso aún no se ha completado.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">Solo de observación:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -1698,7 +1882,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation type="unfinished">Su balance actual gastable</translation>
+        <translation type="unfinished">Tu saldo disponible para gastar actualmente</translation>
     </message>
     <message>
         <source>Pending:</source>
@@ -1706,15 +1890,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished">Total de transacciones que deben ser confirmadas, y que no cuentan con el balance gastable necesario</translation>
+        <translation type="unfinished">Total de transacciones que aún se deben confirmar y que no se contabilizan dentro del saldo disponible para gastar</translation>
     </message>
     <message>
         <source>Immature:</source>
-        <translation type="unfinished">No disponible:</translation>
+        <translation type="unfinished">Inmaduro:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished">Saldo recién minado que aún no está disponible.</translation>
+        <translation type="unfinished">Saldo minado que aún no ha madurado</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1722,15 +1906,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation type="unfinished">Su balance actual total</translation>
+        <translation type="unfinished">Tu saldo total actual</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Tu saldo actual en solo ver direcciones</translation>
+        <translation type="unfinished">Tu saldo actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Disponible:</translation>
+        <translation type="unfinished">Gastable:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
@@ -1738,22 +1922,26 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Transacciones sin confirmar a direcciones de observación</translation>
+        <translation type="unfinished">Transacciones sin confirmar hacia direcciones solo de observación</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">Saldo minado en direcciones solo de observación que aún no ha madurado</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Saldo total actual en direcciones de solo observación</translation>
+        <translation type="unfinished">Saldo total actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anule la selección de Configuración-&gt;Ocultar valores.</translation>
+        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anula la selección de "Configuración-&gt;Ocultar valores".</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>PSBT Operations</source>
-        <translation type="unfinished">Operaciones PSBT</translation>
+        <translation type="unfinished">Operaciones TBPF</translation>
     </message>
     <message>
         <source>Sign Tx</source>
@@ -1789,7 +1977,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">No se pudo firmar más entradas.</translation>
+        <translation type="unfinished">No se pudieron firmar más entradas.</translation>
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
@@ -1813,7 +2001,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT copiada al portapapeles.</translation>
+        <translation type="unfinished">TBPF copiada al portapapeles.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1826,7 +2014,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT guardada en en el disco.</translation>
+        <translation type="unfinished">TBPF guardada en el disco.</translation>
     </message>
     <message>
         <source>Sends %1 to %2</source>
@@ -1846,7 +2034,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>or</source>
@@ -1858,7 +2046,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">A la transacción le falta información sobre entradas.</translation>
+        <translation type="unfinished">Falta información sobre las entradas de la transacción.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
@@ -1880,16 +2068,20 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <source>Transaction is fully signed and ready for broadcast.</source>
         <translation type="unfinished">La transacción se firmó completamente y está lista para transmitirse.</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">El estado de la transacción es desconocido.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
         <source>Payment request error</source>
-        <translation type="unfinished">Error en petición de pago</translation>
+        <translation type="unfinished">Error en la solicitud de pago</translation>
     </message>
     <message>
         <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">No se pudo iniciar bitcoin: manejador de pago-al-clic</translation>
+        <translation type="unfinished">No se puede iniciar el controlador "bitcoin: click-to-pay"</translation>
     </message>
     <message>
         <source>URI handling</source>
@@ -1897,7 +2089,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">"bitcoin://" no es un URI válido. Use "bitcoin:" en su lugar.</translation>
+        <translation type="unfinished">"bitcoin://" no es un URI válido. Usa "bitcoin:" en su lugar.</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
@@ -1905,11 +2097,15 @@ Due to widespread security flaws in BIP70 it's strongly recommended that any mer
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished">No se puede procesar la solicitud de pago porque no existe compatibilidad con BIP70.
 Debido a los fallos de seguridad generalizados en BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de billetera.
-Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
+Si recibes este error, debes solicitar al comerciante que te proporcione un URI compatible con BIP21.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">No se puede analizar el URI. Esto se puede deber a una dirección de Bitcoin inválida o a parámetros de URI con formato incorrecto.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Manejo del archivo de solicitud de pago</translation>
+        <translation type="unfinished">Gestión del archivo de solicitud de pago</translation>
     </message>
 </context>
 <context>
@@ -1927,12 +2123,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Age</source>
         <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
-        <translation type="unfinished">Duración</translation>
+        <translation type="unfinished">Antigüedad</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">Dirección</translation>
     </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>Received</source>
@@ -1942,7 +2143,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">Direccion</translation>
+        <translation type="unfinished">Dirección</translation>
     </message>
     <message>
         <source>Type</source>
@@ -1962,7 +2163,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Outbound</source>
         <extracomment>An Outbound Connection to a Peer.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
 </context>
 <context>
@@ -1973,15 +2174,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished">Copiar imagen</translation>
+        <translation type="unfinished">&amp;Copiar imagen</translation>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">URI resultante demasiado larga. Intente reducir el texto de la etiqueta / mensaje.</translation>
+        <translation type="unfinished">El URI resultante es demasiado largo, así que trata de reducir el texto de la etiqueta o el mensaje.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Error al codificar la URI en el código QR.</translation>
+        <translation type="unfinished">Fallo al codificar URI en código QR.</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
@@ -2009,23 +2210,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Information</source>
-        <translation type="unfinished">Información</translation>
+        <translation type="unfinished">&amp;Información</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Directorio de datos</translation>
     </message>
     <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, use la opción "%1".</translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Blocksdir</source>
-        <translation type="unfinished">Bloques dir</translation>
+        <translation type="unfinished">Directorio de bloques</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, use la opción "%1".</translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Startup time</source>
-        <translation type="unfinished">Hora de inicio</translation>
+        <translation type="unfinished">Tiempo de inicio</translation>
     </message>
     <message>
         <source>Network</source>
@@ -2045,19 +2250,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation type="unfinished">Grupo de memoria</translation>
+        <translation type="unfinished">Pool de memoria</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">Número total de transacciones</translation>
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished">Memoria utilizada</translation>
+        <translation type="unfinished">Uso de memoria</translation>
     </message>
     <message>
         <source>Wallet: </source>
-        <translation type="unfinished">Monedero:</translation>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ninguna)</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Reestablecer</translation>
+        <translation type="unfinished">&amp;Restablecer</translation>
     </message>
     <message>
         <source>Received</source>
@@ -2065,7 +2278,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Sent</source>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
@@ -2089,11 +2302,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The BIP324 session ID string in hex, if any.</source>
-        <translation type="unfinished">Cadena de identificación de la sesión BIP324 en formato hexadecimal, si existe.</translation>
+        <translation type="unfinished">Cadena de identificador de la sesión BIP324 en formato hexadecimal, si existe.</translation>
     </message>
     <message>
         <source>Session ID</source>
         <translation type="unfinished">Identificador de sesión</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">Versión</translation>
     </message>
     <message>
         <source>Whether we relay transactions to this peer.</source>
@@ -2105,11 +2322,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">Bloque de inicio</translation>
+        <translation type="unfinished">Bloque inicial</translation>
     </message>
     <message>
         <source>Synced Headers</source>
         <translation type="unfinished">Encabezados sincronizados</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">Bloques sincronizados</translation>
     </message>
     <message>
         <source>Last Transaction</source>
@@ -2131,17 +2352,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Address Relay</source>
         <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
-        <translation type="unfinished">Retransmisión de dirección</translation>
+        <translation type="unfinished">Retransmisión de direcciones</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones omitidas debido a la limitación de volumen).</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones desestimadas debido a la limitación de volumen).</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que se omitieron (no se procesaron) debido a la limitación de volumen.</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se desestimaron (no se procesaron) debido a la limitación de volumen.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
@@ -2151,7 +2372,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Addresses Rate-Limited</source>
         <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">Direcciones omitidas por limitación de volumen</translation>
+        <translation type="unfinished">Direcciones desestimadas por limitación de volumen</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2159,7 +2380,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -2167,15 +2388,19 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Abra el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
+        <translation type="unfinished">Abrir el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation type="unfinished">Reducir el tamaño de la fuente</translation>
+        <translation type="unfinished">Disminuir tamaño de fuente</translation>
     </message>
     <message>
         <source>Increase font size</source>
-        <translation type="unfinished">Aumentar el tamaño de la fuente</translation>
+        <translation type="unfinished">Aumentar tamaño de fuente</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Permisos</translation>
     </message>
     <message>
         <source>The direction and type of peer connection: %1</source>
@@ -2195,11 +2420,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">Retransmisión de bloque compacto BIP152 en modo de banda ancha: %1</translation>
+        <translation type="unfinished">Retransmisión de bloques compactos BIP152 en banda ancha: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
         <translation type="unfinished">Banda ancha</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">Tiempo de conexión</translation>
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
@@ -2220,19 +2449,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Ultima recepción</translation>
+        <translation type="unfinished">Última recepción</translation>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation type="unfinished">Tiempo de Ping</translation>
+        <translation type="unfinished">Tiempo de ping</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">La duración de un ping actualmente pendiente.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
-        <translation type="unfinished">Espera de Ping</translation>
+        <translation type="unfinished">Espera de ping</translation>
     </message>
     <message>
         <source>Min Ping</source>
         <translation type="unfinished">Ping mínimo</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">Desfase temporal</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -2248,15 +2485,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Tráfico de Red</translation>
+        <translation type="unfinished">&amp;Tráfico de red</translation>
     </message>
     <message>
         <source>Totals</source>
-        <translation type="unfinished">Total:</translation>
+        <translation type="unfinished">Totales</translation>
     </message>
     <message>
         <source>Debug log file</source>
-        <translation type="unfinished">Archivo de registro de depuración</translation>
+        <translation type="unfinished">Archivo del registro de depuración</translation>
     </message>
     <message>
         <source>Clear console</source>
@@ -2308,7 +2545,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>v1: unencrypted, plaintext transport protocol</source>
         <extracomment>Explanatory text for v1 transport type.</extracomment>
-        <translation type="unfinished">v1: protocolo de transporte de texto simple sin cifrar</translation>
+        <translation type="unfinished">v1: protocolo de transporte de texto simple sin encriptar</translation>
     </message>
     <message>
         <source>v2: BIP324 encrypted transport protocol</source>
@@ -2325,7 +2562,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">Ninguna transmisión de banda ancha seleccionada</translation>
+        <translation type="unfinished">No se seleccionó la retransmisión de banda ancha</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2333,12 +2570,24 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;Desconectar</translation>
+    </message>
+    <message>
         <source>1 &amp;hour</source>
-        <translation type="unfinished">1 hora</translation>
+        <translation type="unfinished">1 &amp;hora</translation>
     </message>
     <message>
         <source>1 d&amp;ay</source>
         <translation type="unfinished">1 &amp;día</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;semana</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;año</translation>
     </message>
     <message>
         <source>&amp;Copy IP/Netmask</source>
@@ -2347,7 +2596,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Desbloquear</translation>
+        <translation type="unfinished">&amp;Levantar prohibición</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -2355,11 +2604,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Executing command without any wallet</source>
-        <translation type="unfinished">Ejecutar comando sin monedero</translation>
+        <translation type="unfinished">Ejecutar comando sin ninguna billetera</translation>
     </message>
     <message>
         <source>Node window - [%1]</source>
         <translation type="unfinished">Ventana de nodo - [%1]</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">Ejecutar comando usando la billetera "%1"</translation>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.
@@ -2370,12 +2623,13 @@ For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
         <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Bienvenido a la consola RPC
-%1. Utiliza las flechas arriba y abajo para navegar por el historial, y %2 para borrar la pantalla. 
+        <translation type="unfinished">Te damos la bienvenida a la consola RPC de %1.
+Utiliza las flechas hacia arriba y abajo para navegar por el historial y %2 para borrar la pantalla.
 Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente. 
-Escribe %5 para ver un resumen de los comandos disponibles. Para más información sobre cómo usar esta consola, escribe %6.
+Escribe %5 para ver los comandos disponibles.
+Para obtener más información sobre cómo usar esta consola, escribe %6.
 
-%7 AVISO: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus monederos. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
+%7 ADVERTENCIA: Los estafadores suelen decirles a los usuarios que escriban comandos aquí para robarles el contenido de sus billeteras. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2392,11 +2646,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished">Si</translation>
+        <translation type="unfinished">Sí</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>From</source>
@@ -2404,11 +2658,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished">Bloqueo para</translation>
+        <translation type="unfinished">Prohibir por</translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished">nunca</translation>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2419,7 +2673,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation type="unfinished">Monto:</translation>
+        <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -2427,27 +2681,27 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>&amp;Message:</source>
-        <translation type="unfinished">Mensaje:</translation>
+        <translation type="unfinished">&amp;Mensaje:</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje opcional adjunto a la solicitud de pago, que será mostrado cuando la solicitud sea abierta. Nota: Este mensaje no será enviado con el pago a través de la red Bitcoin.</translation>
+        <translation type="unfinished">Mensaje opcional para adjuntar a la solicitud de pago, que se mostrará cuando se abra la solicitud. Nota: Este mensaje no se enviará con el pago a través de la red de Bitcoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Use este formulario para solicitar pagos. Todos los campos son &lt;b&gt; opcionales &lt;/ b&gt;.</translation>
+        <translation type="unfinished">Usa este formulario para solicitar pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Un importe opcional para solicitar. Deje esto vacío o en cero para no solicitar una cantidad específica.</translation>
+        <translation type="unfinished">Un importe opcional para solicitar. Déjalo vacío o ingresa cero para no solicitar un importe específico.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (utilizada por ti para identificar una factura). También se adjunta a la solicitud de pago.</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (puedes usarla para identificar una factura). También se adjunta a la solicitud de pago.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2455,23 +2709,23 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Crear una nueva dirección de recepción</translation>
+        <translation type="unfinished">&amp;Crear nueva dirección de recepción</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Limpiar todos los campos del formulario</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">Limpiar</translation>
+        <translation type="unfinished">Borrar</translation>
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation type="unfinished">Historial de pagos solicitado</translation>
+        <translation type="unfinished">Historial de pagos solicitados</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Muestra la petición seleccionada (También doble clic)</translation>
+        <translation type="unfinished">Mostrar la solicitud seleccionada (equivale a hacer doble clic en una entrada)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -2479,7 +2733,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Borrar de la lista las direcciónes actualmente seleccionadas</translation>
+        <translation type="unfinished">Eliminar las entradas seleccionadas de la lista</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -2523,11 +2777,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">No se pudo desbloquear el monedero.</translation>
+        <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
     </message>
     <message>
         <source>Could not generate new %1 address</source>
-        <translation type="unfinished">No se ha podido generar una nueva dirección %1</translation>
+        <translation type="unfinished">No se pudo generar nueva dirección %1</translation>
     </message>
 </context>
 <context>
@@ -2537,12 +2791,24 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Solicitar pago a...</translation>
     </message>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Dirección:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
-        <translation type="unfinished">Monto:</translation>
+        <translation type="unfinished">Importe:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">Etiqueta:</translation>
     </message>
     <message>
         <source>Message:</source>
         <translation type="unfinished">Mensaje:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
@@ -2550,7 +2816,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">&amp;Copiar Dirección</translation>
+        <translation type="unfinished">Copiar &amp;dirección</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2558,7 +2824,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Verifica esta dirección, por ejemplo, en la pantalla de una billetera de hardware</translation>
+        <translation type="unfinished">Verificar esta dirección, por ejemplo, en la pantalla de una billetera de hardware.</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2566,7 +2832,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Payment information</source>
-        <translation type="unfinished">Información de pago</translation>
+        <translation type="unfinished">Información del pago</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2581,7 +2847,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Message</source>
@@ -2593,11 +2859,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>(no message)</source>
-        <translation type="unfinished">(Ningun mensaje)</translation>
+        <translation type="unfinished">(sin mensaje)</translation>
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation type="unfinished">(sin importe solicitado)</translation>
+        <translation type="unfinished">(no se solicitó un importe)</translation>
     </message>
     <message>
         <source>Requested</source>
@@ -2612,15 +2878,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Características de control de la moneda</translation>
+        <translation type="unfinished">Funciones de control de monedas</translation>
     </message>
     <message>
         <source>automatically selected</source>
-        <translation type="unfinished">Seleccionado automaticamente</translation>
+        <translation type="unfinished">seleccionado automáticamente</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation type="unfinished">Fondos insuficientes!</translation>
+        <translation type="unfinished">Fondos insuficientes</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -2628,7 +2894,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Monto:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -2636,7 +2902,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Después de tasas:</translation>
+        <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -2644,11 +2910,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Al activarse, si la dirección esta vacía o es inválida, las monedas serán enviadas a una nueva dirección generada.</translation>
+        <translation type="unfinished">Si se activa, pero la dirección de cambio está vacía o es inválida, el cambio se enviará a una dirección generada recientemente.</translation>
     </message>
     <message>
         <source>Custom change address</source>
-        <translation type="unfinished">Dirección propia</translation>
+        <translation type="unfinished">Dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
@@ -2656,11 +2922,19 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Si utilizas la comisión por defecto, la transacción puede tardar varias horas o incluso días (o nunca) en confirmarse. Considera elegir la comisión de forma manual o espera hasta que se haya validado completamente la cadena.</translation>
+        <translation type="unfinished">Si usas la opción "fallbackfee", la transacción puede tardar varias horas o días en confirmarse (o nunca hacerlo). Considera elegir la comisión de forma manual o espera hasta que hayas validado la cadena completa.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Advertencia: En este momento no se puede estimar la cuota.</translation>
+        <translation type="unfinished">Advertencia: En este momento no se puede estimar la comisión.</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">por kilobyte</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>Recommended:</source>
@@ -2672,15 +2946,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation type="unfinished">Enviar a múltiples destinatarios de una vez</translation>
+        <translation type="unfinished">Enviar a múltiples destinatarios a la vez</translation>
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation type="unfinished">Añadir &amp;destinatario</translation>
+        <translation type="unfinished">Agregar &amp;destinatario</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Limpiar todos los campos del formulario</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Inputs…</source>
@@ -2708,19 +2982,27 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Una comisión demasiado pequeña puede resultar en una transacción que nunca será confirmada (leer herramientas de información).</translation>
+        <translation type="unfinished">Si la comisión es demasiado baja, es posible que la transacción nunca se confirme (leer la información en pantalla).</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <translation type="unfinished">(La comisión inteligente no se ha inicializado todavía. Esto tarda normalmente algunos bloques…)</translation>
     </message>
     <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">Objetivo de tiempo de confirmación:</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">Activar "Remplazar por comisión"</translation>
+    </message>
+    <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Con la función "Reemplazar-por-comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
+        <translation type="unfinished">Con la función "Remplazar por comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -2740,7 +3022,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -2748,7 +3030,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de aplicar donación</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -2759,22 +3041,34 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Copiar cambio</translation>
     </message>
     <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 bloques)</translation>
+    </message>
+    <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet.</extracomment>
         <translation type="unfinished">Firmar en el dispositivo</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Conecta tu monedero externo primero.</translation>
+        <translation type="unfinished">Conecta primero tu billetera de hardware.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Configura una ruta externa al script en Opciones -&gt; Monedero</translation>
+        <translation type="unfinished">Establecer la ruta al script del firmante externo en "Opciones -&gt; Billetera"</translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">&amp;Crear sin firmar</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (PSBT) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (TBPF) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 a '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
@@ -2786,17 +3080,17 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign failed</source>
-        <translation type="unfinished">La firma falló</translation>
+        <translation type="unfinished">Error de firma</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">No se encontró el dispositivo firmante externo</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">Error de firmante externo</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2810,7 +3104,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
-        <translation type="unfinished">TBPF guardado </translation>
+        <translation type="unfinished">TBPF guardada</translation>
     </message>
     <message>
         <source>External balance:</source>
@@ -2822,11 +3116,16 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Puedes aumentar la comisión después (indica "Reemplazar-por-comisión", BIP-125).</translation>
+        <translation type="unfinished">Puedes aumentar la comisión después (indica "Remplazar por comisión", BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Revisa por favor la propuesta de transacción. Esto producirá una transacción de Bitcoin parcialmente firmada (TBPF) que puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 fuera de línea o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>%1 from wallet '%2'</source>
-        <translation type="unfinished">%1 desde monedero '%2'</translation>
+        <translation type="unfinished">%1 desde billetera "%2"</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
@@ -2836,12 +3135,12 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
-        <translation type="unfinished">Revisa por favor la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (PSBT), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Revisa la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (TBPF), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
-        <translation type="unfinished">Por favor, revisa tu transacción</translation>
+        <translation type="unfinished">Revisa la transacción.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -2849,11 +3148,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">No indica remplazar-por-comisión, BIP-125.</translation>
+        <translation type="unfinished">No indica "Remplazar por comisión", BIP-125.</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>Unsigned Transaction</source>
@@ -2863,11 +3162,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The PSBT has been copied to the clipboard. You can also save it.</source>
-        <translation type="unfinished">Se copió la PSBT al portapapeles. También puedes guardarla.</translation>
+        <translation type="unfinished">Se copió la TBPF al portapapeles. También puedes guardarla.</translation>
     </message>
     <message>
         <source>PSBT saved to disk</source>
-        <translation type="unfinished">PSBT guardada en el disco</translation>
+        <translation type="unfinished">TBPF guardada en el disco</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -2883,15 +3182,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">La cantidad por pagar tiene que ser mayor de 0.</translation>
+        <translation type="unfinished">El importe por pagar tiene que ser mayor que 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">La cantidad sobrepasa su saldo.</translation>
+        <translation type="unfinished">El importe sobrepasa el saldo.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">El total sobrepasa su saldo cuando se incluye la tasa de envío de %1</translation>
+        <translation type="unfinished">El total sobrepasa el saldo cuando se incluye la comisión de transacción de %1.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
@@ -2899,34 +3198,34 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">¡Ha fallado la creación de la transacción!</translation>
+        <translation type="unfinished">Fallo al crear la transacción</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurda-mente alta.</translation>
+        <translation type="unfinished">Una comisión mayor que %1 se considera absurdamente alta.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloque.</numerusform>
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloques.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloque.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Alerta: Dirección de Bitcoin inválida</translation>
+        <translation type="unfinished">Advertencia: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Alerta: Dirección de Bitcoin inválida</translation>
+        <translation type="unfinished">Advertencia: Dirección de cambio desconocida</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation type="unfinished">Confirmar dirección de cambio personalizada</translation>
+        <translation type="unfinished">Confirmar la dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">La dirección que ha seleccionado para el cambio no es parte de su monedero. Parte o todos sus fondos pueden ser enviados a esta dirección. ¿Está seguro?</translation>
+        <translation type="unfinished">La dirección que seleccionaste para el cambio no es parte de esta billetera. Una parte o la totalidad de los fondos en la billetera se enviará a esta dirección. ¿Seguro deseas continuar?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2937,11 +3236,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation type="unfinished">Monto:</translation>
+        <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation type="unfinished">&amp;Pagar a:</translation>
+        <translation type="unfinished">Pagar &amp;a:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -2949,23 +3248,31 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Escoger dirección previamente usada</translation>
+        <translation type="unfinished">Seleccionar dirección usada anteriormente</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Dirección Bitcoin a la que se enviará el pago</translation>
+        <translation type="unfinished">La dirección de Bitcoin a la que se enviará el pago</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
     <message>
         <source>Remove this entry</source>
-        <translation type="unfinished">Eliminar esta transacción</translation>
+        <translation type="unfinished">Eliminar esta entrada</translation>
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
         <translation type="unfinished">El importe que se enviará en la unidad seleccionada</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">La comisión se deducirá del importe que se envía. El destinatario recibirá menos bitcoins que los que ingreses en el campo del importe. Si se seleccionan varios destinatarios, la comisión se dividirá por igual.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">&amp;Restar la comisión del importe</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -2977,11 +3284,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
+        <translation type="unfinished">Ingresar una etiqueta para esta dirección a fin de agregarla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje que se agrgará al URI de Bitcoin, el cuál será almacenado con la transacción para su referencia. Nota: Este mensaje no será enviado a través de la red de Bitcoin.</translation>
+        <translation type="unfinished">Un mensaje que se adjuntó al bitcoin: URI que se almacenará con la transacción a modo de referencia. Nota: Este mensaje no se enviará por la red de Bitcoin.</translation>
     </message>
 </context>
 <context>
@@ -2999,7 +3306,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">Firmas - Firmar / verificar un mensaje</translation>
+        <translation type="unfinished">Firmas: firmar o verificar un mensaje</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
@@ -3007,23 +3314,23 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Puedes firmar los mensajes con tus direcciones para demostrar que las posees. Ten cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarte firmando tu identidad a través de ellos. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
+        <translation type="unfinished">Puedes firmar mensajes o acuerdos con tus direcciones para demostrar que puedes recibir los bitcoins que se envíen a ellas. Ten cuidado de no firmar cosas confusas o al azar, ya que los ataques de phishing pueden tratar de engañarte para que les envíes la firma con tu identidad. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmará el mensaje</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Escoger dirección previamente usada</translation>
+        <translation type="unfinished">Seleccionar dirección usada anteriormente</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
-        <translation type="unfinished">Introduzca el mensaje que desea firmar aquí</translation>
+        <translation type="unfinished">Ingresar aquí el mensaje que deseas firmar</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -3035,7 +3342,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Firmar el mensaje para demostrar que se posee esta dirección Bitcoin</translation>
+        <translation type="unfinished">Firmar el mensaje para demostrar que esta dirección de Bitcoin te pertenece</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -3043,19 +3350,23 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation type="unfinished">Limpiar todos los campos de la firma de mensaje</translation>
+        <translation type="unfinished">Restablecer todos los campos de firma de mensaje</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
         <translation type="unfinished">&amp;Verificar mensaje</translation>
     </message>
     <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">Ingresa la dirección del destinatario, el mensaje (recuerda copiar los saltos de línea, espacios, tabulaciones, etc. con exactitud) y la firma a continuación para verificar el mensaje. Ten cuidado de no leer en la firma más de lo que está en el mensaje firmado en sí, para evitar ser víctima de un engaño por ataque de intermediario. Ten en cuenta que esto solo demuestra que el firmante recibe con la dirección; no puede demostrar la condición de remitente de ninguna transacción.</translation>
+    </message>
+    <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmó el mensaje</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -3063,11 +3374,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation type="unfinished">La firma proporcionada cuando el mensaje fue firmado</translation>
+        <translation type="unfinished">La firma que se dio cuando el mensaje se firmó</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation type="unfinished">Verificar el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
+        <translation type="unfinished">Verifica el mensaje para asegurarte de que se firmó con la dirección de Bitcoin especificada.</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -3075,39 +3386,39 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation type="unfinished">Limpiar todos los campos de la verificación de mensaje</translation>
+        <translation type="unfinished">Restablecer todos los campos de verificación de mensaje</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Haga clic en "Firmar mensaje" para generar la firma</translation>
+        <translation type="unfinished">Hacer clic en "Firmar mensaje" para generar una firma</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
-        <translation type="unfinished">La dirección introducida es inválida.</translation>
+        <translation type="unfinished">La dirección ingresada es inválida.</translation>
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">Verifique la dirección e inténtelo de nuevo.</translation>
+        <translation type="unfinished">Revisa la dirección e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">La dirección introducida no corresponde a una clave.</translation>
+        <translation type="unfinished">La dirección ingresada no corresponde a una clave.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Se ha cancelado el desbloqueo del monedero. </translation>
+        <translation type="unfinished">Se canceló el desbloqueo de la billetera.</translation>
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">No hay error</translation>
+        <translation type="unfinished">Sin error </translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">No se dispone de la clave privada para la dirección introducida.</translation>
+        <translation type="unfinished">La clave privada para la dirección ingresada no está disponible.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation type="unfinished">Ha fallado la firma del mensaje.</translation>
+        <translation type="unfinished">Error al firmar el mensaje.</translation>
     </message>
     <message>
         <source>Message signed.</source>
@@ -3115,19 +3426,19 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The signature could not be decoded.</source>
-        <translation type="unfinished">No se puede decodificar la firma.</translation>
+        <translation type="unfinished">La firma no pudo decodificarse.</translation>
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Compruebe la firma e inténtelo de nuevo.</translation>
+        <translation type="unfinished">Comprueba la firma e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">La firma no coincide con el resumen del mensaje.</translation>
+        <translation type="unfinished">La firma no coincide con la síntesis del mensaje.</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
-        <translation type="unfinished">La verificación del mensaje ha fallado.</translation>
+        <translation type="unfinished">Falló la verificación del mensaje.</translation>
     </message>
     <message>
         <source>Message verified.</source>
@@ -3138,15 +3449,20 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SplashScreen</name>
     <message>
         <source>(press q to shutdown and continue later)</source>
-        <translation type="unfinished">(presiona q para apagar y seguir luego)</translation>
+        <translation type="unfinished">(Presionar q para apagar y seguir luego)</translation>
     </message>
     <message>
         <source>press q to shutdown</source>
-        <translation type="unfinished">presiona q para apagar </translation>
+        <translation type="unfinished">Presionar q para apagar </translation>
     </message>
 </context>
 <context>
     <name>TransactionDesc</name>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">Hay un conflicto con una transacción con %1 confirmaciones</translation>
+    </message>
     <message>
         <source>0/unconfirmed, in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
@@ -3165,7 +3481,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>%1/unconfirmed</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
-        <translation type="unfinished">%1/no confirmado</translation>
+        <translation type="unfinished">%1/sin confirmar</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
@@ -3198,11 +3514,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>own address</source>
         <translation type="unfinished">dirección propia</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
     </message>
     <message>
         <source>label</source>
@@ -3229,7 +3549,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Total debit</source>
-        <translation type="unfinished">Total enviado</translation>
+        <translation type="unfinished">Débito total</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">Crédito total</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -3237,7 +3561,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Cantidad neta</translation>
+        <translation type="unfinished">Importe neto</translation>
     </message>
     <message>
         <source>Message</source>
@@ -3249,11 +3573,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation type="unfinished">ID</translation>
+        <translation type="unfinished">Identificador de transacción</translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Tamaño total transacción</translation>
+        <translation type="unfinished">Tamaño total de transacción</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -3261,7 +3585,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Indice de salida</translation>
+        <translation type="unfinished">Índice de salida</translation>
     </message>
     <message>
         <source>%1 (Certificate was not verified)</source>
@@ -3269,11 +3593,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Merchant</source>
-        <translation type="unfinished">Vendedor</translation>
+        <translation type="unfinished">Comerciante</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que puedan ser gastadas. Una vez que generas este bloque, es propagado por la red para ser añadido a la cadena de bloques. Si falla el intento de meterse en la cadena, su estado cambiará a "no aceptado" y ya no se puede gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
+        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que se puedan gastar. Cuando generaste este bloque, se transmitió a la red para agregarlo a la cadena de bloques. Si no logra entrar a la cadena, su estado cambiará a "no aceptado" y no se podrá gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -3285,11 +3609,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="unfinished">entradas</translation>
+        <translation type="unfinished">Entradas</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>true</source>
@@ -3304,9 +3628,13 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation type="unfinished">Esta ventana muestra información detallada sobre la transacción</translation>
+        <translation type="unfinished">En este panel se muestra una descripción detallada de la transacción</translation>
     </message>
-    </context>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">Detalles para %1</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
     <message>
@@ -3319,43 +3647,59 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Sin confirmar</translation>
     </message>
     <message>
         <source>Abandoned</source>
         <translation type="unfinished">Abandonada</translation>
     </message>
     <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">Confirmando (%1 de %2 confirmaciones recomendadas)</translation>
+    </message>
+    <message>
         <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">Confirmado (%1 confirmaciones)</translation>
+        <translation type="unfinished">Confirmada (%1 confirmaciones)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">En conflicto</translation>
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">No disponible (%1 confirmaciones, disponible después de %2)</translation>
+        <translation type="unfinished">Inmadura (%1 confirmaciones; estará disponibles después de %2)</translation>
     </message>
     <message>
         <source>Generated but not accepted</source>
-        <translation type="unfinished">Generado pero no aceptado</translation>
+        <translation type="unfinished">Generada pero no aceptada</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished">Recibidos de</translation>
+        <translation type="unfinished">Recibida de</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation type="unfinished">Enviado a</translation>
+        <translation type="unfinished">Enviada a</translation>
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
     </message>
     <message>
         <source>(n/a)</source>
-        <translation type="unfinished">(nd)</translation>
+        <translation type="unfinished">(n/d)</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -3363,11 +3707,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation type="unfinished">Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
+        <translation type="unfinished">Estado de la transacción. Pasa el mouse sobre este campo para ver el número de confirmaciones.</translation>
     </message>
     <message>
         <source>Date and time that the transaction was received.</source>
-        <translation type="unfinished">Fecha y hora en que se recibió la transacción.</translation>
+        <translation type="unfinished">Fecha y hora en las que se recibió la transacción.</translation>
     </message>
     <message>
         <source>Type of transaction.</source>
@@ -3375,7 +3719,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Si una dirección de solo observación está involucrada en esta transacción o no.</translation>
+        <translation type="unfinished">Si una dirección solo de observación está involucrada en esta transacción o no.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
@@ -3383,7 +3727,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Cantidad retirada o añadida al saldo.</translation>
+        <translation type="unfinished">Importe restado del saldo o sumado a este.</translation>
     </message>
 </context>
 <context>
@@ -3414,15 +3758,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation type="unfinished">Enviado a</translation>
+        <translation type="unfinished">Enviada a</translation>
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
     </message>
     <message>
         <source>Other</source>
@@ -3430,11 +3774,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Ingresa la dirección, el identificador de transacción o la etiqueta para buscar</translation>
+        <translation type="unfinished">Ingresar la dirección, el identificador de transacción o la etiqueta para buscar</translation>
     </message>
     <message>
         <source>Min amount</source>
-        <translation type="unfinished">Cantidad mínima</translation>
+        <translation type="unfinished">Importe mínimo</translation>
     </message>
     <message>
         <source>Range…</source>
@@ -3454,11 +3798,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Copiar &amp;ID de transacción</translation>
+        <translation type="unfinished">Copiar &amp;identificador de transacción</translation>
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Copiar transacción &amp;raw</translation>
+        <translation type="unfinished">Copiar transacción &amp;sin procesar</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
@@ -3496,7 +3840,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="unfinished">Confirmada</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
     </message>
     <message>
         <source>Date</source>
@@ -3508,11 +3856,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">Direccion</translation>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation type="unfinished">Identificador</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -3520,15 +3872,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">Ha habido un error al intentar guardar la transacción con %1.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar el historial de transacciones en %1.</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
-        <translation type="unfinished">Exportación finalizada</translation>
+        <translation type="unfinished">Exportación correcta</translation>
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">La transacción ha sido guardada en %1.</translation>
+        <translation type="unfinished">El historial de transacciones se guardó correctamente en %1.</translation>
     </message>
     <message>
         <source>Range:</source>
@@ -3536,7 +3888,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished">para</translation>
+        <translation type="unfinished">a</translation>
     </message>
 </context>
 <context>
@@ -3546,28 +3898,32 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <translation type="unfinished">No se cargó ninguna billetera.
-Ir a Archivo &gt; Abrir billetera para cargar una.
-- OR -</translation>
+Ir a "Archivo &gt; Abrir billetera" para cargar una.
+- O -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Crear monedero nuevo</translation>
+        <translation type="unfinished">Crear una nueva billetera</translation>
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">No se puede decodificar PSBT desde el portapapeles (Base64 inválido)</translation>
+        <translation type="unfinished">No se puede decodificar la TBPF desde el portapapeles (Base64 inválida)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Cargar datos de la transacción</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Transacción firmada parcialmente (*.psbt)</translation>
+        <translation type="unfinished">Transacción parcialmente firmada (*.psbt)</translation>
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">El archivo PSBT debe ser más pequeño de 100 MiB</translation>
+        <translation type="unfinished">El archivo TBPF debe ser más pequeño de 100 MiB</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">No se puede decodificar PSBT</translation>
+        <translation type="unfinished">No se puede decodificar TBPF</translation>
     </message>
 </context>
 <context>
@@ -3578,16 +3934,28 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Fee bump error</source>
-        <translation type="unfinished">Error de incremento de cuota</translation>
+        <translation type="unfinished">Error de incremento de comisión</translation>
+    </message>
+    <message>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">Fallo al incrementar la comisión de transacción</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
         <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
-        <translation type="unfinished">¿Desea incrementar la cuota?</translation>
+        <translation type="unfinished">¿Deseas incrementar la comisión?</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Comisión actual:</translation>
     </message>
     <message>
         <source>Increase:</source>
         <translation type="unfinished">Incremento:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Nueva comisión:</translation>
     </message>
     <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
@@ -3603,7 +3971,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>PSBT copied</source>
-        <translation type="unfinished">PSBT copiada</translation>
+        <translation type="unfinished">TBPF copiada</translation>
     </message>
     <message>
         <source>Copied to clipboard</source>
@@ -3612,7 +3980,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Can't sign transaction.</source>
-        <translation type="unfinished">No se ha podido firmar la transacción.</translation>
+        <translation type="unfinished">No se puede firmar la transacción.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
@@ -3624,7 +3992,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
 </context>
 <context>
@@ -3635,11 +4003,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar los datos en la pestaña actual a un archivo</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">Respaldo de monedero</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -3648,19 +4016,19 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">Ha fallado el respaldo</translation>
+        <translation type="unfinished">Copia de seguridad fallida</translation>
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">Ha habido un error al intentar guardar los datos del monedero en %1.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar los datos de la billetera en %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">Se ha completado con éxito la copia de respaldo</translation>
+        <translation type="unfinished">Copia de seguridad correcta</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished">Los datos del monedero se han guardado con éxito en %1.</translation>
+        <translation type="unfinished">Los datos de la billetera se guardaron correctamente en %1.</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -3675,11 +4043,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s corrupto. Intenta utilizar la herramienta de la billetera de bitcoin para rescatar o restaurar una copia de seguridad.</translation>
+        <translation type="unfinished">%s dañado. Trata de usar la herramienta de la billetera de Bitcoin para rescatar o restaurar una copia de seguridad.</translation>
     </message>
     <message>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea no válida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Comunique este incidente a %s, indicando cómo obtuvo la instantánea. Se dejó el estado de encadenamiento de la instantánea no válida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
+        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea inválida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Reporta este incidente a %s, indicando cómo obtuviste la instantánea. Se dejó el estado de cadena de la instantánea inválida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
     </message>
     <message>
         <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
@@ -3702,28 +4070,32 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">Es posible que el espacio en disco %s no tenga capacidad para los archivos de bloque. Aproximadamente %u GB de datos se almacenarán en este directorio.</translation>
     </message>
     <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">Distribuido bajo la licencia de software MIT; ver el archivo adjunto %s o %s.</translation>
+    </message>
+    <message>
         <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <translation type="unfinished">Error al cargar la billetera. Esta requiere que se descarguen bloques, y el software actualmente no admite la carga de billeteras mientras los bloques se descargan fuera de orden, cuando se usan instantáneas de assumeutxo. La billetera debería poder cargarse correctamente después de que la sincronización del nodo alcance la altura %s.</translation>
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Reescaneando billetera.</translation>
+        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Rescaneando billetera.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "formato".</translation>
+        <translation type="unfinished">Error: El registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "formato".</translation>
     </message>
     <message>
         <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "%s".</translation>
+        <translation type="unfinished">Error: El registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "%s".</translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Error: la versión del archivo volcado no es compatible. Esta versión de la billetera de bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
+        <translation type="unfinished">Error: La versión del archivo de volcado no es compatible. Esta versión de la billetera de Bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Error: las billeteras heredadas solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
+        <translation type="unfinished">Error: Las billeteras "legacy" solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
     </message>
     <message>
         <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
@@ -3735,7 +4107,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <translation type="unfinished">Archivo peers.dat inválido o corrupto (%s). Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
+        <translation type="unfinished">El archivo peers.dat (%s) es inválido o está dañado. Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -3762,8 +4134,12 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">Contribuye si te parece que %s es útil. Visita %s para obtener más información sobre el software.</translation>
     </message>
     <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation type="unfinished">La poda se configuró por debajo del mínimo de %d MiB. Usa un valor más alto.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <translation type="unfinished">El modo de poda no es compatible con -reindex-chainstate. Usa en su lugar un -reindex completo.</translation>
+        <translation type="unfinished">El modo de poda es incompatible con -reindex-chainstate. Usa en su lugar un -reindex completo.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -3771,7 +4147,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <translation type="unfinished">Error de renombrado de «%s» → «%s». Debería resolver esto manualmente moviendo o borrando el directorio %s de la instantánea no válida, en otro caso encontrará el mismo error de nuevo en el arranque siguiente.</translation>
+        <translation type="unfinished">Error al cambiar el nombre de "%s" a "%s". Para resolverlo, mueve o elimina manualmente el directorio %s de la instantánea no válida. De lo contrario, encontrarás el mismo error de nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -3783,7 +4159,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
@@ -3791,7 +4167,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Esta es una versión de pre-prueba - utilícela bajo su propio riesgo. No la utilice para usos comerciales o de minería.</translation>
+        <translation type="unfinished">Esta es una compilación preliminar de prueba. Úsala bajo tu propia responsabilidad. No la uses para aplicaciones comerciales o de minería.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
@@ -3799,15 +4175,15 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Esta es la comisión de transacción que puede descartar si el cambio es más pequeño que el polvo a este nivel.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes descartar si el cambio es más pequeño que el remanente en este nivel.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Impuesto por transacción que pagarás cuando la estimación de impuesto no esté disponible.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes pagar cuando los cálculos de comisiones no estén disponibles.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i ) supera la longitud máxima ( %i ) . Reducir el número o tamaño de uacomments .</translation>
+        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i) supera la longitud máxima (%i). Reduce el número o tamaño de uacomments .</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
@@ -3819,7 +4195,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <translation type="unfinished">Nivel de boletín del acceso especificado en categoría no mantenida en %1$s=%2$s. Se esperaba %1$s=1:2. Categorías válidas: %3$s. Niveles de boletín válidos: %4 $s.</translation>
+        <translation type="unfinished">El nivel de registro de la categoría específica no es compatible: %1$s=%2$s. Se esperaba %1$s=&lt;category&gt;:&lt;loglevel&gt;. Categorías válidas: %3$s. Niveles de registro válidos: %4 $s.</translation>
     </message>
     <message>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
@@ -3831,11 +4207,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <translation type="unfinished">Monedero correctamente cargado. El tipo de billetero heredado está siendo obsoleto y mantenimiento para creación de monederos heredados serán eliminados en el futuro. Los monederos heredados pueden ser migrados a un descriptor de monedero con migratewallet.</translation>
+        <translation type="unfinished">La billetera se creó correctamente. El tipo de billetera "legacy" se está descontinuando, por lo que la asistencia para crear y abrir estas billeteras se eliminará en el futuro. Las billeteras "legacy" se pueden migrar a una billetera basada en descriptores con "migratewallet".</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Advertencia: el formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
+        <translation type="unfinished">Advertencia: El formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -3843,7 +4219,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Atención: ¡Parece que no estamos completamente de acuerdo con nuestros pares! Podría necesitar una actualización, u otros nodos podrían necesitarla.</translation>
+        <translation type="unfinished">Advertencia: Al parecer no estamos completamente de acuerdo con nuestros pares. Es posible que tengas que realizar una actualización, o que los demás nodos tengan que hacerlo.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
@@ -3855,7 +4231,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">¡%s esta configurado muy alto!</translation>
+        <translation type="unfinished">¡El valor de %s es muy alto!</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
@@ -3867,7 +4243,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">No se puede resolver -%s direccion: '%s'</translation>
+        <translation type="unfinished">No se puede resolver la dirección de -%s: "%s"</translation>
     </message>
     <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
@@ -3883,7 +4259,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">La configuración de %s es demasiado alta. Las comisiones tan grandes se podrían pagar en una sola transacción.</translation>
+        <translation type="unfinished">El valor establecido para %s es demasiado alto. Las comisiones tan grandes se podrían pagar en una sola transacción.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
@@ -3895,7 +4271,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <translation type="unfinished">Error leyendo %s. Todas las teclas leídas correctamente, pero los datos de transacción o metadatos de dirección puedan ser ausentes o incorrectos.</translation>
+        <translation type="unfinished">Error al leer %s. Todas las claves se leyeron correctamente, pero es probable que falten los datos de la transacción o metadatos de direcciones, o bien que sean incorrectos.</translation>
     </message>
     <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
@@ -3947,11 +4323,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
-        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar una cantidad menor o consolidar manualmente las UTXO de la billetera.</translation>
+        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar un importe menor o consolidar manualmente las UTXO de la billetera.</translation>
     </message>
     <message>
         <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
-        <translation type="unfinished">La cantidad total de monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
+        <translation type="unfinished">El monto total de las monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
     </message>
     <message>
         <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
@@ -3963,14 +4339,14 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
-        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará el pool de memoria.</translation>
+        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará la mempool.</translation>
     </message>
     <message>
         <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <translation type="unfinished">Se encontró una entrada heredada inesperada en la billetera del descriptor. Cargando billetera%s
+        <translation type="unfinished">Se encontró una entrada inesperada tipo "legacy" en la billetera basada en descriptores. Cargando billetera%s
 
 Es posible que la billetera haya sido manipulada o creada con malas intenciones.
 </translation>
@@ -4004,8 +4380,16 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Se interrumpió la verificación de bloques</translation>
     </message>
     <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">La configuración para %s solo se aplica en la red %s cuando se encuentra en la sección [%s].</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished">Derechos de autor (C) %i-%i</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
-        <translation type="unfinished">Corrupción de base de datos de bloques detectada.</translation>
+        <translation type="unfinished">Se detectó que la base de datos de bloques está dañada.</translation>
     </message>
     <message>
         <source>Could not find asmap file %s</source>
@@ -4025,7 +4409,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Done loading</source>
-        <translation type="unfinished">Carga lista</translation>
+        <translation type="unfinished">Carga completa</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
@@ -4045,7 +4429,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Error al inicializar el entorno de la base de datos del monedero  %s</translation>
+        <translation type="unfinished">Error al inicializar el entorno de la base de datos de la billetera %s.</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">Error al cargar %s</translation>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
@@ -4053,19 +4441,19 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Error cargando %s: Monedero corrupto</translation>
+        <translation type="unfinished">Error al cargar %s: billetera dañada</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Error cargando %s: Monedero requiere una versión mas reciente de %s</translation>
+        <translation type="unfinished">Error al cargar %s: la billetera requiere una versión más reciente de %s</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation type="unfinished">Error cargando base de datos de bloques</translation>
+        <translation type="unfinished">Error al cargar la base de datos de bloques</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation type="unfinished">Error al abrir base de datos de bloques.</translation>
+        <translation type="unfinished">Error al abrir la base de datos de bloques</translation>
     </message>
     <message>
         <source>Error reading configuration file: %s</source>
@@ -4085,7 +4473,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
-        <translation type="unfinished">Error: no se puede extraer el destino del scriptpubkey generado</translation>
+        <translation type="unfinished">Error: No se puede extraer el destino del scriptpubkey generado</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -4105,11 +4493,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió una clave que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió una clave que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió un valor que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió un valor que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
@@ -4129,15 +4517,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: This wallet is already a descriptor wallet</source>
-        <translation type="unfinished">Error: Esta billetera ya es de descriptores</translation>
+        <translation type="unfinished">Error: Esta billetera ya está basada en descriptores</translation>
     </message>
     <message>
         <source>Error: Unable to begin reading all records in the database</source>
-        <translation type="unfinished">Error: No se puede comenzar a leer todos los registros en la base de datos</translation>
+        <translation type="unfinished">Error: No se pueden comenzar a leer todos los registros en la base de datos</translation>
     </message>
     <message>
         <source>Error: Unable to make a backup of your wallet</source>
-        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de tu billetera</translation>
+        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
@@ -4149,7 +4537,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to read wallet's best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de leer el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo leer el registro del mejor localizador de bloques de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to remove watchonly address book data</source>
@@ -4161,16 +4549,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to write solvable wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solucionable.</translation>
     </message>
     <message>
         <source>Error: Unable to write watchonly wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor monedero vigilado del bloque del registro localizador</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: address book copy failed for wallet %s</source>
-        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera 1%s
- </translation>
+        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera %s</translation>
     </message>
     <message>
         <source>Error: database transaction cannot be executed for wallet %s</source>
@@ -4178,7 +4565,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
+        <translation type="unfinished">Fallo al escuchar en todos los puertos. Usa -listen=0 si quieres hacerlo.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -4186,7 +4573,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished">Es erróneo al iniciar indizados, se apaga...</translation>
+        <translation type="unfinished">Error al iniciar índices, cerrando...</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -4194,7 +4581,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failure removing transaction: %s</source>
-        <translation type="unfinished">Error al eliminar la transacción: 1%s</translation>
+        <translation type="unfinished">Error al eliminar la transacción: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4210,15 +4597,19 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Incorrecto o bloque de génesis no encontrado. Datadir equivocada para la red?</translation>
+        <translation type="unfinished">El bloque génesis es incorrecto o no se encontró. ¿El directorio de datos es equivocado para la red?</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">Fallo al inicializar la comprobación de estado. %s se cerrará.</translation>
     </message>
     <message>
         <source>Input not found or already spent</source>
-        <translation type="unfinished">No se encontró o ya se gastó la entrada</translation>
+        <translation type="unfinished">La entrada no se encontró o ya se gastó</translation>
     </message>
     <message>
         <source>Insufficient dbcache for block verification</source>
-        <translation type="unfinished">dbcache insuficiente para la verificación de bloques</translation>
+        <translation type="unfinished">Dbcache insuficiente para la verificación de bloques</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -4226,15 +4617,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">La dirección -i2psam o el nombre de host no es válido: "%s" </translation>
+        <translation type="unfinished">Dirección o nombre de host de -i2psam inválido: "%s" </translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -onion o dominio '%s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -onion inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -proxy o dominio ' %s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -proxy inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
@@ -4249,16 +4640,24 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Importe inválido para %s=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe inválido para -%s=&lt;amount&gt;: "%s"</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation type="unfinished">Máscara de red inválida especificada en -whitelist: "%s"</translation>
+    </message>
+    <message>
         <source>Invalid port specified in %s: '%s'</source>
-        <translation type="unfinished">Puerto no válido especificado en%s: '%s'</translation>
+        <translation type="unfinished">Puerto no válido especificado en %s: "%s"</translation>
     </message>
     <message>
         <source>Invalid pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no válida %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no es válida %s</translation>
     </message>
     <message>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Fallo en la escucha para conexiones entrantes (la escucha devolvió el error %s)</translation>
+        <translation type="unfinished">Fallo al escuchar conexiones entrantes (la escucha devolvió el error %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4266,7 +4665,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Cargando lista de bloqueos...</translation>
+        <translation type="unfinished">Cargando lista de prohibiciones...</translation>
     </message>
     <message>
         <source>Loading block index…</source>
@@ -4278,11 +4677,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Missing amount</source>
-        <translation type="unfinished">Falta la cantidad</translation>
+        <translation type="unfinished">Falta el importe</translation>
     </message>
     <message>
         <source>Missing solving data for estimating transaction size</source>
         <translation type="unfinished">Faltan datos de resolución para estimar el tamaño de la transacción</translation>
+    </message>
+    <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation type="unfinished">Se necesita especificar un puerto con -whitebind: "%s"</translation>
     </message>
     <message>
         <source>No addresses available</source>
@@ -4290,15 +4693,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
-        <translation type="unfinished">No hay suficientes descriptores de archivo disponibles. </translation>
+        <translation type="unfinished">No hay suficientes descriptores de archivo disponibles.</translation>
     </message>
     <message>
         <source>Not found pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no encontrada%s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se encontró %s</translation>
     </message>
     <message>
         <source>Not solvable pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no solucionable %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se puede solucionar %s</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4310,7 +4713,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Podando almacén de bloques…</translation>
+        <translation type="unfinished">Podando almacenamiento de bloques…</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished">Reduciendo -maxconnections de %d a %d, debido a limitaciones del sistema.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
@@ -4342,7 +4749,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation type="unfinished">Transacción falló</translation>
+        <translation type="unfinished">Fallo al firmar la transacción</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
@@ -4370,7 +4777,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">El código fuente esta disponible desde %s.</translation>
+        <translation type="unfinished">El código fuente está disponible en %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
@@ -4378,15 +4785,23 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para pagar la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es muy pequeño para pagar la comisión</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">La billetera evitará pagar menos que la comisión mínima de retransmisión.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Este es un software experimental.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Esta es la tarifa mínima a pagar en cada transacción.</translation>
+        <translation type="unfinished">Esta es la comisión mínima de transacción que pagas en cada transacción.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Esta es la tarifa a pagar si realizas una transacción.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que pagarás si envías una transacción.</translation>
     </message>
     <message>
         <source>Transaction %s does not belong to this wallet</source>
@@ -4394,11 +4809,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
-        <translation type="unfinished">Transacción muy pequeña</translation>
+        <translation type="unfinished">El importe de la transacción es demasiado pequeño</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Los montos de la transacción no debe ser negativo</translation>
+        <translation type="unfinished">Los importes de la transacción no pueden ser negativos</translation>
     </message>
     <message>
         <source>Transaction change output index out of range</source>
@@ -4406,7 +4821,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">La transacción debe tener al menos un destinatario</translation>
+        <translation type="unfinished">La transacción debe incluir al menos un destinatario</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it.</source>
@@ -4414,7 +4829,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction too large</source>
-        <translation type="unfinished">Transacción muy grande</translation>
+        <translation type="unfinished">Transacción demasiado grande</translation>
     </message>
     <message>
         <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
@@ -4453,6 +4868,10 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">No se puede analizar -maxuploadtarget: "%s"</translation>
     </message>
     <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">No se puede iniciar el servidor HTTP. Consulta el registro de depuración para obtener información.</translation>
+    </message>
+    <message>
         <source>Unable to unload the wallet before migrating</source>
         <translation type="unfinished">No se puede descargar la billetera antes de la migración</translation>
     </message>
@@ -4470,7 +4889,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">La red especificada en -onlynet '%s' es desconocida</translation>
+        <translation type="unfinished">Se desconoce la red especificada en -onlynet: "%s"</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
@@ -4478,15 +4897,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <translation type="unfinished">Nivel de acceso global %s = %s no mantenido. Los valores válidos son: %s.</translation>
+        <translation type="unfinished">El nivel de registro global %s=%s no es compatible. Valores válidos: %s.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
-        <translation type="unfinished">Creación errónea del fichero monedero: %s</translation>
+        <translation type="unfinished">Error al crear el archivo de la billetera: %s</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
-        <translation type="unfinished">acceptstalefeeestimates no está mantenido en el encadenamiento %s.</translation>
+        <translation type="unfinished">acceptstalefeeestimates no se admite en la cadena %s.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
@@ -4494,11 +4913,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
-        <translation type="unfinished">Error: no pudo agregar tx de solo vigía %s para monedero de solo vigía</translation>
+        <translation type="unfinished">Error: No se pudo agregar la transacción %s a la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: Could not delete watchonly transactions. </source>
-        <translation type="unfinished">Error: no se pudieron eliminar las transacciones de watchonly.</translation>
+        <translation type="unfinished">Error: No se pudieron eliminar las transacciones solo de observación</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_es_SV.ts
+++ b/src/qt/locale/bitcoin_es_SV.ts
@@ -11,11 +11,11 @@
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">Es Nuevo</translation>
+        <translation type="unfinished">&amp;Nueva</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Copia la dirección actualmente seleccionada al portapapeles del sistema</translation>
+        <translation type="unfinished">Copiar la dirección seleccionada actualmente al portapapeles del sistema</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,41 +27,45 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Borrar de la lista la dirección seleccionada</translation>
+        <translation type="unfinished">Eliminar la dirección seleccionada de la lista</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Introduce una dirección o etiqueta para  buscar</translation>
+        <translation type="unfinished">Ingresar una dirección o etiqueta para buscar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar a un archivo los datos de esta pestaña</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Eliminar</translation>
+        <translation type="unfinished">&amp;Borrar</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Escoja la dirección a la que se enviarán monedas</translation>
+        <translation type="unfinished">Elige la dirección a la que se enviarán monedas</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Escoja la dirección donde quiere recibir monedas</translation>
+        <translation type="unfinished">Elige la dirección con la que se recibirán monedas</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">&amp;Escoger</translation>
+        <translation type="unfinished">&amp;Seleccionar</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estas son sus direcciones Bitcoin para enviar pagos. Compruebe siempre la cantidad y la dirección de recibo antes de transferir monedas.</translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para enviar pagos. Revisa siempre el importe y la dirección de recepción antes de enviar monedas.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Estas son sus direcciones de Bitcoin para recibir los pagos.
-Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir para crear una nueva direccion.  Firmar es posible solo con la direccion del tipo "legado"</translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para recibir pagos. Usa el botón "Crear nueva dirección de recepción" en la pestaña "Recibir" para crear nuevas direcciones.
+Solo es posible firmar con direcciones de tipo legacy.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -69,7 +73,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar y etiquetar</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -77,7 +81,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Exportar la Lista de Direcciones</translation>
+        <translation type="unfinished">Exportar lista de direcciones</translation>
     </message>
     <message>
         <source>Comma separated file</source>
@@ -85,9 +89,17 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <translation type="unfinished">Archivo separado por comas</translation>
     </message>
     <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">Ocurrió un error al intentar guardar la lista de direcciones en %1. Inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">Direcciones de envío - %1</translation>
+    </message>
+    <message>
         <source>Receiving addresses - %1</source>
-        <translation type="unfinished">Recepción de direcciones - %1
-</translation>
+        <translation type="unfinished">Direcciones de recepción - %1</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -98,7 +110,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Address</source>
@@ -112,36 +124,44 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
 <context>
     <name>AskPassphraseDialog</name>
     <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">Diálogo de frase de contraseña</translation>
+    </message>
+    <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">Introduce contraseña actual</translation>
+        <translation type="unfinished">Ingresar la frase de contraseña</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">Nueva contraseña</translation>
+        <translation type="unfinished">Nueva frase de contraseña</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Repita la nueva contraseña</translation>
+        <translation type="unfinished">Repetir la nueva frase de contraseña</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Mostrar contraseña</translation>
+        <translation type="unfinished">Mostrar la frase de contraseña</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Encriptar la billetera</translation>
+        <translation type="unfinished">Encriptar billetera</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Esta operación necesita su contraseña de billetera para desbloquearla.</translation>
+        <translation type="unfinished">Esta operación requiere la frase de contraseña de la billetera para desbloquearla.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Desbloquear billetera</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Cambia contraseña</translation>
+        <translation type="unfinished">Cambiar frase de contraseña</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">Confirma el cifrado de este monedero</translation>
+        <translation type="unfinished">Confirmar el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
@@ -149,55 +169,59 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">¿Esta seguro que quieres cifrar tu monedero?</translation>
+        <translation type="unfinished">¿Seguro quieres encriptar la billetera?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Billetera codificada</translation>
+        <translation type="unfinished">Billetera encriptada</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Introduce la contraseña nueva para la billetera. &lt;br/&gt;Por favor utiliza una contraseña de &lt;b&gt;diez o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
+        <translation type="unfinished">Ingresa la nueva frase de contraseña para la billetera. &lt;br/&gt;Usa una frase de contraseña de &lt;b&gt;diez o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Introduce la contraseña antigua y la nueva para el monedero.</translation>
+        <translation type="unfinished">Ingresa la antigua frase de contraseña y la nueva frase de contraseña para la billetera.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Recuerda que cifrar tu billetera no garantiza total protección de robo de tus bitcoins si tu ordenador es infectado con malware.</translation>
+        <translation type="unfinished">Recuerda que encriptar tu billetera no garantiza la protección total contra el robo de tus bitcoins si la computadora está infectada con malware.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Billetera para cifrar</translation>
+        <translation type="unfinished">Billetera para encriptar</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Tu billetera esta por ser encriptada</translation>
+        <translation type="unfinished">Tu billetera está a punto de encriptarse.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Tu monedero está ahora cifrado</translation>
+        <translation type="unfinished">Tu billetera ahora está encriptada.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">IMPORTANTE: Cualquier respaldo anterior que hayas hecho del archivo de tu billetera debe ser reemplazado por el nuevo archivo encriptado que has generado. Por razones de seguridad, todos los respaldos realizados anteriormente serán inutilizables al momento de que utilices tu nueva billetera encriptada.</translation>
+        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad anterior que hayas hecho del archivo de la billetera se deberá reemplazar por el nuevo archivo encriptado que generaste. Por motivos de seguridad, las copias de seguridad realizadas anteriormente quedarán obsoletas en cuanto empieces a usar la nueva billetera encriptada.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Ha fallado el cifrado del monedero</translation>
+        <translation type="unfinished">Falló el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">La encriptación de la billetera falló debido a un error interno. La billetera no se encriptó.</translation>
+        <translation type="unfinished">El encriptado de la billetera falló debido a un error interno. La billetera no se encriptó.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Las frases de contraseña proporcionadas no coinciden.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">Ha fallado el desbloqueo del monedero</translation>
+        <translation type="unfinished">Falló el desbloqueo de la billetera</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">La frase de contraseña ingresada para el descifrado de la billetera fue incorrecta.</translation>
+        <translation type="unfinished">La frase de contraseña introducida para el cifrado de la billetera es incorrecta.</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
@@ -205,7 +229,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">La contraseña de la billetera ha sido cambiada.</translation>
+        <translation type="unfinished">La frase de contraseña de la billetera se cambió correctamente.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
@@ -215,12 +239,20 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
         <translation type="unfinished">La frase de contraseña que se ingresó para descifrar la billetera es incorrecta. Contiene un carácter nulo (es decir, un byte cero). Si la frase de contraseña se configuró con una versión de este software anterior a la 25.0, vuelve a intentarlo solo con los caracteres hasta el primer carácter nulo, pero sin incluirlo.</translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Advertencia: ¡Las mayúsculas están activadas!</translation>
+    </message>
+</context>
 <context>
     <name>BanTableModel</name>
     <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/Máscara de red</translation>
+    </message>
+    <message>
         <source>Banned Until</source>
-        <translation type="unfinished">Bloqueado hasta</translation>
+        <translation type="unfinished">Prohibido hasta</translation>
     </message>
 </context>
 <context>
@@ -230,8 +262,12 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <translation type="unfinished">El archivo de configuración %1 puede estar corrupto o no ser válido.</translation>
     </message>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción fuera de control</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Se ha producido un error garrafal. %1Ya no podrá continuar de manera segura y abandonará.</translation>
+        <translation type="unfinished">Se produjo un error fatal. %1 ya no puede continuar de manera segura y se cerrará.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -239,7 +275,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Un error interno ocurrió. %1 intentará continuar. Este es un error inesperado que puede ser reportado de las formas que se muestran debajo,</translation>
+        <translation type="unfinished">Se produjo un error interno. %1 intentará continuar de manera segura. Este es un error inesperado que se puede reportar como se describe a continuación.</translation>
     </message>
 </context>
 <context>
@@ -252,11 +288,19 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Un error fatal ha ocurrido. Comprueba que el archivo de configuración soporta escritura, o intenta ejecutar de nuevo el programa con -nosettings</translation>
+        <translation type="unfinished">Se produjo un error fatal. Comprueba que el archivo de configuración soporte escritura o intenta ejecutar el programa con -nosettings.</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 todavía no ha terminado de forma segura...</translation>
+        <translation type="unfinished">%1 aún no salió de forma segura...</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">"%1" integrado</translation>
     </message>
     <message>
         <source>Default system font "%1"</source>
@@ -268,11 +312,11 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Ingresa una dirección de Bitcoin (Ejemplo: %1)</translation>
+        <translation type="unfinished">Ingresar una dirección de Bitcoin (por ejemplo, %1)</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -286,7 +330,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
     <message>
         <source>Full Relay</source>
@@ -296,21 +340,12 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>Block Relay</source>
         <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">Retransmisión de bloque</translation>
-    </message>
-    <message>
-        <source>Feeler</source>
-        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">Sensor</translation>
+        <translation type="unfinished">Retransmisión de bloques</translation>
     </message>
     <message>
         <source>Address Fetch</source>
         <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
         <translation type="unfinished">Recuperación de dirección</translation>
-    </message>
-    <message>
-        <source>%1 h</source>
-        <translation type="unfinished">%1 d</translation>
     </message>
     <message>
         <source>None</source>
@@ -362,7 +397,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n años</numerusform>
+            <numerusform>%n año</numerusform>
             <numerusform>%n años</numerusform>
         </translation>
     </message>
@@ -370,20 +405,81 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;Vista general</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">Muestra una vista general de la billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;Transacciones</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">Explora el historial de transacciones</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">&amp;Salir</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">Salir del programa</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;Acerca de %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Mostrar Información sobre %1</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">Acerca de &amp;Qt</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">Mostrar información sobre Qt</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">Modificar las opciones de configuración para %1</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Crear monedero nuevo</translation>
+        <translation type="unfinished">Crear una nueva billetera</translation>
     </message>
     <message>
         <source>&amp;Minimize</source>
         <translation type="unfinished">&amp;Minimizar</translation>
     </message>
     <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Actividad de red deshabilitada.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proxy &lt;b&gt;habilitado&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">Enviar monedas a una dirección de Bitcoin</translation>
+    </message>
+    <message>
         <source>Backup wallet to another location</source>
-        <translation type="unfinished">Respaldar monedero en otra ubicación</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera en otra ubicación</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">Cambiar la contraseña utilizada para el cifrado del monedero</translation>
+        <translation type="unfinished">Cambiar la frase de contraseña utilizada para encriptar la billetera</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -394,28 +490,44 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <translation type="unfinished">&amp;Recibir</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opciones…</translation>
+    </message>
+    <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Cifrar monedero</translation>
+        <translation type="unfinished">&amp;Encriptar billetera…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">Cifrar las claves privadas de tu monedero</translation>
+        <translation type="unfinished">Encriptar las claves privadas que pertenecen a la billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Realizar copia de seguridad de la billetera...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
         <translation type="unfinished">&amp;Cambiar frase de contraseña...</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Firmar &amp;mensaje...</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Firmar mensajes con sus direcciones Bitcoin para probar la propiedad</translation>
+        <translation type="unfinished">Firmar mensajes con tus direcciones de Bitcoin para demostrar que te pertenecen</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Verificar mensaje...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Verificar un mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
+        <translation type="unfinished">Verificar mensajes para asegurarte de que estén firmados con direcciones de Bitcoin concretas</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Cargar PSBT desde archivo...</translation>
+        <translation type="unfinished">&amp;Cargar TBPF desde archivo...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -423,15 +535,15 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Cerrar monedero...</translation>
+        <translation type="unfinished">Cerrar billetera...</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Crear monedero...</translation>
+        <translation type="unfinished">Crear billetera...</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Cerrar todos los monederos...</translation>
+        <translation type="unfinished">Cerrar todas las billeteras...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -440,6 +552,10 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>&amp;Settings</source>
         <translation type="unfinished">&amp;Configuración</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Ayuda</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
@@ -467,48 +583,54 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished"> 
-Solicitar pagos (genera códigos QR y bitcoin: URI)
- </translation>
+        <translation type="unfinished">Solicitar pagos (genera códigos QR y URI de tipo "bitcoin:")</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Mostrar la lista de direcciones y etiquetas de envío usadas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de envío usadas</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Mostrar la lista de direcciones y etiquetas de recepción usadas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de recepción usadas</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">opciones de la &amp;Linea de comandos</translation>
+        <translation type="unfinished">&amp;Opciones de línea de comandos</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>Procesado %n bloque del historial de transacciones.</numerusform>
-            <numerusform>Procesados %n bloques del historial de transacciones.</numerusform>
+            <numerusform>Se procesó %n bloque del historial de transacciones.</numerusform>
+            <numerusform>Se procesaron %n bloques del historial de transacciones.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 atrás</translation>
     </message>
     <message>
         <source>Catching up…</source>
         <translation type="unfinished">Poniéndose al día...</translation>
     </message>
     <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">El último bloque recibido se generó hace %1.</translation>
+    </message>
+    <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">Las transacciones después de esto todavía no serán visibles.</translation>
+        <translation type="unfinished">Las transacciones posteriores aún no están visibles.</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
+        <translation type="unfinished">Advertencia</translation>
     </message>
     <message>
         <source>Information</source>
-        <translation type="unfinished">Información </translation>
+        <translation type="unfinished">Información</translation>
     </message>
     <message>
         <source>Up to date</source>
-        <translation type="unfinished">Actualizado al dia </translation>
+        <translation type="unfinished">Actualizado</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
@@ -516,7 +638,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
-        <translation type="unfinished">Cargar PSBT desde el &amp;portapapeles...</translation>
+        <translation type="unfinished">Cargar TBPF desde el &amp;portapapeles...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -524,11 +646,11 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Abrir consola de depuración y diagnóstico de nodo</translation>
+        <translation type="unfinished">Abrir la consola de depuración y diagnóstico del nodo</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -536,15 +658,23 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Direcciones de recepción</translation>
+        <translation type="unfinished">&amp;Direcciones de destino</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Bitcoin: abrir URI</translation>
+        <translation type="unfinished">Abrir un URI de tipo "bitcoin:"</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Abrir una billetera</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cerrar billetera</translation>
     </message>
     <message>
         <source>Restore Wallet…</source>
@@ -558,7 +688,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -569,20 +699,24 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">Migrar una billetera</translation>
     </message>
     <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mostrar el mensaje de ayuda %1 para obtener una lista de las posibles opciones de línea de comandos de Bitcoin</translation>
+    </message>
+    <message>
         <source>&amp;Mask values</source>
         <translation type="unfinished">&amp;Ocultar valores</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Ocultar los valores en la pestaña de vista general</translation>
+        <translation type="unfinished">Ocultar los valores en la pestaña "Vista general"</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">Monederos no disponibles</translation>
+        <translation type="unfinished">No hay billeteras disponibles</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -602,11 +736,19 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera</translation>
     </message>
     <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ventana</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Acercar</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Ventana principal</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -618,14 +760,14 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">M&amp;ostrar</translation>
+        <translation type="unfinished">&amp;Mostrar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n conexiones activas con la red Bitcoin</numerusform>
-            <numerusform>%n conexiones activas con la red Bitcoin </numerusform>
+            <numerusform>%n conexión activa con la red de Bitcoin.</numerusform>
+            <numerusform>%n conexiones activas con la red de Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -658,7 +800,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">No se puede crear una nueva billetera, el software se compiló sin soporte sqlite (requerido para billeteras descriptivas)</translation>
+        <translation type="unfinished">No se puede crear una billetera nueva, ya que el software se compiló sin compatibilidad con sqlite (requerida para billeteras basadas en descriptores)</translation>
     </message>
     <message>
         <source>Warning: %1</source>
@@ -691,7 +833,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">Etiqueta: %1
+        <translation type="unfinished">Etiqueta %1
 </translation>
     </message>
     <message>
@@ -706,7 +848,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation type="unfinished">Transacción recibida</translation>
+        <translation type="unfinished">Transacción entrante</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
@@ -714,7 +856,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">La generación de la clave HD está &lt;b&gt; desactivada &lt;/ b&gt;</translation>
+        <translation type="unfinished">La generación de clave HD está &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
@@ -722,11 +864,11 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">La billetera está &lt;b&gt; encriptada &lt;/ b&gt; y actualmente &lt;b&gt; desbloqueada &lt;/ b&gt;</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;desbloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation type="unfinished">La billetera está encriptada y bloqueada recientemente</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;bloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
@@ -737,7 +879,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Unidad en la que se muestran las cantidades. Haga clic para seleccionar otra unidad.</translation>
+        <translation type="unfinished">Unidad en la que se muestran los importes. Haz clic para seleccionar otra unidad.</translation>
     </message>
 </context>
 <context>
@@ -763,12 +905,40 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
+        <source>Change:</source>
+        <translation type="unfinished">Cambio:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">(des)marcar todos</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Modo árbol</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Modo lista</translation>
+    </message>
+    <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Recibido con etiqueta</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation type="unfinished">Recibido con etiqueta</translation>
+        <translation type="unfinished">Recibido con dirección</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmaciones</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -776,7 +946,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -796,7 +966,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">B&amp;loquear no gastado</translation>
+        <translation type="unfinished">&amp;Bloquear importe no gastado</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
@@ -808,11 +978,19 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Tarifa de copia</translation>
+        <translation type="unfinished">Copiar comisión</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de la tarifa</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Copiar bytes</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Copiar cambio</translation>
     </message>
     <message>
         <source>(%1 locked)</source>
@@ -820,7 +998,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Puede variar en +/- %1 satoshi(s) por entrada.</translation>
+        <translation type="unfinished">Puede variar +/- %1 satoshi(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -828,11 +1006,20 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">Cambio desde %1 (%2)</translation>
+        <translation type="unfinished">cambio desde %1 (%2)</translation>
     </message>
-    </context>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(cambio)</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
@@ -844,7 +1031,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Advertencia de crear billetera</translation>
+        <translation type="unfinished">Advertencia al crear la billetera</translation>
     </message>
     <message>
         <source>Can't list signers</source>
@@ -860,12 +1047,12 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     <message>
         <source>Load Wallets</source>
         <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
-        <translation type="unfinished">Cargar monederos</translation>
+        <translation type="unfinished">Cargar billeteras</translation>
     </message>
     <message>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
-        <translation type="unfinished">Cargando monederos...</translation>
+        <translation type="unfinished">Cargando billeteras...</translation>
     </message>
 </context>
 <context>
@@ -876,7 +1063,7 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     </message>
     <message>
         <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Estas seguro de wue deseas migrar la billetera 1 %1 1 ?</translation>
+        <translation type="unfinished">¿Seguro deseas migrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
@@ -885,10 +1072,10 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
         <translation type="unfinished">La migración de la billetera la convertirá en una o más billeteras basadas en descriptores. Será necesario realizar una nueva copia de seguridad de la billetera.
-Si esta billetera contiene scripts solo de lectura, se creará una nueva billetera que los contenga.
-Si esta billetera contiene scripts solucionables pero no de lectura, se creará una nueva billetera diferente que los contenga.
+Si esta billetera contiene scripts solo de observación, se creará una nueva billetera que los contenga.
+Si esta billetera contiene scripts solucionables pero no de observación, se creará una nueva billetera diferente que los contenga.
 
-El proceso de migración creará una copia de seguridad de la billetera antes de migrar. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En el caso de una migración incorrecta, la copia de seguridad puede restaurarse con la funcionalidad "Restore Wallet" (Restaurar billetera).</translation>
+El proceso de migración creará una copia de seguridad de la billetera antes de proceder. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En caso de que la migración falle, se puede restaurar la copia de seguridad con la funcionalidad "Restaurar billetera".</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -904,11 +1091,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Guiones vigilantes han sido migrados a un monedero con el nombre '%1'.</translation>
+        <translation type="unfinished">Los scripts solo de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Solucionable pero ninguno de los guiones vigilados han sido migrados a un monedero llamados '%1'.</translation>
+        <translation type="unfinished">Los scripts solucionables pero no de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -922,22 +1109,26 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
 <context>
     <name>OpenWalletActivity</name>
     <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Fallo al abrir billetera</translation>
+    </message>
+    <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Advertencia sobre crear monedero</translation>
+        <translation type="unfinished">Advertencia al abrir billetera</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">Abriendo Monedero &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Abriendo billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
 </context>
 <context>
@@ -945,12 +1136,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Restore Wallet</source>
         <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
-        <translation type="unfinished">Restaurar monedero</translation>
+        <translation type="unfinished">Restaurar billetera</translation>
     </message>
     <message>
         <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
-        <translation type="unfinished">Restaurando monedero &lt;b&gt;%1&lt;/b&gt;…</translation>
+        <translation type="unfinished">Restaurando billetera &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Restore wallet failed</source>
@@ -971,39 +1162,63 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
 <context>
     <name>WalletController</name>
     <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cerrar billetera</translation>
+    </message>
+    <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">¿Estás seguro de que deseas cerrar el monedero &lt;i&gt;%1&lt;/i&gt;?</translation>
+        <translation type="unfinished">¿Seguro deseas cerrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Cerrar el monedero durante demasiado tiempo puede causar la resincronización de toda la cadena si la poda es habilitada.</translation>
+        <translation type="unfinished">Cerrar la billetera durante demasiado tiempo puede causar la resincronización de toda la cadena si el podado está habilitado.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">¿Está seguro de que desea cerrar todas las billeteras?</translation>
+        <translation type="unfinished">¿Seguro quieres cerrar todas las billeteras?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>You are one step away from creating your new wallet!</source>
         <translation type="unfinished">Estás a un paso de crear tu nueva billetera.</translation>
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
-        <translation type="unfinished">Escribe un nombre y, si lo deseas, activa las opciones avanzadas.</translation>
+        <translation type="unfinished">Escribe un nombre y, si quieres, activa las opciones avanzadas.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera </translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Billetera</translation>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Encriptar la billetera. La billetera será encriptada con una contraseña de tu elección.</translation>
+        <translation type="unfinished">Encriptar la billetera. La billetera se encriptará con una frase de contraseña de tu elección.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Encriptar billetera</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Opciones avanzadas</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Desactivar las claves privadas para esta billetera. Las billeteras con claves privadas desactivadas no tendrán claves privadas y no podrán tener ninguna semilla HD ni claves privadas importadas. Esto es ideal para billeteras solo de observación.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1011,11 +1226,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Crear un monedero vacío. Los monederos vacíos no tienen claves privadas ni scripts. Las claves privadas y direcciones pueden importarse después o también establecer una semilla HD.</translation>
+        <translation type="unfinished">Crea una billetera en blanco. Las billeteras en blanco inicialmente no tienen llaves privadas ni scripts. Las llaves privadas y las direcciones pueden ser importadas o se puede establecer una semilla HD más tarde.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">Crear billetera vacía</translation>
+        <translation type="unfinished">Crear billetera en blanco</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Usa un dispositivo de firma externo, por ejemplo, una billetera de hardware. Configura primero el script del firmante externo en las preferencias de la billetera.</translation>
     </message>
     <message>
         <source>External signer</source>
@@ -1028,42 +1247,62 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">Editar dirección</translation>
+    </message>
+    <message>
         <source>&amp;Label</source>
-        <translation type="unfinished">Y etiqueta</translation>
+        <translation type="unfinished">&amp;Etiqueta</translation>
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">La etiqueta asociada con esta entrada de la lista de direcciones</translation>
+        <translation type="unfinished">La etiqueta asociada con esta entrada en la lista de direcciones</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">La dirección asociada con esta entrada está en la lista de direcciones. Esto solo se puede modificar para enviar direcciones.</translation>
+        <translation type="unfinished">La dirección asociada con esta entrada en la lista de direcciones. Solo se puede modificar para las direcciones de envío.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
-        <translation type="unfinished">Y dirección</translation>
+        <translation type="unfinished">&amp;Dirección</translation>
     </message>
     <message>
         <source>New sending address</source>
-        <translation type="unfinished">Nueva dirección para enviar</translation>
+        <translation type="unfinished">Nueva dirección de envío</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
         <translation type="unfinished">Editar dirección de recepción</translation>
     </message>
     <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Editar dirección de envío</translation>
+    </message>
+    <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">La dirección introducida "%1" no es una dirección Bitcoin valida.</translation>
+        <translation type="unfinished">La dirección ingresada "%1" no es una dirección de Bitcoin válida.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">La dirección "%1" ya existe como dirección de recepción con la etiqueta "%2" y, por lo tanto, no se puede agregar como dirección de envío.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">La dirección ingresada "%1" ya está en la libreta de direcciones con la etiqueta "%2".</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">La generación de la nueva clave fallo</translation>
+        <translation type="unfinished">Error al generar clave nueva.</translation>
     </message>
 </context>
 <context>
@@ -1074,15 +1313,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>name</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">nombre</translation>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">El directorio ya existe. Añada %1 si pretende crear aquí un directorio nuevo.</translation>
+        <translation type="unfinished">El directorio ya existe. Agrega %1 si deseas crear un nuevo directorio aquí.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">Ruta de acceso existente, pero no es un directorio.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished">No puede crear directorio de datos aquí.</translation>
+        <translation type="unfinished">No se puede crear un directorio de datos aquí.</translation>
     </message>
 </context>
 <context>
@@ -1097,15 +1340,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform>(of %n GB needed)</numerusform>
-            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(de %n GB necesario)</numerusform>
+            <numerusform>(de %n GB necesarios)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform>(%n GB needed for full chain)</numerusform>
-            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB necesario para completar la cadena)</numerusform>
+            <numerusform>(%n GB necesarios para completar la cadena)</numerusform>
         </translation>
     </message>
     <message>
@@ -1113,8 +1356,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Elegir directorio de datos</translation>
     </message>
     <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Se almacenará al menos %1 GB de información en este directorio, que aumentará con el tiempo.</translation>
+    </message>
+    <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Aproximadamente %1 GB de información será almacenada en este directorio.</translation>
+        <translation type="unfinished">Se almacenará aproximadamente %1 GB de información en este directorio.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -1130,23 +1377,35 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">El monedero también se almacenará en este directorio.</translation>
+        <translation type="unfinished">La billetera también se almacenará en este directorio.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Error: El directorio de datos especificado «%1» no pudo ser creado.</translation>
+        <translation type="unfinished">Error: No se puede crear el directorio de datos especificado "%1" .</translation>
     </message>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished">bienvenido</translation>
+        <translation type="unfinished">Te damos la bienvenida</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">Te damos la bienvenida a %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Al ser esta la primera vez que se ejecuta el programa, puedes escoger donde %1 almacenará los datos.</translation>
+        <translation type="unfinished">Como es la primera vez que se ejecuta el programa, puedes elegir dónde %1 almacenará los datos.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">Limitar el almacenamiento de cadena de bloques a</translation>
+        <translation type="unfinished">Limitar el almacenamiento de la cadena de bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Para revertir esta configuración, se debe descargar de nuevo la cadena de bloques completa. Es más rápido descargar la cadena completa y podarla después. Desactiva algunas funciones avanzadas.</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">La sincronización inicial consume muchos recursos y es posible que exponga problemas de hardware en la computadora que anteriormente pasaron desapercibidos. Cada vez que ejecutes %1, seguirá descargando desde el punto en el que quedó.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
@@ -1154,19 +1413,23 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Si ha elegido limitar el almacenamiento de la cadena de bloques (pruning o poda), los datos históricos todavía se deben descargar y procesar, pero se eliminarán posteriormente para mantener el uso del disco bajo.</translation>
+        <translation type="unfinished">Si elegiste la opción de limitar el almacenamiento de la cadena de bloques (podado), los datos históricos se deben descargar y procesar de igual manera, pero se eliminarán después para disminuir el uso del disco.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">Usa el directorio de datos predeterminado</translation>
+        <translation type="unfinished">Usar el directorio de datos predeterminado</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">Usa un directorio de datos personalizado:</translation>
+        <translation type="unfinished">Usar un directorio de datos personalizado:</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">versión</translation>
+    </message>
     <message>
         <source>About %1</source>
         <translation type="unfinished">Acerca de %1</translation>
@@ -1177,6 +1440,17 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
 </context>
 <context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">No apagues la computadora hasta que desaparezca esta ventana.</translation>
+    </message>
+</context>
+<context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
@@ -1184,31 +1458,51 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Es posible que las transacciones recientes aún no estén visibles y por lo tanto, el saldo de su monedero podría ser incorrecto. Esta información será correcta una vez que su monedero haya terminado de sincronizarse con la red bitcoin, como se detalla a continuación.</translation>
+        <translation type="unfinished">Es posible que las transacciones recientes aún no sean visibles y, por lo tanto, el saldo de la billetera podría ser incorrecto. Esta información será correcta una vez que la billetera haya terminado de sincronizarse con la red de Bitcoin, como se detalla abajo.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">La red no aceptará si se intenta gastar bitcoins afectados por las transacciones que aún no se muestran.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation type="unfinished">Numero de bloques pendientes</translation>
+        <translation type="unfinished">Número de bloques restantes</translation>
     </message>
     <message>
         <source>Unknown…</source>
         <translation type="unfinished">Desconocido...</translation>
     </message>
     <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Hora del último bloque</translation>
     </message>
     <message>
+        <source>Progress</source>
+        <translation type="unfinished">Progreso</translation>
+    </message>
+    <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Incremento del progreso por hora</translation>
+        <translation type="unfinished">Avance del progreso por hora</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Tiempo estimado restante hasta la sincronización</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 está actualmente sincronizándose. Descargará cabeceras y bloques de nodos semejantes y los validará hasta alcanzar la cabeza de la cadena de bloques.</translation>
+        <translation type="unfinished">%1 se está sincronizando actualmente. Descargará encabezados y bloques de pares, y los validará hasta alcanzar el extremo de la cadena de bloques.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconocido. Sincronizando cabeceras (%1, %2%)…</translation>
+        <translation type="unfinished">Desconocido. Sincronizando encabezados (%1, %2%)…</translation>
     </message>
     <message>
         <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
@@ -1238,16 +1532,24 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">&amp;Principal</translation>
     </message>
     <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">Iniciar automáticamente %1 después de iniciar sesión en el sistema.</translation>
+    </message>
+    <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Iniciar %1 al iniciar el sistema</translation>
+        <translation type="unfinished">&amp;Iniciar %1 al iniciar sesión en el sistema</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Al activar el modo pruning, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+        <translation type="unfinished">Al activar el podado, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Tamaño de la caché de la &amp;base de datos</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Número de hilos de &amp;verificación de scripts</translation>
+        <translation type="unfinished">Número de subprocesos de &amp;verificación de scripts</translation>
     </message>
     <message>
         <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
@@ -1255,15 +1557,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Dirección IP del proxy (Ejemplo. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">Dirección IP del proxy (por ejemplo, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Muestra si el proxy SOCKS5 por defecto suministrado se utiliza para llegar a los pares a través de este tipo de red.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimice en lugar de salir de la aplicación cuando la ventana esté cerrada. Cuando esta opción está habilitada, la aplicación se cerrará solo después de seleccionar Salir en el menú.</translation>
+        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación solo se cerrará después de seleccionar "Salir" en el menú.</translation>
     </message>
     <message>
         <source>Font in the Overview tab: </source>
-        <translation type="unfinished">Fuente en la pestaña Resumen:</translation>
+        <translation type="unfinished">Fuente en la pestaña "Vista general":</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -1286,6 +1592,10 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">&amp;Restablecer opciones</translation>
     </message>
     <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;Red</translation>
+    </message>
+    <message>
         <source>Prune &amp;block storage to</source>
         <translation type="unfinished">Podar el almacenamiento de &amp;bloques a</translation>
     </message>
@@ -1301,7 +1611,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
-        <translation type="unfinished">Establezca el número de hilos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
+        <translation type="unfinished">Establece el número de subprocesos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
@@ -1310,7 +1620,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
-        <translation type="unfinished">Esto le permite a usted o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
+        <translation type="unfinished">Esto te permite a ti o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
@@ -1324,7 +1634,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Whether to set subtract fee from amount as default or not.</source>
         <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">Si se resta la comisión del importe por defecto o no.</translation>
+        <translation type="unfinished">Si se resta o no la comisión del importe por defecto.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1332,8 +1642,16 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Restar &amp;comisión del importe por defecto</translation>
     </message>
     <message>
+        <source>Expert</source>
+        <translation type="unfinished">Experto</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">Habilitar funciones de &amp;control de monedas</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Si deshabilita el gasto de un cambio no confirmado, el cambio de una transacción no se puede usar hasta que esa transacción tenga al menos una confirmación. Esto también afecta cómo se calcula su saldo.</translation>
+        <translation type="unfinished">Si deshabilitas el gasto del cambio sin confirmar, no se puede usar el cambio de una transacción hasta que esta tenga al menos una confirmación. Esto también afecta cómo se calcula el saldo.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1342,12 +1660,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Activar controles de &amp;PSBT</translation>
+        <translation type="unfinished">Activar controles de &amp;TBPF</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Si se muestran los controles de PSBT.</translation>
+        <translation type="unfinished">Si se muestran los controles de TBPF.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -1359,7 +1677,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona cuando el router admite UPnP y está activado.</translation>
+        <translation type="unfinished">Abrir automáticamente el puerto del cliente de Bitcoin en el router. Esto funciona solo cuando tu router es compatible con UPnP y está habilitado.</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">Asignar puerto usando &amp;UPnP</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
@@ -1370,24 +1692,36 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Asignar puerto usando NA&amp;T-PMP</translation>
     </message>
     <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">Aceptar conexiones externas.</translation>
+    </message>
+    <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Permitir conexiones entrantes</translation>
+        <translation type="unfinished">&amp;Permitir conexiones entrantes</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Conectar a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Conectarse a través del proxy SOCKS5 (proxy predeterminado):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">&amp;IP del proxy:</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
-        <translation type="unfinished">Puerto:</translation>
+        <translation type="unfinished">&amp;Puerto:</translation>
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation type="unfinished">Puerto del proxy (ej. 9050)</translation>
+        <translation type="unfinished">Puerto del proxy (p. ej., 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Utilizado para llegar a los compañeros a través de:</translation>
+        <translation type="unfinished">Usado para conectarse con pares a través de:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1399,15 +1733,23 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">Mostrar la &amp;bandeja del sistema.</translation>
+        <translation type="unfinished">&amp;Mostrar el ícono de la bandeja</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">Muestra solo un ícono en la bandeja después de minimizar la ventana</translation>
+        <translation type="unfinished">Mostrar solo un ícono de bandeja después de minimizar la ventana.</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">&amp;Minimizar a la bandeja en vez de la barra de tareas</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">Minimice al cerrar</translation>
+        <translation type="unfinished">&amp;Minimizar al cerrar</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation type="unfinished">&amp;Visualización</translation>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
@@ -1415,15 +1757,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración tendrá efecto después de reiniciar %1.</translation>
+        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración surtirá efecto después de reiniciar %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation type="unfinished">&amp;Unidad en la que mostrar cantitades:</translation>
+        <translation type="unfinished">&amp;Unidad en la que se muestran los importes:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished">Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían monedas.</translation>
+        <translation type="unfinished">Elegir la unidad de subdivisión predeterminada para mostrar en la interfaz y al enviar monedas.</translation>
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
@@ -1431,7 +1773,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>&amp;Third-party transaction URLs</source>
-        <translation type="unfinished">URLs de transacciones de &amp;terceros</translation>
+        <translation type="unfinished">&amp;URL de transacciones de terceros</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">Si se muestran o no las funcionalidades de control de monedas.</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
@@ -1439,12 +1789,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
+        <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1457,7 +1807,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Confirm options reset</source>
         <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
-        <translation type="unfinished">Confirmar reestablecimiento de las opciones</translation>
+        <translation type="unfinished">Confirmar restablecimiento de opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
@@ -1467,12 +1817,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Current settings will be backed up at "%1".</source>
         <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
-        <translation type="unfinished">Los ajustes actuales se guardarán en «%1».</translation>
+        <translation type="unfinished">Se realizará una copia de seguridad de la configuración actual en "%1".</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
-        <translation type="unfinished">El cliente será cluasurado. Quieres proceder?</translation>
+        <translation type="unfinished">El cliente se cerrará. ¿Quieres continuar?</translation>
     </message>
     <message>
         <source>Configuration options</source>
@@ -1482,7 +1832,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">El archivo de configuración se utiliza para especificar opciones de usuario avanzadas que anulan la configuración de la GUI. Además, cualquier opción de línea de comandos anulará este archivo de configuración.</translation>
+        <translation type="unfinished">El archivo de configuración se usa para especificar opciones avanzadas del usuario, que remplazan la configuración de la GUI. Además, las opciones de la línea de comandos remplazarán este archivo de configuración.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1494,14 +1844,22 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">El archivo de configuración no se pudo abrir.</translation>
+        <translation type="unfinished">No se pudo abrir el archivo de configuración.</translation>
     </message>
-    </context>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">Estos cambios requieren reiniciar el cliente.</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">La dirección del proxy proporcionada es inválida.</translation>
+    </message>
+</context>
 <context>
     <name>OptionsModel</name>
     <message>
         <source>Could not read setting "%1", %2.</source>
-        <translation type="unfinished">No se puede leer el ajuste «%1», %2.</translation>
+        <translation type="unfinished">No se puede leer la configuración "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -1512,7 +1870,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red Bitcoin después de que se haya establecido una conexión, pero este proceso aún no se ha completado.</translation>
+        <translation type="unfinished">La información mostrada puede estar desactualizada. La billetera se sincroniza automáticamente con la red de Bitcoin después de establecer una conexión, pero este proceso aún no se ha completado.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">Solo de observación:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -1520,7 +1882,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation type="unfinished">Su balance actual gastable</translation>
+        <translation type="unfinished">Tu saldo disponible para gastar actualmente</translation>
     </message>
     <message>
         <source>Pending:</source>
@@ -1528,15 +1890,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished">Total de transacciones que aún no se han sido confirmadas, y que no son contabilizadas dentro del saldo disponible para gastar</translation>
+        <translation type="unfinished">Total de transacciones que aún se deben confirmar y que no se contabilizan dentro del saldo disponible para gastar</translation>
     </message>
     <message>
         <source>Immature:</source>
-        <translation type="unfinished">No disponible:</translation>
+        <translation type="unfinished">Inmaduro:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished">Saldo recién minado que aún no está disponible.</translation>
+        <translation type="unfinished">Saldo minado que aún no ha madurado</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1544,15 +1906,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation type="unfinished">Saldo total actual</translation>
+        <translation type="unfinished">Tu saldo total actual</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Tu saldo actual en solo ver direcciones</translation>
+        <translation type="unfinished">Tu saldo actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Disponible:</translation>
+        <translation type="unfinished">Gastable:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
@@ -1560,30 +1922,34 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Transacciones sin confirmar a direcciones de observación</translation>
+        <translation type="unfinished">Transacciones sin confirmar hacia direcciones solo de observación</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">Saldo minado en direcciones solo de observación que aún no ha madurado</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Saldo total actual en direcciones de observación</translation>
+        <translation type="unfinished">Saldo total actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anule la selección de Configuración-&gt;Ocultar valores.</translation>
+        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anula la selección de "Configuración-&gt;Ocultar valores".</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>PSBT Operations</source>
-        <translation type="unfinished">Operaciones PSBT</translation>
+        <translation type="unfinished">Operaciones TBPF</translation>
     </message>
     <message>
         <source>Sign Tx</source>
-        <translation type="unfinished">Firmar Tx</translation>
+        <translation type="unfinished">Firmar transacción</translation>
     </message>
     <message>
         <source>Broadcast Tx</source>
-        <translation type="unfinished">Emitir Tx</translation>
+        <translation type="unfinished">Transmitir transacción</translation>
     </message>
     <message>
         <source>Copy to Clipboard</source>
@@ -1599,7 +1965,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Error en la carga de la transacción: %1</translation>
+        <translation type="unfinished">Error al cargar la transacción: %1</translation>
     </message>
     <message>
         <source>Failed to sign transaction: %1</source>
@@ -1610,20 +1976,32 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">No se pueden firmar entradas mientras la billetera está bloqueada.</translation>
     </message>
     <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">No se pudieron firmar más entradas.</translation>
+    </message>
+    <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Se han firmado %1 entradas, pero aún se requieren más firmas.</translation>
+        <translation type="unfinished">Se firmaron %1 entradas, pero aún se requieren más firmas.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">Se ha firmado correctamente. La transacción está lista para difundirse.</translation>
+        <translation type="unfinished">La transacción se firmó correctamente y está lista para transmitirse.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Error desconocido al procesar la transacción.</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">¡La transacción se ha difundido correctamente! Código ID de la transacción: %1</translation>
+        <translation type="unfinished">¡La transacción se transmitió correctamente! Identificador de transacción: %1</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
         <translation type="unfinished">Error al transmitir la transacción: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">TBPF copiada al portapapeles.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1636,7 +2014,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT guardada en en el disco.</translation>
+        <translation type="unfinished">TBPF guardada en el disco.</translation>
     </message>
     <message>
         <source>Sends %1 to %2</source>
@@ -1644,19 +2022,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">dirección personal</translation>
+        <translation type="unfinished">dirección propia</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">No se ha podido calcular la comisión por transacción o la totalidad del importe de la transacción.</translation>
+        <translation type="unfinished">No se puede calcular la comisión o el importe total de la transacción.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
-        <translation type="unfinished">Pagar comisión de transacción:</translation>
+        <translation type="unfinished">Paga comisión de transacción:</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>or</source>
@@ -1664,17 +2042,37 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
-        <translation type="unfinished">La transacción tiene %1 entradas no firmadas.</translation>
+        <translation type="unfinished">La transacción tiene %1 entradas sin firmar.</translation>
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Falta alguna información sobre las entradas de la transacción.</translation>
+        <translation type="unfinished">Falta información sobre las entradas de la transacción.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">La transacción aún necesita firma(s).</translation>
     </message>
     <message>
         <source>(But no wallet is loaded.)</source>
         <translation type="unfinished">(Pero no se cargó ninguna billetera).</translation>
     </message>
-    </context>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Pero esta billetera no puede firmar transacciones).</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Pero esta billetera no tiene las claves adecuadas).</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">La transacción se firmó completamente y está lista para transmitirse.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">El estado de la transacción es desconocido.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1682,20 +2080,32 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Error en la solicitud de pago</translation>
     </message>
     <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">No se puede iniciar el controlador "bitcoin: click-to-pay"</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">Gestión de URI</translation>
+    </message>
+    <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">"bitcoin://" no es un URI válido. Use "bitcoin:" en su lugar.</translation>
+        <translation type="unfinished">"bitcoin://" no es un URI válido. Usa "bitcoin:" en su lugar.</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished">No se puede procesar la solicitud de pago debido a que no se soporta BIP70.
-Debido a los fallos de seguridad generalizados en el BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de monedero.
-Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
+        <translation type="unfinished">No se puede procesar la solicitud de pago porque no existe compatibilidad con BIP70.
+Debido a los fallos de seguridad generalizados en BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de billetera.
+Si recibes este error, debes solicitar al comerciante que te proporcione un URI compatible con BIP21.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">No se puede analizar el URI. Esto se puede deber a una dirección de Bitcoin inválida o a parámetros de URI con formato incorrecto.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Manejo del archivo de solicitud de pago</translation>
+        <translation type="unfinished">Gestión del archivo de solicitud de pago</translation>
     </message>
 </context>
 <context>
@@ -1713,12 +2123,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Age</source>
         <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
-        <translation type="unfinished">Duración</translation>
+        <translation type="unfinished">Antigüedad</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">Dirección</translation>
     </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>Received</source>
@@ -1748,7 +2163,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Outbound</source>
         <extracomment>An Outbound Connection to a Peer.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
 </context>
 <context>
@@ -1758,8 +2173,16 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
     <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;Copiar imagen</translation>
+    </message>
+    <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">URI resultante demasiado larga. Intente reducir el texto de la etiqueta / mensaje.</translation>
+        <translation type="unfinished">El URI resultante es demasiado largo, así que trata de reducir el texto de la etiqueta o el mensaje.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">Fallo al codificar URI en código QR.</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
@@ -1782,24 +2205,32 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">N/D</translation>
     </message>
     <message>
+        <source>Client version</source>
+        <translation type="unfinished">Versión del cliente</translation>
+    </message>
+    <message>
         <source>&amp;Information</source>
         <translation type="unfinished">&amp;Información</translation>
     </message>
     <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Directorio de datos</translation>
+    </message>
+    <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una localización personalizada del directorio de datos, usa la opción «%1».</translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Blocksdir</source>
-        <translation type="unfinished">Bloques dir</translation>
+        <translation type="unfinished">Directorio de bloques</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una localización personalizada del directorio de bloques, usa la opción «%1». </translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Startup time</source>
-        <translation type="unfinished">Hora de inicio</translation>
+        <translation type="unfinished">Tiempo de inicio</translation>
     </message>
     <message>
         <source>Network</source>
@@ -1819,19 +2250,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation type="unfinished">Grupo de memoria</translation>
+        <translation type="unfinished">Pool de memoria</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">Número total de transacciones</translation>
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished">Memoria utilizada</translation>
+        <translation type="unfinished">Uso de memoria</translation>
     </message>
     <message>
         <source>Wallet: </source>
-        <translation type="unfinished">Monedero:</translation>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ninguna)</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Reestablecer</translation>
+        <translation type="unfinished">&amp;Restablecer</translation>
     </message>
     <message>
         <source>Received</source>
@@ -1839,7 +2278,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Sent</source>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
@@ -1863,11 +2302,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The BIP324 session ID string in hex, if any.</source>
-        <translation type="unfinished">Cadena de identificación de la sesión BIP324 en formato hexadecimal, si existe.</translation>
+        <translation type="unfinished">Cadena de identificador de la sesión BIP324 en formato hexadecimal, si existe.</translation>
     </message>
     <message>
         <source>Session ID</source>
         <translation type="unfinished">Identificador de sesión</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">Versión</translation>
     </message>
     <message>
         <source>Whether we relay transactions to this peer.</source>
@@ -1879,11 +2322,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">Bloque de inicio</translation>
+        <translation type="unfinished">Bloque inicial</translation>
     </message>
     <message>
         <source>Synced Headers</source>
         <translation type="unfinished">Encabezados sincronizados</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">Bloques sincronizados</translation>
     </message>
     <message>
         <source>Last Transaction</source>
@@ -1891,7 +2338,11 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">El Sistema Autónomo mapeado utilizado para la selección diversificada de pares.</translation>
+        <translation type="unfinished">El sistema autónomo asignado que se usó para diversificar la selección de pares.</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">SA asignado</translation>
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
@@ -1901,17 +2352,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Address Relay</source>
         <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
-        <translation type="unfinished">Transmisión de la dirección</translation>
+        <translation type="unfinished">Retransmisión de direcciones</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que han sido procesadas (excluyendo las direcciones que han sido desestimadas debido a la limitación de velocidad).</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones desestimadas debido a la limitación de volumen).</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que han sido desestimadas (no procesadas) debido a la limitación de velocidad.</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se desestimaron (no se procesaron) debido a la limitación de volumen.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
@@ -1921,7 +2372,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Addresses Rate-Limited</source>
         <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">Direcciones omitidas por limitación de volumen</translation>
+        <translation type="unfinished">Direcciones desestimadas por limitación de volumen</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -1929,7 +2380,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -1937,15 +2388,19 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Abra el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
+        <translation type="unfinished">Abrir el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation type="unfinished">Reducir el tamaño de la fuente</translation>
+        <translation type="unfinished">Disminuir tamaño de fuente</translation>
     </message>
     <message>
         <source>Increase font size</source>
-        <translation type="unfinished">Aumentar el tamaño de la fuente</translation>
+        <translation type="unfinished">Aumentar tamaño de fuente</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Permisos</translation>
     </message>
     <message>
         <source>The direction and type of peer connection: %1</source>
@@ -1957,7 +2412,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">El protocolo de red de este par está conectado a través de: IPv4, IPv6, Onion, I2P, o CJDNS.</translation>
+        <translation type="unfinished">El protocolo de red mediante el cual está conectado este par: IPv4, IPv6, Onion, I2P o CJDNS.</translation>
     </message>
     <message>
         <source>Services</source>
@@ -1965,11 +2420,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">Retransmisión de bloque compacto BIP152 en modo de banda ancha: %1</translation>
+        <translation type="unfinished">Retransmisión de bloques compactos BIP152 en banda ancha: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
         <translation type="unfinished">Banda ancha</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">Tiempo de conexión</translation>
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
@@ -1990,19 +2449,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Ultima recepción</translation>
+        <translation type="unfinished">Última recepción</translation>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation type="unfinished">Tiempo de Ping</translation>
+        <translation type="unfinished">Tiempo de ping</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">La duración de un ping actualmente pendiente.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
-        <translation type="unfinished">Espera de Ping</translation>
+        <translation type="unfinished">Espera de ping</translation>
     </message>
     <message>
         <source>Min Ping</source>
         <translation type="unfinished">Ping mínimo</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">Desfase temporal</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -2010,7 +2477,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation type="unfinished">Abierto</translation>
+        <translation type="unfinished">&amp;Abrir</translation>
     </message>
     <message>
         <source>&amp;Console</source>
@@ -2018,7 +2485,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Tráfico de Red</translation>
+        <translation type="unfinished">&amp;Tráfico de red</translation>
     </message>
     <message>
         <source>Totals</source>
@@ -2026,11 +2493,11 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Debug log file</source>
-        <translation type="unfinished">Archivo de registro de depuración</translation>
+        <translation type="unfinished">Archivo del registro de depuración</translation>
     </message>
     <message>
         <source>Clear console</source>
-        <translation type="unfinished">Limpiar Consola</translation>
+        <translation type="unfinished">Borrar consola</translation>
     </message>
     <message>
         <source>In:</source>
@@ -2038,17 +2505,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Out:</source>
-        <translation type="unfinished">Fuera:</translation>
+        <translation type="unfinished">Salida:</translation>
     </message>
     <message>
         <source>Inbound: initiated by peer</source>
         <extracomment>Explanatory text for an inbound peer connection.</extracomment>
-        <translation type="unfinished">Entrante: iniciado por el par</translation>
+        <translation type="unfinished">Entrante: iniciada por el par</translation>
     </message>
     <message>
         <source>Outbound Full Relay: default</source>
         <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
-        <translation type="unfinished">Retransmisión completa saliente: predeterminado</translation>
+        <translation type="unfinished">Retransmisión completa saliente: predeterminada</translation>
     </message>
     <message>
         <source>Outbound Block Relay: does not relay transactions or addresses</source>
@@ -2063,7 +2530,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Outbound Feeler: short-lived, for testing addresses</source>
         <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">Tanteador de salida: de corta duración, para probar las direcciones</translation>
+        <translation type="unfinished">Feeler saliente: de corta duración, para probar direcciones</translation>
     </message>
     <message>
         <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
@@ -2078,7 +2545,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>v1: unencrypted, plaintext transport protocol</source>
         <extracomment>Explanatory text for v1 transport type.</extracomment>
-        <translation type="unfinished">v1: protocolo de transporte de texto simple sin cifrar</translation>
+        <translation type="unfinished">v1: protocolo de transporte de texto simple sin encriptar</translation>
     </message>
     <message>
         <source>v2: BIP324 encrypted transport protocol</source>
@@ -2095,7 +2562,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">Ninguna transmisión de banda ancha seleccionada</translation>
+        <translation type="unfinished">No se seleccionó la retransmisión de banda ancha</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2103,12 +2570,24 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;Desconectar</translation>
+    </message>
+    <message>
         <source>1 &amp;hour</source>
-        <translation type="unfinished">1 hora</translation>
+        <translation type="unfinished">1 &amp;hora</translation>
     </message>
     <message>
         <source>1 d&amp;ay</source>
         <translation type="unfinished">1 &amp;día</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;semana</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;año</translation>
     </message>
     <message>
         <source>&amp;Copy IP/Netmask</source>
@@ -2117,7 +2596,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Desbloquear</translation>
+        <translation type="unfinished">&amp;Levantar prohibición</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -2125,11 +2604,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Executing command without any wallet</source>
-        <translation type="unfinished">Ejecutar comando sin monedero</translation>
+        <translation type="unfinished">Ejecutar comando sin ninguna billetera</translation>
     </message>
     <message>
         <source>Node window - [%1]</source>
         <translation type="unfinished">Ventana de nodo - [%1]</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">Ejecutar comando usando la billetera "%1"</translation>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.
@@ -2140,12 +2623,13 @@ For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
         <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Bienvenido a la consola RPC
-%1. Utiliza las flechas arriba y abajo para navegar por el historial, y %2 para borrar la pantalla. 
+        <translation type="unfinished">Te damos la bienvenida a la consola RPC de %1.
+Utiliza las flechas hacia arriba y abajo para navegar por el historial y %2 para borrar la pantalla.
 Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente. 
-Escribe %5 para ver un resumen de los comandos disponibles. Para más información sobre cómo usar esta consola, escribe %6.
+Escribe %5 para ver los comandos disponibles.
+Para obtener más información sobre cómo usar esta consola, escribe %6.
 
-%7 AVISO: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus monederos. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
+%7 ADVERTENCIA: Los estafadores suelen decirles a los usuarios que escriban comandos aquí para robarles el contenido de sus billeteras. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2162,11 +2646,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished">Si</translation>
+        <translation type="unfinished">Sí</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>From</source>
@@ -2174,11 +2658,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished">Bloqueo para</translation>
+        <translation type="unfinished">Prohibir por</translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished">nunca</translation>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2192,28 +2676,32 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;Etiqueta:</translation>
+    </message>
+    <message>
         <source>&amp;Message:</source>
         <translation type="unfinished">&amp;Mensaje:</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje opcional adjunto a la solicitud de pago, que será mostrado cuando la solicitud sea abierta. Nota: Este mensaje no será enviado con el pago a través de la red Bitcoin.</translation>
+        <translation type="unfinished">Mensaje opcional para adjuntar a la solicitud de pago, que se mostrará cuando se abra la solicitud. Nota: Este mensaje no se enviará con el pago a través de la red de Bitcoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Use este formulario para solicitar pagos. Todos los campos son &lt;b&gt; opcionales &lt;/ b&gt;.</translation>
+        <translation type="unfinished">Usa este formulario para solicitar pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Un importe opcional para solicitar. Deje esto vacío o en cero para no solicitar una cantidad específica.</translation>
+        <translation type="unfinished">Un importe opcional para solicitar. Déjalo vacío o ingresa cero para no solicitar un importe específico.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (utilizada por ti para identificar una factura). También se adjunta a la solicitud de pago.</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (puedes usarla para identificar una factura). También se adjunta a la solicitud de pago.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2221,27 +2709,35 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Crear una nueva dirección de recepción</translation>
+        <translation type="unfinished">&amp;Crear nueva dirección de recepción</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Borre todos los campos del formulario.</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">Aclarar</translation>
+        <translation type="unfinished">Borrar</translation>
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation type="unfinished">Historial de pagos solicitado</translation>
+        <translation type="unfinished">Historial de pagos solicitados</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Muestra la petición seleccionada (También doble clic)</translation>
+        <translation type="unfinished">Mostrar la solicitud seleccionada (equivale a hacer doble clic en una entrada)</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished">Mostrar</translation>
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished">Eliminar las entradas seleccionadas de la lista</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
@@ -2280,8 +2776,12 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Bech32m (BIP-350) es una actualización de Bech32. La compatibilidad con la billetera todavía es limitada.</translation>
     </message>
     <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
+    </message>
+    <message>
         <source>Could not generate new %1 address</source>
-        <translation type="unfinished">No se ha podido generar una nueva dirección %1</translation>
+        <translation type="unfinished">No se pudo generar nueva dirección %1</translation>
     </message>
 </context>
 <context>
@@ -2291,8 +2791,24 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Solicitar pago a...</translation>
     </message>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Dirección:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">Importe:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">Etiqueta:</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">Mensaje:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
@@ -2300,7 +2816,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">&amp;Copia dirección</translation>
+        <translation type="unfinished">Copiar &amp;dirección</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2308,18 +2824,34 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Verifica esta dirección, por ejemplo, en la pantalla de una billetera de hardware</translation>
+        <translation type="unfinished">Verificar esta dirección, por ejemplo, en la pantalla de una billetera de hardware.</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
         <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
-    </context>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">Información del pago</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation type="unfinished">Solicitar pago a %1</translation>
+    </message>
+</context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2331,7 +2863,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation type="unfinished">(sin importe solicitado)</translation>
+        <translation type="unfinished">(no se solicitó un importe)</translation>
     </message>
     <message>
         <source>Requested</source>
@@ -2346,11 +2878,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Características de control de moneda</translation>
+        <translation type="unfinished">Funciones de control de monedas</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">seleccionado automáticamente</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation type="unfinished">Fondos insuficientes!</translation>
+        <translation type="unfinished">Fondos insuficientes</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -2369,20 +2905,36 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
+        <source>Change:</source>
+        <translation type="unfinished">Cambio:</translation>
+    </message>
+    <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Al activarse, si la dirección esta vacía o es inválida, las monedas serán enviadas a una nueva dirección generada.</translation>
+        <translation type="unfinished">Si se activa, pero la dirección de cambio está vacía o es inválida, el cambio se enviará a una dirección generada recientemente.</translation>
+    </message>
+    <message>
+        <source>Custom change address</source>
+        <translation type="unfinished">Dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
-        <translation type="unfinished">Comisión transacción:</translation>
+        <translation type="unfinished">Comisión de transacción:</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Si utilizas la comisión por defecto, la transacción puede tardar varias horas o incluso días (o nunca) en confirmarse. Considera elegir la comisión de forma manual o espera hasta que se haya validado completamente la cadena.</translation>
+        <translation type="unfinished">Si usas la opción "fallbackfee", la transacción puede tardar varias horas o días en confirmarse (o nunca hacerlo). Considera elegir la comisión de forma manual o espera hasta que hayas validado la cadena completa.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Advertencia: En este momento no se puede estimar la cuota.</translation>
+        <translation type="unfinished">Advertencia: En este momento no se puede estimar la comisión.</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">por kilobyte</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>Recommended:</source>
@@ -2394,11 +2946,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation type="unfinished">Enviar a múltiples destinatarios</translation>
+        <translation type="unfinished">Enviar a múltiples destinatarios a la vez</translation>
+    </message>
+    <message>
+        <source>Add &amp;Recipient</source>
+        <translation type="unfinished">Agregar &amp;destinatario</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Borre todos los campos del formulario.</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Inputs…</source>
@@ -2422,23 +2978,31 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Cuando hay menos volumen de transacciones que espacio en los bloques, los mineros y los nodos de retransmisión pueden imponer una comisión mínima. Pagar solo esta comisión mínima está bien, pero tenga en cuenta que esto puede resultar en una transacción nunca confirmada una vez que haya más demanda de transacciones de Bitcoin de la que la red puede procesar.</translation>
+        <translation type="unfinished">Cuando hay menos volumen de transacciones que espacio en los bloques, los mineros y los nodos de retransmisión pueden aplicar una comisión mínima. Está bien pagar solo esta comisión mínima, pero ten en cuenta que esto puede ocasionar que una transacción nunca se confirme una vez que haya más demanda de transacciones de Bitcoin de la que puede procesar la red.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Una comisión demasiado pequeña puede resultar en una transacción que nunca será confirmada (leer herramientas de información).</translation>
+        <translation type="unfinished">Si la comisión es demasiado baja, es posible que la transacción nunca se confirme (leer la información en pantalla).</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <translation type="unfinished">(La comisión inteligente no se ha inicializado todavía. Esto tarda normalmente algunos bloques…)</translation>
     </message>
     <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">Objetivo de tiempo de confirmación:</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">Activar "Remplazar por comisión"</translation>
+    </message>
+    <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Con la función "Reemplazar-por-comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
+        <translation type="unfinished">Con la función "Remplazar por comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -2446,7 +3010,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Confirm the send action</source>
-        <translation type="unfinished">Confirma el envio</translation>
+        <translation type="unfinished">Confirmar el envío</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">&amp;Enviar</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -2454,15 +3022,27 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Tarifa de copia</translation>
+        <translation type="unfinished">Copiar comisión</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de la tarifa</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Copiar bytes</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Copiar cambio</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 bloques)</translation>
     </message>
     <message>
         <source>Sign on device</source>
@@ -2471,16 +3051,24 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Conecta tu monedero externo primero.</translation>
+        <translation type="unfinished">Conecta primero tu billetera de hardware.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Configura una ruta externa al script en Opciones -&gt; Monedero</translation>
+        <translation type="unfinished">Establecer la ruta al script del firmante externo en "Opciones -&gt; Billetera"</translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">&amp;Crear sin firmar</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (PSBT) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (TBPF) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 a '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
@@ -2492,17 +3080,17 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign failed</source>
-        <translation type="unfinished">La firma falló</translation>
+        <translation type="unfinished">Error de firma</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">No se encontró el dispositivo firmante externo</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">Error de firmante externo</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2516,7 +3104,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
-        <translation type="unfinished">TBPF guardado </translation>
+        <translation type="unfinished">TBPF guardada</translation>
     </message>
     <message>
         <source>External balance:</source>
@@ -2528,11 +3116,16 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Puedes aumentar la comisión después (indica "Reemplazar-por-comisión", BIP-125).</translation>
+        <translation type="unfinished">Puedes aumentar la comisión después (indica "Remplazar por comisión", BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Revisa por favor la propuesta de transacción. Esto producirá una transacción de Bitcoin parcialmente firmada (TBPF) que puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 fuera de línea o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>%1 from wallet '%2'</source>
-        <translation type="unfinished">%1 desde monedero '%2'</translation>
+        <translation type="unfinished">%1 desde billetera "%2"</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
@@ -2542,38 +3135,42 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
-        <translation type="unfinished">Revisa por favor la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (PSBT), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Revisa la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (TBPF), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
-        <translation type="unfinished">Por favor, revisa tu transacción</translation>
+        <translation type="unfinished">Revisa la transacción.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Comisión por transacción.</translation>
+        <translation type="unfinished">Comisión de transacción</translation>
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">No indica remplazar-por-comisión, BIP-125.</translation>
+        <translation type="unfinished">No indica "Remplazar por comisión", BIP-125.</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>Unsigned Transaction</source>
         <comment>PSBT copied</comment>
         <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
-        <translation type="unfinished">Transacción no asignada</translation>
+        <translation type="unfinished">Transacción sin firmar</translation>
     </message>
     <message>
         <source>The PSBT has been copied to the clipboard. You can also save it.</source>
-        <translation type="unfinished">Se copió la PSBT al portapapeles. También puedes guardarla.</translation>
+        <translation type="unfinished">Se copió la TBPF al portapapeles. También puedes guardarla.</translation>
     </message>
     <message>
         <source>PSBT saved to disk</source>
-        <translation type="unfinished">PSBT guardada en el disco</translation>
+        <translation type="unfinished">TBPF guardada en el disco</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">Confirmar el envío de monedas</translation>
     </message>
     <message>
         <source>Watch-only balance:</source>
@@ -2585,7 +3182,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">La cantidad por pagar tiene que ser mayor que 0.</translation>
+        <translation type="unfinished">El importe por pagar tiene que ser mayor que 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
@@ -2593,38 +3190,42 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">El total sobrepasa su saldo cuando se incluye la tasa de envío de %1</translation>
+        <translation type="unfinished">El total sobrepasa el saldo cuando se incluye la comisión de transacción de %1.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
         <translation type="unfinished">Se encontró una dirección duplicada: las direcciones solo se deben usar una vez.</translation>
     </message>
     <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">Fallo al crear la transacción</translation>
+    </message>
+    <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurda-mente alta.</translation>
+        <translation type="unfinished">Una comisión mayor que %1 se considera absurdamente alta.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloque.</numerusform>
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloques.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloque.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Alerta: Dirección de Bitcoin inválida</translation>
+        <translation type="unfinished">Advertencia: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Peligro: Dirección de cambio desconocida</translation>
+        <translation type="unfinished">Advertencia: Dirección de cambio desconocida</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation type="unfinished">Confirmar dirección de cambio personalizada</translation>
+        <translation type="unfinished">Confirmar la dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">La dirección que ha seleccionado para el cambio no es parte de su monedero. Parte o todos sus fondos pueden ser enviados a esta dirección. ¿Está seguro?</translation>
+        <translation type="unfinished">La dirección que seleccionaste para el cambio no es parte de esta billetera. Una parte o la totalidad de los fondos en la billetera se enviará a esta dirección. ¿Seguro deseas continuar?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2635,11 +3236,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation type="unfinished">Ca&amp;ntidad:</translation>
+        <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation type="unfinished">&amp;Pagar a:</translation>
+        <translation type="unfinished">Pagar &amp;a:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;Etiqueta:</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -2647,7 +3252,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Dirección Bitcoin a la que se enviará el pago</translation>
+        <translation type="unfinished">La dirección de Bitcoin a la que se enviará el pago</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
@@ -2662,8 +3267,20 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">El importe que se enviará en la unidad seleccionada</translation>
     </message>
     <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">La comisión se deducirá del importe que se envía. El destinatario recibirá menos bitcoins que los que ingreses en el campo del importe. Si se seleccionan varios destinatarios, la comisión se dividirá por igual.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">&amp;Restar la comisión del importe</translation>
+    </message>
+    <message>
         <source>Use available balance</source>
         <translation type="unfinished">Usar el saldo disponible</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">Mensaje:</translation>
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
@@ -2671,7 +3288,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje que se agrgará al URI de Bitcoin, el cuál será almacenado con la transacción para su referencia. Nota: Este mensaje no será enviado a través de la red de Bitcoin.</translation>
+        <translation type="unfinished">Un mensaje que se adjuntó al bitcoin: URI que se almacenará con la transacción a modo de referencia. Nota: Este mensaje no se enviará por la red de Bitcoin.</translation>
     </message>
 </context>
 <context>
@@ -2689,19 +3306,19 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">Firmas - Firmar / verificar un mensaje</translation>
+        <translation type="unfinished">Firmas: firmar o verificar un mensaje</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished">&amp;Firmar Mensaje</translation>
+        <translation type="unfinished">&amp;Firmar mensaje</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Puedes firmar los mensajes con tus direcciones para demostrar que las posees. Ten cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarte firmando tu identidad a través de ellos. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
+        <translation type="unfinished">Puedes firmar mensajes o acuerdos con tus direcciones para demostrar que puedes recibir los bitcoins que se envíen a ellas. Ten cuidado de no firmar cosas confusas o al azar, ya que los ataques de phishing pueden tratar de engañarte para que les envíes la firma con tu identidad. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmará el mensaje</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -2710,6 +3327,10 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>Paste address from clipboard</source>
         <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">Ingresar aquí el mensaje que deseas firmar</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -2721,27 +3342,31 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Firmar un mensaje para demostrar que se posee una dirección Bitcoin</translation>
+        <translation type="unfinished">Firmar el mensaje para demostrar que esta dirección de Bitcoin te pertenece</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished">Firmar Mensaje</translation>
+        <translation type="unfinished">Firmar &amp;mensaje</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation type="unfinished">Limpiar todos los campos de la firma de mensaje</translation>
+        <translation type="unfinished">Restablecer todos los campos de firma de mensaje</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation type="unfinished">&amp;Firmar Mensaje</translation>
+        <translation type="unfinished">&amp;Verificar mensaje</translation>
+    </message>
+    <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">Ingresa la dirección del destinatario, el mensaje (recuerda copiar los saltos de línea, espacios, tabulaciones, etc. con exactitud) y la firma a continuación para verificar el mensaje. Ten cuidado de no leer en la firma más de lo que está en el mensaje firmado en sí, para evitar ser víctima de un engaño por ataque de intermediario. Ten en cuenta que esto solo demuestra que el firmante recibe con la dirección; no puede demostrar la condición de remitente de ninguna transacción.</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmó el mensaje</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -2749,39 +3374,51 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation type="unfinished">La firma proporcionada cuando el mensaje fue firmado</translation>
+        <translation type="unfinished">La firma que se dio cuando el mensaje se firmó</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation type="unfinished">Verifique el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
+        <translation type="unfinished">Verifica el mensaje para asegurarte de que se firmó con la dirección de Bitcoin especificada.</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
         <translation type="unfinished">Verificar &amp;mensaje</translation>
     </message>
     <message>
+        <source>Reset all verify message fields</source>
+        <translation type="unfinished">Restablecer todos los campos de verificación de mensaje</translation>
+    </message>
+    <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Haga clic en "Firmar mensaje" para generar la firma</translation>
+        <translation type="unfinished">Hacer clic en "Firmar mensaje" para generar una firma</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
-        <translation type="unfinished">La dirección introducida es inválida</translation>
+        <translation type="unfinished">La dirección ingresada es inválida.</translation>
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">Por favor, revise la dirección e inténtelo nuevamente.</translation>
+        <translation type="unfinished">Revisa la dirección e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">La dirección introducida no corresponde a una clave.</translation>
+        <translation type="unfinished">La dirección ingresada no corresponde a una clave.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Se canceló el desbloqueo de la billetera.</translation>
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">No hay error</translation>
+        <translation type="unfinished">Sin error </translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation type="unfinished">La clave privada para la dirección ingresada no está disponible.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation type="unfinished">Ha fallado la firma del mensaje.</translation>
+        <translation type="unfinished">Error al firmar el mensaje.</translation>
     </message>
     <message>
         <source>Message signed.</source>
@@ -2793,30 +3430,43 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Compruebe la firma e inténtelo de nuevo.</translation>
+        <translation type="unfinished">Comprueba la firma e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">La firma no coincide con el resumen del mensaje.</translation>
+        <translation type="unfinished">La firma no coincide con la síntesis del mensaje.</translation>
     </message>
-    </context>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Falló la verificación del mensaje.</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">Mensaje verificado.</translation>
+    </message>
+</context>
 <context>
     <name>SplashScreen</name>
     <message>
         <source>(press q to shutdown and continue later)</source>
-        <translation type="unfinished">(presione la tecla q para apagar y continuar después)</translation>
+        <translation type="unfinished">(Presionar q para apagar y seguir luego)</translation>
     </message>
     <message>
         <source>press q to shutdown</source>
-        <translation type="unfinished">pulse q para apagar</translation>
+        <translation type="unfinished">Presionar q para apagar </translation>
     </message>
 </context>
 <context>
     <name>TransactionDesc</name>
     <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">Hay un conflicto con una transacción con %1 confirmaciones</translation>
+    </message>
+    <message>
         <source>0/unconfirmed, in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
-        <translation type="unfinished">0/sin confirmar, en la piscina de memoria</translation>
+        <translation type="unfinished">0/sin confirmar, en el pool de memoria</translation>
     </message>
     <message>
         <source>0/unconfirmed, not in memory pool</source>
@@ -2836,33 +3486,57 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>%1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
-        <translation type="unfinished">confirmaciones %1</translation>
+        <translation type="unfinished">%1 confirmaciones</translation>
     </message>
     <message>
         <source>Status</source>
         <translation type="unfinished">Estado</translation>
     </message>
     <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
         <source>Source</source>
         <translation type="unfinished">Fuente</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation type="unfinished">Generado</translation>
     </message>
     <message>
         <source>From</source>
         <translation type="unfinished">De</translation>
     </message>
     <message>
+        <source>unknown</source>
+        <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">dirección personal</translation>
+        <translation type="unfinished">dirección propia</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">etiqueta</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">Crédito</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform>disponible en %n bloque</numerusform>
-            <numerusform>disponible en %n bloques</numerusform>
+            <numerusform>madura en %n bloque más</numerusform>
+            <numerusform>madura en %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -2870,16 +3544,32 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">no aceptada</translation>
     </message>
     <message>
+        <source>Debit</source>
+        <translation type="unfinished">Débito</translation>
+    </message>
+    <message>
         <source>Total debit</source>
-        <translation type="unfinished">Total enviado</translation>
+        <translation type="unfinished">Débito total</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">Crédito total</translation>
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Comisión por transacción.</translation>
+        <translation type="unfinished">Comisión de transacción</translation>
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe neto</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">Comentario</translation>
     </message>
     <message>
         <source>Transaction ID</source>
@@ -2887,7 +3577,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Tamaño total transacción</translation>
+        <translation type="unfinished">Tamaño total de transacción</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -2895,7 +3585,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Indice de salida</translation>
+        <translation type="unfinished">Índice de salida</translation>
     </message>
     <message>
         <source>%1 (Certificate was not verified)</source>
@@ -2903,11 +3593,19 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Merchant</source>
-        <translation type="unfinished">Vendedor</translation>
+        <translation type="unfinished">Comerciante</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que puedan ser gastadas. Una vez que generas este bloque, es propagado por la red para ser añadido a la cadena de bloques. Si falla el intento de meterse en la cadena, su estado cambiará a "no aceptado" y ya no se puede gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
+        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que se puedan gastar. Cuando generaste este bloque, se transmitió a la red para agregarlo a la cadena de bloques. Si no logra entrar a la cadena, su estado cambiará a "no aceptado" y no se podrá gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation type="unfinished">Información de depuración</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation type="unfinished">Transacción</translation>
     </message>
     <message>
         <source>Inputs</source>
@@ -2915,41 +3613,65 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>true</source>
         <translation type="unfinished">verdadero</translation>
     </message>
-    </context>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">falso</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation type="unfinished">Este panel muestra una descripción detallada de la transacción</translation>
+        <translation type="unfinished">En este panel se muestra una descripción detallada de la transacción</translation>
     </message>
-    </context>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">Detalles para %1</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
     <message>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Sin confirmar</translation>
     </message>
     <message>
         <source>Abandoned</source>
         <translation type="unfinished">Abandonada</translation>
     </message>
     <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">Confirmando (%1 de %2 confirmaciones recomendadas)</translation>
+    </message>
+    <message>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished">Confirmada (%1 confirmaciones)</translation>
     </message>
     <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">En conflicto</translation>
+    </message>
+    <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">No disponible (%1 confirmaciones, disponible después de %2)</translation>
+        <translation type="unfinished">Inmadura (%1 confirmaciones; estará disponibles después de %2)</translation>
     </message>
     <message>
         <source>Generated but not accepted</source>
@@ -2957,11 +3679,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished">Recibido de</translation>
+        <translation type="unfinished">Recibida de</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -2969,15 +3691,39 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation type="unfinished">(n/d)</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
     <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation type="unfinished">Estado de la transacción. Pasa el mouse sobre este campo para ver el número de confirmaciones.</translation>
+    </message>
+    <message>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished">Fecha y hora en las que se recibió la transacción.</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">Tipo de transacción.</translation>
+    </message>
+    <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation type="unfinished">Si una dirección solo de observación está involucrada en esta transacción o no.</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation type="unfinished">Intención o propósito de la transacción definidos por el usuario.</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
@@ -2986,6 +3732,14 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
 </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Todo</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">Hoy</translation>
+    </message>
     <message>
         <source>This week</source>
         <translation type="unfinished">Esta semana</translation>
@@ -2996,11 +3750,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Last month</source>
-        <translation type="unfinished">El mes pasado </translation>
+        <translation type="unfinished">Mes pasado</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation type="unfinished">Este año</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3008,7 +3766,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
     </message>
     <message>
         <source>Other</source>
@@ -3016,7 +3774,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Introduzca dirección, id de transacción o etiqueta a buscar</translation>
+        <translation type="unfinished">Ingresar la dirección, el identificador de transacción o la etiqueta para buscar</translation>
     </message>
     <message>
         <source>Min amount</source>
@@ -3040,11 +3798,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Copiar &amp;ID de la transacción</translation>
+        <translation type="unfinished">Copiar &amp;identificador de transacción</translation>
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Copiar transacción &amp;raw</translation>
+        <translation type="unfinished">Copiar transacción &amp;sin procesar</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
@@ -3085,16 +3843,28 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Confirmada</translation>
     </message>
     <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Nombre</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation type="unfinished">Identificador</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -3102,15 +3872,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">Ha habido un error al intentar guardar la transacción con %1.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar el historial de transacciones en %1.</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
-        <translation type="unfinished">Exportación satisfactoria</translation>
+        <translation type="unfinished">Exportación correcta</translation>
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">El historial de transacciones ha sido guardado exitosamente en %1</translation>
+        <translation type="unfinished">El historial de transacciones se guardó correctamente en %1.</translation>
     </message>
     <message>
         <source>Range:</source>
@@ -3128,22 +3898,34 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <translation type="unfinished">No se cargó ninguna billetera.
-Ir a Archivo &gt; Abrir billetera para cargar una.
-- OR -</translation>
+Ir a "Archivo &gt; Abrir billetera" para cargar una.
+- O -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Crear monedero nuevo</translation>
+        <translation type="unfinished">Crear una nueva billetera</translation>
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">No se puede decodificar TBPF desde el portapapeles (inválido base64)</translation>
+        <translation type="unfinished">No se puede decodificar la TBPF desde el portapapeles (Base64 inválida)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Cargar datos de la transacción</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Transacción firmada de manera parcial (*.psbt)</translation>
+        <translation type="unfinished">Transacción parcialmente firmada (*.psbt)</translation>
     </message>
-    </context>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">El archivo TBPF debe ser más pequeño de 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">No se puede decodificar TBPF</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
     <message>
@@ -3152,20 +3934,32 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Fee bump error</source>
-        <translation type="unfinished">Error de incremento de cuota</translation>
+        <translation type="unfinished">Error de incremento de comisión</translation>
+    </message>
+    <message>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">Fallo al incrementar la comisión de transacción</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
         <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
-        <translation type="unfinished">¿Desea incrementar la cuota?</translation>
+        <translation type="unfinished">¿Deseas incrementar la comisión?</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Comisión actual:</translation>
     </message>
     <message>
         <source>Increase:</source>
         <translation type="unfinished">Incremento:</translation>
     </message>
     <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Nueva comisión:</translation>
+    </message>
+    <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <translation type="unfinished">Advertencia: Esto puede pagar la comisión adicional al reducir el cambio de salidas o agregar entradas, cuando sea necesario. Puede agregar una nueva salida de cambio si aún no existe. Potencialmente estos cambios pueden comprometer la privacidad.</translation>
+        <translation type="unfinished">Advertencia: Esta acción puede pagar la comisión adicional al reducir las salidas de cambio o agregar entradas, cuando sea necesario. Asimismo, puede agregar una nueva salida de cambio si aún no existe una. Estos cambios pueden filtrar potencialmente información privada.</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
@@ -3173,11 +3967,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Can't draft transaction.</source>
-        <translation type="unfinished">No se pudo preparar la transacción.</translation>
+        <translation type="unfinished">No se puede crear un borrador de la transacción.</translation>
     </message>
     <message>
         <source>PSBT copied</source>
-        <translation type="unfinished">TBPF copiada </translation>
+        <translation type="unfinished">TBPF copiada</translation>
     </message>
     <message>
         <source>Copied to clipboard</source>
@@ -3186,7 +3980,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Can't sign transaction.</source>
-        <translation type="unfinished">No se ha podido firmar la transacción.</translation>
+        <translation type="unfinished">No se puede firmar la transacción.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
@@ -3198,18 +3992,22 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
 </context>
 <context>
     <name>WalletView</name>
     <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
+    </message>
+    <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar a un archivo los datos de esta pestaña</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">Respaldo de monedero</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -3222,11 +4020,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">Ha habido un error al intentar guardar los datos del monedero a %1.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar los datos de la billetera en %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">Respaldo exitoso</translation>
+        <translation type="unfinished">Copia de seguridad correcta</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
@@ -3245,11 +4043,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s corrupto. Intenta utilizar la herramienta del monedero bitcoin-monedero para salvar o restaurar una copia de seguridad.</translation>
+        <translation type="unfinished">%s dañado. Trata de usar la herramienta de la billetera de Bitcoin para rescatar o restaurar una copia de seguridad.</translation>
     </message>
     <message>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea no válida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Comunique este incidente a %s, indicando cómo obtuvo la instantánea. Se dejó el estado de encadenamiento de la instantánea no válida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
+        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea inválida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Reporta este incidente a %s, indicando cómo obtuviste la instantánea. Se dejó el estado de cadena de la instantánea inválida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
     </message>
     <message>
         <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
@@ -3260,6 +4058,10 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">No se puede pasar de la versión %i a la versión anterior %i.  La versión de la billetera no tiene cambios.</translation>
     </message>
     <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation type="unfinished">No se puede bloquear el directorio de datos %s. %s probablemente ya se está ejecutando.</translation>
+    </message>
+    <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
         <translation type="unfinished">No se puede actualizar una billetera dividida no HD de la versión %i a la versión %i sin actualizar para admitir el pool de claves anterior a la división. Usa la versión %i o no especifiques la versión.</translation>
     </message>
@@ -3268,28 +4070,32 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">Es posible que el espacio en disco %s no tenga capacidad para los archivos de bloque. Aproximadamente %u GB de datos se almacenarán en este directorio.</translation>
     </message>
     <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">Distribuido bajo la licencia de software MIT; ver el archivo adjunto %s o %s.</translation>
+    </message>
+    <message>
         <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <translation type="unfinished">Error al cargar la billetera. Esta requiere que se descarguen bloques, y el software actualmente no admite la carga de billeteras mientras los bloques se descargan fuera de orden, cuando se usan instantáneas de assumeutxo. La billetera debería poder cargarse correctamente después de que la sincronización del nodo alcance la altura %s.</translation>
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">¡Error de lectura %s! Los datos de la transacción pueden faltar o ser incorrectos. Reescaneo del monedero.</translation>
+        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Rescaneando billetera.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo «%s», del «formato» esperado.</translation>
+        <translation type="unfinished">Error: El registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "formato".</translation>
     </message>
     <message>
         <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo «%s» se esperaba «%s».</translation>
+        <translation type="unfinished">Error: El registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "%s".</translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Error: la versión del archivo volcado no es compatible. Esta versión de la billetera de bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
+        <translation type="unfinished">Error: La versión del archivo de volcado no es compatible. Esta versión de la billetera de Bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Error: las billeteras heredadas solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
+        <translation type="unfinished">Error: Las billeteras "legacy" solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
     </message>
     <message>
         <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
@@ -3301,7 +4107,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <translation type="unfinished">Archivo peers.dat inválido o corrupto (%s). Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
+        <translation type="unfinished">El archivo peers.dat (%s) es inválido o está dañado. Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -3309,15 +4115,15 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">No se proporcionó ningún archivo de volcado. Para usar createfromdump, se debe proporcionar  -dumpfile=&lt;filename&gt;.</translation>
+        <translation type="unfinished">No se proporcionó el archivo de volcado. Para usar createfromdump, se debe proporcionar  -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">No se proporcionó ningún archivo de volcado. Para usar dump, se debe proporcionar  -dumpfile=&lt;filename&gt;.</translation>
+        <translation type="unfinished">No se proporcionó el archivo de volcado. Para usar dump, se debe proporcionar  -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished">No se proporcionó el formato de archivo de billetera. Para usar createfromdump, se debe proporcionar  -format=&lt;filename&gt;.</translation>
+        <translation type="unfinished">No se proporcionó el formato de archivo de billetera. Para usar createfromdump, se debe proporcionar  -format=&lt;format&gt;.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3326,6 +4132,10 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation type="unfinished">Contribuye si te parece que %s es útil. Visita %s para obtener más información sobre el software.</translation>
+    </message>
+    <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation type="unfinished">La poda se configuró por debajo del mínimo de %d MiB. Usa un valor más alto.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
@@ -3337,11 +4147,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <translation type="unfinished">Error de renombrado de «%s» → «%s». Debería resolver esto manualmente moviendo o borrando el directorio %s de la instantánea no válida, en otro caso encontrará el mismo error de nuevo en el arranque siguiente.</translation>
+        <translation type="unfinished">Error al cambiar el nombre de "%s" a "%s". Para resolverlo, mueve o elimina manualmente el directorio %s de la instantánea no válida. De lo contrario, encontrarás el mismo error de nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: versión desconocida del esquema de la billetera sqlite %d. Solo se admite la versión %d</translation>
+        <translation type="unfinished">SQLiteDatabase: versión desconocida del esquema de la billetera sqlite %d. Solo se admite la versión %d.</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -3349,7 +4159,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
@@ -3365,27 +4175,27 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Esta es la comisión de transacción que puede descartar si el cambio es más pequeño que el polvo a este nivel.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes descartar si el cambio es más pequeño que el remanente en este nivel.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Impuesto por transacción que pagarás cuando la estimación de impuesto no esté disponible.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes pagar cuando los cálculos de comisiones no estén disponibles.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i ) supera la longitud máxima ( %i ) . Reducir el número o tamaño de uacomments .</translation>
+        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i) supera la longitud máxima (%i). Reduce el número o tamaño de uacomments .</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">No se pudieron reproducir bloques. Tendrás que reconstruir la base de datos usando -reindex-chainstate.</translation>
+        <translation type="unfinished">No se pueden reproducir bloques. Tendrás que reconstruir la base de datos usando -reindex-chainstate.</translation>
     </message>
     <message>
         <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
-        <translation type="unfinished">Se proporcionó un formato de billetera desconocido "%s". Proporciona uno entre "bdb" o "sqlite".</translation>
+        <translation type="unfinished">Se proporcionó un formato de archivo de billetera desconocido "%s". Proporciona uno entre "bdb" o "sqlite".</translation>
     </message>
     <message>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <translation type="unfinished">Nivel de boletín del acceso especificado en categoría no mantenida en %1$s=%2$s. Se esperaba %1$s=1:2. Categorías válidas: %3$s. Niveles de boletín válidos: %4 $s.</translation>
+        <translation type="unfinished">El nivel de registro de la categoría específica no es compatible: %1$s=%2$s. Se esperaba %1$s=&lt;category&gt;:&lt;loglevel&gt;. Categorías válidas: %3$s. Niveles de registro válidos: %4 $s.</translation>
     </message>
     <message>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
@@ -3397,11 +4207,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <translation type="unfinished">Monedero correctamente cargado. El tipo de billetero heredado está siendo obsoleto y mantenimiento para creación de monederos heredados serán eliminados en el futuro. Los monederos heredados pueden ser migrados a un descriptor de monedero con migratewallet.</translation>
+        <translation type="unfinished">La billetera se creó correctamente. El tipo de billetera "legacy" se está descontinuando, por lo que la asistencia para crear y abrir estas billeteras se eliminará en el futuro. Las billeteras "legacy" se pueden migrar a una billetera basada en descriptores con "migratewallet".</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Advertencia: el formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
+        <translation type="unfinished">Advertencia: El formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -3409,7 +4219,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Advertencia: ¡Al parecer no estamos completamente de acuerdo con nuestros pares! Es posible que tengas que actualizarte, o que los demás nodos tengan que hacerlo.</translation>
+        <translation type="unfinished">Advertencia: Al parecer no estamos completamente de acuerdo con nuestros pares. Es posible que tengas que realizar una actualización, o que los demás nodos tengan que hacerlo.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
@@ -3421,7 +4231,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">¡%s esta configurado muy alto!</translation>
+        <translation type="unfinished">¡El valor de %s es muy alto!</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
@@ -3433,7 +4243,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">No se puede resolver -%s direccion: '%s'</translation>
+        <translation type="unfinished">No se puede resolver la dirección de -%s: "%s"</translation>
     </message>
     <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
@@ -3461,7 +4271,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <translation type="unfinished">Error leyendo %s. Todas las teclas leídas correctamente, pero los datos de transacción o metadatos de dirección puedan ser ausentes o incorrectos.</translation>
+        <translation type="unfinished">Error al leer %s. Todas las claves se leyeron correctamente, pero es probable que falten los datos de la transacción o metadatos de direcciones, o bien que sean incorrectos.</translation>
     </message>
     <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
@@ -3513,11 +4323,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
-        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar una cantidad menor o consolidar manualmente las UTXO de la billetera.</translation>
+        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar un importe menor o consolidar manualmente las UTXO de la billetera.</translation>
     </message>
     <message>
         <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
-        <translation type="unfinished">La cantidad total de monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
+        <translation type="unfinished">El monto total de las monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
     </message>
     <message>
         <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
@@ -3529,14 +4339,14 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
-        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará el pool de memoria.</translation>
+        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará la mempool.</translation>
     </message>
     <message>
         <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <translation type="unfinished">Se encontró una entrada heredada inesperada en la billetera del descriptor. Cargando billetera%s
+        <translation type="unfinished">Se encontró una entrada inesperada tipo "legacy" en la billetera basada en descriptores. Cargando billetera%s
 
 Es posible que la billetera haya sido manipulada o creada con malas intenciones.
 </translation>
@@ -3570,6 +4380,18 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Se interrumpió la verificación de bloques</translation>
     </message>
     <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">La configuración para %s solo se aplica en la red %s cuando se encuentra en la sección [%s].</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished">Derechos de autor (C) %i-%i</translation>
+    </message>
+    <message>
+        <source>Corrupted block database detected</source>
+        <translation type="unfinished">Se detectó que la base de datos de bloques está dañada.</translation>
+    </message>
+    <message>
         <source>Could not find asmap file %s</source>
         <translation type="unfinished">No se pudo encontrar el archivo asmap %s</translation>
     </message>
@@ -3580,6 +4402,14 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     <message>
         <source>Disk space is too low!</source>
         <translation type="unfinished">¡El espacio en disco es demasiado pequeño!</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation type="unfinished">¿Quieres reconstruir la base de datos de bloques ahora?</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation type="unfinished">Carga completa</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
@@ -3594,16 +4424,36 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Error al crear %s</translation>
     </message>
     <message>
+        <source>Error initializing block database</source>
+        <translation type="unfinished">Error al inicializar la base de datos de bloques</translation>
+    </message>
+    <message>
+        <source>Error initializing wallet database environment %s!</source>
+        <translation type="unfinished">Error al inicializar el entorno de la base de datos de la billetera %s.</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">Error al cargar %s</translation>
+    </message>
+    <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
         <translation type="unfinished">Error al cargar %s: Las claves privadas solo se pueden deshabilitar durante la creación</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Error cargando %s: Monedero corrupto</translation>
+        <translation type="unfinished">Error al cargar %s: billetera dañada</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Error cargando %s: Monedero requiere una versión mas reciente de %s</translation>
+        <translation type="unfinished">Error al cargar %s: la billetera requiere una versión más reciente de %s</translation>
+    </message>
+    <message>
+        <source>Error loading block database</source>
+        <translation type="unfinished">Error al cargar la base de datos de bloques</translation>
+    </message>
+    <message>
+        <source>Error opening block database</source>
+        <translation type="unfinished">Error al abrir la base de datos de bloques</translation>
     </message>
     <message>
         <source>Error reading configuration file: %s</source>
@@ -3623,7 +4473,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
-        <translation type="unfinished">Error: no se puede extraer el destino del scriptpubkey generado</translation>
+        <translation type="unfinished">Error: No se puede extraer el destino del scriptpubkey generado</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -3643,11 +4493,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió una clave que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió una clave que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió un valor que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió un valor que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
@@ -3667,15 +4517,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: This wallet is already a descriptor wallet</source>
-        <translation type="unfinished">Error: Esta billetera ya es de descriptores</translation>
+        <translation type="unfinished">Error: Esta billetera ya está basada en descriptores</translation>
     </message>
     <message>
         <source>Error: Unable to begin reading all records in the database</source>
-        <translation type="unfinished">Error: No se puede comenzar a leer todos los registros en la base de datos</translation>
+        <translation type="unfinished">Error: No se pueden comenzar a leer todos los registros en la base de datos</translation>
     </message>
     <message>
         <source>Error: Unable to make a backup of your wallet</source>
-        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de tu billetera</translation>
+        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
@@ -3687,7 +4537,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to read wallet's best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de leer el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo leer el registro del mejor localizador de bloques de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to remove watchonly address book data</source>
@@ -3699,20 +4549,23 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to write solvable wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solucionable.</translation>
     </message>
     <message>
         <source>Error: Unable to write watchonly wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor monedero vigilado del bloque del registro localizador</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: address book copy failed for wallet %s</source>
-        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera 1%s
- </translation>
+        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera %s</translation>
     </message>
     <message>
         <source>Error: database transaction cannot be executed for wallet %s</source>
         <translation type="unfinished">Error: la transacción de la base de datos no se puede ejecutar para la billetera %s</translation>
+    </message>
+    <message>
+        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <translation type="unfinished">Fallo al escuchar en todos los puertos. Usa -listen=0 si quieres hacerlo.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -3720,7 +4573,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished">Es erróneo al iniciar indizados, se apaga...</translation>
+        <translation type="unfinished">Error al iniciar índices, cerrando...</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -3728,7 +4581,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failure removing transaction: %s</source>
-        <translation type="unfinished">Error al eliminar la transacción: 1%s</translation>
+        <translation type="unfinished">Error al eliminar la transacción: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -3744,27 +4597,35 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Incorrecto o bloque de génesis no encontrado. ¿datadir equivocada para la red?</translation>
+        <translation type="unfinished">El bloque génesis es incorrecto o no se encontró. ¿El directorio de datos es equivocado para la red?</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">Fallo al inicializar la comprobación de estado. %s se cerrará.</translation>
     </message>
     <message>
         <source>Input not found or already spent</source>
-        <translation type="unfinished">No se encontró o ya se gastó la entrada</translation>
+        <translation type="unfinished">La entrada no se encontró o ya se gastó</translation>
     </message>
     <message>
         <source>Insufficient dbcache for block verification</source>
-        <translation type="unfinished">dbcache insuficiente para la verificación de bloques</translation>
+        <translation type="unfinished">Dbcache insuficiente para la verificación de bloques</translation>
+    </message>
+    <message>
+        <source>Insufficient funds</source>
+        <translation type="unfinished">Fondos insuficientes</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">La dirección -i2psam o el nombre de host no es válido: "%s" </translation>
+        <translation type="unfinished">Dirección o nombre de host de -i2psam inválido: "%s" </translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -onion o dominio '%s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -onion inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -proxy o dominio ' %s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -proxy inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
@@ -3779,16 +4640,24 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Importe inválido para %s=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe inválido para -%s=&lt;amount&gt;: "%s"</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation type="unfinished">Máscara de red inválida especificada en -whitelist: "%s"</translation>
+    </message>
+    <message>
         <source>Invalid port specified in %s: '%s'</source>
-        <translation type="unfinished">Puerto no válido especificado en%s: '%s'</translation>
+        <translation type="unfinished">Puerto no válido especificado en %s: "%s"</translation>
     </message>
     <message>
         <source>Invalid pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no válida %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no es válida %s</translation>
     </message>
     <message>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Fallo en la escucha para conexiones entrantes (la escucha devolvió el error %s)</translation>
+        <translation type="unfinished">Fallo al escuchar conexiones entrantes (la escucha devolvió el error %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -3796,7 +4665,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Cargando lista de bloqueos...</translation>
+        <translation type="unfinished">Cargando lista de prohibiciones...</translation>
     </message>
     <message>
         <source>Loading block index…</source>
@@ -3808,23 +4677,31 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Missing amount</source>
-        <translation type="unfinished">Falta la cantidad</translation>
+        <translation type="unfinished">Falta el importe</translation>
     </message>
     <message>
         <source>Missing solving data for estimating transaction size</source>
         <translation type="unfinished">Faltan datos de resolución para estimar el tamaño de la transacción</translation>
     </message>
     <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation type="unfinished">Se necesita especificar un puerto con -whitebind: "%s"</translation>
+    </message>
+    <message>
         <source>No addresses available</source>
         <translation type="unfinished">No hay direcciones disponibles</translation>
     </message>
     <message>
+        <source>Not enough file descriptors available.</source>
+        <translation type="unfinished">No hay suficientes descriptores de archivo disponibles.</translation>
+    </message>
+    <message>
         <source>Not found pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no encontrada%s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se encontró %s</translation>
     </message>
     <message>
         <source>Not solvable pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no solucionable %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se puede solucionar %s</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -3836,7 +4713,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Podando almacén de bloques…</translation>
+        <translation type="unfinished">Podando almacenamiento de bloques…</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished">Reduciendo -maxconnections de %d a %d, debido a limitaciones del sistema.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
@@ -3868,7 +4749,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation type="unfinished">Firma de transacción fallida</translation>
+        <translation type="unfinished">Fallo al firmar la transacción</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
@@ -3896,7 +4777,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">El código fuente esta disponible desde %s.</translation>
+        <translation type="unfinished">El código fuente está disponible en %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
@@ -3904,15 +4785,23 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para pagar la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es muy pequeño para pagar la comisión</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">La billetera evitará pagar menos que la comisión mínima de retransmisión.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Este es un software experimental.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Mínimo de impuesto que pagarás con cada transacción.</translation>
+        <translation type="unfinished">Esta es la comisión mínima de transacción que pagas en cada transacción.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Esta es la comisión por transacción a pagar si realiza una transacción.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que pagarás si envías una transacción.</translation>
     </message>
     <message>
         <source>Transaction %s does not belong to this wallet</source>
@@ -3924,7 +4813,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Los montos de la transacción no debe ser negativo</translation>
+        <translation type="unfinished">Los importes de la transacción no pueden ser negativos</translation>
     </message>
     <message>
         <source>Transaction change output index out of range</source>
@@ -3932,7 +4821,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">La transacción debe tener al menos un destinatario</translation>
+        <translation type="unfinished">La transacción debe incluir al menos un destinatario</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it.</source>
@@ -3979,6 +4868,10 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">No se puede analizar -maxuploadtarget: "%s"</translation>
     </message>
     <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">No se puede iniciar el servidor HTTP. Consulta el registro de depuración para obtener información.</translation>
+    </message>
+    <message>
         <source>Unable to unload the wallet before migrating</source>
         <translation type="unfinished">No se puede descargar la billetera antes de la migración</translation>
     </message>
@@ -3996,7 +4889,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">La red especificada en -onlynet '%s' es desconocida</translation>
+        <translation type="unfinished">Se desconoce la red especificada en -onlynet: "%s"</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
@@ -4004,15 +4897,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <translation type="unfinished">Nivel de acceso global %s = %s no mantenido. Los valores válidos son: %s.</translation>
+        <translation type="unfinished">El nivel de registro global %s=%s no es compatible. Valores válidos: %s.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
-        <translation type="unfinished">Creación errónea del fichero monedero: %s</translation>
+        <translation type="unfinished">Error al crear el archivo de la billetera: %s</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
-        <translation type="unfinished">acceptstalefeeestimates no está mantenido en el encadenamiento %s.</translation>
+        <translation type="unfinished">acceptstalefeeestimates no se admite en la cadena %s.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
@@ -4020,11 +4913,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
-        <translation type="unfinished">Error: no pudo agregar tx de solo vigía %s para monedero de solo vigía</translation>
+        <translation type="unfinished">Error: No se pudo agregar la transacción %s a la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: Could not delete watchonly transactions. </source>
-        <translation type="unfinished">Error: no se pudieron eliminar las transacciones de watchonly.</translation>
+        <translation type="unfinished">Error: No se pudieron eliminar las transacciones solo de observación</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -4044,7 +4937,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Settings file could not be read</source>
-        <translation type="unfinished">El archivo de configuración no puede leerse</translation>
+        <translation type="unfinished">El archivo de configuración no se puede leer</translation>
     </message>
     <message>
         <source>Settings file could not be written</source>

--- a/src/qt/locale/bitcoin_es_VE.ts
+++ b/src/qt/locale/bitcoin_es_VE.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Haga clic con el botón derecho para editar una dirección o etiqueta</translation>
+        <translation type="unfinished">Hacer clic derecho para editar la dirección o etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -11,11 +11,11 @@
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;Nuevo</translation>
+        <translation type="unfinished">&amp;Nueva</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Copiar la dirección seleccionada al portapapeles del sistema</translation>
+        <translation type="unfinished">Copiar la dirección seleccionada actualmente al portapapeles del sistema</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,15 +27,15 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Borrar de la lista la dirección seleccionada</translation>
+        <translation type="unfinished">Eliminar la dirección seleccionada de la lista</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Introduzca una dirección o etiqueta que buscar</translation>
+        <translation type="unfinished">Ingresar una dirección o etiqueta para buscar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar a un archivo los datos de esta pestaña</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -43,37 +43,37 @@
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Eliminar</translation>
+        <translation type="unfinished">&amp;Borrar</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Escoja la dirección a la que se enviarán monedas</translation>
+        <translation type="unfinished">Elige la dirección a la que se enviarán monedas</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Escoja la dirección donde quiere recibir monedas</translation>
+        <translation type="unfinished">Elige la dirección con la que se recibirán monedas</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">Escoger</translation>
+        <translation type="unfinished">&amp;Seleccionar</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estas son sus direcciones Bitcoin para enviar pagos. Compruebe siempre la cantidad y la dirección de recibo antes de transferir monedas.</translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para enviar pagos. Revisa siempre el importe y la dirección de recepción antes de enviar monedas.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Lista de tus direcciones de Bitcoin para recibir pagos. Para la  creacion de  una nueva direccion seleccione en la pestana "recibir" la opcion "Crear nueva direccion" 
-Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para recibir pagos. Usa el botón "Crear nueva dirección de recepción" en la pestaña "Recibir" para crear nuevas direcciones.
+Solo es posible firmar con direcciones de tipo legacy.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">Copiar dirección</translation>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar &amp;Etiqueta</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -81,7 +81,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Exportar la Lista de Direcciones</translation>
+        <translation type="unfinished">Exportar lista de direcciones</translation>
     </message>
     <message>
         <source>Comma separated file</source>
@@ -91,7 +91,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Hubo un error al intentar guardar la lista de direcciones a %1. Por favor trate de nuevo.</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar la lista de direcciones en %1. Inténtalo de nuevo.</translation>
     </message>
     <message>
         <source>Sending addresses - %1</source>
@@ -103,7 +103,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">La exportación falló</translation>
+        <translation type="unfinished">Error al exportar</translation>
     </message>
 </context>
 <context>
@@ -125,19 +125,19 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">Diálogo de contraseña</translation>
+        <translation type="unfinished">Diálogo de frase de contraseña</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">Introducir contraseña</translation>
+        <translation type="unfinished">Ingresar la frase de contraseña</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">Nueva contraseña</translation>
+        <translation type="unfinished">Nueva frase de contraseña</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Repita la nueva contraseña</translation>
+        <translation type="unfinished">Repetir la nueva frase de contraseña</translation>
     </message>
     <message>
         <source>Show passphrase</source>
@@ -145,35 +145,35 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Cifrar monedero</translation>
+        <translation type="unfinished">Encriptar billetera</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Esta operación requiere su contraseña para desbloquear el monedero.</translation>
+        <translation type="unfinished">Esta operación requiere la frase de contraseña de la billetera para desbloquearla.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">Desbloquear monedero</translation>
+        <translation type="unfinished">Desbloquear billetera</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Cambiar frase secreta</translation>
+        <translation type="unfinished">Cambiar frase de contraseña</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">Confirme cifrado del monedero</translation>
+        <translation type="unfinished">Confirmar el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Atención: Si cifra su monedero y pierde la contraseña, perderá ¡&lt;b&gt;TODOS SUS BITCOINS&lt;/b&gt;!</translation>
+        <translation type="unfinished">Advertencia: Si encriptas la billetera y pierdes tu frase de contraseña, ¡&lt;b&gt;PERDERÁS TODOS TUS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">¿Está seguro que desea cifrar su monedero?</translation>
+        <translation type="unfinished">¿Seguro quieres encriptar la billetera?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Monedero cifrado</translation>
+        <translation type="unfinished">Billetera encriptada</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
@@ -181,47 +181,47 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Introduce la contraseña antigua y la nueva para el monedero.</translation>
+        <translation type="unfinished">Ingresa la antigua frase de contraseña y la nueva frase de contraseña para la billetera.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Recuerda que cifrar tu billetera no garantiza total protección de robo de tus bitcoins si tu ordenador es infectado con malware.</translation>
+        <translation type="unfinished">Recuerda que encriptar tu billetera no garantiza la protección total contra el robo de tus bitcoins si la computadora está infectada con malware.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Billetera a ser cifrada</translation>
+        <translation type="unfinished">Billetera para encriptar</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Tu billetera esta por ser encriptada</translation>
+        <translation type="unfinished">Tu billetera está a punto de encriptarse.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Su billetera está ahora cifrada</translation>
+        <translation type="unfinished">Tu billetera ahora está encriptada.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">IMPORTANTE: Algunas copias de seguridad que hayas hecho de tu archivo de billetera deberían ser reemplazadas con la billetera encriptada generada recientemente. Por razones de seguridad, las copias de seguridad previas del archivo de billetera sin cifrar serán inútiles tan pronto uses la nueva billetera encriptada.</translation>
+        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad anterior que hayas hecho del archivo de la billetera se deberá reemplazar por el nuevo archivo encriptado que generaste. Por motivos de seguridad, las copias de seguridad realizadas anteriormente quedarán obsoletas en cuanto empieces a usar la nueva billetera encriptada.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Encriptado de monedero fallido</translation>
+        <translation type="unfinished">Falló el encriptado de la billetera</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">Encriptación de billetera fallida debido a un error interno. Tu billetera no fue encriptada.</translation>
+        <translation type="unfinished">El encriptado de la billetera falló debido a un error interno. La billetera no se encriptó.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">Las frases secretas introducidas no concuerdan.</translation>
+        <translation type="unfinished">Las frases de contraseña proporcionadas no coinciden.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">Desbloqueo de billetera fallido</translation>
+        <translation type="unfinished">Falló el desbloqueo de la billetera</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">La frase secreta introducida para la desencriptación de la billetera fué incorrecta.</translation>
+        <translation type="unfinished">La frase de contraseña introducida para el cifrado de la billetera es incorrecta.</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
@@ -229,7 +229,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">La frase secreta de la billetera fué cambiada exitosamente.</translation>
+        <translation type="unfinished">La frase de contraseña de la billetera se cambió correctamente.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
@@ -241,14 +241,18 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Aviso: El bloqueo de mayúsculas está activado.</translation>
+        <translation type="unfinished">Advertencia: ¡Las mayúsculas están activadas!</translation>
     </message>
 </context>
 <context>
     <name>BanTableModel</name>
     <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/Máscara de red</translation>
+    </message>
+    <message>
         <source>Banned Until</source>
-        <translation type="unfinished">Bloqueado hasta</translation>
+        <translation type="unfinished">Prohibido hasta</translation>
     </message>
 </context>
 <context>
@@ -258,8 +262,12 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
         <translation type="unfinished">El archivo de configuración %1 puede estar corrupto o no ser válido.</translation>
     </message>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción fuera de control</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Se ha producido un error garrafal. %1Ya no podrá continuar de manera segura y abandonará.</translation>
+        <translation type="unfinished">Se produjo un error fatal. %1 ya no puede continuar de manera segura y se cerrará.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -267,7 +275,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Un error interno ocurrió. %1 intentará continuar. Este es un error inesperado que puede ser reportado de las formas que se muestran debajo,</translation>
+        <translation type="unfinished">Se produjo un error interno. %1 intentará continuar de manera segura. Este es un error inesperado que se puede reportar como se describe a continuación.</translation>
     </message>
 </context>
 <context>
@@ -280,7 +288,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Un error fatal ha ocurrido. Comprueba que el archivo de configuración soporta escritura, o intenta ejecutar de nuevo el programa con -nosettings</translation>
+        <translation type="unfinished">Se produjo un error fatal. Comprueba que el archivo de configuración soporte escritura o intenta ejecutar el programa con -nosettings.</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
@@ -289,6 +297,10 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>unknown</source>
         <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">"%1" integrado</translation>
     </message>
     <message>
         <source>Default system font "%1"</source>
@@ -300,11 +312,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Ingresa una dirección de Bitcoin (Ejemplo: %1)</translation>
+        <translation type="unfinished">Ingresar una dirección de Bitcoin (por ejemplo, %1)</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -318,7 +330,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
     <message>
         <source>Full Relay</source>
@@ -328,7 +340,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>Block Relay</source>
         <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">Retransmisión de bloque</translation>
+        <translation type="unfinished">Retransmisión de bloques</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -398,7 +410,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation type="unfinished">Mostrar vista general del monedero</translation>
+        <translation type="unfinished">Muestra una vista general de la billetera</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -406,7 +418,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation type="unfinished">Examinar el historial de transacciones</translation>
+        <translation type="unfinished">Explora el historial de transacciones</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -414,7 +426,15 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Quit application</source>
-        <translation type="unfinished">Salir de la aplicación</translation>
+        <translation type="unfinished">Salir del programa</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;Acerca de %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Mostrar Información sobre %1</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -422,7 +442,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation type="unfinished">Mostrar información acerca de Qt</translation>
+        <translation type="unfinished">Mostrar información sobre Qt</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">Modificar las opciones de configuración para %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -433,21 +457,29 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
         <translation type="unfinished">&amp;Minimizar</translation>
     </message>
     <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">Actividad de red deshabilitada.</translation>
     </message>
     <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proxy &lt;b&gt;habilitado&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">Enviar monedas a una dirección Bitcoin</translation>
+        <translation type="unfinished">Enviar monedas a una dirección de Bitcoin</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation type="unfinished">Copia de seguridad del monedero en otra ubicación</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera en otra ubicación</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">Cambiar la contraseña utilizada para el cifrado del monedero</translation>
+        <translation type="unfinished">Cambiar la frase de contraseña utilizada para encriptar la billetera</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -458,28 +490,44 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
         <translation type="unfinished">&amp;Recibir</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opciones…</translation>
+    </message>
+    <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Cifrar monedero</translation>
+        <translation type="unfinished">&amp;Encriptar billetera…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">Cifrar las claves privadas de su monedero</translation>
+        <translation type="unfinished">Encriptar las claves privadas que pertenecen a la billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Realizar copia de seguridad de la billetera...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
         <translation type="unfinished">&amp;Cambiar frase de contraseña...</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Firmar &amp;mensaje...</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Firmar mensajes con sus direcciones Bitcoin para demostrar la propiedad</translation>
+        <translation type="unfinished">Firmar mensajes con tus direcciones de Bitcoin para demostrar que te pertenecen</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Verificar mensaje...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Verificar mensajes comprobando que están firmados con direcciones Bitcoin concretas</translation>
+        <translation type="unfinished">Verificar mensajes para asegurarte de que estén firmados con direcciones de Bitcoin concretas</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Cargar PSBT desde archivo...</translation>
+        <translation type="unfinished">&amp;Cargar TBPF desde archivo...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -487,15 +535,15 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Cerrar monedero...</translation>
+        <translation type="unfinished">Cerrar billetera...</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Crear monedero...</translation>
+        <translation type="unfinished">Crear billetera...</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Cerrar todos los monederos...</translation>
+        <translation type="unfinished">Cerrar todas las billeteras...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -507,7 +555,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="unfinished">A&amp;yuda</translation>
+        <translation type="unfinished">&amp;Ayuda</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
@@ -535,25 +583,25 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Solicitar pagos (genera codigo QR y URL's de Bitcoin)</translation>
+        <translation type="unfinished">Solicitar pagos (genera códigos QR y URI de tipo "bitcoin:")</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Mostrar la lista de direcciones de envío y etiquetas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de envío usadas</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Muestra la lista de direcciones de recepción y etiquetas</translation>
+        <translation type="unfinished">Mostrar la lista de etiquetas y direcciones de recepción usadas</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;Opciones de linea de comando</translation>
+        <translation type="unfinished">&amp;Opciones de línea de comandos</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>%n bloque procesado del historial de transacciones.</numerusform>
-            <numerusform>%n bloques procesados del historial de transacciones.</numerusform>
+            <numerusform>Se procesó %n bloque del historial de transacciones.</numerusform>
+            <numerusform>Se procesaron %n bloques del historial de transacciones.</numerusform>
         </translation>
     </message>
     <message>
@@ -566,7 +614,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished">El último bloque recibido fue generado hace %1.</translation>
+        <translation type="unfinished">El último bloque recibido se generó hace %1.</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
@@ -574,7 +622,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
+        <translation type="unfinished">Advertencia</translation>
     </message>
     <message>
         <source>Information</source>
@@ -590,7 +638,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
-        <translation type="unfinished">Cargar PSBT desde el &amp;portapapeles...</translation>
+        <translation type="unfinished">Cargar TBPF desde el &amp;portapapeles...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -598,11 +646,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Abrir consola de depuración y diagnóstico de nodo</translation>
+        <translation type="unfinished">Abrir la consola de depuración y diagnóstico del nodo</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -610,19 +658,23 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Direcciones de recepción</translation>
+        <translation type="unfinished">&amp;Direcciones de destino</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Bitcoin: abrir URI</translation>
+        <translation type="unfinished">Abrir un URI de tipo "bitcoin:"</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Abrir una billetera</translation>
     </message>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Cerrar monedero</translation>
+        <translation type="unfinished">Cerrar billetera</translation>
     </message>
     <message>
         <source>Restore Wallet…</source>
@@ -636,7 +688,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -647,20 +699,24 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
         <translation type="unfinished">Migrar una billetera</translation>
     </message>
     <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mostrar el mensaje de ayuda %1 para obtener una lista de las posibles opciones de línea de comandos de Bitcoin</translation>
+    </message>
+    <message>
         <source>&amp;Mask values</source>
         <translation type="unfinished">&amp;Ocultar valores</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Ocultar los valores en la pestaña de vista general</translation>
+        <translation type="unfinished">Ocultar los valores en la pestaña "Vista general"</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">Monederos no disponibles</translation>
+        <translation type="unfinished">No hay billeteras disponibles</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -680,11 +736,19 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera</translation>
     </message>
     <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ventana</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Acercar</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Ventana principal</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -696,14 +760,14 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">M&amp;ostrar</translation>
+        <translation type="unfinished">&amp;Mostrar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n conexiones activas con la red Bitcoin</numerusform>
-            <numerusform>%n conexiones activas con la red Bitcoin </numerusform>
+            <numerusform>%n conexión activa con la red de Bitcoin.</numerusform>
+            <numerusform>%n conexiones activas con la red de Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -736,7 +800,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">No se puede crear una nueva billetera, el software se compiló sin soporte sqlite (requerido para billeteras descriptivas)</translation>
+        <translation type="unfinished">No se puede crear una billetera nueva, ya que el software se compiló sin compatibilidad con sqlite (requerida para billeteras basadas en descriptores)</translation>
     </message>
     <message>
         <source>Warning: %1</source>
@@ -769,7 +833,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">Etiqueta: %1
+        <translation type="unfinished">Etiqueta %1
 </translation>
     </message>
     <message>
@@ -792,7 +856,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">La generación de la clave HD está &lt;b&gt; desactivada&lt;/b&gt;</translation>
+        <translation type="unfinished">La generación de clave HD está &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
@@ -800,11 +864,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;desbloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation type="unfinished">El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
+        <translation type="unfinished">La billetera está &lt;b&gt;encriptada&lt;/b&gt; y actualmente &lt;b&gt;bloqueda&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
@@ -815,14 +879,14 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Unidad en la que se muestran las cantidades. Haga clic para seleccionar otra unidad.</translation>
+        <translation type="unfinished">Unidad en la que se muestran los importes. Haz clic para seleccionar otra unidad.</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">Selección de moneda</translation>
+        <translation type="unfinished">Selección de monedas</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -830,15 +894,15 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cuantía:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Tasa:</translation>
+        <translation type="unfinished">Comisión:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Después de tasas:</translation>
+        <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -846,11 +910,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(des)selecciona todos</translation>
+        <translation type="unfinished">(des)marcar todos</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">Modo arbol</translation>
+        <translation type="unfinished">Modo árbol</translation>
     </message>
     <message>
         <source>List mode</source>
@@ -858,7 +922,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Received with label</source>
@@ -878,11 +942,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="unfinished">Confirmada</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -902,7 +966,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">B&amp;loquear importe no gastado</translation>
+        <translation type="unfinished">&amp;Bloquear importe no gastado</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
@@ -918,7 +982,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de la tarifa</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -942,7 +1006,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">Cambio desde %1 (%2)</translation>
+        <translation type="unfinished">cambio desde %1 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
@@ -951,6 +1015,11 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
 </context>
 <context>
     <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
@@ -962,7 +1031,7 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Advertencia de crear billetera</translation>
+        <translation type="unfinished">Advertencia al crear la billetera</translation>
     </message>
     <message>
         <source>Can't list signers</source>
@@ -978,12 +1047,12 @@ Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
     <message>
         <source>Load Wallets</source>
         <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
-        <translation type="unfinished">Cargar monederos</translation>
+        <translation type="unfinished">Cargar billeteras</translation>
     </message>
     <message>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
-        <translation type="unfinished">Cargando monederos...</translation>
+        <translation type="unfinished">Cargando billeteras...</translation>
     </message>
 </context>
 <context>
@@ -1003,10 +1072,10 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
         <translation type="unfinished">La migración de la billetera la convertirá en una o más billeteras basadas en descriptores. Será necesario realizar una nueva copia de seguridad de la billetera.
-Si esta billetera contiene scripts solo de lectura, se creará una nueva billetera que los contenga.
-Si esta billetera contiene scripts solucionables pero no de lectura, se creará una nueva billetera diferente que los contenga.
+Si esta billetera contiene scripts solo de observación, se creará una nueva billetera que los contenga.
+Si esta billetera contiene scripts solucionables pero no de observación, se creará una nueva billetera diferente que los contenga.
 
-El proceso de migración creará una copia de seguridad de la billetera antes de migrar. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En el caso de una migración incorrecta, la copia de seguridad puede restaurarse con la funcionalidad "Restore Wallet" (Restaurar billetera).</translation>
+El proceso de migración creará una copia de seguridad de la billetera antes de proceder. Este archivo de copia de seguridad se llamará &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak y se encontrará en el directorio de esta billetera. En caso de que la migración falle, se puede restaurar la copia de seguridad con la funcionalidad "Restaurar billetera".</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -1022,11 +1091,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Guiones vigilantes han sido migrados a un monedero con el nombre '%1'.</translation>
+        <translation type="unfinished">Los scripts solo de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Solucionable pero ninguno de los guiones vigilados han sido migrados a un monedero llamados '%1'.</translation>
+        <translation type="unfinished">Los scripts solucionables pero no de observación se migraron a una nueva billetera llamada "%1".</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -1040,22 +1109,26 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
 <context>
     <name>OpenWalletActivity</name>
     <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Fallo al abrir billetera</translation>
+    </message>
+    <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Advertencia sobre crear monedero</translation>
+        <translation type="unfinished">Advertencia al abrir billetera</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Abrir monedero</translation>
+        <translation type="unfinished">Abrir billetera</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">Abriendo Monedero &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Abriendo billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
 </context>
 <context>
@@ -1090,46 +1163,62 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Cerrar monedero</translation>
+        <translation type="unfinished">Cerrar billetera</translation>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">¿Estás seguro de que deseas cerrar el monedero &lt;i&gt;%1&lt;/i&gt;?</translation>
+        <translation type="unfinished">¿Seguro deseas cerrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Cerrar el monedero durante demasiado tiempo puede causar la resincronización de toda la cadena si la poda es habilitada.</translation>
+        <translation type="unfinished">Cerrar la billetera durante demasiado tiempo puede causar la resincronización de toda la cadena si el podado está habilitado.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Cerrar todos los monederos</translation>
+        <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">¿Está seguro de que desea cerrar todas las billeteras?</translation>
+        <translation type="unfinished">¿Seguro quieres cerrar todas las billeteras?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Crear billetera</translation>
+    </message>
     <message>
         <source>You are one step away from creating your new wallet!</source>
         <translation type="unfinished">Estás a un paso de crear tu nueva billetera.</translation>
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
-        <translation type="unfinished">Escribe un nombre y, si lo deseas, activa las opciones avanzadas.</translation>
+        <translation type="unfinished">Escribe un nombre y, si quieres, activa las opciones avanzadas.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Nombre del monedero</translation>
+        <translation type="unfinished">Nombre de la billetera </translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation type="unfinished">Monedero</translation>
+        <translation type="unfinished">Billetera</translation>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Encriptar la billetera. La billetera será encriptada con una contraseña de tu elección.</translation>
+        <translation type="unfinished">Encriptar la billetera. La billetera se encriptará con una frase de contraseña de tu elección.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Encriptar billetera</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Opciones avanzadas</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Desactivar las claves privadas para esta billetera. Las billeteras con claves privadas desactivadas no tendrán claves privadas y no podrán tener ninguna semilla HD ni claves privadas importadas. Esto es ideal para billeteras solo de observación.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1137,11 +1226,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Crear un monedero vacío. Los monederos vacíos no tienen claves privadas ni scripts. Las claves privadas y direcciones pueden importarse después o también establecer una semilla HD.</translation>
+        <translation type="unfinished">Crea una billetera en blanco. Las billeteras en blanco inicialmente no tienen llaves privadas ni scripts. Las llaves privadas y las direcciones pueden ser importadas o se puede establecer una semilla HD más tarde.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">Crear billetera vacía</translation>
+        <translation type="unfinished">Crear billetera en blanco</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Usa un dispositivo de firma externo, por ejemplo, una billetera de hardware. Configura primero el script del firmante externo en las preferencias de la billetera.</translation>
     </message>
     <message>
         <source>External signer</source>
@@ -1154,14 +1247,14 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation type="unfinished">Editar Dirección</translation>
+        <translation type="unfinished">Editar dirección</translation>
     </message>
     <message>
         <source>&amp;Label</source>
@@ -1169,11 +1262,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">La etiqueta asociada con esta entrada de la lista de direcciones</translation>
+        <translation type="unfinished">La etiqueta asociada con esta entrada en la lista de direcciones</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">La dirección asociada con esta entrada de la lista de direcciones. Solo puede ser modificada para direcciones de envío.</translation>
+        <translation type="unfinished">La dirección asociada con esta entrada en la lista de direcciones. Solo se puede modificar para las direcciones de envío.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -1185,7 +1278,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">Editar dirección de envío</translation>
+        <translation type="unfinished">Editar dirección de recepción</translation>
     </message>
     <message>
         <source>Edit sending address</source>
@@ -1193,7 +1286,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">La dirección introducida "%1" no es una dirección Bitcoin válida.</translation>
+        <translation type="unfinished">La dirección ingresada "%1" no es una dirección de Bitcoin válida.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">La dirección "%1" ya existe como dirección de recepción con la etiqueta "%2" y, por lo tanto, no se puede agregar como dirección de envío.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">La dirección ingresada "%1" ya está en la libreta de direcciones con la etiqueta "%2".</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -1201,7 +1302,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">Creación de la nueva llave fallida</translation>
+        <translation type="unfinished">Error al generar clave nueva.</translation>
     </message>
 </context>
 <context>
@@ -1216,11 +1317,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">El directorio ya existe. Añada %1 si pretende crear aquí un directorio nuevo.</translation>
+        <translation type="unfinished">El directorio ya existe. Agrega %1 si deseas crear un nuevo directorio aquí.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">La ruta ya existe y no es un directorio.</translation>
+        <translation type="unfinished">Ruta de acceso existente, pero no es un directorio.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
@@ -1239,15 +1340,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform>(of %n GB needed)</numerusform>
-            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(de %n GB necesario)</numerusform>
+            <numerusform>(de %n GB necesarios)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform>(%n GB needed for full chain)</numerusform>
-            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB necesario para completar la cadena)</numerusform>
+            <numerusform>(%n GB necesarios para completar la cadena)</numerusform>
         </translation>
     </message>
     <message>
@@ -1255,8 +1356,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Elegir directorio de datos</translation>
     </message>
     <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Se almacenará al menos %1 GB de información en este directorio, que aumentará con el tiempo.</translation>
+    </message>
+    <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Aproximadamente %1 GB de información será almacenada en este directorio.</translation>
+        <translation type="unfinished">Se almacenará aproximadamente %1 GB de información en este directorio.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -1272,27 +1377,35 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">El monedero también se almacenará en este directorio.</translation>
+        <translation type="unfinished">La billetera también se almacenará en este directorio.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Error: Directorio de datos especificado "%1" no puede ser creado.</translation>
+        <translation type="unfinished">Error: No se puede crear el directorio de datos especificado "%1" .</translation>
     </message>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished">Bienvenido</translation>
+        <translation type="unfinished">Te damos la bienvenida</translation>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">Bienvenido a %1.</translation>
+        <translation type="unfinished">Te damos la bienvenida a %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Al ser esta la primera vez que se ejecuta el programa, puedes escoger donde %1 almacenará los datos.</translation>
+        <translation type="unfinished">Como es la primera vez que se ejecuta el programa, puedes elegir dónde %1 almacenará los datos.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">Limitar el almacenamiento de cadena de bloques a</translation>
+        <translation type="unfinished">Limitar el almacenamiento de la cadena de bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Para revertir esta configuración, se debe descargar de nuevo la cadena de bloques completa. Es más rápido descargar la cadena completa y podarla después. Desactiva algunas funciones avanzadas.</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">La sincronización inicial consume muchos recursos y es posible que exponga problemas de hardware en la computadora que anteriormente pasaron desapercibidos. Cada vez que ejecutes %1, seguirá descargando desde el punto en el que quedó.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
@@ -1300,15 +1413,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Si ha elegido limitar el almacenamiento de la cadena de bloques (pruning o poda), los datos históricos todavía se deben descargar y procesar, pero se eliminarán posteriormente para mantener el uso del disco bajo.</translation>
+        <translation type="unfinished">Si elegiste la opción de limitar el almacenamiento de la cadena de bloques (podado), los datos históricos se deben descargar y procesar de igual manera, pero se eliminarán después para disminuir el uso del disco.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">Utilizar el directorio de datos predeterminado</translation>
+        <translation type="unfinished">Usar el directorio de datos predeterminado</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">Utilice un directorio de datos personalizado:</translation>
+        <translation type="unfinished">Usar un directorio de datos personalizado:</translation>
     </message>
 </context>
 <context>
@@ -1323,42 +1436,73 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Opciones de la línea de órdenes</translation>
+        <translation type="unfinished">Opciones de línea de comandos</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">No apagues la computadora hasta que desaparezca esta ventana.</translation>
     </message>
 </context>
 <context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">Desde</translation>
+        <translation type="unfinished">Formulario</translation>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Es posible que las transacciones recientes aún no estén visibles y por lo tanto, el saldo de su monedero podría ser incorrecto. Esta información será correcta una vez que su monedero haya terminado de sincronizarse con la red bitcoin, como se detalla a continuación.</translation>
+        <translation type="unfinished">Es posible que las transacciones recientes aún no sean visibles y, por lo tanto, el saldo de la billetera podría ser incorrecto. Esta información será correcta una vez que la billetera haya terminado de sincronizarse con la red de Bitcoin, como se detalla abajo.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">La red no aceptará si se intenta gastar bitcoins afectados por las transacciones que aún no se muestran.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation type="unfinished">Numero de bloques pendientes</translation>
+        <translation type="unfinished">Número de bloques restantes</translation>
     </message>
     <message>
         <source>Unknown…</source>
         <translation type="unfinished">Desconocido...</translation>
     </message>
     <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Hora del último bloque</translation>
     </message>
     <message>
+        <source>Progress</source>
+        <translation type="unfinished">Progreso</translation>
+    </message>
+    <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Incremento del progreso por hora</translation>
+        <translation type="unfinished">Avance del progreso por hora</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Tiempo estimado restante hasta la sincronización</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 está actualmente sincronizándose. Descargará cabeceras y bloques de nodos semejantes y los validará hasta alcanzar la cabeza de la cadena de bloques.</translation>
+        <translation type="unfinished">%1 se está sincronizando actualmente. Descargará encabezados y bloques de pares, y los validará hasta alcanzar el extremo de la cadena de bloques.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconocido. Sincronizando cabeceras (%1, %2%)…</translation>
+        <translation type="unfinished">Desconocido. Sincronizando encabezados (%1, %2%)…</translation>
     </message>
     <message>
         <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
@@ -1374,7 +1518,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
 </context>
 <context>
@@ -1388,16 +1532,24 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">&amp;Principal</translation>
     </message>
     <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">Iniciar automáticamente %1 después de iniciar sesión en el sistema.</translation>
+    </message>
+    <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Iniciar %1 al iniciar el sistema</translation>
+        <translation type="unfinished">&amp;Iniciar %1 al iniciar sesión en el sistema</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Al activar el modo pruning, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+        <translation type="unfinished">Al activar el podado, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Tamaño de la caché de la &amp;base de datos</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Número de hilos de &amp;verificación de scripts</translation>
+        <translation type="unfinished">Número de subprocesos de &amp;verificación de scripts</translation>
     </message>
     <message>
         <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
@@ -1405,15 +1557,19 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Dirección IP del proxy (ej. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">Dirección IP del proxy (por ejemplo, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Muestra si el proxy SOCKS5 por defecto suministrado se utiliza para llegar a los pares a través de este tipo de red.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimice en lugar de salir de la aplicación cuando la ventana esté cerrada. Cuando esta opción está habilitada, la aplicación se cerrará solo después de seleccionar Salir en el menú.</translation>
+        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación solo se cerrará después de seleccionar "Salir" en el menú.</translation>
     </message>
     <message>
         <source>Font in the Overview tab: </source>
-        <translation type="unfinished">Fuente en la pestaña Resumen:</translation>
+        <translation type="unfinished">Fuente en la pestaña "Vista general":</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -1429,7 +1585,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished">Restablecer todas las opciones del cliente a las predeterminadas.</translation>
+        <translation type="unfinished">Restablecer todas las opciones del cliente a los valores predeterminados.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
@@ -1455,7 +1611,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
-        <translation type="unfinished">Establezca el número de hilos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
+        <translation type="unfinished">Establece el número de subprocesos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
@@ -1464,7 +1620,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
-        <translation type="unfinished">Esto le permite a usted o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
+        <translation type="unfinished">Esto te permite a ti o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
@@ -1473,12 +1629,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished">Monedero</translation>
+        <translation type="unfinished">&amp;Billetera</translation>
     </message>
     <message>
         <source>Whether to set subtract fee from amount as default or not.</source>
         <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">Si se resta la comisión del importe por defecto o no.</translation>
+        <translation type="unfinished">Si se resta o no la comisión del importe por defecto.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1490,8 +1646,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Experto</translation>
     </message>
     <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">Habilitar funciones de &amp;control de monedas</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Si deshabilita el gasto de un cambio no confirmado, el cambio de una transacción no se puede usar hasta que esa transacción tenga al menos una confirmación. Esto también afecta cómo se calcula su saldo.</translation>
+        <translation type="unfinished">Si deshabilitas el gasto del cambio sin confirmar, no se puede usar el cambio de una transacción hasta que esta tenga al menos una confirmación. Esto también afecta cómo se calcula el saldo.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1500,12 +1660,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Activar controles de &amp;PSBT</translation>
+        <translation type="unfinished">Activar controles de &amp;TBPF</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Si se muestran los controles de PSBT.</translation>
+        <translation type="unfinished">Si se muestran los controles de TBPF.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -1517,11 +1677,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona si el router admite UPnP y está activado.</translation>
+        <translation type="unfinished">Abrir automáticamente el puerto del cliente de Bitcoin en el router. Esto funciona solo cuando tu router es compatible con UPnP y está habilitado.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
-        <translation type="unfinished">Mapear el puerto usando &amp;UPnP</translation>
+        <translation type="unfinished">Asignar puerto usando &amp;UPnP</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
@@ -1532,16 +1692,24 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Asignar puerto usando NA&amp;T-PMP</translation>
     </message>
     <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">Aceptar conexiones externas.</translation>
+    </message>
+    <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Permitir conexiones entrantes</translation>
+        <translation type="unfinished">&amp;Permitir conexiones entrantes</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Conectar a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Conectarse a través del proxy SOCKS5 (proxy predeterminado):</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
-        <translation type="unfinished">Dirección &amp;IP del proxy:</translation>
+        <translation type="unfinished">&amp;IP del proxy:</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
@@ -1549,11 +1717,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation type="unfinished">Puerto del servidor proxy (ej. 9050)</translation>
+        <translation type="unfinished">Puerto del proxy (p. ej., 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Utilizado para llegar a los compañeros a través de:</translation>
+        <translation type="unfinished">Usado para conectarse con pares a través de:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1569,35 +1737,35 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">Minimizar la ventana a la bandeja de iconos del sistema.</translation>
+        <translation type="unfinished">Mostrar solo un ícono de bandeja después de minimizar la ventana.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation type="unfinished">&amp;Minimizar a la bandeja en vez de a la barra de tareas</translation>
+        <translation type="unfinished">&amp;Minimizar a la bandeja en vez de la barra de tareas</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">M&amp;inimizar al cerrar</translation>
+        <translation type="unfinished">&amp;Minimizar al cerrar</translation>
     </message>
     <message>
         <source>&amp;Display</source>
-        <translation type="unfinished">&amp;Interfaz</translation>
+        <translation type="unfinished">&amp;Visualización</translation>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation type="unfinished">I&amp;dioma de la interfaz de usuario</translation>
+        <translation type="unfinished">&amp;Idioma de la interfaz de usuario:</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración tendrá efecto después de reiniciar %1.</translation>
+        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración surtirá efecto después de reiniciar %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation type="unfinished">Mostrar las cantidades en la &amp;unidad:</translation>
+        <translation type="unfinished">&amp;Unidad en la que se muestran los importes:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished">Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían monedas.</translation>
+        <translation type="unfinished">Elegir la unidad de subdivisión predeterminada para mostrar en la interfaz y al enviar monedas.</translation>
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
@@ -1609,19 +1777,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Mostrar o no características de control de moneda</translation>
+        <translation type="unfinished">Si se muestran o no las funcionalidades de control de monedas.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Conectarse a la red Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
+        <translation type="unfinished">Conectarse a la red de Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <translation type="unfinished">Usar un proxy SOCKS&amp;5 independiente para comunicarse con pares a través de los servicios onion de Tor:</translation>
-    </message>
-    <message>
-        <source>&amp;OK</source>
-        <translation type="unfinished">&amp;Aceptar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -1630,7 +1794,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+        <translation type="unfinished">Compilado sin compatibilidad con firma externa (requerida para la firma externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1643,12 +1807,12 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Confirm options reset</source>
         <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
-        <translation type="unfinished">Confirme el restablecimiento de las opciones</translation>
+        <translation type="unfinished">Confirmar restablecimiento de opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
         <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
-        <translation type="unfinished">Reinicio del cliente para activar cambios.</translation>
+        <translation type="unfinished">Es necesario reiniciar el cliente para activar los cambios.</translation>
     </message>
     <message>
         <source>Current settings will be backed up at "%1".</source>
@@ -1658,7 +1822,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
-        <translation type="unfinished">El cliente será cluasurado. Quieres proceder?</translation>
+        <translation type="unfinished">El cliente se cerrará. ¿Quieres continuar?</translation>
     </message>
     <message>
         <source>Configuration options</source>
@@ -1668,7 +1832,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">El archivo de configuración se utiliza para especificar opciones de usuario avanzadas que anulan la configuración de la GUI. Además, cualquier opción de línea de comandos anulará este archivo de configuración.</translation>
+        <translation type="unfinished">El archivo de configuración se usa para especificar opciones avanzadas del usuario, que remplazan la configuración de la GUI. Además, las opciones de la línea de comandos remplazarán este archivo de configuración.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1680,15 +1844,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">El archivo de configuración no se pudo abrir.</translation>
+        <translation type="unfinished">No se pudo abrir el archivo de configuración.</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation type="unfinished">Este cambio requiere reinicio por parte del cliente.</translation>
+        <translation type="unfinished">Estos cambios requieren reiniciar el cliente.</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation type="unfinished">La dirección proxy indicada es inválida.</translation>
+        <translation type="unfinished">La dirección del proxy proporcionada es inválida.</translation>
     </message>
 </context>
 <context>
@@ -1702,11 +1866,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">Desde</translation>
+        <translation type="unfinished">Formulario</translation>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red Bitcoin después de que se haya establecido una conexión, pero este proceso aún no se ha completado.</translation>
+        <translation type="unfinished">La información mostrada puede estar desactualizada. La billetera se sincroniza automáticamente con la red de Bitcoin después de establecer una conexión, pero este proceso aún no se ha completado.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">Solo de observación:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -1714,7 +1882,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation type="unfinished">Su balance actual gastable</translation>
+        <translation type="unfinished">Tu saldo disponible para gastar actualmente</translation>
     </message>
     <message>
         <source>Pending:</source>
@@ -1722,15 +1890,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished">Total de transacciones que deben ser confirmadas, y que no cuentan con el balance gastable necesario</translation>
+        <translation type="unfinished">Total de transacciones que aún se deben confirmar y que no se contabilizan dentro del saldo disponible para gastar</translation>
     </message>
     <message>
         <source>Immature:</source>
-        <translation type="unfinished">No disponible:</translation>
+        <translation type="unfinished">Inmaduro:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished">Saldo recién minado que aún no está disponible.</translation>
+        <translation type="unfinished">Saldo minado que aún no ha madurado</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1738,15 +1906,15 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation type="unfinished">Su balance actual total</translation>
+        <translation type="unfinished">Tu saldo total actual</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Tu saldo actual en solo ver direcciones</translation>
+        <translation type="unfinished">Tu saldo actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Disponible:</translation>
+        <translation type="unfinished">Gastable:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
@@ -1754,22 +1922,26 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Transacciones sin confirmar a direcciones de observación</translation>
+        <translation type="unfinished">Transacciones sin confirmar hacia direcciones solo de observación</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">Saldo minado en direcciones solo de observación que aún no ha madurado</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Saldo total actual en direcciones de solo observación</translation>
+        <translation type="unfinished">Saldo total actual en direcciones solo de observación</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anule la selección de Configuración-&gt;Ocultar valores.</translation>
+        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anula la selección de "Configuración-&gt;Ocultar valores".</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>PSBT Operations</source>
-        <translation type="unfinished">Operaciones PSBT</translation>
+        <translation type="unfinished">Operaciones TBPF</translation>
     </message>
     <message>
         <source>Sign Tx</source>
@@ -1805,7 +1977,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">No se pudo firmar más entradas.</translation>
+        <translation type="unfinished">No se pudieron firmar más entradas.</translation>
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
@@ -1829,7 +2001,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT copiada al portapapeles.</translation>
+        <translation type="unfinished">TBPF copiada al portapapeles.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1842,7 +2014,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT guardada en en el disco.</translation>
+        <translation type="unfinished">TBPF guardada en el disco.</translation>
     </message>
     <message>
         <source>Sends %1 to %2</source>
@@ -1850,7 +2022,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">dirección personal</translation>
+        <translation type="unfinished">dirección propia</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
@@ -1862,7 +2034,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>or</source>
@@ -1874,7 +2046,7 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">A la transacción le falta información sobre entradas.</translation>
+        <translation type="unfinished">Falta información sobre las entradas de la transacción.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
@@ -1896,7 +2068,11 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <source>Transaction is fully signed and ready for broadcast.</source>
         <translation type="unfinished">La transacción se firmó completamente y está lista para transmitirse.</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">El estado de la transacción es desconocido.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1904,8 +2080,16 @@ El proceso de migración creará una copia de seguridad de la billetera antes de
         <translation type="unfinished">Error en la solicitud de pago</translation>
     </message>
     <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">No se puede iniciar el controlador "bitcoin: click-to-pay"</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">Gestión de URI</translation>
+    </message>
+    <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">"bitcoin://" no es un URI válido. Use "bitcoin:" en su lugar.</translation>
+        <translation type="unfinished">"bitcoin://" no es un URI válido. Usa "bitcoin:" en su lugar.</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
@@ -1913,11 +2097,15 @@ Due to widespread security flaws in BIP70 it's strongly recommended that any mer
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished">No se puede procesar la solicitud de pago porque no existe compatibilidad con BIP70.
 Debido a los fallos de seguridad generalizados en BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de billetera.
-Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
+Si recibes este error, debes solicitar al comerciante que te proporcione un URI compatible con BIP21.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">No se puede analizar el URI. Esto se puede deber a una dirección de Bitcoin inválida o a parámetros de URI con formato incorrecto.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Manejo del archivo de solicitud de pago</translation>
+        <translation type="unfinished">Gestión del archivo de solicitud de pago</translation>
     </message>
 </context>
 <context>
@@ -1935,12 +2123,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Age</source>
         <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
-        <translation type="unfinished">Duración</translation>
+        <translation type="unfinished">Antigüedad</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">Dirección</translation>
     </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>Received</source>
@@ -1970,7 +2163,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Outbound</source>
         <extracomment>An Outbound Connection to a Peer.</extracomment>
-        <translation type="unfinished">Salida</translation>
+        <translation type="unfinished">Saliente</translation>
     </message>
 </context>
 <context>
@@ -1980,8 +2173,16 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
     <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;Copiar imagen</translation>
+    </message>
+    <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">El URI resultante es demasiado largo, así que trate de reducir el texto de la etiqueta o el mensaje.</translation>
+        <translation type="unfinished">El URI resultante es demasiado largo, así que trata de reducir el texto de la etiqueta o el mensaje.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">Fallo al codificar URI en código QR.</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
@@ -2009,23 +2210,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Information</source>
-        <translation type="unfinished">Información</translation>
+        <translation type="unfinished">&amp;Información</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Directorio de datos</translation>
     </message>
     <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, use la opción "%1".</translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Blocksdir</source>
-        <translation type="unfinished">Bloques dir</translation>
+        <translation type="unfinished">Directorio de bloques</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, use la opción "%1".</translation>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, usa la opción "%1".</translation>
     </message>
     <message>
         <source>Startup time</source>
-        <translation type="unfinished">Hora de inicio</translation>
+        <translation type="unfinished">Tiempo de inicio</translation>
     </message>
     <message>
         <source>Network</source>
@@ -2045,19 +2250,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation type="unfinished">Grupo de memoria</translation>
+        <translation type="unfinished">Pool de memoria</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">Número total de transacciones</translation>
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished">Memoria utilizada</translation>
+        <translation type="unfinished">Uso de memoria</translation>
     </message>
     <message>
         <source>Wallet: </source>
-        <translation type="unfinished">Monedero:</translation>
+        <translation type="unfinished">Billetera:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ninguna)</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Reestablecer</translation>
+        <translation type="unfinished">&amp;Restablecer</translation>
     </message>
     <message>
         <source>Received</source>
@@ -2065,7 +2278,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Sent</source>
-        <translation type="unfinished">Expedido</translation>
+        <translation type="unfinished">Enviado</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
@@ -2089,11 +2302,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The BIP324 session ID string in hex, if any.</source>
-        <translation type="unfinished">Cadena de identificación de la sesión BIP324 en formato hexadecimal, si existe.</translation>
+        <translation type="unfinished">Cadena de identificador de la sesión BIP324 en formato hexadecimal, si existe.</translation>
     </message>
     <message>
         <source>Session ID</source>
         <translation type="unfinished">Identificador de sesión</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">Versión</translation>
     </message>
     <message>
         <source>Whether we relay transactions to this peer.</source>
@@ -2105,11 +2322,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">Bloque de inicio</translation>
+        <translation type="unfinished">Bloque inicial</translation>
     </message>
     <message>
         <source>Synced Headers</source>
         <translation type="unfinished">Encabezados sincronizados</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">Bloques sincronizados</translation>
     </message>
     <message>
         <source>Last Transaction</source>
@@ -2131,17 +2352,17 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Address Relay</source>
         <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
-        <translation type="unfinished">Retransmisión de dirección</translation>
+        <translation type="unfinished">Retransmisión de direcciones</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones omitidas debido a la limitación de volumen).</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones desestimadas debido a la limitación de volumen).</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">El número total de direcciones recibidas desde este par que se omitieron (no se procesaron) debido a la limitación de volumen.</translation>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se desestimaron (no se procesaron) debido a la limitación de volumen.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
@@ -2151,7 +2372,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>Addresses Rate-Limited</source>
         <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">Direcciones omitidas por limitación de volumen</translation>
+        <translation type="unfinished">Direcciones desestimadas por limitación de volumen</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2159,7 +2380,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Ventana de nodo</translation>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -2167,15 +2388,19 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Abra el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
+        <translation type="unfinished">Abrir el archivo de registro de depuración %1 en el directorio de datos actual. Esto puede tardar unos segundos para los archivos de registro grandes.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation type="unfinished">Reducir el tamaño de la fuente</translation>
+        <translation type="unfinished">Disminuir tamaño de fuente</translation>
     </message>
     <message>
         <source>Increase font size</source>
-        <translation type="unfinished">Aumentar el tamaño de la fuente</translation>
+        <translation type="unfinished">Aumentar tamaño de fuente</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Permisos</translation>
     </message>
     <message>
         <source>The direction and type of peer connection: %1</source>
@@ -2195,11 +2420,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">Retransmisión de bloque compacto BIP152 en modo de banda ancha: %1</translation>
+        <translation type="unfinished">Retransmisión de bloques compactos BIP152 en banda ancha: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
         <translation type="unfinished">Banda ancha</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">Tiempo de conexión</translation>
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
@@ -2220,19 +2449,27 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Ultima recepción</translation>
+        <translation type="unfinished">Última recepción</translation>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation type="unfinished">Tiempo de Ping</translation>
+        <translation type="unfinished">Tiempo de ping</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">La duración de un ping actualmente pendiente.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
-        <translation type="unfinished">Espera de Ping</translation>
+        <translation type="unfinished">Espera de ping</translation>
     </message>
     <message>
         <source>Min Ping</source>
         <translation type="unfinished">Ping mínimo</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">Desfase temporal</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -2248,15 +2485,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Tráfico de Red</translation>
+        <translation type="unfinished">&amp;Tráfico de red</translation>
     </message>
     <message>
         <source>Totals</source>
-        <translation type="unfinished">Total:</translation>
+        <translation type="unfinished">Totales</translation>
     </message>
     <message>
         <source>Debug log file</source>
-        <translation type="unfinished">Archivo de registro de depuración</translation>
+        <translation type="unfinished">Archivo del registro de depuración</translation>
     </message>
     <message>
         <source>Clear console</source>
@@ -2264,11 +2501,11 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>In:</source>
-        <translation type="unfinished">Dentro:</translation>
+        <translation type="unfinished">Entrada:</translation>
     </message>
     <message>
         <source>Out:</source>
-        <translation type="unfinished">Fuera:</translation>
+        <translation type="unfinished">Salida:</translation>
     </message>
     <message>
         <source>Inbound: initiated by peer</source>
@@ -2308,7 +2545,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     <message>
         <source>v1: unencrypted, plaintext transport protocol</source>
         <extracomment>Explanatory text for v1 transport type.</extracomment>
-        <translation type="unfinished">v1: protocolo de transporte de texto simple sin cifrar</translation>
+        <translation type="unfinished">v1: protocolo de transporte de texto simple sin encriptar</translation>
     </message>
     <message>
         <source>v2: BIP324 encrypted transport protocol</source>
@@ -2325,7 +2562,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">Ninguna transmisión de banda ancha seleccionada</translation>
+        <translation type="unfinished">No se seleccionó la retransmisión de banda ancha</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2333,12 +2570,24 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;Desconectar</translation>
+    </message>
+    <message>
         <source>1 &amp;hour</source>
-        <translation type="unfinished">1 hora</translation>
+        <translation type="unfinished">1 &amp;hora</translation>
     </message>
     <message>
         <source>1 d&amp;ay</source>
         <translation type="unfinished">1 &amp;día</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;semana</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;año</translation>
     </message>
     <message>
         <source>&amp;Copy IP/Netmask</source>
@@ -2347,7 +2596,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Desbloquear</translation>
+        <translation type="unfinished">&amp;Levantar prohibición</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -2355,11 +2604,15 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Executing command without any wallet</source>
-        <translation type="unfinished">Ejecutar comando sin monedero</translation>
+        <translation type="unfinished">Ejecutar comando sin ninguna billetera</translation>
     </message>
     <message>
         <source>Node window - [%1]</source>
         <translation type="unfinished">Ventana de nodo - [%1]</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">Ejecutar comando usando la billetera "%1"</translation>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.
@@ -2370,12 +2623,13 @@ For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
         <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Bienvenido a la consola RPC
-%1. Utiliza las flechas arriba y abajo para navegar por el historial, y %2 para borrar la pantalla. 
+        <translation type="unfinished">Te damos la bienvenida a la consola RPC de %1.
+Utiliza las flechas hacia arriba y abajo para navegar por el historial y %2 para borrar la pantalla.
 Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente. 
-Escribe %5 para ver un resumen de los comandos disponibles. Para más información sobre cómo usar esta consola, escribe %6.
+Escribe %5 para ver los comandos disponibles.
+Para obtener más información sobre cómo usar esta consola, escribe %6.
 
-%7 AVISO: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus monederos. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
+%7 ADVERTENCIA: Los estafadores suelen decirles a los usuarios que escriban comandos aquí para robarles el contenido de sus billeteras. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2392,11 +2646,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished">Si</translation>
+        <translation type="unfinished">Sí</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>From</source>
@@ -2404,11 +2658,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished">Bloqueo para</translation>
+        <translation type="unfinished">Prohibir por</translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished">nunca</translation>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2419,7 +2673,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -2427,27 +2681,27 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>&amp;Message:</source>
-        <translation type="unfinished">Mensaje:</translation>
+        <translation type="unfinished">&amp;Mensaje:</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje opcional adjunto a la solicitud de pago, que será mostrado cuando la solicitud sea abierta. Nota: Este mensaje no será enviado con el pago a través de la red Bitcoin.</translation>
+        <translation type="unfinished">Mensaje opcional para adjuntar a la solicitud de pago, que se mostrará cuando se abra la solicitud. Nota: Este mensaje no se enviará con el pago a través de la red de Bitcoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Use este formulario para solicitar pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
+        <translation type="unfinished">Usa este formulario para solicitar pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Un importe opcional para solicitar. Deje esto vacío o en cero para no solicitar una cantidad específica.</translation>
+        <translation type="unfinished">Un importe opcional para solicitar. Déjalo vacío o ingresa cero para no solicitar un importe específico.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (utilizada por ti para identificar una factura). También se adjunta a la solicitud de pago.</translation>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (puedes usarla para identificar una factura). También se adjunta a la solicitud de pago.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2455,23 +2709,23 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Crear una nueva dirección de recepción</translation>
+        <translation type="unfinished">&amp;Crear nueva dirección de recepción</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Limpiar todos los campos del formulario</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">Limpiar</translation>
+        <translation type="unfinished">Borrar</translation>
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation type="unfinished">Historial de pagos solicitado</translation>
+        <translation type="unfinished">Historial de pagos solicitados</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Muestra la petición seleccionada (También doble clic)</translation>
+        <translation type="unfinished">Mostrar la solicitud seleccionada (equivale a hacer doble clic en una entrada)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -2479,7 +2733,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Borrar de la lista las direcciónes actualmente seleccionadas</translation>
+        <translation type="unfinished">Eliminar las entradas seleccionadas de la lista</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -2527,7 +2781,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Could not generate new %1 address</source>
-        <translation type="unfinished">No se ha podido generar una nueva dirección %1</translation>
+        <translation type="unfinished">No se pudo generar nueva dirección %1</translation>
     </message>
 </context>
 <context>
@@ -2537,12 +2791,24 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Solicitar pago a...</translation>
     </message>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Dirección:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cuantía:</translation>
+        <translation type="unfinished">Importe:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">Etiqueta:</translation>
     </message>
     <message>
         <source>Message:</source>
         <translation type="unfinished">Mensaje:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Billetera:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
@@ -2550,7 +2816,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">Copiar &amp;Dirección</translation>
+        <translation type="unfinished">Copiar &amp;dirección</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2558,13 +2824,21 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Verifica esta dirección, por ejemplo, en la pantalla de una billetera de hardware</translation>
+        <translation type="unfinished">Verificar esta dirección, por ejemplo, en la pantalla de una billetera de hardware.</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
         <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
-    </context>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">Información del pago</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation type="unfinished">Solicitar pago a %1</translation>
+    </message>
+</context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
@@ -2576,6 +2850,10 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
@@ -2585,7 +2863,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation type="unfinished">(sin importe solicitado)</translation>
+        <translation type="unfinished">(no se solicitó un importe)</translation>
     </message>
     <message>
         <source>Requested</source>
@@ -2600,15 +2878,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Características de control de la moneda</translation>
+        <translation type="unfinished">Funciones de control de monedas</translation>
     </message>
     <message>
         <source>automatically selected</source>
-        <translation type="unfinished">Seleccionado automaticamente</translation>
+        <translation type="unfinished">seleccionado automáticamente</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation type="unfinished">Fondos insuficientes!</translation>
+        <translation type="unfinished">Fondos insuficientes</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -2616,15 +2894,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cuantía:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Tasa:</translation>
+        <translation type="unfinished">Comisión:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Después de tasas:</translation>
+        <translation type="unfinished">Después de la comisión:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -2632,11 +2910,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Al activarse, si la dirección esta vacía o es inválida, las monedas serán enviadas a una nueva dirección generada.</translation>
+        <translation type="unfinished">Si se activa, pero la dirección de cambio está vacía o es inválida, el cambio se enviará a una dirección generada recientemente.</translation>
     </message>
     <message>
         <source>Custom change address</source>
-        <translation type="unfinished">Dirección propia</translation>
+        <translation type="unfinished">Dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
@@ -2644,11 +2922,19 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Si utilizas la comisión por defecto, la transacción puede tardar varias horas o incluso días (o nunca) en confirmarse. Considera elegir la comisión de forma manual o espera hasta que se haya validado completamente la cadena.</translation>
+        <translation type="unfinished">Si usas la opción "fallbackfee", la transacción puede tardar varias horas o días en confirmarse (o nunca hacerlo). Considera elegir la comisión de forma manual o espera hasta que hayas validado la cadena completa.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Advertencia: En este momento no se puede estimar la cuota.</translation>
+        <translation type="unfinished">Advertencia: En este momento no se puede estimar la comisión.</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">por kilobyte</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
     </message>
     <message>
         <source>Recommended:</source>
@@ -2660,15 +2946,15 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation type="unfinished">Enviar a múltiples destinatarios de una vez</translation>
+        <translation type="unfinished">Enviar a múltiples destinatarios a la vez</translation>
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation type="unfinished">Añadir &amp;destinatario</translation>
+        <translation type="unfinished">Agregar &amp;destinatario</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Limpiar todos los campos del formulario</translation>
+        <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
         <source>Inputs…</source>
@@ -2696,19 +2982,27 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Una comisión demasiado pequeña puede resultar en una transacción que nunca será confirmada (leer herramientas de información).</translation>
+        <translation type="unfinished">Si la comisión es demasiado baja, es posible que la transacción nunca se confirme (leer la información en pantalla).</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <translation type="unfinished">(La comisión inteligente no se ha inicializado todavía. Esto tarda normalmente algunos bloques…)</translation>
     </message>
     <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">Objetivo de tiempo de confirmación:</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">Activar "Remplazar por comisión"</translation>
+    </message>
+    <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Con la función "Reemplazar-por-comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
+        <translation type="unfinished">Con la función "Remplazar por comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -2728,7 +3022,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar importe</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -2736,7 +3030,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar después de la tarifa</translation>
+        <translation type="unfinished">Copiar después de la comisión</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -2747,22 +3041,34 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Copiar cambio</translation>
     </message>
     <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 bloques)</translation>
+    </message>
+    <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet.</extracomment>
         <translation type="unfinished">Firmar en el dispositivo</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Conecta tu monedero externo primero.</translation>
+        <translation type="unfinished">Conecta primero tu billetera de hardware.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Configura una ruta externa al script en Opciones -&gt; Monedero</translation>
+        <translation type="unfinished">Establecer la ruta al script del firmante externo en "Opciones -&gt; Billetera"</translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">&amp;Crear sin firmar</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (PSBT) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (TBPF) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 a '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
@@ -2774,17 +3080,17 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign failed</source>
-        <translation type="unfinished">La firma falló</translation>
+        <translation type="unfinished">Error de firma</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">No se encontró el dispositivo firmante externo</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+        <translation type="unfinished">Error de firmante externo</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2798,7 +3104,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
-        <translation type="unfinished">TBPF guardado </translation>
+        <translation type="unfinished">TBPF guardada</translation>
     </message>
     <message>
         <source>External balance:</source>
@@ -2810,11 +3116,16 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Puedes aumentar la comisión después (indica "Reemplazar-por-comisión", BIP-125).</translation>
+        <translation type="unfinished">Puedes aumentar la comisión después (indica "Remplazar por comisión", BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Revisa por favor la propuesta de transacción. Esto producirá una transacción de Bitcoin parcialmente firmada (TBPF) que puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 fuera de línea o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>%1 from wallet '%2'</source>
-        <translation type="unfinished">%1 desde monedero '%2'</translation>
+        <translation type="unfinished">%1 desde billetera "%2"</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
@@ -2824,12 +3135,12 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
-        <translation type="unfinished">Revisa por favor la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (PSBT), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Revisa la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (TBPF), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
-        <translation type="unfinished">Por favor, revisa tu transacción</translation>
+        <translation type="unfinished">Revisa la transacción.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -2837,25 +3148,29 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">No indica remplazar-por-comisión, BIP-125.</translation>
+        <translation type="unfinished">No indica "Remplazar por comisión", BIP-125.</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>Unsigned Transaction</source>
         <comment>PSBT copied</comment>
         <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
-        <translation type="unfinished">Transacción no asignada</translation>
+        <translation type="unfinished">Transacción sin firmar</translation>
     </message>
     <message>
         <source>The PSBT has been copied to the clipboard. You can also save it.</source>
-        <translation type="unfinished">Se copió la PSBT al portapapeles. También puedes guardarla.</translation>
+        <translation type="unfinished">Se copió la TBPF al portapapeles. También puedes guardarla.</translation>
     </message>
     <message>
         <source>PSBT saved to disk</source>
-        <translation type="unfinished">PSBT guardada en el disco</translation>
+        <translation type="unfinished">TBPF guardada en el disco</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">Confirmar el envío de monedas</translation>
     </message>
     <message>
         <source>Watch-only balance:</source>
@@ -2867,7 +3182,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">La cantidad por pagar tiene que ser mayor que 0.</translation>
+        <translation type="unfinished">El importe por pagar tiene que ser mayor que 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
@@ -2875,38 +3190,42 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">El total sobrepasa su saldo cuando se incluye la tasa de envío de %1</translation>
+        <translation type="unfinished">El total sobrepasa el saldo cuando se incluye la comisión de transacción de %1.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
         <translation type="unfinished">Se encontró una dirección duplicada: las direcciones solo se deben usar una vez.</translation>
     </message>
     <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">Fallo al crear la transacción</translation>
+    </message>
+    <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurda-mente alta.</translation>
+        <translation type="unfinished">Una comisión mayor que %1 se considera absurdamente alta.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloque.</numerusform>
-            <numerusform>Estimado para comenzar confirmación dentro de %n bloques.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloque.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Alerta: Dirección de Bitcoin inválida</translation>
+        <translation type="unfinished">Advertencia: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Peligro: Dirección de cambio desconocida</translation>
+        <translation type="unfinished">Advertencia: Dirección de cambio desconocida</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation type="unfinished">Confirmar dirección de cambio personalizada</translation>
+        <translation type="unfinished">Confirmar la dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">La dirección que ha seleccionado para el cambio no es parte de su monedero. Parte o todos sus fondos pueden ser enviados a esta dirección. ¿Está seguro?</translation>
+        <translation type="unfinished">La dirección que seleccionaste para el cambio no es parte de esta billetera. Una parte o la totalidad de los fondos en la billetera se enviará a esta dirección. ¿Seguro deseas continuar?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2917,11 +3236,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation type="unfinished">Ca&amp;ntidad:</translation>
+        <translation type="unfinished">&amp;Importe:</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation type="unfinished">&amp;Pagar a:</translation>
+        <translation type="unfinished">Pagar &amp;a:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -2929,23 +3248,31 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Escoger dirección previamente usada</translation>
+        <translation type="unfinished">Seleccionar dirección usada anteriormente</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Dirección Bitcoin a la que se enviará el pago</translation>
+        <translation type="unfinished">La dirección de Bitcoin a la que se enviará el pago</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
     <message>
         <source>Remove this entry</source>
-        <translation type="unfinished">Eliminar esta transacción</translation>
+        <translation type="unfinished">Eliminar esta entrada</translation>
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
         <translation type="unfinished">El importe que se enviará en la unidad seleccionada</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">La comisión se deducirá del importe que se envía. El destinatario recibirá menos bitcoins que los que ingreses en el campo del importe. Si se seleccionan varios destinatarios, la comisión se dividirá por igual.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">&amp;Restar la comisión del importe</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -2957,11 +3284,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
+        <translation type="unfinished">Ingresar una etiqueta para esta dirección a fin de agregarla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje que se agrgará al URI de Bitcoin, el cuál será almacenado con la transacción para su referencia. Nota: Este mensaje no será enviado a través de la red de Bitcoin.</translation>
+        <translation type="unfinished">Un mensaje que se adjuntó al bitcoin: URI que se almacenará con la transacción a modo de referencia. Nota: Este mensaje no se enviará por la red de Bitcoin.</translation>
     </message>
 </context>
 <context>
@@ -2979,7 +3306,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">Firmas - Firmar / verificar un mensaje</translation>
+        <translation type="unfinished">Firmas: firmar o verificar un mensaje</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
@@ -2987,23 +3314,23 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Puedes firmar los mensajes con tus direcciones para demostrar que las posees. Ten cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarte firmando tu identidad a través de ellos. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
+        <translation type="unfinished">Puedes firmar mensajes o acuerdos con tus direcciones para demostrar que puedes recibir los bitcoins que se envíen a ellas. Ten cuidado de no firmar cosas confusas o al azar, ya que los ataques de phishing pueden tratar de engañarte para que les envíes la firma con tu identidad. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmará el mensaje</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Escoger dirección previamente usada</translation>
+        <translation type="unfinished">Seleccionar dirección usada anteriormente</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde el portapapeles</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
-        <translation type="unfinished">Introduzca el mensaje que desea firmar aquí</translation>
+        <translation type="unfinished">Ingresar aquí el mensaje que deseas firmar</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -3015,7 +3342,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Firmar el mensaje para demostrar que se posee esta dirección Bitcoin</translation>
+        <translation type="unfinished">Firmar el mensaje para demostrar que esta dirección de Bitcoin te pertenece</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -3023,19 +3350,23 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation type="unfinished">Limpiar todos los campos de la firma de mensaje</translation>
+        <translation type="unfinished">Restablecer todos los campos de firma de mensaje</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpiar &amp;todo</translation>
+        <translation type="unfinished">Borrar &amp;todo</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
         <translation type="unfinished">&amp;Verificar mensaje</translation>
     </message>
     <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">Ingresa la dirección del destinatario, el mensaje (recuerda copiar los saltos de línea, espacios, tabulaciones, etc. con exactitud) y la firma a continuación para verificar el mensaje. Ten cuidado de no leer en la firma más de lo que está en el mensaje firmado en sí, para evitar ser víctima de un engaño por ataque de intermediario. Ten en cuenta que esto solo demuestra que el firmante recibe con la dirección; no puede demostrar la condición de remitente de ninguna transacción.</translation>
+    </message>
+    <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+        <translation type="unfinished">La dirección de Bitcoin con la que se firmó el mensaje</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -3043,11 +3374,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation type="unfinished">La firma proporcionada cuando el mensaje fue firmado</translation>
+        <translation type="unfinished">La firma que se dio cuando el mensaje se firmó</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation type="unfinished">Verificar el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
+        <translation type="unfinished">Verifica el mensaje para asegurarte de que se firmó con la dirección de Bitcoin especificada.</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -3055,31 +3386,39 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation type="unfinished">Limpiar todos los campos de la verificación de mensaje</translation>
+        <translation type="unfinished">Restablecer todos los campos de verificación de mensaje</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Haga clic en "Firmar mensaje" para generar la firma</translation>
+        <translation type="unfinished">Hacer clic en "Firmar mensaje" para generar una firma</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
-        <translation type="unfinished">La dirección introducida es inválida</translation>
+        <translation type="unfinished">La dirección ingresada es inválida.</translation>
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">Por favor, revise la dirección e inténtelo nuevamente.</translation>
+        <translation type="unfinished">Revisa la dirección e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">La dirección introducida no corresponde a una clave.</translation>
+        <translation type="unfinished">La dirección ingresada no corresponde a una clave.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Se canceló el desbloqueo de la billetera.</translation>
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">No hay error</translation>
+        <translation type="unfinished">Sin error </translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation type="unfinished">La clave privada para la dirección ingresada no está disponible.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation type="unfinished">Ha fallado la firma del mensaje.</translation>
+        <translation type="unfinished">Error al firmar el mensaje.</translation>
     </message>
     <message>
         <source>Message signed.</source>
@@ -3091,26 +3430,39 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Compruebe la firma e inténtelo de nuevo.</translation>
+        <translation type="unfinished">Comprueba la firma e intenta de nuevo.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">La firma no coincide con el resumen del mensaje.</translation>
+        <translation type="unfinished">La firma no coincide con la síntesis del mensaje.</translation>
     </message>
-    </context>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Falló la verificación del mensaje.</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">Mensaje verificado.</translation>
+    </message>
+</context>
 <context>
     <name>SplashScreen</name>
     <message>
         <source>(press q to shutdown and continue later)</source>
-        <translation type="unfinished">(presiona q para apagar y seguir luego)</translation>
+        <translation type="unfinished">(Presionar q para apagar y seguir luego)</translation>
     </message>
     <message>
         <source>press q to shutdown</source>
-        <translation type="unfinished">presiona q para apagar </translation>
+        <translation type="unfinished">Presionar q para apagar </translation>
     </message>
 </context>
 <context>
     <name>TransactionDesc</name>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">Hay un conflicto con una transacción con %1 confirmaciones</translation>
+    </message>
     <message>
         <source>0/unconfirmed, in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
@@ -3134,7 +3486,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     <message>
         <source>%1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
-        <translation type="unfinished">confirmaciones %1</translation>
+        <translation type="unfinished">%1 confirmaciones</translation>
     </message>
     <message>
         <source>Status</source>
@@ -3149,6 +3501,10 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Fuente</translation>
     </message>
     <message>
+        <source>Generated</source>
+        <translation type="unfinished">Generado</translation>
+    </message>
+    <message>
         <source>From</source>
         <translation type="unfinished">De</translation>
     </message>
@@ -3158,11 +3514,23 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Para</translation>
+        <translation type="unfinished">A</translation>
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">dirección personal</translation>
+        <translation type="unfinished">dirección propia</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">etiqueta</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">Crédito</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
@@ -3176,8 +3544,16 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">no aceptada</translation>
     </message>
     <message>
+        <source>Debit</source>
+        <translation type="unfinished">Débito</translation>
+    </message>
+    <message>
         <source>Total debit</source>
-        <translation type="unfinished">Total enviado</translation>
+        <translation type="unfinished">Débito total</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">Crédito total</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -3185,7 +3561,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe neto</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">Comentario</translation>
     </message>
     <message>
         <source>Transaction ID</source>
@@ -3193,7 +3577,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Tamaño total transacción</translation>
+        <translation type="unfinished">Tamaño total de transacción</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -3201,7 +3585,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Indice de salida</translation>
+        <translation type="unfinished">Índice de salida</translation>
     </message>
     <message>
         <source>%1 (Certificate was not verified)</source>
@@ -3209,11 +3593,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Merchant</source>
-        <translation type="unfinished">Vendedor</translation>
+        <translation type="unfinished">Comerciante</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que se puedan gastar. Cuando generaste este bloque, se transmitió a la red para agregarlo a la cadena de bloques. Si no logra entrar a la cadena, su estado cambiará a "no aceptado" y no se podrá gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation type="unfinished">Información de depuración</translation>
     </message>
     <message>
         <source>Transaction</source>
@@ -3225,20 +3613,28 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>true</source>
         <translation type="unfinished">verdadero</translation>
     </message>
-    </context>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">falso</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation type="unfinished">Esta ventana muestra información detallada sobre la transacción</translation>
+        <translation type="unfinished">En este panel se muestra una descripción detallada de la transacción</translation>
     </message>
-    </context>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">Detalles para %1</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
     <message>
@@ -3254,16 +3650,28 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Sin confirmar</translation>
+    </message>
+    <message>
         <source>Abandoned</source>
         <translation type="unfinished">Abandonada</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">Confirmando (%1 de %2 confirmaciones recomendadas)</translation>
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished">Confirmada (%1 confirmaciones)</translation>
     </message>
     <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">En conflicto</translation>
+    </message>
+    <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">No disponible (%1 confirmaciones, disponible después de %2)</translation>
+        <translation type="unfinished">Inmadura (%1 confirmaciones; estará disponibles después de %2)</translation>
     </message>
     <message>
         <source>Generated but not accepted</source>
@@ -3271,11 +3679,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished">Recibido de</translation>
+        <translation type="unfinished">Recibida de</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3283,19 +3691,35 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation type="unfinished">(n/d)</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
     <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation type="unfinished">Estado de la transacción. Pasa el mouse sobre este campo para ver el número de confirmaciones.</translation>
+    </message>
+    <message>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished">Fecha y hora en las que se recibió la transacción.</translation>
     </message>
     <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">Tipo de transacción.</translation>
+    </message>
+    <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Si una dirección de solo observación está involucrada en esta transacción o no.</translation>
+        <translation type="unfinished">Si una dirección solo de observación está involucrada en esta transacción o no.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
@@ -3309,6 +3733,14 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
 <context>
     <name>TransactionView</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished">Todo</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">Hoy</translation>
+    </message>
+    <message>
         <source>This week</source>
         <translation type="unfinished">Esta semana</translation>
     </message>
@@ -3318,11 +3750,15 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Last month</source>
-        <translation type="unfinished">El mes pasado </translation>
+        <translation type="unfinished">Mes pasado</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation type="unfinished">Este año</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Recibido con</translation>
+        <translation type="unfinished">Recibida con</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3330,7 +3766,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Minado</translation>
+        <translation type="unfinished">Minada</translation>
     </message>
     <message>
         <source>Other</source>
@@ -3338,7 +3774,7 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Ingresa la dirección, el identificador de transacción o la etiqueta para buscar</translation>
+        <translation type="unfinished">Ingresar la dirección, el identificador de transacción o la etiqueta para buscar</translation>
     </message>
     <message>
         <source>Min amount</source>
@@ -3362,11 +3798,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Copiar &amp;ID de transacción</translation>
+        <translation type="unfinished">Copiar &amp;identificador de transacción</translation>
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Copiar transacción &amp;raw</translation>
+        <translation type="unfinished">Copiar transacción &amp;sin procesar</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
@@ -3404,7 +3840,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="unfinished">Confirmada</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">Solo de observación</translation>
     </message>
     <message>
         <source>Date</source>
@@ -3423,8 +3863,12 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
+        <source>ID</source>
+        <translation type="unfinished">Identificador</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">La exportación falló</translation>
+        <translation type="unfinished">Error al exportar</translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
@@ -3432,11 +3876,11 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Exporting Successful</source>
-        <translation type="unfinished">Exportación satisfactoria</translation>
+        <translation type="unfinished">Exportación correcta</translation>
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">El historial de transacciones ha sido guardado exitosamente en %1</translation>
+        <translation type="unfinished">El historial de transacciones se guardó correctamente en %1.</translation>
     </message>
     <message>
         <source>Range:</source>
@@ -3454,8 +3898,8 @@ Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por k
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <translation type="unfinished">No se cargó ninguna billetera.
-Ir a Archivo &gt; Abrir billetera para cargar una.
-- OR -</translation>
+Ir a "Archivo &gt; Abrir billetera" para cargar una.
+- O -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -3463,19 +3907,23 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">No se puede decodificar PSBT desde el portapapeles (Base64 inválido)</translation>
+        <translation type="unfinished">No se puede decodificar la TBPF desde el portapapeles (Base64 inválida)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Cargar datos de la transacción</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Transacción firmada parcialmente (*.psbt)</translation>
+        <translation type="unfinished">Transacción parcialmente firmada (*.psbt)</translation>
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">El archivo PSBT debe ser más pequeño de 100 MiB</translation>
+        <translation type="unfinished">El archivo TBPF debe ser más pequeño de 100 MiB</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">No se puede decodificar PSBT</translation>
+        <translation type="unfinished">No se puede decodificar TBPF</translation>
     </message>
 </context>
 <context>
@@ -3486,16 +3934,28 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Fee bump error</source>
-        <translation type="unfinished">Error de incremento de cuota</translation>
+        <translation type="unfinished">Error de incremento de comisión</translation>
+    </message>
+    <message>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">Fallo al incrementar la comisión de transacción</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
         <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
-        <translation type="unfinished">¿Desea incrementar la cuota?</translation>
+        <translation type="unfinished">¿Deseas incrementar la comisión?</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Comisión actual:</translation>
     </message>
     <message>
         <source>Increase:</source>
         <translation type="unfinished">Incremento:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Nueva comisión:</translation>
     </message>
     <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
@@ -3511,7 +3971,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>PSBT copied</source>
-        <translation type="unfinished">PSBT copiada</translation>
+        <translation type="unfinished">TBPF copiada</translation>
     </message>
     <message>
         <source>Copied to clipboard</source>
@@ -3520,7 +3980,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Can't sign transaction.</source>
-        <translation type="unfinished">No se ha podido firmar la transacción.</translation>
+        <translation type="unfinished">No se puede firmar la transacción.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
@@ -3532,7 +3992,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">billetera por defecto</translation>
+        <translation type="unfinished">billetera predeterminada</translation>
     </message>
 </context>
 <context>
@@ -3543,11 +4003,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar a un archivo los datos de esta pestaña</translation>
+        <translation type="unfinished">Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">Billetera de Respaldo</translation>
+        <translation type="unfinished">Realizar copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -3560,15 +4020,15 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">Hubo un error intentando guardar los datos de la billetera al %1</translation>
+        <translation type="unfinished">Ocurrió un error al intentar guardar los datos de la billetera en %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">Copia de seguridad completada</translation>
+        <translation type="unfinished">Copia de seguridad correcta</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished">Los datos de la billetera fueron guardados exitosamente al %1</translation>
+        <translation type="unfinished">Los datos de la billetera se guardaron correctamente en %1.</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -3583,11 +4043,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s corrupto. Intenta utilizar la herramienta de la billetera de bitcoin para rescatar o restaurar una copia de seguridad.</translation>
+        <translation type="unfinished">%s dañado. Trata de usar la herramienta de la billetera de Bitcoin para rescatar o restaurar una copia de seguridad.</translation>
     </message>
     <message>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea no válida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Comunique este incidente a %s, indicando cómo obtuvo la instantánea. Se dejó el estado de encadenamiento de la instantánea no válida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
+        <translation type="unfinished">%s no pudo validar el estado de la instantánea -assumeutxo. Esto indica un problema de hardware, un error en el software o una modificación incorrecta del software que permitió que se cargara una instantánea inválida. Por consiguiente, el nodo se apagará y dejará de utilizar cualquier estado basado en la instantánea, restableciendo la altura de la cadena de %d a %d. En el siguiente reinicio, el nodo reanudará la sincronización desde %d sin usar datos de instantánea. Reporta este incidente a %s, indicando cómo obtuviste la instantánea. Se dejó el estado de cadena de la instantánea inválida en el disco por si resulta útil para diagnosticar el problema que causó este error.</translation>
     </message>
     <message>
         <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
@@ -3610,28 +4070,32 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">Es posible que el espacio en disco %s no tenga capacidad para los archivos de bloque. Aproximadamente %u GB de datos se almacenarán en este directorio.</translation>
     </message>
     <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">Distribuido bajo la licencia de software MIT; ver el archivo adjunto %s o %s.</translation>
+    </message>
+    <message>
         <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <translation type="unfinished">Error al cargar la billetera. Esta requiere que se descarguen bloques, y el software actualmente no admite la carga de billeteras mientras los bloques se descargan fuera de orden, cuando se usan instantáneas de assumeutxo. La billetera debería poder cargarse correctamente después de que la sincronización del nodo alcance la altura %s.</translation>
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Reescaneando billetera.</translation>
+        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Rescaneando billetera.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "formato".</translation>
+        <translation type="unfinished">Error: El registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "formato".</translation>
     </message>
     <message>
         <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "%s".</translation>
+        <translation type="unfinished">Error: El registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s", mientras que se esperaba "%s".</translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Error: la versión del archivo volcado no es compatible. Esta versión de la billetera de bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
+        <translation type="unfinished">Error: La versión del archivo de volcado no es compatible. Esta versión de la billetera de Bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Error: las billeteras heredadas solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
+        <translation type="unfinished">Error: Las billeteras "legacy" solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
     </message>
     <message>
         <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
@@ -3643,7 +4107,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <translation type="unfinished">Archivo peers.dat inválido o corrupto (%s). Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
+        <translation type="unfinished">El archivo peers.dat (%s) es inválido o está dañado. Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -3670,8 +4134,12 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
         <translation type="unfinished">Contribuye si te parece que %s es útil. Visita %s para obtener más información sobre el software.</translation>
     </message>
     <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation type="unfinished">La poda se configuró por debajo del mínimo de %d MiB. Usa un valor más alto.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <translation type="unfinished">El modo de poda no es compatible con -reindex-chainstate. Usa en su lugar un -reindex completo.</translation>
+        <translation type="unfinished">El modo de poda es incompatible con -reindex-chainstate. Usa en su lugar un -reindex completo.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -3679,7 +4147,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <translation type="unfinished">Error de renombrado de «%s» → «%s». Debería resolver esto manualmente moviendo o borrando el directorio %s de la instantánea no válida, en otro caso encontrará el mismo error de nuevo en el arranque siguiente.</translation>
+        <translation type="unfinished">Error al cambiar el nombre de "%s" a "%s". Para resolverlo, mueve o elimina manualmente el directorio %s de la instantánea no válida. De lo contrario, encontrarás el mismo error de nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -3691,7 +4159,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
@@ -3699,7 +4167,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Esta es una compilación de prueba pre-lanzamiento - use bajo su propio riesgo - no utilizar para aplicaciones de minería o mercantes</translation>
+        <translation type="unfinished">Esta es una compilación preliminar de prueba. Úsala bajo tu propia responsabilidad. No la uses para aplicaciones comerciales o de minería.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
@@ -3707,15 +4175,15 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Esta es la comisión de transacción que puede descartar si el cambio es más pequeño que el polvo a este nivel.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes descartar si el cambio es más pequeño que el remanente en este nivel.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Impuesto por transacción que pagarás cuando la estimación de impuesto no esté disponible.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que puedes pagar cuando los cálculos de comisiones no estén disponibles.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i ) supera la longitud máxima ( %i ) . Reducir el número o tamaño de uacomments .</translation>
+        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i) supera la longitud máxima (%i). Reduce el número o tamaño de uacomments .</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
@@ -3727,7 +4195,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <translation type="unfinished">Nivel de boletín del acceso especificado en categoría no mantenida en %1$s=%2$s. Se esperaba %1$s=&lt;category&gt;:&lt;loglevel&gt;. Categorías válidas: %3$s. Niveles de boletín válidos: %4 $s.</translation>
+        <translation type="unfinished">El nivel de registro de la categoría específica no es compatible: %1$s=%2$s. Se esperaba %1$s=&lt;category&gt;:&lt;loglevel&gt;. Categorías válidas: %3$s. Niveles de registro válidos: %4 $s.</translation>
     </message>
     <message>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
@@ -3739,11 +4207,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <translation type="unfinished">Monedero correctamente cargado. El tipo de billetero heredado está siendo obsoleto y mantenimiento para creación de monederos heredados serán eliminados en el futuro. Los monederos heredados pueden ser migrados a un descriptor de monedero con migratewallet.</translation>
+        <translation type="unfinished">La billetera se creó correctamente. El tipo de billetera "legacy" se está descontinuando, por lo que la asistencia para crear y abrir estas billeteras se eliminará en el futuro. Las billeteras "legacy" se pueden migrar a una billetera basada en descriptores con "migratewallet".</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Advertencia: el formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
+        <translation type="unfinished">Advertencia: El formato de la billetera del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -3751,7 +4219,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Aviso: ¡No parecen estar totalmente de acuerdo con nuestros compañeros! Puede que tengas que actualizar, u otros nodos tengan que actualizarce.</translation>
+        <translation type="unfinished">Advertencia: Al parecer no estamos completamente de acuerdo con nuestros pares. Es posible que tengas que realizar una actualización, o que los demás nodos tengan que hacerlo.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
@@ -3763,7 +4231,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">¡%s esta configurado muy alto!</translation>
+        <translation type="unfinished">¡El valor de %s es muy alto!</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
@@ -3775,7 +4243,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">No se puede resolver -%s direccion: '%s'</translation>
+        <translation type="unfinished">No se puede resolver la dirección de -%s: "%s"</translation>
     </message>
     <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
@@ -3791,7 +4259,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">La configuración de %s es demasiado alta. Las comisiones tan grandes se podrían pagar en una sola transacción.</translation>
+        <translation type="unfinished">El valor establecido para %s es demasiado alto. Las comisiones tan grandes se podrían pagar en una sola transacción.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
@@ -3803,7 +4271,7 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <translation type="unfinished">Error leyendo %s. Todas las teclas leídas correctamente, pero los datos de transacción o metadatos de dirección puedan ser ausentes o incorrectos.</translation>
+        <translation type="unfinished">Error al leer %s. Todas las claves se leyeron correctamente, pero es probable que falten los datos de la transacción o metadatos de direcciones, o bien que sean incorrectos.</translation>
     </message>
     <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
@@ -3855,11 +4323,11 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
-        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar una cantidad menor o consolidar manualmente las UTXO de la billetera.</translation>
+        <translation type="unfinished">El tamaño de las entradas supera el peso máximo. Intenta enviar un importe menor o consolidar manualmente las UTXO de la billetera.</translation>
     </message>
     <message>
         <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
-        <translation type="unfinished">La cantidad total de monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
+        <translation type="unfinished">El monto total de las monedas preseleccionadas no cubre la meta de la transacción. Permite que se seleccionen automáticamente otras entradas o incluye más monedas manualmente.</translation>
     </message>
     <message>
         <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
@@ -3867,18 +4335,18 @@ Ir a Archivo &gt; Abrir billetera para cargar una.
     </message>
     <message>
         <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
-        <translation type="unfinished">No se validó la instantánea de la UTXO. Reinicia para reanudar la descarga normal del bloque inicial o intenta cargar una instantánea diferente.</translation>
+        <translation type="unfinished">No se validó la instantánea de UTXO. Reinicia para reanudar la descarga de bloques inicial normal o intenta cargar una instantánea diferente.</translation>
     </message>
     <message>
         <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
-        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará el pool de memoria.</translation>
+        <translation type="unfinished">Las UTXO sin confirmar están disponibles, pero si se gastan, se crea una cadena de transacciones que rechazará la mempool.</translation>
     </message>
     <message>
         <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <translation type="unfinished">Se encontró una entrada heredada inesperada en la billetera del descriptor. Cargando billetera%s
+        <translation type="unfinished">Se encontró una entrada inesperada tipo "legacy" en la billetera basada en descriptores. Cargando billetera%s
 
 Es posible que la billetera haya sido manipulada o creada con malas intenciones.
 </translation>
@@ -3912,8 +4380,16 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Se interrumpió la verificación de bloques</translation>
     </message>
     <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">La configuración para %s solo se aplica en la red %s cuando se encuentra en la sección [%s].</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished">Derechos de autor (C) %i-%i</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
-        <translation type="unfinished">Corrupción de base de datos de bloques detectada.</translation>
+        <translation type="unfinished">Se detectó que la base de datos de bloques está dañada.</translation>
     </message>
     <message>
         <source>Could not find asmap file %s</source>
@@ -3933,7 +4409,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Done loading</source>
-        <translation type="unfinished">Generado pero no aceptado</translation>
+        <translation type="unfinished">Carga completa</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
@@ -3953,7 +4429,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Error al inicializar el entorno de la base de datos del monedero  %s</translation>
+        <translation type="unfinished">Error al inicializar el entorno de la base de datos de la billetera %s.</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">Error al cargar %s</translation>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
@@ -3961,19 +4441,19 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Error cargando %s: Monedero corrupto</translation>
+        <translation type="unfinished">Error al cargar %s: billetera dañada</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Error cargando %s: Monedero requiere una versión mas reciente de %s</translation>
+        <translation type="unfinished">Error al cargar %s: la billetera requiere una versión más reciente de %s</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation type="unfinished">Error cargando base de datos de bloques</translation>
+        <translation type="unfinished">Error al cargar la base de datos de bloques</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation type="unfinished">Error al abrir base de datos de bloques.</translation>
+        <translation type="unfinished">Error al abrir la base de datos de bloques</translation>
     </message>
     <message>
         <source>Error reading configuration file: %s</source>
@@ -3993,7 +4473,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
-        <translation type="unfinished">Error: no se puede extraer el destino del scriptpubkey generado</translation>
+        <translation type="unfinished">Error: No se puede extraer el destino del scriptpubkey generado</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -4013,11 +4493,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió una clave que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió una clave que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió un valor que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió un valor que no es hexadecimal (%s)</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
@@ -4037,15 +4517,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: This wallet is already a descriptor wallet</source>
-        <translation type="unfinished">Error: Esta billetera ya es de descriptores</translation>
+        <translation type="unfinished">Error: Esta billetera ya está basada en descriptores</translation>
     </message>
     <message>
         <source>Error: Unable to begin reading all records in the database</source>
-        <translation type="unfinished">Error: No se puede comenzar a leer todos los registros en la base de datos</translation>
+        <translation type="unfinished">Error: No se pueden comenzar a leer todos los registros en la base de datos</translation>
     </message>
     <message>
         <source>Error: Unable to make a backup of your wallet</source>
-        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de tu billetera</translation>
+        <translation type="unfinished">Error: No se puede realizar una copia de seguridad de la billetera</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
@@ -4057,7 +4537,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to read wallet's best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de leer el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo leer el registro del mejor localizador de bloques de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to remove watchonly address book data</source>
@@ -4069,16 +4549,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Unable to write solvable wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor registro del localizador del bloque del monedero</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solucionable.</translation>
     </message>
     <message>
         <source>Error: Unable to write watchonly wallet best block locator record</source>
-        <translation type="unfinished">Error: no es capaz de escribir el mejor monedero vigilado del bloque del registro localizador</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro del mejor localizador de bloques de la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: address book copy failed for wallet %s</source>
-        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera 1%s
- </translation>
+        <translation type="unfinished">Error: falló copia de la libreta de direcciones para la billetera %s</translation>
     </message>
     <message>
         <source>Error: database transaction cannot be executed for wallet %s</source>
@@ -4086,7 +4565,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
+        <translation type="unfinished">Fallo al escuchar en todos los puertos. Usa -listen=0 si quieres hacerlo.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -4094,7 +4573,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished">Es erróneo al iniciar indizados, se apaga...</translation>
+        <translation type="unfinished">Error al iniciar índices, cerrando...</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -4102,7 +4581,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Failure removing transaction: %s</source>
-        <translation type="unfinished">Error al eliminar la transacción: 1%s</translation>
+        <translation type="unfinished">Error al eliminar la transacción: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4118,15 +4597,19 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Incorrecto o bloque de génesis no encontrado. Datadir equivocada para la red?</translation>
+        <translation type="unfinished">El bloque génesis es incorrecto o no se encontró. ¿El directorio de datos es equivocado para la red?</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">Fallo al inicializar la comprobación de estado. %s se cerrará.</translation>
     </message>
     <message>
         <source>Input not found or already spent</source>
-        <translation type="unfinished">No se encontró o ya se gastó la entrada</translation>
+        <translation type="unfinished">La entrada no se encontró o ya se gastó</translation>
     </message>
     <message>
         <source>Insufficient dbcache for block verification</source>
-        <translation type="unfinished">dbcache insuficiente para la verificación de bloques</translation>
+        <translation type="unfinished">Dbcache insuficiente para la verificación de bloques</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -4134,15 +4617,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">La dirección -i2psam o el nombre de host no es válido: "%s" </translation>
+        <translation type="unfinished">Dirección o nombre de host de -i2psam inválido: "%s" </translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -onion o dominio '%s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -onion inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -proxy o dominio ' %s' inválido</translation>
+        <translation type="unfinished">Dirección o nombre de host de -proxy inválido: "%s"</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
@@ -4157,16 +4640,24 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">Importe inválido para %s=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe inválido para -%s=&lt;amount&gt;: "%s"</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation type="unfinished">Máscara de red inválida especificada en -whitelist: "%s"</translation>
+    </message>
+    <message>
         <source>Invalid port specified in %s: '%s'</source>
-        <translation type="unfinished">Puerto no válido especificado en%s: '%s'</translation>
+        <translation type="unfinished">Puerto no válido especificado en %s: "%s"</translation>
     </message>
     <message>
         <source>Invalid pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no válida %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no es válida %s</translation>
     </message>
     <message>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Fallo en la escucha para conexiones entrantes (la escucha devolvió el error %s)</translation>
+        <translation type="unfinished">Fallo al escuchar conexiones entrantes (la escucha devolvió el error %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4174,7 +4665,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Cargando lista de bloqueos...</translation>
+        <translation type="unfinished">Cargando lista de prohibiciones...</translation>
     </message>
     <message>
         <source>Loading block index…</source>
@@ -4186,11 +4677,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Missing amount</source>
-        <translation type="unfinished">Falta la cantidad</translation>
+        <translation type="unfinished">Falta el importe</translation>
     </message>
     <message>
         <source>Missing solving data for estimating transaction size</source>
         <translation type="unfinished">Faltan datos de resolución para estimar el tamaño de la transacción</translation>
+    </message>
+    <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation type="unfinished">Se necesita especificar un puerto con -whitebind: "%s"</translation>
     </message>
     <message>
         <source>No addresses available</source>
@@ -4202,11 +4697,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Not found pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no encontrada%s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se encontró %s</translation>
     </message>
     <message>
         <source>Not solvable pre-selected input %s</source>
-        <translation type="unfinished">Entrada preseleccionada no solucionable %s</translation>
+        <translation type="unfinished">La entrada preseleccionada no se puede solucionar %s</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4218,7 +4713,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Podando almacén de bloques…</translation>
+        <translation type="unfinished">Podando almacenamiento de bloques…</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished">Reduciendo -maxconnections de %d a %d, debido a limitaciones del sistema.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
@@ -4250,7 +4749,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation type="unfinished">Transacción falló</translation>
+        <translation type="unfinished">Fallo al firmar la transacción</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
@@ -4278,7 +4777,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">El código fuente esta disponible desde %s.</translation>
+        <translation type="unfinished">El código fuente está disponible en %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
@@ -4286,15 +4785,23 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">El monto de la transacción es demasiado pequeño para pagar la comisión</translation>
+        <translation type="unfinished">El importe de la transacción es muy pequeño para pagar la comisión</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">La billetera evitará pagar menos que la comisión mínima de retransmisión.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Este es un software experimental.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Esta es la tarifa mínima a pagar en cada transacción.</translation>
+        <translation type="unfinished">Esta es la comisión mínima de transacción que pagas en cada transacción.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Esta es la tarifa a pagar si realizas una transacción.</translation>
+        <translation type="unfinished">Esta es la comisión de transacción que pagarás si envías una transacción.</translation>
     </message>
     <message>
         <source>Transaction %s does not belong to this wallet</source>
@@ -4302,11 +4809,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
-        <translation type="unfinished">Monto de la transacción muy pequeño</translation>
+        <translation type="unfinished">El importe de la transacción es demasiado pequeño</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Los montos de la transacción no debe ser negativo</translation>
+        <translation type="unfinished">Los importes de la transacción no pueden ser negativos</translation>
     </message>
     <message>
         <source>Transaction change output index out of range</source>
@@ -4314,7 +4821,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">La transacción debe tener al menos un destinatario</translation>
+        <translation type="unfinished">La transacción debe incluir al menos un destinatario</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it.</source>
@@ -4361,6 +4868,10 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
         <translation type="unfinished">No se puede analizar -maxuploadtarget: "%s"</translation>
     </message>
     <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">No se puede iniciar el servidor HTTP. Consulta el registro de depuración para obtener información.</translation>
+    </message>
+    <message>
         <source>Unable to unload the wallet before migrating</source>
         <translation type="unfinished">No se puede descargar la billetera antes de la migración</translation>
     </message>
@@ -4378,7 +4889,7 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">La red especificada en -onlynet '%s' es desconocida</translation>
+        <translation type="unfinished">Se desconoce la red especificada en -onlynet: "%s"</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
@@ -4386,15 +4897,15 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <translation type="unfinished">Nivel de acceso global %s = %s no mantenido. Los valores válidos son: %s.</translation>
+        <translation type="unfinished">El nivel de registro global %s=%s no es compatible. Valores válidos: %s.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
-        <translation type="unfinished">Creación errónea del fichero monedero: %s</translation>
+        <translation type="unfinished">Error al crear el archivo de la billetera: %s</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
-        <translation type="unfinished">acceptstalefeeestimates no está mantenido en el encadenamiento %s.</translation>
+        <translation type="unfinished">acceptstalefeeestimates no se admite en la cadena %s.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
@@ -4402,11 +4913,11 @@ No se puede restaurar la copia de seguridad de la billetera.</translation>
     </message>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
-        <translation type="unfinished">Error: no pudo agregar tx de solo vigía %s para monedero de solo vigía</translation>
+        <translation type="unfinished">Error: No se pudo agregar la transacción %s a la billetera solo de observación.</translation>
     </message>
     <message>
         <source>Error: Could not delete watchonly transactions. </source>
-        <translation type="unfinished">Error: no se pudieron eliminar las transacciones de watchonly.</translation>
+        <translation type="unfinished">Error: No se pudieron eliminar las transacciones solo de observación</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -2,12 +2,20 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">برای ویرایش آدرس یا برچسب زدن کلیک ‌راست کنید</translation>
+    </message>
+    <message>
         <source>Create a new address</source>
         <translation type="unfinished">یک آدرس جدید ایجاد کنید</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished">کپی آدرسی که اکنون انتخاب کردید در کلیپ بورد سیستم</translation>
+    </message>
+    <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">آدرس‌های گیرنده - %1</translation>
     </message>
     </context>
 <context>
@@ -519,6 +527,14 @@
         <translation type="unfinished">همه‌ی کیف پول‌ها را ببند</translation>
     </message>
     <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">انتقال کیف پول</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">انتقال یک کیف پول</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">کیف پول پیش فرض
  </translation>
@@ -597,6 +613,14 @@
     <message>
         <source>Pre-syncing Headers (%1%)…</source>
         <translation type="unfinished">پیش‌همگام‌سازی سرصفحه‌ها (%1%)…</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">خطا در ایجاد کیف پول</translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">نمی‌توان کیف پول جدیدی ایجاد کرد، نرم‌افزار بدون پشتیبانی sqlite کامپایل شده است (برای کیف پول‌های توصیف‌گر این ویژگی لازم است)</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -815,6 +839,37 @@
     </message>
 </context>
 <context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">انتقال کیف پول</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">آیا برای انتقال کیف پول مطمئن هستید &lt;i&gt;%1&lt;/i&gt;؟</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">انتقال کیف پول</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">در حال انتقال کیف پول &lt;b&gt;%1&lt;/b&gt;... </translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">کیف پول '%1' با موفقیت منتقل گردید.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">انتقال موفق نبود</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">انتقال موفق بود</translation>
+    </message>
+</context>
+<context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
@@ -890,6 +945,10 @@
         <source>Create Wallet</source>
         <translation type="unfinished">ایجاد کیف پول
  </translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">تنها یک قدم با ایجاد کیف پول جدیدتان فاصله دارید!</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1842,6 +1901,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished">انتخاب همتا یا جفت برای جزییات اطلاعات</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation type="unfinished">جابه‌جایی</translation>
     </message>
     <message>
         <source>Version</source>
@@ -3431,6 +3494,10 @@ The wallet might have been tampered with or created with malicious intent.
 </translation>
     </message>
     <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">تايید بلوک دچار قطعی شد</translation>
+    </message>
+    <message>
         <source>Copyright (C) %i-%i</source>
         <translation type="unfinished">کپی رایت (C) %i-%i</translation>
     </message>
@@ -3469,6 +3536,10 @@ The wallet might have been tampered with or created with malicious intent.
     <message>
         <source>Error opening block database</source>
         <translation type="unfinished">خطا در بازکردن پایگاه داده بلاک block</translation>
+    </message>
+    <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">خطا در خواندن فایل تنظیمات: %s</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -90,6 +90,14 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Virhe tallentaessa osoitelistaa kohteeseen %1. Yritä uudelleen.</translation>
     </message>
     <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">Osoitteiden lähettäminen - %1</translation>
+    </message>
+    <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">Vastaanottava osoite - %1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">Vienti epäonnistui</translation>
     </message>
@@ -291,6 +299,18 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">tuntematon</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">upotettu "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Järjestelmän oletuskirjasin "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Mukautettu…</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">Määrä</translation>
     </message>
@@ -303,6 +323,12 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Reitittämätön</translation>
     </message>
     <message>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <extracomment>Name of Tor network in peer info</extracomment>
+        <translation type="unfinished">Sipuli</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Sisääntuleva</translation>
@@ -313,9 +339,24 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Ulosmenevä</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Täysi Rele</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Lohko Rele</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
         <translation type="unfinished">Manuaali</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Tunturi</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -616,6 +657,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Lataa osittain allekirjoitettu bitcoin-siirtotapahtuma</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Lataa PSBT &amp;leikepöydältä…</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Lataa osittain allekirjoitettu bitcoin-siirtotapahtuma leikepöydältä</translation>
     </message>
@@ -664,6 +709,14 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Sulje kaikki lompakot</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Siirrä lompakko</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">Siirrä lompakko</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
@@ -725,6 +778,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>&amp;Hide</source>
         <translation type="unfinished">&amp;Piilota</translation>
     </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">N&amp;äytä</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
@@ -752,6 +809,18 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Ota verkkotoiminta käyttöön</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Esi synkronoidaan otsikot (%1%)…</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Virhe luodessa lompakkoa</translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Uutta lompakkoa ei voi luoda, ohjelmisto on käännetty ilman sqlite-tukea (tarvitaan kuvauslompakoissa)</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -920,6 +989,14 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Kopioi &amp;määrä</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Kopioi tapahtumatunnus &amp;ID ja tulosindeksi</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;kitse käyttämättömät</translation>
+    </message>
+    <message>
         <source>&amp;Unlock unspent</source>
         <translation type="unfinished">&amp;Avaa käyttämättömien lukitus</translation>
     </message>
@@ -1007,6 +1084,57 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     </message>
 </context>
 <context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Siirrä lompakko</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Oletko varma, että haluat siirtää lompakon &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
+If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
+If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
+
+The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
+        <translation type="unfinished"> 
+Migrer le portefeuille convertira ce portefeuille en un ou plusieurs portefeuilles de descripteurs. Une nouvelle sauvegarde du portefeuille devra être effectuée.
+Si ce portefeuille contient des scripts watchonly, un nouveau portefeuille sera créé avec ces scripts watchonly.
+Si ce portefeuille contient des scripts solvables mais non surveillés, un portefeuille différent et nouveau sera créé avec ces scripts.
+
+Le processus de migration créera une sauvegarde du portefeuille avant de migrer. Ce fichier de sauvegarde sera nommé -.legacy.bak et se trouvera dans le répertoire de ce portefeuille. En cas de migration incorrecte, la sauvegarde peut être restaurée avec la fonctionnalité "Restaurer le portefeuille".
+
+
+Lompakon siirtäminen muuntaa tämän lompakon yhdeksi tai useammaksi kuvailluksi lompakoksi. Uusi lompakon varmuuskopio on tehtävä.
+Jos tämä lompakko sisältää vain katseltavia skriptejä, luodaan uusi lompakko, joka sisältää nämä katseltavat skriptit.
+Jos tämä lompakko sisältää ratkaistavia mutta ei katsottuja skriptejä, luodaan eri ja uusi lompakko, joka sisältää nämä skriptit.
+
+Siirtoprosessi luo varmuuskopion lompakosta ennen siirtoa. Tämä varmuuskopiotiedosto nimetään -.legacy.bak ja se löytyy tämän lompakon hakemistosta. Virheellisen siirron sattuessa varmuuskopio voidaan palauttaa "Palauta lompakko" -toiminnolla.</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Siirrä lompakko</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Siirretään lompakkoa &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">Lompakko '%1' siirrettiin onnistuneesti.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">Siirto epäonnistui</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">Siirto onnistui</translation>
+    </message>
+</context>
+<context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
@@ -1048,7 +1176,17 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
         <translation type="unfinished">Lompakon palauttaminen epäonnistui</translation>
     </message>
-    </context>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Palauta lompakkovaroitus</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Palauta lompakkoviesti</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1073,6 +1211,14 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Luo lompakko</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Olet yhden askeleen päässä uuden lompakon luomisesta!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Anna nimi ja ota halutessasi käyttöön lisäasetukset</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1211,8 +1357,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB vapaata tilaa</numerusform>
+            <numerusform>%n GB vapaata tilaa</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1292,6 +1438,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Tämä alustava synkronointi on erittäin vaativa ja saattaa tuoda esiin laiteongelmia, joita ei aikaisemmin ole havaittu. Aina kun ajat %1:n, jatketaan siitä kohdasta, mihin viimeksi jäätiin.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Kun napsautat OK, %1 alkaa ladata ja käsitellä koko %4 lohkoketjun (%2 GB) alkaen ensimmäisistä tapahtumista %3 kun %4 alun perin käynnistetty.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1390,7 +1540,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Tuntematon. Synkronoidaan järjestysnumeroita (%1,%2%)...</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Tuntematon. Esi synkronointi otsikot (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1434,6 +1588,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Säikeiden määrä skriptien &amp;varmistuksessa</translation>
     </message>
     <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Täysi polku %1 yhteensopivaan komentosarjaan (esim. C:\Downloads\hwi.exe tai /Users/you/Downloads/hwi.py). Varo: haittaohjelmat voivat varastaa kolikkosi!</translation>
+    </message>
+    <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished">IP osoite proxille (esim. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
@@ -1444,6 +1602,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Minimoi ikkuna ohjelman sulkemisen sijasta kun ikkuna suljetaan. Kun tämä asetus on käytössä, ohjelma suljetaan vain valittaessa valikosta Poistu.</translation>
+    </message>
+    <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Fontti Yleiskatsaus-välilehdellä:</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -1487,6 +1649,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Tietokannan välimuistin enimmäiskoko. Suurempi välimuisti voi nopeuttaa synkronointia, mutta sen jälkeen hyöty ei ole enää niin merkittävä useimmissa käyttötapauksissa. Välimuistin koon pienentäminen vähentää muistin käyttöä. Käyttämätön mempool-muisti jaetaan tätä välimuistia varten.</translation>
     </message>
     <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Aseta komentosarjan vahvistusketjujen määrä. Negatiiviset arvot vastaavat niiden ytimien määrää, jotka haluat jättää järjestelmälle vapaiksi.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = auto, &lt;0 = jätä näin monta ydintä vapaaksi)</translation>
     </message>
@@ -1503,6 +1670,16 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Lompakko</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Määritetäänkö summasta vähennysmaksu oletusarvoksi vai ei.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Vähennä &amp;maksu oletuksena summasta</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1526,8 +1703,17 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Aktivoi &amp;PSBT kontrollit</translation>
     </message>
     <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Näytetäänkö PSBT-ohjaimet.</translation>
+    </message>
+    <message>
         <source>External Signer (e.g. hardware wallet)</source>
         <translation type="unfinished">Ulkopuolinen allekirjoittaja (esim. laitelompakko)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ulkoisen allekirjoittajan komentosarjapolku</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1622,6 +1808,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Valitse mitä yksikköä käytetään ensisijaisesti bitcoin-määrien näyttämiseen.</translation>
     </message>
     <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;Kolmannen osapuolen tapahtuma-URL-osoitteet</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Näytetäänkö kolikkokontrollin ominaisuuksia vai ei</translation>
     </message>
@@ -1661,6 +1851,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Ohjelman uudelleenkäynnistys aktivoi muutokset.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Nykyiset asetukset varmuuskopioidaan klo"%1"</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Asiakasohjelma sammutetaan. Haluatko jatkaa?</translation>
@@ -1698,6 +1893,13 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Antamasi proxy-osoite on virheellinen.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Ei voinut luke asetusta "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -1782,6 +1984,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>PSBT Operations</source>
+        <translation type="unfinished">PSBT-toiminnot</translation>
+    </message>
+    <message>
         <source>Sign Tx</source>
         <translation type="unfinished">Allekirjoita Tx</translation>
     </message>
@@ -1853,6 +2059,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">PSBT (osittain tallennettu bitcoin-siirto) tallennettiin levylle.</translation>
+    </message>
+    <message>
+        <source>Sends %1 to %2</source>
+        <translation type="unfinished">Lähettää %1 kohteelle %2</translation>
     </message>
     <message>
         <source>own address</source>
@@ -1958,6 +2168,11 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Vertainen</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Ikä</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2127,8 +2342,32 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Valitse vertainen eriteltyjä tietoja varten.</translation>
     </message>
     <message>
+        <source>The transport layer version: %1</source>
+        <translation type="unfinished">Kuljetuskerroksen versio: %1</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation type="unfinished">Kuljetus</translation>
+    </message>
+    <message>
+        <source>The BIP324 session ID string in hex, if any.</source>
+        <translation type="unfinished">BIP324-istunnon tunnusmerkkijono heksadesimaalimuodossa, jos sellainen on.</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">Istunnon tunniste</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Versio</translation>
+    </message>
+    <message>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished">Välitämmekö tapahtumat tälle vertaiselle.</translation>
+    </message>
+    <message>
+        <source>Transaction Relay</source>
+        <translation type="unfinished">Siirtokulu</translation>
     </message>
     <message>
         <source>Starting Block</source>
@@ -2155,9 +2394,34 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Kartoitettu AS</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Välitämmekö osoitteet tälle vertaiselle.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Osoitevälitys</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Tältä vertaiselta käsiteltyjen osoitteiden kokonaismäärä (ei sisällä osoitteita, jotka hylättiin nopeusrajoituksen vuoksi).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Tältä vertaiselta saatujen osoitteiden kokonaismäärä, jotka hylättiin (ei käsitelty) nopeusrajoituksen vuoksi.</translation>
+    </message>
+    <message>
         <source>Addresses Processed</source>
         <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Käsitellyt osoitteet</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Osoitteiden määrärajoitus</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2218,6 +2482,11 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Last Block</source>
         <translation type="unfinished">Viimeisin lohko</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Kulunut aika siitä, kun tältä vertaiskumppanilta vastaanotettiin muistiomme hyväksytty uusi tapahtuma.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2289,6 +2558,53 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Saapuva: vertaisen aloittama</translation>
     </message>
     <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Lähtevä täysi välitys: oletus</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Outbound Block Relay: ei välitä tapahtumia tai osoitteita</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Outbound Feeler: lyhytaikainen, osoitteiden testaamiseen</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Lähtevän osoitteen haku: lyhytkestoinen, osoitteiden pyytämiseen</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">havaitseminen: vertaiskumppani voi olla v1 tai v2</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: salaamaton, selväkielinen siirtoprotokolla</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: BIP324-salattu siirtoprotokolla</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">valitsimme korkean kaistanleveyden releen vertaislaitteen</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">vertaiskumppani valitsi meidät suuren kaistanleveyden välitykseen</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">suuren kaistanleveyden relettä ei ole valittu</translation>
+    </message>
+    <message>
         <source>Ctrl+=</source>
         <extracomment>Secondary shortcut to increase the RPC console font size.</extracomment>
         <translation type="unfinished">Ctrl+-</translation>
@@ -2307,12 +2623,21 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">1 &amp;tunti</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 p&amp;ivä</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;viikko</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;vuosi</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopioi IP/verkkopeite</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2461,6 +2786,27 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Kopioi &amp;määrä</translation>
+    </message>
+    <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Base58 (Vanha)</translation>
+    </message>
+    <message>
+        <source>Not recommended due to higher fees and less protection against typos.</source>
+        <translation type="unfinished">Ei suositella korkeampien maksujen ja heikomman suojan kirjoitusvirheitä vastaan.</translation>
+    </message>
+    <message>
+        <source>Generates an address compatible with older wallets.</source>
+        <translation type="unfinished">Luo osoitteen, joka on yhteensopiva vanhempien lompakoiden kanssa.</translation>
+    </message>
+    <message>
+        <source>Generates a native segwit address (BIP-173). Some old wallets don't support it.</source>
+        <translation type="unfinished"> 
+Luo natiivin segwit-osoitteen (BIP-173). Jotkin vanhat lompakot eivät tue sitä.</translation>
+    </message>
+    <message>
+        <source>Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
+        <translation type="unfinished">Bech32m (BIP-350) on päivitys Bech32, mutta lompakkojen tuki on edelleen rajallinen.</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2660,12 +3006,25 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished"> Piilota siirtomaksuasetukset</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Määritä mukautettu maksu per kB (1 000 tavua) tapahtuman virtuaalikoosta.
+
+Huom: Koska maksu lasketaan per tavu, "100 satoshin per kB" maksunopeus 500 virtuaalitavun (puolet 1 kB
+) tapahtumakoolle johtaisi lopulta vain 50 satoshin maksuun.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">Mikäli lohkoissa ei ole tilaa kaikille siirtotapahtumille, voi louhijat sekä välittävät solmut pakottaa vähimmäispalkkion. Tämän vähimmäispalkkion maksaminen on täysin OK, mutta huomaa, että se saattaa johtaa siihen, ettei siirto vahvistu koskaan, jos bitcoin-siirtoja on enemmän kuin mitä verkko pystyy käsittelemään.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Liian alhainen maksu saattaa johtaa siirtoon, joka ei koskaan vahvistu (lue työkaluohje)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Älykäs maksu ei ole vielä alustettu. Tämä vie yleensä muutaman lohkon...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2763,6 +3122,11 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Ulkopuolista allekirjoittajaa ei löydy</translation>
     </message>
     <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ulkoisen allekirjoittajan virhe</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Tallenna siirtotiedot</translation>
     </message>
@@ -2794,9 +3158,18 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Ole hyvä ja tarkista siirtoehdotuksesi. Tämä luo osittain allekirjoitetun Bitcoin-siirron (PBST), jonka voit tallentaa tai kopioida ja sitten allekirjoittaa esim. verkosta irrannaisella %1-lompakolla tai PBST-yhteensopivalla laitteistolompakolla.</translation>
     </message>
     <message>
+        <source>%1 from wallet '%2'</source>
+        <translation type="unfinished">%1 lompakosta '%2'</translation>
+    </message>
+    <message>
         <source>Do you want to create this transaction?</source>
         <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
         <translation type="unfinished">Haluatko luoda tämän siirtotapahtuman?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Ole hyvä ja tarkista tapahtumasi. Voit luoda ja lähettää tämän tapahtuman tai luoda osittain allekirjoitetun Bitcoin-tapahtuman (PSBT), jonka voit tallentaa tai kopioida ja allekirjoittaa esimerkiksi offline-ympäristössä%1lompakkoosi tai PSBT-yhteensopivalla laitteistolompakolla.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2814,6 +3187,20 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Total Amount</source>
         <translation type="unfinished">Yhteensä</translation>
+    </message>
+    <message>
+        <source>Unsigned Transaction</source>
+        <comment>PSBT copied</comment>
+        <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
+        <translation type="unfinished">Allekirjoittamaton Siirto</translation>
+    </message>
+    <message>
+        <source>The PSBT has been copied to the clipboard. You can also save it.</source>
+        <translation type="unfinished">PSBT on kopioitu leikepöydälle. Voit myös tallentaa sen.</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk</source>
+        <translation type="unfinished">PSBT tallennettu levylle</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3111,6 +3498,16 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">ristiriidassa maksutapahtumalle, jolla on %1 varmistusta</translation>
     </message>
     <message>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/vahvistamatonta, memory poolissa</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/vahvistamatonta, ei memory poolissa</translation>
+    </message>
+    <message>
         <source>abandoned</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">hylätty</translation>
@@ -3223,6 +3620,10 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Output index</source>
         <translation type="unfinished">Ulostulon indeksi</translation>
+    </message>
+    <message>
+        <source>%1 (Certificate was not verified)</source>
+        <translation type="unfinished">%1 (Sertifikaattia ei ole todennettu)</translation>
     </message>
     <message>
         <source>Merchant</source>
@@ -3434,6 +3835,35 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Kopio transaktio &amp;ID</translation>
     </message>
     <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopioi &amp;raaka tapahtuma</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Kopioi koko tapahtuma  &amp;tiedot</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Näytä tapahtuman tiedot</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Lisää tapahtuman &amp;kuluja</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">H&amp;ylkää tapahtuma</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Muokkaa osoitekenttää</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Näytä %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Vie rahansiirtohistoria</translation>
     </message>
@@ -3562,6 +3992,11 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Uusi palkkio:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished"> 
+Varoitus: Tämä voi maksaa ylimääräisen maksun vähentämällä vaihtotuloja tai lisäämällä tuloja tarvittaessa. Se voi lisätä uuden vaihtotulojen, jos sellaista ei jo ole. Nämä muutokset voivat mahdollisesti vuotaa yksityisyyttä.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Vahvista palkkion korotus</translation>
     </message>
@@ -3572,6 +4007,11 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
     <message>
         <source>PSBT copied</source>
         <translation type="unfinished">PSBT kopioitu</translation>
+    </message>
+    <message>
+        <source>Copied to clipboard</source>
+        <comment>Fee-bump PSBT saved</comment>
+        <translation type="unfinished">Kopioi leikepöydälle</translation>
     </message>
     <message>
         <source>Can't sign transaction.</source>
@@ -3639,6 +4079,11 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
         <translation type="unfinished">%s on vioittunut. Yritä käyttää lompakkotyökalua bitcoin-wallet pelastaaksesi sen tai palauttaa varmuuskopio.</translation>
+    </message>
+    <message>
+        <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
+        <translation type="unfinished">%s virheellinen -assumeutxo-snapshot-tila. Tämä viittaa laitteistoon liittyvään ongelmaan, ohjelmistovirheeseen tai huonoon ohjelmistomuutokseen, joka on sallinut virheellisen snapshotin lataamisen. Tämän seurauksena solmu sulkeutuu ja lopettaa kaiken sen tilan käytön, joka perustui snapshottiin, ja nollaa lohkokorkeuden%darvoon%d. Seuraavassa uudelleenkäynnistyksessä solmu jatkaa synkronointia kohdasta%d  
+ilman, että käytetään mitään snapshot-tietoja. Ilmoita tästä tapauksesta osoitteeseen%s, mukaan lukien se, miten sait snapshotin. Virheellinen snapshot-tilatiedosto jätetään levylle, jos se on hyödyllinen ongelman diagnosoinnissa, joka aiheutti tämän virheen.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
@@ -3753,6 +4198,22 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Hakemistoon '%s' ei voida kirjoittaa. Tarkista käyttöoikeudet.</translation>
     </message>
     <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Epäonnistuneen migraation siivoaminen epäonnistui</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Ei voinut palauttaa lompakon varmuuskopiota..</translation>
+    </message>
+    <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">Lohkon vahvistus keskeytettiin</translation>
+    </message>
+    <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
         <translation type="unfinished">Konfigurointiasetuksen %s käyttöön vain %s -verkossa, kun osassa [%s].</translation>
     </message>
@@ -3825,6 +4286,10 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Virhe avattaessa lohkoindeksiä</translation>
     </message>
     <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Virhe luettaessa asetustiedostoa 1%s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Virheitä tietokantaa luettaessa, ohjelma pysäytetään.</translation>
     </message>
@@ -3853,6 +4318,30 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">virhe: Puuttuva tarkistussumma</translation>
     </message>
     <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Virhe: Ei %s osoitteita saatavilla.</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Virhe: Tämä lompakko käyttää jo SQLite:ä</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Virhe: Lompakon varmuuskopion luominen epäonnistui</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Virhe: Kaikkien tietueiden lukeminen tietokannasta ei onnistunut</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Virhe: Tiedon kirjoittaminen lompakkoon epäonnistui</translation>
+    </message>
+    <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Virhe: osoitekirjan kopiointi epäonnistui lompakolle %s</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Ei onnistuttu kuuntelemaan missään portissa. Käytä -listen=0 jos haluat tätä.</translation>
     </message>
@@ -3861,8 +4350,16 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Lompakkoa ei voitu tarkastaa alustuksen yhteydessä.</translation>
     </message>
     <message>
+        <source>Failed to start indexes, shutting down..</source>
+        <translation type="unfinished">Indeksien käynnistäminen epäonnistui, sammutetaan..</translation>
+    </message>
+    <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Tietokannan todennus epäonnistui</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Siirron poistaminen epäonnistui: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -3885,6 +4382,10 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Alustava järkevyyden tarkistus epäonnistui. %s sulkeutuu.</translation>
     </message>
     <message>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished">Riittämätön dbcache lohkon vahvistukseen</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Lompakon saldo ei riitä</translation>
     </message>
@@ -3905,12 +4406,28 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Virheellinen P2P-lupa: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Virheellinen määrä %s=&lt;amount&gt;: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Virheellinen määrä -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Kelvoton verkkopeite määritelty argumentissa -whitelist: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid port specified in %s: '%s'</source>
+        <translation type="unfinished">Virheellinen portti määritetty %s: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished">Virheellinen esivalittu syöte %s</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Saapuvien yhteyksien kuuntelu epäonnistui (kuuntelu palasi virheen %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -3933,6 +4450,10 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Puuttuva summa</translation>
     </message>
     <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Ratkaisutiedot puuttuvat tapahtuman koon arvioimiseksi</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Pitää määritellä portti argumentilla -whitebind: '%s'</translation>
     </message>
@@ -3943,6 +4464,14 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
     <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Ei tarpeeksi tiedostomerkintöjä vapaana.</translation>
+    </message>
+    <message>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished">Esivalittua tuloa ei löydy %s</translation>
+    </message>
+    <message>
+        <source>Not solvable pre-selected input %s</source>
+        <translation type="unfinished">Ei ratkaistavissa esivalittu tulo%s</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4009,6 +4538,14 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Määrättyä lohkohakemistoa "%s" ei ole olemassa.</translation>
     </message>
     <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Määritettyä tietohakemistoa %s ei ole olemassa.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Aloitetaan verkkosäikeitä…</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Lähdekoodi löytyy %s.</translation>
     </message>
@@ -4037,6 +4574,10 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Tämä on se siirtomaksu, jonka maksat, mikäli lähetät siirron.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Tapahtuma %s ei kuulu tähän lompakkoon</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Siirtosumma liian pieni</translation>
     </message>
@@ -4045,12 +4586,24 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Lähetyksen siirtosumman tulee olla positiivinen</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Tapahtuman muutoksen tulosindeksi on alueen ulkopuolella</translation>
+    </message>
+    <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Lähetyksessä tulee olla ainakin yksi vastaanottaja</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Tapahtuma vaatii osoitteenmuutoksen, mutta emme voi luoda sitä.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Siirtosumma liian iso</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Ei voida varata muistia kohteelle %sMiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4065,6 +4618,10 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">PID-tiedostoa '%s' ei voitu luoda: %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Ulkoisen tulon UTXO ei löydy</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Alkuavaimia ei voi luoda</translation>
     </message>
@@ -4077,8 +4634,16 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
         <translation type="unfinished">Ei pystytä avaamaan %s kirjoittamista varten</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Ei voi lukea -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">HTTP-palvelinta ei voitu käynnistää. Katso debug-lokista lisätietoja.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Lompakon lataus epäonnistui ennen siirtoa</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -4099,6 +4664,14 @@ Siirry osioon Tiedosto &gt; Avaa lompakko ladataksesi lompakon.
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
         <translation type="unfinished">Tuntemattomia uusia sääntöjä aktivoitu (versiobitti %i)</translation>
+    </message>
+    <message>
+        <source>Wallet file creation failed: %s</source>
+        <translation type="unfinished">Lompakon luominen epäonnistui: %s</translation>
+    </message>
+    <message>
+        <source>acceptstalefeeestimates is not supported on %s chain.</source>
+        <translation type="unfinished">hyväksyttyjä ilmaisia ​​arvioita ei tueta %s ketju.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>

--- a/src/qt/locale/bitcoin_fo.ts
+++ b/src/qt/locale/bitcoin_fo.ts
@@ -181,6 +181,10 @@
         <translation type="unfinished">Net-virksemi óvirkijað.</translation>
     </message>
     <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Móttak</translation>
+    </message>
+    <message>
         <source>Sign &amp;message…</source>
         <translation type="unfinished">&amp;Undirrita  boð</translation>
     </message>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -1137,7 +1137,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Migration Successful</source>
-        <translation type="unfinished">Migration réussie</translation>
+        <translation type="unfinished">La migration est terminée</translation>
     </message>
 </context>
 <context>
@@ -1223,7 +1223,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
-        <translation type="unfinished">Veuillez fournir un nom et, si désiré, activer toutes les options avancées.</translation>
+        <translation type="unfinished">Indiquez un nom et, si désiré, activez les options avancées.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1382,7 +1382,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Choose data directory</source>
-        <translation type="unfinished">Choisissez un répertoire de donnée</translation>
+        <translation type="unfinished">Choisissez le répertoire des données</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1446,7 +1446,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quand vous cliquerez sur Valider, %1 commencera à télécharger et à traiter l’intégralité de la chaîne de blocs %4 (%2 Go) en débutant avec les transactions les plus anciennes de %3, quand %4 a été lancé initialement.</translation>
+        <translation type="unfinished">Quand vous cliquerez sur Valider, %1 commencera à télécharger et à traiter l’intégralité de la chaîne de blocs %4 (%2 Go) en débutant avec les transactions les plus anciennes de %3, lors du lancement de %4 a été lancé initialement.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1543,7 +1543,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Inconnu. En-têtes de présynchronisation (%1, %2%)...</translation>
+        <translation type="unfinished">Inconnu. En-têtes de présynchronisation (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1590,7 +1590,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <translation type="unfinished">Chemin complet vers un %1 script compatible (par exemple, C:\Downloads\hwi.exe ou /Users/you/Downloads/hwi.py). Attention : les malwares peuvent voler vos pièces !</translation>
+        <translation type="unfinished">Chemin complet vers un script compatible avec %1 (p. ex. C:\Téléchargements\hwi.exe ou /Utilisateurs/vous/Téléchargements/hwi.py). Attention : des programmes malveillants peuvent voler vos pièces !</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
@@ -1610,7 +1610,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
-        <translation type="unfinished">Les options définies dans cette boîte de dialogue sont remplacées par la ligne de commande :</translation>
+        <translation type="unfinished">Les options définies dans cette boîte de dialogue sont remplacées par la ligne de commande :</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1862,7 +1862,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     <message>
         <source>Current settings will be backed up at "%1".</source>
         <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
-        <translation type="unfinished">Les paramètres actuels vont être restaurés à "%1".</translation>
+        <translation type="unfinished">Les paramètres actuels seront sauvegardés à « %1 ».</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
@@ -1908,7 +1908,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     <name>OptionsModel</name>
     <message>
         <source>Could not read setting "%1", %2.</source>
-        <translation type="unfinished">Impossible de lire le paramètre "%1", %2.</translation>
+        <translation type="unfinished">Impossible de lire le paramètre « %1 », %2.</translation>
     </message>
 </context>
 <context>
@@ -1994,7 +1994,7 @@ Le processus de migration créera une sauvegarde du porte-monnaie avant migratio
     <name>PSBTOperationsDialog</name>
     <message>
         <source>PSBT Operations</source>
-        <translation type="unfinished">Opération PSBT</translation>
+        <translation type="unfinished">Opération TBSP</translation>
     </message>
     <message>
         <source>Sign Tx</source>
@@ -2172,6 +2172,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Pair</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Âge</translation>
+    </message>
+    <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation type="unfinished">Envoyé</translation>
@@ -2334,19 +2339,19 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The transport layer version: %1</source>
-        <translation type="unfinished">La version de la couche de transport : %1</translation>
+        <translation type="unfinished">Version de la couche de transport : %1</translation>
     </message>
     <message>
         <source>The BIP324 session ID string in hex, if any.</source>
-        <translation type="unfinished">La chaîne d'ID de session BIP324 en hexadécimal, le cas échéant.</translation>
+        <translation type="unfinished">ID hexadécimale de la session BIP324, le cas échéant.</translation>
     </message>
     <message>
         <source>Session ID</source>
-        <translation type="unfinished">ID de session</translation>
+        <translation type="unfinished">ID de la session</translation>
     </message>
     <message>
         <source>Whether we relay transactions to this peer.</source>
-        <translation type="unfinished">Si nous relayons des transactions à ce pair.</translation>
+        <translation type="unfinished">Relayer ou non des transactions à ce pair.</translation>
     </message>
     <message>
         <source>Transaction Relay</source>
@@ -2389,12 +2394,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">Nombre total d'adresses reçues de ce pair qui ont été traitées (à l'exclusion des adresses qui ont été abandonnées en raison de la limitation du débit).</translation>
+        <translation type="unfinished">Nombre total d’adresses reçues de ce pair qui ont été traitées (les adresses abandonnées en raison de la limite du débit sont exclues).</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">Nombre total d'adresses reçues de ce pair qui ont été abandonnées (non traitées) en raison de la limitation du débit.</translation>
+        <translation type="unfinished">Nombre total d’adresses reçues de ce pair qui ont été abandonnées (non traitées) en raison de la limite du débit.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
@@ -2437,6 +2442,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>The direction and type of peer connection: %1</source>
         <translation type="unfinished">La direction et le type de la connexion au pair : %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Direction ou type</translation>
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
@@ -2560,17 +2569,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>detecting: peer could be v1 or v2</source>
         <extracomment>Explanatory text for "detecting" transport type.</extracomment>
-        <translation type="unfinished">détection : paires pourrait être v1 ou v2</translation>
+        <translation type="unfinished">détection : les paires pourraient être v1 ou v2</translation>
     </message>
     <message>
         <source>v1: unencrypted, plaintext transport protocol</source>
         <extracomment>Explanatory text for v1 transport type.</extracomment>
-        <translation type="unfinished">v1: protocole de transport non chiffré en texte clair</translation>
+        <translation type="unfinished">v1 : protocole de transport non chiffré en texte clair</translation>
     </message>
     <message>
         <source>v2: BIP324 encrypted transport protocol</source>
         <extracomment>Explanatory text for v2 transport type.</extracomment>
-        <translation type="unfinished">v2: Protocole de transport chiffré BIP324</translation>
+        <translation type="unfinished">v2 : protocole de transport chiffré BIP324</translation>
     </message>
     <message>
         <source>we selected the peer for high bandwidth relay</source>
@@ -2783,8 +2792,12 @@ Pour plus de précisions sur cette console, tapez %6.
         <translation type="unfinished">Copier le mont&amp;ant</translation>
     </message>
     <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Base58 (ancien)</translation>
+    </message>
+    <message>
         <source>Not recommended due to higher fees and less protection against typos.</source>
-        <translation type="unfinished">Non recommandé en raison de frais élevés et d'une faible protection contre les fautes de frappe.</translation>
+        <translation type="unfinished">Non recommandé en raison de frais élevés et d’une protection moindre contre les fautes de frappe.</translation>
     </message>
     <message>
         <source>Generates an address compatible with older wallets.</source>
@@ -2843,7 +2856,7 @@ Pour plus de précisions sur cette console, tapez %6.
     </message>
     <message>
         <source>&amp;Verify</source>
-        <translation type="unfinished">&amp;Vérifier</translation>
+        <translation type="unfinished">&amp;Confirmer</translation>
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
@@ -3162,6 +3175,12 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
         <translation type="unfinished">Frais de transaction</translation>
     </message>
     <message>
+        <source>%1 kvB</source>
+        <comment>PSBT transaction creation</comment>
+        <extracomment>When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with "virtual size" of the transaction displayed for context</extracomment>
+        <translation type="unfinished">%1 kvB</translation>
+    </message>
+    <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
         <translation type="unfinished">Ne signale pas Remplacer-par-des-frais, BIP-125.</translation>
     </message>
@@ -3177,11 +3196,11 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>The PSBT has been copied to the clipboard. You can also save it.</source>
-        <translation type="unfinished">Le PSBT a été copié dans le presse-papiers. Vous pouvez également le sauvegarder.</translation>
+        <translation type="unfinished">La TBSP a été copiée dans le presse-papiers. Vous pouvez aussi l’enregistrer.</translation>
     </message>
     <message>
         <source>PSBT saved to disk</source>
-        <translation type="unfinished">PSBT sauvegardé sur le disque</translation>
+        <translation type="unfinished">La TBSP a été enregistrée sur le disque</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3477,12 +3496,12 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     <message>
         <source>0/unconfirmed, in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
-        <translation type="unfinished">0/non confirmé, dans la pool de mémoire</translation>
+        <translation type="unfinished">0/non confirmée, dans la réserve de mémoire</translation>
     </message>
     <message>
         <source>0/unconfirmed, not in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
-        <translation type="unfinished">0/non confirmé, pas dans la pool de mémoire</translation>
+        <translation type="unfinished">0/non confirmée, absente de la réserve de mémoire</translation>
     </message>
     <message>
         <source>abandoned</source>
@@ -3912,7 +3931,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Fee bump error</source>
-        <translation type="unfinished">Erreur d’augmentation des frais</translation>
+        <translation type="unfinished">Erreur de majoration des frais</translation>
     </message>
     <message>
         <source>Increasing transaction fee failed</source>
@@ -3941,7 +3960,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Confirmer l’augmentation des frais</translation>
+        <translation type="unfinished">Confirmer la majoration des frais</translation>
     </message>
     <message>
         <source>Can't draft transaction.</source>
@@ -4025,11 +4044,11 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <translation type="unfinished">%s a échoué à valider l'état instantané -assumeutxo. Cela indique un problème matériel, ou un bug dans le logiciel, ou une mauvaise modification du logiciel qui a permis de charger un instantané invalide. En conséquence, le nœud s'arrêtera et cessera d'utiliser tout état qui a été construit sur l'instantané, réinitialisant la hauteur de la chaîne de %d à %d. Au prochain redémarrage, le nœud reprendra la synchronisation à partir de %d sans utiliser de données d'instantané. Veuillez signaler cet incident à %s, en précisant comment vous avez obtenu l'instantané. L'état de chaîne d'instantané invalide sera conservé sur le disque au cas où il serait utile pour diagnostiquer le problème qui a causé cette erreur.</translation>
+        <translation type="unfinished">%s n’a pas réussi à valider l’état de l’instantané -assumeutxo. Cela indique un problème matériel, un bogue logiciel ou une mauvaise modification logicielle qui a permis le chargement d’un instantané invalide. Par conséquent, le nœud s’arrêtera et cessera d’utiliser tout état fondé sur cet instantané, ce qui réinitialisera à le niveau de la chaîne de %d à %d. Lors du prochain démarrage, la synchronisation reprendra de %d, sans utiliser les données d’un instantané. Signalez cet incident à %s en indiquant comment vous avez obtenu l’instantané. L’état de chaîne de l’instantané invalide sera laissé sur le disque au cas afin d’aider éventuellement à diagnostiquer le problème à l’origine de cette erreur.</translation>
     </message>
     <message>
         <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
-        <translation type="unfinished">%s demande d'écouter sur le port %u. Ce port est considéré comme "mauvais" et il est donc peu probable qu'un pair s'y connecte. Voir doc/p2p-bad-ports.md pour plus de détails et une liste complète.</translation>
+        <translation type="unfinished">%s demande d’écouter sur le port %u. Ce port est considéré comme « mauvais » et il est donc peu probable qu’un pair s’y connecte. Voir doc/p2p-bad-ports.md pour plus de précisions et une liste complète.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
@@ -4045,7 +4064,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
-        <translation type="unfinished">L'espace disque %s peut ne pas être suffisant pour les fichiers en bloc. Environ %u Go de données seront stockés dans ce répertoire.</translation>
+        <translation type="unfinished">L’espace disque pourrait être insuffisant sur %s pour accueillir les fichiers de bloc. Environ %u Go de données seront stockés dans ce répertoire.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -4117,7 +4136,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <translation type="unfinished">Le mode Prune est incompatible avec -reindex-chainstate. Utilisez plutôt -reindex complet.</translation>
+        <translation type="unfinished">Le mode d’élagage est incompatible avec -reindex-chainstate. Utilisez plutôt -reindex complet.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -4125,7 +4144,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <translation type="unfinished">La modification de '%s' -&gt; '%s' a échoué. Vous devriez résoudre cela en déplaçant ou en supprimant manuellement le répertoire de snapshot invalide %s, sinon vous rencontrerez la même erreur à nouveau au prochain démarrage.</translation>
+        <translation type="unfinished">Le renommage de '%s' en '%s' a échoué. Vous devriez résoudre cela en déplaçant ou en supprimant manuellement le répertoire de l’instantané invalide %s, sinon la même erreur surviendra de nouveau lors du prochain démarrage.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -4173,11 +4192,11 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <translation type="unfinished">Niveau de journalisation spécifique à la catégorie non pris en charge %1$s=%2$s. Attendu %1$s=&lt;catégorie&gt;:&lt;niveaudejournal&gt;. Catégories valides : %3$s. Niveaux de journalisation valides : %4$s.</translation>
+        <translation type="unfinished">Le niveau de journalisation propre à la catégorie n’est pas pris en charge %1$s=%2$s. Attendu %1$s=&lt;category&gt;:&lt;loglevel&gt;. Catégories valides : %3$s. Niveaux de journalisation valides : %4$s.</translation>
     </message>
     <message>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <translation type="unfinished">Le format de la base de données chainstate n'est pas supporté. Veuillez redémarrer avec -reindex-chainstate. Cela reconstruira la base de données chainstate.</translation>
+        <translation type="unfinished">Un format non pris en charge de la base de données d’état de la chaîne a été trouvé. Redémarrez avec -reindex-chainstate. La base de données d’état de la chaîne sera reconstruite.</translation>
     </message>
     <message>
         <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
@@ -4237,7 +4256,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">%s est très élevé ! Des frais aussi importants pourraient être payés sur une seule transaction.</translation>
+        <translation type="unfinished">%s est un montant très élevé. Des frais aussi élevés pourraient être payés en une seule transaction.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
@@ -4249,7 +4268,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <translation type="unfinished">Erreur de lecture de %s! Toutes les clés ont été lues correctement, mais les données de transaction ou les métadonnées d'adresse peuvent être manquantes ou incorrectes.</translation>
+        <translation type="unfinished">Erreur de lecture de %s. Toutes les clés ont été lues correctement, mais les données de la transaction ou les métadonnées de l’adresse sont peut-être manquantes ou incorrectes.</translation>
     </message>
     <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
@@ -4265,7 +4284,7 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
-        <translation type="unfinished">Échec du calcul des frais de majoration, car les UTXO non confirmés dépendent d'un énorme groupe de transactions non confirmées.</translation>
+        <translation type="unfinished">Échec de calcul de la majoration des frais, car les UTXO non confirmés dépendent d’un groupe énorme de transactions non confirmées.</translation>
     </message>
     <message>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
@@ -4273,31 +4292,31 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
-        <translation type="unfinished">L'estimation des frais a échoué. Fallbackfee est désactivé. Attendez quelques blocs ou activez %s.</translation>
+        <translation type="unfinished">Échec d’estimation des frais. L’option de frais de repli « Fallbackfee » est désactivée. Attendez quelques blocs ou activez %s.</translation>
     </message>
     <message>
         <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
-        <translation type="unfinished">Options incompatibles : -dnsseed=1 a été explicitement spécifié, mais -onlynet interdit les connexions vers IPv4/IPv6</translation>
+        <translation type="unfinished">Options incompatibles : -dnsseed=1 a été indiqué explicitement, mais -onlynet interdit les connexions vers IPv4 et IPv6</translation>
     </message>
     <message>
         <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Montant non valide pour %s=&lt;amount&gt; : '%s' (doit être au moins égal au minrelay fee de %s pour éviter les transactions bloquées)</translation>
+        <translation type="unfinished">Le montant est invalide pour %s=&lt;amount&gt; : « %s » (doit être au moins égal aux frais minrelay de %s pour prévenir le blocage des transactions)</translation>
     </message>
     <message>
         <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
-        <translation type="unfinished">Connexions sortantes limitées à CJDNS (-onlynet=cjdns) mais -cjdnsreachable n'est pas fourni</translation>
+        <translation type="unfinished">Les connexions sortantes sont limitées à CJDNS (-onlynet=cjdns), mais -cjdnsreachable n’est pas indiqué</translation>
     </message>
     <message>
         <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
-        <translation type="unfinished">Connexions sortantes limitées à Tor (-onlynet=onion) mais le proxy pour atteindre le réseau Tor est explicitement interdit : -onion=0</translation>
+        <translation type="unfinished">Les connexions sortantes sont limitées à Tor (-onlynet=onion), mais le mandataire pour accéder au réseau Tor est explicitement interdit : -onion=0</translation>
     </message>
     <message>
         <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
-        <translation type="unfinished">Connexions sortantes limitées à Tor (-onlynet=onion) mais le proxy pour atteindre le réseau Tor n'est pas fourni : aucun des paramètres -proxy, -onion ou -listenonion n'est donné</translation>
+        <translation type="unfinished">Les connexions sortantes sont limitées à Tor (-onlynet=onion), mais le mandataire pour accéder au réseau Tor n’est pas indiqué : ni -proxy, ni -onion, ni -onion=0 n’est indiqué</translation>
     </message>
     <message>
         <source>Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
-        <translation type="unfinished">Connexions sortantes limitées à i2p (-onlynet=i2p) mais -i2psam n'est pas fourni</translation>
+        <translation type="unfinished">Les connexions sortantes sont limitées à i2p (-onlynet=i2p), mais -i2psam n’est pas indiqué</translation>
     </message>
     <message>
         <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
@@ -4305,15 +4324,15 @@ Accédez à Fichier &gt; Ouvrir un porte-monnaie pour en charger un.
     </message>
     <message>
         <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
-        <translation type="unfinished">Le montant total des pièces présélectionnées ne couvre pas l'objectif de la transaction. Veuillez permettre à d'autres entrées d'être sélectionnées automatiquement ou inclure plus de pièces manuellement</translation>
+        <translation type="unfinished">Le montant total des pièces présélectionnées ne couvre pas l’objectif de la transaction. Permettez la sélection automatique d’autres entrées ou ajoutez d’autres pièces manuellement</translation>
     </message>
     <message>
         <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
-        <translation type="unfinished">La transaction nécessite une destination d'une valeur non nulle, un ratio de frais non nul, ou une entrée présélectionnée.</translation>
+        <translation type="unfinished">Une destination d’une valeur non nulle, des taux de frais non nuls, ou une entrée présélectionnée sont nécessaires pour cette transaction</translation>
     </message>
     <message>
         <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
-        <translation type="unfinished">La validation de la snapshot UTXO a échoué. Redémarrez pour reprendre le téléchargement normal du bloc initial, ou essayez de charger une autre snapshot.</translation>
+        <translation type="unfinished">Échec de validation de l’instantané UTXO. Redémarrez pour reprendre le téléchargement normal du bloc initial ou essayez de charger un instantané différent</translation>
     </message>
     <message>
         <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
@@ -4345,7 +4364,7 @@ Essayez d’utiliser la version la plus récente du logiciel.
         <source>
 Unable to cleanup failed migration</source>
         <translation type="unfinished">
-Impossible de corriger l'échec de la migration</translation>
+Impossible de nettoyer la migration en échec</translation>
     </message>
     <message>
         <source>
@@ -4435,7 +4454,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Error reading configuration file: %s</source>
-        <translation type="unfinished">Erreur de lecture du fichier de configuration : %s</translation>
+        <translation type="unfinished">Erreur de lecture du fichier de configuration : %s</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
@@ -4451,7 +4470,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
-        <translation type="unfinished">Erreur : Impossible d'extraire la destination du scriptpubkey généré</translation>
+        <translation type="unfinished">Erreur : impossible d’extraire la destination de la scriptpubkey générée</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -4551,7 +4570,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished">Échec du démarrage des index, arrêt.</translation>
+        <translation type="unfinished">Échec du démarrage des index, arrêt</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -4587,7 +4606,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Insufficient dbcache for block verification</source>
-        <translation type="unfinished">Insuffisance de dbcache pour la vérification des blocs</translation>
+        <translation type="unfinished">dbcache est insuffisant pour la vérification des blocs</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -4611,11 +4630,11 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Montant non valide pour %s=&lt;amount&gt; : '%s' (doit être au moins %s)</translation>
+        <translation type="unfinished">Le montant est invalide pour %s=&lt;amount&gt; : « %s » (doit être au moins %s)</translation>
     </message>
     <message>
         <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Montant non valide pour %s=&lt;amount&gt; : '%s'</translation>
+        <translation type="unfinished">Le montant est invalide pour %s=&lt;amount&gt; : « %s »</translation>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
@@ -4627,15 +4646,15 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Invalid port specified in %s: '%s'</source>
-        <translation type="unfinished">Port non valide spécifié dans %s: '%s'</translation>
+        <translation type="unfinished">Un port non valide est indiqué dans %s : « %s »</translation>
     </message>
     <message>
         <source>Invalid pre-selected input %s</source>
-        <translation type="unfinished">Entrée présélectionnée non valide %s</translation>
+        <translation type="unfinished">L’entrée présélectionnée %s est invalide</translation>
     </message>
     <message>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">L'écoute des connexions entrantes a échoué ( l'écoute a renvoyé une erreur %s)</translation>
+        <translation type="unfinished">L’écoute des connexions entrantes a échoué (l’écoute a retourné l’erreur %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4675,7 +4694,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Not found pre-selected input %s</source>
-        <translation type="unfinished">Entrée présélectionnée introuvable %s</translation>
+        <translation type="unfinished">L’entrée présélectionnée %s est introuvable</translation>
     </message>
     <message>
         <source>Not solvable pre-selected input %s</source>
@@ -4747,7 +4766,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Specified data directory "%s" does not exist.</source>
-        <translation type="unfinished">Le répertoire de données spécifié "%s" n'existe pas.</translation>
+        <translation type="unfinished">Le répertoire de données indiqué « %s » n’existe pas</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
@@ -4807,11 +4826,11 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Transaction too large</source>
-        <translation type="unfinished">La transaction est trop grosse</translation>
+        <translation type="unfinished">La transaction est trop élevée</translation>
     </message>
     <message>
         <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
-        <translation type="unfinished">Impossible d'allouer de la mémoire pour -maxsigcachesize : '%s' Mo</translation>
+        <translation type="unfinished">Impossible d’allouer de la mémoire pour -maxsigcachesize : « %s » Mio</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4827,7 +4846,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Unable to find UTXO for external input</source>
-        <translation type="unfinished">Impossible de trouver l'UTXO pour l'entrée externe</translation>
+        <translation type="unfinished">Impossible de trouver l’UTXO pour l’entrée externe</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -4851,7 +4870,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Unable to unload the wallet before migrating</source>
-        <translation type="unfinished">Impossible de vider le portefeuille avant la migration</translation>
+        <translation type="unfinished">Impossible de décharger le porte-monnaie avant migration</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -4875,7 +4894,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <translation type="unfinished">Niveau de journalisation global non pris en charge %s=%s. Valeurs valides : %s.</translation>
+        <translation type="unfinished">Niveau de journalisation global non pris en charge %s=%s. Valeurs valides : %s.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
@@ -4883,7 +4902,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
-        <translation type="unfinished">acceptstalefeeestimates n'est pas pris en charge sur la chaîne %s.</translation>
+        <translation type="unfinished">acceptstalefeeestimates n’est pas pris en charge sur la chaîne %s.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
@@ -4911,7 +4930,7 @@ Impossible de restaurer la sauvegarde du porte-monnaie</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">Le portefeuille doit être réécrit : redémarrer %s pour terminer</translation>
+        <translation type="unfinished">Le porte-monnaie devait être réécrit : redémarrer %s pour terminer l’opération.</translation>
     </message>
     <message>
         <source>Settings file could not be read</source>

--- a/src/qt/locale/bitcoin_ga.ts
+++ b/src/qt/locale/bitcoin_ga.ts
@@ -215,6 +215,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Athraíodh pasfhrása sparán go rathúil.</translation>
     </message>
     <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">Theip ar athrú pasfhocail</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Tá an seanphasfhrása a cuireadh isteach le haghaidh díchriptithe an sparán mícheart. Tá carachtar nialasach ann (ie - beart nialasach). Má socraíodh an pasfhrása le leagan den bhogearra seo roimh 25.0, bain triail eile as gan ach na carachtair suas go dtí — ach gan a bheith san áireamh — an chéad charachtar null.</translation>
+    </message>
+    <message>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished">Rabhadh: Tá an eochair Glas Ceannlitreacha ar!</translation>
     </message>
@@ -233,19 +241,53 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Eisceacht runaway</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Tharla earráid mharfach. Ní féidir le %1 leanúint ar aghaidh go sábháilte agus scoirfidh sé.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Earráid inmheánach</translation>
     </message>
     </context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Ar mhaith leat socruithe a athshocrú go luachanna réamhshocraithe, nó deireadh a chur leis gan athruithe a dhéanamh?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Tharla earráid mharfach. Cinntigh go bhfuil an comhad socruithe inscríofa, nó bain triail as rith le -nosettings.</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">Earráid: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">Níor scoir %1 go sábháilte fós…</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">neamhaithnid</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Leabaithe "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Cló réamhshocraithe an chórais "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Saincheaptha…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -256,6 +298,16 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Iontráil seoladh Bitcoin (m.sh.%1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Dothreoraithe</translation>
+    </message>
+    <message>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <extracomment>Name of Tor network in peer info</extracomment>
+        <translation type="unfinished">Oinniún</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Isteach</translation>
@@ -264,6 +316,31 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
         <translation type="unfinished">Amach</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Sealaíocht Iomlán</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Sealaíocht Bloc</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">Lámhleabhar</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Fearacht</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Seoladh Fetch</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -288,41 +365,41 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n soicind(í)</numerusform>
+            <numerusform>%n soicind(í)</numerusform>
+            <numerusform>%n soicind(í)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n nóiméad(a)</numerusform>
+            <numerusform>%n nóiméad(a)</numerusform>
+            <numerusform>%n nóiméad(a)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n uair(eanta)</numerusform>
+            <numerusform>%n uair(eanta)</numerusform>
+            <numerusform>%n uair(eanta)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n lá(/a)</numerusform>
+            <numerusform>%n lá(/a)</numerusform>
+            <numerusform>%n lá(/a)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n seachtain(/a)</numerusform>
+            <numerusform>%n seachtain(/a)</numerusform>
+            <numerusform>%n seachtain(/a)</numerusform>
         </translation>
     </message>
     <message>
@@ -332,9 +409,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n bliain(/a)</numerusform>
+            <numerusform>%n bliain(/a)</numerusform>
+            <numerusform>%n bliain(/a)</numerusform>
         </translation>
     </message>
     </context>
@@ -381,6 +458,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cruthaigh sparán nua</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Íoslaghdaigh</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Sparán:</translation>
     </message>
@@ -414,16 +495,60 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Glac</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Roghanna…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Criptigh Sparán…</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Criptigh na heochracha príobháideacha a bhaineann le do sparán</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Sparán Cúltaca…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Athraigh Pasfhocal…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Sínigh &amp;teachtaireacht…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Sínigh teachtaireachtaí le do sheoltaí Bitcoin chun a chruthú gur leat iad</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Fíoraigh teachtaireacht…</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Teachtaireachtaí a fhíorú lena chinntiú go raibh siad sínithe le seoltaí sainithe Bitcoin</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Lódáil PSBT ón gcomhad…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Oscail &amp;URI…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Dún Sparán…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Cruthaigh Sparán…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Dún Gach Sparán…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -440,6 +565,26 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Barra uirlisí cluaisíní</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Ceanntásca á Sioncronú (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Ag sioncronú le líonra…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Bloic á n-innéacsú ar an diosca…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bloic ar diosca á bpróiseáil…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Ag nascadh le piaraí…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -460,14 +605,18 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 taobh thiar</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ag teacht suas…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -496,6 +645,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Lódáil Idirbheart Bitcoin Sínithe go Páirteach</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Luchtaigh PSBT ón &amp;gearrthaisce…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -534,8 +687,26 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Dún sparán</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Athchóirigh sparán ó chomhad cúltaca</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Dún gach sparán</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Imirce Sparán</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">Imirce sparán</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
@@ -558,6 +729,21 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Níl aon sparán ar fáil</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Sonraí Sparán</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Luchtaigh Cúltaca Sparán</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán</translation>
+    </message>
+    <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
         <translation type="unfinished">Ainm Sparán</translation>
@@ -578,14 +764,54 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>%1 client</source>
         <translation type="unfinished">%1 cliaint</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Folaigh</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">S&amp;conas</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Cliceáil le haghaidh tuilleadh gníomhartha.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Taispeáin cluaisín Piaraí</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Díchumasaigh gníomhaíocht líonra</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Cumasaigh gníomhaíocht líonra</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Ceanntásca a réamhshioncronú (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Earráid agus sparán á chruthú</translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Ní féidir sparán nua a chruthú, tiomsaíodh na bogearraí gan tacaíocht sqlite (riachtanach le haghaidh sparán tuairisceora)</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -742,6 +968,30 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil suim</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Cóipeáil idirbheart &amp; ID agus innéacs aschuir</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ocáil neamhchaite</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">L&amp;ocáil neamhchaite</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Cóipeáil méid</translation>
     </message>
@@ -802,7 +1052,79 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Rabhadh cruthú  sparán</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Ní féidir sínitheoirí a liostú</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Fuarthas an iomarca sínitheoirí seachtracha</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Luchtaigh Sparán</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Sparán á lódáil…</translation>
+    </message>
+</context>
+<context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Imirce sparán</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">An bhfuil tú cinnte gur mian leat an sparán &lt;i&gt;%1 &lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
+If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
+If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
+
+The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
+        <translation type="unfinished">Má dhéantar an sparán a aistriú, déanfar an sparán seo a thiontú go sparán tuairisceora amháin nó níos mó. Beidh gá le cúltaca sparán nua.
+Má tá aon scripteanna faire amháin sa sparán seo, cruthófar sparán nua ina mbeidh na scripteanna faire amháin sin.
+Má tá aon scripteanna intuaslagtha ach nach bhfuil faire orthu sa sparán seo, cruthófar sparán difriúil agus nua ina mbeidh na scripteanna sin.
+
+Cruthóidh an próiseas imirce cúltaca den sparán roimh imirce. Ainmneofar an comhad cúltaca seo &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak agus is féidir é a fháil san eolaire don sparán seo. I gcás imirce mícheart, is féidir an cúltaca a chur ar ais leis an bhfeidhmiúlacht "Athchóirigh Sparán".</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Imirce Sparán</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Sparán á Ascnamh &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">D'éirigh le haistriú an sparán '%1'.</translation>
+    </message>
+    <message>
+        <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Aistríodh scripteanna faire amháin go sparán nua darb ainm '%1'.</translation>
+    </message>
+    <message>
+        <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Aistríodh scripteanna intuaslagtha ach nach bhfuiltear ag faire orthu go sparán nua darb ainm '%1'.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">Theip ar an imirce</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">D'éirigh leis an Imirce</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -822,7 +1144,40 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Oscail Sparán</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Sparán Oscailte&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Sparán á Athchóiriú&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Theip ar athchóiriú an sparán</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Athchóirigh rabhadh sparán</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Athchóirigh teachtaireacht sparán</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -851,6 +1206,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Cruthaigh Sparán</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Tá tú céim amháin ar shiúl ó chruthú do sparán nua!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Tabhair ainm le do thoil agus, más mian leat, cumasaigh aon ardroghanna</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -889,10 +1252,23 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Déan Sparán Glan</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Bain úsáid as gléas sínithe seachtrach cosúil le sparán crua-earraí. Cumraigh an script sínitheora sheachtraigh i sainroghanna an sparán ar dtús.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Sínitheoir seachtrach</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Cruthaigh</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tiomsaithe gan tacaíocht sínithe seachtrach (riachtanach le haghaidh síniú seachtrach)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -972,9 +1348,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB de spás ar fáil</numerusform>
+            <numerusform>%n GB de spás ar fáil</numerusform>
+            <numerusform>%n GB de spás ar fáil</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -994,6 +1370,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         </translation>
     </message>
     <message>
+        <source>Choose data directory</source>
+        <translation type="unfinished">Roghnaigh eolaire sonraí</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Ar a laghad stórálfar %1 GB de shonraí  sa comhadlann seo, agus fásfaidh sé le himeacht ama.</translation>
     </message>
@@ -1005,9 +1385,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
         </translation>
     </message>
     <message>
@@ -1039,12 +1419,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Mar gurb é seo an chéad uair a lainseáil an clár, is féidir leat a roghnú cá stórálfaidh %1 a chuid sonraí.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Teorainn a chur le blocshlabhra stórála go</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Teastaíonn an blocshlabhra iomlán a íoslódáil arís chun an socrú seo a fhilleadh. Tá sé níos sciobtha an slabhra iomlán a íoslódáil ar dtús agus é a bhearradh níos déanaí. Díchumasaíodh roinnt ardgnéithe.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Tá an sioncrónú tosaigh seo an-dhian, agus d’fhéadfadh sé fadhbanna crua-earraí a nochtadh le do ríomhaire nach tugadh faoi deara roimhe seo. Gach uair a ritheann tú %1, leanfaidh sé ar aghaidh ag íoslódáil san áit ar fhág sé as.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Nuair a chliceálann tú OK, tosóidh %1 ag íosluchtú agus ag próiseáil slabhra iomlán %4 (%2 GB) ag tosú leis na hidirbhearta is luaithe i %3 nuair a seoladh %4 ar dtús.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1077,6 +1465,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">Tá %1 ag múchadh…</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Ná múch an ríomhaire go dtí go n-imíonn an fhuinneog seo.</translation>
     </message>
@@ -1098,6 +1490,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">Líon na mbloic fágtha</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Anaithnid…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">ag ríomh…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1123,7 +1523,15 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">Tá %1 ag sioncronú faoi láthair. Déanfaidh sé é a íoslódáil agus a fíorú ar ceanntásca agus bloic ó phiaraí go dtí barr an blocshlabhra.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Anaithnid. Ceanntásca á Sioncronú (%1, %2 %)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Anaithnid. Ceanntásca a Réamhshioncronú (%1, %2 %)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1155,12 +1563,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Tosaigh %1 ar logáil isteach an chórais</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Laghdaítear go mór an spás diosca a theastaíonn chun idirbhearta a stóráil má dhéantar bearradh a chumasú. Tá gach bloc fós bailíochtaithe go hiomlán. Chun an socrú seo a thabhairt ar ais ní mór an blockchain iomlán a athíoslódáil.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Méid taisce &amp;bunachar sonraí</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished">Líon snáitheanna &amp;fíorú scripte</translation>
+    </message>
+    <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Conair iomlán chuig script comhoiriúnach %1 (m.sh. C:\Downloads\hwi.exe nó /Users/you/Downloads/hwi.py). Tabhair aire: is féidir le malware do bhoinn a ghoid!</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
@@ -1173,6 +1589,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Íoslaghdaigh in ionad scoir an feidhmchlár nuair a bhíonn an fhuinneog dúnta. Nuair a chumasófar an rogha seo, ní dhúnfar an feidhmchlár ach amháin tar éis Scoir a roghnú sa roghchlár.</translation>
+    </message>
+    <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Cló sa chluaisín Forbhreathnú:</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Tá na roghanna atá socraithe sa dialóg seo sáraithe ag an líne ordaithe:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1203,12 +1627,42 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Teastaíonn an blocshlabhra iomlán a íoslódáil arís chun an socrú seo a fhilleadh.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Uasmhéid taisce bunachar sonraí. Is féidir le taisce níos mó cur le sioncrónú níos tapúla, agus ina dhiaidh sin ní bhíonn an tairbhe chomh soiléir don chuid is mó de chásanna úsáide. Laghdófar úsáid chuimhne má laghdaítear méid an taisce. Roinntear cuimhne mempool neamhúsáidte don taisce seo.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Socraigh líon na snáitheanna fíoraithe scripte. Freagraíonn luachanna diúltacha do líon na gcroíthe is mian leat a fhágáil saor sa chóras.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = uath, &lt;0 = fág an méid sin cóir saor)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Ligeann sé seo duit féin nó d’uirlis tríú páirtí cumarsáid a dhéanamh leis an nód trí orduithe ordú-líne agus JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Cumasaigh freastalaí R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Sp&amp;arán</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Cibé an táille a dhealú ón méid a shocrú mar réamhshocrú nó nach bhfuil.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Dealaigh &amp;táille ón méid de réir réamhshocraithe</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1227,12 +1681,38 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Caith &amp;sóinseáil neamhdheimhnithe</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Cumasaigh &amp; rialuithe PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Cibé ar cheart rialuithe PSBT a thaispeáint.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Sínitheoir Seachtrach (m.sh. sparán crua-earraí)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Conair scripte sínithe seachtraí</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Oscail port cliant Bitcoin go huathoibríoch ar an ródaire. Ní oibríonn sé seo ach nuair a thacaíonn do ródaire le UPnP agus nuair a chumasaítear é.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Mapáil port ag úsáid &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Oscail calafort cliant Bitcoin go huathoibríoch ar an ródaire. Ní oibríonn sé seo ach amháin nuair a thacaíonn do ródaire le NAT-PMP agus go bhfuil sé cumasaithe. D'fhéadfadh an port seachtrach a bheith randamach.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Port léarscáil le NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1267,6 +1747,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Fuinneog</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Taispeáin an deilbhín i dtráidire an chórais.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Taispeáin íocón an tráidire</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Ná taispeáin ach deilbhín tráidire t'éis an fhuinneog a íoslaghdú.</translation>
     </message>
@@ -1299,6 +1787,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Roghnaigh an t-aonad foroinnte réamhshocraithe le taispeáint sa chomhéadan agus nuair a sheoltar boinn.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URLanna tríú páirtí (m.sh. taiscéalaí bloc) atá le feiceáil sa chluaisín idirbheart mar mhíreanna roghchláir comhthéacs. Cuirtear hais idirbhirt in ionad%s sa URL. Déantar URLanna iolracha a dheighilt le barra ingearach |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URLanna idirbheart tríú páirtí</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Gnéithe rialúchán bonn a thaispeáint nó nach.</translation>
     </message>
@@ -1319,6 +1815,11 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Cealaigh</translation>
     </message>
     <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tiomsaithe gan tacaíocht sínithe seachtrach (riachtanach le haghaidh síniú seachtrach)</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation type="unfinished">réamhshocrú</translation>
     </message>
@@ -1337,6 +1838,11 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Atosú cliant ag teastáil chun athruithe a ghníomhachtú.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Déanfar cúltaca de na socruithe reatha ag "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Múchfar an cliant. Ar mhaith leat dul ar aghaidh?</translation>
@@ -1350,6 +1856,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Úsáidtear an comhad cumraíochta chun ardroghanna úsáideora a shonrú a sháraíonn socruithe GUI. Freisin, sáróidh aon roghanna líne na n-orduithe an comhad cumraíochta seo.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Leanúint ar aghaidh</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1370,6 +1880,13 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Tá an seoladh seachfhreastalaí soláthartha neamhbhailí.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Níorbh fhéidir socrú "%1", %2 a léamh.</translation>
     </message>
 </context>
 <context>
@@ -1454,6 +1971,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>PSBT Operations</source>
+        <translation type="unfinished">Oibríochtaí PSBT</translation>
+    </message>
+    <message>
         <source>Sign Tx</source>
         <translation type="unfinished">Sínigh Tx</translation>
     </message>
@@ -1466,6 +1987,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil chuig Gearrthaisce</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Sábháil…</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Dún</translation>
     </message>
@@ -1476,6 +2001,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Failed to sign transaction: %1</source>
         <translation type="unfinished">Theip ar síniú idirbheart: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Ní féidir ionchuir a shíniú agus an sparán glasáilte.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -1510,8 +2039,17 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Sábháil Sonraí Idirbheart</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Idirbheart Páirt-Sínithe (Dénártha)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">IBSP sábháilte ar dhiosca.</translation>
+    </message>
+    <message>
+        <source>Sends %1 to %2</source>
+        <translation type="unfinished">Seoltar %1 go %2</translation>
     </message>
     <message>
         <source>own address</source>
@@ -1544,6 +2082,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">Tá síni(ú/the) fós ag teastáil ón idirbheart.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ach níl aon sparán luchtaithe.)</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -1581,6 +2123,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ní URI bailí é 'bitcoin://'. Úsáid 'bitcoin:' ina ionad.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Ní féidir iarratas íocaíochta a phróiseáil toisc nach dtacaítear le BIP70.
+De bharr lochtanna slándála forleathan in BIP70, moltar go láidir neamhaird a dhéanamh d’aon treoracha ceannaithe chun sparán a athrú.
+Má tá an earráid seo á fáil agat ba cheart duit iarraidh ar an díoltóir URI atá comhoiriúnach le BIP21 a sholáthar.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">Ní féidir URI a pharsáil! Is féidir le seoladh neamhbhailí Bitcoin nó paraiméadair URI drochfhoirmithe a bheith mar an chúis.</translation>
     </message>
@@ -1595,6 +2145,16 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Gníomhaire Úsáideora</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Piaraí</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Aois</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -1640,6 +2200,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Sábháil Íomhá…</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Cóipeáil Íomhá</translation>
     </message>
@@ -1659,7 +2223,12 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Save QR Code</source>
         <translation type="unfinished">Sabháil cód QR.</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">Íomhá PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1759,8 +2328,32 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Roghnaigh piara chun faisnéis mhionsonraithe a fheiceáil.</translation>
     </message>
     <message>
+        <source>The transport layer version: %1</source>
+        <translation type="unfinished">Leagan na sraithe iompair: %1</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation type="unfinished">Iompar</translation>
+    </message>
+    <message>
+        <source>The BIP324 session ID string in hex, if any.</source>
+        <translation type="unfinished">Teaghrán ID an tseisiúin BIP324 i heicsidheachúlach, más ann dó.</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">Aitheantas an tseisiúin</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Leagan</translation>
+    </message>
+    <message>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished">Cibé an ndéanaimid idirbhearta a athsheoladh chuig an bpiaraí seo.</translation>
+    </message>
+    <message>
+        <source>Transaction Relay</source>
+        <translation type="unfinished">Leaschraolacháin Idirbheart</translation>
     </message>
     <message>
         <source>Starting Block</source>
@@ -1775,12 +2368,46 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Bloic Sioncronaithe</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Idirbheart Deiridh</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">An Córas Uathrialach mapáilte a úsáidtear chun roghnú piaraí a éagsúlú.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">CU Mapáilte</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Cibé an gcuirfimid seoltaí chuig an bpiaraí seo.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Sealaíocht Seoladh</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Líon iomlán na seoltaí a fuarthas ón bpiaraí seo a próiseáladh (ní áirítear seoltaí a laghdaíodh mar gheall ar theorannú rátaí).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Líon iomlán na seoltaí a fuarthas ón bpiaraí seo a thit (nár próiseáladh) mar gheall ar theorannú rátaí.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Seoltaí Próiseáilte</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Seoltaí Ráta-Teoranta</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -1811,12 +2438,45 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ceadanna</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Treo agus cineál an naisc phiara: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Treo/Cineál</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">An prótacal líonra a bhfuil an piara seo ceangailte trí: IPv4, IPv6, Oinniún, I2P, nó CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Seirbhísí</translation>
     </message>
     <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Bandaleithead ard BIP152 sealaíochta bloc dhlúth: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Bandaleithid Ard</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Am Ceangail</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tá achar ama caite ó fuarthas bloc úrscéil a rinne na seiceálacha bailíochta tosaigh ón gcomhghleacaí seo.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Bloc Deireanach</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Chuaigh an t-am caite ó fuarthas idirbheart úrnua a glacadh isteach inár mempool ón bpiaraí seo.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1883,6 +2543,63 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Amach:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Isteach: arna thionscnamh ag piaraí</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Sealaíocht Iomlán Amach: réamhshocraithe</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Leaschraolacháin Bloc Amach: ní athsheoltar idirbhearta ná seoltaí</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Feeler Amach: gearrthéarmach, le haghaidh seoltaí tástála</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Faigh Seoladh Amach: gearrthéarmach, chun seoltaí a lorg</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">bhrath: d’fhéadfadh v1 nó v2 a bheith i gcomhghleacaí</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: prótacal iompair gnáththéacs gan chriptiú</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: BIP324 prótacal iompair criptithe</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">roghnaigh muid an piaraí le haghaidh sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">roghnaigh an piaraí sinn le haghaidh sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">níor roghnaíodh aon sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Scaoil</translation>
     </message>
@@ -1891,12 +2608,21 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">1 &amp;uair</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 l&amp;á</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;seachtain</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;bhliain</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Cóipeáil IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -1911,8 +2637,38 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ag rith ordú gan aon sparán</translation>
     </message>
     <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">Fuinneog nód - [%1]</translation>
+    </message>
+    <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Ag rith ordú ag úsáid sparán "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Fáilte go consól RPC %1.
+Úsáid saigheada suas agus síos chun an stair a nascleanúint, agus %2 chun an scáileán a ghlanadh.
+Úsáid %3 agus %4 chun an clómhéid a mhéadú nó a laghdú.
+Clóscríobh %5 le haghaidh forbhreathnú ar na horduithe atá ar fáil.
+Chun tuilleadh eolais a fháil faoin gconsól seo a úsáid, clóscríobh %6.
+
+%7 RABHADH: Bhí scamadóirí gníomhach, ag rá le húsáideoirí orduithe a chlóscríobh anseo, ag goid a n-inneachar sparán. Ná húsáid an consól seo gan iarmhairtí ordaithe a thuiscint go hiomlán.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Ag rith…</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(piara: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -1937,6 +2693,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Cosc do</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Riamh</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2018,6 +2778,46 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Cóipeáil &amp; teachtaireacht</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Bonn58 (Oidhreacht)</translation>
+    </message>
+    <message>
+        <source>Not recommended due to higher fees and less protection against typos.</source>
+        <translation type="unfinished">Ní mholtar mar gheall ar tháillí níos airde agus cosaint níos lú i gcoinne typos.</translation>
+    </message>
+    <message>
+        <source>Base58 (P2SH-SegWit)</source>
+        <translation type="unfinished">Base58 (P2SH- SegWit)</translation>
+    </message>
+    <message>
+        <source>Generates an address compatible with older wallets.</source>
+        <translation type="unfinished">Gineann seoladh atá comhoiriúnach le sparán níos sine.</translation>
+    </message>
+    <message>
+        <source>Generates a native segwit address (BIP-173). Some old wallets don't support it.</source>
+        <translation type="unfinished">Gineann sé seoladh segwit dúchais (BIP-173). Ní thacaíonn roinnt sean-sparán leis.</translation>
+    </message>
+    <message>
+        <source>Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
+        <translation type="unfinished">Is uasghrádú é Bech32m (BIP-350) go Bech32, tá tacaíocht sparán fós teoranta.</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Níorbh fhéidir sparán a dhíghlasáil.</translation>
     </message>
@@ -2028,6 +2828,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Iarr íocaíocht chuig…</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Seoladh:</translation>
@@ -2055,6 +2859,18 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Cóipeáil &amp;Seoladh</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Fíoraigh</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Fíoraigh an seoladh seo ar e.g. scáileán sparán crua-earraí</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Sábháil Íomhá…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2187,8 +3003,24 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Glan gach réimse den fhoirm.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Ionchuir…</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Roghnaigh…</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Folaigh socruithe táillí idirbhirt</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Sonraigh táille shaincheaptha in aghaidh an kB (1,000 beart) de mhéid fíorúil an idirbhirt.
+
+Nóta: Ós rud é go ríomhtar an táille ar bhonn in aghaidh an bheart, ní thabharfadh ráta táille "100 satoshis in aghaidh an kvB" le haghaidh méid idirbhirt 500 beart fíorúil (leath de 1 kvB) táille ach 50 satoshis ar deireadh thiar.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2197,6 +3029,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">D’fhéadfadh idirbheart nach ndeimhnítear riamh a bheith mar thoradh ar tháille ró-íseal (léigh an leid uirlise)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Níor cuireadh tús leis an táille chliste go fóill. Tógann sé seo cúpla bloc de ghnáth...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2255,6 +3091,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">%1 (%2 bloic)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Sínigh ar an ngléas</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Ceangail do sparán crua-earraí ar dtús.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Socraigh cosán script sínitheora seachtrach i Roghanna -&gt; Sparán</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Cruthaigh Gan Sín</translation>
     </message>
@@ -2271,13 +3121,40 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">%1 go %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Chun liosta na bhfaighteoirí a athbhreithniú cliceáil "Taispeáin Sonraí…"</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Theip ar an síniú</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Níor aimsíodh sínitheoir seachtrach</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Teip sínitheora sheachtraigh</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Sábháil Sonraí Idirbheart</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Idirbheart Páirt-Sínithe (Dénártha)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
         <translation type="unfinished">IBSP sábháilte</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Iarmhéid seachtrach:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2291,6 +3168,15 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">Le do thoil, déan athbhreithniú ar do thogra idirbhirt. Tabharfaidh sé seo Idirbheart Bitcoin Sínithe go Páirteach (IBSP) ar féidir leat a shábháil nó a chóipeáil agus a shíniú ansin le m.sh. sparán as líne %1, nó sparán crua-earraí atá comhoiriúnach le IBSP.</translation>
+    </message>
+    <message>
+        <source>%1 from wallet '%2'</source>
+        <translation type="unfinished">%1 ó sparán '%2'</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Ar mhaith leat an t-idirbheart seo a chruthú?</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2308,6 +3194,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Total Amount</source>
         <translation type="unfinished">Iomlán</translation>
+    </message>
+    <message>
+        <source>Unsigned Transaction</source>
+        <comment>PSBT copied</comment>
+        <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
+        <translation type="unfinished">Idirbheart Gan Sínithe</translation>
+    </message>
+    <message>
+        <source>The PSBT has been copied to the clipboard. You can also save it.</source>
+        <translation type="unfinished">Tá an PSBT cóipeáilte chuig an ngearrthaisce. Is féidir leat é a shábháil freisin.</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk</source>
+        <translation type="unfinished">PSBT sábháilte ar diosca</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -2348,9 +3248,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -2588,11 +3488,32 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(brúigh q chun múchadh agus lean ar aghaidh ar ball)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">brúigh q chun múchadh</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">faoi choimhlint le idirbheart le %1 dearbhuithe</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/neamhdhearbhaithe, i linn cuimhne</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/neamhdhearbhaithe, ní sa linn cuimhne</translation>
     </message>
     <message>
         <source>abandoned</source>
@@ -2656,9 +3577,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
         </translation>
     </message>
     <message>
@@ -2708,6 +3629,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Output index</source>
         <translation type="unfinished">Innéacs aschuir</translation>
+    </message>
+    <message>
+        <source>%1 (Certificate was not verified)</source>
+        <translation type="unfinished">%1 (Níor fíoraíodh an teastas)</translation>
     </message>
     <message>
         <source>Merchant</source>
@@ -2895,6 +3820,55 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Íosmhéid</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Raon…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Cóipeáil idirbheart &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Cóipeáil &amp;amh-idirbheart</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Cóipeáil idirbheart agus sonraí iomlána</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Taispeáin sonraí idirbhirt</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Méadaigh idirbheart &amp; táille</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Idirbheart&amp;tréigean</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Cuir lipéad seolta in eagar</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Taispeáin i %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Easpórtáil Stair Idirbheart</translation>
     </message>
@@ -3023,6 +3997,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Táille nua:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Rabhadh: D’fhéadfadh sé seo an táille bhreise a íoc trí aschuir athraithe a laghdú nó trí ionchuir a chur leis, nuair is gá. Féadfaidh sé aschur athraithe nua a chur leis mura bhfuil ceann ann cheana. D'fhéadfadh na hathruithe seo príobháideacht a sceitheadh.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Dearbhaigh preab táille</translation>
     </message>
@@ -3035,12 +4013,21 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">IBSP cóipeáilte</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <comment>Fee-bump PSBT saved</comment>
+        <translation type="unfinished">Cóipeáladh chuig an ngearrthaisce</translation>
+    </message>
+    <message>
         <source>Can't sign transaction.</source>
         <translation type="unfinished">Ní féidir síniú idirbheart.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Níorbh fhéidir feidhmiú idirbheart</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Ní féidir an seoladh a thaispeáint</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3060,6 +4047,11 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Sparán Chúltaca</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Sonraí Sparán</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -3093,16 +4085,84 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Tá %s truaillithe. Triail an uirlis sparán bitcoin-wallet a úsáid chun tharrtháil nó chun cúltaca a athbhunú.</translation>
     </message>
     <message>
+        <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
+        <translation type="unfinished">Theip ar %s an staid snapshot -assumeutxo a bhailíochtú. Léiríonn sé seo fadhb crua-earraí, nó fabht sna bogearraí, nó droch-mhodhnú bogearraí a cheadaigh pictiúr neamhbhailí a luchtú. Mar thoradh air seo, stopfar an nód agus stopfaidh sé de úsáid a bhaint as staid ar bith a tógadh ar an seat, ag athshocrú airde an tslabhra ó%dgo%d. Ar an gcéad atosú eile, athchromfar ar an nód ag sioncronú ó %d gan úsáid a bhaint as sonraí seat. Tuairiscigh an teagmhas seo do %s lena n-áirítear conas a fuair tú an pictiúr. Fágfar an slabhrashlabhra neamhbhailí ar an diosca ar eagla go mbeadh sé ina chuidiú leis an tsaincheist ba chúis leis an earráid seo a dhiagnóisiú.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">Iarraidh %s éisteacht ar phort %u. Meastar go bhfuil an port seo "olc" agus dá bhrí sin ní dócha go nascfaidh piaraí ar bith leis. Féach doc/p2p-bad-ports.md le haghaidh sonraí agus liosta iomlán.</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Ní féidir an sparán a íosghrádú ó leagan %igo leagan%i. Leagan sparán gan athrú.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Ní féidir glas a fháil ar eolaire sonraí %s. Is dócha go bhfuil %s ag rith cheana.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Ní féidir sparán scoilte neamh-HD a uasghrádú ó leagan%igo leagan%i gan uasghrádú chun tacú le heochrach réamh-scoilte. Úsáid leagan %i nó níl aon leagan sonraithe.</translation>
+    </message>
+    <message>
+        <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Ní féidir spás diosca le haghaidh %sa chur san áireamh sna blocchomhaid. Stórálfar thart ar %u GB de shonraí san eolaire seo.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Dáilte faoin gceadúnas bogearraí MIT, féach na comhad atá in éindí %s nó %s</translation>
     </message>
     <message>
+        <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
+        <translation type="unfinished">Earráid agus an sparán á lódáil. Éilíonn Sparán go n-íoslódálfar bloic, agus ní thacaíonn bogearraí faoi láthair le sparán a luchtú agus bloic á n-íoslódáil as ord nuair a úsáidtear snapshots assumeutxo. Ba cheart go mbeadh Sparán in ann luchtú go rathúil nuair a shroicheann sioncronú nód an airde %s</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Earráid agus %s á léamh! Seans go bhfuil sonraí idirbhirt in easnamh nó mícheart. Sparán athscanadh.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Earráid agus%s á léamh! Seans go bhfuil sonraí idirbhirt in easnamh nó mícheart. Sparán athscanadh.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Earráid: Tá taifead aitheantóra Dumpfile mícheart. Fuair ​​​​tú "%s", bhíothas ag súil le "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Earráid: Ní thacaítear leis an leagan Dumpfile. Ní thacaíonn an leagan seo de bitcoin-sparán ach le leagan 1 dumpfiles. Fuair ​​​​tú dumpfile le leagan %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Earráid: Ní thacaíonn sparán oidhreachta ach na cineálacha seoltaí "oidhreacht", "p2sh-segwit", agus "bech32"</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
+        <translation type="unfinished">Earráid: Ní féidir tuairisceoirí a tháirgeadh don sparán oidhreachta seo. Bí cinnte pasfhrása an sparán a sholáthar má tá sé criptithe.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Tá comhad %s ann cheana. Má tá tú cinnte gurb é seo a theastaíonn uait, bog é as an mbealach ar dtús.</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Peers.dat neamhbhailí nó truaillithe (%s). Má chreideann tú gur fabht é seo, cuir in iúl do %s é le do thoil. Mar shruth oibre, is féidir leat an comhad (%s) a bhogadh as an mbealach (athainmnigh, bog nó scrios) chun ceann nua a chruthú ar an gcéad thús eile.</translation>
+    </message>
+    <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Tá níos mó ná seoladh ceangail oinniún amháin curtha ar fáil. Ag baint úsáide as %s don tseirbhís Tor oinniún a cruthaíodh go huathoibríoch.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh aon chomhad dumpála. Chun createfromdump a úsáid, ní mór -dumpfile=&lt;filename&gt; a sholáthar.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh aon chomhad dumpála. Chun Dumpáil a úsáid, ní mór -dumpfile=&lt;filename&gt; a sholáthar.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh formáid comhaid sparán. Chun createfromdump a úsáid, ní mór -format=&lt;format&gt; a sholáthar.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3117,8 +4177,16 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Bearradh cumraithe faoi bhun an íosmhéid %d MiB. Úsáid uimhir níos airde le do thoil.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Níl an modh prúnaí ag luí le -reindex-chainstate. Úsáid lán-reindex ina ionad sin.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Bearradh: téann sioncrónú deireanach an sparán thar sonraí bearrtha. Ní mór duit -reindex (déan an blockchain iomlán a íoslódáil arís i gcás nód bearrtha)</translation>
+    </message>
+    <message>
+        <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
+        <translation type="unfinished">Theip ar athainmniú '%s' -&gt; '%s'. Ba cheart duit é seo a réiteach tríd an gcomhadlann achomair neamhbhailí %s a bhogadh nó a scriosadh de láimh, nó beidh an earráid chéanna agat arís ar an gcéad tosaithe eile.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -3161,12 +4229,40 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir bloic a aithrise. Beidh ort an bunachar sonraí a atógáil ag úsáid -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Cuireadh formáid comhaid sparán anaithnid "%s" ar fáil. Tabhair ceann de "bdb" nó "sqlite".</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
+        <translation type="unfinished">Leibhéal logála catagóir ar leith nach dtacaítear leis%11$s=%2$s. Bhíothas ag súil le %1$s=1:2. Catagóirí bailí: %3$s. Leibhéil loga bailí: %4$s.</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Aimsíodh formáid bhunachar sonraí chainstáit nach dtacaítear léi. Atosaigh le -reindex-chainstate. Déanfaidh sé seo an bunachar sonraí slabhrach a atógáil.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Sparán cruthaithe go rathúil. Tá an cineál sparán oidhreachta á dhímheas agus bainfear an tacaíocht chun sparán oidhreachta a chruthú agus a oscailt amach anseo.</translation>
+    </message>
+    <message>
+        <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
+        <translation type="unfinished">D'éirigh leis an sparán a lódáil. Tá an cineál sparán oidhreachta á dhímheas agus bainfear an tacaíocht chun sparán oidhreachta a chruthú agus a oscailt amach anseo. Is féidir sparán oidhreachta a aistriú chuig sparán tuairisceora le sparán imirceach.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Rabhadh: Ní mheaitseálann formáid sparán Dumpfile "%s" an fhormáid ordaithe sonraithe "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Rabhadh: Eochracha príobháideacha braite i sparán {%s} le heochracha príobháideacha díchumasaithe</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Rabhadh: Is cosúil nach n-aontaímid go hiomlán lenár piaraí! B’fhéidir go mbeidh ort uasghrádú a dhéanamh, nó b’fhéidir go mbeidh ar nóid eile uasghrádú.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Teastaíonn bailíochtú sonraí finné maidir le bloic tar éis airde %d. Atosaigh le -reindex le do thoil.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3189,12 +4285,136 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir réiteach seoladh -%s: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Ní féidir -forcednsseed a shocrú go fíor agus -dnsseed á shocrú go bréagach.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Ní féidir -peerblockfilters a shocrú gan -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Ní féidir scríobh chuig eolaire sonraí '%s'; seiceáil ceadanna.</translation>
+    </message>
+    <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">Tá%s socraithe an-ard! D’fhéadfaí táillí chomh mór seo a íoc ar idirbheart amháin.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Ní féidir naisc ar leith a sholáthar agus tá addrman chun naisc amach a aimsiú ag an am céanna.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Earráid agus %s á lódáil: sparán an tsínitheora sheachtraigh á luchtú gan tacaíocht sínitheoir seachtrach a chur le chéile</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">Earráid agus %s á léamh! Léann na heochracha go léir i gceart, ach seans go bhfuil sonraí idirbhirt nó meiteashonraí seolta in easnamh nó mícheart.</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Earráid: Ní féidir sonraí an leabhair seoltaí sa sparán a shainaithint mar go mbaineann siad le sparán aistrithe</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Earráid: Tuairisceoirí dúblacha a cruthaíodh le linn imirce. Seans go bhfuil do sparán truaillithe.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Earráid: Ní féidir idirbheart %s sa sparán a aithint gur le sparán aistrithe é</translation>
+    </message>
+    <message>
+        <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
+        <translation type="unfinished">Theip ar tháillí tuairte a ríomh, toisc go mbraitheann UTXOanna neamhdhearbhaithe ar bhraisle ollmhór idirbheart neamhdheimhnithe.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Theip ar an gcomhad peers.dat neamhbhailí a athainmniú. Bog nó scrios é agus bain triail eile as.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">Theip ar mheastachán na dtáillí. Tá fallbackfee díchumasaithe. Fan cúpla bloc nó cumasaigh %s.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Roghanna neamh-chomhoiriúnacha: -dnsseed=1 sonraíodh go sainráite, ach cuireann -onlynet cosc ​​ar naisc le IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=1: '%s' (ní mór an táille sealaíochta nóiméad de %s a bheith ann ar a laghad chun idirbhearta bhfostú a chosc)</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <translation type="unfinished">Naisc amach teoranta do CJDNS (-onlynet=cjdns) ach ní chuirtear -cjdnsreachable ar fáil</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Tá naisc amach teoranta do Tor (-onlynet=onion) ach tá cosc ​​sainráite ar an seachfhreastalaí chun líonra Tor a bhaint amach: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Naisc amach teoranta do Tor (-onlynet=onion) ach ní thugtar an seachfhreastalaí chun líonra Tor a bhaint amach: ní thugtar aon seachfhreastalaí, -oinniún nó -listenonion</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <translation type="unfinished">Tá naisc amach teoranta do i2p (-onlynet=i2p) ach ní chuirtear -i2psam ar fáil</translation>
+    </message>
+    <message>
+        <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
+        <translation type="unfinished">Sáraíonn méid an ionchuir an t-uasmheáchan. Bain triail as méid níos lú a sheoladh nó UTXO do sparán a chomhdhlúthú de láimh</translation>
+    </message>
+    <message>
+        <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <translation type="unfinished">Ní chlúdaíonn méid iomlán na monaí réamhroghnaithe sprioc an idirbhirt. Ceadaigh le do thoil ionchuir eile a roghnú go huathoibríoch nó cuir níos mó bonn san áireamh de láimh</translation>
+    </message>
+    <message>
+        <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
+        <translation type="unfinished">Éilíonn an t-idirbheart ceann scríbe amháin de luach neamh-0, táille neamh-0, nó ionchur réamhroghnaithe</translation>
+    </message>
+    <message>
+        <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
+        <translation type="unfinished">Theip ar bhailíochtú a dhéanamh ar achomair UTXO. Atosaigh chun gnáthíoslódáil na mbloc tosaigh a atosú, nó bain triail as pictiúr eile a lódáil.</translation>
+    </message>
+    <message>
+        <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
+        <translation type="unfinished">Tá UTXOanna neamhdheimhnithe ar fáil, ach cruthaítear slabhra idirbheart a ndiúltóidh an mempool dóibh má dhéantar iad a chaitheamh</translation>
+    </message>
+    <message>
+        <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
+
+The wallet might have been tampered with or created with malicious intent.
+</source>
+        <translation type="unfinished">Fuarthas iontráil oidhreachta gan choinne sa sparán tuairisceora. Sparán %s á lódáil
+
+Seans gur cuireadh isteach ar an sparán nó gur cruthaíodh é le hintinn mhailíseach.</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Tuairisceoir neamhaitheanta aimsithe. Sparán %s á lódáil
+
+Seans gur cruthaíodh an sparán ar leagan níos nuaí.
+Bain triail as an leagan bogearraí is déanaí a rith.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Ní féidir an t-imirce theip a ghlanadh</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Ní féidir cúltaca an sparán a chur ar ais.</translation>
+    </message>
+    <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">Cuireadh isteach ar an bhfíorú blocála</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -3229,6 +4449,18 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Lódáil déanta</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Níl an comhad dumpála %s ann.</translation>
+    </message>
+    <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">Earráid agus db txn á dhéanamh chun idirbhearta sparán a bhaint</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Earráid cruthaithe %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">Earráid ag túsú bunachar sonraí bloic</translation>
     </message>
@@ -3261,16 +4493,112 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Earráid ag oscailt bunachar sonraí bloic</translation>
     </message>
     <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Earráid agus an comhad cumraíochta á léamh: %s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Earráid ag léamh ón mbunachar sonraí, ag múchadh.</translation>
+    </message>
+    <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Earráid agus an chéad taifead eile á léamh ón mbunachar sonraí sparán</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">Earráid agus db txn á thosú chun idirbhearta sparán a bhaint</translation>
+    </message>
+    <message>
+        <source>Error: Cannot extract destination from the generated scriptpubkey</source>
+        <translation type="unfinished">Earráid: Ní féidir an ceann scríbe a bhaint as an scriptpubkey ginte</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir an cúrsóir a chruthú sa bhunachar sonraí</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Earráid: Tá spás ar diosca íseal do %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Earráid: Ní hionann seiceála Dumpfile. Ríomh %s, bhíothas ag súil le %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Earráid: Theip ar chruthú sparán faire amháin nua</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Earráid: Fuair ​​​​tú eochair nach heicsidheachúlach í: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Earráid: Fuair ​​tú luach nach heicsidheachúlach é: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Earráid: Rith keypool amach, glaoigh ar keypoolrefill ar dtús</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Earráid: Seiceáil in easnamh</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Earráid: Níl seoladh %s ar fáil.</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Earráid: Úsáideann an sparán seo SQLite cheana féin</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Earráid: Is sparán tuairisceora é an sparán seo cheana féin</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Earráid: Ní féidir tosú ag léamh gach taifead sa bhunachar sonraí</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Earráid: Ní féidir cúltaca a dhéanamh de do sparán</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Earráid: Ní féidir leagan%u a pharsáil mar uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Earráid: Ní féidir gach taifead sa bhunachar sonraí a léamh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read wallet's best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr sa sparán a léamh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Earráid: Ní féidir sonraí leabhar seoltaí faire amháin a bhaint</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Earráid: Ní féidir taifead a scríobh chuig an sparán nua</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write solvable wallet best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr ar an sparán intuaslagtha a scríobh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write watchonly wallet best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr le sparán faire amháin a scríobh</translation>
+    </message>
+    <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Earráid: theip ar chóip leabhar seoltaí do sparán %s</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">Earráid: ní féidir idirbheart bunachar sonraí a chur i gcrích le haghaidh sparán %s</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3281,8 +4609,16 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Theip athscanadh ar an sparán le linn túsúchán</translation>
     </message>
     <message>
+        <source>Failed to start indexes, shutting down..</source>
+        <translation type="unfinished">Theip ar thús a chur leis na hinnéacsanna, dúnadh.</translation>
+    </message>
+    <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Theip ar fhíorú an mbunachar sonraí</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Teip ag baint an idirbhirt: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -3293,6 +4629,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Neamhaird ar sparán dhúbailt %s.</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Á iompórtáil…</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">Bloc geineasas mícheart nó ní aimsithe. datadir mícheart don líonra?</translation>
     </message>
@@ -3301,8 +4641,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Theip ar seiceáil slánchiall túsúchán. Tá %s ag múchadh.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Ionchur gan aimsiú nó caite cheana féin</translation>
+    </message>
+    <message>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished">Dbcache neamhleor le haghaidh fíorú blocála</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Neamhleor ciste</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Seoladh neamhbhailí -i2psam nó óstainm: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3317,6 +4669,14 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Cead neamhbhailí P2P: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=1: '%s' (ar a laghad %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=&lt;amount&gt;: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Suim neamhbhailí do -%s=&lt;amount&gt;: '%s'</translation>
     </message>
@@ -3325,12 +4685,60 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Mascghréas neamhbhailí sonraithe sa geal-liosta: '%s'</translation>
     </message>
     <message>
+        <source>Invalid port specified in %s: '%s'</source>
+        <translation type="unfinished">Port neamhbhailí sonraithe i %s: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished">Ionchur réamhroghnaithe %s neamhbhailí</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Theip ar éisteacht le naisc isteach (éisteacht ar ais earráid %s)</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Seoltaí P2P á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Liosta toirmeasc á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Innéacs bloc á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Sparán á lódáil…</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Méid ar iarraidh</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Sonraí réitigh ar iarraidh le haghaidh meastachán a dhéanamh ar mhéid an idirbhirt</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Is gá port a shainiú le -whitebind: '%s'</translation>
     </message>
     <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">Níl aon seoltaí ar fáil</translation>
+    </message>
+    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Níl dóthain tuairisceoirí comhaid ar fáil.</translation>
+    </message>
+    <message>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished">Níor aimsíodh ionchur réamhroghnaithe %s</translation>
+    </message>
+    <message>
+        <source>Not solvable pre-selected input %s</source>
+        <translation type="unfinished">Ní féidir ionchur réamhroghnaithe %s a réiteach</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -3341,8 +4749,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Tá an mód bearrtha neamh-chomhoiriúnach le -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Blocsiopa á bhearradh…</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Laghdú -maxconnections ó %d go %d, mar gheall ar shrianadh an chórais.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Bloic á n-athsheinn…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Á athscanadh…</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3385,8 +4805,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níl eolaire bloic shonraithe "%s" ann.</translation>
     </message>
     <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Níl comhadlann sonraí sonraithe "%s" ann.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Snáitheanna líonra á dtosú…</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Tá an cód foinseach ar fáil ó %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Níl an comhad cumraíochta sonraithe %s ann</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3409,6 +4841,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Seo an táille idirbhirt a íocfaidh tú má sheolann tú idirbheart.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Ní bhaineann an t-idirbheart %s leis an sparán seo</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Méid an idirbhirt ró-bheag</translation>
     </message>
@@ -3417,12 +4853,24 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níor cheart go mbeadh suimeanna idirbhirt diúltach</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Innéacs aschuir athraithe idirbhirt as raon</translation>
+    </message>
+    <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Caithfidh ar a laghad faighteoir amháin a bheith ag idirbheart</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Teastaíonn seoladh athraithe ón idirbheart, ach ní féidir linn é a ghiniúint.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Idirbheart ró-mhór</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Ní féidir cuimhne a leithdháileadh le haghaidh -maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -3437,6 +4885,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níorbh fhéidir cruthú comhad PID '%s': %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Ní féidir UTXO a aimsiú le haghaidh ionchur seachtrach</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Ní féidir eochracha tosaigh a ghiniúint</translation>
     </message>
@@ -3445,8 +4897,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir eochracha a ghiniúint</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Ní féidir %s a oscailt chun scríobh</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Ní féidir a pharsáil -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Ní féidir freastalaí HTTP a thosú. Féach loga dífhabhtúcháin le tuilleadh sonraí.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Ní féidir an sparán a dhíluchtú roimh aistriú</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -3465,16 +4929,56 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Líonra anaithnid sonraithe san -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Rialacha nua anaithnid curtha i ngníomh (leagan giotán %ii)</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
+        <translation type="unfinished">Leibhéal logála domhanda nach dtacaítear leis %s=%s. Luachanna bailí: %s.</translation>
+    </message>
+    <message>
+        <source>Wallet file creation failed: %s</source>
+        <translation type="unfinished">Theip ar chruthú comhaid sparán: %s</translation>
+    </message>
+    <message>
+        <source>acceptstalefeeestimates is not supported on %s chain.</source>
+        <translation type="unfinished">ní thacaítear le acceptstalefeeestimates ar slabhra %s.</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Catagóir logáil gan tacaíocht %s=%s.</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir watch amháin tx %s a chur le sparán faire amháin</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir idirbhearta faire amháin a scriosadh.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Tá carachtair neamhshábháilte i nóta tráchta (%s) Gníomhaire Úsáideora.</translation>
     </message>
     <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Bloic á bhfíorú…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Sparán(aí) á fhíorú…</translation>
+    </message>
+    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation type="unfinished">Ba ghá an sparán a athscríobh: atosaigh %s chun críochnú</translation>
     </message>
-    </context>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Níorbh fhéidir an comhad socruithe a léamh</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Níorbh fhéidir an comhad socruithe a scríobh</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_ga_IE.ts
+++ b/src/qt/locale/bitcoin_ga_IE.ts
@@ -211,8 +211,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Bhí an pasfhrása iontráilte le haghaidh díchriptiú an sparán mícheart.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">Tá an pasfhrása a iontráladh le haghaidh díchriptithe an sparán mícheart. Tá carachtar nialasach ann (ie - beart nialasach). Má socraíodh an pasfhrása le leagan den bhogearra seo roimh 25.0, bain triail eile as gan ach na carachtair suas go dtí — ach gan a bheith san áireamh — an chéad charachtar null. Má éiríonn leis seo, socraigh pasfhrása nua le do thoil chun an cheist seo a sheachaint amach anseo.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Athraíodh pasfhrása sparán go rathúil.</translation>
+    </message>
+    <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">Theip ar athrú pasfhocail</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Tá an seanphasfhrása a cuireadh isteach le haghaidh díchriptithe an sparán mícheart. Tá carachtar nialasach ann (ie - beart nialasach). Má socraíodh an pasfhrása le leagan den bhogearra seo roimh 25.0, bain triail eile as gan ach na carachtair suas go dtí — ach gan a bheith san áireamh — an chéad charachtar null.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -233,19 +245,57 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Eisceacht runaway</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Tharla earráid mharfach. Ní féidir le %1 leanúint ar aghaidh go sábháilte agus scoirfidh sé.</translation>
     </message>
-    </context>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Earráid inmheánach</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Tharla earráid inmheánach. Déanfaidh %1 iarracht leanúint ar aghaidh go sábháilte. Is fabht gan choinne é seo ar féidir a thuairisciú mar a thuairiscítear thíos.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Ar mhaith leat socruithe a athshocrú go luachanna réamhshocraithe, nó deireadh a chur leis gan athruithe a dhéanamh?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Tharla earráid mharfach. Cinntigh go bhfuil an comhad socruithe inscríofa, nó bain triail as rith le -nosettings.</translation>
+    </message>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Earráid: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">Níor scoir %1 go sábháilte fós…</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">neamhaithnid</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Leabaithe "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Cló réamhshocraithe an chórais "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Saincheaptha…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -256,6 +306,16 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Iontráil seoladh Bitcoin (m.sh.%1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Dothreoraithe</translation>
+    </message>
+    <message>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <extracomment>Name of Tor network in peer info</extracomment>
+        <translation type="unfinished">Oinniún</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Isteach</translation>
@@ -264,6 +324,31 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
         <translation type="unfinished">Amach</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Sealaíocht Iomlán</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Sealaíocht Bloc</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">Lámhleabhar</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Fearacht</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Seoladh Fetch</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -288,41 +373,41 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n soicind(í)</numerusform>
+            <numerusform>%n soicind(í)</numerusform>
+            <numerusform>%n soicind(í)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n nóiméad(a)</numerusform>
+            <numerusform>%n nóiméad(a)</numerusform>
+            <numerusform>%n nóiméad(a)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n uair(eanta)</numerusform>
+            <numerusform>%n uair(eanta)</numerusform>
+            <numerusform>%n uair(eanta)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n lá(/a)</numerusform>
+            <numerusform>%n lá(/a)</numerusform>
+            <numerusform>%n lá(/a)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n seachtain(/a)</numerusform>
+            <numerusform>%n seachtain(/a)</numerusform>
+            <numerusform>%n seachtain(/a)</numerusform>
         </translation>
     </message>
     <message>
@@ -332,9 +417,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n bliain(/a)</numerusform>
+            <numerusform>%n bliain(/a)</numerusform>
+            <numerusform>%n bliain(/a)</numerusform>
         </translation>
     </message>
     </context>
@@ -381,6 +466,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cruthaigh sparán nua</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Íoslaghdaigh</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Sparán:</translation>
     </message>
@@ -414,16 +503,60 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Glac</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Roghanna…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Criptigh Sparán…</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Criptigh na heochracha príobháideacha a bhaineann le do sparán</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Sparán Cúltaca…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Athraigh Pasfhocal…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Sínigh &amp;teachtaireacht…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Sínigh teachtaireachtaí le do sheoltaí Bitcoin chun a chruthú gur leat iad</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Fíoraigh teachtaireacht…</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Teachtaireachtaí a fhíorú lena chinntiú go raibh siad sínithe le seoltaí sainithe Bitcoin</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Lódáil PSBT ón gcomhad…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Oscail &amp;URI…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Dún Sparán…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Cruthaigh Sparán…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Dún Gach Sparán…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -440,6 +573,26 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Barra uirlisí cluaisíní</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Ceanntásca á Sioncronú (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Ag sioncronú le líonra…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Bloic á n-innéacsú ar an diosca…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bloic ar diosca á bpróiseáil…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Ag nascadh le piaraí…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -460,14 +613,18 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
+            <numerusform>Próiseáladh %n bloc de stair na n-idirbheart.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 taobh thiar</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ag teacht suas…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -496,6 +653,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Lódáil Idirbheart Bitcoin Sínithe go Páirteach</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Luchtaigh PSBT ón &amp;gearrthaisce…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -534,8 +695,26 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Dún sparán</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Athchóirigh sparán ó chomhad cúltaca</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Dún gach sparán</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Imirce Sparán</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">Imirce sparán</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
@@ -558,6 +737,21 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Níl aon sparán ar fáil</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Sonraí Sparán</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Luchtaigh Cúltaca Sparán</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán</translation>
+    </message>
+    <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
         <translation type="unfinished">Ainm Sparán</translation>
@@ -578,14 +772,54 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>%1 client</source>
         <translation type="unfinished">%1 cliaint</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Folaigh</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">S&amp;conas</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
+            <numerusform>%n nasc(í) gníomhacha le líonra Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Cliceáil le haghaidh tuilleadh gníomhartha.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Taispeáin cluaisín Piaraí</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Díchumasaigh gníomhaíocht líonra</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Cumasaigh gníomhaíocht líonra</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Ceanntásca a réamhshioncronú (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Earráid agus sparán á chruthú</translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Ní féidir sparán nua a chruthú, tiomsaíodh na bogearraí gan tacaíocht sqlite (riachtanach le haghaidh sparán tuairisceora)</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -742,6 +976,30 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil suim</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Cóipeáil idirbheart &amp; ID agus innéacs aschuir</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ocáil neamhchaite</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Díghlasáil neamhchaite</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Cóipeáil méid</translation>
     </message>
@@ -802,7 +1060,79 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Rabhadh cruthú  sparán</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Ní féidir sínitheoirí a liostú</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Fuarthas an iomarca sínitheoirí seachtracha</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Luchtaigh Sparán</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Sparán á lódáil…</translation>
+    </message>
+</context>
+<context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Imirce sparán</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">An bhfuil tú cinnte gur mian leat an sparán &lt;i&gt;%1 &lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
+If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
+If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
+
+The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
+        <translation type="unfinished">Má dhéantar an sparán a aistriú, déanfar an sparán seo a thiontú go sparán tuairisceora amháin nó níos mó. Beidh gá le cúltaca sparán nua.
+Má tá aon scripteanna faire amháin sa sparán seo, cruthófar sparán nua ina mbeidh na scripteanna faire amháin sin.
+Má tá aon scripteanna intuaslagtha ach nach bhfuil faire orthu sa sparán seo, cruthófar sparán difriúil agus nua ina mbeidh na scripteanna sin.
+
+Cruthóidh an próiseas imirce cúltaca den sparán roimh imirce. Ainmneofar an comhad cúltaca seo &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak agus is féidir é a fháil san eolaire don sparán seo. I gcás imirce mícheart, is féidir an cúltaca a chur ar ais leis an bhfeidhmiúlacht "Athchóirigh Sparán".</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Imirce Sparán</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Sparán á Ascnamh &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">D'éirigh le haistriú an sparán '%1'.</translation>
+    </message>
+    <message>
+        <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Aistríodh scripteanna faire amháin go sparán nua darb ainm '%1'.</translation>
+    </message>
+    <message>
+        <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Aistríodh scripteanna intuaslagtha ach nach bhfuiltear ag faire orthu go sparán nua darb ainm '%1'.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">Theip ar an imirce</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">D'éirigh leis an Imirce</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -822,7 +1152,40 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Oscail Sparán</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Sparán Oscailte&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Athchóirigh Sparán</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Sparán á Athchóiriú&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Theip ar athchóiriú an sparán</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Athchóirigh rabhadh sparán</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Athchóirigh teachtaireacht sparán</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -851,6 +1214,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Cruthaigh Sparán</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Tá tú céim amháin ar shiúl ó chruthú do sparán nua!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Tabhair ainm le do thoil agus, más mian leat, cumasaigh aon ardroghanna</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -889,10 +1260,23 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Déan Sparán Glan</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Bain úsáid as gléas sínithe seachtrach cosúil le sparán crua-earraí. Cumraigh an script sínitheora sheachtraigh i sainroghanna an sparán ar dtús.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Sínitheoir seachtrach</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Cruthaigh</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tiomsaithe gan tacaíocht sínithe seachtrach (riachtanach le haghaidh síniú seachtrach)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -972,9 +1356,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB de spás ar fáil</numerusform>
+            <numerusform>%n GB de spás ar fáil</numerusform>
+            <numerusform>%n GB de spás ar fáil</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -994,6 +1378,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         </translation>
     </message>
     <message>
+        <source>Choose data directory</source>
+        <translation type="unfinished">Roghnaigh eolaire sonraí</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Ar a laghad stórálfar %1 GB de shonraí  sa comhadlann seo, agus fásfaidh sé le himeacht ama.</translation>
     </message>
@@ -1005,9 +1393,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
+            <numerusform>(leor chun cúltacaí a aischur %n lá(laethanta) d'aois)</numerusform>
         </translation>
     </message>
     <message>
@@ -1039,12 +1427,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Mar gurb é seo an chéad uair a lainseáil an clár, is féidir leat a roghnú cá stórálfaidh %1 a chuid sonraí.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Teorainn a chur le blocshlabhra stórála go</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Teastaíonn an blocshlabhra iomlán a íoslódáil arís chun an socrú seo a fhilleadh. Tá sé níos sciobtha an slabhra iomlán a íoslódáil ar dtús agus é a bhearradh níos déanaí. Díchumasaíodh roinnt ardgnéithe.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Tá an sioncrónú tosaigh seo an-dhian, agus d’fhéadfadh sé fadhbanna crua-earraí a nochtadh le do ríomhaire nach tugadh faoi deara roimhe seo. Gach uair a ritheann tú %1, leanfaidh sé ar aghaidh ag íoslódáil san áit ar fhág sé as.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Nuair a chliceálann tú OK, tosóidh %1 ag íosluchtú agus ag próiseáil slabhra iomlán %4 (%2 GB) ag tosú leis na hidirbhearta is luaithe i %3 nuair a seoladh %4 ar dtús.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1077,6 +1473,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">Tá %1 ag múchadh…</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Ná múch an ríomhaire go dtí go n-imíonn an fhuinneog seo.</translation>
     </message>
@@ -1098,6 +1498,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">Líon na mbloic fágtha</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Anaithnid…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">ag ríomh…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1123,7 +1531,15 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">Tá %1 ag sioncronú faoi láthair. Déanfaidh sé é a íoslódáil agus a fíorú ar ceanntásca agus bloic ó phiaraí go dtí barr an blocshlabhra.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Anaithnid. Ceanntásca á Sioncronú (%1, %2 %)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Anaithnid. Ceanntásca a Réamhshioncronú (%1, %2 %)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1155,12 +1571,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Tosaigh %1 ar logáil isteach an chórais</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Laghdaítear go mór an spás diosca a theastaíonn chun idirbhearta a stóráil má dhéantar bearradh a chumasú. Tá gach bloc fós bailíochtaithe go hiomlán. Chun an socrú seo a thabhairt ar ais ní mór an blockchain iomlán a athíoslódáil.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Méid taisce &amp;bunachar sonraí</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished">Líon snáitheanna &amp;fíorú scripte</translation>
+    </message>
+    <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Conair iomlán chuig script comhoiriúnach %1 (m.sh. C:\Downloads\hwi.exe nó /Users/you/Downloads/hwi.py). Tabhair aire: is féidir le malware do bhoinn a ghoid!</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
@@ -1173,6 +1597,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Íoslaghdaigh in ionad scoir an feidhmchlár nuair a bhíonn an fhuinneog dúnta. Nuair a chumasófar an rogha seo, ní dhúnfar an feidhmchlár ach amháin tar éis Scoir a roghnú sa roghchlár.</translation>
+    </message>
+    <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Cló sa chluaisín Forbhreathnú:</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Tá na roghanna atá socraithe sa dialóg seo sáraithe ag an líne ordaithe:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1203,12 +1635,42 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Teastaíonn an blocshlabhra iomlán a íoslódáil arís chun an socrú seo a fhilleadh.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Uasmhéid taisce bunachar sonraí. Is féidir le taisce níos mó cur le sioncrónú níos tapúla, agus ina dhiaidh sin ní bhíonn an tairbhe chomh soiléir don chuid is mó de chásanna úsáide. Laghdófar úsáid chuimhne má laghdaítear méid an taisce. Roinntear cuimhne mempool neamhúsáidte don taisce seo.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Socraigh líon na snáitheanna fíoraithe scripte. Freagraíonn luachanna diúltacha do líon na gcroíthe is mian leat a fhágáil saor sa chóras.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = uath, &lt;0 = fág an méid sin cóir saor)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Ligeann sé seo duit féin nó d’uirlis tríú páirtí cumarsáid a dhéanamh leis an nód trí orduithe ordú-líne agus JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Cumasaigh freastalaí R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Sp&amp;arán</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Cibé an táille a dhealú ón méid a shocrú mar réamhshocrú nó nach bhfuil.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Dealaigh &amp;táille ón méid de réir réamhshocraithe</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1227,12 +1689,38 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Caith &amp;sóinseáil neamhdheimhnithe</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Cumasaigh &amp; rialuithe PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Cibé ar cheart rialuithe PSBT a thaispeáint.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Sínitheoir Seachtrach (m.sh. sparán crua-earraí)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Conair scripte sínithe seachtraí</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Oscail port cliant Bitcoin go huathoibríoch ar an ródaire. Ní oibríonn sé seo ach nuair a thacaíonn do ródaire le UPnP agus nuair a chumasaítear é.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Mapáil port ag úsáid &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Oscail calafort cliant Bitcoin go huathoibríoch ar an ródaire. Ní oibríonn sé seo ach amháin nuair a thacaíonn do ródaire le NAT-PMP agus go bhfuil sé cumasaithe. D'fhéadfadh an port seachtrach a bheith randamach.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Port léarscáil le NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1267,6 +1755,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Fuinneog</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Taispeáin an deilbhín i dtráidire an chórais.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Taispeáin íocón an tráidire</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Ná taispeáin ach deilbhín tráidire t'éis an fhuinneog a íoslaghdú.</translation>
     </message>
@@ -1299,6 +1795,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Roghnaigh an t-aonad foroinnte réamhshocraithe le taispeáint sa chomhéadan agus nuair a sheoltar boinn.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URLanna tríú páirtí (m.sh. taiscéalaí bloc) atá le feiceáil sa chluaisín idirbheart mar mhíreanna roghchláir comhthéacs. Cuirtear hais idirbhirt in ionad%s sa URL. Déantar URLanna iolracha a dheighilt le barra ingearach |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URLanna idirbheart tríú páirtí</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Gnéithe rialúchán bonn a thaispeáint nó nach.</translation>
     </message>
@@ -1319,6 +1823,11 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">&amp;Cealaigh</translation>
     </message>
     <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tiomsaithe gan tacaíocht sínithe seachtrach (riachtanach le haghaidh síniú seachtrach)</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation type="unfinished">réamhshocrú</translation>
     </message>
@@ -1337,6 +1846,11 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Atosú cliant ag teastáil chun athruithe a ghníomhachtú.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Déanfar cúltaca de na socruithe reatha ag "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Múchfar an cliant. Ar mhaith leat dul ar aghaidh?</translation>
@@ -1350,6 +1864,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Úsáidtear an comhad cumraíochta chun ardroghanna úsáideora a shonrú a sháraíonn socruithe GUI. Freisin, sáróidh aon roghanna líne na n-orduithe an comhad cumraíochta seo.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Leanúint ar aghaidh</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1370,6 +1888,13 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Tá an seoladh seachfhreastalaí soláthartha neamhbhailí.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Níorbh fhéidir socrú "%1", %2 a léamh.</translation>
     </message>
 </context>
 <context>
@@ -1454,6 +1979,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>PSBT Operations</source>
+        <translation type="unfinished">Oibríochtaí PSBT</translation>
+    </message>
+    <message>
         <source>Sign Tx</source>
         <translation type="unfinished">Sínigh Tx</translation>
     </message>
@@ -1466,6 +1995,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil chuig Gearrthaisce</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Sábháil…</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Dún</translation>
     </message>
@@ -1476,6 +2009,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Failed to sign transaction: %1</source>
         <translation type="unfinished">Theip ar síniú idirbheart: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Ní féidir ionchuir a shíniú agus an sparán glasáilte.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -1510,8 +2047,17 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Sábháil Sonraí Idirbheart</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Idirbheart Páirt-Sínithe (Dénártha)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">IBSP sábháilte ar dhiosca.</translation>
+    </message>
+    <message>
+        <source>Sends %1 to %2</source>
+        <translation type="unfinished">Seoltar %1 go %2</translation>
     </message>
     <message>
         <source>own address</source>
@@ -1544,6 +2090,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">Tá síni(ú/the) fós ag teastáil ón idirbheart.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ach níl aon sparán luchtaithe.)</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -1581,6 +2131,14 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ní URI bailí é 'bitcoin://'. Úsáid 'bitcoin:' ina ionad.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Ní féidir iarratas íocaíochta a phróiseáil toisc nach dtacaítear le BIP70.
+De bharr lochtanna slándála forleathan in BIP70, moltar go láidir neamhaird a dhéanamh d’aon treoracha ceannaithe chun sparán a athrú.
+Má tá an earráid seo á fáil agat ba cheart duit iarraidh ar an díoltóir URI atá comhoiriúnach le BIP21 a sholáthar.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">Ní féidir URI a pharsáil! Is féidir le seoladh neamhbhailí Bitcoin nó paraiméadair URI drochfhoirmithe a bheith mar an chúis.</translation>
     </message>
@@ -1595,6 +2153,16 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Gníomhaire Úsáideora</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Piaraí</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Aois</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -1640,6 +2208,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Sábháil Íomhá…</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Cóipeáil Íomhá</translation>
     </message>
@@ -1659,7 +2231,12 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Save QR Code</source>
         <translation type="unfinished">Sabháil cód QR.</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">Íomhá PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1759,8 +2336,32 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Roghnaigh piara chun faisnéis mhionsonraithe a fheiceáil.</translation>
     </message>
     <message>
+        <source>The transport layer version: %1</source>
+        <translation type="unfinished">Leagan na sraithe iompair: %1</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation type="unfinished">Iompar</translation>
+    </message>
+    <message>
+        <source>The BIP324 session ID string in hex, if any.</source>
+        <translation type="unfinished">Teaghrán ID an tseisiúin BIP324 i heicsidheachúlach, más ann dó.</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">Aitheantas an tseisiúin</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Leagan</translation>
+    </message>
+    <message>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished">Cibé an ndéanaimid idirbhearta a athsheoladh chuig an bpiaraí seo.</translation>
+    </message>
+    <message>
+        <source>Transaction Relay</source>
+        <translation type="unfinished">Leaschraolacháin Idirbheart</translation>
     </message>
     <message>
         <source>Starting Block</source>
@@ -1775,12 +2376,46 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Bloic Sioncronaithe</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Idirbheart Deiridh</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">An Córas Uathrialach mapáilte a úsáidtear chun roghnú piaraí a éagsúlú.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">CU Mapáilte</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Cibé an gcuirfimid seoltaí chuig an bpiaraí seo.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Sealaíocht Seoladh</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Líon iomlán na seoltaí a fuarthas ón bpiaraí seo a próiseáladh (ní áirítear seoltaí a laghdaíodh mar gheall ar theorannú rátaí).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Líon iomlán na seoltaí a fuarthas ón bpiaraí seo a thit (nár próiseáladh) mar gheall ar theorannú rátaí.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Seoltaí Próiseáilte</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Seoltaí Ráta-Teoranta</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -1811,12 +2446,45 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ceadanna</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Treo agus cineál an naisc phiara: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Treo/Cineál</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">An prótacal líonra a bhfuil an piara seo ceangailte trí: IPv4, IPv6, Oinniún, I2P, nó CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Seirbhísí</translation>
     </message>
     <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Bandaleithead ard BIP152 sealaíochta bloc dhlúth: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Bandaleithid Ard</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Am Ceangail</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tá achar ama caite ó fuarthas bloc úrscéil a rinne na seiceálacha bailíochta tosaigh ón gcomhghleacaí seo.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Bloc Deireanach</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Chuaigh an t-am caite ó fuarthas idirbheart úrnua a glacadh isteach inár mempool ón bpiaraí seo.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1883,6 +2551,68 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Amach:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Isteach: arna thionscnamh ag piaraí</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Sealaíocht Iomlán Amach: réamhshocraithe</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Leaschraolacháin Bloc Amach: ní athsheoltar idirbhearta ná seoltaí</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Lámhleabhar Amach: curtha leis ag úsáid roghanna cumraíochta RPC %1 nó %2/ %3</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Feeler Amach: gearrthéarmach, le haghaidh seoltaí tástála</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Faigh Seoladh Amach: gearrthéarmach, chun seoltaí a lorg</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">bhrath: d’fhéadfadh v1 nó v2 a bheith i gcomhghleacaí</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: prótacal iompair gnáththéacs gan chriptiú</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: BIP324 prótacal iompair criptithe</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">roghnaigh muid an piaraí le haghaidh sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">roghnaigh an piaraí sinn le haghaidh sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">níor roghnaíodh aon sealaíochta bandaleithead ard</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Scaoil</translation>
     </message>
@@ -1891,12 +2621,21 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">1 &amp;uair</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 l&amp;á</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;seachtain</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;bhliain</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Cóipeáil IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -1911,8 +2650,38 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Ag rith ordú gan aon sparán</translation>
     </message>
     <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">Fuinneog nód - [%1]</translation>
+    </message>
+    <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Ag rith ordú ag úsáid sparán "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Fáilte go consól RPC %1.
+Úsáid saigheada suas agus síos chun an stair a nascleanúint, agus %2 chun an scáileán a ghlanadh.
+Úsáid %3 agus %4 chun an clómhéid a mhéadú nó a laghdú.
+Clóscríobh %5 le haghaidh forbhreathnú ar na horduithe atá ar fáil.
+Chun tuilleadh eolais a fháil faoin gconsól seo a úsáid, clóscríobh %6.
+
+%7 RABHADH: Bhí scamadóirí gníomhach, ag rá le húsáideoirí orduithe a chlóscríobh anseo, ag goid a n-inneachar sparán. Ná húsáid an consól seo gan iarmhairtí ordaithe a thuiscint go hiomlán.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Ag rith…</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(piara: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -1937,6 +2706,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Cosc do</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Riamh</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2018,6 +2791,46 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Cóipeáil &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Cóipeáil &amp; teachtaireacht</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Bonn58 (Oidhreacht)</translation>
+    </message>
+    <message>
+        <source>Not recommended due to higher fees and less protection against typos.</source>
+        <translation type="unfinished">Ní mholtar mar gheall ar tháillí níos airde agus cosaint níos lú i gcoinne typos.</translation>
+    </message>
+    <message>
+        <source>Base58 (P2SH-SegWit)</source>
+        <translation type="unfinished">Base58 (P2SH- SegWit)</translation>
+    </message>
+    <message>
+        <source>Generates an address compatible with older wallets.</source>
+        <translation type="unfinished">Gineann seoladh atá comhoiriúnach le sparán níos sine.</translation>
+    </message>
+    <message>
+        <source>Generates a native segwit address (BIP-173). Some old wallets don't support it.</source>
+        <translation type="unfinished">Gineann sé seoladh segwit dúchais (BIP-173). Ní thacaíonn roinnt sean-sparán leis.</translation>
+    </message>
+    <message>
+        <source>Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
+        <translation type="unfinished">Is uasghrádú é Bech32m (BIP-350) go Bech32, tá tacaíocht sparán fós teoranta.</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Níorbh fhéidir sparán a dhíghlasáil.</translation>
     </message>
@@ -2028,6 +2841,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Iarr íocaíocht chuig…</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Seoladh:</translation>
@@ -2055,6 +2872,18 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Cóipeáil &amp;Seoladh</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Fíoraigh</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Fíoraigh an seoladh seo ar e.g. scáileán sparán crua-earraí</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Sábháil Íomhá…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2187,8 +3016,24 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Glan gach réimse den fhoirm.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Ionchuir…</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Roghnaigh…</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Folaigh socruithe táillí idirbhirt</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Sonraigh táille shaincheaptha in aghaidh an kB (1,000 beart) de mhéid fíorúil an idirbhirt.
+
+Nóta: Ós rud é go ríomhtar an táille ar bhonn in aghaidh an bheart, ní thabharfadh ráta táille "100 satoshis in aghaidh an kvB" le haghaidh méid idirbhirt 500 beart fíorúil (leath de 1 kvB) táille ach 50 satoshis ar deireadh thiar.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2197,6 +3042,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">D’fhéadfadh idirbheart nach ndeimhnítear riamh a bheith mar thoradh ar tháille ró-íseal (léigh an leid uirlise)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Níor cuireadh tús leis an táille chliste go fóill. Tógann sé seo cúpla bloc de ghnáth...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2255,6 +3104,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">%1 (%2 bloic)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Sínigh ar an ngléas</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Ceangail do sparán crua-earraí ar dtús.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Socraigh cosán script sínitheora seachtrach i Roghanna -&gt; Sparán</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Cruthaigh Gan Sín</translation>
     </message>
@@ -2271,13 +3134,40 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">%1 go %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Chun liosta na bhfaighteoirí a athbhreithniú cliceáil "Taispeáin Sonraí…"</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Theip ar an síniú</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Níor aimsíodh sínitheoir seachtrach</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Teip sínitheora sheachtraigh</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Sábháil Sonraí Idirbheart</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Idirbheart Páirt-Sínithe (Dénártha)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
         <translation type="unfinished">IBSP sábháilte</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Iarmhéid seachtrach:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2291,6 +3181,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">Le do thoil, déan athbhreithniú ar do thogra idirbhirt. Tabharfaidh sé seo Idirbheart Bitcoin Sínithe go Páirteach (IBSP) ar féidir leat a shábháil nó a chóipeáil agus a shíniú ansin le m.sh. sparán as líne %1, nó sparán crua-earraí atá comhoiriúnach le IBSP.</translation>
+    </message>
+    <message>
+        <source>%1 from wallet '%2'</source>
+        <translation type="unfinished">%1 ó sparán '%2'</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Ar mhaith leat an t-idirbheart seo a chruthú?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Le do thoil, athbhreithnigh d'idirbheart. Is féidir leat an t-idirbheart seo a chruthú agus a sheoladh nó Idirbheart Bitcoin Páirt-Sínithe (PSBT) a chruthú, ar féidir leat a shábháil nó a chóipeáil agus a shíniú ansin le, m.sh., sparán %1 as líne, nó sparán crua-earraí PSBT-comhoiriúnach.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2308,6 +3212,20 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Total Amount</source>
         <translation type="unfinished">Iomlán</translation>
+    </message>
+    <message>
+        <source>Unsigned Transaction</source>
+        <comment>PSBT copied</comment>
+        <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
+        <translation type="unfinished">Idirbheart Gan Sínithe</translation>
+    </message>
+    <message>
+        <source>The PSBT has been copied to the clipboard. You can also save it.</source>
+        <translation type="unfinished">Tá an PSBT cóipeáilte chuig an ngearrthaisce. Is féidir leat é a shábháil freisin.</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk</source>
+        <translation type="unfinished">PSBT sábháilte ar diosca</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -2348,9 +3266,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
+            <numerusform>Meastar go dtosóidh an deimhniú laistigh de %n bloc(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -2588,11 +3506,32 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(brúigh q chun múchadh agus lean ar aghaidh ar ball)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">brúigh q chun múchadh</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">faoi choimhlint le idirbheart le %1 dearbhuithe</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/neamhdhearbhaithe, i linn cuimhne</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/neamhdhearbhaithe, ní sa linn cuimhne</translation>
     </message>
     <message>
         <source>abandoned</source>
@@ -2656,9 +3595,9 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
+            <numerusform>aibíonn i %n bloc(anna) eile</numerusform>
         </translation>
     </message>
     <message>
@@ -2708,6 +3647,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Output index</source>
         <translation type="unfinished">Innéacs aschuir</translation>
+    </message>
+    <message>
+        <source>%1 (Certificate was not verified)</source>
+        <translation type="unfinished">%1 (Níor fíoraíodh an teastas)</translation>
     </message>
     <message>
         <source>Merchant</source>
@@ -2895,6 +3838,55 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Íosmhéid</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Raon…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Cóipeáil seoladh</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Cóipeáil &amp;lipéad</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Cóipeáil &amp; méid</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Cóipeáil idirbheart &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Cóipeáil &amp;amh-idirbheart</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Cóipeáil idirbheart agus sonraí iomlána</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Taispeáin sonraí idirbhirt</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Méadaigh idirbheart &amp; táille</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Idirbheart&amp;tréigean</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Cuir lipéad seolta in eagar</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Taispeáin i %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Easpórtáil Stair Idirbheart</translation>
     </message>
@@ -3023,6 +4015,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Táille nua:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Rabhadh: D’fhéadfadh sé seo an táille bhreise a íoc trí aschuir athraithe a laghdú nó trí ionchuir a chur leis, nuair is gá. Féadfaidh sé aschur athraithe nua a chur leis mura bhfuil ceann ann cheana. D'fhéadfadh na hathruithe seo príobháideacht a sceitheadh.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Dearbhaigh preab táille</translation>
     </message>
@@ -3035,12 +4031,21 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">IBSP cóipeáilte</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <comment>Fee-bump PSBT saved</comment>
+        <translation type="unfinished">Cóipeáladh chuig an ngearrthaisce</translation>
+    </message>
+    <message>
         <source>Can't sign transaction.</source>
         <translation type="unfinished">Ní féidir síniú idirbheart.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Níorbh fhéidir feidhmiú idirbheart</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Ní féidir an seoladh a thaispeáint</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3060,6 +4065,11 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Sparán Chúltaca</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Sonraí Sparán</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -3093,16 +4103,84 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Tá %s truaillithe. Triail an uirlis sparán bitcoin-wallet a úsáid chun tharrtháil nó chun cúltaca a athbhunú.</translation>
     </message>
     <message>
+        <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
+        <translation type="unfinished">Theip ar %s an staid snapshot -assumeutxo a bhailíochtú. Léiríonn sé seo fadhb crua-earraí, nó fabht sna bogearraí, nó droch-mhodhnú bogearraí a cheadaigh pictiúr neamhbhailí a luchtú. Mar thoradh air seo, stopfar an nód agus stopfaidh sé de úsáid a bhaint as staid ar bith a tógadh ar an seat, ag athshocrú airde an tslabhra ó%dgo%d. Ar an gcéad atosú eile, athchromfar ar an nód ag sioncronú ó %d gan úsáid a bhaint as sonraí seat. Tuairiscigh an teagmhas seo do %s lena n-áirítear conas a fuair tú an pictiúr. Fágfar an slabhrashlabhra neamhbhailí ar an diosca ar eagla go mbeadh sé ina chuidiú leis an tsaincheist ba chúis leis an earráid seo a dhiagnóisiú.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">Iarraidh %s éisteacht ar phort %u. Meastar go bhfuil an port seo "olc" agus dá bhrí sin ní dócha go nascfaidh piaraí ar bith leis. Féach doc/p2p-bad-ports.md le haghaidh sonraí agus liosta iomlán.</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Ní féidir an sparán a íosghrádú ó leagan %igo leagan%i. Leagan sparán gan athrú.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Ní féidir glas a fháil ar eolaire sonraí %s. Is dócha go bhfuil %s ag rith cheana.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Ní féidir sparán scoilte neamh-HD a uasghrádú ó leagan%igo leagan%i gan uasghrádú chun tacú le heochrach réamh-scoilte. Úsáid leagan %i nó níl aon leagan sonraithe.</translation>
+    </message>
+    <message>
+        <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Ní féidir spás diosca le haghaidh %sa chur san áireamh sna blocchomhaid. Stórálfar thart ar %u GB de shonraí san eolaire seo.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Dáilte faoin gceadúnas bogearraí MIT, féach na comhad atá in éindí %s nó %s</translation>
     </message>
     <message>
+        <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
+        <translation type="unfinished">Earráid agus an sparán á lódáil. Éilíonn Sparán go n-íoslódálfar bloic, agus ní thacaíonn bogearraí faoi láthair le sparán a luchtú agus bloic á n-íoslódáil as ord nuair a úsáidtear snapshots assumeutxo. Ba cheart go mbeadh Sparán in ann luchtú go rathúil nuair a shroicheann sioncronú nód an airde %s</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Earráid agus %s á léamh! Seans go bhfuil sonraí idirbhirt in easnamh nó mícheart. Sparán athscanadh.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Earráid agus%s á léamh! Seans go bhfuil sonraí idirbhirt in easnamh nó mícheart. Sparán athscanadh.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Earráid: Tá taifead aitheantóra Dumpfile mícheart. Fuair ​​​​tú "%s", bhíothas ag súil le "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Earráid: Ní thacaítear leis an leagan Dumpfile. Ní thacaíonn an leagan seo de bitcoin-sparán ach le leagan 1 dumpfiles. Fuair ​​​​tú dumpfile le leagan %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Earráid: Ní thacaíonn sparán oidhreachta ach na cineálacha seoltaí "oidhreacht", "p2sh-segwit", agus "bech32"</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
+        <translation type="unfinished">Earráid: Ní féidir tuairisceoirí a tháirgeadh don sparán oidhreachta seo. Bí cinnte pasfhrása an sparán a sholáthar má tá sé criptithe.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Tá comhad %s ann cheana. Má tá tú cinnte gurb é seo a theastaíonn uait, bog é as an mbealach ar dtús.</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Peers.dat neamhbhailí nó truaillithe (%s). Má chreideann tú gur fabht é seo, cuir in iúl do %s é le do thoil. Mar shruth oibre, is féidir leat an comhad (%s) a bhogadh as an mbealach (athainmnigh, bog nó scrios) chun ceann nua a chruthú ar an gcéad thús eile.</translation>
+    </message>
+    <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Tá níos mó ná seoladh ceangail oinniún amháin curtha ar fáil. Ag baint úsáide as %s don tseirbhís Tor oinniún a cruthaíodh go huathoibríoch.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh aon chomhad dumpála. Chun createfromdump a úsáid, ní mór -dumpfile=&lt;filename&gt; a sholáthar.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh aon chomhad dumpála. Chun Dumpáil a úsáid, ní mór -dumpfile=&lt;filename&gt;a sholáthar.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Níor soláthraíodh formáid comhaid sparán. Chun createfromdump a úsáid, ní mór -format=&lt;format&gt; a sholáthar.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3117,8 +4195,16 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Bearradh cumraithe faoi bhun an íosmhéid %d MiB. Úsáid uimhir níos airde le do thoil.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Níl an modh prúnaí ag luí le -reindex-chainstate. Úsáid lán-reindex ina ionad sin.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Bearradh: téann sioncrónú deireanach an sparán thar sonraí bearrtha. Ní mór duit -reindex (déan an blockchain iomlán a íoslódáil arís i gcás nód bearrtha)</translation>
+    </message>
+    <message>
+        <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
+        <translation type="unfinished">Theip ar athainmniú '%s' -&gt; '%s'. Ba cheart duit é seo a réiteach tríd an gcomhadlann achomair neamhbhailí %s a bhogadh nó a scriosadh de láimh, nó beidh an earráid chéanna agat arís ar an gcéad tosaithe eile.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -3161,12 +4247,40 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir bloic a aithrise. Beidh ort an bunachar sonraí a atógáil ag úsáid -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Cuireadh formáid comhaid sparán anaithnid "%s" ar fáil. Tabhair ceann de "bdb" nó "sqlite".</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
+        <translation type="unfinished">Leibhéal logála catagóir ar leith nach dtacaítear leis %1$s=%2$s. Bhíothas ag súil le %1$s=1:2. Catagóirí bailí: %3$s. Leibhéil loga bailí: %4$s.</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Aimsíodh formáid bhunachar sonraí chainstáit nach dtacaítear léi. Atosaigh le -reindex-chainstate. Déanfaidh sé seo an bunachar sonraí slabhrach a atógáil.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Sparán cruthaithe go rathúil. Tá an cineál sparán oidhreachta á dhímheas agus bainfear an tacaíocht chun sparán oidhreachta a chruthú agus a oscailt amach anseo.</translation>
+    </message>
+    <message>
+        <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
+        <translation type="unfinished">D'éirigh leis an sparán a lódáil. Tá an cineál sparán oidhreachta á dhímheas agus bainfear an tacaíocht chun sparán oidhreachta a chruthú agus a oscailt amach anseo. Is féidir sparán oidhreachta a aistriú chuig sparán tuairisceora le sparán imirceach.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Rabhadh: Ní mheaitseálann formáid sparán Dumpfile "%s" an fhormáid ordaithe sonraithe "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Rabhadh: Eochracha príobháideacha braite i sparán {%s} le heochracha príobháideacha díchumasaithe</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Rabhadh: Is cosúil nach n-aontaímid go hiomlán lenár piaraí! B’fhéidir go mbeidh ort uasghrádú a dhéanamh, nó b’fhéidir go mbeidh ar nóid eile uasghrádú.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Teastaíonn bailíochtú sonraí finné maidir le bloic tar éis airde %d. Atosaigh le -reindex le do thoil.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3189,12 +4303,138 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir réiteach seoladh -%s: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Ní féidir -forcednsseed a shocrú go fíor agus -dnsseed á shocrú go bréagach.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Ní féidir -peerblockfilters a shocrú gan -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Ní féidir scríobh chuig eolaire sonraí '%s'; seiceáil ceadanna.</translation>
+    </message>
+    <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">Tá%s socraithe an-ard! D’fhéadfaí táillí chomh mór seo a íoc ar idirbheart amháin.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Ní féidir naisc ar leith a sholáthar agus tá addrman chun naisc amach a aimsiú ag an am céanna.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Earráid agus %s á lódáil: sparán an tsínitheora sheachtraigh á luchtú gan tacaíocht sínitheoir seachtrach a chur le chéile</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <translation type="unfinished">Earráid agus %s á léamh! Léann na heochracha go léir i gceart, ach seans go bhfuil sonraí idirbhirt nó meiteashonraí seolta in easnamh nó mícheart.</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Earráid: Ní féidir sonraí an leabhair seoltaí sa sparán a shainaithint mar go mbaineann siad le sparán aistrithe</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Earráid: Tuairisceoirí dúblacha a cruthaíodh le linn imirce. Seans go bhfuil do sparán truaillithe.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Earráid: Ní féidir idirbheart %s sa sparán a aithint gur le sparán aistrithe é</translation>
+    </message>
+    <message>
+        <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
+        <translation type="unfinished">Theip ar tháillí tuairte a ríomh, toisc go mbraitheann UTXOanna neamhdhearbhaithe ar bhraisle ollmhór idirbheart neamhdheimhnithe.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Theip ar an gcomhad peers.dat neamhbhailí a athainmniú. Bog nó scrios é agus bain triail eile as.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">Theip ar mheastachán na dtáillí. Tá fallbackfee díchumasaithe. Fan cúpla bloc nó cumasaigh %s.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Roghanna neamh-chomhoiriúnacha: -dnsseed=1 sonraíodh go sainráite, ach cuireann -onlynet cosc ​​ar naisc le IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=&lt;amount&gt;: '%s' (ní mór an táille sealaíochta nóiméad de %s a bheith ann ar a laghad chun idirbhearta bhfostú a chosc)</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <translation type="unfinished">Naisc amach teoranta do CJDNS (-onlynet=cjdns) ach ní chuirtear -cjdnsreachable ar fáil</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Tá naisc amach teoranta do Tor (-onlynet=onion) ach tá cosc ​​sainráite ar an seachfhreastalaí chun líonra Tor a bhaint amach: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Naisc amach teoranta do Tor (-onlynet=onion) ach ní thugtar an seachfhreastalaí chun líonra Tor a bhaint amach: ní thugtar aon seachfhreastalaí, -oinniún nó -listenonion</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <translation type="unfinished">Tá naisc amach teoranta do i2p (-onlynet=i2p) ach ní chuirtear -i2psam ar fáil</translation>
+    </message>
+    <message>
+        <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
+        <translation type="unfinished">Sáraíonn méid an ionchuir an t-uasmheáchan. Bain triail as méid níos lú a sheoladh nó UTXO do sparán a chomhdhlúthú de láimh</translation>
+    </message>
+    <message>
+        <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <translation type="unfinished">Ní chlúdaíonn méid iomlán na monaí réamhroghnaithe sprioc an idirbhirt. Ceadaigh le do thoil ionchuir eile a roghnú go huathoibríoch nó cuir níos mó bonn san áireamh de láimh</translation>
+    </message>
+    <message>
+        <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
+        <translation type="unfinished">Éilíonn an t-idirbheart ceann scríbe amháin de luach neamh-0, táille neamh-0, nó ionchur réamhroghnaithe</translation>
+    </message>
+    <message>
+        <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
+        <translation type="unfinished">Theip ar bhailíochtú a dhéanamh ar achomair UTXO. Atosaigh chun gnáthíoslódáil na mbloc tosaigh a atosú, nó bain triail as pictiúr eile a lódáil.</translation>
+    </message>
+    <message>
+        <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
+        <translation type="unfinished">Tá UTXOanna neamhdheimhnithe ar fáil, ach cruthaítear slabhra idirbheart a ndiúltóidh an mempool dóibh má dhéantar iad a chaitheamh</translation>
+    </message>
+    <message>
+        <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
+
+The wallet might have been tampered with or created with malicious intent.
+</source>
+        <translation type="unfinished">Fuarthas iontráil oidhreachta gan choinne sa sparán tuairisceora. Sparán %s á lódáil
+
+Seans gur cuireadh isteach ar an sparán nó gur cruthaíodh é le hintinn mhailíseach.
+</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Tuairisceoir neamhaitheanta aimsithe. Sparán %s á lódáil
+
+Seans gur cruthaíodh an sparán ar leagan níos nuaí.
+Bain triail as an leagan bogearraí is déanaí a rith.
+</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Ní féidir an t-imirce theip a ghlanadh</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Ní féidir cúltaca an sparán a chur ar ais.</translation>
+    </message>
+    <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">Cuireadh isteach ar an bhfíorú blocála</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -3229,6 +4469,18 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Lódáil déanta</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Níl an comhad dumpála %s ann.</translation>
+    </message>
+    <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">Earráid agus db txn á dhéanamh chun idirbhearta sparán a bhaint</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Earráid cruthaithe %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">Earráid ag túsú bunachar sonraí bloic</translation>
     </message>
@@ -3261,16 +4513,112 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Earráid ag oscailt bunachar sonraí bloic</translation>
     </message>
     <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Earráid agus an comhad cumraíochta á léamh: %s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Earráid ag léamh ón mbunachar sonraí, ag múchadh.</translation>
+    </message>
+    <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Earráid agus an chéad taifead eile á léamh ón mbunachar sonraí sparán</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">Earráid agus db txn á thosú chun idirbhearta sparán a bhaint</translation>
+    </message>
+    <message>
+        <source>Error: Cannot extract destination from the generated scriptpubkey</source>
+        <translation type="unfinished">Earráid: Ní féidir an ceann scríbe a bhaint as an scriptpubkey ginte</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir an cúrsóir a chruthú sa bhunachar sonraí</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Earráid: Tá spás ar diosca íseal do %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Earráid: Ní hionann seiceála Dumpfile. Ríomh %s, bhíothas ag súil le %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Earráid: Theip ar chruthú sparán faire amháin nua</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Earráid: Fuair ​​​​tú eochair nach heicsidheachúlach í: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Earráid: Fuair ​​tú luach nach heicsidheachúlach é: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Earráid: Rith keypool amach, glaoigh ar keypoolrefill ar dtús</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Earráid: Seiceáil in easnamh</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Earráid: Níl seoladh %s ar fáil.</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Earráid: Úsáideann an sparán seo SQLite cheana féin</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Earráid: Is sparán tuairisceora é an sparán seo cheana féin</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Earráid: Ní féidir tosú ag léamh gach taifead sa bhunachar sonraí</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Earráid: Ní féidir cúltaca a dhéanamh de do sparán</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Earráid: Ní féidir leagan%u a pharsáil mar uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Earráid: Ní féidir gach taifead sa bhunachar sonraí a léamh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read wallet's best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr sa sparán a léamh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Earráid: Ní féidir sonraí leabhar seoltaí faire amháin a bhaint</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Earráid: Ní féidir taifead a scríobh chuig an sparán nua</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write solvable wallet best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr ar an sparán intuaslagtha a scríobh</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write watchonly wallet best block locator record</source>
+        <translation type="unfinished">Earráid: Ní féidir an taifead aimsitheoir bloc is fearr le sparán faire amháin a scríobh</translation>
+    </message>
+    <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Earráid: theip ar chóip leabhar seoltaí do sparán %s</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">Earráid: ní féidir idirbheart bunachar sonraí a chur i gcrích le haghaidh sparán %s</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3281,8 +4629,16 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Theip athscanadh ar an sparán le linn túsúchán</translation>
     </message>
     <message>
+        <source>Failed to start indexes, shutting down..</source>
+        <translation type="unfinished">Theip ar thús a chur leis na hinnéacsanna, dúnadh.</translation>
+    </message>
+    <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Theip ar fhíorú an mbunachar sonraí</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Teip ag baint an idirbhirt: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -3293,6 +4649,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Neamhaird ar sparán dhúbailt %s.</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Á iompórtáil…</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">Bloc geineasas mícheart nó ní aimsithe. datadir mícheart don líonra?</translation>
     </message>
@@ -3301,8 +4661,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Theip ar seiceáil slánchiall túsúchán. Tá %s ag múchadh.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Ionchur gan aimsiú nó caite cheana féin</translation>
+    </message>
+    <message>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished">Dbcache neamhleor le haghaidh fíorú blocála</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Neamhleor ciste</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Seoladh neamhbhailí -i2psam nó óstainm: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3317,6 +4689,14 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Cead neamhbhailí P2P: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=&lt;amount&gt;: '%s' (ar a laghad %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Méid neamhbhailí le haghaidh %s=&lt;amount&gt;: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Suim neamhbhailí do -%s=&lt;amount&gt;: '%s'</translation>
     </message>
@@ -3325,12 +4705,60 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Mascghréas neamhbhailí sonraithe sa geal-liosta: '%s'</translation>
     </message>
     <message>
+        <source>Invalid port specified in %s: '%s'</source>
+        <translation type="unfinished">Port neamhbhailí sonraithe i %s: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished">Ionchur réamhroghnaithe %s neamhbhailí</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Theip ar éisteacht le naisc isteach (éisteacht ar ais earráid %s)</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Seoltaí P2P á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Liosta toirmeasc á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Innéacs bloc á lódáil…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Sparán á lódáil…</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Méid ar iarraidh</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Sonraí réitigh ar iarraidh le haghaidh meastachán a dhéanamh ar mhéid an idirbhirt</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Is gá port a shainiú le -whitebind: '%s'</translation>
     </message>
     <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">Níl aon seoltaí ar fáil</translation>
+    </message>
+    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Níl dóthain tuairisceoirí comhaid ar fáil.</translation>
+    </message>
+    <message>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished">Níor aimsíodh ionchur réamhroghnaithe %s</translation>
+    </message>
+    <message>
+        <source>Not solvable pre-selected input %s</source>
+        <translation type="unfinished">Ní féidir ionchur réamhroghnaithe %s a réiteach</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -3341,8 +4769,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Tá an mód bearrtha neamh-chomhoiriúnach le -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Blocsiopa á bhearradh…</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Laghdú -maxconnections ó %d go %d, mar gheall ar shrianadh an chórais.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Bloic á n-athsheinn…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Á athscanadh…</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3385,8 +4825,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níl eolaire bloic shonraithe "%s" ann.</translation>
     </message>
     <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Níl comhadlann sonraí sonraithe "%s" ann.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Snáitheanna líonra á dtosú…</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Tá an cód foinseach ar fáil ó %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Níl an comhad cumraíochta sonraithe %s ann</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3409,6 +4861,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Seo an táille idirbhirt a íocfaidh tú má sheolann tú idirbheart.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Ní bhaineann an t-idirbheart %s leis an sparán seo</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Méid an idirbhirt ró-bheag</translation>
     </message>
@@ -3417,12 +4873,24 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níor cheart go mbeadh suimeanna idirbhirt diúltach</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Innéacs aschuir athraithe idirbhirt as raon</translation>
+    </message>
+    <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Caithfidh ar a laghad faighteoir amháin a bheith ag idirbheart</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Teastaíonn seoladh athraithe ón idirbheart, ach ní féidir linn é a ghiniúint.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Idirbheart ró-mhór</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Ní féidir cuimhne a leithdháileadh le haghaidh -maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -3437,6 +4905,10 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Níorbh fhéidir cruthú comhad PID '%s': %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Ní féidir UTXO a aimsiú le haghaidh ionchur seachtrach</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Ní féidir eochracha tosaigh a ghiniúint</translation>
     </message>
@@ -3445,8 +4917,20 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Ní féidir eochracha a ghiniúint</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Ní féidir %s a oscailt chun scríobh</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Ní féidir a pharsáil -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Ní féidir freastalaí HTTP a thosú. Féach loga dífhabhtúcháin le tuilleadh sonraí.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Ní féidir an sparán a dhíluchtú roimh aistriú</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -3465,16 +4949,56 @@ Téigh go Comhad &gt; Oscail Sparán chun sparán a lódáil.
         <translation type="unfinished">Líonra anaithnid sonraithe san -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Rialacha nua anaithnid curtha i ngníomh (leagan giotán %ii)</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
+        <translation type="unfinished">Leibhéal logála domhanda nach dtacaítear leis %s=%s. Luachanna bailí: %s.</translation>
+    </message>
+    <message>
+        <source>Wallet file creation failed: %s</source>
+        <translation type="unfinished">Theip ar chruthú comhaid sparán: %s</translation>
+    </message>
+    <message>
+        <source>acceptstalefeeestimates is not supported on %s chain.</source>
+        <translation type="unfinished">ní thacaítear le acceptstalefeeestimates ar slabhra %s.</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Catagóir logáil gan tacaíocht %s=%s.</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir watch amháin tx %s a chur le sparán faire amháin</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Earráid: Níorbh fhéidir idirbhearta faire amháin a scriosadh.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Tá carachtair neamhshábháilte i nóta tráchta (%s) Gníomhaire Úsáideora.</translation>
     </message>
     <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Bloic á bhfíorú…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Sparán(aí) á fhíorú…</translation>
+    </message>
+    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation type="unfinished">Ba ghá an sparán a athscríobh: atosaigh %s chun críochnú</translation>
     </message>
-    </context>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Níorbh fhéidir an comhad socruithe a léamh</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Níorbh fhéidir an comhad socruithe a scríobh</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -84,9 +84,22 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">Exportar Lista de Enderezos</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Ficheiro separado por comas</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Houbo un erro tentando gardar a lista de enderezos en %1. Por favor proba de novo.</translation>
+    </message>
+    <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">Enviando enderezos - %1</translation>
+    </message>
+    <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">Recibindo enderezos - %1</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -211,8 +224,20 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">O contrasinal introducido para a desencriptación do moedeiro foi incorrecto.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">A frase de acceso introducida para o descifrado da carteira é incorrecta. Contén un carácter nulo (é dicir, un byte cero). Se a frase de paso se estableceu cunha versión deste software anterior á 25.0, téntao de novo con só os caracteres ata, pero sen incluír, o primeiro carácter nulo. Se se realiza correctamente, establece unha nova frase de acceso para evitar este problema no futuro.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Cambiouse con éxito o contrasinal do moedeiro.</translation>
+    </message>
+    <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">Produciuse un erro no cambio de frase de contrasinal</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">A contrasinal antiga introducida para o descifrado da carteira é incorrecta. Contén un carácter nulo (é dicir, un byte cero). Se a frase de paso se estableceu cunha versión deste software anterior á 25.0, téntao de novo con só os caracteres ata, pero sen incluír, o primeiro carácter nulo.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -233,12 +258,32 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">O ficheiro de configuración %1 pode estar danado ou non válido.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción de fuga</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Produciuse un erro fatal. %1 xa non pode continuar con seguridade e sairá.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Erro interno</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Produciuse un erro interno. %1 tentará continuar con seguridade. Este é un erro inesperado que se pode informar como se describe a continuación.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 aínda non saíu con seguridade...</translation>
+    </message>
     <message>
         <source>unknown</source>
         <translation type="unfinished">descoñecido</translation>
@@ -382,8 +427,20 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">&amp;Opcións...</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cifrar carteira...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Encriptar as claves privadas que pertencen ao teu moedeiro</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Copia de seguranza da carteira...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Cambiar a frase de contrasinal...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -1874,6 +1931,11 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Exportar Historial de Transaccións</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Ficheiro separado por comas</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_gl_ES.ts
+++ b/src/qt/locale/bitcoin_gl_ES.ts
@@ -84,6 +84,11 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">Exporta a Lista de Enderezos</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Ficheiro separado por comas</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Houbo un erro tentando gardar a lista de enderezos en %1. Por favor proba de novo.</translation>
@@ -207,8 +212,20 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">A frase contrasinal introducida para o desencriptamento da carteira é incorrecto.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">A frase de acceso introducida para o descifrado da carteira é incorrecta. Contén un carácter nulo (é dicir, un byte cero). Se a frase de paso se estableceu cunha versión deste software anterior á 25.0, téntao de novo con só os caracteres ata, pero sen incluír, o primeiro carácter nulo. Se se realiza correctamente, establece unha nova frase de acceso para evitar este problema no futuro.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">A frase contrasinal da carteira mudouse correctamente.</translation>
+    </message>
+    <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">Produciuse un erro no cambio de frase de contrasinal</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Produciuse un erro non cambio de frase de contrasinal</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -229,10 +246,22 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción de fuga</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Produciuse un erro fatal. %1 xa non pode continuar con seguridade e sairá.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Erro interno</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Produciuse un erro interno. %1 tentará continuar con seguridade. Este é un erro inesperado que se pode informar como se describe a continuación.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -374,8 +403,20 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <translation type="unfinished">&amp;Opcións...</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cifrar carteira...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Encripta as claves privadas que pertencen á túa carteira</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Copia de seguranza da carteira...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Cambiar a frase de contrasinal...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -1059,6 +1100,11 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Copiar enderezo</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Ficheiro separado por comas</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_gu.ts
+++ b/src/qt/locale/bitcoin_gu.ts
@@ -94,6 +94,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">સરનામાં સૂચિને માં સાચવવાનો પ્રયાસ કરતી વખતે ભૂલ આવી હતી %1. મહેરબાની કરીને ફરીથી પ્રયતન કરો.</translation>
     </message>
     <message>
+        <source>Sending addresses - %1</source>
+        <translation type="unfinished">મોકલવાના સરનામા - %1</translation>
+    </message>
+    <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">સરનામુ લેવુ-%1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">નિકાસ ની પ્ર્રાક્રિયા નિષ્ફળ ગયેલ છે</translation>
     </message>
@@ -168,19 +176,157 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">પાકીટ એન્ક્રિપ્ટ થયેલ</translation>
     </message>
     <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">વૉલેટ માટે નવો પાસફ્રેઝ દાખલ કરો. 1 કૃપા કરીને  2 દસ અથવા વધુ અજાન્યા અક્ષરો 2 અથવા 3 આઠ અથવા વધુ શબ્દોના પાસફ્રેઝનો ઉપયોગ કરો 3 .</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">પાકીટ માટે જુના શબ્દસમૂહ અને નવા શબ્દસમૂહ દાખલ કરો.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">યાદ રાખો કે તમારા વૉલેટને એન્ક્રિપ્ટ કરવાથી તમારા કમ્પ્યુટરને સંક્રમિત કરતા માલવેર દ્વારા ચોરાઈ જવાથી તમારા બિટકોઈનને સંપૂર્ણપણે સુરક્ષિત કરી શકાશે નહીં.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">એ વોલેટ જે એન્ક્રિપ્ટેડ થવાનું છે</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">તમારું વૉલેટ એન્ક્રિપ્ટ થવાનું છે</translation>
+    </message>
+    <message>
         <source>Your wallet is now encrypted. </source>
         <translation type="unfinished">તમારું વૉલેટ હવે એન્ક્રિપ્ટેડ છે.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">મહત્વપૂર્ણ: તમે તમારી વૉલેટ ફાઇલમાંથી બનાવેલા કોઈપણ અગાઉના બેકઅપને નવી બનાવેલી , એન્ક્રિપ્ટેડ વૉલેટ ફાઇલ સાથે બદલવું જોઈએ. સુરક્ષાના કારણોસર, તમે નવા, એનક્રિપ્ટેડ વૉલેટનો ઉપયોગ કરવાનું શરૂ કરો કે તરત જ અનએન્ક્રિપ્ટેડ વૉલેટ ફાઇલના અગાઉના બેકઅપ નકામું થઈ જશે.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
         <translation type="unfinished">વૉલેટ એન્ક્રિપ્શન નિષ્ફળ થયું.</translation>
     </message>
-    </context>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">આંતરિક ભૂલને કારણે વૉલેટ એન્ક્રિપ્શન નિષ્ફળ થયું. તમારું વૉલેટ એન્ક્રિપ્ટેડ નહોતું</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">પૂરા પાડવામાં આવેલ પાસફ્રેઝ મેળ ખાતા નથી.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">વૉલેટ અનલૉક નિષ્ફળ થયું</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">વૉલેટ ડિક્રિપ્શન માટે દાખલ કરેલ પાસફ્રેઝ ખોટો હતો.</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">વૉલેટ ડિક્રિપ્શન માટે દાખલ કરેલ પાસફ્રેઝ ખોટો છે. તેમાં નલ અક્ષર (એટલે ​​કે - શૂન્ય બાઈટ) છે. જો પાસફ્રેઝ 25.0 પહેલા આ સૉફ્ટવેરના સંસ્કરણ સાથે સેટ કરવામાં આવ્યો હોય, તો કૃપા કરીને ફક્ત પ્રથમ શૂન્ય અક્ષર સુધીના અક્ષરો સાથે ફરી પ્રયાસ કરો — પરંતુ તેમાં શામેલ નથી. જો આ સફળ થાય, તો ભવિષ્યમાં આ સમસ્યાને ટાળવા માટે કૃપા કરીને નવો પાસફ્રેઝ સેટ કરો.</translation>
+    </message>
+    <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">પાસફ્રેઝ ફેરફાર નિષ્ફળ ગયો</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">વૉલેટ ડિક્રિપ્શન માટે દાખલ કરેલ જૂનો પાસફ્રેઝ ખોટો છે. તેમાં નલ અક્ષર (એટલે ​​કે - શૂન્ય બાઈટ) છે. જો પાસફ્રેઝ 25.0 પહેલા આ સૉફ્ટવેરના સંસ્કરણ સાથે સેટ કરવામાં આવ્યો હોય, તો કૃપા કરીને ફક્ત પ્રથમ શૂન્ય અક્ષર સુધીના અક્ષરો સાથે ફરી પ્રયાસ કરો — પરંતુ તેમાં શામેલ નથી.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">ચેતવણી: ( Caps Lock ) કી ચાલુ છે!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">આઈપી/નેટમાસ્ક </translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">સુધી પ્રતિબંધિત</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">સેટિંગ્સ ફાઈલ %1 દૂષિત અથવા અમાન્ય હોઈ શકે છે.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">ભાગેડુ અપવાદ</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">એક જીવલેણ ભૂલ આવી. %1 હવે સુરક્ષિત રીતે ચાલુ રાખી શકશે નહીં અને બહાર નીકળી જશે.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">આંતરિક ભૂલ</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">આંતરિક ભૂલ આવી. %1 સુરક્ષિત રીતે ચાલુ રાખવાનો પ્રયાસ કરશે. આ એક અણધારી બગ છે જે નીચે વર્ણવ્યા પ્રમાણે જાણ કરી શકાય છે.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">શું તમે સેટિંગ્સને ડિફૉલ્ટ મૂલ્યો પર રીસેટ કરવા માંગો છો, અથવા ફેરફારો કર્યા વિના બંધ કરવા માંગો છો?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">એક જીવલેણ ભૂલ આવી. તપાસો કે સેટિંગ્સ ફાઇલ લખી શકાય તેવી છે, અથવા -nosettings સાથે ચલાવવાનો પ્રયાસ કરો.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">ભૂલ: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 હજુ સુરક્ષિત રીતે બહાર નીકળ્યું નથી..</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">અજ્ઞાત</translation>
+    </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">એમ્બેડેડ "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">ડિફૉલ્ટ સિસ્ટમ ફોન્ટ "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">કસ્ટમ…</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">રકમ</translation>
+    </message>
+    <message>
+        <source>Enter a Bitcoin address (e.g. %1)</source>
+        <translation type="unfinished">Bitcoin સરનામું દાખલ કરો (દા.ત. %1 )</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">રૂટ કરી શકાતો નથી</translation>
+    </message>
+    <message>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <extracomment>Name of Tor network in peer info</extracomment>
+        <translation type="unfinished">Onion (ડુંગળી)</translation>
     </message>
     <message>
         <source>Inbound</source>
@@ -192,25 +338,58 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
         <translation type="unfinished">બહારનું </translation>
     </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">સંપૂર્ણ રિલે</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">બ્લોક રિલે</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">માનવ સંચાલિત</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">ભરવા</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">સરનામું મેળવો</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">કોઈ નહિ</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">ઉપલબ્ધ નથી</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n સેકન્ડ</numerusform>
+            <numerusform>%n સેકન્ડો</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n મિનિટ</numerusform>
+            <numerusform>1%n મિનિટો</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n કલાક</numerusform>
+            <numerusform>%n કલાકો</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -238,66 +417,996 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;ઝાંખી</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">વૉલેટની સામાન્ય ઝાંખી બતાવો</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;વ્યવહારો</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">વ્યવહાર ઇતિહાસ બ્રાઉઝ કરો</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">બહાર નીકળો</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">એપ્લિકેશન છોડો</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;વિશે %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">વિશે માહિતી બતાવો %1</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">&amp;Qt વિશે</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">Qt વિશે માહિતી બતાવો</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">માટે રૂપરેખાંકન વિકલ્પો સંશોધિત કરો %1</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">નવું વૉલેટ બનાવો</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;ઘટાડો</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">વૉલેટ:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">નેટવર્ક પ્રવૃત્તિ અક્ષમ છે.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">પ્રોક્સી &lt;b&gt;સક્ષમ છે &lt;/b&gt; : %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">બિટકોઈન એડ્રેસ પર સિક્કા મોકલો</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">અન્ય સ્થાન પર બેકઅપ વૉલેટ</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">વૉલેટ એન્ક્રિપ્શન માટે ઉપયોગમાં લેવાતો પાસફ્રેઝ બદલો</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;મોકલો</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;પ્રાપ્ત કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;વિકલ્પો...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;વોલેટ એન્ક્રિપ્ટ કરો...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">તમારા વૉલેટની ખાનગી કીને એન્ક્રિપ્ટ કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;બેકઅપ વૉલેટ...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;પાસફ્રેઝ &amp;બદલો...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">સહી&amp;સંદેશ...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">તમારા બિટકોઈન સરનામાંઓ સાથે તમે તેમના માલિક છો તે સાબિત કરવા માટે સંદેશાઓ પર સહી કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;સંદેશ ચકાસો...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">સંદેશાઓની ખાતરી કરવા માટે કે તેઓ નિર્દિષ્ટ Bitcoin સરનામાંઓ સાથે સહી કરેલ છે તેની ખાતરી કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;ફાઇલમાંથી PSBT લોડ કરો...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">ખોલો&amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">વૉલેટ બંધ કરો...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">વૉલેટ બનાવો...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">બધા વોલેટ બંધ કરો...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;ફાઇલ</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;સેટિંગ્સ</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;મદદ</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">ટૅબ્સ ટૂલબાર</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">મથાળાઓ સમન્વયિત કરી રહ્યાં છે (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">નેટવર્ક સાથે સિંક્રનાઇઝ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">ડિસ્ક પર ઇન્ડેક્સીંગ બ્લોક્સ...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">ડિસ્ક પર બ્લોક્સની પ્રક્રિયા કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">સાથીદારોએ સાથે જોડાઈ…</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">ચુકવણીની વિનંતી કરો (QR કોડ અને બિટકોઈન જનરેટ કરે છે: URI)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">મોકલવા માટે વપરાયેલ સરનામાં અને લેબલોની યાદી બતાવો</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">વપરાયેલ પ્રાપ્ત સરનામાંઓ અને લેબલોની સૂચિ બતાવો</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;કમાન્ડ-લાઇન વિકલ્પો</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>ટ્રાન્ઝેક્શન ઇતિહાસના પ્રોસેસ્ડ 1%n બ્લોક(ઓ)</numerusform>
+            <numerusform>ટ્રાન્ઝેક્શન ઇતિહાસના પ્રોસેસ્ડ %nબ્લોક(ઓ)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1પાછળ</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">પકડી રહ્યું છે </translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">છેલ્લે પ્રાપ્ત થયેલ બ્લોક પહેલા જનરેટ કરવામાં%1 આવ્યો હતો.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">આ પછીના વ્યવહારો હજી દેખાશે નહીં.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">ભૂલ</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">ચેતવણી</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">માહિતી</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">આજ સુધીનુ</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">આંશિક રીતે સહી કરેલ બિટકોઈન ટ્રાન્ઝેક્શન લોડ કરો</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">&amp;ક્લિપબોર્ડ માંથી PSBT લોડ કરો...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">ક્લિપબોર્ડથી આંશિક રીતે સહી કરેલ બિટકોઈન ટ્રાન્ઝેક્શન લોડ કરો</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">નોડ બારી</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">નોડ ડીબગીંગ અને ડાયગ્નોસ્ટિક કન્સોલ ખોલો</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;સરનામાં મોકલી રહ્યાં છીએ</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;પ્રાપ્ત સરનામાં</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">બીટકોઈન ખોલો: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">વૉલેટ ખોલો</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">એક પાકીટ ખોલો</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">વૉલેટ બંધ કરો</translation>
+    </message>
+    <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">વૉલેટ પુનઃસ્થાપિત કરો...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">બેકઅપ ફાઇલમાંથી વૉલેટ પુનઃસ્થાપિત કરો</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">બધા પાકીટ બંધ કરો</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">વૉલેટ સ્થાનાંતરિત કરો</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">વૉલેટ સ્થાનાંતરિત કરો</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">સંભવિત બિટકોઈન કમાન્ડ-લાઇન વિકલ્પો સાથે સૂચિ મેળવવા માટે મદદ સંદેશ બતાવો %1 </translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;માસ્ક મૂલ્યો</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">વિહંગાવલોકન ટેબમાં મૂલ્યોને માસ્ક કરો</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">મૂળભૂત વૉલેટ</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">કોઈ પાકીટ ઉપલબ્ધ નથી</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">વૉલેટ ડેટા</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">વૉલેટ બેકઅપ લોડ કરો</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">વૉલેટ પુનઃસ્થાપિત કરો</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">વૉલેટનું નામ</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;બારી</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">મોટું કરવું</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">મુખ્ય વિન્ડો</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1ગ્રાહક</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;છુપાવો</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp; કેવી રીતે</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n બિટકોઈન નેટવર્ક સાથે સક્રિય જોડાણ(ઓ).</numerusform>
+            <numerusform>%n બિટકોઈન નેટવર્ક સાથે સક્રિય જોડાણ(ઓ).</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">વધુ ક્રિયાઓ માટે ક્લિક કરો.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">પીઅર ટેબ બતાવો</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">નેટવર્ક પ્રવૃત્તિને અક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">નેટવર્ક પ્રવૃત્તિ સક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">પ્રી-સિંકિંગ હેડર્સ (%1%)…</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">વૉલેટ બનાવવામાં ભૂલ</translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">નવું વૉલેટ બનાવી શકાતું નથી, સૉફ્ટવેર sqlite સપોર્ટ વિના સંકલિત કરવામાં આવ્યું હતું (વર્ણનકર્તા વૉલેટ માટે જરૂરી)</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">ભૂલ: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">ચેતવણી:%1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">તારીખ:%1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">રકમ:%1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">વૉલેટ: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">પ્રકાર: %1 
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">લેબલ: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">સરનામું: %1 
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">મોકલેલ વ્યવહાર</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">ઇનકમિંગ વ્યવહાર</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD ચાવી જનરેશન &lt;b&gt;સક્ષમ&lt;/b&gt; કરેલ છે</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD કી જનરેશન &lt;b&gt;અક્ષમ&lt;/b&gt; છે</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">ખાનગી કી &lt;b&gt;અક્ષમ&lt;/b&gt; છે</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">વૉલેટ &lt;b&gt;એન્ક્રિપ્ટેડ&lt;/b&gt; છે અને હાલમાં &lt;b&gt;અનલૉક&lt;/b&gt; કરેલું છે</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">વૉલેટ &lt;b&gt;એન્ક્રિપ્ટેડ&lt;/b&gt; છે અને હાલમાં &lt;b&gt;લૉક&lt;/b&gt; કરેલું છે</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">મૂળ સંદેશ:</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">સિક્કાની પસંદગી</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">જથ્થો:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">બાઇટ્સ:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">રકમ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">ફી:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">પછીની ફી:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">બદલો:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">બધા (na)પસંદ કરો</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">ટ્રી મોડ</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">સૂચિ મોડ</translation>
+    </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">રકમ</translation>
     </message>
     <message>
+        <source>Received with label</source>
+        <translation type="unfinished">લેબલ સાથે પ્રાપ્ત</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">સરનામા સાથે પ્રાપ્ત</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">તારીખ</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">પુષ્ટિકરણો</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">પુષ્ટિ</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">રકમની નકલ કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">સરનામું &amp;નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">કૉપિ કરો &amp;લેબલ બનાવો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">નકલ  &amp;રકમ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શન &amp;ID અને આઉટપુટ ઇન્ડેક્સની નકલ કરો</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">બિનખર્ચિત લો&amp;ક</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">બિનખર્ચિત &amp;અનલૉક</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">નકલ જથ્થો</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">નકલ ફી</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">ફી પછી નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">બાઇટ્સ કૉપિ કરો</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">ફેરફારની નકલ કરો</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1લોક કરેલ)</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">ઇનપુટ દીઠ +/-%1 સતોશી(ઓ) બદલાઈ શકે છે.</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">લેબલ નથી</translation>
     </message>
-    </context>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">થી બદલો%1(%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(બદલો)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">વૉલેટ બનાવો</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">વૉલેટ બનાવી રહ્યાં છીએ&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">વૉલેટ બનાવવાનું નિષ્ફળ થયું</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">વૉલેટ ચેતવણી બનાવો</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">સહી કરનારની યાદી બનાવી શકાતી નથી</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">ઘણા બધા બાહ્ય સહી કરનારા મળ્યા</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">પાકીટ લોડ કરો</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">પાકીટ લોડ કરી રહ્યું છે...</translation>
+    </message>
+</context>
+<context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">વૉલેટ સ્થાનાંતરિત કરો</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">શું તમે ખરેખર વૉલેટને સ્થાનાંતરિત કરવા માંગો છો&lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
+If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
+If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
+
+The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
+        <translation type="unfinished">વૉલેટનું સ્થાનાંતરણ આ વૉલેટને એક અથવા વધુ વર્ણનકર્તા વૉલેટમાં રૂપાંતરિત કરશે. નવું વૉલેટ બેકઅપ લેવાની જરૂર પડશે.
+જો આ વૉલેટમાં કોઈ માત્ર વૉચનલી સ્ક્રિપ્ટ્સ હોય, તો એક નવું વૉલેટ બનાવવામાં આવશે જેમાં તે માત્ર વૉચનલી સ્ક્રિપ્ટ્સ હશે.
+જો આ વૉલેટમાં કોઈ ઉકેલી શકાય તેવી પરંતુ જોઈ ન હોય તેવી સ્ક્રિપ્ટો હોય, તો એક અલગ અને નવું વૉલેટ બનાવવામાં આવશે જેમાં તે સ્ક્રિપ્ટો હશે.
+
+સ્થળાંતર પ્રક્રિયા સ્થળાંતર કરતા પહેલા વૉલેટનો બેકઅપ બનાવશે. આ બેકઅપ ફાઇલને &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak નામ આપવામાં આવશે અને આ વૉલેટ માટેની ડિરેક્ટરીમાં મળી શકશે. અયોગ્ય સ્થાનાંતરણની ઘટનામાં, બેકઅપને "રીસ્ટોર વોલેટ" કાર્યક્ષમતા સાથે પુનઃસ્થાપિત કરી શકાય છે.</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">વૉલેટ સ્થાનાંતરિત કરો</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">વૉલેટ સ્થાનાંતરિત કરી રહ્યાં છીએ&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">વૉલેટ '%1' સફળતાપૂર્વક સ્થાનાંતરિત થયું.</translation>
+    </message>
+    <message>
+        <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">વોચઓનલી સ્ક્રિપ્ટોને '%1' નામના નવા વૉલેટમાં સ્થાનાંતરિત કરવામાં આવી છે.</translation>
+    </message>
+    <message>
+        <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">ઉકેલી શકાય તેવી પરંતુ જોયેલી સ્ક્રિપ્ટો '%1' નામના નવા વૉલેટમાં સ્થાનાંતરિત કરવામાં આવી છે.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">સ્થળાંતર નિષ્ફળ થયું</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">સ્થળાંતર સફળ</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">ઓપન વૉલેટ નિષ્ફળ થયું</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">ઓપન વૉલેટ ચેતવણી</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">ડિફૉલ્ટ વૉલેટ</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">વૉલેટ ખોલો</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">વૉલેટ ખોલી રહ્યાં છીએ &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">વૉલેટ પુનઃસ્થાપિત કરો</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">વૉલેટ પુનઃસ્થાપિત કરી રહ્યાં છીએ &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">વૉલેટ રિસ્ટોર નિષ્ફળ થયું</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">વૉલેટ ચેતવણી પુનઃસ્થાપિત કરો</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">વૉલેટ સંદેશ પુનઃસ્થાપિત કરો</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">વૉલેટ બંધ કરો</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">શું તમે ખરેખર વોલેટ બંધ કરવા માંગો છો &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">પાકીટને ખૂબ લાંબા સમય સુધી બંધ કરવાથી જો કાપણી સક્ષમ હોય તો સમગ્ર સાંકળને ફરીથી સમન્વયિત કરવી પડી શકે છે.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">બધા પાકીટ બંધ કરો</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">શું તમે ખરેખર બધા પાકીટ બંધ કરવા માંગો છો?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">વૉલેટ બનાવો</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">તમે તમારું નવું વૉલેટ બનાવવાથી એક પગલું દૂર છો!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">કૃપા કરીને નામ આપો અને, જો ઇચ્છિત હોય, તો કોઈપણ અદ્યતન વિકલ્પોને સક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">વૉલેટનું નામ</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">પાકીટ</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">વૉલેટને એન્ક્રિપ્ટ કરો. વૉલેટને તમારી પસંદગીના પાસફ્રેઝ સાથે એન્ક્રિપ્ટ કરવામાં આવશે.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">વૉલેટને એન્ક્રિપ્ટ કરો</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">અદ્યતન વિકલ્પો</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">આ વૉલેટ માટે ખાનગી કીને અક્ષમ કરો. ખાનગી કી અક્ષમ કરેલ વોલેટ્સમાં કોઈ ખાનગી કી હશે નહીં અને તેમાં HD સીડ અથવા આયાત કરેલ ખાનગી કી હોઈ શકતી નથી. આ ફક્ત વૉચ-વૉલેટ માટે આદર્શ છે.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">ખાનગી ચાવીને અક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">ખાલી પાકીટ બનાવો. ખાલી વોલેટ્સમાં શરૂઆતમાં ખાનગી કી અથવા સ્ક્રિપ્ટ હોતી નથી. ખાનગી કીઓ અને સરનામાંઓ આયાત કરી શકાય છે અથવા પછીના સમયે HD સીડ સેટ કરી શકાય છે.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">ખાલી વોલેટ બનાવો</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">હાર્ડવેર વોલેટ જેવા બાહ્ય હસ્તાક્ષર ઉપકરણનો ઉપયોગ કરો. પહેલા વૉલેટ પસંદગીઓમાં બાહ્ય સહી કરનાર સ્ક્રિપ્ટને ગોઠવો.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">બાહ્ય સહી કરનાર</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">બનાવો</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">બાહ્ય હસ્તાક્ષર આધાર વિના સંકલિત (બાહ્ય હસ્તાક્ષર માટે જરૂરી)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">સરનામું સંપાદિત કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;લેબલ</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">આ સરનામાં સૂચિ એન્ટ્રી સાથે સંકળાયેલ લેબલ</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">આ સરનામાં સૂચિ એન્ટ્રી સાથે સંકળાયેલ સરનામું. આ ફક્ત સરનામાં મોકલવા માટે સુધારી શકાય છે.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;સરનામું</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">નવું મોકલવાનું સરનામું</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">પ્રાપ્ત સરનામું સંપાદિત કરો</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">મોકલવાનું સરનામું સંપાદિત કરો</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">દાખલ કરેલ સરનામું "%1" માન્ય બીટકોઈન સરનામું નથી.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">સરનામું "%1" પહેલેથી જ "%2" લેબલ સાથે પ્રાપ્ત સરનામા તરીકે અસ્તિત્વમાં છે અને તેથી તેને મોકલવાના સરનામા તરીકે ઉમેરી શકાતું નથી.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">દાખલ કરેલ સરનામું "%1" પહેલાથી જ "%2" લેબલ સાથે એડ્રેસ બુકમાં છે.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">વૉલેટ અનલૉક કરી શકાયું નથી.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">નવી કી જનરેશન નિષ્ફળ ગઈ.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">નવી ડેટા ડિરેક્ટરી બનાવવામાં આવશે.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">નામ</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">ડિરેક્ટરી પહેલેથી જ અસ્તિત્વમાં છે. જો તમે અહીં નવી ડિરેક્ટરી બનાવવા માંગતા હોવ તો %1 ઉમેરો.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">પાથ પહેલેથી જ અસ્તિત્વમાં છે, અને તે ડિરેક્ટરી નથી.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">અહીં ડેટા ડિરેક્ટરી બનાવી શકાતી નથી.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">બીટકોઈન </translation>
+    </message>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n GB ની જગ્યા ઉપલબ્ધ છે</numerusform>
+            <numerusform>%n GB ની જગ્યા ઉપલબ્ધ છે</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(1%n GB ની જરૂર છે)</numerusform>
+            <numerusform>(%n GB ની જરૂર છે)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(સંપૂર્ણ સાંકળ માટે 1%n GB જરૂરી છે)</numerusform>
+            <numerusform>(સંપૂર્ણ સાંકળ માટે %n GB જરૂરી છે)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Choose data directory</source>
+        <translation type="unfinished">ડેટા ડિરેક્ટરી પસંદ કરો</translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">આ નિર્દેશિકામાં ઓછામાં ઓછો %1 GB ડેટા સંગ્રહિત થશે, અને તે સમય જતાં વધશે.</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">આ ડિરેક્ટરીમાં અંદાજે %1 GB ડેટા સ્ટોર કરવામાં આવશે.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(બૅકઅપ 1%n દિવસ(ઓ) જૂના પુનઃસ્થાપિત કરવા માટે પૂરતું)</numerusform>
+            <numerusform>(બૅકઅપ %n દિવસ(ઓ) જૂના પુનઃસ્થાપિત કરવા માટે પૂરતું)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 બિટકોઈન બ્લોક ચેઈનની કોપી ડાઉનલોડ અને સ્ટોર કરશે.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">વૉલેટ પણ આ ડિરેક્ટરીમાં સ્ટોર કરવામાં આવશે.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">ભૂલ: ઉલ્લેખિત ડેટા ડિરેક્ટરી "%1" બનાવી શકાતી નથી.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">ભૂલ</translation>
     </message>
     <message>
         <source>Welcome</source>
@@ -307,25 +1416,775 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Welcome to %1.</source>
         <translation type="unfinished">સ્વાગત છે %1.</translation>
     </message>
-    </context>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">આ પ્રથમ વખત પ્રોગ્રામ લોન્ચ થયો હોવાથી, , તમે પસંદ કરી શકો છો કે %1 તેનો ડેટા ક્યાં સંગ્રહિત કરશે</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">બ્લોક ચેઇન સ્ટોરેજ સુધી મર્યાદિત કરો</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">આ સેટિંગને પાછું ફેરવવા માટે સમગ્ર બ્લોકચેનને ફરીથી ડાઉનલોડ કરવાની જરૂર છે. પહેલા સંપૂર્ણ શૃંખલાને ડાઉનલોડ કરવી અને પછીથી તેને કાપવું વધુ ઝડપી છે. કેટલીક અદ્યતન સુવિધાઓને અક્ષમ કરે છે.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">જીબી (GB)</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">જ્યારે તમે ઓકે ક્લિક કરો છો,%1સંપૂર્ણ ડાઉનલોડ અને પ્રક્રિયા કરવાનું શરૂ કરશે%4બ્લોક ચેન (સાંકળ) (%2GB) માં સૌથી પહેલાના વ્યવહારોથી શરૂ થાય છે%3જ્યારે%4શરૂઆતમાં લોન્ચ કર્યું.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">જો તમે બ્લોક ચેઈન સ્ટોરેજ (કાપણી)ને મર્યાદિત કરવાનું પસંદ કર્યું હોય, તો ઐતિહાસિક ડેટા હજુ પણ ડાઉનલોડ અને પ્રોસેસ થવો જોઈએ, પરંતુ તમારા ડિસ્ક વપરાશને ઓછો રાખવા માટે પછીથી કાઢી નાખવામાં આવશે.</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">ડિફૉલ્ટ ડેટા ડિરેક્ટરીનો ઉપયોગ કરો</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">કસ્ટમ ડેટા ડિરેક્ટરીનો ઉપયોગ કરો:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">આવૃત્તિ</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">વિશે%1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">કમાન્ડ-લાઇન વિકલ્પો</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1બંધ થઈ રહ્યું છે…</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">આ વિન્ડો અદૃશ્ય થઈ જાય ત્યાં સુધી કમ્પ્યુટરને બંધ કરશો નહીં.</translation>
+    </message>
+</context>
 <context>
     <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">ફોર્મ</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">તાજેતરના વ્યવહારો હજુ સુધી દેખાતા ન હોઈ શકે અને તેથી તમારા વૉલેટનું બેલેન્સ ખોટું હોઈ શકે છે. એકવાર તમારું વૉલેટ બિટકોઇન નેટવર્ક સાથે સિંક્રનાઇઝ થઈ જાય પછી આ માહિતી સાચી હશે, જેમ કે નીચે વિગતવાર છે.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">હજુ સુધી પ્રદર્શિત ન થયેલા વ્યવહારોથી પ્રભાવિત બિટકોઇન્સનો ખર્ચ કરવાનો પ્રયાસ નેટવર્ક દ્વારા સ્વીકારવામાં આવશે નહીં.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">બાકી રહેલા બ્લોકની સંખ્યા</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">અજ્ઞાત…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">ગણતરી કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">છેલ્લો બ્લોક નો સમય</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">પ્રગતિ</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">પ્રતિ કલાક પ્રગતિ વધે છે</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">સમન્વયિત થવામાં અંદાજિત સમય બાકી છે</translation>
+    </message>
     <message>
         <source>Hide</source>
         <translation type="unfinished">છુપાવો</translation>
     </message>
-    </context>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished">Esc (બહાર)</translation>
+    </message>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">હાલમાં %1 સમન્વયિત થઈ રહ્યું છે. તે સાથીદારો પાસેથી હેડરો અને બ્લોક્સ ડાઉનલોડ કરશે અને બ્લોક ચેઇનની ટોચ સુધી પહોંચે ત્યાં સુધી તેને માન્ય કરશે.</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">અજ્ઞાત. મથાળાને સમન્વયિત કરી રહ્યું છે (%1,%2%)...</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">અજ્ઞાત. પહેલાંથી સમન્વય હેડર્સ (%1,%2 %)…</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">બિટકોઈન URI ખોલો</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">ક્લિપબોર્ડમાંથી સરનામું પેસ્ટ કરો</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">વિકલ્પો</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;મુખ્ય</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">સિસ્ટમમાં લોગ ઇન કર્યા પછી આપમેળે %1 શરૂ કરો.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">સિસ્ટમ લૉગિન પર %1 &amp;પ્રારંભ કરો</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">કાપણીને સક્ષમ કરવાથી વ્યવહારો સ્ટોર કરવા માટે જરૂરી ડિસ્ક જગ્યા નોંધપાત્ર રીતે ઘટાડે છે. બધા બ્લોક હજુ પણ સંપૂર્ણ રીતે માન્ય છે. આ સેટિંગને પાછું ફેરવવા માટે સમગ્ર બ્લોકચેનને ફરીથી ડાઉનલોડ કરવાની જરૂર છે.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">&amp;ડેટાબેઝ કેશનું કદ</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">સ્ક્રિપ્ટ અને ચકાસણી દોરિયોની સંખ્યા</translation>
+    </message>
+    <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">%1 સુસંગત સ્ક્રિપ્ટનો સંપૂર્ણ માર્ગ (દા.ત. C:\Downloads\hwi.exe અથવા /Users/you/Downloads/hwi.py). સાવચેત રહો: ​​માલવેર તમારા સિક્કા ચોરી શકે છે!</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">પ્રોક્સીનું IP સરનામું (દા.ત. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">પૂરા પાડવામાં આવેલ ડિફોલ્ટ SOCKS5 પ્રોક્સીનો ઉપયોગ આ નેટવર્ક પ્રકાર દ્વારા સાથીદારો સુધી પહોંચવા માટે થાય છે કે કેમ તે બતાવે છે.</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">જ્યારે વિન્ડો બંધ હોય ત્યારે એપ્લિકેશનમાંથી બહાર નીકળવાને બદલે નાનું કરો. જ્યારે આ વિકલ્પ સક્ષમ હશે, ત્યારે મેનુમાં બહાર નીકળો પસંદ કર્યા પછી જ એપ્લિકેશન બંધ થશે.</translation>
+    </message>
+    <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">વિહંગાવલોકન ટૅબમાં ફૉન્ટ:</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">આ સંવાદમાં સેટ કરેલ વિકલ્પો આદેશ વાક્ય દ્વારા ઓવરરાઇડ થાય છે:</translation>
+    </message>
+    <message>
+        <source>Open the %1 configuration file from the working directory.</source>
+        <translation type="unfinished">કાર્યકારી નિર્દેશિકામાંથી%1રૂપરેખાંકન ફાઇલ ખોલો.</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">રૂપરેખાંકન ફાઇલ ખોલો</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">બધા ક્લાયંટ વિકલ્પોને ડિફોલ્ટ પર ફરીથી સેટ કરો.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">&amp;રીસેટ વિકલ્પો</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;નેટવર્ક</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">સ્ટોરેજને કાપો અને અવરોધિત કરો</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">આ સેટિંગને પાછું ફેરવવા માટે સમગ્ર બ્લોકચેનને ફરીથી ડાઉનલોડ કરવાની જરૂર છે.</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">મહત્તમ ડેટાબેઝ કેશ કદ. એક મોટી કેશ ઝડપી સમન્વયનમાં યોગદાન આપી શકે છે, જે પછી મોટાભાગના ઉપયોગના કેસોમાં લાભ ઓછો ઉચ્ચારવામાં આવે છે. કેશનું કદ ઘટાડવાથી મેમરીનો વપરાશ ઘટશે. આ કેશ માટે નહિ વપરાયેલ મેમ્પૂલ મેમરી શેર કરવામાં આવી છે.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">સ્ક્રિપ્ટ ચકાસણી થ્રેડોની સંખ્યા સેટ કરો. નકારાત્મક મૂલ્યો કોરોની સંખ્યાને અનુરૂપ છે જે તમે સિસ્ટમને મફતમાં છોડવા માંગો છો.</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = ઓટો, &lt;0 = ઘણા બધા કોર મફત છોડો)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">આ તમને અથવા તૃતીય પક્ષ ટૂલને કમાન્ડ-લાઇન અને JSON-RPC આદેશો દ્વારા નોડ સાથે વાતચીત કરવાની મંજૂરી આપે છે.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC સર્વર સક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">વૉલેટ</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">રકમમાંથી બાદબાકી ફી ડિફોલ્ટ તરીકે સેટ કરવી કે નહીં.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">ડિફોલ્ટ રૂપે રકમમાંથી &amp;ફી બાદ કરો</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">નિષ્ણાત</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">સિક્કો અને નિયંત્રણ સુવિધાઓ સક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">જો તમે અપ્રમાણિત ફેરફારના ખર્ચને અક્ષમ કરો છો, તો જ્યાં સુધી તે વ્યવહારમાં ઓછામાં ઓછી એક પુષ્ટિ ન થાય ત્યાં સુધી વ્યવહારમાંથી ફેરફારનો ઉપયોગ કરી શકાતો નથી. આ તમારા બેલેન્સની ગણતરી કેવી રીતે કરવામાં આવે છે તેની પણ અસર કરે છે.</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;અપ્રમાણિત ફેરફાર ખર્ચો</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">&amp;PSBT નિયંત્રણો સક્ષમ કરો</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT નિયંત્રણો દર્શાવવા કે કેમ.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">બાહ્ય સહી કરનાર (દા.ત. હાર્ડવેર વોલેટ)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;બાહ્ય સહી કરનાર સ્ક્રિપ્ટ પાથ</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation type="unfinished">રાઉટર પર બિટકોઇન ક્લાયંટ પોર્ટને આપમેળે ખોલો. આ ત્યારે જ કામ કરે છે જ્યારે તમારું રાઉટર UPnP ને સપોર્ટ કરતું હોય અને તે સક્ષમ હોય.</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">&amp;UPnP નો ઉપયોગ કરીને નકશો પોર્ટ</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">રાઉટર પર બિટકોઇન ક્લાયંટ પોર્ટને આપમેળે ખોલો. આ ત્યારે જ કામ કરે છે જ્યારે તમારું રાઉટર NAT-PMP ને સપોર્ટ કરે અને તે સક્ષમ હોય. બાહ્ય પોર્ટ રેન્ડમ હોઈ શકે છે.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">NA&amp;T-PMP નો ઉપયોગ કરીને નકશો પોર્ટ</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">બહારથી જોડાણો સ્વીકારો.</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">ઇનકમિંગ કનેક્શન્સને મંજૂરી આપો</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <translation type="unfinished">SOCKS5 પ્રોક્સી દ્વારા Bitcoin નેટવર્કથી કનેક્ટ થાઓ.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">SOCKS5 પ્રોક્સી (ડિફોલ્ટ પ્રોક્સી) દ્વારા &amp;કનેક્ટ કરો:</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">પ્રોક્સી IP:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation type="unfinished">&amp;પોર્ટ:</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation type="unfinished">પ્રોક્સીનું પોર્ટ (દા.ત. 9050)</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation type="unfinished">આ દ્વારા સાથીદારો સુધી પહોંચવા માટે વપરાય છે:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;બારી</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">સિસ્ટમ ટ્રેમાં ચિહ્ન બતાવો.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;ટ્રે આઇકન બતાવો</translation>
+    </message>
+    <message>
+        <source>Show only a tray icon after minimizing the window.</source>
+        <translation type="unfinished">વિન્ડોને નાની કર્યા પછી માત્ર ટ્રે આઇકોન બતાવો.</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">&amp;ટાસ્કબારને બદલે ટ્રેમાં નાની કરો</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation type="unfinished">બંધ થવા પર નાનું કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation type="unfinished">&amp;પ્રદર્શિત કરો</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation type="unfinished">વપરાશકર્તા ઈન્ટરફેસ અને ભાષા:</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation type="unfinished">વપરાશકર્તા ઈન્ટરફેસ ભાષા અહીં સેટ કરી શકાય છે. આ સેટિંગ %1 પુનઃપ્રારંભ કર્યા પછી પ્રભાવી થશે.</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation type="unfinished">આમાં રકમો બતાવવા માટે &amp;એકમ:</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation type="unfinished">ઇન્ટરફેસમાં અને સિક્કા મોકલતી વખતે બતાવવા માટે ડિફોલ્ટ પેટાવિભાગ એકમ પસંદ કરો.</translation>
+    </message>
+    <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">તૃતીય-પક્ષ URL (દા.ત. બ્લોક એક્સપ્લોરર) જે વ્યવહારો ટેબમાં સંદર્ભ મેનૂ આઇટમ તરીકે દેખાય છે. URL માં %s ટ્રાન્ઝેક્શન હેશ દ્વારા બદલવામાં આવે છે. બહુવિધ URL ને વર્ટિકલ બાર દ્વારા અલગ કરવામાં આવે છે |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;તૃતીય-પક્ષ વ્યવહાર URLs</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">સિક્કા નિયંત્રણ સુવિધાઓ દર્શાવવી કે નહીં.</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">ટોર ઓનિયન સેવાઓ માટે અલગ SOCKS5 પ્રોક્સી દ્વારા બિટકોઇન નેટવર્ક સાથે કનેક્ટ થાઓ.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">ટોર ઓનિયન સેવાઓ દ્વારા સાથીદારો સુધી પહોંચવા માટે અલગ SOCKS&amp;5 પ્રોક્સીનો ઉપયોગ કરો:</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation type="unfinished">&amp;બરાબર</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">&amp;રદ કરો</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">બાહ્ય હસ્તાક્ષર આધાર વિના સંકલિત (બાહ્ય હસ્તાક્ષર માટે જરૂરી)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation type="unfinished">મૂળભૂત</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">કોઈ નહીં</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
+        <translation type="unfinished">વિકલ્પો રીસેટની પુષ્ટિ કરો</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
+        <translation type="unfinished">ફેરફારોને સક્રિય કરવા માટે ક્લાયન્ટ પુનઃપ્રારંભ જરૂરી છે.</translation>
+    </message>
+    <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">વર્તમાન સેટિંગ્સનું "%1" પર બેકઅપ લેવામાં આવશે.</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
+        <translation type="unfinished">ક્લાયન્ટ બંધ થઈ જશે. શું તમે આગળ વધવા માંગો છો?</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">રૂપરેખાંકન વિકલ્પો</translation>
+    </message>
+    <message>
+        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
+        <translation type="unfinished">રૂપરેખાંકન ફાઇલનો ઉપયોગ અદ્યતન વપરાશકર્તા વિકલ્પોનો ઉલ્લેખ કરવા માટે થાય છે જે GUI સેટિંગ્સને ઓવરરાઇડ કરે છે. વધુમાં, કોઈપણ આદેશ-વાક્ય વિકલ્પો આ રૂપરેખાંકન ફાઈલને ઓવરરાઈડ કરશે.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">ચાલુ રાખો</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">રદ કરો</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">ભૂલ</translation>
+    </message>
+    <message>
+        <source>The configuration file could not be opened.</source>
+        <translation type="unfinished">રૂપરેખાંકન ફાઈલ ખોલી શકાઈ નથી.</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">આ ફેરફારને ક્લાયંટ પુનઃપ્રારંભની જરૂર પડશે.</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">પૂરું પાડવામાં આવેલ પ્રોક્સી સરનામું અમાન્ય છે.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">સેટિંગ "%1", %2  વાંચી શકાયું નથી.</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">ફોર્મ</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">પ્રદર્શિત માહિતી જૂની હોઈ શકે છે. કનેક્શન સ્થાપિત થયા પછી તમારું વૉલેટ આપમેળે બિટકોઇન નેટવર્ક સાથે સિંક્રનાઇઝ થાય છે, પરંતુ આ પ્રક્રિયા હજી પૂર્ણ થઈ નથી.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">માત્ર જોવા માટે:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">ઉપલબ્ધ:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation type="unfinished">તમારું વર્તમાન ખર્ચપાત્ર બેલેન્સ</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">બાકી:</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished">કુલ વ્યવહારો કે જેની પુષ્ટિ થવાની બાકી છે અને હજુ સુધી ખર્ચપાત્ર બેલેન્સમાં ગણવામાં આવતા નથી</translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation type="unfinished">અપરિપક્વ:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">ખનન કરેલ સંતુલન જે હજુ પરિપક્વ નથી</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">બેલેન્સ</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">કુલ:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">તમારું વર્તમાન કુલ બેલેન્સ</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">ફક્ત જોવા માટેના સરનામામાં તમારું વર્તમાન બેલેન્સ</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">ખર્ચપાત્ર:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">તાજેતરના વ્યવહારો</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">માત્ર જોવા માટેના સરનામાંઓ પર અપ્રમાણિત વ્યવહારો</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">માત્ર વોચ-ઓન્લી એડ્રેસમાં માઇન કરેલ બેલેન્સ કે જે હજુ પરિપક્વ નથી</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">માત્ર જોવા માટેના સરનામામાં વર્તમાન કુલ બેલેન્સ</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">વિહંગાવલોકન ટેબ માટે ગોપનીયતા મોડ સક્રિય કર્યો. મૂલ્યોને અનમાસ્ક કરવા માટે, સેટિંગ્સ-&gt;માસ્ક મૂલ્યોને અનચેક કરો.</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>PSBT Operations</source>
+        <translation type="unfinished">PSBT કામગીરી</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">સાઇન Tx</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">બ્રોડકાસ્ટ Tx</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">ક્લિપબોર્ડ પર કૉપિ કરો</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">સાચવો...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">બંધ</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">વ્યવહાર લોડ કરવામાં નિષ્ફળ: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">વ્યવહાર પર સહી કરવામાં નિષ્ફળ: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">વૉલેટ લૉક હોય ત્યારે ઇનપુટ્સ પર સહી કરી શકાતી નથી.</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">કોઈપણ વધુ ઇનપુટ્સ પર સહી કરી શકાઈ નથી.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">સહી કરેલ %1 ઇનપુટ્સ, પરંતુ હજુ વધુ સહીઓ જરૂરી છે.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">હસ્તાક્ષર કરેલ વ્યવહાર સફળતાપૂર્વક. વ્યવહાર પ્રસારિત કરવા માટે તૈયાર છે.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">અજ્ઞાત ભૂલ પ્રક્રિયા વ્યવહાર વ્યવહાર.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">વ્યવહારનું સફળતાપૂર્વક પ્રસારણ થયું! ટ્રાન્ઝેક્શન આઈડી: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">વ્યવહાર પ્રસારણ નિષ્ફળ: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT ક્લિપબોર્ડ પર કૉપિ કર્યું.</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શન ડેટા સાચવો</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">આંશિક રીતે હસ્તાક્ષરિત વ્યવહાર (દ્વિસંગી)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT ડિસ્કમાં સાચવ્યું.</translation>
+    </message>
+    <message>
+        <source>Sends %1 to %2</source>
+        <translation type="unfinished">%1 , %2 ને મોકલે છે</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">પોતાનું સરનામું</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">વ્યવહાર ફી અથવા કુલ વ્યવહારની રકમની ગણતરી કરવામાં અસમર્થ.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શન ફી ચૂકવે છે:</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">કુલ રકમ</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">અથવા</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">વ્યવહારમાં સહી વગરના %1 ઇનપુટ્સ છે.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">વ્યવહારમાં ઇનપુટ્સ વિશે કેટલીક માહિતી ખૂટે છે.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શનને હજુ પણ સહી (ઓ)ની જરૂર છે.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(પરંતુ કોઈ વૉલેટ લોડ થયેલ નથી.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(પરંતુ આ વૉલેટ વ્યવહારો પર સહી કરી શકતું નથી.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(પરંતુ આ વૉલેટમાં યોગ્ય ચાવીઓ નથી.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">વ્યવહાર સંપૂર્ણપણે સહી થયેલ છે અને પ્રસારણ માટે તૈયાર છે.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">વ્યવહારની સ્થિતિ અજાણ છે.</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">ચુકવણી વિનંતી ભૂલ</translation>
+    </message>
+    <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">બિટકોઇન શરૂ કરી શકતા નથી: ક્લિક-ટુ-પે હેન્ડલર</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">URI હેન્ડલિંગ</translation>
+    </message>
+    <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">'bitcoin://' એ માન્ય URI નથી. તેના બદલે 'bitcoin:' નો ઉપયોગ કરો.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">ચુકવણી વિનંતી પર પ્રક્રિયા કરી શકાતી નથી કારણ કે BIP70 સમર્થિત નથી.
+BIP70 માં વ્યાપક સુરક્ષા ખામીઓને લીધે, વોલેટ બદલવા માટેની કોઈપણ વેપારીની સૂચનાઓને અવગણવાની ભારપૂર્વક ભલામણ કરવામાં આવે છે.
+જો તમને આ ભૂલ મળી રહી હોય તો તમારે વેપારીને BIP21 સુસંગત URI પ્રદાન કરવાની વિનંતી કરવી જોઈએ.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">URI વિશ્લેષિત કરી શકાતું નથી! આ અમાન્ય Bitcoin સરનામું અથવા દૂષિત URI પરિમાણોને કારણે થઈ શકે છે.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation type="unfinished">ચુકવણી વિનંતી ફાઇલ હેન્ડલિંગ</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">વપરાશકર્તા એજન્ટ</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
+        <translation type="unfinished">પિંગ</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">પીઅર</translation>
+    </message>
     <message>
         <source>Age</source>
         <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
         <translation type="unfinished">ઉંમર</translation>
     </message>
     <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">દિશા</translation>
+    </message>
+    <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation type="unfinished">મોકલેલ</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">પ્રાપ્ત</translation>
     </message>
     <message>
         <source>Address</source>
@@ -336,6 +2195,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Type</source>
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
         <translation type="unfinished">પ્રકાર</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">નેટવર્ક</translation>
     </message>
     <message>
         <source>Inbound</source>
@@ -349,29 +2213,656 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;છબી સાચવો…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;છબી કોપી કરો</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">પરિણામી URI ખૂબ લાંબી છે, લેબલ/સંદેશ માટે ટેક્સ્ટ ઘટાડવાનો પ્રયાસ કરો.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">QR કોડમાં URI ને એન્કોડ કરવામાં ભૂલ.</translation>
+    </message>
+    <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">QR કોડ સપોર્ટ ઉપલબ્ધ નથી.</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">QR કોડ સાચવો</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG ચિત્ર</translation>
+    </message>
+</context>
+<context>
     <name>RPCConsole</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">ઉપલબ્ધ નથી</translation>
+    </message>
+    <message>
+        <source>Client version</source>
+        <translation type="unfinished">ક્લાયંટ સંસ્કરણ</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">&amp;માહિતી</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">જનરલ</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">ડેટાડર</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">ડેટા ડિરેક્ટરીનું બિન-ડિફોલ્ટ સ્થાન સ્પષ્ટ કરવા માટે '%1' વિકલ્પનો ઉપયોગ કરો.</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">બ્લોક્સડર</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">બ્લોક્સ ડિરેક્ટરીનું બિન-મૂળભૂત સ્થાન સ્પષ્ટ કરવા માટે '%1' વિકલ્પનો ઉપયોગ કરો.</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">સ્ટાર્ટઅપ સમય</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">નેટવર્ક</translation>
+    </message>
     <message>
         <source>Name</source>
         <translation type="unfinished">નામ </translation>
     </message>
     <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">જોડાણોની સંખ્યા</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">બ્લોક સાંકળ</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">મેમરી પૂલ</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">વ્યવહારોની વર્તમાન સંખ્યા</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">મેમરી વપરાશ</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">વૉલેટ:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(કઈ નહીં)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;રીસેટ કરો</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">પ્રાપ્ત</translation>
+    </message>
+    <message>
         <source>Sent</source>
         <translation type="unfinished">મોકલેલ</translation>
     </message>
-    </context>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">&amp;સાથીઓ</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">પ્રતિબંધિત સાથીદારો</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">વિગતવાર માહિતી જોવા માટે પીઅર પસંદ કરો.</translation>
+    </message>
+    <message>
+        <source>The transport layer version: %1</source>
+        <translation type="unfinished">પરિવહન સ્તર સંસ્કરણ:%1</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation type="unfinished">પરિવહન</translation>
+    </message>
+    <message>
+        <source>The BIP324 session ID string in hex, if any.</source>
+        <translation type="unfinished">હેક્સમાં BIP324 સત્ર ID સ્ટ્રિંગ, જો કોઈ હોય તો.</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">પ્રક્રિયા નંબર</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">સંસ્કરણ</translation>
+    </message>
+    <message>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished">શું આપણે આ પીઅરને વ્યવહારો રીલે કરીએ છીએ.</translation>
+    </message>
+    <message>
+        <source>Transaction Relay</source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શન રિલે</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">પ્રારંભ બ્લોક</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation type="unfinished">સમન્વયિત હેડરો</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">સમન્વયિત બ્લોક્સ</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">છેલ્લો વ્યવહાર</translation>
+    </message>
+    <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">પીઅર પસંદગીમાં વિવિધતા લાવવા માટે વપરાયેલ મેપ કરેલ સ્વાયત્ત સિસ્ટમ.</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">મેપ કરેલ AS</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">શું અમે આ પીઅરને સરનામાં રિલે કરીએ છીએ.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">સરનામું રિલે</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">આ પીઅર પાસેથી પ્રાપ્ત થયેલા સરનામાઓની કુલ સંખ્યા કે જેની પર પ્રક્રિયા કરવામાં આવી હતી (દર-મર્યાદાને કારણે છોડવામાં આવેલા સરનામાંને બાદ કરતા).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">દર-મર્યાદાને કારણે આ પીઅર પાસેથી પ્રાપ્ત થયેલા સરનામાંની કુલ સંખ્યા જે છોડવામાં આવી હતી (પ્રક્રિયા કરવામાં આવી નથી).</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">સરનામાંઓ પર પ્રક્રિયા કરી</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">સરનામાં દર-મર્યાદિત</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">વપરાશકર્તા એજન્ટ</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">નોડ બારી</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">વર્તમાન બ્લોક ઊંચાઈ</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation type="unfinished">વર્તમાન ડેટા ડિરેક્ટરીમાંથી %1 ડીબગ લોગ ફાઇલ ખોલો. મોટી લોગ ફાઇલો માટે આમાં થોડી સેકંડ લાગી શકે છે.</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">ફોન્ટનું કદ ઘટાડો</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">ફોન્ટનું કદ વધારો</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">પરવાનગીઓ</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">પીઅર કનેક્શનની દિશા અને પ્રકાર: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">દિશા/પ્રકાર</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">આ પીઅર જે નેટવર્ક પ્રોટોકોલ દ્વારા જોડાયેલ છે: IPv4, IPv6, Onion, I2P, અથવા CJDNS.</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">સેવાઓ</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">ઉચ્ચ બેન્ડવિડ્થ BIP152 કોમ્પેક્ટ બ્લોક રિલે: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">ઉચ્ચ બેન્ડવિડ્થ</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">કનેક્શન સમય</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">આ પીઅર તરફથી પ્રારંભિક માન્યતા તપાસો પસાર કરતો નવલકથા બ્લોક પ્રાપ્ત થયો ત્યારથી વીત્યો સમય.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">છેલ્લો બ્લોક</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">અમારા મેમ્પૂલમાં સ્વીકારવામાં આવેલ નવલકથા વ્યવહારને આ પીઅર તરફથી પ્રાપ્ત થયો ત્યારથી વીત્યો સમય.</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">છેલ્લે મોકલો</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">છેલ્લે પ્રાપ્ત</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">પિંગ સમય</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">હાલમાં બાકી પિંગનો સમયગાળો.</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">પિંગ રાહ જુઓ</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">ન્યૂનતમ પિંગ</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">સમય ઓફસેટ</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">છેલ્લો બ્લોક નો સમય</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">ઇનબાઉન્ડ: પીઅર દ્વારા શરૂ</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">આઉટબાઉન્ડ પૂર્ણ રિલે: ડિફોલ્ટ</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">આઉટબાઉન્ડ બ્લોક રિલે: વ્યવહારો અથવા સરનામાં રિલે કરતું નથી</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">આઉટબાઉન્ડ મેન્યુઅલ: RPC %1 અથવા %2 / %3 રૂપરેખાંકન વિકલ્પોનો ઉપયોગ કરીને ઉમેરવામાં આવે છે</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">આઉટબાઉન્ડ ફીલર: અલ્પજીવી, પરીક્ષણ સરનામા માટે</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">આઉટબાઉન્ડ સરનામું મેળવો: અલ્પજીવી, સરનામાંની વિનંતી કરવા માટે</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">શોધવું: પીઅર v1 અથવા v2 હોઈ શકે છે</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: એનક્રિપ્ટેડ, પ્લેનટેક્સ્ટ ટ્રાન્સપોર્ટ પ્રોટોકોલ</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: BIP324 એન્ક્રિપ્ટેડ ટ્રાન્સપોર્ટ પ્રોટોકોલ</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">અમે ઉચ્ચ બેન્ડવિડ્થ રિલે માટે પીઅર પસંદ કર્યું છે</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">પીઅરે અમને ઉચ્ચ બેન્ડવિડ્થ રિલે માટે પસંદ કર્યા</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">કોઈ ઉચ્ચ બેન્ડવિડ્થ રિલે પસંદ કરેલ નથી</translation>
+    </message>
+    <message>
+        <source>Ctrl++</source>
+        <extracomment>Main shortcut to increase the RPC console font size.</extracomment>
+        <translation type="unfinished">કંટ્રોલ++</translation>
+    </message>
+    <message>
+        <source>Ctrl+=</source>
+        <extracomment>Secondary shortcut to increase the RPC console font size.</extracomment>
+        <translation type="unfinished">કંટ્રોલ+=</translation>
+    </message>
+    <message>
+        <source>Ctrl+-</source>
+        <extracomment>Main shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">કંટ્રોલ+-</translation>
+    </message>
+    <message>
+        <source>Ctrl+_</source>
+        <extracomment>Secondary shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">કંટ્રોલ+_</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">સરનામું &amp;નકલ કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;ડિસ્કનેક્ટ</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 &amp;કલાક</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;દિવસ</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;અઠવાડિયું</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;વર્ષ</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;કોપી IP/Netmask</translation>
+    </message>
+    <message>
+        <source>&amp;Unban</source>
+        <translation type="unfinished">&amp;અપ્રતિબંધ</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation type="unfinished">નેટવર્ક પ્રવૃત્તિ અક્ષમ છે</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">કોઈપણ વૉલેટ વિના આદેશનો અમલ</translation>
+    </message>
+    <message>
+        <source>Ctrl+I</source>
+        <translation type="unfinished">કંટ્રોલ+I</translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished">કંટ્રોલ+T</translation>
+    </message>
+    <message>
+        <source>Ctrl+N</source>
+        <translation type="unfinished">કંટ્રોલ+N</translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished">કંટ્રોલ+P</translation>
+    </message>
+    <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">નોડ વિન્ડો- [%1]</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">" %1 "વોલેટનો ઉપયોગ કરીને આદેશ ચલાવી રહ્યા છીએ</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">%1 RPC કન્સોલ પર આપનું સ્વાગત છે.
+ઇતિહાસ નેવિગેટ કરવા માટે ઉપર અને નીચે તીરોનો ઉપયોગ કરો અને સ્ક્રીન સાફ કરવા માટે %2 નો ઉપયોગ કરો.
+ફોન્ટનું કદ વધારવા અથવા ઘટાડવા માટે %3 અને %4 નો ઉપયોગ કરો.
+ઉપલબ્ધ આદેશોની ઝાંખી માટે %5 લખો.
+આ કન્સોલનો ઉપયોગ કરવા પર વધુ માહિતી માટે, %6 લખો.
+
+%7 ચેતવણી: સ્કેમર્સ સક્રિય છે, વપરાશકર્તાઓને અહીં આદેશો લખવાનું કહે છે, તેમના વૉલેટની સામગ્રી ચોરી કરે છે. આ કન્સોલનો ઉપયોગ કમાન્ડની અસરને સંપૂર્ણપણે સમજ્યા વિના કરશો નહીં. %8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">અમલ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(સાથીદાર: %1)</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation type="unfinished">મારફતે %1</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">હા</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">ના</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">પ્રતિ</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">થી</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation type="unfinished">માટે પ્રતિબંધ</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">ક્યારેય</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">અજ્ઞાત</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">&amp;રકમ:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;લેબલ:</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation type="unfinished">&amp;સંદેશ:</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">ચુકવણીની વિનંતી સાથે જોડવા માટેનો વૈકલ્પિક સંદેશ, જે વિનંતી ખોલવામાં આવશે ત્યારે પ્રદર્શિત થશે. નોંધ: Bitcoin નેટવર્ક પર ચુકવણી સાથે સંદેશ મોકલવામાં આવશે નહીં.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">નવા પ્રાપ્ત સરનામા સાથે સાંકળવા માટે વૈકલ્પિક લેબલ.</translation>
+    </message>
+    <message>
+        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <translation type="unfinished">ચુકવણીની વિનંતી કરવા માટે આ ફોર્મનો ઉપયોગ કરો. બધા ક્ષેત્રો &lt;b&gt;વૈકલ્પિક&lt;/b&gt; છે.</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">વિનંતી કરવા માટે વૈકલ્પિક રકમ. ચોક્કસ રકમની વિનંતી ન કરવા માટે આ ખાલી અથવા શૂન્ય છોડો.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">નવા પ્રાપ્ત સરનામા સાથે સાંકળવા માટેનું વૈકલ્પિક લેબલ (તમારા દ્વારા ઇન્વોઇસ ઓળખવા માટે વપરાય છે). તે ચુકવણીની વિનંતી સાથે પણ જોડાયેલ છે.</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">એક વૈકલ્પિક સંદેશ જે ચુકવણીની વિનંતી સાથે જોડાયેલ છે અને પ્રેષકને પ્રદર્શિત થઈ શકે છે.</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">&amp;નવું પ્રાપ્ત કરવાનું સરનામું બનાવો</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">ફોર્મના તમામ ક્ષેત્રો સાફ કરો.</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">ચોખ્ખુ</translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation type="unfinished">વિનંતી કરેલ ચુકવણી ઇતિહાસ</translation>
+    </message>
+    <message>
+        <source>Show the selected request (does the same as double clicking an entry)</source>
+        <translation type="unfinished">પસંદ કરેલી વિનંતી બતાવો (એન્ટ્રી પર ડબલ ક્લિક કરવા જેવું જ છે)</translation>
+    </message>
     <message>
         <source>Show</source>
         <translation type="unfinished">બતાવો</translation>
     </message>
     <message>
+        <source>Remove the selected entries from the list</source>
+        <translation type="unfinished">સૂચિમાંથી પસંદ કરેલી એન્ટ્રીઓ દૂર કરો</translation>
+    </message>
+    <message>
         <source>Remove</source>
         <translation type="unfinished">દૂર કરો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">કૉપિ &amp;URI </translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">સરનામું &amp;નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">કૉપિ કરો &amp;લેબલ બનાવો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">નકલ &amp; સંદેશ</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">નકલ  &amp;રકમ</translation>
+    </message>
+    <message>
+        <source>Not recommended due to higher fees and less protection against typos.</source>
+        <translation type="unfinished">વધુ ફી અને ટાઇપો સામે ઓછા રક્ષણને કારણે ભલામણ કરવામાં આવતી નથી.</translation>
+    </message>
+    <message>
+        <source>Generates an address compatible with older wallets.</source>
+        <translation type="unfinished">જૂના પાકીટ સાથે સુસંગત સરનામું જનરેટ કરે છે.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">વૉલેટ અનલૉક કરી શકાયું નથી.</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">આને ચુકવણીની વિનંતી કરો…</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">સરનામું:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">રકમ:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">વૉલેટ:</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">&amp;URI કૉપિ કરો</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;છબી સાચવો…</translation>
     </message>
     </context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">તારીખ</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">ચિઠ્ઠી</translation>
@@ -384,8 +2875,77 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">જથ્થો:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">બાઇટ્સ:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">રકમ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">ફી:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">પછીની ફી:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">બદલો:</translation>
+    </message>
+    <message>
         <source>Hide</source>
         <translation type="unfinished">છુપાવો</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">ફોર્મના તમામ ક્ષેત્રો સાફ કરો.</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">નકલ જથ્થો</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">રકમની નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">નકલ ફી</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">ફી પછી નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">બાઇટ્સ કૉપિ કરો</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">ફેરફારની નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">ટ્રાન્ઝેક્શન ડેટા સાચવો</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">આંશિક રીતે હસ્તાક્ષરિત વ્યવહાર (દ્વિસંગી)</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">અથવા</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">કુલ રકમ</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -400,7 +2960,45 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;લેબલ:</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">ક્લિપબોર્ડમાંથી સરનામું પેસ્ટ કરો</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">ક્લિપબોર્ડમાંથી સરનામું પેસ્ટ કરો</translation>
+    </message>
+    </context>
+<context>
     <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">તારીખ</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">થી</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">અજ્ઞાત</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">પ્રતિ</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">પોતાનું સરનામું</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
@@ -415,6 +3013,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">તારીખ</translation>
+    </message>
     <message>
         <source>Type</source>
         <translation type="unfinished">પ્રકાર</translation>
@@ -431,9 +3033,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">સરનામું &amp;નકલ કરો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">કૉપિ કરો &amp;લેબલ બનાવો</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">નકલ  &amp;રકમ</translation>
+    </message>
+    <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
         <translation type="unfinished">અલ્પવિરામથી વિભાજિત ફાઇલ</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">પુષ્ટિ</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">તારીખ</translation>
     </message>
     <message>
         <source>Type</source>
@@ -458,7 +3080,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create a new wallet</source>
         <translation type="unfinished">નવું વૉલેટ બનાવો</translation>
     </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">ભૂલ</translation>
+    </message>
     </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">ડિફૉલ્ટ વૉલેટ</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>
@@ -469,5 +3102,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">હાલ માં પસંદ કરેલ માહિતી ને ફાઇલમાં નિકાસ કરો</translation>
     </message>
-    </context>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">વૉલેટ ડેટા</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">રદ કરો</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_hi.ts
+++ b/src/qt/locale/bitcoin_hi.ts
@@ -533,6 +533,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">बटवा निर्माण में गलती</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">त्रुटि: %1</translation>
     </message>
@@ -682,6 +686,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>MigrateWalletActivity</name>
     <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">वॉलेट माइग्रेट करें</translation>
+    </message>
+    <message>
         <source>Migrate Wallet</source>
         <translation type="unfinished">वॉलेट माइग्रेट करें</translation>
     </message>
@@ -694,6 +702,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">माइग्रेशन हो गया</translation>
     </message>
 </context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">आपके नए बटवे के निर्माण से आप सिर्फ एक कदम दूर है</translation>
+    </message>
+    </context>
 <context>
     <name>Intro</name>
     <message numerus="yes">

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -303,6 +303,18 @@ Aláírni csak régi típusú, egyessel kezdődő címekkel lehet.</translation>
         <translation type="unfinished">ismeretlen</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Beágyazva "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Alapértelmezett betűtípus "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Egyedi…</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">Összeg</translation>
     </message>
@@ -1598,6 +1610,10 @@ A migrációs folyamat készít biztonsági mentést a tárcáról migrálás el
         <translation type="unfinished">Az alkalmazásból való kilépés helyett az eszköztárba kicsinyíti az alkalmazást az ablak bezárásakor. Ez esetben az alkalmazás csak a Kilépés menüponttal zárható be.</translation>
     </message>
     <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">A Főoldal fül betűtípusa:</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line:</source>
         <translation type="unfinished">Ebben az ablakban megadott beállítások felülbírálásra kerültek a parancssori kapcsolók által:</translation>
     </message>
@@ -2633,6 +2649,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Parancs végrehajtása tárca nélkül</translation>
+    </message>
+    <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">Node ablak - [%1]</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -4453,6 +4473,10 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
         <translation type="unfinished">A %s elérési úton fájl nem létezik.</translation>
     </message>
     <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">Hiba tietokannan transaktion vahvistamisessa lompakon tapahtumien poistamiseksi.</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">Hiba %s létrehozása közben</translation>
     </message>
@@ -4499,6 +4523,10 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">A tárca-adatbázisból a következő rekord beolvasása sikertelen.</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">Hinta tietokannan transaktion aloittamisessa lompakon tapahtumien poistamiseksi.</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
@@ -4585,6 +4613,14 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
         <translation type="unfinished">Hiba: Nem lehet írni a figyelő tárca legfelső blokkját megadó rekordot</translation>
     </message>
     <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Virhe: osoitekirjan kopioiminen epäonnistui lompakolle %s</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">Virhe: tietokantatransaktiota ei voida suorittaa lompakolle %s</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Egyik hálózati portot sem sikerül figyelni. Használja a -listen=0 kapcsolót, ha ezt szeretné.</translation>
     </message>
@@ -4599,6 +4635,11 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
     <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Adatbázis ellenőrzése sikertelen</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished"> 
+Virhe tapahtuman poistamisessa: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4821,6 +4862,10 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
         <translation type="unfinished">Ez a tranzakció díja, amelyet kifizet, ha tranzakciót indít.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">tranzakció%s ei kuulu tähän lompakkoon.</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Tranzakció összege túl alacsony</translation>
     </message>
@@ -4927,6 +4972,10 @@ A tárca biztonsági mentésének visszaállítása sikertelen.</translation>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
         <translation type="unfinished">Hiba: Nem sikerült hozzáadni a megfigyelt %s tranzakciót a figyelő tárcához</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Virhe: Ei voitu poistaa vain seurantatapahtumia.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_id.ts
+++ b/src/qt/locale/bitcoin_id.ts
@@ -259,6 +259,18 @@ Tanda tangan hanya bisa digunakan dengan tipe alamat 'warisan'</translation>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
         <translation type="unfinished">Error yang fatal telah terjadi. Periksa bahwa file pengaturan dapat ditulis atau coba jalankan dengan -nosettings</translation>
     </message>
+    <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Di embed "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Font bawaan sistem "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Pilihan...</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -551,6 +563,10 @@ Proses migrasi akan mencadangkan dompet sebelum melakukan pemindahan. Fail cadan
     <message>
         <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
         <translation type="unfinished">Skrip hanya lihat telah dimigrasikan ke dompet yang baru '%1'.</translation>
+    </message>
+    <message>
+        <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Skrip hanya lihat telah diimigrasikan ke dompet baru yang bernama '%1'.</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -974,6 +990,10 @@ Proses migrasi akan mencadangkan dompet sebelum melakukan pemindahan. Fail cadan
         <translation type="unfinished">Minimalisasi aplikasi ketika jendela ditutup. Ketika pilihan ini dipilih, aplikasi akan menutup seluruhnya jika anda memilih Keluar di menu yang tersedia.</translation>
     </message>
     <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Font pada tab Overview:</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line:</source>
         <translation type="unfinished">Set opsi pengaturan pada jendela dialog ini tertutup oleh baris perintah:</translation>
     </message>
@@ -1112,6 +1132,10 @@ Proses migrasi akan mencadangkan dompet sebelum melakukan pemindahan. Fail cadan
         <source>PSBT Operations</source>
         <translation type="unfinished">Operasi PBST</translation>
     </message>
+    <message>
+        <source>Sends %1 to %2</source>
+        <translation type="unfinished">Mengirim %1 ke %2</translation>
+    </message>
     </context>
 <context>
     <name>PeerTableModel</name>
@@ -1244,6 +1268,10 @@ Proses migrasi akan mencadangkan dompet sebelum melakukan pemindahan. Fail cadan
         <translation type="unfinished">Salin Perubahan</translation>
     </message>
     <message>
+        <source>%1 from wallet '%2'</source>
+        <translation type="unfinished">%1 dari dompet '%2'</translation>
+    </message>
+    <message>
         <source>Unsigned Transaction</source>
         <comment>PSBT copied</comment>
         <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
@@ -1285,6 +1313,10 @@ Proses migrasi akan mencadangkan dompet sebelum melakukan pemindahan. Fail cadan
         <translation type="unfinished">
             <numerusform>matures in %n more block(s)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 (Certificate was not verified)</source>
+        <translation type="unfinished">%1 (Sertifikat tidak terverifikasi)</translation>
     </message>
     </context>
 <context>
@@ -1507,8 +1539,16 @@ Tidak dapat memulihkan cadangan dompet..</translation>
         <translation type="unfinished">Verifikasi Blok terganggu</translation>
     </message>
     <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">Kesalahan dalam melakukan db txn untuk penghapusan transaksi dompet</translation>
+    </message>
+    <message>
         <source>Error reading configuration file: %s</source>
         <translation type="unfinished">Kesalahan membaca file konfigurasi: %s</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">Kesalahan memulai db txn untuk penghapusan transaksi dompet</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
@@ -1539,12 +1579,36 @@ Tidak dapat memulihkan cadangan dompet..</translation>
         <translation type="unfinished">Kesalahan: Tidak dapat membaca semua catatan dalam database</translation>
     </message>
     <message>
+        <source>Error: Unable to read wallet's best block locator record</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat membaca catatan pencari blok terbaik dompet</translation>
+    </message>
+    <message>
         <source>Error: Unable to remove watchonly address book data</source>
         <translation type="unfinished">Kesalahan: Tidak dapat menghapus data buku alamat yang hanya dilihat</translation>
     </message>
     <message>
+        <source>Error: Unable to write solvable wallet best block locator record</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat menulis catatan pencari blok terbaik dompet solvable</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write watchonly wallet best block locator record</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat menulis catatan pencari blok terbaik dompet watchonly</translation>
+    </message>
+    <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Kesalahan: penyalinan daftar kontak gagal untuk dompet %s</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">Kesalahan: database transaksi tidak dapat dilakukan untuk dompet %s</translation>
+    </message>
+    <message>
         <source>Failed to start indexes, shutting down..</source>
         <translation type="unfinished">Gagal memulai indeks, mematikan..</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Gagal menghapus transaksi: %s</translation>
     </message>
     <message>
         <source>Insufficient dbcache for block verification</source>
@@ -1583,6 +1647,10 @@ Tidak dapat memulihkan cadangan dompet..</translation>
         <translation type="unfinished">Direktori data yang ditentukan "%s" tidak ada.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Transaksi %s tidak termasuk dompet ini</translation>
+    </message>
+    <message>
         <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
         <translation type="unfinished">Tidak dapat mengalokasikan memori untuk -maxsigcachesize: '%s' MiB</translation>
     </message>
@@ -1599,8 +1667,20 @@ Tidak dapat memulihkan cadangan dompet..</translation>
         <translation type="unfinished">Tingkat penebangan global yang tidak didukung %s = %s. Nilai yang valid: %s.</translation>
     </message>
     <message>
+        <source>Wallet file creation failed: %s</source>
+        <translation type="unfinished">Pembuatan berkas dompet gagal: %s</translation>
+    </message>
+    <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
         <translation type="unfinished">menerima estimasi biaya basi tidak didukung pada %s rantai.</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <translation type="unfinished">Kesalahan: Tidak mampu menambahkan watchonly tx %s ke dompet watchonly</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Kesalahan: Tidak mampu menghapus transaksi watchonly.</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -303,6 +303,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">不明</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">埋込み "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">デフォルトシステムフォント "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">カスタム…</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">金額</translation>
     </message>
@@ -1594,6 +1606,10 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation type="unfinished">ウィンドウが閉じられたとき、アプリケーションを終了するのではなく最小化します。このオプションが有効の場合、メニューから終了が選択されたときのみアプリケーションが終了します。</translation>
     </message>
     <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">概要タブのフォント</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line:</source>
         <translation type="unfinished">このダイアログで設定されたオプションは、コマンド ラインによって上書きされます。</translation>
     </message>
@@ -2635,6 +2651,10 @@ BIP70には広範なセキュリティー上の問題があるので、ウォレ
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">どのウォレットも使わずにコマンドを実行しています</translation>
+    </message>
+    <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">ノードウィンドウ - [%1]</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -4457,6 +4477,10 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished">ダンプファイル %s が存在しません。</translation>
     </message>
     <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">ウォレットトランザクションの削除のためdb txnのコミット中にエラーが発生しました</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">%sの作成エラー</translation>
     </message>
@@ -4503,6 +4527,10 @@ Unable to restore backup of wallet.</source>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">ウォレットデータベースから次のレコードの読み取りでエラー</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">ウォレットトランザクションの削除のためのdb txnの開始でエラーが発生しました</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
@@ -4589,6 +4617,14 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished">エラー：監視専用ウォレットのベストブロックロケーターレコードを書き込めません</translation>
     </message>
     <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">エラー: ウォレット%sのアドレス帳のコピーに失敗しました</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">エラー: ウォレット%sに対してデータベーストランザクションを実行できません</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">ポートのリッスンに失敗しました。必要であれば -listen=0 を指定してください。</translation>
     </message>
@@ -4603,6 +4639,10 @@ Unable to restore backup of wallet.</source>
     <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">データベースの検証に失敗しました</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">取引の削除に失敗: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4825,6 +4865,10 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished">これは、取引を送信する場合に支払う取引手数料です。</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">取引%sはこのウォレットのものではありません</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">取引の金額が小さすぎます</translation>
     </message>
@@ -4931,6 +4975,10 @@ Unable to restore backup of wallet.</source>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
         <translation type="unfinished">エラー:  監視対象取引%sを監視専用ウォレットに追加できませんでした</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">エラー:  監視対象取引を削除できませんでした</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -188,43 +188,43 @@
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
         </translation>
     </message>
     </context>
@@ -325,8 +325,8 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
         </translation>
     </message>
     <message>
@@ -361,8 +361,8 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     <message>
@@ -464,30 +464,30 @@
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     </context>
@@ -872,8 +872,8 @@
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -1066,8 +1066,8 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -94,6 +94,10 @@ Pasirašymas galimas tik su 'legacy' tipo adresais.</translation>
         <translation type="unfinished">Bandant išsaugoti adresų sąrašą - įvyko klaida keliant į %1. Prašome bandyti dar kartą.</translation>
     </message>
     <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">Gaunami adresai - %1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">Eksportavimas nepavyko</translation>
     </message>

--- a/src/qt/locale/bitcoin_ml.ts
+++ b/src/qt/locale/bitcoin_ml.ts
@@ -265,6 +265,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് ക്രമീകരണം പുനഃസജ്ജമാക്കണോ അതോ മാറ്റങ്ങൾ വരുത്താതെ തന്നെ നിർത്തലാക്കണോ?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">ഒരു മാരകമായ പിശക് സംഭവിച്ചു. ക്രമീകരണ ഫയൽ എഴുതാനാവുന്നതാണോയെന്ന് പരിശോധിക്കുക അല്ലെങ്കിൽ ക്രമീകരണങ്ങളില്ലാതെ പ്രവർത്തിപ്പിക്കാൻ ശ്രമിക്കുക.</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">തെറ്റ് : %1 </translation>
     </message>
@@ -380,6 +390,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ഒരു പുതിയ വാലറ്റ് സൃഷ്ടിക്കുക</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished"> ഒപ്പം ചെറുതാക്കുക</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">പണസഞ്ചി </translation>
     </message>
@@ -417,16 +431,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ഇഷ്‌ടമുള്ളത്‌ തിരഞ്ഞെടുക്കല്‍</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">വാലറ്റ് എൻക്രിപ്റ്റ് ചെയ്യുക…</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">നിങ്ങളുടെ വാലറ്റിന്റെ സ്വകാര്യ കീകൾ എൻ‌ക്രിപ്റ്റ് ചെയ്യുക</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished"> ബാക്കപ്പ് വാലറ്റും…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">പാസ്ഫ്രെയ്സ് മാറ്റുക</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">ഒപ്പിടുക, സന്ദേശം നൽകുക</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">നിങ്ങളുടെ ബിറ്റ്കോയിൻ വിലാസങ്ങൾ സ്വന്തമാണെന്ന് തെളിയിക്കാൻ സന്ദേശങ്ങൾ ഒപ്പിടുക</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">സന്ദേശം പരിശോധിക്കുക...</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">നിർദ്ദിഷ്ട ബിറ്റ്കോയിൻ വിലാസങ്ങളിൽ സന്ദേശങ്ങൾ ഒപ്പിട്ടിട്ടുണ്ടെന്ന് ഉറപ്പാക്കാൻ സ്ഥിരീകരിക്കുക</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished"> തുറന്ന് URL</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">വാലറ്റ് അടയ്ക്കുക</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -443,6 +485,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">ടാബുകളുടെ ടൂൾബാർ</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished"> നെറ്റ്‌വർക്കുമായി സമന്വയിപ്പിക്കുന്നു...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -532,6 +578,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">വാലറ്റ് പൂട്ടുക </translation>
     </message>
     <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">ഒരു ബാക്കപ്പ് ഫയലിൽ നിന്ന് ഒരു വാലറ്റ് പുനഃസ്ഥാപിക്കുക</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">എല്ലാ വാലറ്റുകളും അടയ്‌ക്കുക ...</translation>
     </message>
@@ -554,6 +605,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">വാലറ്റ് ഒന്നും ലഭ്യം അല്ല </translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">വാലറ്റ് ബാക്കപ്പ് ലോഡ് ചെയ്യുക</translation>
     </message>
     <message>
         <source>Restore Wallet</source>
@@ -588,6 +644,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">പുതിയ വാലറ്റ് സൃഷ്ടിക്കാൻ കഴിയില്ല, സ്‌ക്ലൈറ്റ്
+പിന്തുണയില്ലാതെ സോഫ്‌റ്റ്‌വെയർ കംപൈൽ ചെയ്‌തു (ഡിസ്‌ക്രിപ്‌റ്റർ വാലറ്റുകൾക്ക് ആവശ്യമാണ്)</translation>
     </message>
     <message>
         <source>Error: %1</source>

--- a/src/qt/locale/bitcoin_ms.ts
+++ b/src/qt/locale/bitcoin_ms.ts
@@ -81,6 +81,10 @@ Alihkan fail data ke dalam tab semasa</translation>
         <translation type="unfinished">Terdapat ralat semasa cubaan menyimpan senarai alamat kepada %1. Sila cuba lagi.</translation>
     </message>
     <message>
+        <source>Receiving addresses - %1</source>
+        <translation type="unfinished">Alamat Terima - %1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">Mengeksport Gagal</translation>
     </message>

--- a/src/qt/locale/bitcoin_my.ts
+++ b/src/qt/locale/bitcoin_my.ts
@@ -78,6 +78,37 @@
     </message>
     </context>
 <context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">စကားဝှက် ဒိုင်ယာလော့ဂ်</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">စကားဝှက် ရိုက်ထည့်ရန်</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">စကားဝှက် အသစ်</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">စကားဝှက် အသစ်ပြန်ရိုက်ပါ</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">စကားဝှက် ပြရန်</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">ပိုက်ဆံအိတ် ကို ဝှက်စာပြုလုပ်ပါ</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">ဤလုပ်ဆောင်ချက်သည် ပိုက်ဆံအိတ်ကို လော့ခ်ဖွင့်ရန် သင့်ပိုက်ဆံအိတ် စကားဝှက် လိုအပ်ပါသည်။</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: %1</source>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -299,6 +299,18 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
         <translation type="unfinished">onbekend</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Ingebed "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Standaard systeemlettertype "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Aangepast...</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">Bedrag</translation>
     </message>
@@ -1556,6 +1568,10 @@ Het migratieproces maakt voorafgaand aan het migreren een backup van de wallet. 
         <translation type="unfinished">Minimaliseren in plaats van de applicatie af te sluiten wanneer het venster is afgesloten. Als deze optie is ingeschakeld, zal de toepassing pas worden afgesloten na het selecteren van Exit in het menu.</translation>
     </message>
     <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Lettertype in het Overzicht tab:</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line:</source>
         <translation type="unfinished">Gekozen opties in dit dialoogvenster worden overschreven door de command line:</translation>
     </message>
@@ -2541,6 +2557,10 @@ Als je deze fout ziet zou je de aanbieder moeten verzoeken om een BIP21-compatib
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Uitvoeren van commando zonder gebruik van een wallet</translation>
+    </message>
+    <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">Nodevenster - [%1]</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -4278,6 +4298,10 @@ Kan mislukte migratie niet opschonen</translation>
         <translation type="unfinished">Dumpbestand %s bestaat niet.</translation>
     </message>
     <message>
+        <source>Error committing db txn for wallet transactions removal</source>
+        <translation type="unfinished">Fout bij db txn verwerking voor verwijderen wallet transacties</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">Fout bij het maken van %s</translation>
     </message>
@@ -4324,6 +4348,10 @@ Kan mislukte migratie niet opschonen</translation>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">Fout bij het lezen van het volgende record in de walletdatabase</translation>
+    </message>
+    <message>
+        <source>Error starting db txn for wallet transactions removal</source>
+        <translation type="unfinished">Fout bij starten db txn voor verwijderen wallet transacties</translation>
     </message>
     <message>
         <source>Error: Cannot extract destination from the generated scriptpubkey</source>
@@ -4410,6 +4438,14 @@ Kan mislukte migratie niet opschonen</translation>
         <translation type="unfinished">Fout: Kan beste block locatie aanduiding niet opslaan in alleen lezen wallet</translation>
     </message>
     <message>
+        <source>Error: address book copy failed for wallet %s</source>
+        <translation type="unfinished">Fout: Kopiëren adresboek mislukt voor wallet %s</translation>
+    </message>
+    <message>
+        <source>Error: database transaction cannot be executed for wallet %s</source>
+        <translation type="unfinished">Fout: Kan databasetransactie niet uitvoeren voor wallet %s</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Mislukt om op welke poort dan ook te luisteren. Gebruik -listen=0 as u dit wilt.</translation>
     </message>
@@ -4424,6 +4460,10 @@ Kan mislukte migratie niet opschonen</translation>
     <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Mislukt om de databank te controleren</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Verwijderen transactie mislukt: %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4646,6 +4686,10 @@ Kan mislukte migratie niet opschonen</translation>
         <translation type="unfinished">Dit is de transactievergoeding dat je betaalt wanneer je een transactie verstuurt.</translation>
     </message>
     <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Transactie %s behoort niet tot deze wallet</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Transactiebedrag te klein</translation>
     </message>
@@ -4752,6 +4796,10 @@ Kan mislukte migratie niet opschonen</translation>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
         <translation type="unfinished">Fout: Kon alleen lezen tx %s niet toevoegen aan alleen lezen wallet</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Fout: Kon alleen-lezen transacties niet verwijderen</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -257,6 +257,18 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">nieznane</translation>
     </message>
     <message>
+        <source>Embedded "%1"</source>
+        <translation type="unfinished">Osadzony "%1"</translation>
+    </message>
+    <message>
+        <source>Default system font "%1"</source>
+        <translation type="unfinished">Domyślna czcionka systemu "%1"</translation>
+    </message>
+    <message>
+        <source>Custom…</source>
+        <translation type="unfinished">Własna:</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">Kwota</translation>
     </message>
@@ -1062,6 +1074,14 @@ Proces migracji utworzy kopię zapasową portfela przed migracją. Plik kopii za
         <translation type="unfinished">Portfel '%1' został poprawnie przeniesiony.</translation>
     </message>
     <message>
+        <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Skrypty tylko do odczytu zostały przeniesione do nowego portfela '%1'</translation>
+    </message>
+    <message>
+        <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Sprawne, ale nie oglądane skrypty tylko do odczytu zostały przeniesione do nowego portfela '%1'</translation>
+    </message>
+    <message>
         <source>Migration failed</source>
         <translation type="unfinished">Przeniesienie nie powiodło się</translation>
     </message>
@@ -1155,6 +1175,10 @@ Proces migracji utworzy kopię zapasową portfela przed migracją. Plik kopii za
     <message>
         <source>You are one step away from creating your new wallet!</source>
         <translation type="unfinished">Jesteś jeden krok od stworzenia swojego nowego portfela!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Proszę podać nazwę, i jeśli potrzeba, włącz zaawansowane ustawienia.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1542,6 +1566,10 @@ Proces migracji utworzy kopię zapasową portfela przed migracją. Plik kopii za
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Minimalizuje zamiast zakończyć działanie programu przy zamykaniu okna. Kiedy ta opcja jest włączona, program zakończy działanie po wybieraniu Zamknij w menu.</translation>
+    </message>
+    <message>
+        <source>Font in the Overview tab: </source>
+        <translation type="unfinished">Czcionka w zakładce Przegląd:</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
@@ -2265,6 +2293,18 @@ Jeśli pojawia się ten błąd, poproś sprzedawcę o podanie URI zgodnego z BIP
         <translation type="unfinished">Wersja warstwy transportowej: %1</translation>
     </message>
     <message>
+        <source>Transport</source>
+        <translation type="unfinished">Transfer</translation>
+    </message>
+    <message>
+        <source>The BIP324 session ID string in hex, if any.</source>
+        <translation type="unfinished">ID sesji BIP324 jest szestnastkowym ciągiem znaków, jeśli istnieje.</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">ID sesji</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Wersja</translation>
     </message>
@@ -2557,6 +2597,10 @@ Jeśli pojawia się ten błąd, poproś sprzedawcę o podanie URI zgodnego z BIP
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Wykonuję komendę bez portfela</translation>
+    </message>
+    <message>
+        <source>Node window - [%1]</source>
+        <translation type="unfinished">Okno węzła  - [%1]</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -4012,6 +4056,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd: starsze portfele obsługują tylko typy adresów „legacy”, „p2sh-segwit” i „bech32”</translation>
     </message>
     <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
+        <translation type="unfinished">Błąd: Nie można wygenerować deskryptorów dla tego starego portfela. Upewnij się najpierw, że portfel jest odblokowany.</translation>
+    </message>
+    <message>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
         <translation type="unfinished">Plik 1%s już istnieje. Jeśli jesteś pewien, że tego chcesz, najpierw usuń to z drogi.</translation>
     </message>
@@ -4096,6 +4144,18 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Podano nieznany typ pliku portfela "%s". Proszę podać jeden z "bdb" lub "sqlite".</translation>
     </message>
     <message>
+        <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
+        <translation type="unfinished">Nieobsługiwany poziom rejestrowania specyficzny dla kategorii %1$s=%2$s. Oczekiwano %1$s=&lt;category&gt;:&lt;loglevel&gt;. Poprawne kategorie %3$s. Poprawne poziomy logowania: %4 $s.</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Znaleziono nieobsługiwany format bazy danych chainstate. Proszę uruchomić ponownie z opcją -reindex-chainstate. To odbuduje bazę danych chainstate.</translation>
+    </message>
+    <message>
+        <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
+        <translation type="unfinished">Portfel został załadowany pomyślnie. Starszy typ portfela jest przestarzały, a obsługa tworzenia i otwierania starszych portfeli zostanie usunięta w przyszłości. Starsze portfele można migrować do portfela deskryptora za pomocą migratewallet.</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Uwaga: Wykryto klucze prywatne w portfelu [%s] który ma wyłączone klucze prywatne</translation>
     </message>
@@ -4124,12 +4184,20 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Nie można rozpoznać -%s adresu: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Nie można ustawić -forcednsseed na true gdy ustawienie -dnsseed wynosi false.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Nie można ustawić -peerblockfilters bez -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Nie mogę zapisać do katalogu danych '%s'; sprawdź uprawnienia.</translation>
+    </message>
+    <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">%sto bardzo dużo!  Tak duże opłaty można uiścić w ramach jednej transakcji.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
@@ -4148,8 +4216,40 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd: Podczas migracji utworzono zduplikowane deskryptory. Twój portfel może być uszkodzony.</translation>
     </message>
     <message>
+        <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
+        <translation type="unfinished">Nie udało się obliczyć opłat za uderzenia, ponieważ niepotwierdzone UTXO zależą od ogromnego skupiska niepotwierdzonych transakcji.</translation>
+    </message>
+    <message>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
         <translation type="unfinished">Zmiana nazwy nieprawidłowego pliku peers.dat nie powiodła się. Przenieś go lub usuń i spróbuj ponownie.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">Estymacja opłat nieudana. Domyślna opłata jest wyłączona. Poczekaj kilka bloków lub włącz  -%s.</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <translation type="unfinished">Połączenia wychodzące ograniczone do CJDNS (-onlynet=cjdns), ale nie podano -cjdnsreachable</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Połączenia wychodzące ograniczone do sieci Tor (-onlynet=onion), ale proxy do uzyskania dostępu do sieci Tor jest wyraźnie zabronione: -onion=0</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Nie można wyczyścić nieudanej migracji</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Nie można przywrócić kopii zapasowej portfela</translation>
+    </message>
+    <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">Weryfikacja bloku została przerwana</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -4182,6 +4282,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Wczytywanie zakończone</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Plik zrzutu aplikacji %s nie istnieje.</translation>
     </message>
     <message>
         <source>Error creating %s</source>
@@ -4220,6 +4324,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd otwierania bazy bloków</translation>
     </message>
     <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Błąd: nie można odczytać pliku konfiguracyjnego: %s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Błąd odczytu z bazy danych, wyłączam się.</translation>
     </message>
@@ -4228,12 +4336,32 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd odczytu kolejnego rekordu z bazy danych portfela</translation>
     </message>
     <message>
+        <source>Error: Cannot extract destination from the generated scriptpubkey</source>
+        <translation type="unfinished">Błąd: Nie można wyodrębnić miejsca docelowego z wygenerowanego scriptpubkey</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Błąd: Nie udało się utworzyć kursora w bazie danych</translation>
+    </message>
+    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Błąd: zbyt mało miejsca na dysku dla %s</translation>
     </message>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Błąd: Plik zrzutu suma kontrolna nie pasuje. Obliczone %s,  spodziewane %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Błąd: Utworzenie portfela tylko do odczytu nie powiodło się</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Błąd: Otrzymana wartość nie jest szestnastkowa%s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Błąd: Otrzymana wartość nie jest szestnastkowa%s</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
@@ -4252,8 +4380,32 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd: Ten portfel już używa SQLite</translation>
     </message>
     <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Błąd: Ten portfel jest już portfelem opisowym (descriptor wallet)</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Błąd: Nie można odczytać wszystkich rekordów z bazy danych</translation>
+    </message>
+    <message>
         <source>Error: Unable to make a backup of your wallet</source>
         <translation type="unfinished">Błąd: Nie mogę zrobić kopii twojego portfela</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Błąd: Nie można zapisać wersji %u jako uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Błąd: Nie można odczytać wszystkich rekordów z bazy danych</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read wallet's best block locator record</source>
+        <translation type="unfinished">Błąd: Nie można odczytać najlepszego rekordu lokalizatora bloków portfela</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Błąd: Nie można usunąć danych książki adresowej tylko do odczytu</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -4268,8 +4420,16 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Nie udało się ponownie przeskanować portfela podczas inicjalizacji.</translation>
     </message>
     <message>
+        <source>Failed to start indexes, shutting down..</source>
+        <translation type="unfinished">Nie udało się uruchomić indeksów, zamykanie...</translation>
+    </message>
+    <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Nie udało się zweryfikować bazy danych</translation>
+    </message>
+    <message>
+        <source>Failure removing transaction: %s</source>
+        <translation type="unfinished">Nie udało się usunąć transakcji %s</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
@@ -4296,6 +4456,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Wejście nie znalezione lub już wydane</translation>
     </message>
     <message>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished">Niewystarczająca pamięć podręczna bazy danych (dbcache) do weryfikacji bloków</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Niewystarczające środki</translation>
     </message>
@@ -4316,12 +4480,28 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Nieprawidłowe uprawnienia P2P: '%s'</translation>
     </message>
     <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Nieprawidłowa kwota dla %s=&lt;amount&gt;: '%s' (musi być co najmniej %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Nieprawidłowa kwota dla %s=&lt;amount&gt;: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
         <translation type="unfinished">Nieprawidłowa kwota dla -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Nieprawidłowa maska sieci określona w -whitelist: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid port specified in %s: '%s'</source>
+        <translation type="unfinished">Nieprawidłowa maska sieci określona w %s: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished">Niepoprawne wstępnie wybrane dane wejściowe %s</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -4358,6 +4538,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
     <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Brak wystarczającej liczby deskryptorów plików.</translation>
+    </message>
+    <message>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished">Nie znaleziono wstępnie wybranego wejścia %s</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4425,12 +4609,20 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
 </translation>
     </message>
     <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">Określony katalog danych "%s" nie istnieje</translation>
+    </message>
+    <message>
         <source>Starting network threads…</source>
         <translation type="unfinished">Startowanie wątków sieciowych...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Kod źródłowy dostępny jest z %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Podany plik konfiguracyjny %s nie istnieje</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -4451,6 +4643,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished">To jest opłata transakcyjna którą zapłacisz jeśli wyślesz transakcję.</translation>
+    </message>
+    <message>
+        <source>Transaction %s does not belong to this wallet</source>
+        <translation type="unfinished">Transakcja %s nie należy do tego portfela</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
@@ -4541,8 +4737,28 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Aktywowano nieznane nowe reguły (versionbit %i)</translation>
     </message>
     <message>
+        <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
+        <translation type="unfinished">Niewspierany globalny poziom logowania%s=%s. Poprawne wartości: %s.</translation>
+    </message>
+    <message>
+        <source>Wallet file creation failed: %s</source>
+        <translation type="unfinished">Utworzenie pliku portfela nie powiodło się: %s</translation>
+    </message>
+    <message>
+        <source>acceptstalefeeestimates is not supported on %s chain.</source>
+        <translation type="unfinished">akceptowalne nieaktualne szacunki opłat nie są wspierane na łańcuchu %s</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nieobsługiwana kategoria rejestrowania %s=%s.</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <translation type="unfinished">Błąd: Nie można dodać tx %s tylko do odczytu do portfela tylko do odczytu</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions. </source>
+        <translation type="unfinished">Błąd: Nie można usunąć transakcji tylko do odczytu.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>

--- a/src/qt/locale/bitcoin_pt.ts
+++ b/src/qt/locale/bitcoin_pt.ts
@@ -7,7 +7,7 @@
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">Crie um endereço novo</translation>
+        <translation type="unfinished">Criar um novo endereço</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -35,19 +35,19 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar os dados no separador atual para um ficheiro</translation>
+        <translation type="unfinished">Exportar os dados na aba atual para um ficheiro</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">e exportar</translation>
+        <translation type="unfinished">&amp;Exportar</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Eliminar</translation>
+        <translation type="unfinished">El&amp;iminar</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Escolha o endereço para enviar as moedas</translation>
+        <translation type="unfinished">Escolha o endereço para onde enviar as moedas</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
@@ -59,21 +59,21 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estes são os seus endereços Bitcoin para enviar pagamentos. Verifique sempre o valor e o endereço de receção antes de enviar moedas.</translation>
+        <translation type="unfinished">Estes são os seus endereços Bitcoin para enviar pagamentos. Verifique sempre a quantia e o endereço de receção antes de enviar moedas.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Estes são seus novos endereços Bitcoin para o recebimento de pagamentos. Use o botão "Criar novo endereço de recebimento" na aba "Receber"  para criar novos endereços.
-Assinar só é possível com endereços do tipo "legado".</translation>
+        <translation type="unfinished">Estes são os seus endereços Bitcoin para receber pagamentos. Utilize o botão "Criar novo endereço de receção" na aba "Receber" para criar novos endereços.
+A assinatura só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Copiar Endereço</translation>
+        <translation type="unfinished">&amp;Copiar endereço</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar &amp;Etiqueta</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -81,7 +81,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Exportar Lista de Endereços</translation>
+        <translation type="unfinished">Exportar lista de endereços</translation>
     </message>
     <message>
         <source>Comma separated file</source>
@@ -91,19 +91,19 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Ocorreu um erro ao tentar guardar a lista de endereços para %1. Por favor, tente novamente.</translation>
+        <translation type="unfinished">Ocorreu um erro ao tentar guardar a lista de endereços em %1. Por favor, tente novamente.</translation>
     </message>
     <message>
         <source>Sending addresses - %1</source>
-        <translation type="unfinished">Enviando endereços - %1</translation>
+        <translation type="unfinished">Endereço de envio - %1</translation>
     </message>
     <message>
         <source>Receiving addresses - %1</source>
-        <translation type="unfinished">Recebendo endereços - %1</translation>
+        <translation type="unfinished">Endereços de receção - %1</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Exportação Falhou</translation>
+        <translation type="unfinished">Falha na exportação</translation>
     </message>
 </context>
 <context>
@@ -125,7 +125,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">Janela da Frase de Segurança</translation>
+        <translation type="unfinished">Janela da frase de segurança</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
@@ -133,15 +133,15 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">Nova frase de frase de segurança</translation>
+        <translation type="unfinished">Nova frase de segurança</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Repita a nova frase de frase de segurança</translation>
+        <translation type="unfinished">Repita a nova frase de segurança</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Mostrar Password</translation>
+        <translation type="unfinished">Mostrar frase de segurança</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
@@ -149,7 +149,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Esta operação precisa da sua frase de segurança da carteira para desbloquear a mesma.</translation>
+        <translation type="unfinished">Esta operação necessita da frase de segurança da sua carteira para a desbloquear.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -177,15 +177,15 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Insira nova password para a carteira.&lt;br/&gt;Por favor use uma password de &lt;b&gt;dez ou mais caracteres&lt;/b&gt;, ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
+        <translation type="unfinished">Insira a nova frase de segurança para a carteira.&lt;br/&gt;Por favor use uma frase de segurança de &lt;b&gt;dez ou mais caracteres&lt;/b&gt; ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Insira a password antiga e a nova para a carteira.</translation>
+        <translation type="unfinished">Insira a frase de segurança antiga e a nova para a carteira.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Lembra se que encrostar a sua carteira não o pode defender na totalidade os seus bitcoins de serem roubados por um malware que possa infectar o seu computador.</translation>
+        <translation type="unfinished">Lembre-se que a encriptação da sua carteira não impede totalmente os seus bitcoins de serem roubados por programas maliciosos (malware) que infetem o seu computador.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
@@ -205,7 +205,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Encriptação da carteira falhou</translation>
+        <translation type="unfinished">Falha na encriptação da carteira</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
@@ -217,7 +217,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">Desbloqueio da carteira falhou</translation>
+        <translation type="unfinished">Falha no desbloqueio da carteira</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
@@ -225,7 +225,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
-        <translation type="unfinished">A palavra passe inserida para a de-criptografia da carteira é incorreta . Ela contém um caractere nulo (ou seja - um byte zero). Se a palavra passe foi configurada em uma versão anterior deste software antes da versão 25.0, por favor tente novamente apenas com os caracteres maiúsculos — mas não incluindo — o primeiro caractere nulo. Se for bem-sucedido, defina uma nova senha para evitar esse problema no futuro.</translation>
+        <translation type="unfinished">A frase de segurança introduzida para a desencriptação da carteira está incorreta. Contém um carácter nulo (ou seja, um byte zero). Se a frase de segurança foi definida com uma versão deste software anterior à 25.0, tente novamente com apenas os caracteres até - mas não incluindo - o primeiro carácter nulo. Se isso for bem-sucedido, defina uma nova frase de segurança para evitar esse problema no futuro.</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
@@ -233,26 +233,26 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
-        <translation type="unfinished">A alteração da frase de segurança falhou</translation>
+        <translation type="unfinished">Falha na alteração da frase de segurança</translation>
     </message>
     <message>
         <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
-        <translation type="unfinished">A senha antiga inserida para a de-criptografia da carteira está incorreta. Ele contém um caractere nulo (ou seja, um byte zero). Se a senha foi definida com uma versão deste software anterior a 25.0, tente novamente apenas com os caracteres maiúsculo — mas não incluindo — o primeiro caractere nulo.</translation>
+        <translation type="unfinished">A frase de segurança antiga introduzida para a desencriptação da carteira está incorreta. Contém um carácter nulo (ou seja, um byte zero). Se a frase de segurança foi definida com uma versão deste software anterior à 25.0, tente novamente com apenas os caracteres até - mas não incluindo - o primeiro carácter nulo.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Aviso: a tecla Caps Lock está ativa!</translation>
+        <translation type="unfinished">Aviso: a tecla de bloqueio de maiúsculas está ativa!</translation>
     </message>
 </context>
 <context>
     <name>BanTableModel</name>
     <message>
         <source>IP/Netmask</source>
-        <translation type="unfinished">IP/Máscara de Rede</translation>
+        <translation type="unfinished">IP / máscara de rede</translation>
     </message>
     <message>
         <source>Banned Until</source>
-        <translation type="unfinished">Banido Até</translation>
+        <translation type="unfinished">Banido até</translation>
     </message>
 </context>
 <context>
@@ -263,11 +263,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Runaway exception</source>
-        <translation type="unfinished">Exceção de Runaway</translation>
+        <translation type="unfinished">Exceção de fuga (runaway)</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Um erro fatal ocorreu. %1 não pode mais continuar de maneira segura e será terminada.</translation>
+        <translation type="unfinished">Ocorreu um erro fatal. %1 já não pode continuar em segurança e vai ser encerrado.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -288,7 +288,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Ocorreu um erro fatal. Verifique se o arquivo de configurações é editável, ou tente correr com -nosettings.</translation>
+        <translation type="unfinished">Ocorreu um erro fatal. Verifique se o ficheiro de configurações pode ser escrito ou tente executar com -nosettings.</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -296,7 +296,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 ainda não terminou com segurança...</translation>
+        <translation type="unfinished">%1 ainda não encerrou de forma segura…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -304,15 +304,15 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Embedded "%1"</source>
-        <translation type="unfinished">Embutido "%1"</translation>
+        <translation type="unfinished">"%1" embutido</translation>
     </message>
     <message>
         <source>Default system font "%1"</source>
-        <translation type="unfinished">Fonte padrão do sistema "%1"</translation>
+        <translation type="unfinished">Tipo de letra do sistema "%1"</translation>
     </message>
     <message>
         <source>Custom…</source>
-        <translation type="unfinished">Personalizado...</translation>
+        <translation type="unfinished">Personalizado…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -344,17 +344,17 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Block Relay</source>
         <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">Retransmissão de Blocos</translation>
+        <translation type="unfinished">Retransmissão de blocos</translation>
     </message>
     <message>
         <source>Feeler</source>
         <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">Antena</translation>
+        <translation type="unfinished">Sensor</translation>
     </message>
     <message>
         <source>Address Fetch</source>
         <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
-        <translation type="unfinished">Procura de endreços</translation>
+        <translation type="unfinished">Obtenção de endereços</translation>
     </message>
     <message>
         <source>None</source>
@@ -431,7 +431,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Fec&amp;har</translation>
+        <translation type="unfinished">&amp;Sair</translation>
     </message>
     <message>
         <source>Quit application</source>
@@ -455,11 +455,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">Modificar opções de configuração para %1</translation>
+        <translation type="unfinished">Alterar opções de configuração de %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Criar novo carteira</translation>
+        <translation type="unfinished">Criar nova carteira</translation>
     </message>
     <message>
         <source>&amp;Minimize</source>
@@ -476,7 +476,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <translation type="unfinished">Proxy está &lt;b&gt;ativado&lt;/b&gt;: %1</translation>
+        <translation type="unfinished"> O proxy está &lt;b&gt;ativado&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
@@ -484,7 +484,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation type="unfinished">Efetue uma cópia de segurança da carteira para outra localização</translation>
+        <translation type="unfinished">Fazer uma cópia de segurança da carteira para outra localização</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
@@ -504,7 +504,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">Carteira &amp;encriptada…</translation>
+        <translation type="unfinished">&amp;Encriptar carteira…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -532,11 +532,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Verifique mensagens para assegurar que foram assinadas com o endereço Bitcoin especificado</translation>
+        <translation type="unfinished">Verificar mensagens para garantir que foram assinadas com endereços Bitcoin especificados</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Carregar PSBT do arquivo...</translation>
+        <translation type="unfinished">&amp;Carregar PSBT do ficheiro…</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -568,11 +568,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation type="unfinished">Barra de ferramentas dos separadores</translation>
+        <translation type="unfinished">Barra de ferramentas das abas</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">A sincronizar cabeçalhos (%1%)...</translation>
+        <translation type="unfinished">A sincronizar cabeçalhos (%1%)…</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
@@ -592,7 +592,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Solicitar pagamentos (gera códigos QR e bitcoin: URIs)</translation>
+        <translation type="unfinished">Pedir pagamentos (gera códigos QR e bitcoin: URIs)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
@@ -604,7 +604,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;Opções da linha de &amp;comando</translation>
+        <translation type="unfinished">Opções da linha de &amp;comandos</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
@@ -615,11 +615,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation type="unfinished">%1 em atraso</translation>
+        <translation type="unfinished">%1 atrás</translation>
     </message>
     <message>
         <source>Catching up…</source>
-        <translation type="unfinished">Recuperando o atraso...</translation>
+        <translation type="unfinished">A recuperar o atraso…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -627,7 +627,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">As transações depois de isto ainda não serão visíveis.</translation>
+        <translation type="unfinished">As transações posteriores a esta data ainda não serão visíveis.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -651,7 +651,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
-        <translation type="unfinished">Carregar PSBT da área de transferência...</translation>
+        <translation type="unfinished">Carregar PSBT da área de transferência…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -663,23 +663,23 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Abrir o depurador de nó e o console de diagnóstico</translation>
+        <translation type="unfinished">Abrir a consola de diagnóstico e depuração de nó</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
-        <translation type="unfinished">&amp;Endereço de envio</translation>
+        <translation type="unfinished">&amp;Endereços de envio</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Endereços de receção</translation>
+        <translation type="unfinished">Endereços de &amp;receção</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Abrir um bitcoin URI</translation>
+        <translation type="unfinished">Abrir um bitcoin: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">Abrir Carteira</translation>
+        <translation type="unfinished">Abrir carteira</translation>
     </message>
     <message>
         <source>Open a wallet</source>
@@ -687,7 +687,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Fechar a carteira</translation>
+        <translation type="unfinished">Fechar carteira</translation>
     </message>
     <message>
         <source>Restore Wallet…</source>
@@ -701,7 +701,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Fechar todas carteiras.</translation>
+        <translation type="unfinished">Fechar todas carteiras</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -713,15 +713,15 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Mostrar a mensagem de ajuda %1 para obter uma lista com possíveis opções a usar na linha de comandos.</translation>
+        <translation type="unfinished">Mostrar a mensagem de ajuda %1 para obter uma lista com as possíveis opções de linha de comandos do Bitcoin</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp;Valores de Máscara</translation>
+        <translation type="unfinished">&amp;Mascarar valores</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Mascare os valores na aba de visão geral</translation>
+        <translation type="unfinished">Mascarar os valores na aba Resumo</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -739,7 +739,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Load Wallet Backup</source>
         <extracomment>The title for Restore Wallet File Windows</extracomment>
-        <translation type="unfinished">Carregar cópia de segurança de carteira</translation>
+        <translation type="unfinished">Carregar cópia de segurança da carteira</translation>
     </message>
     <message>
         <source>Restore Wallet</source>
@@ -749,7 +749,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
-        <translation type="unfinished">Nome da Carteira</translation>
+        <translation type="unfinished">Nome da carteira</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -769,7 +769,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>&amp;Hide</source>
-        <translation type="unfinished">Ocultar</translation>
+        <translation type="unfinished">&amp;Ocultar</translation>
     </message>
     <message>
         <source>S&amp;how</source>
@@ -779,19 +779,19 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n conexão ativa na rede Bitcoin.</numerusform>
-            <numerusform>%n conexões ativas na rede Bitcoin.</numerusform>
+            <numerusform>%n conexão ativa com a rede Bitcoin.</numerusform>
+            <numerusform>%n conexões ativas com a rede Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
-        <translation type="unfinished">Clique para mais acções.</translation>
+        <translation type="unfinished">Clique para mais ações.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">Mostra aba de Pares</translation>
+        <translation type="unfinished">Mostra aba Pares</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -801,7 +801,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
-        <translation type="unfinished">Activar atividade da rede</translation>
+        <translation type="unfinished">Ativar atividade da rede</translation>
     </message>
     <message>
         <source>Pre-syncing Headers (%1%)…</source>
@@ -832,7 +832,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Amount: %1
 </source>
-        <translation type="unfinished">Valor: %1
+        <translation type="unfinished">Quantia: %1
 </translation>
     </message>
     <message>
@@ -869,11 +869,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation type="unfinished">Criação de chave HD está &lt;b&gt;ativada&lt;/b&gt;</translation>
+        <translation type="unfinished">A criação de chave HD está &lt;b&gt;ativada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Criação de chave HD está &lt;b&gt;desativada&lt;/b&gt;</translation>
+        <translation type="unfinished">A criação de chave HD está &lt;b&gt;desativada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
@@ -896,14 +896,14 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Unidade de valores recebidos. Clique para selecionar outra unidade.</translation>
+        <translation type="unfinished">Unidade de quantias recebidas. Clique para selecionar outra unidade.</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">Seleção de Moeda</translation>
+        <translation type="unfinished">Seleção de moeda</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -919,7 +919,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Depois da taxa:</translation>
+        <translation type="unfinished">Após a taxa:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -927,7 +927,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(des)selecionar todos</translation>
+        <translation type="unfinished">(des)selecionar tudo</translation>
     </message>
     <message>
         <source>Tree mode</source>
@@ -959,11 +959,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmada</translation>
+        <translation type="unfinished">Confirmado</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar valor</translation>
+        <translation type="unfinished">Copiar quantia</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -979,7 +979,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID and output index</source>
-        <translation type="unfinished">Copiar &amp;ID da transação e index do output</translation>
+        <translation type="unfinished">Copiar o &amp;ID da transação e o índice de saída</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
@@ -999,7 +999,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar depois da taxa</translation>
+        <translation type="unfinished">Copiar após a taxa</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -1015,7 +1015,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Pode variar +/- %1 satoshi(s) por input.</translation>
+        <translation type="unfinished">Pode variar +/- %1 satoshi(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1035,7 +1035,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Create Wallet</source>
         <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
-        <translation type="unfinished">Criar Carteira</translation>
+        <translation type="unfinished">Criar carteira</translation>
     </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
@@ -1052,7 +1052,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Can't list signers</source>
-        <translation type="unfinished">Não é possível listar signatários</translation>
+        <translation type="unfinished">Não é possível listar os signatários</translation>
     </message>
     <message>
         <source>Too many external signers found</source>
@@ -1069,7 +1069,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
-        <translation type="unfinished">A carregar carteiras...</translation>
+        <translation type="unfinished">A carregar carteiras…</translation>
     </message>
 </context>
 <context>
@@ -1088,11 +1088,11 @@ If this wallet contains any watchonly scripts, a new wallet will be created whic
 If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
 
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the "Restore Wallet" functionality.</source>
-        <translation type="unfinished">A migração irá converter esta carteira em uma ou mais carteiras com descritores. Será necessário realizar um novo backup da carteira.
-Se esta carteira contiver scripts watchonly, uma carteira nova será criada contendo estes scripts watchonly.
-Se esta carteira contiver algum script solucionável, mas não monitorado, uma carteira nova e diferente será criada contendo esses scripts.
+        <translation type="unfinished">A migração da carteira converterá esta carteira numa ou mais carteiras descritoras. Terá de ser efetuada uma nova cópia de segurança da carteira.
+Se esta carteira contiver quaisquer scripts só de observação, será criada uma nova carteira que contenha esses scripts só de observação.
+Se esta carteira contiver quaisquer scripts solucionáveis mas não observados, será criada uma carteira nova e diferente que contenha esses scripts.
 
-O processo de migração criará um backup da carteira antes da migração. Este arquivo de backup será nomeado &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak e pode ser encontrado no diretório desta carteira. No caso de uma migração incorreta, o backup pode ser restaurado com a funcionalidade “Restaurar Carteira”.</translation>
+O processo de migração criará uma cópia de segurança da carteira antes da migração. Este ficheiro de cópia de segurança será denominado &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak e pode ser encontrado no diretório para esta carteira. Na eventualidade de uma migração incorreta, a cópia de segurança pode ser restaurada com a funcionalidade "Restaurar carteira".</translation>
     </message>
     <message>
         <source>Migrate Wallet</source>
@@ -1100,15 +1100,19 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <translation type="unfinished">Migrando Carteira &lt;b&gt;%1&lt;/b&gt;…</translation>
+        <translation type="unfinished">A migrar a carteira &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>The wallet '%1' was migrated successfully.</source>
         <translation type="unfinished">A carteira '%1' foi migrada com sucesso.</translation>
     </message>
     <message>
+        <source>Watchonly scripts have been migrated to a new wallet named '%1'.</source>
+        <translation type="unfinished">Os scripts de observação/watchonly foram migrados para uma nova carteira chamada '%1'.</translation>
+    </message>
+    <message>
         <source>Solvable but not watched scripts have been migrated to a new wallet named '%1'.</source>
-        <translation type="unfinished">Os guiões solucionáveis mas não observados foram migrados para uma nova pasta chamada '%1'.</translation>
+        <translation type="unfinished">Os scripts solucionáveis mas não observados/watched foram migrados para uma nova carteira chamada '%1'.</translation>
     </message>
     <message>
         <source>Migration failed</source>
@@ -1127,7 +1131,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Aviso abertura carteira</translation>
+        <translation type="unfinished">Aviso de carteira aberta</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -1136,7 +1140,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Abrir Carteira</translation>
+        <translation type="unfinished">Abrir carteira</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
@@ -1164,7 +1168,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Restore wallet warning</source>
         <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
-        <translation type="unfinished">Aviso de restaurar carteira</translation>
+        <translation type="unfinished">Aviso de restaurar a carteira</translation>
     </message>
     <message>
         <source>Restore wallet message</source>
@@ -1176,34 +1180,34 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Fechar a carteira</translation>
+        <translation type="unfinished">Fechar carteira</translation>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Tem a certeza que deseja fechar esta carteira &lt;i&gt;%1&lt;/i&gt;?</translation>
+        <translation type="unfinished">Tem a certeza que deseja fechar a carteira &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Fechar a carteira durante demasiado tempo pode resultar em ter de resincronizar a cadeia inteira se pruning estiver ativado.</translation>
+        <translation type="unfinished">Fechar a carteira durante demasiado tempo pode resultar na necessidade de voltar a sincronizar toda a cadeia se a redução (prune) estiver ativada.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Fechar todas carteiras.</translation>
+        <translation type="unfinished">Fechar todas carteiras</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Você tem certeza que deseja fechar todas as carteira?</translation>
+        <translation type="unfinished">Tem a certeza de que deseja fechar todas as carteiras?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Criar Carteira</translation>
+        <translation type="unfinished">Criar carteira</translation>
     </message>
     <message>
         <source>You are one step away from creating your new wallet!</source>
-        <translation type="unfinished">Você está a um passo de criar a sua nova carteira!</translation>
+        <translation type="unfinished">Está a um passo de criar a sua nova carteira!</translation>
     </message>
     <message>
         <source>Please provide a name and, if desired, enable any advanced options</source>
@@ -1211,7 +1215,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Nome da Carteira</translation>
+        <translation type="unfinished">Nome da carteira</translation>
     </message>
     <message>
         <source>Wallet</source>
@@ -1219,11 +1223,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Encriptar carteira. A carteira vai ser encriptada com uma password de sua escolha.</translation>
+        <translation type="unfinished">Encriptar carteira. A carteira vai ser encriptada com uma frase de segurança à sua escolha.</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
-        <translation type="unfinished">Encriptar Carteira</translation>
+        <translation type="unfinished">Encriptar carteira</translation>
     </message>
     <message>
         <source>Advanced Options</source>
@@ -1231,19 +1235,19 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Desative chaves privadas para esta carteira. As carteiras com chaves privadas desativadas não terão chaves privadas e não poderão ter uma semente em HD ou chaves privadas importadas. Isso é ideal para carteiras sem movimentos.</translation>
+        <translation type="unfinished">Desativar as chaves privadas para esta carteira. As carteiras com chaves privadas desativadas não terão chaves privadas e não podem ter uma semente HD ou chaves privadas importadas. Isto é ideal para carteiras só de observação.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">Desactivar Chaves Privadas</translation>
+        <translation type="unfinished">Desativar chaves privadas</translation>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Faça uma carteira em branco. As carteiras em branco não possuem inicialmente chaves ou scripts privados. Chaves e endereços privados podem ser importados ou uma semente HD pode ser configurada posteriormente.</translation>
+        <translation type="unfinished">Crie uma carteira em branco. As carteiras em branco não têm inicialmente chaves privadas ou scripts. As chaves privadas e os endereços podem ser importados ou pode ser definida uma semente HD numa altura posterior.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">Fazer Carteira em Branco</translation>
+        <translation type="unfinished">Criar uma carteira em branco</translation>
     </message>
     <message>
         <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
@@ -1251,7 +1255,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>External signer</source>
-        <translation type="unfinished">Signatário externo</translation>
+        <translation type="unfinished">Assinante externo</translation>
     </message>
     <message>
         <source>Create</source>
@@ -1260,14 +1264,14 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sem suporte de assinatura externa. (necessário para assinatura externa)</translation>
+        <translation type="unfinished">Compilado sem suporte de assinatura externa (necessário para assinatura externa)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation type="unfinished">Editar Endereço</translation>
+        <translation type="unfinished">Editar endereço</translation>
     </message>
     <message>
         <source>&amp;Label</source>
@@ -1275,11 +1279,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">A etiqueta associada com esta entrada da lista de endereços</translation>
+        <translation type="unfinished">A etiqueta associada a esta entrada da lista de endereços</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">O endereço associado com o esta entrada da lista de endereços. Isto só pode ser alterado para os endereços de envio.</translation>
+        <translation type="unfinished">O endereço associado a esta entrada da lista de endereços. Isto só pode ser alterado para os endereços de envio.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -1295,7 +1299,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">Editar o endereço de envio</translation>
+        <translation type="unfinished">Editar endereço de envio</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
@@ -1366,22 +1370,22 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Choose data directory</source>
-        <translation type="unfinished">Escolha o diretório dos dados</translation>
+        <translation type="unfinished">Escolha a pasta dos dados</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">No mínimo %1 GB de dados irão ser armazenados nesta pasta.</translation>
+        <translation type="unfinished">Serão armazenados nesta pasta pelo menos %1 GB de dados, que irão aumentar com o tempo.</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Aproximadamente %1 GB de dados irão ser guardados nesta pasta.</translation>
+        <translation type="unfinished">Serão guardados nesta pasta aproximadamente %1 GB de dados.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(suficiente para restaurar backups de %n dia atrás)</numerusform>
-            <numerusform>(suficiente para restaurar backups de %n dias atrás)</numerusform>
+            <numerusform>(suficiente para restaurar cópias de segurança de %n dia atrás)</numerusform>
+            <numerusform>(suficiente para restaurar cópias de segurança de %n dias atrás)</numerusform>
         </translation>
     </message>
     <message>
@@ -1394,7 +1398,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Erro: não pode ser criada a pasta de dados especificada como "%1.</translation>
+        <translation type="unfinished">Erro: não pode ser criada a pasta de dados especificada como "%1".</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1414,23 +1418,23 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">Limitar o tamanho da blockchain para</translation>
+        <translation type="unfinished">Limitar o armazenamento da cadeia de blocos a</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation type="unfinished">Para reverter essa configuração, é necessário o download de todo o blockchain novamente. É mais rápido fazer o download da blockchain completa primeiro e removê-la mais tarde. Desativa alguns recursos avançados.</translation>
+        <translation type="unfinished">Se reverter esta configuração terá de descarregar novamente toda a cadeia de blocos. É mais rápido fazer o descarregamento da cadeia completa primeiro e reduzi-la (prune) mais tarde. Isto desativa alguns recursos avançados.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Esta sincronização inicial é muito exigente, e pode expor problemas com o seu computador que previamente podem ter passado despercebidos. Cada vez que corre %1, este vai continuar a descarregar de onde deixou.</translation>
+        <translation type="unfinished">Esta sincronização inicial é muito exigente e pode expor problemas de hardware no seu computador que anteriormente tinham passado despercebidos. Sempre que executar o %1, este continuará a descarregar a partir do ponto em que foi interrompido.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quando clicar em OK, %1 iniciará o download e irá processar a cadeia de blocos completa %4 (%2 GB) iniciando com as transações mais recentes em %3 enquanto %4 é processado. </translation>
+        <translation type="unfinished">Quando clicar em OK, %1 começará a descarregar e a processar toda a cadeia de blocos de %4 (%2 GB), começando com as primeiras transações em %3 quando %4 foi lançado inicialmente.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Se escolheu limitar o armazenamento da cadeia de blocos (poda), a data histórica ainda tem de ser descarregada e processada, mas irá ser apagada no final para manter uma utilização baixa do espaço de disco.</translation>
+        <translation type="unfinished">Se tiver optado por reduzir o armazenamento da cadeia de blocos (prune), os dados históricos ainda têm de ser descarregados e processados, mas serão eliminados posteriormente para manter a utilização do disco baixa.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1453,14 +1457,14 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Opções da linha de comando</translation>
+        <translation type="unfinished">Opções da linha de comandos</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down…</source>
-        <translation type="unfinished">%1 está a desligar…</translation>
+        <translation type="unfinished">%1 está a encerrar…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -1475,11 +1479,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Transações recentes podem não ser visíveis por agora, portanto o saldo da sua carteira pode estar incorreto. Esta informação será corrigida quando a sua carteira acabar de sincronizar com a rede, como está explicado em baixo.</translation>
+        <translation type="unfinished">As transações recentes podem ainda não ser visíveis e, por isso, o saldo da sua carteira pode estar incorreto. Esta informação estará correta assim que a sua carteira terminar a sincronização com a rede bitcoin, conforme detalhado abaixo.</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Tentar enviar bitcoins que estão afetadas por transações ainda não exibidas não será aceite pela rede.</translation>
+        <translation type="unfinished">A rede não aceitará tentativas de gastar bitcoins afetados por transações que ainda não foram mostradas.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
@@ -1503,19 +1507,15 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Aumento horário do progresso</translation>
+        <translation type="unfinished">Aumento do progresso por hora</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">tempo restante estimado até à sincronização</translation>
+        <translation type="unfinished">Tempo estimado até à sincronização</translation>
     </message>
     <message>
         <source>Hide</source>
         <translation type="unfinished">Ocultar</translation>
-    </message>
-    <message>
-        <source>Esc</source>
-        <translation type="unfinished">Sair</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
@@ -1523,23 +1523,23 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconhecido. A sincronizar cabeçalhos (%1, %2%)...</translation>
+        <translation type="unfinished">Desconhecido. A sincronizar cabeçalhos (%1, %2%)…</translation>
     </message>
     <message>
         <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconhecido. Pré-Sincronizando Cabeçalhos (%1, %2%)...</translation>
+        <translation type="unfinished">Desconhecido. A pré-sincronizar cabeçalhos (%1, %2%)…</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation type="unfinished">Abrir um Bitcoin URI</translation>
+        <translation type="unfinished">Abrir um URI de bitcoin</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">Cole endereço da área de transferência</translation>
+        <translation type="unfinished">Colar endereço da área de transferência</translation>
     </message>
 </context>
 <context>
@@ -1562,7 +1562,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">A ativação do pruning reduz significativamente o espaço em disco necessário para armazenar transações. Todos os blocos ainda estão totalmente validados. Reverter esta configuração requer que faça novamente o download de toda a blockchain.</translation>
+        <translation type="unfinished">A ativação da poda reduz significativamente o espaço em disco necessário para armazenar transações. Todos os blocos continuam a ser totalmente validados. Reverter esta configuração requer fazer o descarregamento de toda a cadeia de blocos.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1573,40 +1573,44 @@ O processo de migração criará um backup da carteira antes da migração. Este
         <translation type="unfinished">Número de processos de &amp;verificação de scripts</translation>
     </message>
     <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Caminho completo para um script compatível %1 (exemplo C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Cuidado: um programa malicioso (malware) pode roubar as suas moedas!</translation>
+    </message>
+    <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished">Endereço de IP do proxy (exemplo, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Mostra se o padrão fornecido SOCKS5 proxy, está a ser utilizado para alcançar utilizadores participantes através deste tipo de rede.</translation>
+        <translation type="unfinished">Mostra se o proxy SOCKS5 padrão fornecido é usado para alcançar os pares através deste tipo de rede.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimize em vez de sair da aplicação quando a janela é fechada. Quando esta opção é ativada, a aplicação apenas será encerrada quando escolher Sair no menu.</translation>
+        <translation type="unfinished">Minimizar em vez de sair da aplicação quando a janela é fechada. Quando esta opção é ativada, a aplicação apenas será encerrada quando selecionar "Sair" no menu.</translation>
     </message>
     <message>
         <source>Font in the Overview tab: </source>
-        <translation type="unfinished">Fonte no painel de visualização:</translation>
+        <translation type="unfinished">Tipo de letra na aba Resumo:</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line:</source>
-        <translation type="unfinished">Opções configuradas nessa caixa de diálogo serão sobrescritas pela linhas de comando: </translation>
+        <translation type="unfinished">As opções definidas nesta caixa de diálogo são substituídas pela linha de comandos:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Abrir o ficheiro de configuração %1 da pasta aberta.</translation>
+        <translation type="unfinished">Abrir o ficheiro de configuração %1 a partir da pasta de trabalho.</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
-        <translation type="unfinished">Abrir Ficheiro de Configuração</translation>
+        <translation type="unfinished">Abrir ficheiro de configuração</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished">Repor todas as opções de cliente para a predefinição.</translation>
+        <translation type="unfinished">Repor todas as opções do cliente para os valores de origem.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation type="unfinished">&amp;Repor Opções</translation>
+        <translation type="unfinished">&amp;Repor opções</translation>
     </message>
     <message>
         <source>&amp;Network</source>
@@ -1617,26 +1621,22 @@ O processo de migração criará um backup da carteira antes da migração. Este
         <translation type="unfinished">Reduzir o armazenamento de &amp;bloco para</translation>
     </message>
     <message>
-        <source>GB</source>
-        <translation type="unfinished">PT</translation>
-    </message>
-    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Reverter esta configuração requer descarregar de novo a cadeia de blocos inteira.</translation>
+        <translation type="unfinished">Se reverter esta configuração terá de descarregar novamente toda a cadeia de blocos.</translation>
     </message>
     <message>
         <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
-        <translation type="unfinished">Tamanho máximo da cache da base de dados. Uma cache maior pode contribuir para uma sincronização mais rápida, a partir do qual os benefícios são menos visíveis. Ao baixar o tamanho da cache irá diminuir a utilização de memória. Memória da mempool não usada será partilhada com esta cache.</translation>
+        <translation type="unfinished">Tamanho máximo da cache da base de dados. Uma cache maior pode contribuir para uma sincronização mais rápida, da qual os benefícios são menos visíveis. Diminuir o tamanho da cache reduzirá a utilização de memória. A memória mempool não utilizada será partilhada com esta cache.</translation>
     </message>
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
-        <translation type="unfinished">Define o número de threads do script de verificação. Valores negativos correspondem ao número de núcleos que deseja deixar livres para o sistema.</translation>
+        <translation type="unfinished">Define o número de sub-processos (threads) de verificação de scripts. Os valores negativos correspondem ao número de núcleos que pretende deixar livres para o sistema.</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = automático, &lt;0 = deixar essa quantidade de núcleos livre)</translation>
+        <translation type="unfinished">(0 = automático, &lt;0 = deixar este número de núcleos livres)</translation>
     </message>
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
@@ -1655,7 +1655,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Whether to set subtract fee from amount as default or not.</source>
         <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">Mostrar a quantia com a taxa já subtraída, por padrão.</translation>
+        <translation type="unfinished">Se deve ser mostrado por padrão a quantia com a taxa já subtraída.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1686,19 +1686,19 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Mostrar os controlos PSBT.</translation>
+        <translation type="unfinished">Se devem ser mostrados os controlos PSBT.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
-        <translation type="unfinished">Signatário externo (ex: carteira física)</translation>
+        <translation type="unfinished">Assinante externo (por exemplo, carteira de hardware)</translation>
     </message>
     <message>
         <source>&amp;External signer script path</source>
-        <translation type="unfinished">&amp;Caminho do script para signatário externo </translation>
+        <translation type="unfinished">&amp;Caminho do script para assinante externo</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">Abrir a porta do cliente bitcoin automaticamente no seu router. Isto apenas funciona se o seu router suportar UPnP e este se encontrar ligado.</translation>
+        <translation type="unfinished">Abrir automaticamente a porta do cliente Bitcoin no seu router. Isto só funciona quando o seu router suporta UPnP e este está ativado.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -1706,7 +1706,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <translation type="unfinished">Abrir a porta do cliente bitcoin automaticamente no seu router. Isto só funciona se o seu router suportar NAT-PMP e este se encontrar ligado. A porta externa poderá ser aleatória.</translation>
+        <translation type="unfinished">Abrir automaticamente a porta do cliente Bitcoin no seu router. Isto só funciona quando o seu router suporta NAT-PMP e este está ativado. A porta externa pode ser aleatória.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -1714,11 +1714,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Accept connections from outside.</source>
-        <translation type="unfinished">Aceitar ligações externas.</translation>
+        <translation type="unfinished">Aceitar conexões do exterior.</translation>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Permitir ligações de "a receber"</translation>
+        <translation type="unfinished">Permitir cone&amp;xões de entrada</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
@@ -1726,7 +1726,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;Ligar através dum proxy SOCKS5 (proxy por defeito):</translation>
+        <translation type="unfinished">&amp;Conectar através de um proxy SOCKS5 (proxy padrão):</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
@@ -1754,7 +1754,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">&amp;Mostrar ícone de bandeja</translation>
+        <translation type="unfinished">&amp;Mostrar ícone da bandeja</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1774,11 +1774,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation type="unfinished">&amp;Linguagem da interface de utilizador:</translation>
+        <translation type="unfinished">&amp;Idioma da interface:</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">A linguagem da interface do utilizador pode ser definida aqui. Esta definição entrará em efeito após reiniciar %1.</translation>
+        <translation type="unfinished">O idioma da interface do utilizador pode ser definido aqui. Esta definição entra em vigor depois de reiniciar %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1790,7 +1790,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">URLs de outrem (ex. um explorador de blocos) que aparece no separador de transações como itens do menu de contexto. %s do URL é substituído pela hash de transação. Múltiplos URLs são separados pela barra vertical I.</translation>
+        <translation type="unfinished">URLs de terceiros (por exemplo, um explorador de blocos) que aparecem na aba de transações como itens de menu de contexto. %s no URL é substituído pelo hash da transação. Vários URLs são separados por barras verticais |.</translation>
     </message>
     <message>
         <source>&amp;Third-party transaction URLs</source>
@@ -1802,11 +1802,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Conecte-se a rede Bitcoin através de um proxy SOCKS5 separado para serviços Tor Onion</translation>
+        <translation type="unfinished">Conecte-se à rede Bitcoin através de um proxy SOCKS5 separado para serviços Tor Onion</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Use um proxy SOCKS5 separado para alcançar pares por meio dos serviços Tor onion:</translation>
+        <translation type="unfinished">Utilizar um proxy SOCKS5 separado para aceder aos pares através dos serviços Tor onion:</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -1815,7 +1815,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilado sem suporte de assinatura externa. (necessário para assinatura externa)</translation>
+        <translation type="unfinished">Compilado sem suporte de assinatura externa (necessário para assinatura externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1838,22 +1838,22 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Current settings will be backed up at "%1".</source>
         <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
-        <translation type="unfinished">Configuração atuais serão copiadas em "%1".</translation>
+        <translation type="unfinished">As definições atuais serão guardadas em "%1".</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
         <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
-        <translation type="unfinished">O cliente será desligado. Deseja continuar?</translation>
+        <translation type="unfinished">O cliente será encerrado. Quer continuar?</translation>
     </message>
     <message>
         <source>Configuration options</source>
         <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
-        <translation type="unfinished">Opções da configuração</translation>
+        <translation type="unfinished">Opções de configuração</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">O ficheiro de configuração é usado para especificar opções de utilizador avançado, que sobrescrevem as configurações do interface gráfico. Adicionalmente, qualquer opção da linha de comandos vai sobrescrever este ficheiro de configuração.</translation>
+        <translation type="unfinished">O ficheiro de configuração é utilizado para especificar opções avançadas do utilizador que se sobrepõem às definições da GUI. Além disso, quaisquer opções da linha de comandos substituirão este ficheiro de configuração.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1873,7 +1873,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation type="unfinished">Esta alteração obrigará a um reinício do cliente.</translation>
+        <translation type="unfinished">Esta alteração requer que o cliente seja reiniciado.</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
@@ -1884,7 +1884,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <name>OptionsModel</name>
     <message>
         <source>Could not read setting "%1", %2.</source>
-        <translation type="unfinished">Não foi possível ler as configurações "%1", %2.</translation>
+        <translation type="unfinished">Não foi possível ler a configuração "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -1895,11 +1895,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">A informação mostrada poderá estar desatualizada. A sua carteira sincroniza automaticamente com a rede Bitcoin depois de estabelecer ligação, mas este processo ainda não está completo.</translation>
+        <translation type="unfinished">A informação apresentada pode estar desatualizada. A sua carteira sincroniza-se automaticamente com a rede Bitcoin após o estabelecimento de conexões, mas este processo ainda não está concluído.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">Apenas vigiar:</translation>
+        <translation type="unfinished">Apenas observação:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -1923,7 +1923,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished">O saldo minado ainda não amadureceu</translation>
+        <translation type="unfinished">Saldo minerado que ainda não atingiu a maturidade</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1935,31 +1935,31 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">O seu balanço atual em endereços de apenas vigiar</translation>
+        <translation type="unfinished">O seu saldo atual em endereços de observação</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Dispensável:</translation>
+        <translation type="unfinished">Gastável:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
-        <translation type="unfinished">transações recentes</translation>
+        <translation type="unfinished">Transações recentes</translation>
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Transações não confirmadas para endereços de apenas vigiar</translation>
+        <translation type="unfinished">Transações não confirmadas para endereços de observação</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Saldo minado ainda não disponível de endereços de apenas vigiar</translation>
+        <translation type="unfinished">Saldo minerado em endereços só de observação que ainda não atingiram a maturidade</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Saldo disponível em endereços de apenas vigiar</translation>
+        <translation type="unfinished">Saldo disponível em endereços de observação</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Modo de privacidade ativado para a aba de visão geral. para desmascarar os valores, desmarque nas Configurações -&gt; Valores de máscara</translation>
+        <translation type="unfinished">Modo de privacidade ativado para a aba Resumo. para desmascarar os valores, desmarque nas Configurações -&gt; Valores de máscara</translation>
     </message>
 </context>
 <context>
@@ -1990,15 +1990,15 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Falha ao carregar transação: %1</translation>
+        <translation type="unfinished">Falha ao carregar a transação: %1</translation>
     </message>
     <message>
         <source>Failed to sign transaction: %1</source>
-        <translation type="unfinished">Falha ao assinar transação: %1</translation>
+        <translation type="unfinished">Falha ao assinar a transação: %1</translation>
     </message>
     <message>
         <source>Cannot sign inputs while wallet is locked.</source>
-        <translation type="unfinished">Não é possível assinar entradas enquanto a carteira está trancada.</translation>
+        <translation type="unfinished">Não é possível assinar entradas enquanto a carteira estiver bloqueada.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -2006,11 +2006,11 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Assinadas entradas %1, mas mais assinaturas ainda são necessárias.</translation>
+        <translation type="unfinished">%1 entradas assinadas, mas ainda são necessárias mais assinaturas.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">Transação assinada com sucesso. Transação está pronta para ser transmitida.</translation>
+        <translation type="unfinished">Transação assinada com sucesso. A transação está pronta para ser transmitida.</translation>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
@@ -2019,7 +2019,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
         <translation type="unfinished">Transação transmitida com sucesso.
-ID transação: %1</translation>
+ID da transação: %1</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
@@ -2031,16 +2031,16 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">Salvar informação de transação</translation>
+        <translation type="unfinished">Guardar informação da transação</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Transação parcialmente assinada (Binário)</translation>
+        <translation type="unfinished">Transação parcialmente assinada (binário)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT salva no disco.</translation>
+        <translation type="unfinished">PSBT guardada no disco.</translation>
     </message>
     <message>
         <source>Sends %1 to %2</source>
@@ -2048,11 +2048,11 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">endereço próprio</translation>
+        <translation type="unfinished">próprio endereço</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Incapaz de calcular a taxa de transação ou o valor total da transação.</translation>
+        <translation type="unfinished">Não foi possível calcular a taxa de transação ou a quantia total da transação.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
@@ -2060,7 +2060,7 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Valor Total</translation>
+        <translation type="unfinished">Quantia total</translation>
     </message>
     <message>
         <source>or</source>
@@ -2068,15 +2068,15 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
-        <translation type="unfinished">Transação tem %1 entradas não assinadas.</translation>
+        <translation type="unfinished">A transação tem %1 entradas não assinadas.</translation>
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Transação está com alguma informação faltando sobre as entradas.</translation>
+        <translation type="unfinished">A transação não contém algumas informações sobre as entradas.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Transação continua precisando de assinatura(s).</translation>
+        <translation type="unfinished">A transação ainda precisa de assinatura(s).</translation>
     </message>
     <message>
         <source>(But no wallet is loaded.)</source>
@@ -2092,11 +2092,11 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Transação está completamente assinada e pronta para ser transmitida.</translation>
+        <translation type="unfinished">A transação está totalmente assinada e pronta para ser transmitida.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
-        <translation type="unfinished">Status da transação é desconhecido.</translation>
+        <translation type="unfinished">O estado da transação é desconhecido.</translation>
     </message>
 </context>
 <context>
@@ -2107,7 +2107,7 @@ ID transação: %1</translation>
     </message>
     <message>
         <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">Impossível iniciar o controlador de bitcoin: click-to-pay</translation>
+        <translation type="unfinished">Não é possível iniciar o bitcoin: manipulador do click-to-pay</translation>
     </message>
     <message>
         <source>URI handling</source>
@@ -2122,20 +2122,25 @@ ID transação: %1</translation>
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished">Não é possível processar o pagamento pedido porque o BIP70 não é suportado.
-Devido a falhas de segurança no BIP70, é recomendado que todas as instruçōes ao comerciante para mudar de carteiras sejam ignorada.
+Devido a falhas de segurança no BIP70, é recomendado que todas as instruções ao comerciante para mudar de carteiras sejam ignorada.
 Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI compatível com BIP21.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">URI não foi lido corretamente! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
+        <translation type="unfinished">O URI não pode ser analisado! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Controlo de pedidos de pagamento.</translation>
+        <translation type="unfinished">Manuseamento do ficheiro de pedidos de pagamento.</translation>
     </message>
 </context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">Agente do utilizador</translation>
+    </message>
     <message>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
@@ -2149,7 +2154,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     <message>
         <source>Age</source>
         <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
-        <translation type="unfinished">idade</translation>
+        <translation type="unfinished">Idade</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2200,7 +2205,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished">&amp;Copiar Imagem</translation>
+        <translation type="unfinished">&amp;Copiar imagem</translation>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
@@ -2208,15 +2213,15 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Erro ao codificar URI em Código QR.</translation>
+        <translation type="unfinished">Erro ao codificar URI em código QR.</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
-        <translation type="unfinished">Suporte códigos QR não disponível</translation>
+        <translation type="unfinished">Suporte para código QR não disponível.</translation>
     </message>
     <message>
         <source>Save QR Code</source>
-        <translation type="unfinished">Guardar o código QR</translation>
+        <translation type="unfinished">Guardar código QR</translation>
     </message>
     <message>
         <source>PNG Image</source>
@@ -2232,7 +2237,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Client version</source>
-        <translation type="unfinished">Versão do Cliente</translation>
+        <translation type="unfinished">Versão do cliente</translation>
     </message>
     <message>
         <source>&amp;Information</source>
@@ -2243,8 +2248,16 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
         <translation type="unfinished">Geral</translation>
     </message>
     <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Pasta de dados</translation>
+    </message>
+    <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
         <translation type="unfinished">Para especificar um local não padrão da pasta de dados, use a opção '%1'.</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">Pasta de blocos</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
@@ -2252,7 +2265,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Startup time</source>
-        <translation type="unfinished">Hora de Arranque</translation>
+        <translation type="unfinished">Hora de arranque</translation>
     </message>
     <message>
         <source>Network</source>
@@ -2264,7 +2277,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Number of connections</source>
-        <translation type="unfinished">Número de ligações</translation>
+        <translation type="unfinished">Número de conexões</translation>
     </message>
     <message>
         <source>Block chain</source>
@@ -2272,7 +2285,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation type="unfinished">Banco de Memória</translation>
+        <translation type="unfinished">Pool de memória</translation>
     </message>
     <message>
         <source>Current number of transactions</source>
@@ -2280,7 +2293,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished">Utilização de memória</translation>
+        <translation type="unfinished">Utilização da memória</translation>
     </message>
     <message>
         <source>Wallet: </source>
@@ -2292,7 +2305,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Reiniciar</translation>
+        <translation type="unfinished">&amp;Repor</translation>
     </message>
     <message>
         <source>Received</source>
@@ -2328,7 +2341,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Session ID</source>
-        <translation type="unfinished">ID de sessão</translation>
+        <translation type="unfinished">ID da sessão</translation>
     </message>
     <message>
         <source>Version</source>
@@ -2336,7 +2349,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Whether we relay transactions to this peer.</source>
-        <translation type="unfinished">Se retransmitimos transações para este nó.</translation>
+        <translation type="unfinished">Se retransmitimos transações para este par.</translation>
     </message>
     <message>
         <source>Transaction Relay</source>
@@ -2344,19 +2357,19 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">Bloco Inicial</translation>
+        <translation type="unfinished">Bloco inicial</translation>
     </message>
     <message>
         <source>Synced Headers</source>
-        <translation type="unfinished">Cabeçalhos Sincronizados</translation>
+        <translation type="unfinished">Cabeçalhos sincronizados</translation>
     </message>
     <message>
         <source>Synced Blocks</source>
-        <translation type="unfinished">Blocos Sincronizados</translation>
+        <translation type="unfinished">Blocos sincronizados</translation>
     </message>
     <message>
         <source>Last Transaction</source>
-        <translation type="unfinished">Última Transação</translation>
+        <translation type="unfinished">Última transação</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
@@ -2364,12 +2377,12 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Mapped AS</source>
-        <translation type="unfinished">Mapeado como</translation>
+        <translation type="unfinished">S.A. mapeado</translation>
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
         <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
-        <translation type="unfinished">Endereços são retransmitidos para este nó.</translation>
+        <translation type="unfinished">Se retransmitimos endereços para este par.</translation>
     </message>
     <message>
         <source>Address Relay</source>
@@ -2379,22 +2392,26 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     <message>
         <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">O número total de endereços recebidos deste peer que foram processados (exclui endereços que foram descartados devido à limitação de taxa).</translation>
+        <translation type="unfinished">O número total de endereços recebidos deste par que foram processados (exclui os endereços que foram eliminados devido à limitação da taxa).</translation>
     </message>
     <message>
         <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">O número total de endereços recebidos deste peer que não foram processados devido à limitação da taxa.</translation>
+        <translation type="unfinished">O número total de endereços recebidos deste par que foram descartados (não processados) devido à limitação de taxa.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
         <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
-        <translation type="unfinished">Endereços Processados</translation>
+        <translation type="unfinished">Endereços processados</translation>
     </message>
     <message>
         <source>Addresses Rate-Limited</source>
         <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
-        <translation type="unfinished">Endereços com limite de taxa</translation>
+        <translation type="unfinished">Endereços rejeitados devido a limitação de volume</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">Agente do utilizador</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -2406,7 +2423,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Abrir o ficheiro de registo de depuração %1 da pasta de dados atual. Isto pode demorar alguns segundos para ficheiros de registo maiores.</translation>
+        <translation type="unfinished">Abrir o ficheiro de registo de depuração %1 da pasta de dados atual. Isto pode demorar alguns segundos para ficheiros de registo grandes.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -2426,7 +2443,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Direction/Type</source>
-        <translation type="unfinished">Direção/tipo</translation>
+        <translation type="unfinished">Direção / tipo</translation>
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
@@ -2437,12 +2454,16 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
         <translation type="unfinished">Serviços</translation>
     </message>
     <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Relé de bloco compacto BIP152 de largura de banda elevada: %1</translation>
+    </message>
+    <message>
         <source>High Bandwidth</source>
-        <translation type="unfinished">Alta largura de banda</translation>
+        <translation type="unfinished">Largura de banda elevada</translation>
     </message>
     <message>
         <source>Connection Time</source>
-        <translation type="unfinished">Tempo de Ligação</translation>
+        <translation type="unfinished">Tempo de conexão</translation>
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
@@ -2455,19 +2476,19 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
-        <translation type="unfinished">Tempo decorrido desde que uma nova transação aceite para a nossa mempool foi recebida deste par.</translation>
+        <translation type="unfinished">Tempo decorrido desde que foi recebida deste par uma nova transação aceite na nossa pool de memória.</translation>
     </message>
     <message>
         <source>Last Send</source>
-        <translation type="unfinished">Último Envio</translation>
+        <translation type="unfinished">Último envio</translation>
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Último Recebimento</translation>
+        <translation type="unfinished">Última receção</translation>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation type="unfinished">Tempo de Latência</translation>
+        <translation type="unfinished">Tempo de latência</translation>
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
@@ -2475,15 +2496,15 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>Ping Wait</source>
-        <translation type="unfinished">Espera do Ping</translation>
+        <translation type="unfinished">Espera da latência</translation>
     </message>
     <message>
         <source>Min Ping</source>
-        <translation type="unfinished">Latência mínima</translation>
+        <translation type="unfinished">Ping mínimo</translation>
     </message>
     <message>
         <source>Time Offset</source>
-        <translation type="unfinished">Fuso Horário</translation>
+        <translation type="unfinished">Desvio de tempo</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -2499,7 +2520,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Tráfego de Rede</translation>
+        <translation type="unfinished">&amp;Tráfego de rede</translation>
     </message>
     <message>
         <source>Totals</source>
@@ -2524,34 +2545,59 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     <message>
         <source>Inbound: initiated by peer</source>
         <extracomment>Explanatory text for an inbound peer connection.</extracomment>
-        <translation type="unfinished">Entrando: iniciado por par</translation>
+        <translation type="unfinished">Entrada: iniciado pelo par</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Relé completo de saída: predefinição</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Relé de bloco de saída: não retransmite transações ou endereços</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Manual de saída: adicionado utilizando as opções de configuração RPC %1 ou %2/%3</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Sensor (feeler) de saída: de curta duração, para testar endereços</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Obtenção de endereço de saída: de curta duração, para solicitar endereços</translation>
     </message>
     <message>
         <source>detecting: peer could be v1 or v2</source>
         <extracomment>Explanatory text for "detecting" transport type.</extracomment>
-        <translation type="unfinished">detectando: o par pode ser v1 ou v2</translation>
+        <translation type="unfinished">a detetar: o par pode ser v1 ou v2</translation>
     </message>
     <message>
         <source>v1: unencrypted, plaintext transport protocol</source>
         <extracomment>Explanatory text for v1 transport type.</extracomment>
-        <translation type="unfinished">v1: protocolo de transporte de texto simples não criptografado</translation>
+        <translation type="unfinished">v1: protocolo de transporte de texto simples e não encriptado</translation>
     </message>
     <message>
         <source>v2: BIP324 encrypted transport protocol</source>
         <extracomment>Explanatory text for v2 transport type.</extracomment>
-        <translation type="unfinished">v2: protocolo de transporte criptografado BIP324</translation>
+        <translation type="unfinished">v2: protocolo de transporte encriptado BIP324</translation>
     </message>
     <message>
         <source>we selected the peer for high bandwidth relay</source>
-        <translation type="unfinished">selecionámos o par para uma retransmissão de alta banda larga</translation>
+        <translation type="unfinished">selecionámos o par para retransmissão de largura de banda elevada</translation>
     </message>
     <message>
         <source>the peer selected us for high bandwidth relay</source>
-        <translation type="unfinished">o par selecionou-nos para uma retransmissão de alta banda larga</translation>
+        <translation type="unfinished">o par selecionou-nos para uma retransmissão de largura de banda elevada</translation>
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">nenhum retransmissor de alta banda larga selecionado</translation>
+        <translation type="unfinished">nenhum retransmissor de largura de banda elevada selecionado</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2568,7 +2614,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     </message>
     <message>
         <source>1 d&amp;ay</source>
-        <translation type="unfinished">1 di&amp;a</translation>
+        <translation type="unfinished">1 &amp;dia</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2581,7 +2627,7 @@ Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI 
     <message>
         <source>&amp;Copy IP/Netmask</source>
         <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
-        <translation type="unfinished">&amp;Copiar IP/Netmask</translation>
+        <translation type="unfinished">&amp;Copiar IP / máscara de rede</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2612,18 +2658,18 @@ For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
         <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Bem vindo à %1 consola RPC.
+        <translation type="unfinished">Bem-vindo à %1 consola RPC.
 Utilize as setas para cima e para baixo para navegar no histórico, e %2 para limpar o ecrã.
 Utilize o %3 e %4 para aumentar ou diminuir o tamanho da letra.
 Escreva %5 para uma visão geral dos comandos disponíveis.
 Para mais informação acerca da utilização desta consola, escreva %6.
 
-%7ATENÇÃO: Foram notadas burlas, dizendo aos utilizadores para escreverem comandos aqui, roubando os conteúdos da sua carteira. Não utilize esta consola sem perceber as ramificações de um comando.%8</translation>
+%7ATENÇÃO: foram notadas burlas, dizendo aos utilizadores para escreverem comandos aqui, roubando os conteúdos da sua carteira. Não utilize esta consola sem perceber as ramificações de um comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
-        <translation type="unfinished">A executar...</translation>
+        <translation type="unfinished">A executar…</translation>
     </message>
     <message>
         <source>(peer: %1)</source>
@@ -2674,7 +2720,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Uma mensagem opcional para anexar ao pedido de pagamento, que será exibida quando o pedido for aberto. Nota: A mensagem não será enviada com o pagamento através da rede Bitcoin.</translation>
+        <translation type="unfinished">Uma mensagem opcional a anexar ao pedido de pagamento, que será mostrada quando o pedido for aberto. Nota: a mensagem não será enviada com o pagamento através da rede Bitcoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
@@ -2682,19 +2728,19 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Utilize este formulário para solicitar pagamentos. Todos os campos são &lt;b&gt;opcionais&lt;/b&gt;.</translation>
+        <translation type="unfinished">Utilize este formulário para pedir pagamentos. Todos os campos são &lt;b&gt;opcionais&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Uma quantia opcional a solicitar. Deixe em branco ou zero para não solicitar uma quantidade específica.</translation>
+        <translation type="unfinished">Uma quantia opcional a solicitar. Deixe em branco ou zero para não solicitar uma quantia específica.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Um legenda opcional para associar com o novo endereço de recebimento (usado por você para identificar uma fatura).  Ela é também anexada ao pedido de pagamento.</translation>
+        <translation type="unfinished">Uma etiqueta opcional para associar ao novo endereço de receção (usada por si para identificar uma fatura). É também anexada ao pedido de pagamento.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Uma mensagem opicional que é anexada ao pedido de pagamento e pode ser mostrada para o remetente.</translation>
+        <translation type="unfinished">Uma mensagem opcional que é anexada ao pedido de pagamento e que pode ser mostrada ao remetente.</translation>
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
@@ -2710,7 +2756,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation type="unfinished">Histórico de pagamentos solicitados</translation>
+        <translation type="unfinished">Histórico de pagamentos pedidos</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
@@ -2749,6 +2795,10 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <translation type="unfinished">Copiar &amp;quantia</translation>
     </message>
     <message>
+        <source>Base58 (Legacy)</source>
+        <translation type="unfinished">Base58 (legado)</translation>
+    </message>
+    <message>
         <source>Not recommended due to higher fees and less protection against typos.</source>
         <translation type="unfinished">Não recomendado devido a taxas mais altas e menor proteção contra erros de digitação.</translation>
     </message>
@@ -2762,7 +2812,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
-        <translation type="unfinished">Bech32m (BIP-350) é uma atualização para o Bech32,</translation>
+        <translation type="unfinished">O Bech32m (BIP-350) é uma atualização do Bech32, mas o suporte da carteira ainda é limitado.</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2789,7 +2839,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Label:</source>
-        <translation type="unfinished">Legenda:</translation>
+        <translation type="unfinished">Etiqueta:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -2805,7 +2855,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">Copi&amp;ar Endereço</translation>
+        <translation type="unfinished">Copi&amp;ar endereço</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2813,7 +2863,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Verifique este endreço, por exemplo, no ecrã de uma wallet física</translation>
+        <translation type="unfinished">Verifique este endereço, por exemplo, no ecrã de uma carteira física</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2821,11 +2871,11 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Payment information</source>
-        <translation type="unfinished">Informação de Pagamento</translation>
+        <translation type="unfinished">Informação de pagamento</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
-        <translation type="unfinished">Requisitar Pagamento para %1</translation>
+        <translation type="unfinished">Pedir pagamento a %1</translation>
     </message>
 </context>
 <context>
@@ -2863,15 +2913,15 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Enviar Moedas</translation>
+        <translation type="unfinished">Enviar moedas</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Funcionalidades do Controlo de Moedas:</translation>
+        <translation type="unfinished">Funcionalidades do controlo de moedas</translation>
     </message>
     <message>
         <source>automatically selected</source>
-        <translation type="unfinished">selecionadas automáticamente</translation>
+        <translation type="unfinished">selecionadas automaticamente</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
@@ -2891,7 +2941,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Depois da taxa:</translation>
+        <translation type="unfinished">Após a taxa:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -2915,7 +2965,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Aviso: atualmente, não é possível a estimativa da taxa.</translation>
+        <translation type="unfinished">Aviso: neste momento não é possível fazer uma estimativa das taxas.</translation>
     </message>
     <message>
         <source>per kilobyte</source>
@@ -2939,7 +2989,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation type="unfinished">Adicionar &amp;Destinatário</translation>
+        <translation type="unfinished">Adicionar &amp;destinatário</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
@@ -2947,7 +2997,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Inputs…</source>
-        <translation type="unfinished">Entradas...</translation>
+        <translation type="unfinished">Entradas…</translation>
     </message>
     <message>
         <source>Choose…</source>
@@ -2963,35 +3013,35 @@ Para mais informação acerca da utilização desta consola, escreva %6.
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <translation type="unfinished">Especifique uma taxa personalizada por kB (1.000 bytes) do tamanho virtual da transação.
 
-Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para um tamanho de transação de 500 bytes virtuais (metade de 1 kvB) resultaria em uma taxa de apenas 50 satoshis.</translation>
+Nota: como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para um tamanho de transação de 500 bytes virtuais (metade de 1 kvB) resultaria em uma taxa de apenas 50 satoshis.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Quando o volume de transações é maior que o espaço nos blocos, os mineradores, bem como os nós de retransmissão, podem impor uma taxa mínima. Pagar apenas esta taxa mínima é muito bom, mas esteja ciente que isso pode resultar numa transação nunca confirmada, uma vez que há mais pedidos para transações do que a rede pode processar.</translation>
+        <translation type="unfinished">Quando há menos volume de transações do que espaço nos blocos, os mineradores, bem como os pares de retransmissão, podem impor uma taxa mínima. Pagar apenas esta taxa mínima não faz mal, mas tenha em atenção que isto pode resultar numa transação nunca confirmada, uma vez que há mais procura de transações de bitcoin do que a rede pode processar.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Uma taxa muito baixa pode resultar numa transação nunca confirmada (leia a dica)</translation>
+        <translation type="unfinished">Uma taxa muito baixa pode resultar numa transação nunca confirmada (leia a dica no menu de contexto)</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
-        <translation type="unfinished">(A taxa inteligente ainda não foi inicializada. Isto demora normalmente alguns blocos...)</translation>
+        <translation type="unfinished">(A taxa inteligente ainda não foi inicializada. Isto demora normalmente alguns blocos…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
-        <translation type="unfinished">Tempo de confirmação:</translation>
+        <translation type="unfinished">Objetivo de tempo de confirmação:</translation>
     </message>
     <message>
         <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Ativar substituir-por-taxa</translation>
+        <translation type="unfinished">Ativar "substituir por taxa"</translation>
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Com substituir-por-taxa (BIP-125) pode aumentar a taxa da transação após ela ser enviada. Sem isto, pode ser recomendável uma taxa maior para compensar o risco maior de atraso na transação.</translation>
+        <translation type="unfinished">Com "substituir por taxa" (Replace-By-Fee) (BIP-125) pode aumentar a taxa da transação após ela ser enviada. Sem isto, pode ser recomendável uma taxa maior para compensar o risco maior de atraso na transação.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpar &amp;Tudo</translation>
+        <translation type="unfinished">Limpar &amp;tudo</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -2999,7 +3049,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Confirm the send action</source>
-        <translation type="unfinished">Confirme ação de envio</translation>
+        <translation type="unfinished">Confirme o envio</translation>
     </message>
     <message>
         <source>S&amp;end</source>
@@ -3011,7 +3061,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar valor</translation>
+        <translation type="unfinished">Copiar quantia</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -3019,7 +3069,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copiar depois da taxa</translation>
+        <translation type="unfinished">Copiar após a taxa</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -3036,11 +3086,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet.</extracomment>
-        <translation type="unfinished">entrar no dispositivo</translation>
+        <translation type="unfinished">Assinar no dispositivo</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Por favor conecte a sua wallet física primeiro.</translation>
+        <translation type="unfinished">Conecte primeiro a sua carteira de hardware.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
@@ -3049,15 +3099,15 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">Criar não assinado</translation>
+        <translation type="unfinished">Criar &amp;não assinado</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Cria uma transação de Bitcoin parcialmente assinada (PSBT)(sigla em inglês) para ser usada por exemplo com uma carteira %1 offline ou uma carteira de hardware compatível com PSBT.</translation>
+        <translation type="unfinished">Cria uma transação de Bitcoin parcialmente assinada (PSBT - sigla em inglês) para ser usada por exemplo com uma carteira %1 offline ou uma carteira de hardware compatível com PSBT.</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 a '%2'</translation>
+        <translation type="unfinished">%1 para '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
@@ -3065,7 +3115,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>To review recipient list click "Show Details…"</source>
-        <translation type="unfinished">Para rever a lista de destinatários clique "Mostrar detalhes..."</translation>
+        <translation type="unfinished">Para rever a lista de destinatários clique em "Mostrar detalhes…"</translation>
     </message>
     <message>
         <source>Sign failed</source>
@@ -3074,30 +3124,30 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Signatário externo não encontrado</translation>
+        <translation type="unfinished">Assinante externo não encontrado</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Falha do signatário externo</translation>
+        <translation type="unfinished">Falha do assinante externo</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">Salvar informação de transação</translation>
+        <translation type="unfinished">Guardar informação da transação</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Transação parcialmente assinada (Binário)</translation>
+        <translation type="unfinished">Transação parcialmente assinada (binário)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
         <extracomment>Popup message when a PSBT has been saved to a file</extracomment>
-        <translation type="unfinished">PSBT salva</translation>
+        <translation type="unfinished">PSBT guardada</translation>
     </message>
     <message>
         <source>External balance:</source>
-        <translation type="unfinished">Balanço externo:</translation>
+        <translation type="unfinished">Saldo externo:</translation>
     </message>
     <message>
         <source>or</source>
@@ -3105,16 +3155,16 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Pode aumentar a taxa depois (sinaliza substituir-por-taxa, BIP-125).</translation>
+        <translation type="unfinished">Pode aumentar a taxa depois (sinaliza "substituir por taxa", BIP-125).</translation>
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
-        <translation type="unfinished">Por favor, reveja sua proposta de transação. Isto irá produzir uma Transação de Bitcoin parcialmente assinada (PSBT, sigla em inglês) a qual você pode salvar ou copiar e então assinar com por exemplo uma carteira %1 offiline ou uma PSBT compatível com carteira de hardware.</translation>
+        <translation type="unfinished">Por favor, reveja a sua proposta de transação. Isto produzirá uma transação Bitcoin parcialmente assinada (PSBT) que pode guardar ou copiar e depois assinar com, por exemplo, uma carteira %1 offline, ou uma carteira de hardware compatível com PSBT.</translation>
     </message>
     <message>
         <source>%1 from wallet '%2'</source>
-        <translation type="unfinished">%1 da pasta "%2</translation>
+        <translation type="unfinished">%1 da carteira "%2"</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
@@ -3124,7 +3174,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
-        <translation type="unfinished">Por favor, revise sua transação. Você pode assinar e enviar a transação ou criar uma Transação de Bitcoin Parcialmente Assinada (PSBT), que você pode copiar e assinar com, por exemplo, uma carteira %1 offline ou uma carteira física compatível com PSBT.</translation>
+        <translation type="unfinished">Por favor, reveja a sua transação. Pode criar e enviar esta transação ou criar uma transação Bitcoin parcialmente assinada (PSBT), que pode guardar ou copiar e depois assinar com, por exemplo, uma carteira %1 offline, ou uma carteira de hardware compatível com PSBT.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -3137,25 +3187,25 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Não sinalizar substituir-por-taxa, BIP-125.</translation>
+        <translation type="unfinished">Não indica "substituir por taxa", BIP-125.</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Valor Total</translation>
+        <translation type="unfinished">Quantia total</translation>
     </message>
     <message>
         <source>Unsigned Transaction</source>
         <comment>PSBT copied</comment>
         <extracomment>Caption of "PSBT has been copied" messagebox</extracomment>
-        <translation type="unfinished">Transação Não Assinada</translation>
+        <translation type="unfinished">Transação não assinada</translation>
     </message>
     <message>
         <source>The PSBT has been copied to the clipboard. You can also save it.</source>
-        <translation type="unfinished">O PSBT foi salvo na área de transferência. Você pode também salva-lo.</translation>
+        <translation type="unfinished">O PSBT foi copiado para a área de transferência. Também o pode guardar.</translation>
     </message>
     <message>
         <source>PSBT saved to disk</source>
-        <translation type="unfinished">PSBT salvo no disco.</translation>
+        <translation type="unfinished">PSBT guardada no disco</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3163,19 +3213,19 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Watch-only balance:</source>
-        <translation type="unfinished">Saldo apenas para visualização:</translation>
+        <translation type="unfinished">Saldo de observação:</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">O endereço do destinatário é inválido. Por favor, reverifique.</translation>
+        <translation type="unfinished">O endereço do destinatário não é válido. Por favor, verifique novamente.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">O valor a pagar dever maior que 0.</translation>
+        <translation type="unfinished">A quantia a pagar dever maior que 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">O valor excede o seu saldo.</translation>
+        <translation type="unfinished">A quantia excede o seu saldo.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
@@ -3191,13 +3241,13 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Uma taxa superior a %1 é considerada uma taxa altamente absurda.</translation>
+        <translation type="unfinished">Uma taxa superior a %1 é considerada uma taxa absurdamente elevada.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>Confirmação estimada para iniciar em %n bloco.</numerusform>
-            <numerusform>Confirmação estimada para iniciar em %n blocos.</numerusform>
+            <numerusform>Estima-se que a confirmação comece dentro de %n bloco.</numerusform>
+            <numerusform>Estima-se que a confirmação comece dentro de %n blocos.</numerusform>
         </translation>
     </message>
     <message>
@@ -3214,7 +3264,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">O endereço que selecionou para alterar não faz parte desta carteira. Qualquer ou todos os fundos na sua carteira podem ser enviados para este endereço. Tem certeza?</translation>
+        <translation type="unfinished">O endereço que selecionou para o troco não faz parte desta carteira. Todos ou quaisquer fundos na sua carteira podem ser enviados para este endereço. Tem a certeza?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -3225,11 +3275,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation type="unfinished">Qu&amp;antia:</translation>
+        <translation type="unfinished">Qua&amp;ntia:</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation type="unfinished">&amp;Pagar A:</translation>
+        <translation type="unfinished">&amp;Pagar a:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -3241,11 +3291,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">O endereço Bitcoin para enviar o pagamento</translation>
+        <translation type="unfinished">O endereço Bitcoin para onde enviar o pagamento</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Cole endereço da área de transferência</translation>
+        <translation type="unfinished">Colar endereço da área de transferência</translation>
     </message>
     <message>
         <source>Remove this entry</source>
@@ -3253,15 +3303,15 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">A quantidade para enviar na unidade selecionada</translation>
+        <translation type="unfinished">A quantia a enviar na unidade selecionada</translation>
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">A taxa será deduzida ao valor que está a ser enviado. O destinatário irá receber menos bitcoins do que as que inseridas no campo do valor. Se estiverem selecionados múltiplos destinatários, a taxa será repartida equitativamente.</translation>
+        <translation type="unfinished">A taxa será deduzida à quantia que está a ser enviada. O destinatário irá receber menos bitcoins do que as que inseridas no campo da quantia. Se estiverem selecionados múltiplos destinatários, a taxa será repartida equitativamente.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">S&amp;ubtrair a taxa ao montante</translation>
+        <translation type="unfinished">S&amp;ubtrair a taxa à quantia</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -3277,7 +3327,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Uma mensagem que estava anexada ao URI bitcoin: que será armazenada com a transação para sua referência. Nota: Esta mensagem não será enviada através da rede Bitcoin.</translation>
+        <translation type="unfinished">Uma mensagem que foi anexada ao bitcoin: URI que será armazenada com a transação para sua referência. Nota: esta mensagem não será enviada através da rede Bitcoin.</translation>
     </message>
 </context>
 <context>
@@ -3295,19 +3345,19 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">Assinaturas - Assinar / Verificar uma Mensagem</translation>
+        <translation type="unfinished">Assinaturas - assinar / verificar uma mensagem</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished">&amp;Assinar Mensagem</translation>
+        <translation type="unfinished">&amp;Assinar mensagem</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Pode assinar mensagens com os seus endereços para provar que são seus. Tenha atenção ao assinar mensagens ambíguas, pois ataques de phishing podem tentar enganá-lo de modo a assinar a sua identidade para os atacantes. Apenas assine declarações detalhadas com as quais concorde.</translation>
+        <translation type="unfinished">Pode assinar mensagens/acordos com os seus endereços para provar que pode receber bitcoins enviados para eles. Tenha cuidado para não assinar nada vago ou aleatório, pois os ataques de phishing podem tentar induzi-lo a assinar a sua identidade. Assine apenas declarações totalmente detalhadas com as quais concorda.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">O endereço Bitcoin para designar a mensagem</translation>
+        <translation type="unfinished">O endereço Bitcoin com o qual assinar a mensagem</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -3315,7 +3365,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Cole endereço da área de transferência</translation>
+        <translation type="unfinished">Colar endereço da área de transferência</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
@@ -3331,11 +3381,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Assine uma mensagem para provar que é dono deste endereço Bitcoin</translation>
+        <translation type="unfinished">Assine a mensagem para provar que é o proprietário deste endereço Bitcoin</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished">Assinar &amp;Mensagem</translation>
+        <translation type="unfinished">Assinar &amp;mensagem</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
@@ -3343,19 +3393,19 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Limpar &amp;Tudo</translation>
+        <translation type="unfinished">Limpar &amp;tudo</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation type="unfinished">&amp;Verificar Mensagem</translation>
+        <translation type="unfinished">&amp;Verificar mensagem</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Introduza o endereço de assinatura, mensagem (assegure-se que copia quebras de linha, espaços, tabulações, etc. exatamente) e assinatura abaixo para verificar a mensagem. Tenha atenção para não ler mais na assinatura do que o que estiver na mensagem assinada, para evitar ser enganado por um atacante que se encontre entre si e quem assinou a mensagem.</translation>
+        <translation type="unfinished">Introduza o endereço do destinatário, a mensagem (certifique-se que copia com exatidão as quebras de linha, os espaços, tabulações, etc.) e a assinatura abaixo para verificar a mensagem. Tenha cuidado para não ler mais na assinatura do que o que está na própria mensagem assinada, para evitar ser enganado por um ataque de intermediário (man-in-the-middle). Note que isto apenas prova que a parte que assina recebe com este endereço, não podendo provar o remetente de nenhuma transação!</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">O endereço Bitcoin com que a mensagem foi designada</translation>
+        <translation type="unfinished">O endereço Bitcoin com o qual a mensagem foi assinada</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -3371,7 +3421,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation type="unfinished">Verificar &amp;Mensagem</translation>
+        <translation type="unfinished">Verificar &amp;mensagem</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
@@ -3379,7 +3429,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Clique "Assinar Mensagem" para gerar a assinatura</translation>
+        <translation type="unfinished">Clique em "Assinar mensagem" para gerar a assinatura</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
@@ -3391,7 +3441,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">O endereço introduzido não refere-se a nenhuma chave.</translation>
+        <translation type="unfinished">O endereço introduzido não se refere a uma chave.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
@@ -3399,7 +3449,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">Sem erro</translation>
+        <translation type="unfinished">Nenhum erro</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
@@ -3407,7 +3457,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation type="unfinished">Assinatura da mensagem falhou.</translation>
+        <translation type="unfinished">A assinatura da mensagem falhou.</translation>
     </message>
     <message>
         <source>Message signed.</source>
@@ -3423,11 +3473,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">A assinatura não corresponde com o conteúdo da mensagem.</translation>
+        <translation type="unfinished">A assinatura não corresponde ao resumo da mensagem.</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
-        <translation type="unfinished">Verificação da mensagem falhou.</translation>
+        <translation type="unfinished">A verificação da mensagem falhou.</translation>
     </message>
     <message>
         <source>Message verified.</source>
@@ -3438,11 +3488,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <name>SplashScreen</name>
     <message>
         <source>(press q to shutdown and continue later)</source>
-        <translation type="unfinished">(tecle q para desligar e continuar mais tarde)</translation>
+        <translation type="unfinished">(pressione Q para desligar e continuar mais tarde)</translation>
     </message>
     <message>
         <source>press q to shutdown</source>
-        <translation type="unfinished">Carregue q para desligar</translation>
+        <translation type="unfinished">pressione Q para desligar</translation>
     </message>
 </context>
 <context>
@@ -3450,17 +3500,17 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
-        <translation type="unfinished">incompatível com uma transação com %1 confirmações</translation>
+        <translation type="unfinished">em conflito com uma transação com %1 confirmações</translation>
     </message>
     <message>
         <source>0/unconfirmed, in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
-        <translation type="unfinished">0/não confirmada, no memory pool</translation>
+        <translation type="unfinished">0/não confirmado, na pool de memória</translation>
     </message>
     <message>
         <source>0/unconfirmed, not in memory pool</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
-        <translation type="unfinished">0/não confirmada, ausente no memory pool</translation>
+        <translation type="unfinished">0/não confirmado, não está na pool de memória</translation>
     </message>
     <message>
         <source>abandoned</source>
@@ -3470,7 +3520,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>%1/unconfirmed</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
-        <translation type="unfinished">%1/não confirmada</translation>
+        <translation type="unfinished">%1/não confirmado</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
@@ -3491,7 +3541,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Generated</source>
-        <translation type="unfinished">Gerado</translation>
+        <translation type="unfinished">Gerada</translation>
     </message>
     <message>
         <source>From</source>
@@ -3507,11 +3557,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">endereço próprio</translation>
+        <translation type="unfinished">próprio endereço</translation>
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">apenas vigiar</translation>
+        <translation type="unfinished">apenas observação</translation>
     </message>
     <message>
         <source>label</source>
@@ -3524,8 +3574,8 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform>pronta em mais %n bloco</numerusform>
-            <numerusform>prontas em mais %n blocos</numerusform>
+            <numerusform>maturo em mais %n bloco</numerusform>
+            <numerusform>maturo em mais %n blocos</numerusform>
         </translation>
     </message>
     <message>
@@ -3550,7 +3600,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Valor líquido</translation>
+        <translation type="unfinished">Quantia líquida</translation>
     </message>
     <message>
         <source>Message</source>
@@ -3562,11 +3612,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation type="unfinished">Id. da Transação</translation>
+        <translation type="unfinished">ID da transação</translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Tamanho total da transição</translation>
+        <translation type="unfinished">Tamanho total da transação</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -3574,12 +3624,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Índex de saída</translation>
+        <translation type="unfinished">Índice de saída</translation>
     </message>
     <message>
         <source>%1 (Certificate was not verified)</source>
-        <translation type="unfinished">
-%1 (O certificado não foi verificado)</translation>
+        <translation type="unfinished">%1 (O certificado não foi verificado)</translation>
     </message>
     <message>
         <source>Merchant</source>
@@ -3587,7 +3636,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">As moedas geradas precisam amadurecer %1 blocos antes que possam ser gastas. Quando gerou este bloco, ele foi transmitido para a rede para ser adicionado à cadeia de blocos. Se este não conseguir entrar na cadeia, seu estado mudará para "não aceite" e não poderá ser gasto. Isto pode acontecer ocasionalmente se outro nó gerar um bloco dentro de alguns segundos do seu.</translation>
+        <translation type="unfinished">As moedas geradas têm de amadurecer %1 blocos antes que possam ser gastas. Quando gerou este bloco, ele foi transmitido para a rede para ser adicionado à cadeia de blocos. Se este não conseguir entrar na cadeia, o seu estado mudará para "não aceite" e não poderá ser gasto. Isto pode acontecer ocasionalmente se outro nó gerar um bloco dentro de alguns segundos do seu.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -3653,11 +3702,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">Confirmada (%1 confirmações)</translation>
+        <translation type="unfinished">Confirmado (%1 confirmações)</translation>
     </message>
     <message>
         <source>Conflicted</source>
-        <translation type="unfinished">Incompatível</translation>
+        <translation type="unfinished">Em conflito</translation>
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
@@ -3685,7 +3734,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">apenas vigiar</translation>
+        <translation type="unfinished">apenas observação</translation>
     </message>
     <message>
         <source>(n/a)</source>
@@ -3709,15 +3758,15 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Se um endereço de apenas vigiar está ou não envolvido nesta transação.</translation>
+        <translation type="unfinished">Se um endereço de observação está ou não envolvido nesta transação.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">Intenção do utilizador/motivo da transação</translation>
+        <translation type="unfinished">Intenção do utilizador / motivo da transação.</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Montante retirado ou adicionado ao saldo</translation>
+        <translation type="unfinished">Quantia retirada ou adicionada ao saldo.</translation>
     </message>
 </context>
 <context>
@@ -3764,11 +3813,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Escreva endereço, identificação de transação ou etiqueta para procurar</translation>
+        <translation type="unfinished">Introduzir endereço, identificador da transação ou etiqueta para procurar</translation>
     </message>
     <message>
         <source>Min amount</source>
-        <translation type="unfinished">Valor mín.</translation>
+        <translation type="unfinished">Quantia mín.</translation>
     </message>
     <message>
         <source>Range…</source>
@@ -3788,15 +3837,15 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Copiar Id. da transação</translation>
+        <translation type="unfinished">Copiar ID da transação</translation>
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Copiar &amp;transação bruta</translation>
+        <translation type="unfinished">Copiar transação em b&amp;ruto</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
-        <translation type="unfinished">Copie toda a transação &amp;details</translation>
+        <translation type="unfinished">Copiar a transação completa e os &amp;detalhes</translation>
     </message>
     <message>
         <source>&amp;Show transaction details</source>
@@ -3821,7 +3870,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Export Transaction History</source>
-        <translation type="unfinished">Exportar Histórico de Transações</translation>
+        <translation type="unfinished">Exportar histórico de transações</translation>
     </message>
     <message>
         <source>Comma separated file</source>
@@ -3830,11 +3879,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmada</translation>
+        <translation type="unfinished">Confirmado</translation>
     </message>
     <message>
         <source>Watch-only</source>
-        <translation type="unfinished">Apenas vigiar</translation>
+        <translation type="unfinished">Apenas observação</translation>
     </message>
     <message>
         <source>Date</source>
@@ -3853,12 +3902,8 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
         <translation type="unfinished">Endereço</translation>
     </message>
     <message>
-        <source>ID</source>
-        <translation type="unfinished">Id.</translation>
-    </message>
-    <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Exportação Falhou</translation>
+        <translation type="unfinished">Falha na exportação</translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
@@ -3866,7 +3911,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Exporting Successful</source>
-        <translation type="unfinished">Exportação Bem Sucedida</translation>
+        <translation type="unfinished">Exportação bem sucedida</translation>
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
@@ -3874,7 +3919,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Range:</source>
-        <translation type="unfinished">Período:</translation>
+        <translation type="unfinished">Intervalo:</translation>
     </message>
     <message>
         <source>to</source>
@@ -3887,13 +3932,13 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
         <source>No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
-        <translation type="unfinished">Nenhuma carteira foi carregada
-Ir para o arquivo &gt; Abrir carteira para carregar a carteira
+        <translation type="unfinished">Nenhuma carteira foi carregada.
+Vá ao menu Ficheiro &gt; Abrir carteira para carregar uma carteira
 - OU -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Criar novo carteira</translation>
+        <translation type="unfinished">Criar nova carteira</translation>
     </message>
     <message>
         <source>Error</source>
@@ -3901,7 +3946,7 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">Incapaz de decifrar a PSBT da área de transferência (base64 inválida)</translation>
+        <translation type="unfinished">Não foi possível descodificar a transação de Bitcoin parcialmente assinada (PSTB) da área de transferência (base64 inválida)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
@@ -3913,18 +3958,18 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">Arquivo PSBT deve ser menor que 100 MiB</translation>
+        <translation type="unfinished">O ficheiro PSBT deve ser inferior a 100 MiB</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Incapaz de decifrar a PSBT</translation>
+        <translation type="unfinished">Não foi possível descodificar a transação de Bitcoin parcialmente assinada (PSTB)</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Enviar Moedas</translation>
+        <translation type="unfinished">Enviar moedas</translation>
     </message>
     <message>
         <source>Fee bump error</source>
@@ -3932,7 +3977,7 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>Increasing transaction fee failed</source>
-        <translation type="unfinished">Aumento da taxa de transação falhou</translation>
+        <translation type="unfinished">O aumento da taxa de transação falhou</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
@@ -3952,8 +3997,12 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Nova taxa:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Aviso: pode pagar a taxa adicional reduzindo as saídas ou aumentando as entradas, quando necessário. Poderá ser acrescentada uma nova moeda, caso ainda não exista nenhuma. Estas alterações podem potencialmente causar fugas de privacidade.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Confirme aumento de taxa</translation>
+        <translation type="unfinished">Confirmar aumento da taxa</translation>
     </message>
     <message>
         <source>Can't draft transaction.</source>
@@ -3974,11 +4023,11 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>Could not commit transaction</source>
-        <translation type="unfinished">Não foi possível cometer a transação</translation>
+        <translation type="unfinished">Não foi possível confirmar a transação</translation>
     </message>
     <message>
         <source>Can't display address</source>
-        <translation type="unfinished">Não é possível exibir o endereço</translation>
+        <translation type="unfinished">Não é possível visualizar o endereço</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3989,15 +4038,15 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">e exportar</translation>
+        <translation type="unfinished">&amp;Exportar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar os dados no separador atual para um ficheiro</translation>
+        <translation type="unfinished">Exportar os dados na aba atual para um ficheiro</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">Cópia de Segurança da Carteira</translation>
+        <translation type="unfinished">Cópia de segurança da carteira</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -4006,7 +4055,7 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">Cópia de Segurança Falhou</translation>
+        <translation type="unfinished">Falha na cópia de segurança</translation>
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
@@ -4014,7 +4063,7 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">Cópia de Segurança Bem Sucedida</translation>
+        <translation type="unfinished">Cópia de segurança efetuada com êxito</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
@@ -4033,60 +4082,87 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s corrompido. Tente usar a ferramenta de carteira bitcoin-wallet para salvar ou restaurar um backup.</translation>
+        <translation type="unfinished">%s corrompido. Tente usar a ferramenta de carteira bitcoin-wallet para guardar ou restaurar uma cópia de segurança.</translation>
     </message>
     <message>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <translation type="unfinished">%s falhou ao validar o estado da cópia -assumeutxo. Isso indica um problema de hardware, um bug no software ou uma modificação incorreta do software que permitiu o carregamento de uma cópia inválida. Como resultado disso, o nó será desligado e parará de usar qualquer estado criado na cópia, redefinindo a altura da corrente de %d para %d. Na próxima reinicialização, o nó retomará a sincronização de%d sem usar nenhum dado da cópia. Por favor, reporte este incidente para %s, incluindo como você obteve a cópia. A cópia inválida do estado de cadeia será deixada no disco caso sirva para diagnosticar o problema que causou esse erro.</translation>
+        <translation type="unfinished">%s falhou ao validar o estado do instantâneo -assumeutxo. Isso indica um problema de hardware ou um erro no software ou uma modificação de software incorreta que permitiu que um instantâneo inválido fosse carregado. Como resultado disso, o nó será desligado e deixará de usar qualquer estado que tenha sido construído no instantâneo, redefinindo a altura da cadeia de %d para %d. Na próxima reinicialização, o nó retomará a sincronização a partir de %d sem utilizar quaisquer dados de instantâneos. Por favor, comunique este incidente a %s, incluindo a forma como obteve o instantâneo. O estado em cadeia do instantâneo inválido será deixado no disco, caso seja útil para diagnosticar o problema que causou este erro.</translation>
     </message>
     <message>
         <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
-        <translation type="unfinished">1%s solicitação para escutar na porta 2%u. Esta porta é considerada "ruim" e, portanto, é improvável que qualquer ponto se conecte-se a ela. Consulte doc/p2p-bad-ports.md para obter detalhes e uma lista completa.</translation>
+        <translation type="unfinished">%s solicita a escuta na porta %u. Esta porta é considerada "má" e, por isso, é improvável que qualquer par se conecte a ela. Veja doc/p2p-bad-ports.md para detalhes e uma lista completa.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished">Não é possível fazer o downgrade da carteira da versão %i para %i. Versão da carteira inalterada.</translation>
+        <translation type="unfinished">Não é possível fazer o downgrade da carteira da versão %i para %i. A versão da carteira não foi alterada.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Não foi possível obter o bloqueio de escrita no da pasta de dados %s. %s provavelmente já está a ser executado.</translation>
+        <translation type="unfinished">Não foi possível obter o bloqueio de escrita da pasta de dados %s. %s provavelmente já está em execução.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Não é possível atualizar uma carteira não dividida em HD da versão %i para a versão %i sem atualizar para suportar o conjunto de chaves pré-dividido. Por favor, use a versão %i ou nenhuma versão especificada.</translation>
     </message>
     <message>
         <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
-        <translation type="unfinished">O espaço em disco para 1%s pode não acomodar os arquivos de bloco. Aproximadamente 2%u GB de dados serão armazenados neste diretório.</translation>
+        <translation type="unfinished">O espaço em disco para %s pode não acomodar os ficheiros de bloco. Serão armazenados neste diretório aproximadamente %u GB de dados.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished">Distribuído sob licença de software MIT, veja o ficheiro %s ou %s</translation>
+        <translation type="unfinished">Distribuído sob a licença de software MIT, ver o ficheiro que o acompanha %s ou %s</translation>
     </message>
     <message>
         <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
-        <translation type="unfinished">Erro ao carregar a carteira. A carteira requer que os blocos sejam baixados e o software atualmente não suporta o carregamento de carteiras enquanto os blocos estão sendo baixados fora de ordem ao usar instantâneos assumeutxo. A carteira deve ser carregada com êxito após a sincronização do nó atingir o patamar 1%s</translation>
+        <translation type="unfinished">Erro ao carregar a carteira. A carteira requer que os blocos sejam descarregados, e o software não suporta atualmente o carregamento de carteiras enquanto os blocos estão a ser descarregados fora de ordem quando se utilizam instantâneos "assumeutxo". A carteira deve poder ser carregada com sucesso depois que a sincronização do nó atingir a altura %s</translation>
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">Erro ao ler %s! Dados de transações podem estar incorretos ou faltando. Reescaneando a carteira.</translation>
+        <translation type="unfinished">Erro ao ler %s! Os dados da transação podem estar em falta ou incorretos. A verificar novamente a carteira.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Erro: o registo do formato do ficheiro de dump está incorreto. Obteve-se "%s", mas era esperado "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Erro: o registo do identificador do ficheiro de dump está incorreto. Obteve-se "%s", mas era esperado "%s".</translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Erro: Esta versão do bitcoin-wallet apenas suporta arquivos de despejo na versão 1. (Versão atual: %s)</translation>
+        <translation type="unfinished">Erro: esta versão do bitcoin-wallet apenas suporta ficheiros dump na versão 1. (Versão atual: %s)</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Erro: as carteiras legadas apenas suportam os tipos de endereço "legado", "p2sh-segwit" e "bech32</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.</source>
+        <translation type="unfinished">Erro: não é possível produzir descritores para esta carteira antiga. Certifique-se de que fornece a frase de segurança da carteira se esta estiver encriptada.</translation>
     </message>
     <message>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <translation type="unfinished">Arquivo%sjá existe. Se você tem certeza de que é isso que quer, tire-o do caminho primeiro.</translation>
+        <translation type="unfinished">O ficheiro%s já existe. Se tem a certeza que é isso que quer, mova-o primeiro para fora do caminho.</translation>
     </message>
     <message>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <translation type="unfinished">O arquivo peers.dat (%s) está corrompido ou inválido. Se você acredita se tratar de um bug, por favor reporte para %s. Como solução, você pode mover, renomear ou deletar (%s) para um novo ser criado na próxima inicialização</translation>
+        <translation type="unfinished">O ficheiro peers.dat (%s) está corrompido ou é inválido. Se acredita qua se trata de um "bug", por favor reporte para %s. Como solução, pode mover, alterar o nome ou eliminar (%s) para ser criado um novo na próxima inicialização</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation type="unfinished">Mais de um endereço de ligação onion é fornecido. Usando %s para o serviço Tor onion criado automaticamente.</translation>
+        <translation type="unfinished">É fornecido mais do que um endereço onion bind. A utilizar %s para o serviço Tor onion criado automaticamente.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Não foi fornecido nenhum ficheiro de dump. Para utilizar createfromdump tem de ser fornecido -dumpfile=&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Não foi fornecido nenhum ficheiro de dump. Para utilizar o dump, tem de ser fornecido -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished">Nenhum formato de arquivo de carteira fornecido. Para usar createfromdump, -format = &lt;format&gt;
-deve ser fornecido.</translation>
+        <translation type="unfinished">Não foi fornecido nenhum formato de ficheiro de carteira. Para usar createfromdump, é necessário fornecer -format=&lt;format&gt;.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -4098,47 +4174,47 @@ deve ser fornecido.</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">Poda configurada abaixo do mínimo de %d MiB.  Por favor, utilize um valor mais elevado.</translation>
+        <translation type="unfinished">O modo de redução (prune) está configurado abaixo do mínimo de %d MiB. Utilize um valor mais elevado.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <translation type="unfinished">O modo Prune é incompatível com a opção "-reindex-chainstate". Ao invés disso utilize "-reindex".</translation>
+        <translation type="unfinished">O modo de redução (prune) é incompatível com a opção "-reindex-chainstate". Ao invés disso utilize "-reindex".</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Poda: a última sincronização da carteira vai além dos dados podados.  Precisa de -reindex (descarregar novamente a cadeia de blocos completa em caso de nó podado)</translation>
+        <translation type="unfinished">Redução (prune): a última sincronização da carteira vai além dos dados reduzidos. Precisa de -reindex (descarregar novamente a cadeia de blocos completa no caso de nó com redução)</translation>
     </message>
     <message>
         <source>Rename of '%s' -&gt; '%s' failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <translation type="unfinished">Falha ao renomear '%s' -&gt; '%s'. Você deve resolver este problema manualmente movendo ou removendo o diretório de cópia inválido %s, caso contrário o mesmo erro ocorrerá novamente na próxima inicialização.</translation>
+        <translation type="unfinished">A renomeação de '%s' -&gt; '%s' falhou. Deve resolver este problema movendo ou eliminando manualmente o diretório de instantâneos inválido %s, caso contrário, voltará a encontrar o mesmo erro no arranque seguinte.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: Versão %d do esquema de carteira sqlite desconhecido. Apenas a versão %d é suportada</translation>
+        <translation type="unfinished">SQLiteDatabase: versão %d do esquema de carteira sqlite desconhecido. Apenas é suportada a versão %d</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">A base de dados de blocos contém um bloco que aparenta ser do futuro. Isto pode ser causado por uma data incorreta definida no seu computador. Reconstrua apenas a base de dados de blocos caso tenha a certeza de que a data e hora do seu computador estão corretos.</translation>
+        <translation type="unfinished">A base de dados de blocos contém um bloco que parece ser do futuro. Isto pode dever-se ao facto de a data e a hora do computador não estarem corretas. Só reconstrua a base de dados de blocos se tiver a certeza de que a data e a hora do seu computador estão corretas</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">O montante da transação é demasiado baixo após a dedução da taxa</translation>
+        <translation type="unfinished">A quantia da transação é demasiado baixa para enviar após a dedução da taxa</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Este erro pode ocorrer se a carteira não foi desligada corretamente e foi carregada da ultima vez usando uma compilação com uma versão mais recente da Berkeley DB. Se sim, por favor use o programa que carregou esta carteira da ultima vez.</translation>
+        <translation type="unfinished">Este erro pode ocorrer se a carteira não foi desligada corretamente e foi carregada da última vez usando uma compilação com uma versão mais recente da Berkeley DB. Se sim, por favor use o programa que carregou esta carteira da última vez.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Isto é uma compilação de teste de pré-lançamento - use por sua conta e risco - não use para mineração ou comércio</translation>
+        <translation type="unfinished">Esta é uma versão de teste de pré-lançamento - use por sua conta e risco - não use para mineração ou aplicações comerciais</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Este é a taxa de transação máxima que você paga (em adição à taxa normal) para priorizar evitar gastos parciais sobre seleção de moeda normal.</translation>
+        <translation type="unfinished">Esta é a taxa de transação máxima que paga (para além da taxa normal) para dar prioridade à prevenção de gastos parciais em detrimento da seleção regular de moedas.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Esta é a taxa de transação que poderá descartar, se o troco for menor que o pó a este nível</translation>
+        <translation type="unfinished">Esta é a taxa de transação que poderá descartar, se o troco for menor que o remanescente a este nível</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
@@ -4146,31 +4222,39 @@ deve ser fornecido.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">Comprimento total da entrada da versão de rede (%i) excede o comprimento máximo (%i). Reduzir o número ou o tamanho de uacomments.</translation>
+        <translation type="unfinished">O comprimento total da entrada da versão de rede (%i) excede o comprimento máximo (%i). Reduza o número ou o tamanho de uacomments.</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation type="unfinished">Não é possível reproduzir os blocos. Terá de reconstruir a base de dados utilizando -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Formato "%s" de ficheiro de carteira desconhecido. Por favor, forneça um dos formatos "bdb" ou "sqlite".</translation>
+    </message>
+    <message>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <translation type="unfinished">Categoria especificada no nível de log não suportada %1$s=%2$s. Esperado %1$s=&lt;category&gt;:&lt;loglevel&gt;. Categorias validas: %3$s. Níveis de log válidos: %4$s.</translation>
+        <translation type="unfinished">Nível de registo específico da categoria não suportado %1$s=%2$s. Esperado %1$s=&lt;categoria&gt;:&lt;nívelderegisto&gt;. Categorias válidas: %3$s. Níveis de registo válidos: %4$s.</translation>
     </message>
     <message>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <translation type="unfinished">Formato de banco de dados incompatível na chainstate. Por favor reinicie com a opção "-reindex-chainstate". Isto irá recriar o banco de dados da chainstate.</translation>
+        <translation type="unfinished">Foi encontrado um formato de base de dados chainstate não suportado. Por favor reinicie com -reindex-chainstate. Isto irá reconstruir a base de dados do estado da cadeia.</translation>
     </message>
     <message>
         <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
-        <translation type="unfinished">Carteira criada com sucesso. As carteiras antigas estão sendo descontinuadas e o suporte para a criação de abertura de carteiras antigas será removido no futuro.</translation>
+        <translation type="unfinished">Carteira criada com sucesso. O tipo de carteira antiga está a ser descontinuado e o suporte para a criação e abertura de carteiras antigas será removido no futuro.</translation>
     </message>
     <message>
         <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <translation type="unfinished">Carteira carregada com sucesso. As carteiras legadas estão sendo descontinuadas e o suporte para a criação e abertura de carteiras legadas será removido no futuro. Carteiras legadas podem ser migradas para uma carteira com descritor com a ferramenta migratewallet. </translation>
+        <translation type="unfinished">Carteira carregada com sucesso. O tipo de carteira antiga legada está a ser descontinuado e o suporte para criar e abrir carteiras antigas será removido no futuro. As carteiras antigas podem ser migradas para uma carteira descritora com migratewallet.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Aviso: o formato da carteira do ficheiro de dump "%s" não corresponde ao formato especificado na linha de comando "%s".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Aviso: chaves privadas detetadas na carteira {%s} com chaves privadas desativadas</translation>
+        <translation type="unfinished">Aviso: foram detetadas chaves privadas na carteira {%s} com chaves privadas desativadas</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
@@ -4178,11 +4262,11 @@ deve ser fornecido.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <translation type="unfinished">Testemunhar dados de blocos após 1%d requer validação. Por favor reinicie com -reindex.</translation>
+        <translation type="unfinished">Os dados da testemunha para blocos após a altura %d requerem validação. Reinicie com -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">Necessita reconstruir a base de dados, utilizando -reindex para voltar ao modo sem poda. Isto irá descarregar novamente a cadeia de blocos completa</translation>
+        <translation type="unfinished">Tem de reconstruir a base de dados, utilizando -reindex para voltar ao modo sem redução (prune). Isto irá descarregar novamente a cadeia de blocos completa</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
@@ -4190,71 +4274,121 @@ deve ser fornecido.</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">- máximo do banco de memória deverá ser pelo menos %d MB</translation>
+        <translation type="unfinished">-maxmempool tem de ser pelo menos %d MB</translation>
     </message>
     <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Um erro fatal interno occoreu, veja o debug.log para detalhes</translation>
+        <translation type="unfinished">Ocorreu um erro interno fatal, ver debug.log para mais pormenores</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Não é possível resolver -%s endereço '%s'</translation>
+        <translation type="unfinished">Não é possível resolver o endereço de -%s: "%s"</translation>
     </message>
     <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
-        <translation type="unfinished">Não é possível definir -forcednsseed para true quando -dnsseed for false.</translation>
+        <translation type="unfinished">Não é possível definir -forcednsseed como true ao definir -dnsseed como false.</translation>
     </message>
     <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Não é possível ajustar -peerblockfilters sem -blockfilterindex.</translation>
+        <translation type="unfinished">Não é possível definir -peerblockfilters sem -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Não foi possível escrever na pasta de dados '%s': verifique as permissões.</translation>
+        <translation type="unfinished">Não foi possível escrever na pasta de dados "%s": verifique as permissões.</translation>
+    </message>
+    <message>
+        <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">%s é muito elevado! As taxas tão elevadas como esta poderiam ser pagas numa única transação.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
-        <translation type="unfinished">Não é possível fornecer conexões específicas e ter addrman procurando conexões ao mesmo tempo.</translation>
+        <translation type="unfinished">Não é possível fornecer conexões específicas e fazer com que o addrman encontre conexões de saída ao mesmo tempo.</translation>
     </message>
     <message>
         <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
-        <translation type="unfinished">Erro ao abrir %s: Carteira com assinador externo. Não foi compilado suporte para assinadores externos</translation>
+        <translation type="unfinished">Erro ao abrir %s: carteira com assinante externo. Não foi compilado suporte para assinantes externos</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <translation type="unfinished">Erro ao ler arquivo %s! Todas as chaves foram lidas corretamente, mas os dados de transação ou os metadados de endereço podem estar incorretos ou faltando.</translation>
+        <translation type="unfinished">Erro ao ler o ficheiro %s! Todas as chaves foram lidas corretamente, mas os dados da transação ou os metadados do endereço podem estar em falta ou incorretos.</translation>
     </message>
     <message>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
-        <translation type="unfinished">Erro: Os dados do livro de endereços da carteira  não puderam ser identificados por pertencerem a carteiras migradas</translation>
+        <translation type="unfinished">Erro: os dados do livro de endereços na carteira não podem ser identificados como pertencentes a carteiras migradas</translation>
     </message>
     <message>
         <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
-        <translation type="unfinished">Erro: Descritores duplicados criados durante a migração. Sua carteira pode estar corrompida.</translation>
+        <translation type="unfinished">Erro: foram criados descritores duplicados durante a migração. A sua carteira pode estar corrompida.</translation>
     </message>
     <message>
         <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
-        <translation type="unfinished">Erro: A transação %s na carteira não pôde ser identificada por pertencer a carteiras migradas</translation>
+        <translation type="unfinished">Erro: a transação %s na carteira não pode ser identificada como pertencente a carteiras migradas</translation>
     </message>
     <message>
         <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
-        <translation type="unfinished">Falha ao calcular as taxas de colisão porque os UTXOs não confirmados dependem de um enorme conjunto de transações não confirmadas.</translation>
+        <translation type="unfinished">Não foi possível calcular as taxas de compensação, porque os UTXOs não confirmados dependem de um enorme conjunto de transações não confirmadas..</translation>
     </message>
     <message>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
-        <translation type="unfinished">Impossível renomear o arquivo peers.dat (inválido). Por favor mova-o ou delete-o e tente novamente.</translation>
+        <translation type="unfinished">Falha ao alterar o nome do ficheiro peers.dat inválido. Mova-o ou elimine-o e tente novamente.</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <translation type="unfinished">A estimativa da taxa falhou. A taxa de retrocesso está desativada. Aguardar alguns blocos ou ativar %s.</translation>
     </message>
     <message>
         <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
-        <translation type="unfinished">Opções incompatíveis: "-dnsseed=1" foi explicitamente específicada, mas "-onlynet" proíbe conexões para IPv4/IPv6</translation>
+        <translation type="unfinished">Opções incompatíveis: "-dnsseed=1" foi explicitamente especificada, mas "-onlynet" proíbe conexões para IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Quantia inválida para %s=&lt;amount&gt;: '%s' (tem de ser, pelo menos, a taxa mínima de retransmissão de %s para evitar transações bloqueadas)</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <translation type="unfinished">Conexões de saída restritas ao CJDNS (-onlynet=cjdns) mas -cjdnsreachable não é fornecido</translation>
     </message>
     <message>
         <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
-        <translation type="unfinished">As conexões de saída foram restringidas a rede Tor (-onlynet-onion) mas o proxy para alcançar a rede Tor foi explicitamente proibido: "-onion=0"</translation>
+        <translation type="unfinished">As conexões de saída foram restringidas à rede Tor (-onlynet-onion) mas o proxy para alcançar a rede Tor foi explicitamente proibido: "-onion=0"</translation>
     </message>
     <message>
         <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
-        <translation type="unfinished">As conexões de saída foram restringidas a rede Tor  (-onlynet=onion) mas o proxy para acessar a rede Tor não foi fornecido: nenhuma opção "-proxy", "-onion" ou "-listenonion" foi fornecida</translation>
+        <translation type="unfinished">As conexões de saída foram restringidas à rede Tor  (-onlynet=onion) mas o proxy para aceder à rede Tor não foi fornecido: nenhuma opção "-proxy", "-onion" ou "-listenonion" foi fornecida</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <translation type="unfinished">Conexões de saída restringidas ao i2p (-onlynet=i2p) mas não foi fornecido -i2psam</translation>
+    </message>
+    <message>
+        <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs</source>
+        <translation type="unfinished">O tamanho das entradas excede o peso máximo. Por favor, tente enviar uma quantia menor ou consolidar manualmente os UTXOs da sua carteira</translation>
+    </message>
+    <message>
+        <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <translation type="unfinished">A quantia total de moedas pré-selecionadas não cobre o objetivo da transação. Permita que sejam selecionadas automaticamente outras entradas ou inclua mais moedas manualmente</translation>
+    </message>
+    <message>
+        <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
+        <translation type="unfinished">A transação requer um destino com montante não-0, uma taxa diferente de 0 ou uma entrada pré-selecionada</translation>
+    </message>
+    <message>
+        <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
+        <translation type="unfinished">Falha na validação do instantâneo UTXO. Reinicie para retomar o descarregamento normal do bloco inicial ou tente carregar um instantâneo diferente.</translation>
+    </message>
+    <message>
+        <source>Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
+        <translation type="unfinished">Estão disponíveis UTXOs não confirmados, mas gastá-los cria uma cadeia de transações que será rejeitada pelo mempool</translation>
+    </message>
+    <message>
+        <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
+
+The wallet might have been tampered with or created with malicious intent.
+</source>
+        <translation type="unfinished">Encontrada uma entrada legada inesperada na carteira descritora. A carregar a carteira %s
+
+A carteira pode ter sido adulterada ou criada com intenções maliciosas.
+</translation>
     </message>
     <message>
         <source>Unrecognized descriptor found. Loading wallet %s
@@ -4262,9 +4396,9 @@ deve ser fornecido.</translation>
 The wallet might had been created on a newer version.
 Please try running the latest software version.
 </source>
-        <translation type="unfinished">Descriptor não reconhecido foi encontrado. Carregando carteira %s
+        <translation type="unfinished">Encontrado descritor não reconhecido. A carregar a carteira %s
 
-A carteira pode ter sido criada em uma versão mais nova.
+A carteira pode ter sido criada numa versão mais recente.
 Por favor tente atualizar o software para a última versão.
 </translation>
     </message>
@@ -4272,41 +4406,45 @@ Por favor tente atualizar o software para a última versão.
         <source>
 Unable to cleanup failed migration</source>
         <translation type="unfinished">
-Impossível limpar a falha de migração</translation>
+Não foi possível efetuar a limpeza da migração falhada</translation>
     </message>
     <message>
         <source>
 Unable to restore backup of wallet.</source>
         <translation type="unfinished">
-Impossível restaurar backup da carteira.</translation>
+Não foi possível restaurar a cópia de segurança da carteira.</translation>
+    </message>
+    <message>
+        <source>Block verification was interrupted</source>
+        <translation type="unfinished">A verificação do bloco foi interrompida</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">A configuração %s apenas é aplicada na rede %s quando na secção [%s].</translation>
+        <translation type="unfinished">A configuração para %s apenas é aplicada na rede %s quando se encontra na secção [%s].</translation>
     </message>
     <message>
         <source>Copyright (C) %i-%i</source>
-        <translation type="unfinished">Direitos de Autor (C) %i-%i</translation>
+        <translation type="unfinished">Direitos de autor (C) %i-%i</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation type="unfinished">Detetada cadeia de blocos corrompida</translation>
+        <translation type="unfinished">Detetada base de dados de blocos corrompida</translation>
     </message>
     <message>
         <source>Could not find asmap file %s</source>
-        <translation type="unfinished">Não foi possível achar o arquivo asmap %s</translation>
+        <translation type="unfinished">Não foi possível encontrar o ficheiro asmap %s</translation>
     </message>
     <message>
         <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Não foi possível analisar o arquivo asmap %s.</translation>
+        <translation type="unfinished">Não foi possível analisar o ficheiro asmap %s.</translation>
     </message>
     <message>
         <source>Disk space is too low!</source>
-        <translation type="unfinished">Espaço de disco é muito pouco!</translation>
+        <translation type="unfinished">O espaço em disco é demasiado pequeno!</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">Deseja reconstruir agora a base de dados de blocos.</translation>
+        <translation type="unfinished">Pretende reconstruir a base de dados de blocos agora?</translation>
     </message>
     <message>
         <source>Done loading</source>
@@ -4314,19 +4452,19 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">Arquivo de despejo %s não existe</translation>
+        <translation type="unfinished">O ficheiro de dump %s não existe</translation>
     </message>
     <message>
         <source>Error committing db txn for wallet transactions removal</source>
-        <translation type="unfinished">Erro durante commiting db txn para a remoção das transações da carteira.</translation>
+        <translation type="unfinished">Erro ao confirmar a transação da base de dados para remover transações da carteira</translation>
     </message>
     <message>
         <source>Error creating %s</source>
-        <translation type="unfinished">Erro a criar %s</translation>
+        <translation type="unfinished">Erro ao criar %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation type="unfinished">Erro ao inicializar a cadeia de blocos</translation>
+        <translation type="unfinished">Erro ao inicializar a base de dados de blocos</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
@@ -4350,15 +4488,19 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation type="unfinished">Erro ao carregar base de dados de blocos</translation>
+        <translation type="unfinished">Erro ao carregar a base de dados de blocos</translation>
     </message>
     <message>
         <source>Error opening block database</source>
         <translation type="unfinished">Erro ao abrir a base de dados de blocos</translation>
     </message>
     <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Erro ao ler o ficheiro de configuração: %s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">Erro ao ler da base de dados. A encerrar.</translation>
+        <translation type="unfinished">Erro ao ler a base de dados. A encerrar.</translation>
     </message>
     <message>
         <source>Error reading next record from wallet database</source>
@@ -4366,103 +4508,115 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Error starting db txn for wallet transactions removal</source>
-        <translation type="unfinished">Erro durante o início db txn para a remoção das transações da carteira.</translation>
+        <translation type="unfinished">Erro ao iniciar a transação da base de dados para remoção de transações da carteira</translation>
+    </message>
+    <message>
+        <source>Error: Cannot extract destination from the generated scriptpubkey</source>
+        <translation type="unfinished">Erro: não é possível extrair o destino da scriptpubkey gerada</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Erro: não foi possível criar o cursor na base de dados</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Erro: espaço em disco demasiado baixo para %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Erro: a soma de controlo do ficheiro de dump não corresponde. Calculado %s, esperado %s</translation>
+    </message>
+    <message>
         <source>Error: Failed to create new watchonly wallet</source>
-        <translation type="unfinished">Erro: Falha ao criar carteira apenas-visualização</translation>
+        <translation type="unfinished">Erro: falha ao criar uma nova carteira de observação</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Erro: Chave obtida sem ser no formato hex: %s</translation>
+        <translation type="unfinished">Erro: obteve-se uma chave que não era hexadecimal: %s</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Erro: Valor obtido sem ser no formato hex: %s</translation>
+        <translation type="unfinished">Erro: obtido um valor que não era hexadecimal: %s</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">A keypool esgotou-se, por favor execute primeiro keypoolrefill1</translation>
+        <translation type="unfinished">Erro: a pool de chaves esgotou-se. Invoque primeiro keypoolrefill</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
-        <translation type="unfinished">Erro: soma de verificação ausente</translation>
+        <translation type="unfinished">Erro: falta a soma de controlo / checksum</translation>
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">Erro: Não existem %s endereços disponíveis.</translation>
+        <translation type="unfinished">Erro: não existem endereços %s disponíveis.</translation>
     </message>
     <message>
         <source>Error: This wallet already uses SQLite</source>
-        <translation type="unfinished">Erro: Essa carteira já utiliza o SQLite</translation>
+        <translation type="unfinished">Erro: esta carteira já usa SQLite</translation>
     </message>
     <message>
         <source>Error: This wallet is already a descriptor wallet</source>
-        <translation type="unfinished">Erro: Esta carteira já contém um descritor</translation>
+        <translation type="unfinished">Erro: esta carteira já é uma carteira descritora</translation>
     </message>
     <message>
         <source>Error: Unable to begin reading all records in the database</source>
-        <translation type="unfinished">Erro: impossível ler todos os registros no banco de dados</translation>
+        <translation type="unfinished">Erro: não foi possível iniciar a leitura de todos os registos na base de dados</translation>
     </message>
     <message>
         <source>Error: Unable to make a backup of your wallet</source>
-        <translation type="unfinished">Erro: Impossível efetuar backup da carteira</translation>
+        <translation type="unfinished">Erro: não é possível efetuar uma cópia de segurança da sua carteira</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
-        <translation type="unfinished">Erro: Não foi possível converter versão %u como uint32_t</translation>
+        <translation type="unfinished">Erro: não foi possível analisar a versão %u como um uint32_t</translation>
     </message>
     <message>
         <source>Error: Unable to read all records in the database</source>
-        <translation type="unfinished">Error: Não é possivel ler todos os registros no banco de dados</translation>
+        <translation type="unfinished">Erro: não foi possível ler todos os registos na base de dados</translation>
     </message>
     <message>
         <source>Error: Unable to read wallet's best block locator record</source>
-        <translation type="unfinished">Erro: Não foi possível ler o melhor registo de localização de bloqueio da pasta</translation>
+        <translation type="unfinished">Erro: não foi possível ler o melhor registo de localização de blocos da carteira</translation>
     </message>
     <message>
         <source>Error: Unable to remove watchonly address book data</source>
-        <translation type="unfinished">Erro: Impossível remover dados somente-visualização do Livro de Endereços </translation>
+        <translation type="unfinished">Erro: não foi possível remover os dados só de observação do livro de endereços</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
-        <translation type="unfinished">Erro: Não foi possível escrever registro para a nova carteira</translation>
+        <translation type="unfinished">Erro: não foi possível escrever o registo para a nova carteira</translation>
     </message>
     <message>
         <source>Error: Unable to write solvable wallet best block locator record</source>
-        <translation type="unfinished">Erro: Não foi possível escrever o registo do melhor localizador de bloqueio da pasta solvível</translation>
+        <translation type="unfinished">Erro: não foi possível escrever o registo do melhor localizador de blocos da carteira solvente</translation>
     </message>
     <message>
         <source>Error: Unable to write watchonly wallet best block locator record</source>
-        <translation type="unfinished">Erro: Não é possível escrever o registo do melhor localizador de blocos da pasta watchonly</translation>
+        <translation type="unfinished">Erro: não foi possível escrever o registo do melhor localizador de blocos da carteira só de observação</translation>
     </message>
     <message>
         <source>Error: address book copy failed for wallet %s</source>
-        <translation type="unfinished">Erro: falha na cópia da agenda de endereços para a carteira %s</translation>
+        <translation type="unfinished">Erro: falha na cópia do livro de endereços para a carteira %s</translation>
     </message>
     <message>
         <source>Error: database transaction cannot be executed for wallet %s</source>
-        <translation type="unfinished">Erro: a transação do banco de dados não pode ser executada para a carteira %s</translation>
+        <translation type="unfinished">Erro: a transação da base de dados não pode ser executada para a carteira %s</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Falhou a escutar em qualquer porta. Use -listen=0 se quiser isto.</translation>
+        <translation type="unfinished">Falha ao escutar em qualquer porta. Use -listen=0 se quiser isso.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">Reexaminação da carteira falhou durante a inicialização</translation>
+        <translation type="unfinished">Falha ao verificar novamente a carteira durante a inicialização</translation>
     </message>
     <message>
         <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished">Falha ao iniciar índices, desligando..</translation>
+        <translation type="unfinished">Falha ao iniciar os índices. A encerrar…</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
-        <translation type="unfinished">Falha ao verificar base de dados</translation>
+        <translation type="unfinished">Falha ao verificar a base de dados</translation>
     </message>
     <message>
         <source>Failure removing transaction: %s</source>
@@ -4470,11 +4624,11 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <translation type="unfinished">A variação da taxa (%s) é menor que a mínima variação de taxa (%s) configurada.</translation>
+        <translation type="unfinished">A taxa de transação (%s) é inferior à taxa mínima de transação fixada (%s)</translation>
     </message>
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished">Ignorando -carteira %s duplicada.</translation>
+        <translation type="unfinished">Ignorando -wallet %s duplicada.</translation>
     </message>
     <message>
         <source>Importing…</source>
@@ -4486,11 +4640,15 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation type="unfinished">Verificação de integridade inicial falhou. O %s está a desligar-se.</translation>
+        <translation type="unfinished">A verificação da integridade inicial falhou. O %s está a encerrar.</translation>
     </message>
     <message>
         <source>Input not found or already spent</source>
         <translation type="unfinished">Entrada não encontrada ou já gasta</translation>
+    </message>
+    <message>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished">Cache da base de dados (Dbcache) insuficiente para verificação de blocos</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -4498,11 +4656,11 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Endereço ou nome de servidor -i2psam inválido: '%s'</translation>
+        <translation type="unfinished">Endereço -i2psam ou nome do servidor inválido: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Endereço -onion ou hostname inválido: '%s'</translation>
+        <translation type="unfinished">Endereço -onion ou nome do servidor inválido: '%s'</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
@@ -4510,31 +4668,47 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Permissões P2P inválidas : '%s'</translation>
+        <translation type="unfinished">Permissões P2P inválidas: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Quantia inválida para %s=&lt;amount&gt;: '%s' (tem de ser pelo menos %s)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for %s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Quantia inválida para %s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Valor inválido para -%s=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Quantia inválida para -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Máscara de rede inválida especificada em -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Invalid port specified in %s: '%s'</source>
+        <translation type="unfinished">Porta inválida especificada em %s: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished">Entrada pré-selecionada %s inválida</translation>
+    </message>
+    <message>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">A espera por conexões de entrada falharam (a espera retornou o erro %s)</translation>
+        <translation type="unfinished">A escuta de conexões de entrada falhou (a escuta devolveu o erro %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
-        <translation type="unfinished">Carregando endereços P2P...</translation>
+        <translation type="unfinished">A carregar endereços P2P…</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">A carregar a lista de banidos...</translation>
+        <translation type="unfinished">A carregar a lista de banidos…</translation>
     </message>
     <message>
         <source>Loading block index…</source>
-        <translation type="unfinished">Carregando índice do bloco...</translation>
+        <translation type="unfinished">A carregar o índice de blocos…</translation>
     </message>
     <message>
         <source>Loading wallet…</source>
@@ -4550,7 +4724,7 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Necessário especificar uma porta com -whitebind: '%s'</translation>
+        <translation type="unfinished">É necessário especificar uma porta com -whitebind: '%s'</translation>
     </message>
     <message>
         <source>No addresses available</source>
@@ -4558,47 +4732,55 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
-        <translation type="unfinished">Os descritores de ficheiros disponíveis são insuficientes.</translation>
+        <translation type="unfinished">Não estão disponíveis descritores de ficheiros suficientes.</translation>
+    </message>
+    <message>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished">Entrada pré-selecionada %s não encontrada</translation>
+    </message>
+    <message>
+        <source>Not solvable pre-selected input %s</source>
+        <translation type="unfinished">Entrada pré-selecionada %s não solucionável</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">A redução não pode ser configurada com um valor negativo.</translation>
+        <translation type="unfinished">A redução (prune) não pode ser configurada com um valor negativo.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">O modo de redução é incompatível com -txindex.</translation>
+        <translation type="unfinished">O modo de redução (prune) é incompatível com -txindex.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Prunando os blocos existentes...</translation>
+        <translation type="unfinished">Prunando os blocos existentes…</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Reduzindo -maxconnections de %d para %d, devido a limitações no sistema.</translation>
+        <translation type="unfinished">A reduzir -maxconnections de %d para %d devido a limitações no sistema.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
-        <translation type="unfinished">Repetindo blocos...</translation>
+        <translation type="unfinished">Repetindo blocos…</translation>
     </message>
     <message>
         <source>Rescanning…</source>
-        <translation type="unfinished">.Reexaminando...</translation>
+        <translation type="unfinished">A tornar a examinar…</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Falha ao executar a instrução para verificar o banco de dados: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: falha na execução da instrução para verificar a base de dados: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Falha ao preparar a instrução para verificar o banco de dados: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: falha ao preparar a instrução para verificar a base de dados: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to read database verification error: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Falha ao ler base de dados erro de verificação %s</translation>
+        <translation type="unfinished">SQLiteDatabase: falha na leitura do erro de verificação da base de dados: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase: ID de aplicativo inesperado. Esperado %u, obteve %u</translation>
+        <translation type="unfinished">SQLiteDatabase: ID de aplicação inesperado. Era esperado %u, obteve-se %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -4606,7 +4788,7 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation type="unfinished">Falhou assinatura da transação</translation>
+        <translation type="unfinished">Falha ao assinar a transação</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
@@ -4622,37 +4804,39 @@ Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">
-A pasta de blocos especificados "%s" não existe.</translation>
+        <translation type="unfinished">A pasta de blocos especificados "%s" não existe.</translation>
+    </message>
+    <message>
+        <source>Specified data directory "%s" does not exist.</source>
+        <translation type="unfinished">O diretório de dados especificado "%s" não existe.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
-        <translation type="unfinished">A iniciar threads de rede...</translation>
+        <translation type="unfinished">A iniciar threads de rede…</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">O código fonte está disponível pelo %s.</translation>
+        <translation type="unfinished">O código-fonte está disponível em %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
-        <translation type="unfinished">O ficheiro de configuração especificado %s não existe
-</translation>
+        <translation type="unfinished">O ficheiro de configuração especificado %s não existe</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">O montante da transação é demasiado baixo para pagar a taxa</translation>
+        <translation type="unfinished">A quantia da transação é demasiado baixa para pagar a taxa</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">A carteira evitará pagar menos que a taxa minima de propagação.</translation>
+        <translation type="unfinished">A carteira evitará pagar menos do que a taxa mínima de retransmissão.</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
-        <translation type="unfinished">Isto é software experimental.</translation>
+        <translation type="unfinished">Isto é um software experimental.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Esta é a taxa minima de transação que paga em cada transação.</translation>
+        <translation type="unfinished">Esta é a taxa mínima de transação que paga em cada transação.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
@@ -4660,19 +4844,19 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Transaction %s does not belong to this wallet</source>
-        <translation type="unfinished">A transação %s não pertence a esta carteira.</translation>
+        <translation type="unfinished">A transação %s não pertence a esta carteira</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
-        <translation type="unfinished">Quantia da transação é muito baixa</translation>
+        <translation type="unfinished">Quantia da transação demasiado baixa</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Os valores da transação não devem ser negativos</translation>
+        <translation type="unfinished">As quantias das transações não devem ser negativas</translation>
     </message>
     <message>
         <source>Transaction change output index out of range</source>
-        <translation type="unfinished">Endereço de troco da transação fora da faixa</translation>
+        <translation type="unfinished">O índice de saídas de troca de transações está fora do alcance</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
@@ -4680,23 +4864,23 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it.</source>
-        <translation type="unfinished">Transação precisa de uma mudança de endereço, mas nós não a podemos gerar.</translation>
+        <translation type="unfinished">A transação precisa de um endereço de troco, mas não o conseguimos gerar.</translation>
     </message>
     <message>
         <source>Transaction too large</source>
-        <translation type="unfinished">Transação grande demais</translation>
+        <translation type="unfinished">Transação demasiado grande</translation>
     </message>
     <message>
         <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
-        <translation type="unfinished">Impossível alocar memória para a opção "-maxsigcachesize: '%s' MiB</translation>
+        <translation type="unfinished">Não foi possível atribuir memória para -maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Incapaz de vincular à porta %s neste computador (vínculo retornou erro %s)</translation>
+        <translation type="unfinished">Não foi possível vincular a %s neste computador (a vinculação devolveu o erro %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Impossível associar a %s neste computador. %s provavelmente já está em execução.</translation>
+        <translation type="unfinished">Não foi possível vincular a %s neste computador. %s provavelmente já está em execução.</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
@@ -4704,11 +4888,11 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Unable to find UTXO for external input</source>
-        <translation type="unfinished">Impossível localizar e entrada externa UTXO</translation>
+        <translation type="unfinished">Não é possível encontrar UTXO para a entrada externa</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Incapaz de gerar as chaves iniciais</translation>
+        <translation type="unfinished">Não foi possível gerar as chaves iniciais</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
@@ -4724,23 +4908,23 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Não é possível iniciar o servidor HTTP. Verifique o debug.log para detalhes.</translation>
+        <translation type="unfinished">Não é possível iniciar o servidor HTTP. Consulte o registo de depuração para obter detalhes.</translation>
     </message>
     <message>
         <source>Unable to unload the wallet before migrating</source>
-        <translation type="unfinished">Impossível desconectar carteira antes de migrá-la</translation>
+        <translation type="unfinished">Não foi possível desconectar a carteira antes de a migrar</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Desconhecido -blockfilterindex valor %s.</translation>
+        <translation type="unfinished">Valor %s de -blockfilterindex desconhecido.</translation>
     </message>
     <message>
         <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Tipo de endereço desconhecido '%s'</translation>
+        <translation type="unfinished">Tipo de endereço desconhecido: "%s"</translation>
     </message>
     <message>
         <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Tipo de mudança desconhecido '%s'</translation>
+        <translation type="unfinished">Tipo de troco desconhecido: "%s"</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
@@ -4756,7 +4940,7 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Wallet file creation failed: %s</source>
-        <translation type="unfinished">falha na criação do ficheiro da pasta: %s</translation>
+        <translation type="unfinished">Falha na criação do ficheiro da carteira: %s</translation>
     </message>
     <message>
         <source>acceptstalefeeestimates is not supported on %s chain.</source>
@@ -4764,19 +4948,19 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Categoria de registos desconhecida %s=%s.</translation>
+        <translation type="unfinished">Categoria de registo não suportada %s=%s.</translation>
     </message>
     <message>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
-        <translation type="unfinished">Erro: Não foi possível adicionar tx %s de vigilância à pasta de vigilância</translation>
+        <translation type="unfinished">Erro: não foi possível adicionar a transação só de observação %s à carteira de observação</translation>
     </message>
     <message>
         <source>Error: Could not delete watchonly transactions. </source>
-        <translation type="unfinished">Erro: Impossível excluir transações apenas-visualização.</translation>
+        <translation type="unfinished">Erro: não foi possível eliminar transações só de observação.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation type="unfinished">Comentário no User Agent (%s) contém caracteres inseguros.</translation>
+        <translation type="unfinished">O comentário no agente do utilizador/user agent (%s) contém caracteres inseguros.</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>
@@ -4788,7 +4972,7 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">A carteira precisou de ser reescrita: reinicie %s para completar</translation>
+        <translation type="unfinished">Foi necessário reescrever a carteira: reinicie %s para concluir</translation>
     </message>
     <message>
         <source>Settings file could not be read</source>
@@ -4796,7 +4980,7 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Settings file could not be written</source>
-        <translation type="unfinished">Não foi possível editar o ficheiro de configurações</translation>
+        <translation type="unfinished">Não foi possível escrever o ficheiro de configurações</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -95,11 +95,11 @@ Só é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>Sending addresses - %1</source>
-        <translation type="unfinished">Enviando endereços - %1</translation>
+        <translation type="unfinished">Endereços de envio - %1</translation>
     </message>
     <message>
         <source>Receiving addresses - %1</source>
-        <translation type="unfinished">Recebendo endereços - %1</translation>
+        <translation type="unfinished">Endereços de recebimento - %1</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -2253,7 +2253,7 @@ O processo de migração criará um backup da carteira antes da migração. Este
     </message>
     <message>
         <source>Mapped AS</source>
-        <translation type="unfinished">Mapeado como</translation>
+        <translation type="unfinished">S.A. de mapeamento</translation>
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -225,6 +225,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Parola portofelului a fost schimbata.</translation>
     </message>
     <message>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished">Schimbarea frazei de acces a esuat</translation>
+    </message>
+    <message>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished">Atenţie! Caps Lock este pornit!</translation>
     </message>
@@ -365,6 +369,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1kB</translation>
+    </message>
     </context>
 <context>
     <name>BitcoinGUI</name>
@@ -415,6 +423,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Crează un portofel nou</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Reduce</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -598,8 +610,16 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Actualizat</translation>
     </message>
     <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished">Ctr+Q</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Încărcați Tranzacția Bitcoin Parțial Semnată</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Incarca PSBT din &amp;notite</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -638,8 +658,26 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Inchide portofel</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Recupereaza Portofelul...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Recupereaza Portofelul din fisierele rezerva</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Închideți toate portofelele</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Transfera Portofelul</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">Transfera un portofel</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
@@ -686,12 +724,24 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">&amp;Fereastră</translation>
     </message>
     <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished">Ctr+M</translation>
+    </message>
+    <message>
         <source>Main Window</source>
         <translation type="unfinished">Fereastra principală</translation>
     </message>
     <message>
         <source>%1 client</source>
         <translation type="unfinished">Client %1</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ascunde</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">A&amp;rata</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -706,6 +756,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">Pulsează pentru mai multe acțiuni.</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Eroare creare portofel</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -862,6 +916,22 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Copiază suma</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiaza adresa</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiaza si eticheteaza</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">copiaza &amp;valoarea</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">copiaza ID-ul de tranzactie si indexul de iesire</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copiază cantitea</translation>
     </message>
@@ -910,6 +980,11 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Crează portofel</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Creeaza Protofel&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Crearea portofelului a eşuat</translation>
     </message>
@@ -929,6 +1004,29 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
         <translation type="unfinished">Încărcând portmonee</translation>
+    </message>
+</context>
+<context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Muta portofelul</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Esti sigur ca vrei sa muti portofelul &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Transfera Portofelul</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">Mutare esuata</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">Mutarea s-a efectuat cu succes</translation>
     </message>
 </context>
 <context>
@@ -1002,6 +1100,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Crează portofel</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Esti la un pas distanta pentru a-ti crea noul tau portofel!</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1247,6 +1349,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 </context>
 <context>
     <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se închide</translation>
+    </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Nu închide calculatorul pînă ce această fereastră nu dispare.</translation>
@@ -1554,6 +1660,13 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     </message>
 </context>
 <context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">nu s-a putut citi setarea "%1", %2</translation>
+    </message>
+</context>
+<context>
     <name>OverviewPage</name>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
@@ -1635,12 +1748,28 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Inchide</translation>
     </message>
     <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Nu s-a reusit incarcarea tranzactiei: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Nu s-a reusit semnarea tranzactiei: %1</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Salvați datele tranzacției</translation>
     </message>
     <message>
         <source>own address</source>
         <translation type="unfinished">adresa proprie</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Nu s-a putut calcula comisionul de tranzactie sau suma totala al tranzactiei.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Plateste comisionul de tranzactie: </translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1690,6 +1819,11 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Agent utilizator</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Ani</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">Direcţie</translation>
@@ -1733,6 +1867,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Salveaza Imaginea...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Copiaza Imaginea</translation>
     </message>
@@ -1752,7 +1890,12 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>Save QR Code</source>
         <translation type="unfinished">Salvează codul QR</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">Imagine PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1836,6 +1979,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Selectaţi un partener pentru a vedea informaţiile detaliate.</translation>
     </message>
     <message>
+        <source>Session ID</source>
+        <translation type="unfinished">ID-ul Sesiunii</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation type="unfinished">Versiune</translation>
     </message>
@@ -1850,6 +1997,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Synced Blocks</source>
         <translation type="unfinished">Blocuri Sincronizate</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Ultima Tranzactie</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -1870,6 +2021,14 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Increase font size</source>
         <translation type="unfinished">Mareste fontul</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Permisiuni</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Directie/Tip</translation>
     </message>
     <message>
         <source>Services</source>
@@ -1940,6 +2099,11 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Ieşire:</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Copiaza adresa</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Deconectare</translation>
     </message>
@@ -1964,6 +2128,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Executarea comenzii fara nici un portofel.</translation>
     </message>
     <message>
+        <source>Ctrl+I</source>
+        <translation type="unfinished">Ctrl+l</translation>
+    </message>
+    <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Executarea comenzii folosind portofelul "%1"</translation>
     </message>
@@ -1986,6 +2154,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Interzicere pentru</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Niciodata</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2055,6 +2227,18 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Copiază &amp;URl</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiaza adresa</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiaza si eticheteaza</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">copiaza &amp;valoarea</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Portofelul nu a putut fi deblocat.</translation>
     </message>
@@ -2084,6 +2268,14 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Copiază &amp;adresa</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verifica</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Salveaza Imaginea...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2216,6 +2408,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Şterge toate câmpurile formularului.</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Alege...</translation>
+    </message>
+    <message>
         <source>Confirmation time target:</source>
         <translation type="unfinished">Timp confirmare tinta:</translation>
     </message>
@@ -2274,6 +2470,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>%1 to %2</source>
         <translation type="unfinished">%1 la %2</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Semnatura esuata</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2858,6 +3058,31 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Suma minimă</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiaza adresa</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiaza si eticheteaza</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">copiaza &amp;valoarea</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiaza ID-ul de tranzactie</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copiaza toate detaliile tranzacţiei</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Arata in %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Export istoric tranzacţii</translation>
     </message>
@@ -2918,12 +3143,24 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 <context>
     <name>WalletFrame</name>
     <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">Nu a fost incarcat nici un portofel.
+Mergi la Fisiere&gt;Deschide Portofel ca sa incarci un portofel.
+-SAU-</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Crează un portofel nou</translation>
     </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Incarca datele tranzactiei</translation>
     </message>
     </context>
 <context>
@@ -2962,12 +3199,21 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Confirma cresterea comisionului</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <comment>Fee-bump PSBT saved</comment>
+        <translation type="unfinished">Copiat in Notite</translation>
+    </message>
+    <message>
         <source>Can't sign transaction.</source>
         <translation type="unfinished">Nu s-a reuşit semnarea tranzacţiei</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Tranzactia nu a putut fi consemnata.</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Nu se poate afisa adresa</translation>
     </message>
     <message>
         <source>default wallet</source>

--- a/src/qt/locale/bitcoin_sl.ts
+++ b/src/qt/locale/bitcoin_sl.ts
@@ -730,6 +730,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Predsinhronizacija zaglavij (%1 %)...</translation>
     </message>
     <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Napaka pri ustvarjanju denarnice</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">Napaka: %1</translation>
     </message>
@@ -4210,6 +4214,10 @@ Obnovitev varnostne kopije denarnice ni bila mogoča.</translation>
     <message>
         <source>Error opening block database</source>
         <translation type="unfinished">Napaka pri odpiranju podatkovne baze blokov</translation>
+    </message>
+    <message>
+        <source>Error reading configuration file: %s</source>
+        <translation type="unfinished">Napaka pri branju nastavitvene datoteke: 1%s</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -224,12 +224,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Лозинка коју сте унели за дешифровање новчаника је погрешна.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">Приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново само са знаковима до — али не укључујући — првог нултог знака. Ако је ово успешно, поставите нову приступну фразу да бисте избегли овај проблем у будућности.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Лозинка новчаника успешно је промењена.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
         <translation type="unfinished">Promena lozinke nije uspela</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Стара приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново са само знаковима до — али не укључујући — првог нултог знака.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -249,6 +257,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Датотека подешавања %1 је можда оштећена или неважећа.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Изузетак покретања</translation>
@@ -638,6 +650,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Учитај ”PSBT” из привремене меморије</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију из clipboard-a</translation>
     </message>
@@ -714,6 +730,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Wallet Data</source>
         <extracomment>Name of the wallet data file format.</extracomment>
         <translation type="unfinished">Подаци Новчаника</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Учитај резевну копију новчаника</translation>
     </message>
     <message>
         <source>Restore Wallet</source>

--- a/src/qt/locale/bitcoin_sr@ijekavianlatin.ts
+++ b/src/qt/locale/bitcoin_sr@ijekavianlatin.ts
@@ -224,12 +224,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Лозинка коју сте унели за дешифровање новчаника је погрешна.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">Приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново само са знаковима до — али не укључујући — првог нултог знака. Ако је ово успешно, поставите нову приступну фразу да бисте избегли овај проблем у будућности.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Pristupna fraza novčanika je uspešno promenjena.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
         <translation type="unfinished">Promena lozinke nije uspela</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Стара приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново са само знаковима до — али не укључујући — првог нултог знака.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -245,6 +253,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Датотека подешавања %1 је можда оштећена или неважећа.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Изузетак покретања</translation>
@@ -634,6 +646,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Учитај ”PSBT” из привремене меморије</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију из clipboard-a</translation>
     </message>
@@ -710,6 +726,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Wallet Data</source>
         <extracomment>Name of the wallet data file format.</extracomment>
         <translation type="unfinished">Подаци Новчаника</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Учитај резевну копију новчаника</translation>
     </message>
     <message>
         <source>Restore Wallet</source>

--- a/src/qt/locale/bitcoin_sr@latin.ts
+++ b/src/qt/locale/bitcoin_sr@latin.ts
@@ -224,12 +224,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Pristupna fraza za dekriptovanje novčanika nije tačna.</translation>
     </message>
     <message>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished">Приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново само са знаковима до — али не укључујући — првог нултог знака. Ако је ово успешно, поставите нову приступну фразу да бисте избегли овај проблем у будућности.</translation>
+    </message>
+    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Pristupna fraza novčanika je uspešno promenjena.</translation>
     </message>
     <message>
         <source>Passphrase change failed</source>
         <translation type="unfinished">Promena lozinke nije uspela</translation>
+    </message>
+    <message>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished">Стара приступна фраза унета за дешифровање новчаника је нетачна. Садржи нулти карактер (тј. - нулти бајт). Ако је приступна фраза постављена са верзијом овог софтвера старијом од 25.0, покушајте поново са само знаковима до — али не укључујући — првог нултог знака.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -245,6 +253,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Датотека подешавања %1 је можда оштећена или неважећа.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Изузетак покретања</translation>
@@ -634,6 +646,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Учитај ”PSBT” из привремене меморије</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију из clipboard-a</translation>
     </message>
@@ -710,6 +726,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Wallet Data</source>
         <extracomment>Name of the wallet data file format.</extracomment>
         <translation type="unfinished">Подаци Новчаника</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Учитај резевну копију новчаника</translation>
     </message>
     <message>
         <source>Restore Wallet</source>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -1397,6 +1397,10 @@ Om den här plånboken innehåller lösbara</translation>
         <translation type="unfinished">Denna första synkronisering är väldigt krävande, och kan påvisa hårdvaruproblem hos din dator som tidigare inte visat sig. Varje gång du kör %1, kommer nerladdningen att fortsätta där den avslutades.</translation>
     </message>
     <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">När du trycker OK kommer %1 att börja ladda ner och bearbeta den fullständiga %4-blockkedjan (%2 GB), med början vid de tidigaste transaktionerna %3 när %4 först startades.</translation>
+    </message>
+    <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <translation type="unfinished">Om du valt att begränsa storleken på blockkedjan (gallring), måste historiska data ändå laddas ner och behandlas, men kommer därefter att tas bort för att spara lagringsutrymme.</translation>
     </message>
@@ -1481,7 +1485,15 @@ Om den här plånboken innehåller lösbara</translation>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 synkroniserar. Den kommer att ladda ner metadata och block från noder och validera dem fram tills att toppen på blockkedjan är nådd.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Okänd. Synkar huvuden (%1, %2%)...</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Okänd. För-synkar rubriker (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1513,12 +1525,20 @@ Om den här plånboken innehåller lösbara</translation>
         <translation type="unfinished">&amp;Starta %1 vid systemlogin</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Aktivering av ansning reducerar diskutrymmet som behövs för att lagra transaktioner. Alla block är fortfarande fullt validerade. Inaktivering av denna funktion betyder att hela blockkedjan måste laddas ner på nytt.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Storleken på &amp;databascache</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished">Antalet skript&amp;verifikationstrådar</translation>
+    </message>
+    <message>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Hela sökvägen till ett %1 kompatibelt script (t,ex. C:\Downloads\hwi.exe eller /Users/du/Downloads/hwi.py). Varning: Skadlig programvara kan stjäla dina mynt!</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
@@ -1535,6 +1555,10 @@ Om den här plånboken innehåller lösbara</translation>
     <message>
         <source>Font in the Overview tab: </source>
         <translation type="unfinished">Typsnitt på översiktsfliken:</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Alternativ som anges i denna dialog åsidosätts av kommandoraden:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1565,8 +1589,23 @@ Om den här plånboken innehåller lösbara</translation>
         <translation type="unfinished">Vid avstängning av denna inställning kommer den fullständiga blockkedjan behövas laddas ned igen.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maximal storlek för databasens cacheminne. Större cache kan bidra till snabbare synkronisering, dock blir fördelen mindre uppenbar för de flesta användningsområdena efter den initiala synkroniseringen. En lägre storlek på databasens cacheminne minskar minnesanvändningen. Mempoolens outnyttjade minne delas med denna cache.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Sätt antalet trådar för skriptverifiering. Negativa värden motsvarar antalet kärnor som skall lämnas tillgängliga för systemet. </translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = auto, &lt;0 = lämna så många kärnor lediga)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Detta tillåter dig eller ett tredjepartsverktyg att kommunicera med noden genom kommandotolken och JSON-RPC-kommandon. </translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>

--- a/src/qt/locale/bitcoin_sw.ts
+++ b/src/qt/locale/bitcoin_sw.ts
@@ -357,6 +357,10 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
         <translation type="unfinished">Kuhusu &amp;Qt</translation>
     </message>
     <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">Onyesha habari kuhusu Qt</translation>
+    </message>
+    <message>
         <source>Modify configuration options for %1</source>
         <translation type="unfinished">Badilisha chaguo za usanidi kwa %1</translation>
     </message>
@@ -396,6 +400,10 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
     <message>
         <source>&amp;Send</source>
         <translation type="unfinished">&amp;TUMA</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Pokea</translation>
     </message>
     <message>
         <source>&amp;Options…</source>
@@ -497,9 +505,37 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
         </translation>
     </message>
     <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Shughuli baada ya hii bado hazitaonekana.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Onyo</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Onyo</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">Habari</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Fungua Pochi</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Funga Pochi</translation>
+    </message>
+    <message>
         <source>Wallet Name</source>
         <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
         <translation type="unfinished">Jina la Wallet</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ficha</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -526,6 +562,18 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
         <translation type="unfinished">Wingi</translation>
     </message>
     <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Kiasi:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Ada:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Baada ya Ada</translation>
+    </message>
+    <message>
         <source>Received with label</source>
         <translation type="unfinished">Imepokelewa na chapa</translation>
     </message>
@@ -539,6 +587,14 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
     </message>
     </context>
 <context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Fungua Pochi</translation>
+    </message>
+    </context>
+<context>
     <name>RestoreWalletActivity</name>
     <message>
         <source>Restore wallet warning</source>
@@ -548,6 +604,10 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
     </context>
 <context>
     <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Funga Pochi</translation>
+    </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <translation type="unfinished">Kufunga pochi kwa muda mrefu sana kunaweza kusababisha kusawazisha tena mnyororo mzima ikiwa upogoaji umewezeshwa.</translation>
@@ -657,6 +717,17 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Onyo</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Onyo</translation>
+    </message>
     </context>
 <context>
     <name>PeerTableModel</name>
@@ -699,6 +770,10 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Kiasi:</translation>
+    </message>
+    <message>
         <source>Label:</source>
         <translation type="unfinished">Chapa:</translation>
     </message>
@@ -723,6 +798,18 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
     <message>
         <source>Quantity:</source>
         <translation type="unfinished">Wingi</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Kiasi:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Ada:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Baada ya Ada</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -817,6 +904,10 @@ Kutia sahihi kunawezekana tu kwa anwani za aina ya 'urithi'.</translation>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Unda mkoba mpya</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Onyo</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -661,6 +661,14 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Tüm cüzdanları kapat</translation>
     </message>
     <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Cüzdanı Taşı</translation>
+    </message>
+    <message>
+        <source>Migrate a wallet</source>
+        <translation type="unfinished">Bir Cüzdanı Taşı</translation>
+    </message>
+    <message>
         <source>&amp;Mask values</source>
         <translation type="unfinished">&amp; Değerleri maskele</translation>
     </message>
@@ -750,6 +758,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Pre-syncing Headers (%1%)…</source>
         <translation type="unfinished">Üstbilgiler senkronize ediliyor (%1%)...</translation>
+    </message>
+    <message>
+        <source>Error creating wallet</source>
+        <translation type="unfinished">Cüzdan oluşturulurken hata meydana geldi</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1001,6 +1013,37 @@ Cüzdan kilidini aç.</translation>
     </message>
 </context>
 <context>
+    <name>MigrateWalletActivity</name>
+    <message>
+        <source>Migrate wallet</source>
+        <translation type="unfinished">Cüzdanı taşı</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Cüzdanı taşımak istediğine emin misin &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Migrate Wallet</source>
+        <translation type="unfinished">Cüzdanı Taşı</translation>
+    </message>
+    <message>
+        <source>Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Cüzdan Taşınıyor &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>The wallet '%1' was migrated successfully.</source>
+        <translation type="unfinished">Cüzdan '%1' başarıyla taşındı.</translation>
+    </message>
+    <message>
+        <source>Migration failed</source>
+        <translation type="unfinished">Taşıma başarısız oldu.</translation>
+    </message>
+    <message>
+        <source>Migration Successful</source>
+        <translation type="unfinished">Taşıma Başarılı</translation>
+    </message>
+</context>
+<context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
@@ -1081,6 +1124,14 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Create Wallet</source>
         <translation type="unfinished">Cüzdan Oluştur</translation>
+    </message>
+    <message>
+        <source>You are one step away from creating your new wallet!</source>
+        <translation type="unfinished">Yeni cüzdanını yaratmaktan bir adım uzaktasın!</translation>
+    </message>
+    <message>
+        <source>Please provide a name and, if desired, enable any advanced options</source>
+        <translation type="unfinished">Lütfen bir isim sağla ve, isteğe bağlı olarak, gelişmiş seçenekleri etkinleştir.</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -2056,8 +2107,16 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Ayrıntılı bilgi görmek için bir eş seçin.</translation>
     </message>
     <message>
+        <source>The transport layer version: %1</source>
+        <translation type="unfinished">Taşıma katmanı versiyonu: %1</translation>
+    </message>
+    <message>
         <source>Transport</source>
         <translation type="unfinished">Aktar</translation>
+    </message>
+    <message>
+        <source>Session ID</source>
+        <translation type="unfinished">Oturum ID</translation>
     </message>
     <message>
         <source>Version</source>
@@ -2224,6 +2283,21 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Out:</source>
         <translation type="unfinished">Dışarı:</translation>
+    </message>
+    <message>
+        <source>detecting: peer could be v1 or v2</source>
+        <extracomment>Explanatory text for "detecting" transport type.</extracomment>
+        <translation type="unfinished">keşfediliyor: eş v1 veya v2 olabilir</translation>
+    </message>
+    <message>
+        <source>v1: unencrypted, plaintext transport protocol</source>
+        <extracomment>Explanatory text for v1 transport type.</extracomment>
+        <translation type="unfinished">v1: şifrelenmemiş, açık metin taşıma protokolü</translation>
+    </message>
+    <message>
+        <source>v2: BIP324 encrypted transport protocol</source>
+        <extracomment>Explanatory text for v2 transport type.</extracomment>
+        <translation type="unfinished">v2: BIP324 şifrelenmiş taşıma protokolü</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -3633,6 +3707,10 @@ Cüzdan yedeği geri yüklenemiyor.</translation>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
         <translation type="unfinished">Başlatma sırasında cüzdanı yeniden tarama işlemi başarısız oldu</translation>
+    </message>
+    <message>
+        <source>Failed to start indexes, shutting down..</source>
+        <translation type="unfinished">Endekslerin başlatılması başarısız oldu, kapatılıyor..</translation>
     </message>
     <message>
         <source>Failed to verify database</source>

--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -611,7 +611,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">连到同行...</translation>
+        <translation type="unfinished">连接到节点...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -1308,7 +1308,7 @@ The migration process will create a backup of the wallet before migrating. This 
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">跟這個地址清單關聯的地址。只有發送地址能被修改。</translation>
+        <translation type="unfinished">与这个地址列表项关联的地址。只有发送地址可以修改。</translation>
     </message>
     <message>
         <source>&amp;Address</source>

--- a/src/qt/locale/bitcoin_zh.ts
+++ b/src/qt/locale/bitcoin_zh.ts
@@ -434,10 +434,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 字节</translation>
     </message>
     <message>
-        <source>%1 MB</source>
-        <translation type="unfinished">%1 MB (百萬位元組)</translation>
-    </message>
-    <message>
         <source>%1 GB</source>
         <translation type="unfinished">%1 GB (十億位元組)</translation>
     </message>


### PR DESCRIPTION
This PR follows our [Release Process](https://github.com/bitcoin/bitcoin/blob/4c62f4b53561bce5b2eb8639cdc24d284be537eb/doc/release-process.md).

Note: (possible) vandalism/damage has been prevented by reverting the deletion of `bitcoin_af`, `bitcoin_es_MX`, and `bitcoin_ru` translations.

Required to open Transifex translations for v28.0 as it's scheduled in https://github.com/bitcoin/bitcoin/issues/29891.

The previous similar PR: https://github.com/bitcoin/bitcoin/pull/29397.