### PR TITLE
test: fix constructor of msg_tx

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1294,8 +1294,11 @@ class msg_tx:
     __slots__ = ("tx",)
     msgtype = b"tx"
 
-    def __init__(self, tx=CTransaction()):
-        self.tx = tx
+    def __init__(self, tx=None):
+        if tx is None:
+            self.tx = CTransaction()
+        else:
+            self.tx = tx
 
     def deserialize(self, f):
         self.tx.deserialize(f)


### PR DESCRIPTION
In python, if the default value is a mutable object (here: a class) it is shared over all instances, so that one instance being changed would affect others to be changed as well.
This was the source of #30543, and possibly various other intermittent bugs in the functional tests, see 
https://github.com/bitcoin/bitcoin/issues/29621#issuecomment-1999298224.

Fixes #30543
Fixes #29621
Fixes #25128 