### PR TITLE
ci: Use clang-19 in msan tasks

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -36,7 +36,7 @@ if [ -n "$PIP_PACKAGES" ]; then
 fi
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
-  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-18.1.3" /msan/llvm-project
+  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-19.1.0" /msan/llvm-project
 
   cmake -G Ninja -B /msan/clang_build/ \
     -DLLVM_ENABLE_PROJECTS="clang" \


### PR DESCRIPTION
A new clang version generally comes with bugfixes, new sanitizer features, deprecations, as well as new features.

Upgrade the memory sanitizer tasks to use the new version.

(Ref https://github.com/bitcoin/bitcoin/pull/30634)