### PR TITLE
ci: Silent Homebrew's reinstall warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           # A workaround for "The `brew link` step did not complete successfully" error.
-          brew install python@3 || brew link --overwrite python@3
-          brew install automake libtool pkg-config gnu-getopt ccache boost libevent miniupnpc libnatpmp zeromq qt@5 qrencode
+          brew install --quiet python@3 || brew link --overwrite python@3
+          brew install --quiet automake libtool pkg-config gnu-getopt ccache boost libevent miniupnpc libnatpmp zeromq qt@5 qrencode
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
Homebrew's warnings are quite noisy on the master branch: 
![image](https://github.com/user-attachments/assets/dcd74414-0e52-4827-88fa-0d2f5b867705)

This PR silents them to allow us to focus on other CI infra warnings once they happen.

Similar to https://github.com/bitcoin-core/secp256k1/pull/1578.