### PR TITLE
test: XORed blocks test follow up

### DIFF
--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test support for XORed block data and undo files (`-blocksxor` option)."""
-import os
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import ErrorMatch
@@ -54,7 +53,7 @@ class BlocksXORTest(BitcoinTestFramework):
             match=ErrorMatch.PARTIAL_REGEX)
 
         self.log.info("Delete XOR key, restart node with '-blocksxor=0', check blk*.dat/rev*.dat file integrity")
-        os.remove(node.blocks_key_path)
+        node.blocks_key_path.unlink()
         self.start_node(0, extra_args=['-blocksxor=0'])
         # checklevel=2 -> verify block validity + undo data
         # nblocks=0    -> verify all blocks

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -9,7 +9,6 @@ from test_framework.test_node import ErrorMatch
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
-    read_xor_key,
     util_xor,
 )
 from test_framework.wallet import MiniWallet
@@ -39,7 +38,7 @@ class BlocksXORTest(BitcoinTestFramework):
 
         self.log.info("Shut down node and un-XOR block/undo files manually")
         self.stop_node(0)
-        xor_key = read_xor_key(node=node)
+        xor_key = node.read_xor_key()
         for data_file in sorted(block_files + undo_files):
             self.log.debug(f"Rewriting file {data_file}...")
             with open(data_file, 'rb+') as f:

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -54,7 +54,7 @@ class BlocksXORTest(BitcoinTestFramework):
             match=ErrorMatch.PARTIAL_REGEX)
 
         self.log.info("Delete XOR key, restart node with '-blocksxor=0', check blk*.dat/rev*.dat file integrity")
-        os.remove(node.blocks_path / 'xor.dat')
+        os.remove(node.blocks_key_path)
         self.start_node(0, extra_args=['-blocksxor=0'])
         # checklevel=2 -> verify block validity + undo data
         # nblocks=0    -> verify all blocks

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -5,7 +5,10 @@
 """Test support for XORed block data and undo files (`-blocksxor` option)."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.test_node import ErrorMatch
+from test_framework.test_node import (
+    ErrorMatch,
+    NULL_BLK_XOR_KEY,
+)
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
@@ -57,6 +60,8 @@ class BlocksXORTest(BitcoinTestFramework):
         # checklevel=2 -> verify block validity + undo data
         # nblocks=0    -> verify all blocks
         node.verifychain(checklevel=2, nblocks=0)
+        self.log.info("Check that blocks XOR key is recreated")
+        assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -14,7 +14,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
 from test_framework.util import (
     assert_equal,
-    read_xor_key,
     util_xor,
 )
 
@@ -43,7 +42,7 @@ class ReindexTest(BitcoinTestFramework):
         # we're generating them rather than getting them from peers), so to
         # test out-of-order handling, swap blocks 1 and 2 on disk.
         blk0 = self.nodes[0].blocks_path / "blk00000.dat"
-        xor_dat = read_xor_key(node=self.nodes[0])
+        xor_dat = self.nodes[0].read_xor_key()
 
         with open(blk0, 'r+b') as bf:
             # Read at least the first few blocks (including genesis)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -466,6 +466,10 @@ class TestNode():
         return self.chain_path / "blocks"
 
     @property
+    def blocks_key_path(self) -> Path:
+        return self.blocks_path / "xor.dat"
+
+    @property
     def wallets_path(self) -> Path:
         return self.chain_path / "wallets"
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -46,6 +46,8 @@ BITCOIND_PROC_WAIT_TIMEOUT = 60
 # The size of the blocks xor key
 # from InitBlocksdirXorKey::xor_key.size()
 NUM_XOR_BYTES = 8
+# The null blocks key (all 0s)
+NULL_BLK_XOR_KEY = bytes([0] * NUM_XOR_BYTES)
 
 
 class FailedToStartError(Exception):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -469,6 +469,11 @@ class TestNode():
     def blocks_key_path(self) -> Path:
         return self.blocks_path / "xor.dat"
 
+    def read_xor_key(self) -> bytes:
+        with open(self.blocks_key_path, "rb") as xor_f:
+            NUM_XOR_BYTES = 8 # From InitBlocksdirXorKey::xor_key.size()
+            return xor_f.read(NUM_XOR_BYTES)
+
     @property
     def wallets_path(self) -> Path:
         return self.chain_path / "wallets"

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -43,6 +43,9 @@ from .util import (
 )
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
+# The size of the blocks xor key
+# from InitBlocksdirXorKey::xor_key.size()
+NUM_XOR_BYTES = 8
 
 
 class FailedToStartError(Exception):
@@ -471,7 +474,6 @@ class TestNode():
 
     def read_xor_key(self) -> bytes:
         with open(self.blocks_key_path, "rb") as xor_f:
-            NUM_XOR_BYTES = 8 # From InitBlocksdirXorKey::xor_key.size()
             return xor_f.read(NUM_XOR_BYTES)
 
     @property

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -515,12 +515,6 @@ def check_node_connections(*, node, num_in, num_out):
     assert_equal(info["connections_out"], num_out)
 
 
-def read_xor_key(*, node):
-    with open(node.blocks_key_path, "rb") as xor_f:
-        NUM_XOR_BYTES = 8 # From InitBlocksdirXorKey::xor_key.size()
-        return xor_f.read(NUM_XOR_BYTES)
-
-
 # Transaction/Block functions
 #############################
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -516,7 +516,7 @@ def check_node_connections(*, node, num_in, num_out):
 
 
 def read_xor_key(*, node):
-    with open(node.blocks_path / "xor.dat", "rb") as xor_f:
+    with open(node.blocks_key_path, "rb") as xor_f:
         NUM_XOR_BYTES = 8 # From InitBlocksdirXorKey::xor_key.size()
         return xor_f.read(NUM_XOR_BYTES)
 


### PR DESCRIPTION
Builds on PR #30657.

Refactors `read_xor_key()` from `util.py` to `test_node.py` (comment https://github.com/bitcoin/bitcoin/pull/30657#discussion_r1723358327)

Adds a check that `xor.dat` is created when missing (comment https://github.com/bitcoin/bitcoin/pull/30657#discussion_r1717724161)

Help states:
```
-blocksxor
       Whether an XOR-key applies to blocksdir *.dat files. The created XOR-key
       will be zeros for an existing blocksdir or when `-blocksxor=0` is
       set, and random for a freshly initialized blocksdir. (default: 1)
```