### PR TITLE
coins: remove logic for spent-and-FRESH cache entries and writing non-DIRTY entries

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -51,10 +51,6 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
         if (auto coin{base->GetCoin(outpoint)}) {
             ret->second.coin = std::move(*coin);
             cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
-            if (ret->second.coin.IsSpent()) { // TODO GetCoin cannot return spent coins
-                // The parent only has an empty entry for this outpoint; we can consider our version as fresh.
-                CCoinsCacheEntry::SetFresh(*ret, m_sentinel);
-            }
         } else {
             cacheCoins.erase(ret);
             return cacheCoins.end();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -311,12 +311,13 @@ void CCoinsViewCache::SanityCheck() const
     size_t recomputed_usage = 0;
     size_t count_flagged = 0;
     for (const auto& [_, entry] : cacheCoins) {
-        unsigned attr = 0;
-        if (entry.IsDirty()) attr |= 1;
-        if (entry.IsFresh()) attr |= 2;
-        if (entry.coin.IsSpent()) attr |= 4;
-        // Only 4 combinations are possible.
-        assert(attr != 2 && attr != 4 && attr != 6 && attr != 7);
+        if (entry.coin.IsSpent()) {
+            // A spent coin must be dirty and cannot be fresh
+            assert(entry.IsDirty() && !entry.IsFresh());
+        } else {
+            // An unspent coin must not be fresh if not dirty
+            assert(entry.IsDirty() || !entry.IsFresh());
+        }
 
         // Recompute cachedCoinsUsage.
         recomputed_usage += entry.coin.DynamicMemoryUsage();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -178,33 +178,32 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
 
 bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlockIn) {
     for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-        // Ignore non-dirty entries (optimization).
         if (!it->second.IsDirty()) {
-            continue;
+            throw std::logic_error("A non-DIRTY coin was returned from the cursor in BatchWrite");
+        }
+        if (it->second.IsFresh() && it->second.coin.IsSpent()) {
+            throw std::logic_error("A FRESH coin was not removed when it was spent");
         }
         CCoinsMap::iterator itUs = cacheCoins.find(it->first);
         if (itUs == cacheCoins.end()) {
             // The parent cache does not have an entry, while the child cache does.
-            // We can ignore it if it's both spent and FRESH in the child
-            if (!(it->second.IsFresh() && it->second.coin.IsSpent())) {
-                // Create the coin in the parent cache, move the data up
-                // and mark it as dirty.
-                itUs = cacheCoins.try_emplace(it->first).first;
-                CCoinsCacheEntry& entry{itUs->second};
-                if (cursor.WillErase(*it)) {
-                    // Since this entry will be erased,
-                    // we can move the coin into us instead of copying it
-                    entry.coin = std::move(it->second.coin);
-                } else {
-                    entry.coin = it->second.coin;
-                }
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
-                // We can mark it FRESH in the parent if it was FRESH in the child
-                // Otherwise it might have just been flushed from the parent's cache
-                // and already exist in the grandparent
-                if (it->second.IsFresh()) CCoinsCacheEntry::SetFresh(*itUs, m_sentinel);
+            // Create the coin in the parent cache, move the data up
+            // and mark it as dirty.
+            itUs = cacheCoins.try_emplace(it->first).first;
+            CCoinsCacheEntry& entry{itUs->second};
+            if (cursor.WillErase(*it)) {
+                // Since this entry will be erased,
+                // we can move the coin into us instead of copying it
+                entry.coin = std::move(it->second.coin);
+            } else {
+                entry.coin = it->second.coin;
             }
+            cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
+            CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
+            // We can mark it FRESH in the parent if it was FRESH in the child
+            // Otherwise it might have just been flushed from the parent's cache
+            // and already exist in the grandparent
+            if (it->second.IsFresh()) CCoinsCacheEntry::SetFresh(*itUs, m_sentinel);
         } else {
             // Found the entry in the parent cache
             if (it->second.IsFresh() && !itUs->second.coin.IsSpent()) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -268,8 +268,7 @@ bool CCoinsViewCache::Sync()
 
 void CCoinsViewCache::Uncache(const COutPoint& hash)
 {
-    CCoinsMap::iterator it = cacheCoins.find(hash);
-    if (it != cacheCoins.end() && !it->second.IsDirty() && !it->second.IsFresh()) {
+    if (auto it{cacheCoins.find(hash)}; it != cacheCoins.end() && !it->second.IsDirty()) {
         cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
         TRACEPOINT(utxocache, uncache,
                hash.hash.data(),
@@ -316,14 +315,14 @@ void CCoinsViewCache::SanityCheck() const
         if (entry.IsDirty()) attr |= 1;
         if (entry.IsFresh()) attr |= 2;
         if (entry.coin.IsSpent()) attr |= 4;
-        // Only 5 combinations are possible.
-        assert(attr != 2 && attr != 4 && attr != 7);
+        // Only 4 combinations are possible.
+        assert(attr != 2 && attr != 4 && attr != 6 && attr != 7);
 
         // Recompute cachedCoinsUsage.
         recomputed_usage += entry.coin.DynamicMemoryUsage();
 
         // Count the number of entries we expect in the linked list.
-        if (entry.IsDirty() || entry.IsFresh()) ++count_flagged;
+        if (entry.IsDirty()) ++count_flagged;
     }
     // Iterate over the linked list of flagged entries.
     size_t count_linked = 0;
@@ -332,7 +331,7 @@ void CCoinsViewCache::SanityCheck() const
         assert(it->second.Next()->second.Prev() == it);
         assert(it->second.Prev()->second.Next() == it);
         // Verify they are actually flagged.
-        assert(it->second.IsDirty() || it->second.IsFresh());
+        assert(it->second.IsDirty());
         // Count the number of entries actually in the list.
         ++count_linked;
     }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -79,20 +79,18 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         if (!it->second.coin.IsSpent()) {
             throw std::logic_error("Attempted to overwrite an unspent coin (when possible_overwrite is false)");
         }
-        // If the coin exists in this cache as a spent coin and is DIRTY, then
+        // If the coin exists in this cache as a spent coin, then
         // its spentness hasn't been flushed to the parent cache. We're
         // re-adding the coin to this cache now but we can't mark it as FRESH.
-        // If we mark it FRESH and then spend it before the cache is flushed
-        // we would remove it from this cache and would never flush spentness
-        // to the parent cache.
+        // A spent FRESH coin cannot exist in the cache because a FRESH coin
+        // is simply erased when it is spent.
         //
         // Re-adding a spent coin can happen in the case of a re-org (the coin
         // is 'spent' when the block adding it is disconnected and then
         // re-added when it is also added in a newly connected block).
         //
-        // If the coin doesn't exist in the current cache, or is spent but not
-        // DIRTY, then it can be marked FRESH.
-        fresh = !it->second.IsDirty();
+        // If the coin doesn't exist in the current cache then it can be marked FRESH.
+        fresh = inserted;
     }
     it->second.coin = std::move(coin);
     CCoinsCacheEntry::SetDirty(*it, m_sentinel);

--- a/src/coins.h
+++ b/src/coins.h
@@ -102,7 +102,6 @@ using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
  * - unspent, FRESH, DIRTY (e.g. a new coin created in the cache)
  * - unspent, not FRESH, DIRTY (e.g. a coin changed in the cache during a reorg)
  * - unspent, not FRESH, not DIRTY (e.g. an unspent coin fetched from the parent cache)
- * - spent, FRESH, not DIRTY (e.g. a spent coin fetched from the parent cache)
  * - spent, not FRESH, DIRTY (e.g. a coin is spent and spentness needs to be flushed to the parent)
  */
 struct CCoinsCacheEntry
@@ -117,12 +116,6 @@ private:
      * the parent cache for batch writing. This is a performance optimization
      * compared to giving all entries in the cache to the parent and having the
      * parent scan for only modified entries.
-     *
-     * FRESH-but-not-DIRTY coins can not occur in practice, since that would
-     * mean a spent coin exists in the parent CCoinsView and not in the child
-     * CCoinsViewCache. Nevertheless, if a spent coin is retrieved from the
-     * parent cache, the FRESH-but-not-DIRTY coin will be tracked by the linked
-     * list and deleted when Sync or Flush is called on the CCoinsViewCache.
      */
     CoinsCachePair* m_prev{nullptr};
     CoinsCachePair* m_next{nullptr};

--- a/src/coins.h
+++ b/src/coins.h
@@ -109,7 +109,7 @@ struct CCoinsCacheEntry
 private:
     /**
      * These are used to create a doubly linked list of flagged entries.
-     * They are set in SetDirty, SetFresh, and unset in SetClean.
+     * They are set in SetDirty and unset in SetClean.
      * A flagged entry is any entry that is either DIRTY, FRESH, or both.
      *
      * DIRTY entries are tracked so that only modified entries can be passed to
@@ -167,8 +167,10 @@ public:
         SetClean();
     }
 
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(DIRTY, pair, sentinel); }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); }
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
+    {
+        AddFlags(fresh ? FRESH | DIRTY : DIRTY, pair, sentinel);
+    }
 
     void SetClean() noexcept
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -181,17 +181,15 @@ public:
     bool IsDirty() const noexcept { return m_flags & DIRTY; }
     bool IsFresh() const noexcept { return m_flags & FRESH; }
 
-    //! Only call Next when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Next() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_next;
     }
 
-    //! Only call Prev when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Prev() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_prev;
     }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -48,11 +48,7 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
     {
-        if (auto it{map_.find(outpoint)}; it != map_.end()) {
-            if (!it->second.IsSpent() || m_rng.randbool()) {
-                return it->second; // TODO spent coins shouldn't be returned
-            }
-        }
+        if (auto it{map_.find(outpoint)}; it != map_.end() && !it->second.IsSpent()) return it->second;
         return std::nullopt;
     }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -56,14 +56,12 @@ public:
 
     bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256& hashBlock) override
     {
-        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)){
-            if (it->second.IsDirty()) {
-                // Same optimization used in CCoinsViewDB is to only write dirty entries.
-                map_[it->first] = it->second.coin;
-                if (it->second.coin.IsSpent() && m_rng.randrange(3) == 0) {
-                    // Randomly delete empty entries on write.
-                    map_.erase(it->first);
-                }
+        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
+            assert(it->second.IsDirty());
+            map_[it->first] = it->second.coin;
+            if (it->second.coin.IsSpent() && m_rng.randrange(3) == 0) {
+                // Randomly delete spent entries on write.
+                map_.erase(it->first);
             }
         }
         if (!hashBlock.IsNull())

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE(ccoins_add)
         CheckAddCoin(base_value, MISSING,            VALUE3, VALUE3_DIRTY_FRESH,   false);
         CheckAddCoin(base_value, MISSING,            VALUE3, VALUE3_DIRTY,         true );
 
-        CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY_FRESH,   false);
+        CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY,         false);
         CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY,         true );
         CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   false);
         CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   true );

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -562,7 +562,7 @@ constexpr CAmount VALUE2{200};
 constexpr CAmount VALUE3{300};
 
 struct CoinEntry {
-    enum class State { CLEAN, DIRTY, FRESH, DIRTY_FRESH };
+    enum class State { CLEAN, DIRTY, DIRTY_FRESH };
 
     const CAmount value;
     const State state;
@@ -574,12 +574,11 @@ struct CoinEntry {
 
     constexpr bool IsDirtyFresh() const { return state == State::DIRTY_FRESH; }
     constexpr bool IsDirty() const { return state == State::DIRTY || IsDirtyFresh(); }
-    constexpr bool IsFresh() const { return state == State::FRESH || IsDirtyFresh(); }
 
     static constexpr State ToState(const bool is_dirty, const bool is_fresh) {
         if (is_dirty && is_fresh) return State::DIRTY_FRESH;
         if (is_dirty) return State::DIRTY;
-        if (is_fresh) return State::FRESH;
+        assert(!is_fresh);
         return State::CLEAN;
     }
 };
@@ -589,24 +588,18 @@ using CoinOrError = std::variant<MaybeCoin, std::string>;
 
 constexpr MaybeCoin MISSING           {std::nullopt};
 constexpr MaybeCoin SPENT_DIRTY       {{SPENT,  CoinEntry::State::DIRTY}};
-constexpr MaybeCoin SPENT_DIRTY_FRESH {{SPENT,  CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin SPENT_FRESH       {{SPENT,  CoinEntry::State::FRESH}};
 constexpr MaybeCoin SPENT_CLEAN       {{SPENT,  CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE1_DIRTY      {{VALUE1, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE1_DIRTY_FRESH{{VALUE1, CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin VALUE1_FRESH      {{VALUE1, CoinEntry::State::FRESH}};
 constexpr MaybeCoin VALUE1_CLEAN      {{VALUE1, CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE2_DIRTY      {{VALUE2, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE2_DIRTY_FRESH{{VALUE2, CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin VALUE2_FRESH      {{VALUE2, CoinEntry::State::FRESH}};
 constexpr MaybeCoin VALUE2_CLEAN      {{VALUE2, CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE3_DIRTY      {{VALUE3, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE3_DIRTY_FRESH{{VALUE3, CoinEntry::State::DIRTY_FRESH}};
 
 constexpr auto EX_OVERWRITE_UNSPENT{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"};
 constexpr auto EX_FRESH_MISAPPLIED {"FRESH flag misapplied to coin that exists in parent cache"};
-constexpr auto EX_NON_DIRTY_WRITE{"A non-DIRTY coin was returned from the cursor in BatchWrite"};
-constexpr auto EX_FRESH_AND_SPENT{"A FRESH coin was not removed when it was spent"};
 
 static void SetCoinsValue(const CAmount value, Coin& coin)
 {
@@ -626,8 +619,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, cons
     SetCoinsValue(cache_coin.value, entry.coin);
     auto [iter, inserted] = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted);
-    if (cache_coin.IsDirty()) CCoinsCacheEntry::SetDirty(*iter, sentinel);
-    if (cache_coin.IsFresh()) CCoinsCacheEntry::SetFresh(*iter, sentinel);
+    if (cache_coin.IsDirty()) CCoinsCacheEntry::SetDirty(*iter, sentinel, cache_coin.IsDirtyFresh());
     return iter->second.coin.DynamicMemoryUsage();
 }
 
@@ -687,12 +679,9 @@ BOOST_AUTO_TEST_CASE(ccoins_access)
         CheckAccessCoin(base_value, MISSING,            base_value == VALUE1 ? VALUE1_CLEAN : MISSING);
 
         CheckAccessCoin(base_value, SPENT_CLEAN,        SPENT_CLEAN       );
-        CheckAccessCoin(base_value, SPENT_FRESH,        SPENT_FRESH       );
         CheckAccessCoin(base_value, SPENT_DIRTY,        SPENT_DIRTY       );
-        CheckAccessCoin(base_value, SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
 
         CheckAccessCoin(base_value, VALUE2_CLEAN,       VALUE2_CLEAN      );
-        CheckAccessCoin(base_value, VALUE2_FRESH,       VALUE2_FRESH      );
         CheckAccessCoin(base_value, VALUE2_DIRTY,       VALUE2_DIRTY      );
         CheckAccessCoin(base_value, VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
     }
@@ -717,12 +706,9 @@ BOOST_AUTO_TEST_CASE(ccoins_spend)
         CheckSpendCoins(base_value, MISSING,            base_value == VALUE1 ? SPENT_DIRTY : MISSING);
 
         CheckSpendCoins(base_value, SPENT_CLEAN,        SPENT_DIRTY);
-        CheckSpendCoins(base_value, SPENT_FRESH,        MISSING    );
         CheckSpendCoins(base_value, SPENT_DIRTY,        SPENT_DIRTY);
-        CheckSpendCoins(base_value, SPENT_DIRTY_FRESH,  MISSING    );
 
         CheckSpendCoins(base_value, VALUE2_CLEAN,       SPENT_DIRTY);
-        CheckSpendCoins(base_value, VALUE2_FRESH,       MISSING    );
         CheckSpendCoins(base_value, VALUE2_DIRTY,       SPENT_DIRTY);
         CheckSpendCoins(base_value, VALUE2_DIRTY_FRESH, MISSING    );
     }
@@ -756,17 +742,11 @@ BOOST_AUTO_TEST_CASE(ccoins_add)
 
         CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY,         false);
         CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY,         true );
-        CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   false);
-        CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   true );
         CheckAddCoin(base_value, SPENT_DIRTY,        VALUE3, VALUE3_DIRTY,         false);
         CheckAddCoin(base_value, SPENT_DIRTY,        VALUE3, VALUE3_DIRTY,         true );
-        CheckAddCoin(base_value, SPENT_DIRTY_FRESH,  VALUE3, VALUE3_DIRTY_FRESH,   false);
-        CheckAddCoin(base_value, SPENT_DIRTY_FRESH,  VALUE3, VALUE3_DIRTY_FRESH,   true );
 
         CheckAddCoin(base_value, VALUE2_CLEAN,       VALUE3, EX_OVERWRITE_UNSPENT, false);
         CheckAddCoin(base_value, VALUE2_CLEAN,       VALUE3, VALUE3_DIRTY,         true );
-        CheckAddCoin(base_value, VALUE2_FRESH,       VALUE3, EX_OVERWRITE_UNSPENT, false);
-        CheckAddCoin(base_value, VALUE2_FRESH,       VALUE3, VALUE3_DIRTY_FRESH,   true );
         CheckAddCoin(base_value, VALUE2_DIRTY,       VALUE3, EX_OVERWRITE_UNSPENT, false);
         CheckAddCoin(base_value, VALUE2_DIRTY,       VALUE3, VALUE3_DIRTY,         true );
         CheckAddCoin(base_value, VALUE2_DIRTY_FRESH, VALUE3, EX_OVERWRITE_UNSPENT, false);
@@ -796,49 +776,28 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
      */
     CheckWriteCoins(MISSING,            MISSING,            MISSING            );
     CheckWriteCoins(MISSING,            SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(MISSING,            SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(MISSING,            VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(MISSING,            VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_CLEAN,        MISSING,            SPENT_CLEAN        );
-    CheckWriteCoins(SPENT_FRESH,        MISSING,            SPENT_FRESH        );
     CheckWriteCoins(SPENT_DIRTY,        MISSING,            SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  MISSING,            SPENT_DIRTY_FRESH  );
 
     CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
-    CheckWriteCoins(SPENT_FRESH,        SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(SPENT_FRESH,        SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
 
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY       );
-    CheckWriteCoins(SPENT_FRESH,        VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
-    CheckWriteCoins(SPENT_FRESH,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_DIRTY,        VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_DIRTY,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY       );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
 
     CheckWriteCoins(VALUE1_CLEAN,       MISSING,            VALUE1_CLEAN       );
-    CheckWriteCoins(VALUE1_FRESH,       MISSING,            VALUE1_FRESH       );
     CheckWriteCoins(VALUE1_DIRTY,       MISSING,            VALUE1_DIRTY       );
     CheckWriteCoins(VALUE1_DIRTY_FRESH, MISSING,            VALUE1_DIRTY_FRESH );
     CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
-    CheckWriteCoins(VALUE1_FRESH,       SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(VALUE1_FRESH,       SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
 
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
-    CheckWriteCoins(VALUE1_FRESH,       VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
-    CheckWriteCoins(VALUE1_FRESH,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY,       VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(VALUE1_DIRTY,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY_FRESH, VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
@@ -849,14 +808,10 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     // cases). The loop below covers these cases and makes sure the parent cache
     // is always left unchanged.
     for (const MaybeCoin& parent : {MISSING,
-                                    SPENT_CLEAN, SPENT_DIRTY, SPENT_FRESH, SPENT_DIRTY_FRESH,
-                                    VALUE1_CLEAN, VALUE1_DIRTY, VALUE1_FRESH, VALUE1_DIRTY_FRESH}) {
+                                    SPENT_CLEAN, SPENT_DIRTY,
+                                    VALUE1_CLEAN, VALUE1_DIRTY, VALUE1_DIRTY_FRESH}) {
         for (const MaybeCoin& child : {MISSING, SPENT_CLEAN, VALUE2_CLEAN}) {
             auto expected{CoinOrError{parent}};
-            CheckWriteCoins(parent, child, expected);
-        }
-        for (const MaybeCoin& child : {SPENT_FRESH, VALUE2_FRESH}) {
-            auto expected{CoinOrError{EX_NON_DIRTY_WRITE}};
             CheckWriteCoins(parent, child, expected);
         }
     }

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -154,9 +154,10 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
 
-    // Check that setting FRESH on new node inserts it after n1
+    // Check that setting DIRTY and FRESH on new node inserts it after n1
+    CCoinsCacheEntry::SetDirty(n2, sentinel);
     CCoinsCacheEntry::SetFresh(n2, sentinel);
-    BOOST_CHECK(n2.second.IsFresh() && !n2.second.IsDirty());
+    BOOST_CHECK(n2.second.IsDirty() && n2.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -155,21 +155,12 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
 
     // Check that setting DIRTY and FRESH on new node inserts it after n1
-    CCoinsCacheEntry::SetDirty(n2, sentinel);
-    CCoinsCacheEntry::SetFresh(n2, sentinel);
+    CCoinsCacheEntry::SetDirty(n2, sentinel, true);
     BOOST_CHECK(n2.second.IsDirty() && n2.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
-
-    // Check that we can set extra state, but they don't change our position
-    CCoinsCacheEntry::SetFresh(n1, sentinel);
-    BOOST_CHECK(n1.second.IsDirty() && n1.second.IsFresh());
-    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
-    BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
-    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
-    BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
 
     // Check that we can clear state then re-set it
     n1.second.SetClean();

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -164,7 +164,9 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                     coins_view_cache.BatchWrite(cursor, best_block);
                     expected_code_path = true;
                 } catch (const std::logic_error& e) {
-                    if (e.what() == std::string{"FRESH flag misapplied to coin that exists in parent cache"}) {
+                    if (e.what() == std::string{"FRESH flag misapplied to coin that exists in parent cache"}
+                        || e.what() == std::string{"A FRESH coin was not removed when it was spent"}
+                        || e.what() == std::string{"A non-DIRTY coin was returned from the cursor in BatchWrite"}) {
                         expected_code_path = true;
                     }
                 }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -163,25 +163,13 @@ public:
     bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) final
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-            if (it->second.IsDirty()) {
-                if (it->second.coin.IsSpent()) {
-                    m_data.erase(it->first);
-                } else if (cursor.WillErase(*it)) {
-                    m_data[it->first] = std::move(it->second.coin);
-                } else {
-                    m_data[it->first] = it->second.coin;
-                }
+            assert(it->second.IsDirty());
+            if (it->second.coin.IsSpent()) {
+                m_data.erase(it->first);
+            } else if (cursor.WillErase(*it)) {
+                m_data[it->first] = std::move(it->second.coin);
             } else {
-                /* For non-dirty entries being written, compare them with what we have. */
-                auto it2 = m_data.find(it->first);
-                if (it->second.coin.IsSpent()) {
-                    assert(it2 == m_data.end() || it2->second.IsSpent());
-                } else {
-                    assert(it2 != m_data.end());
-                    assert(it->second.coin.out == it2->second.out);
-                    assert(it->second.coin.fCoinBase == it2->second.fCoinBase);
-                    assert(it->second.coin.nHeight == it2->second.nHeight);
-                }
+                m_data[it->first] = it->second.coin;
             }
         }
         return true;

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -138,8 +138,6 @@ struct CacheLevel
 /** Class for the base of the hierarchy (roughly simulating a memory-backed CCoinsViewDB).
  *
  * The initial state consists of the empty UTXO set.
- * Coins whose output index is 4 (mod 5) have GetCoin() always succeed after being spent.
- * This exercises code paths with spent, non-DIRTY cache entries.
  */
 class CoinsViewBottom final : public CCoinsView
 {
@@ -148,14 +146,13 @@ class CoinsViewBottom final : public CCoinsView
 public:
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const final
     {
-        // TODO GetCoin shouldn't return spent coins
-        if (auto it = m_data.find(outpoint); it != m_data.end()) return it->second;
+        if (auto it{m_data.find(outpoint)}; it != m_data.end() && !it->second.IsSpent()) return it->second;
         return std::nullopt;
     }
 
     bool HaveCoin(const COutPoint& outpoint) const final
     {
-        return m_data.count(outpoint);
+        return GetCoin(outpoint).has_value();
     }
 
     uint256 GetBestBlock() const final { return {}; }
@@ -167,7 +164,7 @@ public:
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
             if (it->second.IsDirty()) {
-                if (it->second.coin.IsSpent() && (it->first.n % 5) != 4) {
+                if (it->second.coin.IsSpent()) {
                     m_data.erase(it->first);
                 } else if (cursor.WillErase(*it)) {
                     m_data[it->first] = std::move(it->second.coin);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -12,6 +12,7 @@
 #include <random.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/vector.h>
 
 #include <cassert>
@@ -93,7 +94,6 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
 bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {
     CDBBatch batch(*m_db);
     size_t count = 0;
-    size_t changed = 0;
     assert(!hashBlock.IsNull());
 
     uint256 old_tip = GetBestBlock();
@@ -116,22 +116,17 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     batch.Erase(DB_BEST_BLOCK);
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
-    for (auto it{cursor.Begin()}; it != cursor.End();) {
-        if (it->second.IsDirty()) {
-            CoinEntry entry(&it->first);
-            if (it->second.coin.IsSpent()) {
-                batch.Erase(entry);
-            } else {
-                batch.Write(entry, it->second.coin);
-            }
-
-            changed++;
+    for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
+        Assume(it->second.IsDirty());
+        CoinEntry entry(&it->first);
+        if (it->second.coin.IsSpent()) {
+            batch.Erase(entry);
+        } else {
+            batch.Write(entry, it->second.coin);
         }
         count++;
-        it = cursor.NextAndMaybeErase(*it);
         if (batch.ApproximateSize() > m_options.batch_write_bytes) {
             LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.ApproximateSize() * (1.0 / 1048576.0));
-
             m_db->WriteBatch(batch);
             batch.Clear();
             if (m_options.simulate_crash_ratio) {
@@ -150,7 +145,7 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
 
     LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() * (1.0 / 1048576.0));
     bool ret = m_db->WriteBatch(batch);
-    LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);
+    LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs to coin database...", count);
     return ret;
 }
 


### PR DESCRIPTION
Following up from https://github.com/bitcoin/bitcoin/pull/28280#discussion_r1655477509, which suggested a revival of #18746.

`GetCoin` will never return `true` for a spent entry, so we can safely assume that any entry we fetch will not be spent. This lets us remove the only non-test code path which adds a FRESH-but-not-DIRTY entry to the flagged linked list. This in turn ensures all entries being sent to `BatchWrite` are `DIRTY` entries.

A corollary is that all spent coins must be DIRTY. The only time a coin can be spent and not DIRTY is when the `CCoinsViewCacheEntry` is created with an empty coin. The last commit makes this more clear by checking for freshness if inserted instead of if spent and not DIRTY.

This is a pure refactor removing dead code which handles a non-existent corner case of a FRESH-but-not-DIRTY entry in the `CCoinsViewCache` or a spent entry in `CCoinsViewDB`. There is a lot of test code which tries to exercise this corner case, which is also updated in this PR to behave like non-test code.