### PR TITLE
coins: Simplify std::move to ternary in `coins.cpp`

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -197,13 +197,9 @@ bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &ha
                 // and mark it as dirty.
                 itUs = cacheCoins.try_emplace(it->first).first;
                 CCoinsCacheEntry& entry{itUs->second};
-                if (cursor.WillErase(*it)) {
-                    // Since this entry will be erased,
-                    // we can move the coin into us instead of copying it
-                    entry.coin = std::move(it->second.coin);
-                } else {
-                    entry.coin = it->second.coin;
-                }
+                cursor.WillErase(*it)
+                    ? (entry.coin = std::move(it->second.coin))
+                    : (entry.coin = it->second.coin);
                 cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
                 entry.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // We can mark it FRESH in the parent if it was FRESH in the child
@@ -231,13 +227,9 @@ bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &ha
             } else {
                 // A normal modification.
                 cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                if (cursor.WillErase(*it)) {
-                    // Since this entry will be erased,
-                    // we can move the coin into us instead of copying it
-                    itUs->second.coin = std::move(it->second.coin);
-                } else {
-                    itUs->second.coin = it->second.coin;
-                }
+                cursor.WillErase(*it)
+                    ? (itUs->second.coin = std::move(it->second.coin))
+                    : (itUs->second.coin = it->second.coin);
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
                 itUs->second.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent

--- a/src/coins.h
+++ b/src/coins.h
@@ -43,7 +43,12 @@ public:
 
     //! construct a Coin from a CTxOut and height/coinbase information.
     Coin(CTxOut&& outIn, int nHeightIn, bool fCoinBaseIn) : out(std::move(outIn)), fCoinBase(fCoinBaseIn), nHeight(nHeightIn) {}
-    Coin(const CTxOut& outIn, int nHeightIn, bool fCoinBaseIn) : out(outIn), fCoinBase(fCoinBaseIn),nHeight(nHeightIn) {}
+    Coin(const CTxOut& outIn, int nHeightIn, bool fCoinBaseIn) : out(outIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn) {}
+
+    Coin(Coin&& other) noexcept = default;
+    Coin& operator=(Coin&&) = default;
+    Coin(const Coin&) noexcept = default;
+    Coin& operator=(const Coin&) noexcept = default;
 
     void Clear() {
         out.SetNull();


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/30643

To avoid repetition and make the diff trivial between the two branches (calling the copy vs move constructors), this expression was originally written as a ternary, which unfortunately introduced an additional copy operation (and was reverted to a verbose if statement with a comment).
This change attempts to restore the signal to noise ratio of such a simple expression while retaining its performance.

See related discussions:
* https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1676800505
* https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1676801434
* https://github.com/bitcoin/bitcoin/pull/17487#discussion_r402037193

And reproducer that demonstrates the behavior of all 3 cases:
* https://gist.github.com/paplorinc/66f13938d867d82893d7ab7a2ebc5717