### PR TITLE
Use MiniWallet in functional test rpc_signrawtransactionwithkey.

### DIFF
--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -46,7 +46,7 @@ OUTPUTS = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
 
 class SignRawTransactionWithKeyTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 1
 
     def send_to_address(self, addr, amount):
         script_pub_key = address_to_scriptpubkey(addr)
@@ -76,12 +76,12 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         self.log.info("Test signing transaction to P2SH-P2WSH addresses without wallet")
         # Create a new P2SH-P2WSH 1-of-1 multisig address:
         embedded_privkey, embedded_pubkey = generate_keypair(wif=True)
-        p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey.hex()], "p2sh-segwit")
+        p2sh_p2wsh_address = self.nodes[0].createmultisig(1, [embedded_pubkey.hex()], "p2sh-segwit")
         # send transaction to P2SH-P2WSH 1-of-1 multisig address
         self.send_to_address(p2sh_p2wsh_address["address"], 49.999)
         self.generate(self.nodes[0], 1)
         # Get the UTXO info from scantxoutset
-        unspent_output = self.nodes[1].scantxoutset('start', [p2sh_p2wsh_address['descriptor']])['unspents'][0]
+        unspent_output = self.nodes[0].scantxoutset('start', [p2sh_p2wsh_address['descriptor']])['unspents'][0]
         spk = script_to_p2sh_p2wsh_script(p2sh_p2wsh_address['redeemScript']).hex()
         unspent_output['witnessScript'] = p2sh_p2wsh_address['redeemScript']
         unspent_output['redeemScript'] = script_to_p2wsh_script(unspent_output['witnessScript']).hex()

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -4,8 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test transaction signing using the signrawtransactionwithkey RPC."""
 
-from test_framework.blocktools import (
-    COINBASE_MATURITY,
+from test_framework.messages import (
+    COIN,
 )
 from test_framework.address import (
     address_to_scriptpubkey,
@@ -16,7 +16,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    find_vout_for_address,
 )
 from test_framework.script_util import (
     key_to_p2pk_script,
@@ -26,6 +25,7 @@ from test_framework.script_util import (
 )
 from test_framework.wallet import (
     getnewdestination,
+    MiniWallet,
 )
 from test_framework.wallet_util import (
     generate_keypair,
@@ -46,16 +46,12 @@ OUTPUTS = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
 
 class SignRawTransactionWithKeyTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
         self.num_nodes = 2
 
     def send_to_address(self, addr, amount):
-        input = {"txid": self.nodes[0].getblock(self.block_hash[self.blk_idx])["tx"][0], "vout": 0}
-        output = {addr: amount}
-        self.blk_idx += 1
-        rawtx = self.nodes[0].createrawtransaction([input], output)
-        txid = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransactionwithkey(rawtx, [self.nodes[0].get_deterministic_priv_key().key])["hex"], 0)
-        return txid
+        script_pub_key = address_to_scriptpubkey(addr)
+        tx = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=script_pub_key, amount=int(amount * COIN))
+        return tx["txid"], tx["sent_vout"]
 
     def assert_signing_completed_successfully(self, signed_tx):
         assert 'errors' not in signed_tx
@@ -82,8 +78,6 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         embedded_privkey, embedded_pubkey = generate_keypair(wif=True)
         p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey.hex()], "p2sh-segwit")
         # send transaction to P2SH-P2WSH 1-of-1 multisig address
-        self.block_hash = self.generate(self.nodes[0], COINBASE_MATURITY + 1)
-        self.blk_idx = 0
         self.send_to_address(p2sh_p2wsh_address["address"], 49.999)
         self.generate(self.nodes[0], 1)
         # Get the UTXO info from scantxoutset
@@ -103,9 +97,9 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
 
     def keyless_signing_test(self):
         self.log.info("Test that keyless 'signing' of pay-to-anchor input succeeds")
-        funding_txid = self.send_to_address(p2a(), 49.999)
+        [txid, vout] = self.send_to_address(p2a(), 49.999)
         spending_tx = self.nodes[0].createrawtransaction(
-            [{"txid": funding_txid, "vout": 0}],
+            [{"txid": txid, "vout": vout}],
             [{getnewdestination()[2]: Decimal("49.998")}])
         spending_tx_signed = self.nodes[0].signrawtransactionwithkey(spending_tx, [], [])
         self.assert_signing_completed_successfully(spending_tx_signed)
@@ -124,9 +118,7 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         addr = script_to_p2sh(redeem_script)
         script_pub_key = address_to_scriptpubkey(addr).hex()
         # Fund that address
-        txid = self.send_to_address(addr, 10)
-        vout = find_vout_for_address(self.nodes[0], txid, addr)
-        self.generate(self.nodes[0], 1)
+        [txid, vout] = self.send_to_address(addr, 10)
         # Now create and sign a transaction spending that output on node[0], which doesn't know the scripts or keys
         spending_tx = self.nodes[0].createrawtransaction([{'txid': txid, 'vout': vout}], {getnewdestination()[2]: Decimal("9.999")})
         spending_tx_signed = self.nodes[0].signrawtransactionwithkey(spending_tx, [embedded_privkey], [{'txid': txid, 'vout': vout, 'scriptPubKey': script_pub_key, 'redeemScript': redeem_script, 'witnessScript': witness_script, 'amount': 10}])
@@ -149,6 +141,7 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
         assert_raises_rpc_error(-22, "TX decode failed. Make sure the tx has at least one input.", self.nodes[0].signrawtransactionwithkey, tx + "00", privkeys)
 
     def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
         self.successful_signing_test()
         self.witness_script_test()
         self.keyless_signing_test()


### PR DESCRIPTION
In response to issue https://github.com/bitcoin/bitcoin/issues/30600, optimizations have been implemented to enhance test efficiency and readability:

This PR refactors the `rpc_signrawtransactionwithkey.py` functional test to use MiniWallet for creating funding transactions. This simplifies the test code and improves performance by eliminating the need to mine new blocks for each funding transaction.

Key changes:
- Replaced custom `send_to_address` method with MiniWallet's `send_to` method
- Removed unnecessary setup of a clean chain and second node
- Simplified transaction creation and signing process