### PR TITLE
test: Fuzz the human-readable part of bech32 as well

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -364,7 +364,7 @@ std::string Encode(Encoding encoding, const std::string& hrp, const data& values
     std::string ret;
     ret.reserve(hrp.size() + 1 + values.size() + CHECKSUM_SIZE);
     ret += hrp;
-    ret += '1';
+    ret += SEPARATOR;
     for (const uint8_t& i : values) ret += CHARSET[i];
     for (const uint8_t& i : CreateChecksum(encoding, hrp, values)) ret += CHARSET[i];
     return ret;
@@ -374,7 +374,7 @@ std::string Encode(Encoding encoding, const std::string& hrp, const data& values
 DecodeResult Decode(const std::string& str, CharLimit limit) {
     std::vector<int> errors;
     if (!CheckCharacters(str, errors)) return {};
-    size_t pos = str.rfind('1');
+    size_t pos = str.rfind(SEPARATOR);
     if (str.size() > limit) return {};
     if (pos == str.npos || pos == 0 || pos + CHECKSUM_SIZE >= str.size()) {
         return {};
@@ -413,7 +413,7 @@ std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, Ch
         return std::make_pair("Invalid character or mixed case", std::move(error_locations));
     }
 
-    size_t pos = str.rfind('1');
+    size_t pos = str.rfind(SEPARATOR);
     if (pos == str.npos) {
         return std::make_pair("Missing separator", std::vector<int>{});
     }

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -21,8 +21,8 @@
 namespace bech32
 {
 
-/** The Bech32 and Bech32m checksum size */
-constexpr size_t CHECKSUM_SIZE = 6;
+static constexpr size_t CHECKSUM_SIZE = 6;
+static constexpr char SEPARATOR = '1';
 
 enum class Encoding {
     INVALID, //!< Failed decoding

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -4,41 +4,66 @@
 
 #include <bech32.h>
 #include <test/fuzz/fuzz.h>
+#include <test/fuzz/FuzzedDataProvider.h>
 #include <test/util/str.h>
 #include <util/strencodings.h>
 
 #include <cassert>
 #include <cstdint>
 #include <string>
-#include <utility>
 #include <vector>
 
-FUZZ_TARGET(bech32)
+FUZZ_TARGET(bech32_random_decode)
 {
-    const std::string random_string(buffer.begin(), buffer.end());
-    const auto r1 = bech32::Decode(random_string);
-    if (r1.hrp.empty()) {
-        assert(r1.encoding == bech32::Encoding::INVALID);
-        assert(r1.data.empty());
+    auto limit = bech32::CharLimit::BECH32;
+    FuzzedDataProvider fdp(buffer.data(), buffer.size());
+    auto random_string = fdp.ConsumeRandomLengthString(limit + 1);
+    auto decoded = bech32::Decode(random_string, limit);
+
+    if (decoded.hrp.empty()) {
+        assert(decoded.encoding == bech32::Encoding::INVALID);
+        assert(decoded.data.empty());
     } else {
-        assert(r1.encoding != bech32::Encoding::INVALID);
-        const std::string reencoded = bech32::Encode(r1.encoding, r1.hrp, r1.data);
+        assert(decoded.encoding != bech32::Encoding::INVALID);
+        auto reencoded = bech32::Encode(decoded.encoding, decoded.hrp, decoded.data);
         assert(CaseInsensitiveEqual(random_string, reencoded));
     }
+}
 
-    std::vector<unsigned char> input;
-    ConvertBits<8, 5, true>([&](unsigned char c) { input.push_back(c); }, buffer.begin(), buffer.end());
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki and https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+std::string GenerateRandomHRP(FuzzedDataProvider& fdp)
+{
+    std::string hrp;
+    size_t length = fdp.ConsumeIntegralInRange<size_t>(1, 83);
+    for (size_t i = 0; i < length; ++i) {
+        // Generate lowercase ASCII characters in ([33-126] - ['A'-'Z']) range
+        char c = fdp.ConsumeBool()
+                 ? fdp.ConsumeIntegralInRange<char>(33, 'A' - 1)
+                 : fdp.ConsumeIntegralInRange<char>('Z' + 1, 126);
+        hrp += c;
+    }
+    return hrp;
+}
 
-    // Input data part + 3 characters for the HRP and separator (bc1) + the checksum characters
-    if (input.size() + 3 + bech32::CHECKSUM_SIZE <= bech32::CharLimit::BECH32) {
-        // If it's possible to encode input in Bech32(m) without exceeding the bech32-character limit:
-        for (auto encoding : {bech32::Encoding::BECH32, bech32::Encoding::BECH32M}) {
-            const std::string encoded = bech32::Encode(encoding, "bc", input);
+FUZZ_TARGET(bech32_roundtrip)
+{
+    FuzzedDataProvider fdp(buffer.data(), buffer.size());
+    auto hrp = GenerateRandomHRP(fdp);
+
+    auto input_chars = fdp.ConsumeBytes<unsigned char>(fdp.ConsumeIntegralInRange<size_t>(0, 82));
+    std::vector<uint8_t> converted_input;
+    ConvertBits<8, 5, true>([&](auto c) { converted_input.push_back(c); }, input_chars.begin(), input_chars.end());
+
+    auto size = converted_input.size() + hrp.length() + std::string({bech32::SEPARATOR}).size() + bech32::CHECKSUM_SIZE;
+    if (size <= bech32::CharLimit::BECH32) {
+        for (auto encoding: {bech32::Encoding::BECH32, bech32::Encoding::BECH32M}) {
+            auto encoded = bech32::Encode(encoding, hrp, converted_input);
             assert(!encoded.empty());
-            const auto r2 = bech32::Decode(encoded);
-            assert(r2.encoding == encoding);
-            assert(r2.hrp == "bc");
-            assert(r2.data == input);
+
+            const auto decoded = bech32::Decode(encoded);
+            assert(decoded.encoding == encoding);
+            assert(decoded.hrp == hrp);
+            assert(decoded.data == converted_input);
         }
     }
 }


### PR DESCRIPTION
Instead of the static "bc" human-readable part, it's now randomly generated based on https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki and the extra restrictions in the code:

> The human-readable part, which is intended to convey the type of data, or anything else that is relevant to the reader. This part MUST contain 1 to 83 US-ASCII characters, with each character having a value in the range [33-126]. HRP validity may be further restricted by specific applications.

Since `bech32::Encode` rejects uppercase letters, we're actually generating values in the `[33-126] - ['A'-'Z']` range.

Split out of https://github.com/bitcoin/bitcoin/pull/30596/files#r1706957219