### PR TITLE
build: Mark `x86_64-linux-gnu` release binaries as CET-enabled

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -230,6 +230,10 @@ case "$HOST" in
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 
+case "$HOST" in
+    x86_64-linux-gnu)  HARDENED_LDFLAGS="-Wl,-z,cet-report=error" ;;
+esac
+
 # Make $HOST-specific native binaries from depends available in $PATH
 export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 mkdir -p "$DISTSRC"
@@ -251,7 +255,8 @@ mkdir -p "$DISTSRC"
                     ${CONFIGFLAGS} \
                     ${HOST_CFLAGS:+CFLAGS="${HOST_CFLAGS}"} \
                     ${HOST_CXXFLAGS:+CXXFLAGS="${HOST_CXXFLAGS}"} \
-                    ${HOST_LDFLAGS:+LDFLAGS="${HOST_LDFLAGS}"}
+                    ${HOST_LDFLAGS:+LDFLAGS="${HOST_LDFLAGS}"} \
+                    ${HARDENED_LDFLAGS:+HARDENED_LDFLAGS="${HARDENED_LDFLAGS}"}
 
     sed -i.old 's/-lstdc++ //g' config.status libtool
 

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -480,6 +480,7 @@ inspecting signatures in Mach-O binaries.")
           `(append ,flags
             ;; https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html
             (list "--enable-stack-protector=all",
+                  "--enable-cet",
                   "--enable-bind-now",
                   "--disable-werror",
                   building-on)))

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -39,4 +39,12 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
+
+ifeq (86,$(findstring 86,$(host_arch)))
+ifeq ($(NO_HARDEN),)
+linux_CFLAGS += -fcf-protection=full
+linux_CXXFLAGS += -fcf-protection=full
+endif
+endif
+
 linux_cmake_system=Linux


### PR DESCRIPTION
CET is Intel’s [Control-flow Enforcement Technology](https://www.intel.com/content/www/us/en/developer/articles/technical/technical-look-control-flow-enforcement-technology.html).

The current GCC implementation of the `-fcf-protection` option is [based](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection) on CET for `x86_64-linux-gnu`.

However, on the master branch @ d79ea809d28197b1b4e3748aa1715272b53601d0, the release binaries are not marked as CET-enabled:
```
$ env HOSTS=x86_64-linux-gnu ./contrib/guix/guix-build
$ tar -xf guix-build-d79ea809d281/output/x86_64-linux-gnu/bitcoin-d79ea809d281-x86_64-linux-gnu.tar.gz
$ readelf -n bitcoin-d79ea809d281/bin/bitcoind | grep -A 5 "\.note\.gnu\.property"
Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000020	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature used: x86, x87, XMM, YMM, XSAVE
	x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3

```

This occurs because not all object files, including those from the depends and the `secp256k1` subtree, have the required properties.

This PR resolves the issue by explicitly enabling `-fcf-protection=full` for all object files, which will be beneficial for all targets, not just `x86_64-linux-gnu`.

With this PR:
```
$ env HOSTS=x86_64-linux-gnu ./contrib/guix/guix-build
$ tar -xf guix-build-c5bed747e6e9/output/x86_64-linux-gnu/bitcoin-c5bed747e6e9-x86_64-linux-gnu.tar.gz
$ readelf -n bitcoin-c5bed747e6e9/bin/bitcoind | grep -A 6 "\.note\.gnu\.property"
Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000030	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature: IBT, SHSTK
	x86 feature used: x86, x87, XMM, YMM, XSAVE
	x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3

```

Please note `Properties: x86 feature: IBT, SHSTK`.

A runtime check on Ubuntu 24.04 (GLIBC 2.39):
```
$ export GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK
$ bitcoin-c5bed747e6e9/bin/bitcoind -printtoconsole=0 &
$ cat /proc/$(cat .bitcoin/bitcoind.pid)/status | grep x86
x86_Thread_features:	shstk 
x86_Thread_features_locked:	shstk wrss 
```

As a follow-up, a check for the `IBT` and `SHSTK` can be added to the `contrib/devtools/security-check.py` script.

Fixes https://github.com/bitcoin/bitcoin/issues/30677.