### PR TITLE
test: fix check SENDTXRCNCL without WTXIDRELAY is ignored in `p2p_sendtxrcncl.py`

### DIFF
--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -217,7 +217,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
 
         self.log.info('SENDTXRCNCL without WTXIDRELAY is ignored (recon state is erased after VERACK)')
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(wtxidrelay=False), send_version=True, wait_for_verack=False)
-        with self.nodes[0].assert_debug_log(['Forget txreconciliation state of peer']):
+        with self.nodes[0].assert_debug_log(['Register peer', 'Forget txreconciliation state of peer']):
             peer.send_message(create_sendtxrcncl_msg())
             peer.send_message(msg_verack())
         self.nodes[0].disconnect_p2ps()


### PR DESCRIPTION
Sending a `verack` without `wtxidrelay`, regardless of `sendtxrcncl`, will trigger `Forget txreconciliation state of peer`. To ensure that we are testing that `SENDTXRCNCL` without `WTXIDRELAY` is ignored, we can first verify that the peer was registered.