### PR TITLE
doc: fix CI codespell warnings

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -109,7 +109,7 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
-      * Enfore BIP94 timewarp attack mitigation. On testnet4 this also enforces
+      * Enforce BIP94 timewarp attack mitigation. On testnet4 this also enforces
       * the block storm mitigation.
       */
     bool enforce_BIP94;

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -155,7 +155,7 @@ struct DepGraphFormatter
                 // Ignore transactions which are already known to be ancestors.
                 if (depgraph.Descendants(dep_idx).Overlaps(written_parents)) continue;
                 if (depgraph.Ancestors(idx)[dep_idx]) {
-                    // When an actual parent is encounted, encode how many non-parents were skipped
+                    // When an actual parent is encountered, encode how many non-parents were skipped
                     // before it.
                     s << VARINT(diff);
                     diff = 0;

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -1,7 +1,6 @@
 afile
 amountIn
 asend
-ba
 blockin
 bu
 cachable
@@ -13,14 +12,14 @@ fo
 fpr
 hashIn
 hights
-inflight
+incomin
 invokable
-keypair
 lief
 mor
 nd
 nin
 outIn
+re-use
 requestor
 ser
 siz
@@ -29,5 +28,4 @@ unparseable
 unser
 useable
 viewIn
-warmup
 wit


### PR DESCRIPTION
Can be checked locally by running `test/lint/lint-spelling.py`