### PR TITLE
test: Avoid intermittent block download timeout in p2p_ibd_stalling

### DIFF
--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -73,6 +73,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         peers = []
 
         self.log.info("Check that a staller does not get disconnected if the 1024 block lookahead buffer is filled")
+        self.mocktime = int(time.time()) + 1
         for id in range(NUM_PEERS):
             peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
             peers[-1].block_store = block_dict
@@ -85,7 +86,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
         self.all_sync_send_with_ping(peers)
         # If there was a peer marked for stalling, it would get disconnected
-        self.mocktime = int(time.time()) + 3
+        self.mocktime += 3
         node.setmocktime(self.mocktime)
         self.all_sync_send_with_ping(peers)
         assert_equal(node.num_test_p2p_connections(), NUM_PEERS)


### PR DESCRIPTION
Fixes #30704

The goal of the test is to check the stalling timeout, not the block download timeout.

On extremely slow hardware (for example qemu virtual hardware), downloading the 1023 blocks may take longer than the block download timeout.

Fix it by pinning the time using mocktime, and only advance it when testing the stalling timeout.