### PR TITLE
Halt processing of unrequested transactions v2

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4554,6 +4554,17 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         LOCK2(cs_main, m_tx_download_mutex);
 
+        // Do not process unrequested transactions to mitigate potential DoS risks.
+        // We check both identifiers as txid mode may happen with wtxidrelay peers
+        // due to parent-orphan fetching.
+        bool is_expected = tx.HasWitness() ? m_txrequest.ExpectedTx(pfrom.GetId(), wtxid) ||
+            m_txrequest.ExpectedTx(pfrom.GetId(), txid) : m_txrequest.ExpectedTx(pfrom.GetId(), txid);
+        if (!pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION &&
+            !is_expected) {
+            LogPrint(BCLog::NET, "unrequested transaction from peer=%d\n", pfrom.GetId());
+            return;
+        }
+
         m_txrequest.ReceivedResponse(pfrom.GetId(), txid);
         if (tx.HasWitness()) m_txrequest.ReceivedResponse(pfrom.GetId(), wtxid);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4556,8 +4556,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         // Do not process unrequested transactions to mitigate potential DoS risks.
         // We check both identifiers as txid mode may happen with wtxidrelay peers
-        // due to parent-orphan fetching.
-        if (!pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION) {
+        // due to parent-orphan fetching. For backward-compatibility reasons, we only
+        // apply this transaction relay policy to node signaling NODE_TXRELAY_V2.
+        if ((peer->m_our_services & NODE_TXRELAY_V2) && !pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION) {
             bool is_expected = tx.HasWitness() ? m_txrequest.ExpectedTx(pfrom.GetId(), wtxid) ||
                 m_txrequest.ExpectedTx(pfrom.GetId(), txid) : m_txrequest.ExpectedTx(pfrom.GetId(), txid);
             if (!is_expected) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4557,13 +4557,14 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // Do not process unrequested transactions to mitigate potential DoS risks.
         // We check both identifiers as txid mode may happen with wtxidrelay peers
         // due to parent-orphan fetching.
-        bool is_expected = tx.HasWitness() ? m_txrequest.ExpectedTx(pfrom.GetId(), wtxid) ||
-            m_txrequest.ExpectedTx(pfrom.GetId(), txid) : m_txrequest.ExpectedTx(pfrom.GetId(), txid);
-        if (!pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION &&
-            !is_expected) {
-            LogPrint(BCLog::NET, "unrequested transaction from peer=%d\n", pfrom.GetId());
-            Misbehaving(*peer, "unsolicited txn from peer");
-            return;
+        if (!pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION) {
+            bool is_expected = tx.HasWitness() ? m_txrequest.ExpectedTx(pfrom.GetId(), wtxid) ||
+                m_txrequest.ExpectedTx(pfrom.GetId(), txid) : m_txrequest.ExpectedTx(pfrom.GetId(), txid);
+            if (!is_expected) {
+                LogPrint(BCLog::NET, "unrequested transaction from peer=%d\n", pfrom.GetId());
+                Misbehaving(*peer, "unsolicited txn from peer");
+                return;
+            }
         }
 
         m_txrequest.ReceivedResponse(pfrom.GetId(), txid);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4562,6 +4562,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         if (!pfrom.HasPermission(NetPermissionFlags::Relay) && pfrom.GetCommonVersion() >= REJECT_UNSOLICITED_TX_VERSION &&
             !is_expected) {
             LogPrint(BCLog::NET, "unrequested transaction from peer=%d\n", pfrom.GetId());
+            Misbehaving(*peer, "unsolicited txn from peer");
             return;
         }
 

--- a/src/node/protocol_version.h
+++ b/src/node/protocol_version.h
@@ -35,4 +35,7 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
 
+//! reject unsolicited tx is enabled with this version
+static const int REJECT_UNSOLICITED_TX_VERSION = 70017;
+
 #endif // BITCOIN_NODE_PROTOCOL_VERSION_H

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -329,6 +329,9 @@ enum ServiceFlags : uint64_t {
     // NODE_P2P_V2 means the node supports BIP324 transport
     NODE_P2P_V2 = (1 << 11),
 
+    // NODE_TXRELAY_V2 means the node supports BIPXXX transaction-relay v2 protocol
+    NODE_TXRELAY_V2 = (1 << 12),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -677,14 +677,14 @@ public:
 
     bool ExpectedTx(NodeId peer, const uint256& txhash)
     {
-        auto it_hash = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::REQUESTED, 0});
         // We need to traverse all the REQUEST / COMPLETED announcements to verify we effectively
         // requested the txhash from this peer.
-        while (it_hash != m_index.get<ByTxHash>().end() && it_hash->m_txhash == txhash) {
-            if (it_hash->m_peer == peer) return true;
-            ++it_hash;
+        auto it = m_index.get<ByPeer>().find(ByPeerView{peer, false, txhash});
+        if (it == m_index.get<ByPeer>().end()) {
+            it = m_index.get<ByPeer>().find(ByPeerView{peer, true, txhash});
         }
-        return false;
+        if (it != m_index.get<ByPeer>().end()) { return false; }
+        return true;
     }
 
 

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -181,6 +181,8 @@ public:
      */
     void ReceivedResponse(NodeId peer, const uint256& txhash);
 
+    bool ExpectedTx(NodeId peer, const uint256& txhash);
+
     // The operations below inspect the data structure.
 
     /** Count how many REQUESTED announcements a peer has. */


### PR DESCRIPTION
This is a re-work of #21224.

Motivation is still the same to limit the DoS exposure in face of some DoSy behaviors from tx-relay peers.

Difference w.r.t 21224 is adding a protocol upgrade (`REJECT_UNSOLICITED_TX_VERSION`) for the rejection of unsolicited txn solely to happen for new upgraded peers. That way no disruption of all the undocumented clients and node currently participating in the transaction-relay network.

Opening as a draft - There should be indeed test, there a bunch of old on 21224 branch.