### PR TITLE
doc: Add missed cmake package to build depends

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -29,7 +29,7 @@ First, install the general dependencies:
 
     sudo apt update
     sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils cmake curl git
 
 A host toolchain (`build-essential`) is necessary because some dependency
 packages need to build host utilities that are used in the build process.


### PR DESCRIPTION
CMake is used to build the following packages in depends when cross-compiling for Windows:
- `libevent` (https://github.com/bitcoin/bitcoin/pull/29835)
- `libnatpmp` (https://github.com/bitcoin/bitcoin/pull/29708)
- `miniupnpc` (https://github.com/bitcoin/bitcoin/pull/29707)
- `qrencode` (https://github.com/bitcoin/bitcoin/pull/29725)
- `zeromq` (https://github.com/bitcoin/bitcoin/pull/29723)