### PR TITLE
Cluster linearization: separate tests from tests-of-tests

### DIFF
--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -1016,6 +1016,10 @@ FUZZ_TARGET(clusterlin_simple_linearize)
                 auto perm_chunking = ChunkLinearization(depgraph, perm_linearization);
                 auto cmp = CompareChunks(simple_chunking, perm_chunking);
                 assert(cmp >= 0);
+                // If perm_chunking is diagram-optimal, it cannot have more chunks than
+                // simple_chunking (as simple_chunking claims to be optimal, which implies minimal
+                // chunks.
+                if (cmp == 0) assert(simple_chunking.size() >= perm_chunking.size());
             } else {
                 // Otherwise, fast forward to the last permutation with the same non-topological
                 // prefix.
@@ -1110,6 +1114,9 @@ FUZZ_TARGET(clusterlin_linearize)
         // If SimpleLinearize finds the optimal result too, they must be equal (if not,
         // SimpleLinearize is broken).
         if (simple_optimal) assert(cmp == 0);
+        // If simple_chunking is diagram-optimal, it cannot have more chunks than chunking (as
+        // chunking is claimed to be optimal, which implies minimal chunks).
+        if (cmp == 0) assert(chunking.size() >= simple_chunking.size());
 
         // Compare with a linearization read from the fuzz input.
         auto read = ReadLinearization(depgraph, reader);

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -17,6 +17,63 @@
 #include <utility>
 #include <vector>
 
+/*
+ * The tests in this file primarily cover the candidate finder classes and linearization algorithms.
+ *
+ *   <----: An implementation (at the start of the line --) is tested in the test marked with *,
+ *          possibly by comparison with other implementations (at the end of the line ->).
+ *   <<---: The right side is implemented using the left side.
+ *
+ *   +-----------------------+
+ *   | SearchCandidateFinder | <<---------------------\
+ *   +-----------------------+                        |
+ *     |                                            +-----------+
+ *     |                                            | Linearize |
+ *     |                                            +-----------+
+ *     |        +-------------------------+           |  |
+ *     |        | AncestorCandidateFinder | <<--------/  |
+ *     |        +-------------------------+              |
+ *     |          |                     ^                |        ^^  PRODUCTION CODE
+ *     |          |                     |                |        ||
+ *  ==============================================================================================
+ *     |          |                     |                |        ||
+ *     | clusterlin_ancestor_finder*    |                |        vv  TEST CODE
+ *     |                                |                |
+ *     |-clusterlin_search_finder*      |                |-clusterlin_linearize*
+ *     |                                |                |
+ *     v                                |                v
+ *   +-----------------------+          |           +-----------------+
+ *   | SimpleCandidateFinder | <<-------------------| SimpleLinearize |
+ *   +-----------------------+          |           +-----------------+
+ *                  |                   |                |
+ *                  +-------------------/                |
+ *                  |                                    |
+ *                  |-clusterlin_simple_finder*          |-clusterlin_simple_linearize*
+ *                  v                                    v
+ *   +---------------------------+                  +---------------------+
+ *   | ExhaustiveCandidateFinder |                  | ExhaustiveLinearize |
+ *   +---------------------------+                  +---------------------+
+ *
+ * More tests are included for lower-level and related functions and classes:
+ * - DepGraph tests:
+ *   - clusterlin_depgraph_sim
+ *   - clusterlin_depgraph_serialization
+ *   - clusterlin_components
+ * - ChunkLinearization and LinearizationChunking tests:
+ *   - clusterlin_chunking
+ *   - clusterlin_linearization_chunking
+ * - PostLinearize tests:
+ *   - clusterlin_postlinearize
+ *   - clusterlin_postlinearize_tree
+ *   - clusterlin_postlinearize_moved_leaf
+ * - MergeLinearization tests:
+ *   - clusterlin_merge
+ * - FixLinearization tests:
+ *   - clusterlin_fix_linearization
+ * - MakeConnected tests (a test-only function):
+ *   - clusterlin_make_connected
+ */
+
 using namespace cluster_linearize;
 
 namespace {

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -1010,6 +1010,14 @@ FUZZ_TARGET(clusterlin_simple_linearize)
             }
         } while(std::next_permutation(perm_linearization.begin(), perm_linearization.end()));
     }
+
+    if (optimal) {
+        // Compare with a linearization read from the fuzz input.
+        auto read = ReadLinearization(depgraph, reader);
+        auto read_chunking = ChunkLinearization(depgraph, read);
+        auto cmp = CompareChunks(simple_chunking, read_chunking);
+        assert(cmp >= 0);
+    }
 }
 
 FUZZ_TARGET(clusterlin_linearize)
@@ -1087,6 +1095,12 @@ FUZZ_TARGET(clusterlin_linearize)
         // If SimpleLinearize finds the optimal result too, they must be equal (if not,
         // SimpleLinearize is broken).
         if (simple_optimal) assert(cmp == 0);
+
+        // Compare with a linearization read from the fuzz input.
+        auto read = ReadLinearization(depgraph, reader);
+        auto read_chunking = ChunkLinearization(depgraph, read);
+        auto cmp_read = CompareChunks(chunking, read_chunking);
+        assert(cmp_read >= 0);
     }
 }
 

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -64,7 +64,6 @@ public:
         SetInfo best(m_depgraph, m_todo);
         // Process the queue.
         while (!queue.empty() && iterations_left) {
-            --iterations_left;
             // Pop top element of the queue.
             auto [inc, und] = queue.back();
             queue.pop_back();
@@ -75,6 +74,7 @@ public:
                 // transactions that share ancestry with inc so far (which means only connected
                 // sets will be considered).
                 if (inc_none || inc.Overlaps(m_depgraph.Ancestors(split))) {
+                    --iterations_left;
                     // Add a queue entry with split included.
                     SetInfo new_inc(m_depgraph, inc | (m_todo & m_depgraph.Ancestors(split)));
                     queue.emplace_back(new_inc.transactions, und - new_inc.transactions);

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -707,6 +707,10 @@ FUZZ_TARGET(clusterlin_simple_finder)
                 auto exhaustive = exh_finder.FindCandidateSet();
                 assert(exhaustive.feerate == found.feerate);
             }
+
+            // Compare with a topological set read from the fuzz input.
+            auto read_topo = ReadTopologicalSet(depgraph, todo, reader);
+            if (read_topo.Any()) assert(found.feerate >= depgraph.FeeRate(read_topo));
         }
 
         // Find a topologically valid subset of transactions to remove from the graph.
@@ -807,6 +811,10 @@ FUZZ_TARGET(clusterlin_search_finder)
             // Compare with AncestorCandidateFinder;
             auto anc = anc_finder.FindCandidateSet();
             assert(found.feerate >= anc.feerate);
+
+            // Compare with a topological set read from the fuzz input.
+            auto read_topo = ReadTopologicalSet(depgraph, todo, reader);
+            if (read_topo.Any()) assert(found.feerate >= depgraph.FeeRate(read_topo));
         }
 
         // Find a topologically valid subset of transactions to remove from the graph.

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -92,9 +92,8 @@ public:
 
 /** A very simple finder class for optimal candidate sets, which tries every subset.
  *
- * It is even simpler than SimpleCandidateFinder, and is primarily included here to test the
- * correctness of SimpleCandidateFinder, which is then used to test the correctness of
- * SearchCandidateFinder.
+ * It is even simpler than SimpleCandidateFinder, and exists just to help test the correctness of
+ * SimpleCandidateFinder, which is then used to test the correctness of SearchCandidateFinder.
  */
 template<typename SetType>
 class ExhaustiveCandidateFinder
@@ -640,11 +639,94 @@ FUZZ_TARGET(clusterlin_ancestor_finder)
 
 static constexpr auto MAX_SIMPLE_ITERATIONS = 300000;
 
+FUZZ_TARGET(clusterlin_simple_finder)
+{
+    // Verify that SimpleCandidateFinder works as expected by sanity checking the results
+    // and comparing them (if claimed to be optimal) against the sets found by
+    // ExhaustiveCandidateFinder and AncestorCandidateFinder.
+    //
+    // Note that SimpleCandidateFinder is only used in tests; the purpose of this fuzz test is to
+    // establish confidence in SimpleCandidateFinder, so that it can be used to test
+    // SearchCandidateFinder below.
+
+    // Retrieve a depgraph from the fuzz input.
+    SpanReader reader(buffer);
+    DepGraph<TestBitSet> depgraph;
+    try {
+        reader >> Using<DepGraphFormatter>(depgraph);
+    } catch (const std::ios_base::failure&) {}
+
+    // Instantiate the SimpleCandidateFinder to be tested, and the ExhaustiveCandidateFinder and
+    // AncestorCandidateFinder it is being tested against.
+    SimpleCandidateFinder smp_finder(depgraph);
+    ExhaustiveCandidateFinder exh_finder(depgraph);
+    AncestorCandidateFinder anc_finder(depgraph);
+
+    auto todo = depgraph.Positions();
+    while (todo.Any()) {
+        assert(!smp_finder.AllDone());
+        assert(!exh_finder.AllDone());
+        assert(!anc_finder.AllDone());
+        assert(anc_finder.NumRemaining() == todo.Count());
+
+        // Call SimpleCandidateFinder.
+        auto [found, iterations_done] = smp_finder.FindCandidateSet(MAX_SIMPLE_ITERATIONS);
+        bool optimal = (iterations_done != MAX_SIMPLE_ITERATIONS);
+
+        // Sanity check the result.
+        assert(iterations_done <= MAX_SIMPLE_ITERATIONS);
+        assert(found.transactions.Any());
+        assert(found.transactions.IsSubsetOf(todo));
+        assert(depgraph.FeeRate(found.transactions) == found.feerate);
+        // Check that it is topologically valid.
+        for (auto i : found.transactions) {
+            assert(found.transactions.IsSupersetOf(depgraph.Ancestors(i) & todo));
+        }
+
+        // At most 2^(N-1) iterations can be required: the number of non-empty connected subsets a
+        // graph with N transactions can have. If MAX_SIMPLE_ITERATIONS exceeds this number, the
+        // result is necessarily optimal.
+        assert(iterations_done <= (uint64_t{1} << (todo.Count() - 1)));
+        if (MAX_SIMPLE_ITERATIONS > (uint64_t{1} << (todo.Count() - 1))) assert(optimal);
+
+        // Perform quality checks only if SimpleCandidateFinder claims an optimal result.
+        if (optimal) {
+            // Optimal sets are always connected.
+            assert(depgraph.IsConnected(found.transactions));
+
+            // Compare with AncestorCandidateFinder.
+            auto anc = anc_finder.FindCandidateSet();
+            assert(anc.feerate <= found.feerate);
+
+            if (todo.Count() <= 12) {
+                // Compare with ExhaustiveCandidateFinder. This quickly gets computationally
+                // expensive for large clusters (O(2^n)), so only do it for sufficiently small ones.
+                auto exhaustive = exh_finder.FindCandidateSet();
+                assert(exhaustive.feerate == found.feerate);
+            }
+        }
+
+        // Find a topologically valid subset of transactions to remove from the graph.
+        auto del_set = ReadTopologicalSet(depgraph, todo, reader);
+        // If we did not find anything, use found itself, because we should remove something.
+        if (del_set.None()) del_set = found.transactions;
+        todo -= del_set;
+        smp_finder.MarkDone(del_set);
+        exh_finder.MarkDone(del_set);
+        anc_finder.MarkDone(del_set);
+    }
+
+    assert(smp_finder.AllDone());
+    assert(exh_finder.AllDone());
+    assert(anc_finder.AllDone());
+    assert(anc_finder.NumRemaining() == 0);
+}
+
 FUZZ_TARGET(clusterlin_search_finder)
 {
     // Verify that SearchCandidateFinder works as expected by sanity checking the results
-    // and comparing with the results from SimpleCandidateFinder, ExhaustiveCandidateFinder, and
-    // AncestorCandidateFinder.
+    // and comparing with the results from SimpleCandidateFinder and AncestorCandidateFinder,
+    // if the result is claimed to be optimal.
 
     // Retrieve an RNG seed, a depgraph, and whether to make it connected, from the fuzz input.
     SpanReader reader(buffer);
@@ -658,17 +740,15 @@ FUZZ_TARGET(clusterlin_search_finder)
     // the graph to be connected.
     if (make_connected) MakeConnected(depgraph);
 
-    // Instantiate ALL the candidate finders.
+    // Instantiate the candidate finders.
     SearchCandidateFinder src_finder(depgraph, rng_seed);
     SimpleCandidateFinder smp_finder(depgraph);
-    ExhaustiveCandidateFinder exh_finder(depgraph);
     AncestorCandidateFinder anc_finder(depgraph);
 
     auto todo = depgraph.Positions();
     while (todo.Any()) {
         assert(!src_finder.AllDone());
         assert(!smp_finder.AllDone());
-        assert(!exh_finder.AllDone());
         assert(!anc_finder.AllDone());
         assert(anc_finder.NumRemaining() == todo.Count());
 
@@ -684,6 +764,7 @@ FUZZ_TARGET(clusterlin_search_finder)
 
         // Call the search finder's FindCandidateSet for what remains of the graph.
         auto [found, iterations_done] = src_finder.FindCandidateSet(max_iterations, init_best);
+        bool optimal = iterations_done < max_iterations;
 
         // Sanity check the result.
         assert(iterations_done <= max_iterations);
@@ -709,7 +790,7 @@ FUZZ_TARGET(clusterlin_search_finder)
         }
 
         // Perform quality checks only if SearchCandidateFinder claims an optimal result.
-        if (iterations_done < max_iterations) {
+        if (optimal) {
             // Optimal sets are always connected.
             assert(depgraph.IsConnected(found.transactions));
 
@@ -723,19 +804,6 @@ FUZZ_TARGET(clusterlin_search_finder)
             // Compare with AncestorCandidateFinder;
             auto anc = anc_finder.FindCandidateSet();
             assert(found.feerate >= anc.feerate);
-
-            // Compare with ExhaustiveCandidateFinder. This quickly gets computationally expensive
-            // for large clusters (O(2^n)), so only do it for sufficiently small ones.
-            if (todo.Count() <= 12) {
-                auto exhaustive = exh_finder.FindCandidateSet();
-                assert(exhaustive.feerate == found.feerate);
-                // Also compare ExhaustiveCandidateFinder with SimpleCandidateFinder (this is
-                // primarily a test for SimpleCandidateFinder's correctness).
-                assert(exhaustive.feerate >= simple.feerate);
-                if (simple_iters < MAX_SIMPLE_ITERATIONS) {
-                    assert(exhaustive.feerate == simple.feerate);
-                }
-            }
         }
 
         // Find a topologically valid subset of transactions to remove from the graph.
@@ -745,13 +813,11 @@ FUZZ_TARGET(clusterlin_search_finder)
         todo -= del_set;
         src_finder.MarkDone(del_set);
         smp_finder.MarkDone(del_set);
-        exh_finder.MarkDone(del_set);
         anc_finder.MarkDone(del_set);
     }
 
     assert(src_finder.AllDone());
     assert(smp_finder.AllDone());
-    assert(exh_finder.AllDone());
     assert(anc_finder.AllDone());
     assert(anc_finder.NumRemaining() == 0);
 }


### PR DESCRIPTION
Part of the cluster mempool project: #30289
 
The current cluster linearization fuzz tests contain two tests which combine testing of production code with testing of the test code itself:
* `clusterlin_search_finder`: establishes the correctness of `SearchCandidateFinder` by comparing against both `SimpleCandidateFinder` and `ExhaustiveCandidateFinder` (which is even more simple than `SimpleCandidateFinder`). If `SimpleCandidateFinder` works correctly, then this comparison with `ExhaustiveCandidateFinder` is redundant. If it isn't, we ought to find that in a test specific to `SimpleCandidateFinder` rather than as a side-effect of testing `SearchCandidateFinder`. Split this functionality out into a new `clusterlin_simple_finder`.
* `clusterlin_linearize`: establishes the correctness of `Linearize` by comparing against both `SimpleLinearize` and literally every valid linearization for the cluster. Again, if `SimpleLinearize` works correctly, then this comparison with all valid linearizations is redundant, and if it isn't we should find it in a test for `SimpleLinearize`. Do so by splitting off that functionality into `clusterlin_simple_linearize`.

After that, a few general improvements to the affected tests are made (comparing with linearizations and subsets read from the fuzz input, plus a performance improvement).