### PR TITLE
fuzz: Add missing fuzz targets to cmake build

### DIFF
--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(fuzz
   headerssync.cpp
   hex.cpp
   http_request.cpp
+  i2p.cpp
   integer.cpp
   key.cpp
   key_io.cpp

--- a/src/wallet/test/fuzz/CMakeLists.txt
+++ b/src/wallet/test/fuzz/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(fuzz
   PRIVATE
     coincontrol.cpp
     coinselection.cpp
+    crypter.cpp
     fees.cpp
     $<$<BOOL:${USE_SQLITE}>:${CMAKE_CURRENT_LIST_DIR}/notifications.cpp>
     parse_iso8601.cpp


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/pull/30454#discussion_r1726881676

Can be tested via:

```
PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 ./bld-autot/src/test/fuzz/fuzz > /tmp/f_autot
PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 ./bld-cmake/src/test/fuzz/fuzz > /tmp/f_cmake
diff --unified /tmp/{f_autot,f_cmake}