### PR TITLE
depends: Fix `zeromq` build on OpenBSD

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -8,6 +8,7 @@ $(package)_patches = remove_libstd_link.patch
 $(package)_patches += macos_mktemp_check.patch
 $(package)_patches += builtin_sha1.patch
 $(package)_patches += fix_have_windows.patch
+$(package)_patches += openbsd_kqueue_headers.patch
 $(package)_patches += cmake_minimum.patch
 $(package)_patches += no_librt.patch
 
@@ -25,6 +26,7 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/macos_mktemp_check.patch && \
   patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch && \
+  patch -p1 < $($(package)_patch_dir)/openbsd_kqueue_headers.patch && \
   patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch && \
   patch -p1 < $($(package)_patch_dir)/no_librt.patch
 endef

--- a/depends/patches/zeromq/openbsd_kqueue_headers.patch
+++ b/depends/patches/zeromq/openbsd_kqueue_headers.patch
@@ -1,0 +1,24 @@
+commit ff231d267370493814f933d151441866bf1e200b
+Author: Min RK <benjaminrk@gmail.com>
+Date:   Fri Feb 23 13:21:08 2024 +0100
+
+    Problem: cmake search for kqueue missing headers
+    
+    Solution: include sys/types.h and sys/time.h as documented by kqueue
+    and used in autotools
+    
+    fixes kqueue detection on openbsd
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f956f3fd..814d5d46 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -380,7 +380,7 @@ endif(WIN32)
+ 
+ if(NOT MSVC)
+   if(POLLER STREQUAL "")
+-    check_cxx_symbol_exists(kqueue sys/event.h HAVE_KQUEUE)
++    check_cxx_symbol_exists(kqueue "sys/types.h;sys/event.h;sys/time.h" HAVE_KQUEUE)
+     if(HAVE_KQUEUE)
+       set(POLLER "kqueue")
+     endif()


### PR DESCRIPTION
On the master branch @ 66e82dc90c598c9c42ff980693ef5367a845e1d0, the `zeromq` package fails to build on OpenBSD 7.5:
```
[ 19%] Building CXX object CMakeFiles/objects.dir/src/io_thread.cpp.o
/home/hebasto/bitcoin/depends/work/build/amd64-unknown-openbsd7.5/zeromq/4.3.5-df5b1b9f936/src/io_thread.cpp:14:22: error: static_cast from 'std::nullptr_t' to 'poller_t::handle_t' (aka 'int') is not allowed
    _mailbox_handle (static_cast<poller_t::handle_t> (NULL))
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This [regression](https://github.com/bitcoin/bitcoin/pull/29723#issuecomment-2261513105) was overlooked by me in https://github.com/bitcoin/bitcoin/pull/29723.

This PR fixes the issue by backporting an upstream commit from https://github.com/zeromq/libzmq/pull/4659.