### PR TITLE
guix: bump time-machine to 7bf1d7aeaffba15c4f680f93ae88fbef25427252

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=efc26826400762207cde9f23802cfe75a737963c \
+                      --commit=7bf1d7aeaffba15c4f680f93ae88fbef25427252 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
Includes:
https://git.savannah.gnu.org/cgit/guix.git/commit/?id=d428237642e1e4ac8fda4597205ffec89926c0ec.

which removes the need to build Python2, and OpenSSL `1.x` (which has historically caused issues) when building for Windows (Python2 (with a dependency on OpenSSL `1.x`) used to be a dependency of NSIS).

Linux Kernel Headers `6.1.100` -> `6.1.102`

```bash
d079858fb1bc526217ee06f312d97a56c34986440e5f9e108af66eaecacea073  guix-build-eca20bead2da/output/aarch64-linux-gnu/SHA256SUMS.part
2db780ffe39210a3ba113e52362d94840449218ac1747e3a3484606cc36acead  guix-build-eca20bead2da/output/aarch64-linux-gnu/bitcoin-eca20bead2da-aarch64-linux-gnu-debug.tar.gz
b56b602bd87e73b11a6b68147c52c6dfa53f0ec4bac52ac749765025e7b43bc9  guix-build-eca20bead2da/output/aarch64-linux-gnu/bitcoin-eca20bead2da-aarch64-linux-gnu.tar.gz
d56a9a6ac683da2e347d2ea71fab0cd54a126604ac1c9cc4d8fa89f6343ddb52  guix-build-eca20bead2da/output/arm-linux-gnueabihf/SHA256SUMS.part
6555b6d837605b35c5cf72ab4e5728d9205f8481e3e4bc9e1bbe44e09a1aa1a3  guix-build-eca20bead2da/output/arm-linux-gnueabihf/bitcoin-eca20bead2da-arm-linux-gnueabihf-debug.tar.gz
d310e9a532d035db238552ad3fa3779b93d062e655f8e477ff029682af4f7cf4  guix-build-eca20bead2da/output/arm-linux-gnueabihf/bitcoin-eca20bead2da-arm-linux-gnueabihf.tar.gz
eab39d953890e2d36b92b53e43a711ab615090d5b9030861229386e4a41344d8  guix-build-eca20bead2da/output/arm64-apple-darwin/SHA256SUMS.part
394473362a4d4895431d9250702e9e87f8ccb880a2b723eeb0cfd8eed1635518  guix-build-eca20bead2da/output/arm64-apple-darwin/bitcoin-eca20bead2da-arm64-apple-darwin-unsigned.tar.gz
3e72306a34e69647200fe5b3d5e8da3bc3b75105d3eeb9f5d5b5332de5d8e464  guix-build-eca20bead2da/output/arm64-apple-darwin/bitcoin-eca20bead2da-arm64-apple-darwin-unsigned.zip
1b0515ab24a57706278bde37b88a0dc51188373154876997dcbf61f2c9cf2c65  guix-build-eca20bead2da/output/arm64-apple-darwin/bitcoin-eca20bead2da-arm64-apple-darwin.tar.gz
fba7470833ff076c01de5f2ed4a4d697f8a2e06cec49098f89d40e84c4798357  guix-build-eca20bead2da/output/dist-archive/bitcoin-eca20bead2da.tar.gz
935cc2ebec9b595da67bcde22a395060817fdf16b3a31f14e6b2252cb5073640  guix-build-eca20bead2da/output/powerpc64-linux-gnu/SHA256SUMS.part
85ee64aa6d0ab6d3431b7c0af3e26a9bfdb365343ba1b5198e321ae0f6778d33  guix-build-eca20bead2da/output/powerpc64-linux-gnu/bitcoin-eca20bead2da-powerpc64-linux-gnu-debug.tar.gz
52a1a8e8fdb48589cfb00c35001ae8765f6127d472d11ad03c3faa3621e45032  guix-build-eca20bead2da/output/powerpc64-linux-gnu/bitcoin-eca20bead2da-powerpc64-linux-gnu.tar.gz
72ccb2577dd11342dfce124346d359b19d8bc4af12cd445447e0568321dd39b9  guix-build-eca20bead2da/output/riscv64-linux-gnu/SHA256SUMS.part
80a0d80c3adb8e2de27605ed0b2bd7f5442c8316397a53a3e0e840a14587b057  guix-build-eca20bead2da/output/riscv64-linux-gnu/bitcoin-eca20bead2da-riscv64-linux-gnu-debug.tar.gz
62de93f8defc9e561caed1586bee20e208be1d66cdc8bf593f5e09e3c28d03a6  guix-build-eca20bead2da/output/riscv64-linux-gnu/bitcoin-eca20bead2da-riscv64-linux-gnu.tar.gz
e5af6b6bb63d88f7797531f855ad0a8fb5bf0e4645a7b2f83516b4cb26bf1da4  guix-build-eca20bead2da/output/x86_64-apple-darwin/SHA256SUMS.part
3743509c6ad5fb3837bd8d420885b49221515e89d1bba12f8816f401879bee7a  guix-build-eca20bead2da/output/x86_64-apple-darwin/bitcoin-eca20bead2da-x86_64-apple-darwin-unsigned.tar.gz
cc6fb35a57506250790ddea4aaa7888aa9d1db66f8ce3f09c830898f83f2f39f  guix-build-eca20bead2da/output/x86_64-apple-darwin/bitcoin-eca20bead2da-x86_64-apple-darwin-unsigned.zip
4b4d2096e87ca10847e5a543ff32f002325c882856523f0fc5d70564009f9244  guix-build-eca20bead2da/output/x86_64-apple-darwin/bitcoin-eca20bead2da-x86_64-apple-darwin.tar.gz
1989106147fc5f77bc27a08886bb2120ff0c49cbe6ea97b9e234752740ec81ad  guix-build-eca20bead2da/output/x86_64-linux-gnu/SHA256SUMS.part
bdb48a649f9ca026e6bbab28159f716a1ad4b84257588e1a12bf4467e4c7acb6  guix-build-eca20bead2da/output/x86_64-linux-gnu/bitcoin-eca20bead2da-x86_64-linux-gnu-debug.tar.gz
aff4717e841508bd6284d846d8c6da7da3622bf54d68a8919e3fd95814beb309  guix-build-eca20bead2da/output/x86_64-linux-gnu/bitcoin-eca20bead2da-x86_64-linux-gnu.tar.gz
fdc8346e0b0f03648399b74a0d38d961c985c5ec8128193443be0b7208632f06  guix-build-eca20bead2da/output/x86_64-w64-mingw32/SHA256SUMS.part
a50f517e3f2467e5931349315bbe0968e190e8bcdbb024e3a8d4c37333938155  guix-build-eca20bead2da/output/x86_64-w64-mingw32/bitcoin-eca20bead2da-win64-debug.zip
38223484c214a90193f88f8c60743b376ce0c80f9401ec863ccb36a1337c85a2  guix-build-eca20bead2da/output/x86_64-w64-mingw32/bitcoin-eca20bead2da-win64-setup-unsigned.exe
07fca2496b2c59ea928684c4bf4ef163686f8fb11934117c6c37407a3a374363  guix-build-eca20bead2da/output/x86_64-w64-mingw32/bitcoin-eca20bead2da-win64-unsigned.tar.gz
8e71711db17c69000627c44965eb7070fc92788f792ea3d0778a55bdadf36cdb  guix-build-eca20bead2da/output/x86_64-w64-mingw32/bitcoin-eca20bead2da-win64.zip
```