### PR TITLE
coins: Add move operations to Coin and CCoinsCacheEntry

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -43,7 +43,12 @@ public:
 
     //! construct a Coin from a CTxOut and height/coinbase information.
     Coin(CTxOut&& outIn, int nHeightIn, bool fCoinBaseIn) : out(std::move(outIn)), fCoinBase(fCoinBaseIn), nHeight(nHeightIn) {}
-    Coin(const CTxOut& outIn, int nHeightIn, bool fCoinBaseIn) : out(outIn), fCoinBase(fCoinBaseIn),nHeight(nHeightIn) {}
+    Coin(const CTxOut& outIn, int nHeightIn, bool fCoinBaseIn) : out(outIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn) {}
+
+    Coin(Coin&&) noexcept = default;
+    Coin& operator=(Coin&&) noexcept = default;
+    Coin(const Coin&) noexcept = default;
+    Coin& operator=(const Coin&) noexcept = default;
 
     void Clear() {
         out.SetNull();
@@ -168,6 +173,13 @@ public:
     };
 
     CCoinsCacheEntry() noexcept = default;
+
+    // No implicit copying, only moves.
+    CCoinsCacheEntry(CCoinsCacheEntry&&) noexcept = default;
+    CCoinsCacheEntry& operator=(CCoinsCacheEntry&&) noexcept = default;
+    CCoinsCacheEntry(const CCoinsCacheEntry&) noexcept = delete;
+    CCoinsCacheEntry& operator=(const CCoinsCacheEntry&) noexcept = delete;
+
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
     ~CCoinsCacheEntry()
     {


### PR DESCRIPTION
Related to https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1703187118, the CI build had a Sonar warning, namely:
> "std::move" should not be called on an object of a type with neither move constructor nor move-assignment operator.

Added defaulted move constructor and move assignment operator to `CCoinsCacheEntry`.

Based on comments I've also added explicit special member functions to `Coin`.