### PR TITLE
ci: Use clang-19 from apt.llvm.org

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -19,14 +19,15 @@ else
 fi
 
 export CONTAINER_NAME=ci_native_asan
-export PACKAGES="systemtap-sdt-dev clang-18 llvm-18 libclang-rt-18-dev python3-zmq qtbase5-dev qttools5-dev qttools5-dev-tools libevent-dev libboost-dev libdb5.3++-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
+export APT_LLVM_V="19"
+export PACKAGES="systemtap-sdt-dev clang-${APT_LLVM_V} llvm-${APT_LLVM_V} libclang-rt-${APT_LLVM_V}-dev python3-zmq qtbase5-dev qttools5-dev qttools5-dev-tools libevent-dev libboost-dev libdb5.3++-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="\
  -DWITH_USDT=ON -DWITH_ZMQ=ON -DWITH_BDB=ON -DWARN_INCOMPATIBLE_BDB=OFF -DBUILD_GUI=ON \
  -DSANITIZERS=address,float-divide-by-zero,integer,undefined \
- -DCMAKE_C_COMPILER=clang-18 \
- -DCMAKE_CXX_COMPILER=clang++-18 \
+ -DCMAKE_C_COMPILER=clang-${APT_LLVM_V} \
+ -DCMAKE_CXX_COMPILER=clang++-${APT_LLVM_V} \
  -DCMAKE_C_FLAGS='-ftrivial-auto-var-init=pattern' \
  -DCMAKE_CXX_FLAGS='-ftrivial-auto-var-init=pattern -Wno-error=deprecated-declarations' \
  -DAPPEND_CXXFLAGS='-std=c++23' \

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -8,7 +8,8 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_fuzz
-export PACKAGES="clang-18 llvm-18 libclang-rt-18-dev libevent-dev libboost-dev libsqlite3-dev"
+export APT_LLVM_V="19"
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} libclang-rt-${APT_LLVM_V}-dev libevent-dev libboost-dev libsqlite3-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
@@ -18,9 +19,9 @@ export CI_CONTAINER_CAP="--cap-add SYS_PTRACE"  # If run with (ASan + LSan), the
 export BITCOIN_CONFIG="\
  -DBUILD_FOR_FUZZING=ON \
  -DSANITIZERS=fuzzer,address,undefined,float-divide-by-zero,integer \
- -DCMAKE_C_COMPILER=clang-18 \
- -DCMAKE_CXX_COMPILER=clang++-18 \
+ -DCMAKE_C_COMPILER=clang-${APT_LLVM_V} \
+ -DCMAKE_CXX_COMPILER=clang++-${APT_LLVM_V} \
  -DCMAKE_C_FLAGS='-ftrivial-auto-var-init=pattern' \
  -DCMAKE_CXX_FLAGS='-ftrivial-auto-var-init=pattern' \
 "
-export LLVM_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-18"
+export LLVM_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-${APT_LLVM_V}"

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -8,8 +8,9 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
 export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
-export PACKAGES="clang-18 llvm-18 libclang-rt-18-dev libc++abi-18-dev libc++-18-dev python3-zmq"
-export DEP_OPTS="CC=clang-18 CXX='clang++-18 -stdlib=libc++'"
+export APT_LLVM_V="19"
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} libclang-rt-${APT_LLVM_V}-dev libc++abi-${APT_LLVM_V}-dev libc++-${APT_LLVM_V}-dev python3-zmq"
+export DEP_OPTS="CC=clang-${APT_LLVM_V} CXX='clang++-${APT_LLVM_V} -stdlib=libc++'"
 export GOAL="install"
 export BITCOIN_CONFIG="-DWITH_ZMQ=ON -DSANITIZERS=thread \
 -DAPPEND_CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES'"

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -21,6 +21,17 @@ if [ -n "$DPKG_ADD_ARCH" ]; then
   dpkg --add-architecture "$DPKG_ADD_ARCH"
 fi
 
+if [ -n "${APT_LLVM_V}" ]; then
+  ${CI_RETRY_EXE} apt-get update
+  ${CI_RETRY_EXE} apt-get install curl -y
+  curl "https://apt.llvm.org/llvm-snapshot.gpg.key" | tee "/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
+  (
+    # shellcheck disable=SC2034
+    source /etc/os-release
+    echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${APT_LLVM_V} main" > "/etc/apt/sources.list.d/llvm-toolchain-${VERSION_CODENAME}-${APT_LLVM_V}.list"
+  )
+fi
+
 if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
   bash -c "dnf -y install epel-release"
   bash -c "dnf -y --allowerasing install $CI_BASE_PACKAGES $PACKAGES"


### PR DESCRIPTION
A new clang version generally comes with bugfixes, new sanitizer features, deprecations, as well as new features.

Upgrade the sanitizer tasks to use the new version.