### PR TITLE
qt, build: Drop `QT_STATICPLUGIN` macro

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -123,7 +123,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       fi
     fi
 
-    AC_DEFINE([QT_STATICPLUGIN], [1], [Define this symbol if qt plugins are static])
     _BITCOIN_QT_CHECK_STATIC_PLUGIN([QMinimalIntegrationPlugin], [-lqminimal])
     AC_DEFINE([QT_QPA_PLATFORM_MINIMAL], [1], [Define this symbol if the minimal qt platform exists])
     if test "$TARGET_OS" = "windows"; then

--- a/build_msvc/bitcoin_config.h.in
+++ b/build_msvc/bitcoin_config.h.in
@@ -73,9 +73,6 @@
 /* Define this symbol if the qt platform is windows */
 #define QT_QPA_PLATFORM_WINDOWS 1
 
-/* Define this symbol if qt plugins are static */
-#define QT_STATICPLUGIN 1
-
 /* Windows Universal Platform constraints */
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 /* Either a desktop application without API restrictions, or and older system

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -60,7 +60,7 @@
 #include <QTranslator>
 #include <QWindow>
 
-#if defined(QT_STATICPLUGIN)
+#if defined(QT_STATIC)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #include <qt/guiutil.h>
 
 #include <qt/bitcoinaddressvalidator.h>
@@ -918,12 +916,7 @@ void LogQtInfo()
 #else
     const std::string qt_link{"dynamic"};
 #endif
-#ifdef QT_STATICPLUGIN
-    const std::string plugin_link{"static"};
-#else
-    const std::string plugin_link{"dynamic"};
-#endif
-    LogPrintf("Qt %s (%s), plugin=%s (%s)\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString(), plugin_link);
+    LogPrintf("Qt %s (%s), plugin=%s\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString());
     const auto static_plugins = QPluginLoader::staticPlugins();
     if (static_plugins.empty()) {
         LogPrintf("No static plugins.\n");

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -916,24 +916,24 @@ void LogQtInfo()
 #else
     const std::string qt_link{"dynamic"};
 #endif
-    LogPrintf("Qt %s (%s), plugin=%s\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString());
+    LogInfo("Qt %s (%s), plugin=%s\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString());
     const auto static_plugins = QPluginLoader::staticPlugins();
     if (static_plugins.empty()) {
-        LogPrintf("No static plugins.\n");
+        LogInfo("No static plugins.\n");
     } else {
-        LogPrintf("Static plugins:\n");
+        LogInfo("Static plugins:\n");
         for (const QStaticPlugin& p : static_plugins) {
             QJsonObject meta_data = p.metaData();
             const std::string plugin_class = meta_data.take(QString("className")).toString().toStdString();
             const int plugin_version = meta_data.take(QString("version")).toInt();
-            LogPrintf(" %s, version %d\n", plugin_class, plugin_version);
+            LogInfo(" %s, version %d\n", plugin_class, plugin_version);
         }
     }
 
-    LogPrintf("Style: %s / %s\n", QApplication::style()->objectName().toStdString(), QApplication::style()->metaObject()->className());
-    LogPrintf("System: %s, %s\n", QSysInfo::prettyProductName().toStdString(), QSysInfo::buildAbi().toStdString());
+    LogInfo("Style: %s / %s\n", QApplication::style()->objectName().toStdString(), QApplication::style()->metaObject()->className());
+    LogInfo("System: %s, %s\n", QSysInfo::prettyProductName().toStdString(), QSysInfo::buildAbi().toStdString());
     for (const QScreen* s : QGuiApplication::screens()) {
-        LogPrintf("Screen: %s %dx%d, pixel ratio=%.1f\n", s->name().toStdString(), s->size().width(), s->size().height(), s->devicePixelRatio());
+        LogInfo("Screen: %s %dx%d, pixel ratio=%.1f\n", s->name().toStdString(), s->size().width(), s->size().height(), s->devicePixelRatio());
     }
 }
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,7 +28,7 @@
 
 #include <functional>
 
-#if defined(QT_STATICPLUGIN)
+#if defined(QT_STATIC)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_MINIMAL)
 Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);


### PR DESCRIPTION
Broken out of https://github.com/bitcoin/bitcoin/pull/30454.

Our `QT_STATICPLUGIN` macro is effectively equivalent to the Qt's `QT_STATIC` macro.

It is easy to see in the `_BITCOIN_QT_IS_STATIC` macro implementation: https://github.com/bitcoin/bitcoin/blob/ebd82fa9fae13d5a7a395800295dd7fd34185b58/build-aux/m4/bitcoin_qt.m4#L269-L292

No need to handle both macros.