### PR TITLE
[tests] New fuzz target wallet_rpc

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -23,6 +23,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>
+#include <wallet/rpc/wallet.h>
 
 #include <algorithm>
 #include <cassert>
@@ -34,35 +35,36 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
+#include <test/fuzz/rpc.h>
 enum class ChainType;
 
 using util::Join;
 using util::ToString;
 
-namespace {
-struct RPCFuzzTestingSetup : public TestingSetup {
-    RPCFuzzTestingSetup(const ChainType chain_type, TestOpts opts) : TestingSetup{chain_type, opts}
-    {
+namespace RPCFuzz {
+RPCFuzzTestingSetup::RPCFuzzTestingSetup(const ChainType chain_type, TestOpts opts) : TestingSetup{chain_type, opts}
+{
+}
+
+// Member function definitions
+void RPCFuzzTestingSetup::CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments)
+{
+    JSONRPCRequest request;
+    request.context = &m_node;
+    request.strMethod = rpc_method;
+    try {
+        request.params = RPCConvertValues(rpc_method, arguments);
+    } catch (const std::runtime_error&) {
+        return;
     }
 
-    void CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments)
-    {
-        JSONRPCRequest request;
-        request.context = &m_node;
-        request.strMethod = rpc_method;
-        try {
-            request.params = RPCConvertValues(rpc_method, arguments);
-        } catch (const std::runtime_error&) {
-            return;
-        }
-        tableRPC.execute(request);
-    }
+    tableRPC.execute(request);
+}
 
-    std::vector<std::string> GetRPCCommands() const
-    {
-        return tableRPC.listCommands();
-    }
-};
+std::vector<std::string> RPCFuzzTestingSetup::GetRPCCommands() const
+{
+    return tableRPC.listCommands();
+}
 
 RPCFuzzTestingSetup* rpc_testing_setup = nullptr;
 std::string g_limit_to_rpc_command;
@@ -337,21 +339,18 @@ RPCFuzzTestingSetup* InitializeRPCFuzzTestingSetup()
     SetRPCWarmupFinished();
     return setup.get();
 }
-}; // namespace
 
-void initialize_rpc()
+void initialize(std::vector<std::string> rpc_commands_safe_for_fuzzing, std::vector<std::string> rpc_commands_not_safe_for_fuzzing, std::vector<std::string> supported_rpc_commands)
 {
-    rpc_testing_setup = InitializeRPCFuzzTestingSetup();
-    const std::vector<std::string> supported_rpc_commands = rpc_testing_setup->GetRPCCommands();
     for (const std::string& rpc_command : supported_rpc_commands) {
-        const bool safe_for_fuzzing = std::find(RPC_COMMANDS_SAFE_FOR_FUZZING.begin(), RPC_COMMANDS_SAFE_FOR_FUZZING.end(), rpc_command) != RPC_COMMANDS_SAFE_FOR_FUZZING.end();
-        const bool not_safe_for_fuzzing = std::find(RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.begin(), RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.end(), rpc_command) != RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.end();
+        const bool safe_for_fuzzing = std::find(rpc_commands_safe_for_fuzzing.begin(), rpc_commands_safe_for_fuzzing.end(), rpc_command) != rpc_commands_safe_for_fuzzing.end();
+        const bool not_safe_for_fuzzing = std::find(rpc_commands_not_safe_for_fuzzing.begin(), rpc_commands_not_safe_for_fuzzing.end(), rpc_command) != rpc_commands_not_safe_for_fuzzing.end();
         if (!(safe_for_fuzzing || not_safe_for_fuzzing)) {
-            std::cerr << "Error: RPC command \"" << rpc_command << "\" not found in RPC_COMMANDS_SAFE_FOR_FUZZING or RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
+            std::cerr << "Error: RPC command \"" << rpc_command << "\" not found in rpc_commands_safe_for_fuzzing or RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
             std::terminate();
         }
         if (safe_for_fuzzing && not_safe_for_fuzzing) {
-            std::cerr << "Error: RPC command \"" << rpc_command << "\" found in *both* RPC_COMMANDS_SAFE_FOR_FUZZING and RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
+            std::cerr << "Error: RPC command \"" << rpc_command << "\" found in *both* rpc_commands_safe_for_fuzzing and RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
             std::terminate();
         }
     }
@@ -361,7 +360,15 @@ void initialize_rpc()
     }
 }
 
-FUZZ_TARGET(rpc, .init = initialize_rpc)
+void FuzzInitRPC()
+{
+    rpc_testing_setup = InitializeRPCFuzzTestingSetup();
+    const std::vector<std::string> supported_rpc_commands = rpc_testing_setup->GetRPCCommands();
+    initialize(RPC_COMMANDS_SAFE_FOR_FUZZING, RPC_COMMANDS_NOT_SAFE_FOR_FUZZING, supported_rpc_commands);
+}
+
+
+void ExecuteFuzzCommands(std::vector<std::string> list_of_safe_commands, Span<const unsigned char> buffer)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     bool good_data{true};
@@ -370,7 +377,7 @@ FUZZ_TARGET(rpc, .init = initialize_rpc)
     if (!g_limit_to_rpc_command.empty() && rpc_command != g_limit_to_rpc_command) {
         return;
     }
-    const bool safe_for_fuzzing = std::find(RPC_COMMANDS_SAFE_FOR_FUZZING.begin(), RPC_COMMANDS_SAFE_FOR_FUZZING.end(), rpc_command) != RPC_COMMANDS_SAFE_FOR_FUZZING.end();
+    const bool safe_for_fuzzing = std::find(list_of_safe_commands.begin(), list_of_safe_commands.end(), rpc_command) != list_of_safe_commands.end();
     if (!safe_for_fuzzing) {
         return;
     }
@@ -388,4 +395,12 @@ FUZZ_TARGET(rpc, .init = initialize_rpc)
             assert(error_msg.find("trigger_internal_bug") != std::string::npos);
         }
     }
+
 }
+
+
+FUZZ_TARGET(rpc, .init = FuzzInitRPC)
+{
+    ExecuteFuzzCommands(RPC_COMMANDS_SAFE_FOR_FUZZING, buffer);
+}
+}; // namespace

--- a/src/test/fuzz/rpc.h
+++ b/src/test/fuzz/rpc.h
@@ -1,0 +1,72 @@
+// rpc.h
+
+#ifndef BITCOIN_TEST_FUZZ_RPC_H
+#define BITCOIN_TEST_FUZZ_RPC_H
+
+#include <base58.h>
+#include <key.h>
+#include <key_io.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <psbt.h>
+#include <rpc/client.h>
+#include <rpc/request.h>
+#include <rpc/server.h>
+#include <span.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <tinyformat.h>
+#include <uint256.h>
+#include <univalue.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/time.h>
+#include <wallet/rpc/wallet.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+#include <string>
+#include <span>
+
+// Forward declarations
+enum class ChainType;
+class FuzzedDataProvider;
+
+namespace RPCFuzz {
+
+// Externally visible functions and variables
+extern struct RPCFuzzTestingSetup* rpc_testing_setup;
+extern std::string g_limit_to_rpc_command;
+
+struct RPCFuzzTestingSetup : public TestingSetup {
+    RPCFuzzTestingSetup(const ChainType chain_type, TestOpts opts);
+
+    void CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments);
+    std::vector<std::string> GetRPCCommands() const;
+};
+
+// Functions
+std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+std::string ConsumeArrayRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+std::string ConsumeRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+RPCFuzzTestingSetup* InitializeRPCFuzzTestingSetup();
+void initialize(std::vector<std::string> rpc_commands_safe_for_fuzzing, std::vector<std::string> rpc_commands_not_safe_for_fuzzing, std::vector<std::string> supported_rpc_commands);
+void FuzzInitRPC();
+void ExecuteFuzzCommands(std::vector<std::string> list_of_safe_commands, Span<const unsigned char> buffer);
+
+} // namespace RPCFuzz
+
+#endif // BITCOIN_TEST_FUZZ_RPC_H
+

--- a/src/wallet/test/fuzz/CMakeLists.txt
+++ b/src/wallet/test/fuzz/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(fuzz
     fees.cpp
     $<$<BOOL:${USE_SQLITE}>:${CMAKE_CURRENT_LIST_DIR}/notifications.cpp>
     parse_iso8601.cpp
+    rpc.cpp
     $<$<BOOL:${USE_SQLITE}>:${CMAKE_CURRENT_LIST_DIR}/scriptpubkeyman.cpp>
     wallet_bdb_parser.cpp
 )

--- a/src/wallet/test/fuzz/rpc.cpp
+++ b/src/wallet/test/fuzz/rpc.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/rpc.h>
+
+enum class ChainType;
+
+namespace {
+struct RPCWalletFuzzTestingSetup : public TestingSetup {
+    RPCWalletFuzzTestingSetup(const ChainType chain_type, TestOpts opts) : TestingSetup{chain_type, opts}
+    {
+    }
+
+    void CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments)
+    {
+        JSONRPCRequest request;
+        request.context = &m_node;
+        request.strMethod = rpc_method;
+        try {
+            request.params = RPCConvertValues(rpc_method, arguments);
+        } catch (const std::runtime_error&) {
+            return;
+        }
+
+        tableRPC.execute(request);
+    }
+
+    std::vector<std::string> GetWalletRPCCommands() const
+    {
+        Span<const CRPCCommand> tableWalletRPC = wallet::GetWalletRPCCommands();
+        std::vector<std::string> supported_rpc_commands;
+        for (const auto& c : tableWalletRPC) {
+            tableRPC.appendCommand(c.name, &c);
+            supported_rpc_commands.push_back(c.name);
+        }
+        return supported_rpc_commands;
+    }
+};
+
+RPCWalletFuzzTestingSetup* rpc_wallet_testing_setup = nullptr;
+std::string g_limit_to_rpc_command_wallet;
+
+// RPC commands which are safe for fuzzing.
+const std::vector<std::string> WALLET_RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
+    "importwallet",
+    "loadwallet",
+};
+// RPC commands which are safe for fuzzing.
+const std::vector<std::string> WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING{
+    "getbalances",
+    "keypoolrefill",
+    "newkeypool",
+    "listaddressgroupings",
+    "getwalletinfo",
+    "createwalletdescriptor",
+    "getnewaddress",
+    "getrawchangeaddress",
+    "setlabel",
+    "fundrawtransaction",
+    "abandontransaction",
+    "abortrescan",
+    "addmultisigaddress",
+    "backupwallet",
+    "bumpfee",
+    "psbtbumpfee",
+    "createwallet",
+    "restorewallet",
+    "dumpprivkey",
+    "importmulti",
+    "importdescriptors",
+    "listdescriptors",
+    "dumpwallet",
+    "encryptwallet",
+    "getaddressesbylabel",
+    "listlabels",
+    "walletdisplayaddress",
+    "importprivkey",
+    "importaddress",
+    "importprunedfunds",
+    "removeprunedfunds",
+    "importpubkey",
+    "getaddressinfo",
+    "getbalance",
+    "gethdkeys",
+    "getreceivedbyaddress",
+    "getreceivedbylabel",
+    "gettransaction",
+    "getunconfirmedbalance",
+    "lockunspent",
+    "listlockunspent",
+    "listunspent",
+    "walletpassphrase",
+    "walletpassphrasechange",
+    "walletlock",
+    "signmessage",
+    "sendtoaddress",
+    "sendmany",
+    "settxfee",
+    "signrawtransactionwithwallet",
+    "psbtbumpfee",
+    "bumpfee",
+    "send",
+    "sendall",
+    "walletprocesspsbt",
+    "walletcreatefundedpsbt",
+    "listreceivedbyaddress",
+    "listreceivedbylabel",
+    "listtransactions",
+    "listsinceblock",
+    "rescanblockchain",
+    "listwalletdir",
+    "listwallets",
+    "setwalletflag",
+    "createwallet",
+    "unloadwallet",
+    "sethdseed",
+    "upgradewallet",
+    "simulaterawtransaction",
+    "migratewallet",
+};
+
+
+RPCWalletFuzzTestingSetup* InitializeRPCWalletFuzzTestingSetup()
+{
+    static const auto setup = MakeNoLogFileContext<RPCWalletFuzzTestingSetup>();
+    SetRPCWarmupFinished();
+    return setup.get();
+}
+}; // namespace
+
+
+void FuzzInitWalletRPC()
+{
+    rpc_wallet_testing_setup = InitializeRPCWalletFuzzTestingSetup();
+    const std::vector<std::string> supported_rpc_commands = rpc_wallet_testing_setup->GetWalletRPCCommands();
+    RPCFuzz::initialize(WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING, WALLET_RPC_COMMANDS_NOT_SAFE_FOR_FUZZING, supported_rpc_commands);
+}
+
+void ExecuteFuzzCommandsForWalletRPC(std::vector<std::string> list_of_safe_commands, Span<const unsigned char> buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    bool good_data{true};
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
+    const std::string rpc_command = fuzzed_data_provider.ConsumeRandomLengthString(64);
+    if (!g_limit_to_rpc_command_wallet.empty() && rpc_command != g_limit_to_rpc_command_wallet) {
+        return;
+    }
+    const bool safe_for_fuzzing = std::find(list_of_safe_commands.begin(), list_of_safe_commands.end(), rpc_command) != list_of_safe_commands.end();
+    if (!safe_for_fuzzing) {
+        return;
+    }
+    std::vector<std::string> arguments;
+    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 100)
+    {
+        arguments.push_back(RPCFuzz::ConsumeRPCArgument(fuzzed_data_provider, good_data));
+    }
+    try {
+        rpc_wallet_testing_setup->CallRPC(rpc_command, arguments);
+    } catch (const UniValue& json_rpc_error) {
+        const std::string error_msg{json_rpc_error.find_value("message").get_str()};
+        if (error_msg.starts_with("Internal bug detected")) {
+            // Only allow the intentional internal bug
+            assert(error_msg.find("trigger_internal_bug") != std::string::npos);
+        }
+    }
+
+}
+
+FUZZ_TARGET(wallet_rpc, .init = FuzzInitWalletRPC)
+{
+    ExecuteFuzzCommandsForWalletRPC(WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING, buffer);
+}
+


### PR DESCRIPTION
This change adds a new fuzz target `wallet_rpc`,
this change was suggested in https://github.com/bitcoin/bitcoin/issues/29901

This change use some of the functionality of the fuzz target `rpc` to also target the wallet rpc's