### PR TITLE
doc: Change `nproc` in docs to `getconf _NPROCESSORS_ONLN`

### DIFF
--- a/contrib/devtools/bitcoin-tidy/README.md
+++ b/contrib/devtools/bitcoin-tidy/README.md
@@ -5,7 +5,7 @@ Example Usage:
 ```bash
 cmake -S . -B build -DLLVM_DIR=$(llvm-config --cmakedir) -DCMAKE_BUILD_TYPE=Release
 
-cmake --build build -j$(nproc)
+cmake --build build -j$(getconf _NPROCESSORS_ONLN)
 
-cmake --build build --target bitcoin-tidy-tests -j$(nproc)
+cmake --build build --target bitcoin-tidy-tests -j$(getconf _NPROCESSORS_ONLN)
 ```

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -349,7 +349,7 @@ details.
 
 Build Guix (this will take a while):
 ```
-make -j$(nproc)
+make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
 Install Guix:

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -221,7 +221,7 @@ Then, pass clang as compiler to configure, and use bear to produce the `compile_
 
 ```sh
 ./autogen.sh && ./configure CC=clang CXX=clang++
-make clean && bear --config src/.bear-tidy-config -- make -j $(nproc)
+make clean && bear --config src/.bear-tidy-config -- make -j $(getconf _NPROCESSORS_ONLN)
 ```
 
 The output is denoised of errors from external dependencies.
@@ -229,13 +229,13 @@ The output is denoised of errors from external dependencies.
 To run clang-tidy on all source files:
 
 ```sh
-( cd ./src/ && run-clang-tidy  -j $(nproc) )
+( cd ./src/ && run-clang-tidy -j $(getconf _NPROCESSORS_ONLN) )
 ```
 
 To run clang-tidy on the changed source lines:
 
 ```sh
-git diff | ( cd ./src/ && clang-tidy-diff -p2 -j $(nproc) )
+git diff | ( cd ./src/ && clang-tidy-diff -p2 -j $(getconf _NPROCESSORS_ONLN) )
 ```
 
 Coding Style (Python)

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -62,10 +62,16 @@ If you do need the wallet enabled, it is common for devs to add `--with-incompat
 
 ### Make use of your threads with `make -j`
 
-If you have multiple threads on your machine, you can tell `make` to utilize all of them with:
+If you have multiple threads on your machine, you can tell `make` to utilize them with:
 
 ```sh
-make -j"$(($(nproc)+1))"
+make -j$(getconf _NPROCESSORS_ONLN)
+```
+
+Linux has the less verbose:
+
+```sh
+make -j$(nproc)
 ```
 
 ### Only build what you need


### PR DESCRIPTION
Split out of https://github.com/hebasto/bitcoin/pull/316/files#r1711537463

`nproc` is linux only, `getconf _NPROCESSORS_ONLN` is used in the Linux kernel for the same task (works on Mac as well): https://github.com/torvalds/linux/blob/master/tools/testing/selftests/rcutorture/bin/kvm-build.sh#L44

On linux:
```
# nproc
8
root@rescue ~ # getconf _NPROCESSORS_ONLN
8
```

Note that in the productivity doc the recommended core count is one less than before, seems simpler to me this way.