### PR TITLE
doc: Remove outdated nTx faking comment

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5399,7 +5399,7 @@ void ChainstateManager::CheckBlockIndex()
                     // and the transactions were not pruned (pindexFirstMissing
                     // is null), it is a potential candidate. The check
                     // excludes pruned blocks, because if any blocks were
-                    // pruned between pindex the current chain tip, pindex will
+                    // pruned between pindex and the current chain tip, pindex will
                     // only temporarily be added to setBlockIndexCandidates,
                     // before being moved to m_blocks_unlinked. This check
                     // could be improved to verify that if all blocks between

--- a/src/validation.h
+++ b/src/validation.h
@@ -1094,8 +1094,7 @@ public:
     //! - Verify that the hash of the resulting coinsdb matches the expected hash
     //!   per assumeutxo chain parameters.
     //! - Wait for our headers chain to include the base block of the snapshot.
-    //! - "Fast forward" the tip of the new chainstate to the base of the snapshot,
-    //!   faking nTx* block index data along the way.
+    //! - "Fast forward" the tip of the new chainstate to the base of the snapshot.
     //! - Move the new chainstate to `m_snapshot_chainstate` and make it our
     //!   ChainstateActive().
     [[nodiscard]] util::Result<CBlockIndex*> ActivateSnapshot(

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -96,8 +96,6 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.log.info("  - snapshot file referring to a block that is not in the assumeutxo parameters")
         prev_block_hash = self.nodes[0].getblockhash(SNAPSHOT_BASE_HEIGHT - 1)
         bogus_block_hash = "0" * 64  # Represents any unknown block hash
-        # The height is not used for anything critical currently, so we just
-        # confirm the manipulation in the error message
         for bad_block_hash in [bogus_block_hash, prev_block_hash]:
             with open(bad_snapshot_path, 'wb') as f:
                 f.write(valid_snapshot_contents[:11] + bytes.fromhex(bad_block_hash)[::-1] + valid_snapshot_contents[43:])


### PR DESCRIPTION
This problematic  `nTx` "faking" was removed in commit b50554babdddf452acaa51bac757736766c70e81.

So fix the wrong comment.

Also, address the typo nits from:

* https://github.com/bitcoin/bitcoin/pull/29370#discussion_r1531789314
* https://github.com/bitcoin/bitcoin/pull/30598#discussion_r1711982543