### PR TITLE
test: check that keyless P2A 'signing' via `signrawtransactionwithkey` succeeds

### DIFF
--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -155,6 +155,9 @@ def output_key_to_p2tr(key, main=False):
     assert len(key) == 32
     return program_to_witness(1, key, main)
 
+def p2a(main=False):
+    return program_to_witness(1, "4e73", main)
+
 def check_key(key):
     if (type(key) is str):
         key = bytes.fromhex(key)  # Assuming this is hex string


### PR DESCRIPTION
This small PR adds a sanity check to verify that transactions with P2A inputs can be 'signed' successfully, using the non-wallet RPC `signrawtransactionwithkey`. Note that in the this flow, `SignStep` (which was also extended for the new `ANCHOR` output type in #30352) is never called, as signing is only tried if the locking script verification isn't successful already. See the review discussion https://github.com/bitcoin/bitcoin/pull/30352#discussion_r1690530356 ff.