### PR TITLE
test: Enable detect_leaks=1 in ASAN_OPTIONS explicitly

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 set -ex
 
-export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
 export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -23,10 +23,10 @@ def get_fuzz_env(*, target, source_dir):
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
-        'UBSAN_SYMBOLIZER_PATH':symbolizer,
-        "ASAN_OPTIONS": "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
-        'ASAN_SYMBOLIZER_PATH':symbolizer,
-        'MSAN_SYMBOLIZER_PATH':symbolizer,
+        'UBSAN_SYMBOLIZER_PATH': symbolizer,
+        "ASAN_OPTIONS": "detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        'ASAN_SYMBOLIZER_PATH': symbolizer,
+        'MSAN_SYMBOLIZER_PATH': symbolizer,
     }
     if platform.system() == "Windows":
         # On Windows, `env` option must include valid `SystemRoot`.


### PR DESCRIPTION
It should be enabled by default, but being explicit can't hurt.