### PR TITLE
devtools, utxo-snapshot: Fix block height out of range in script

### DIFF
--- a/contrib/devtools/utxo_snapshot.sh
+++ b/contrib/devtools/utxo_snapshot.sh
@@ -36,6 +36,16 @@ if (( GENERATE_AT_HEIGHT < PRUNED )); then
   exit 1
 fi
 
+# Check current block height to ensure the node has synchronized past the required block
+CURRENT_BLOCK_HEIGHT=$(${BITCOIN_CLI_CALL} getblockcount)
+PIVOT_BLOCK_HEIGHT=$(( GENERATE_AT_HEIGHT + 1 ))
+
+if (( PIVOT_BLOCK_HEIGHT > CURRENT_BLOCK_HEIGHT )); then
+  (>&2 echo "Error: The node has not yet synchronized to block height ${PIVOT_BLOCK_HEIGHT}.")
+  (>&2 echo "Please wait until the node has synchronized past this block height and try again.")
+  exit 1
+fi
+
 # Early exit if file at OUTPUT_PATH already exists
 if [[ -e "$OUTPUT_PATH" ]]; then
   (>&2 echo "Error: $OUTPUT_PATH already exists or is not a valid path.")


### PR DESCRIPTION
<details>
<summary>Fixing a <a href="https://github.com/bitcoin/bitcoin/pull/28553#pullrequestreview-2251032570">bug</a> in <code>utxo_snapshot.sh</code>.</summary>

```
/contrib/devtools/utxo_snapshot.sh 840000 snapshot2.dat ./src/bitcoin-cli -datadir=${AU_DATADIR}
Do you want to disable network activity (setnetworkactive false) before running invalidateblock? (Y/n): 
Disabling network activity
false
error code: -8
error message:
Block height out of range
```

And the user will see the following in the node and it would stay there if not reset:

```
2024-08-21T14:44:13Z UpdateTip: new best=00000000000000afa0cd000a16e244f56032735d41acd32ac00337aceb2a5240 height=235382 version=0x00000002 log2_work=69.987697 tx=17492185 date='2013-05-09T23:54:32Z' progress=0.016219 cache=71.0MiB(571085txo)
2024-08-21T14:44:13Z UpdateTip: new best=0000000000000087c5e0b820afff496b95ba44ad64640c73b234d3261d3f99d2 height=235383 version=0x00000002 log2_work=69.987750 tx=17492341 date='2013-05-09T23:54:47Z' progress=0.016219 cache=71.0MiB(571291txo)
2024-08-21T14:44:13Z UpdateTip: new best=000000000000014a4b5fddf3c8abb6209247255ca9e8df786b271dd1b2ac82a6 height=235384 version=0x00000002 log2_work=69.987804 tx=17492344 date='2013-05-10T00:20:18Z' progress=0.016219 cache=71.0MiB(571297txo)
2024-08-21T14:44:13Z SetNetworkActive: false


```

</details>

This is a "temporary" fix until #29553 gets merged, which will remove the script entirely. 

Handle the "Block height out of range" error gracefully by checking if the node has synchronized to or beyond the required block height, otherwise without this validation the node would keep the network disabled if the user selected that option.

<details>
<summary>Provide a user-friendly message if the block height is out of range and exit the script cleanly.</summary>

```
/contrib/devtools/utxo_snapshot.sh 840000 snapshot2.dat ./src/bitcoin-cli -datadir=${AU_DATADIR}
Error: The node has not yet synchronized to block height 840001.
Please wait until the node has synchronized past this block height and try again.
```

</details>