### PR TITLE
doc: Drop no longer needed workaround for WSL

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -66,7 +66,6 @@ is to temporarily disable WSL support for Win32 applications.
 
 Build using:
 
-    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     sudo bash -c "echo 0 > /proc/sys/fs/binfmt_misc/status" # Disable WSL support for Win32 applications.
     cd depends
     make HOST=x86_64-w64-mingw32


### PR DESCRIPTION
This PR effectively reverts commit 4f890ba6bc8caba5394c7a5388d7f07959ced78b from https://github.com/bitcoin/bitcoin/pull/11437, which fixed some build issues on WSL seven years ago.

Testing the current master branch @ 31a3ff55154bf15fb35b157c3f67ec05408ecdf9 on Windows 11 + WSL using Ubuntu 24.04 or Debian images, I noticed that the workaround is no longer required. Moreover, it doesn't affect the build process at all, which means the hashes of the built packages in depends remain the same and the `configure` log in the main build system remains the same as well.