### PR TITLE
DO NOT MERGE: CCoinsCacheEntry move constructor Sonar fix

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -589,7 +589,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, CAmo
     assert(flags != NO_ENTRY);
     CCoinsCacheEntry entry;
     SetCoinsValue(value, entry.coin);
-    auto inserted = map.emplace(OUTPOINT, std::move(entry));
+    auto inserted = map.emplace(OUTPOINT, std::move(entry)); // TODO this should trigger a Sonar warning
     assert(inserted.second);
     inserted.first->second.AddFlags(flags, *inserted.first, sentinel);
     return inserted.first->second.coin.DynamicMemoryUsage();


### PR DESCRIPTION
Related to https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1703187118

WIP: First, I have to make sure I can reproduce the Sonar warning, I'll push the fix after that.