### PR TITLE
feat(build): improve dependency error reporting in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,7 +12,7 @@ if [ -z "${LIBTOOLIZE}" ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
   export LIBTOOLIZE
 fi
 command -v autoreconf >/dev/null || \
-  (echo "configuration failed, please install autoconf first" && exit 1)
+  (echo "configuration failed, please install autoconf first" >&2 && exit 1)
 autoreconf --install --force --warnings=all
 
 if expr "'$(build-aux/config.guess --timestamp)" \< "'$(depends/config.guess --timestamp)" > /dev/null; then


### PR DESCRIPTION
Improve error reporting in `autogen.sh` by redirecting the autoreconf dependency check's error message to stderr.

## Impact

This PR modifies `autogen.sh` in the root directory.

- No change to the functional behavior of these files.
- Enhances error reporting by directing error messages to stderr, aligning with best practices.

## Background

1. **9 years ago:** Added the check for the `autoreconf` dependency to the `autogen.sh` build script. This check avoids a `not found` error because the next line runs autoreconf.

   - Original error message: `./autogen.sh: 9: ./autogen.sh: autoreconf: not found`
   - Updated error message: `configuration failed, please install autoconf first`
   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/889426d37e331c9e6c914dae824663a7167effdf) to the commit.

2. **5 years ago:** Updated the check from `which` to `command -v` to improve portability and reliability as part of a large lint refactor.

   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/1ac454a3844b9b8389de0f660fa9455c0efa7140#diff-7544c8642acdd15d295934770061473e64323316cd9797fb78c1830ebba08cf2L14) to that commit.
