### PR TITLE
doc: Add note about distro's `g++-mingw-w64-x86-64-posix` version

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -13,6 +13,9 @@ Other options which may work, but which have not been extensively tested are (pl
 
 * On Windows, using a POSIX compatibility layer application such as [cygwin](https://www.cygwin.com/) or [msys2](https://www.msys2.org/).
 
+The instructions below work on Ubuntu and Debian. Make sure the distribution's `g++-mingw-w64-x86-64-posix`
+package meets the minimum required `g++` version specified in [dependencies.md](dependencies.md).
+
 Installing Windows Subsystem for Linux
 ---------------------------------------
 


### PR DESCRIPTION
This PR stems from a requirement for the `g++` minimum supported version [being >= 11](https://github.com/bitcoin/bitcoin/pull/29091):
- https://packages.ubuntu.com/noble/g++-mingw-w64-x86-64-posix
- https://packages.debian.org/bookworm/g++-mingw-w64-x86-64-posix