### PR TITLE
refactor: Migrate EmplaceCoinInternalDANGER to try_emplace

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -110,10 +110,7 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
     cachedCoinsUsage += coin.DynamicMemoryUsage();
-    auto [it, inserted] = cacheCoins.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(std::move(outpoint)),
-        std::forward_as_tuple(std::move(coin)));
+    auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
     if (inserted) {
         it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
     }


### PR DESCRIPTION
Leftover from https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1652853326:

[`try_emplace`](https://en.cppreference.com/w/cpp/container/map/try_emplace) doc states
> 2) Behaves like emplace except that the element is constructed as
value_type(std::piecewise_construct,
           std::forward_as_tuple(std::move(k)),
           std::forward_as_tuple(std::forward<Args>(args)...))

---

The [`DANGER` part](https://github.com/bitcoin/bitcoin/pull/19806/commits/f6e2da5fb7c6406c37612c838c998078ea8d2252#diff-095ce1081a930998a10b37358fae5499ac47f8cb6f25f5df5d88e920a54e0341R272) in the method's name refers to:
> NOT FOR GENERAL USE
