### PR TITLE
test: replace deprecated secp256k1 context flags usage

### DIFF
--- a/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
+++ b/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
@@ -17,7 +17,7 @@ int ec_seckey_export_der(const secp256k1_context* ctx, unsigned char* seckey, si
 FUZZ_TARGET(secp256k1_ec_seckey_import_export_der)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    secp256k1_context* secp256k1_context_sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context* secp256k1_context_sign = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     {
         std::vector<uint8_t> out32(32);
         (void)ec_seckey_import_der(secp256k1_context_sign, out32.data(), ConsumeFixedLengthByteVector(fuzzed_data_provider, CKey::SIZE).data(), CKey::SIZE);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(bip341_test_h)
 BOOST_AUTO_TEST_CASE(key_schnorr_tweak_smoke_test)
 {
     // Sanity check to ensure we get the same tweak using CPubKey vs secp256k1 functions
-    secp256k1_context* secp256k1_context_sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context* secp256k1_context_sign = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
 
     CKey key;
     key.MakeNewKey(true);


### PR DESCRIPTION
The flags `SECP256K1_CONTEXT_{SIGN,VERIFY}` have been marked as deprecated since libsecp256k1 version 0.2 (released in December 2022), with the recommendation to use SECP256K1_CONTEXT_NONE instead, see https://github.com/bitcoin-core/secp256k1/pull/1126 and https://github.com/bitcoin-core/secp256k1/blob/1988855079fa8161521b86515e77965120fdc734/CHANGELOG.md?plain=1#L132. Note that in contrast to other deprecated functions/variables, these defines don't have a deprecated attribute and hence don't lead to a compiler warning (see https://github.com/bitcoin-core/secp256k1/pull/1126#discussion_r922105271), so they are not easily detected.