### PR TITLE
doc: Extend developer-notes with file-name-only debugging fix

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -375,12 +375,12 @@ There are a few possible fixes:
 
 1. Configure source file mapping.
 
-For `gdb` create or append to `.gdbinit` file:
+For `gdb` create or append to [`.gdbinit` file](https://sourceware.org/gdb/current/onlinedocs/gdb#gdbinit-man):
 ```
 set substitute-path ./src /path/to/project/root/src
 ```
 
-For `lldb` create or append to `.lldbinit` file:
+For `lldb` create or append to [`.lldbinit` file](https://lldb.llvm.org/man/lldb.html#configuration-files):
 ```
 settings set target.source-map ./src /path/to/project/root/src
 ```

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -369,7 +369,7 @@ If you have ccache enabled, absolute paths are stripped from debug information
 with the `-fdebug-prefix-map` and `-fmacro-prefix-map` options (if supported by the
 compiler). This might break source file detection in case you move binaries
 after compilation, debug from the directory other than the project root or use
-an IDE that only supports absolute paths for debugging.
+an IDE that only supports absolute paths for debugging (e.g. it won't stop at breakpoints).
 
 There are a few possible fixes:
 
@@ -391,6 +391,8 @@ ln -s /path/to/project/root/src src
 ```
 
 3. Use `debugedit` to modify debug information in the binary.
+
+4. If your IDE has an option for this, change your breakpoints to use the file name only.
 
 ### `debug.log`
 


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/30454#discussion_r1714285678

While testing the new `cmake` build with [CLion](https://youtrack.jetbrains.com/issue/CPP-15850/Debugger-doesnt-stop-on-breakpoints-in-case-of-fdebug-prefix-map#focus=Comments-27-4926356.0-0), I noticed that the tests don't always stop at the set breakpoints, so I've updated the `developer-notes.md`, hoping it will be useful for others experiencing the same.

Added links to  gdb and lldb documentations.

Assumed a default directory (similarly to https://github.com/hebasto/bitcoin/pull/328/files#diff-4d2a64ce14cb8b971dbba9455421b04ae7ed0c489c66d983664be5632b0de4a3R19) to make the commands more realistic.

Extended the possible debugging fixes with `file-name-only` option.
