### PR TITLE
test: remove `ExtractDestination` false assertion for `ANCHOR` script

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -76,13 +76,11 @@ FUZZ_TARGET(script, .init = initialize_script)
         assert(which_type == TxoutType::PUBKEY ||
                which_type == TxoutType::NONSTANDARD ||
                which_type == TxoutType::NULL_DATA ||
-               which_type == TxoutType::MULTISIG ||
-               which_type == TxoutType::ANCHOR);
+               which_type == TxoutType::MULTISIG);
     }
     if (which_type == TxoutType::NONSTANDARD ||
         which_type == TxoutType::NULL_DATA ||
-        which_type == TxoutType::MULTISIG ||
-        which_type == TxoutType::ANCHOR) {
+        which_type == TxoutType::MULTISIG) {
         assert(!extract_destination_ret);
     }
 


### PR DESCRIPTION
This PR fixes #30615

`ExtractDestination` returns `true` when `TxoutType` is `ANCHOR` see https://github.com/bitcoin/bitcoin/issues/30615#issuecomment-2277538703