### PR TITLE
Refactor: MiniWallet functionality for more readable code in functional test `rpc_signtransactionwithkey.py`

### DIFF
--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -26,6 +26,8 @@ from test_framework.script_util import (
 )
 from test_framework.wallet import (
     getnewdestination,
+    MiniWallet,
+    MiniWalletMode,
 )
 from test_framework.wallet_util import (
     generate_keypair,
@@ -48,13 +50,11 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
-
+    
     def send_to_address(self, addr, amount):
-        input = {"txid": self.nodes[0].getblock(self.block_hash[self.blk_idx])["tx"][0], "vout": 0}
-        output = {addr: amount}
-        self.blk_idx += 1
-        rawtx = self.nodes[0].createrawtransaction([input], output)
-        txid = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransactionwithkey(rawtx, [self.nodes[0].get_deterministic_priv_key().key])["hex"], 0)
+        wallet = MiniWallet(self.node[0], mode=MiniWalletMode.ADDRESS_OP_TRUE)
+        result = wallet.sendrawtransaction(self.node[0], addr, amount)
+        txid = result["txid"]
         return txid
 
     def assert_signing_completed_successfully(self, signed_tx):

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -52,8 +52,9 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         self.num_nodes = 2
     
     def send_to_address(self, addr, amount):
+        script_pub_key = address_to_scriptpubkey(addr).hex()
         wallet = MiniWallet(self.node[0], mode=MiniWalletMode.ADDRESS_OP_TRUE)
-        result = wallet.sendrawtransaction(self.node[0], addr, amount)
+        result = wallet.sendrawtransaction(self.node[0], script_pub_key, amount)
         txid = result["txid"]
         return txid
 


### PR DESCRIPTION
Addressing issue #30600, this pull request simplifies the `send_to_address` functional test in rpc_signrawtransactionwithkey.py. The code is more terse with a MiniWallet object, its ADDRESS_OP_TRUE mode and `send_to` method on line 54, thus removing the "low-level" details of the transaction. Suggestions will be addressed. Thank you for reviewing!