### PR TITLE
fuzz: replace hardcoded numbers for bech32 limits

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -19,9 +19,6 @@ namespace
 
 typedef std::vector<uint8_t> data;
 
-/** The Bech32 and Bech32m checksum size */
-constexpr size_t CHECKSUM_SIZE = 6;
-
 /** The Bech32 and Bech32m character set for encoding. */
 const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -21,6 +21,9 @@
 namespace bech32
 {
 
+/** The Bech32 and Bech32m checksum size */
+constexpr size_t CHECKSUM_SIZE = 6;
+
 enum class Encoding {
     INVALID, //!< Failed decoding
 

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -29,8 +29,9 @@ FUZZ_TARGET(bech32)
     std::vector<unsigned char> input;
     ConvertBits<8, 5, true>([&](unsigned char c) { input.push_back(c); }, buffer.begin(), buffer.end());
 
-    if (input.size() + 3 + 6 <= 90) {
-        // If it's possible to encode input in Bech32(m) without exceeding the 90-character limit:
+    // Input data part + 3 characters for the HRP and separator (bc1) + the checksum characters
+    if (input.size() + 3 + bech32::CHECKSUM_SIZE <= bech32::CharLimit::BECH32) {
+        // If it's possible to encode input in Bech32(m) without exceeding the bech32-character limit:
         for (auto encoding : {bech32::Encoding::BECH32, bech32::Encoding::BECH32M}) {
             const std::string encoded = bech32::Encode(encoding, "bc", input);
             assert(!encoded.empty());


### PR DESCRIPTION
Follow-up to #30047 to replace a hardcoded value that was missed in the original PR 