### PR TITLE
fuzz: fix timeout in crypter target

### DIFF
--- a/src/wallet/test/fuzz/crypter.cpp
+++ b/src/wallet/test/fuzz/crypter.cpp
@@ -29,28 +29,23 @@ FUZZ_TARGET(crypter, .init = initialize_crypter)
     CKeyingMaterial plain_text_ed;
     const std::vector<unsigned char> random_key = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
 
-    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10000)
+    if (fuzzed_data_provider.ConsumeBool()) {
+        const std::string random_string = fuzzed_data_provider.ConsumeRandomLengthString(100);
+        SecureString secure_string(random_string.begin(), random_string.end());
+
+        const unsigned int derivation_method = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+
+        // Limiting the value of nRounds since it is otherwise uselessly expensive and causes a timeout when fuzzing.
+        crypt.SetKeyFromPassphrase(/*strKeyData=*/secure_string,
+                                    /*chSalt=*/ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_SALT_SIZE),
+                                    /*nRounds=*/fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 25000),
+                                    /*nDerivationMethod=*/derivation_method);
+    }
+
+    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 100)
     {
         CallOneOf(
             fuzzed_data_provider,
-            [&] {
-                const std::string random_string = fuzzed_data_provider.ConsumeRandomLengthString(100);
-                SecureString secure_string(random_string.begin(), random_string.end());
-
-                const unsigned int derivation_method = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-
-                // Limiting the value of nRounds since it is otherwise uselessly expensive and causes a timeout when fuzzing.
-                crypt.SetKeyFromPassphrase(/*strKeyData=*/secure_string,
-                                           /*chSalt=*/ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_SALT_SIZE),
-                                           /*nRounds=*/fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 25000),
-                                           /*nDerivationMethod=*/derivation_method);
-            },
-            [&] {
-                const std::vector<unsigned char> random_vector = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
-                const CKeyingMaterial new_key(random_vector.begin(), random_vector.end());
-                const std::vector<unsigned char>& new_IV = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_IV_SIZE);
-                crypt.SetKey(new_key, new_IV);
-            },
             [&] {
                 const std::vector<unsigned char> random_vector = ConsumeFixedLengthByteVector(fuzzed_data_provider, WALLET_CRYPTO_KEY_SIZE);
                 plain_text_ed = CKeyingMaterial(random_vector.begin(), random_vector.end());
@@ -67,12 +62,12 @@ FUZZ_TARGET(crypter, .init = initialize_crypter)
             [&] {
                 const CKeyingMaterial master_key(random_key.begin(), random_key.end());
                 const uint256 iv = ConsumeUInt256(fuzzed_data_provider);
-                EncryptSecret(master_key, plain_text_ed, iv, cipher_text_ed);
+                (void)EncryptSecret(master_key, plain_text_ed, iv, cipher_text_ed);
             },
             [&] {
                 const CKeyingMaterial master_key(random_key.begin(), random_key.end());
                 const uint256 iv = ConsumeUInt256(fuzzed_data_provider);
-                DecryptSecret(master_key, cipher_text_ed, iv, plain_text_ed);
+                (void)DecryptSecret(master_key, cipher_text_ed, iv, plain_text_ed);
             },
             [&] {
                 std::optional<CPubKey> random_pub_key = ConsumeDeserializable<CPubKey>(fuzzed_data_provider);
@@ -84,7 +79,7 @@ FUZZ_TARGET(crypter, .init = initialize_crypter)
                 const CKeyingMaterial master_key(random_key.begin(), random_key.end());
                 const std::vector<unsigned char> crypted_secret = ConsumeRandomLengthByteVector(fuzzed_data_provider, 64);
                 CKey key;
-                DecryptKey(master_key, crypted_secret, pub_key, key);
+                (void)DecryptKey(master_key, crypted_secret, pub_key, key);
             });
     }
 }


### PR DESCRIPTION
Fixes #30503

- Move SetKeyFromPassphrase to out of LIMITED_WHILE
- Remove `SetKey` calls since it is already called internally by other functions.
- Reduce number of iterations (100 is enough, no need for 10,000).
