### PR TITLE
Fix maybe-uninitialized warning in IsSpentKey

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1039,21 +1039,20 @@ bool CWallet::IsSpentKey(const CScript& scriptPubKey) const
         return true;
     }
 
-    LegacyScriptPubKeyMan* spk_man = GetLegacyScriptPubKeyMan();
-    if (!spk_man) return false;
-
-    for (const auto& keyid : GetAffectedKeys(scriptPubKey, *spk_man)) {
-        WitnessV0KeyHash wpkh_dest(keyid);
-        if (IsAddressPreviouslySpent(wpkh_dest)) {
-            return true;
-        }
-        ScriptHash sh_wpkh_dest(GetScriptForDestination(wpkh_dest));
-        if (IsAddressPreviouslySpent(sh_wpkh_dest)) {
-            return true;
-        }
-        PKHash pkh_dest(keyid);
-        if (IsAddressPreviouslySpent(pkh_dest)) {
-            return true;
+    if (LegacyScriptPubKeyMan* spk_man = GetLegacyScriptPubKeyMan()) {
+        for (const auto& keyid : GetAffectedKeys(scriptPubKey, *spk_man)) {
+            WitnessV0KeyHash wpkh_dest(keyid);
+            if (IsAddressPreviouslySpent(wpkh_dest)) {
+                return true;
+            }
+            ScriptHash sh_wpkh_dest(GetScriptForDestination(wpkh_dest));
+            if (IsAddressPreviouslySpent(sh_wpkh_dest)) {
+                return true;
+            }
+            PKHash pkh_dest(keyid);
+            if (IsAddressPreviouslySpent(pkh_dest)) {
+                return true;
+            }
         }
     }
     return false;


### PR DESCRIPTION
After 6ed424f2db609f9f39ec1d1da2077c7616f3a0c2, I started seeing a maybe-unitialized warning in `CWallet::IsSpentKey`:

```
In destructor ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/stl_vector.h:738:7,
    inlined from ‘constexpr WitnessUnknown::~WitnessUnknown()’ at ./addresstype.h:95:8,
    inlined from ‘constexpr void std::destroy_at(_Tp*) [with _Tp = WitnessUnknown]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/stl_construct.h:88:18,
    inlined from ‘constexpr void std::_Destroy(_Tp*) [with _Tp = WitnessUnknown]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/stl_construct.h:149:22,
    inlined from ‘std::__detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_reset()::<lambda(auto:20&&)> mutable [with auto:20 = WitnessUnknown&]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:498:19,
    inlined from ‘constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = __detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_reset()::<lambda(auto:20&&)>; _Args = {WitnessUnknown&}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/invoke.h:61:36,
    inlined from ‘constexpr std::enable_if_t<is_invocable_r_v<_Res, _Callable, _Args ...>, _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = __detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_reset()::<lambda(auto:20&&)>; _Args = {WitnessUnknown&}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/invoke.h:111:28,
    inlined from ‘static constexpr decltype(auto) std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<_Result_type (*)(_Visitor, _Variants ...)>, std::integer_sequence<long unsigned int, __indices ...> >::__visit_invoke(_Visitor&&, _Variants ...) [with _Result_type = void; _Visitor = std::__detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_reset()::<lambda(auto:20&&)>&&; _Variants = {std::variant<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>&}; long unsigned int ...__indices = {8}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:1064:40,
    inlined from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = void; _Visitor = __detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_reset()::<lambda(auto:20&&)>; _Variants = {variant<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>&}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:1823:5,
    inlined from ‘constexpr void std::__detail::__variant::_Variant_storage<false, _Types ...>::_M_reset() [with _Types = {CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:496:23,
    inlined from ‘constexpr std::__detail::__variant::_Variant_storage<false, _Types ...>::~_Variant_storage() [with _Types = {CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:506:17,
    inlined from ‘constexpr std::__detail::__variant::_Copy_ctor_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::~_Copy_ctor_base()’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:581:12,
    inlined from ‘constexpr std::__detail::__variant::_Move_ctor_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::~_Move_ctor_base()’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:618:12,
    inlined from ‘constexpr std::__detail::__variant::_Copy_assign_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::~_Copy_assign_base()’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:656:12,
    inlined from ‘constexpr std::__detail::__variant::_Move_assign_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::~_Move_assign_base()’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:708:12,
    inlined from ‘constexpr std::__detail::__variant::_Variant_base<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::~_Variant_base()’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:762:12,
    inlined from ‘constexpr std::variant<_Types>::~variant() [with _Types = {CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown}]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/variant:1432:28,
    inlined from ‘bool wallet::CWallet::IsSpentKey(const CScript&) const’ at wallet/wallet.cpp:1055:37:
/usr/lib/gcc/x86_64-pc-linux-gnu/13.3.0/include/c++/bits/stl_vector.h:370:31: error: ‘*(std::_Vector_base<unsigned char, std::allocator<unsigned char> >*)((char*)&<unnamed> + offsetof(const std::CTxDestination, std::variant<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Variant_base<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Move_assign_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Copy_assign_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Move_ctor_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Copy_ctor_base<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::<unnamed>.std::__detail::__variant::_Variant_storage<false, CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, PayToAnchor, WitnessUnknown>::_M_u) + 8).std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_M_impl.std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_Vector_impl::<anonymous>.std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_Vector_impl_data::_M_end_of_storage’ may be used uninitialized [-Werror=maybe-uninitialized]
  370 |                       _M_impl._M_end_of_storage - _M_impl._M_start);
      |                       ~~~~~~~~^~~~~~~~~~~~~~~~~
wallet/wallet.cpp: In member function ‘bool wallet::CWallet::IsSpentKey(const CScript&) const’:
wallet/wallet.cpp:1055:37: note: ‘<anonymous>’ declared here
 1055 |         if (IsAddressPreviouslySpent(pkh_dest)) {
      |             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```

Refactoring the function so that the `WitnessV0KeyHash`, `ScriptHash`, and `PKHash` are constructed within an `if` statement seems to make it go away without changing behavior.