### PR TITLE
rpc: Set best header in reconsiderblock

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1647,6 +1647,7 @@ static RPCHelpMan reconsiderblock()
 
     BlockValidationState state;
     chainman.ActiveChainstate().ActivateBestChain(state);
+    WITH_LOCK(::cs_main, chainman.m_best_header = chainman.ActiveChain().Tip());
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -83,6 +83,8 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes[1].reconsiderblock(blocks[-4])
         # Should be back at the tip by now
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
+        # Should report consistent blockchain info
+        assert_equal(self.nodes[1].getblockchaininfo()["headers"], self.nodes[1].getblockchaininfo()["blocks"])
 
         self.log.info("Verify that invalidating an unknown block throws an error")
         assert_raises_rpc_error(-5, "Block not found", self.nodes[1].invalidateblock, "00" * 32)


### PR DESCRIPTION
The `reconsiderblock` RPC resets the blocks flags and then calls `ActivateBestChain()`. But this doesn't set `m_best_header` which leaves us in an inconsistent state until something else triggers a change, like connecting a new block. But, until then, `getblockchaininfo`, for example, reports having less headers than blocks.

I found this while working on a more extensive tests for #29553.