### PR TITLE
node: reduce unsafe uint256S usage

### DIFF
--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -39,7 +39,13 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
         }
     }
 
-    if (auto value{args.GetArg("-assumevalid")}) opts.assumed_valid_block = uint256S(*value);
+    if (auto value{args.GetArg("-assumevalid")}) {
+        if (auto block_hash{uint256::FromUserHex(*value)}) {
+            opts.assumed_valid_block = *block_hash;
+        } else {
+            return util::Error{strprintf(Untranslated("Invalid assumevalid block hash specified (%s), must be up to %d hex digits (or 0 to disable)"), *value, uint256::size() * 2)};
+        }
+    }
 
     if (auto value{args.GetIntArg("-maxtipage")}) opts.max_tip_age = std::chrono::seconds{*value};
 

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -32,10 +32,11 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
     if (auto value{args.GetBoolArg("-checkpoints")}) opts.checkpoints_enabled = *value;
 
     if (auto value{args.GetArg("-minimumchainwork")}) {
-        if (!IsHexNumber(*value)) {
-            return util::Error{strprintf(Untranslated("Invalid non-hex (%s) minimum chain work value specified"), *value)};
+        if (auto min_work{uint256::FromUserHex(*value)}) {
+            opts.minimum_chain_work = UintToArith256(*min_work);
+        } else {
+            return util::Error{strprintf(Untranslated("Invalid minimum work specified (%s), must be up to %d hex digits"), *value, uint256::size() * 2)};
         }
-        opts.minimum_chain_work = UintToArith256(uint256S(*value));
     }
 
     if (auto value{args.GetArg("-assumevalid")}) opts.assumed_valid_block = uint256S(*value);

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -27,7 +27,6 @@ FUZZ_TARGET(hex)
     if (IsHex(random_hex_string)) {
         assert(ToLower(random_hex_string) == hex_data);
     }
-    (void)IsHexNumber(random_hex_string);
     if (uint256::FromHex(random_hex_string)) {
         assert(random_hex_string.length() == 64);
         assert(Txid::FromHex(random_hex_string));

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -32,6 +32,10 @@ FUZZ_TARGET(hex)
         assert(random_hex_string.length() == 64);
         assert(Txid::FromHex(random_hex_string));
         assert(Wtxid::FromHex(random_hex_string));
+        assert(uint256::FromUserHex(random_hex_string));
+    }
+    if (const auto result{uint256::FromUserHex(random_hex_string)}) {
+        assert(uint256::FromHex(result->ToString()));
     }
     (void)uint256S(random_hex_string);
     try {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -386,6 +386,35 @@ BOOST_AUTO_TEST_CASE(from_hex)
     TestFromHex<Wtxid>();
 }
 
+BOOST_AUTO_TEST_CASE(from_user_hex)
+{
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("").value(), uint256::ZERO);
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("0x").value(), uint256::ZERO);
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("0").value(), uint256::ZERO);
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("00").value(), uint256::ZERO);
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("1").value(), uint256::ONE);
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("0x10").value(), uint256{0x10});
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("10").value(), uint256{0x10});
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("0xFf").value(), uint256{0xff});
+    BOOST_CHECK_EQUAL(uint256::FromUserHex("Ff").value(), uint256{0xff});
+    const std::string valid_hex_64{"0x0123456789abcdef0123456789abcdef0123456789ABDCEF0123456789ABCDEF"};
+    BOOST_REQUIRE_EQUAL(valid_hex_64.size(), 2 + 64); // 0x prefix and 64 hex digits
+    BOOST_CHECK_EQUAL(uint256::FromUserHex(valid_hex_64.substr(2)).value().ToString(), ToLower(valid_hex_64.substr(2)));
+    BOOST_CHECK_EQUAL(uint256::FromUserHex(valid_hex_64.substr(0)).value().ToString(), ToLower(valid_hex_64.substr(2)));
+
+    BOOST_CHECK(!uint256::FromUserHex("0x0 "));                       // no spaces at end,
+    BOOST_CHECK(!uint256::FromUserHex(" 0x0"));                       // or beginning,
+    BOOST_CHECK(!uint256::FromUserHex("0x 0"));                       // or middle,
+    BOOST_CHECK(!uint256::FromUserHex(" "));                          // etc.
+    BOOST_CHECK(!uint256::FromUserHex("0x0ga"));                      // invalid character
+    BOOST_CHECK(!uint256::FromUserHex("x0"));                         // broken prefix
+    BOOST_CHECK(!uint256::FromUserHex("0x0x00"));                     // two prefixes not allowed
+    BOOST_CHECK(!uint256::FromUserHex(valid_hex_64.substr(2) + "0")); // 1 hex digit too many
+    BOOST_CHECK(!uint256::FromUserHex(valid_hex_64 + "a"));           // 1 hex digit too many
+    BOOST_CHECK(!uint256::FromUserHex(valid_hex_64 + " "));           // whitespace after max length
+    BOOST_CHECK(!uint256::FromUserHex(valid_hex_64 + "z"));           // invalid character after max length
+}
+
 BOOST_AUTO_TEST_CASE( check_ONE )
 {
     uint256 one = uint256S("0000000000000000000000000000000000000000000000000000000000000001");

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -432,31 +432,6 @@ BOOST_AUTO_TEST_CASE(util_IsHex)
     BOOST_CHECK(!IsHex("0x0000"));
 }
 
-BOOST_AUTO_TEST_CASE(util_IsHexNumber)
-{
-    BOOST_CHECK(IsHexNumber("0x0"));
-    BOOST_CHECK(IsHexNumber("0"));
-    BOOST_CHECK(IsHexNumber("0x10"));
-    BOOST_CHECK(IsHexNumber("10"));
-    BOOST_CHECK(IsHexNumber("0xff"));
-    BOOST_CHECK(IsHexNumber("ff"));
-    BOOST_CHECK(IsHexNumber("0xFfa"));
-    BOOST_CHECK(IsHexNumber("Ffa"));
-    BOOST_CHECK(IsHexNumber("0x00112233445566778899aabbccddeeffAABBCCDDEEFF"));
-    BOOST_CHECK(IsHexNumber("00112233445566778899aabbccddeeffAABBCCDDEEFF"));
-
-    BOOST_CHECK(!IsHexNumber(""));   // empty string not allowed
-    BOOST_CHECK(!IsHexNumber("0x")); // empty string after prefix not allowed
-    BOOST_CHECK(!IsHexNumber("0x0 ")); // no spaces at end,
-    BOOST_CHECK(!IsHexNumber(" 0x0")); // or beginning,
-    BOOST_CHECK(!IsHexNumber("0x 0")); // or middle,
-    BOOST_CHECK(!IsHexNumber(" "));    // etc.
-    BOOST_CHECK(!IsHexNumber("0x0ga")); // invalid character
-    BOOST_CHECK(!IsHexNumber("x0"));    // broken prefix
-    BOOST_CHECK(!IsHexNumber("0x0x00")); // two prefixes not allowed
-
-}
-
 BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
 {
     SeedRandomForTest(SeedRand::ZEROS);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -814,6 +814,9 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_args, BasicTestingSetup)
     const std::string cmd{"-assumevalid=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"};
     BOOST_CHECK_EQUAL(get_valid_opts({cmd.c_str()}).assumed_valid_block.value().ToString(), cmd.substr(13, cmd.size()));
 
+    BOOST_CHECK(!get_opts({"-assumevalid=xyz"}));                                                               // invalid hex characters
+    BOOST_CHECK(!get_opts({"-assumevalid=01234567890123456789012345678901234567890123456789012345678901234"})); // > 64 hex chars
+
     // test -minimumchainwork
     BOOST_CHECK(!get_valid_opts({}).minimum_chain_work.has_value());
     BOOST_CHECK_EQUAL(get_valid_opts({"-minimumchainwork=0"}).minimum_chain_work.value().GetCompact(), 0U);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -820,7 +820,8 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_args, BasicTestingSetup)
     BOOST_CHECK_EQUAL(get_valid_opts({"-nominimumchainwork"}).minimum_chain_work.value().GetCompact(), 0U);
     BOOST_CHECK_EQUAL(get_valid_opts({"-minimumchainwork=0x1234"}).minimum_chain_work.value().GetCompact(), 0x02123400U);
 
-    BOOST_CHECK(!get_opts({"-minimumchainwork=xyz"})); // invalid hex characters
+    BOOST_CHECK(!get_opts({"-minimumchainwork=xyz"}));                                                               // invalid hex characters
+    BOOST_CHECK(!get_opts({"-minimumchainwork=01234567890123456789012345678901234567890123456789012345678901234"})); // > 64 hex chars
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -46,16 +46,6 @@ bool IsHex(std::string_view str)
     return (str.size() > 0) && (str.size()%2 == 0);
 }
 
-bool IsHexNumber(std::string_view str)
-{
-    if (str.substr(0, 2) == "0x") str.remove_prefix(2);
-    for (char c : str) {
-        if (HexDigit(c) < 0) return false;
-    }
-    // Return false for empty string or "0x".
-    return str.size() > 0;
-}
-
 template <typename Byte>
 std::optional<std::vector<Byte>> TryParseHex(std::string_view str)
 {

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -70,10 +70,6 @@ std::vector<Byte> ParseHex(std::string_view hex_str)
 /* Returns true if each character in str is a hex character, and has an even
  * number of hex digits.*/
 bool IsHex(std::string_view str);
-/**
-* Return true if the string is a hex number, optionally prefixed with "0x"
-*/
-bool IsHexNumber(std::string_view str);
 std::optional<std::vector<unsigned char>> DecodeBase64(std::string_view str);
 std::string EncodeBase64(Span<const unsigned char> input);
 inline std::string EncodeBase64(Span<const std::byte> input) { return EncodeBase64(MakeUCharSpan(input)); }

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -139,8 +139,8 @@ class AssumeValidTest(BitcoinTestFramework):
             height += 1
 
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
-        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256)])
-        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256)])
+        self.start_node(1, extra_args=["-assumevalid=" + block102.hash])
+        self.start_node(2, extra_args=["-assumevalid=" + block102.hash])
 
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
         p2p0.send_header_for_blocks(self.blocks[0:2000])

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -110,7 +110,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         self.stop_node(0)
         self.nodes[0].assert_start_raises_init_error(
             ["-minimumchainwork=test"],
-            expected_msg='Error: Invalid non-hex (test) minimum chain work value specified',
+            expected_msg='Error: Invalid minimum work specified (test), must be up to 64 hex digits',
         )
 
 


### PR DESCRIPTION
Since fad2991ba073de0bd1f12e42bf0fbaca4a265508, `uint256S` has been [deprecated](https://github.com/bitcoin/bitcoin/pull/30482/commits/fad2991ba073de0bd1f12e42bf0fbaca4a265508#diff-800776e2dda39116e889839f69409571a5d397de048a141da7e4003bc099e3e2R138) because it is less robust than the `base_blob::FromHex()` introduced in [the same PR](https://github.com/bitcoin/bitcoin/pull/30482). Specifically, it tries to recover from length-mismatches, recover from untrimmed whitespace, 0x-prefix and garbage at the end, instead of simply requiring exactly 64 hex-only characters. _(see also #30532)_

This PR carves out the few `uint256S` callsites that may potentially prove a bit more controversial to change because they deal with user input and backwards incompatible behaviour change.

The main behaviour change introduced in this PR is:
- `-minimumchainwork` will raise an error when input is longer than 64 hex digits
- `-assumevalid` will raise an error when input contains invalid hex characters, or when it is longer than 64 hex digits
- test: the optional RANDOM_CTX_SEED env var will now cause tests to abort when it contains invalid hex characters, or when it is longer than 64 hex digits

After this PR, the remaining work to remove `uint256S` completely is almost entirely mechanical and/or test related. I will open that PR once #30560 is merged because it builds on that.