### PR TITLE
test: Fix test log file name

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -474,7 +474,7 @@ endif
 	  cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
 	) from $<
 	$(AM_V_at)export TEST_LOGFILE=$(abs_builddir)/$$(\
-	  echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/.log/ \
+	  echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/\&.log/ \
 	) && \
 	$(TEST_BINARY) --catch_system_errors=no -l test_suite -t "$$(\
 	  cat $< | \


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/19385 dropped `.cpp` infix (see https://github.com/bitcoin/bitcoin/pull/19385#issuecomment-1078960406 and https://github.com/bitcoin/bitcoin/pull/19385#issuecomment-1078970958). However, `src/test/README.md` still refers to the `foo_tests.cpp.log` pattern: https://github.com/bitcoin/bitcoin/blob/e682e7db7e399ce888e492eab8f99c389aae05b5/src/test/README.md?plain=1#L113

This PR restores the pre-PR19385 behaviour, as appending is easier to implement than replacing when porting this functionality to CMake.