### PR TITLE
Revert "depends: Fetch miniupnpc sources from an alternative website"

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,6 +1,6 @@
 package=miniupnpc
 $(package)_version=2.2.7
-$(package)_download_path=http://miniupnp.free.fr/files/
+$(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=b0c3a27056840fd0ec9328a5a9bac3dc5e0ec6d2e8733349cf577b0aa1e70ac1
 $(package)_patches=dont_leak_info.patch cmake_get_src_addr.patch fix_windows_snprintf.patch


### PR DESCRIPTION
This reverts commit 21b8a14d37c19ce292d5529597e0d52338db48a9.

started fresh fanquake 