### PR TITLE
doc: mention optional dependencies (qrencode, zmq) in OpenBSD build docs

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -66,6 +66,22 @@ Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compi
 pkg_add qtbase qttools
 ```
 
+###### libqrencode
+
+The GUI can encode addresses in a QR Code. To build in QR support for the GUI, install `libqrencode`. Skip if not using the GUI or don't want QR code functionality.
+```bash
+pkg_add libqrencode
+```
+---
+
+#### Notifications
+###### ZeroMQ
+
+Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+```bash
+pkg_add zeromq
+```
+
 ## Building Bitcoin Core
 
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error).


### PR DESCRIPTION
The wording is taken from the FreeBSD build docs.

Tested on OpenBSD 7.5. See the following links for the package names:
- https://openbsd.app/?search=libqrencode
- https://openbsd.app/?search=zeromq

Thanks to hebasto for noticing that this was missing.