### PR TITLE
test: Avoid duplicate curl call in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -133,20 +133,9 @@ def download_binary(tag, args) -> int:
 
     print('Fetching: {tarballUrl}'.format(tarballUrl=tarballUrl))
 
-    header, status = subprocess.Popen(
-        ['curl', '--head', tarballUrl], stdout=subprocess.PIPE).communicate()
-    if re.search("404 Not Found", header.decode("utf-8")):
-        print("Binary tag was not found")
-        return 1
-
-    curlCmds = [
-        ['curl', '--remote-name', tarballUrl]
-    ]
-
-    for cmd in curlCmds:
-        ret = subprocess.run(cmd).returncode
-        if ret:
-            return ret
+    ret = subprocess.run(['curl', '--fail', '--remote-name', tarballUrl]).returncode
+    if ret:
+        return ret
 
     hasher = hashlib.sha256()
     with open(tarball, "rb") as afile:


### PR DESCRIPTION
Seems odd having to translate `404` to "Binary tag was not found". Also, it seems odd to write a for-loop over a list with one item.

Fix both issues by just using a single call to `curl --fail ...`.

Can be tested with: `test/get_previous_releases.py -b v99.99.99`

Before:

```
Releases directory: releases
Fetching: https://bitcoincore.org/bin/bitcoin-core-99.99.99/bitcoin-99.99.99-x86_64-linux-gnu.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  286k    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
Binary tag was not found
```

After:

```
Releases directory: releases
Fetching: https://bitcoincore.org/bin/bitcoin-core-99.99.99/bitcoin-99.99.99-x86_64-linux-gnu.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  286k    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404
