### PR TITLE
fuzz: speed up addrman

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -236,7 +236,7 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
         }
     }
     AddrManDeterministic& addr_man = *addr_man_ptr;
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 1000) {
         CallOneOf(
             fuzzed_data_provider,
             [&] {
@@ -247,7 +247,8 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
             },
             [&] {
                 std::vector<CAddress> addresses;
-                LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
+                // Maximum number of addresses permitted in an ADDR message (MAX_ADDR_TO_SEND).
+                LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 1000) {
                     addresses.push_back(ConsumeAddress(fuzzed_data_provider));
                 }
                 auto net_addr = ConsumeNetAddr(fuzzed_data_provider);


### PR DESCRIPTION
There is no need to iterate 10'000 times and
call `Add` 10'000 times at once (we only add
1000 addresses at once in practice). These values
were introduced in 214d9055acdd72189a2f415477ce472ca8db4191.

I see an avg of 40 exec/s on master for this target and 115 exec/s on this branch.