### PR TITLE
rpc: add `relevant_blocks` to `scanblocks status`

### DIFF
--- a/doc/release-notes-30713.md
+++ b/doc/release-notes-30713.md
@@ -1,0 +1,5 @@
+Updated RPCs
+------------
+
+- The `status` action of the`scanblocks` RPC now returns an additional array `relevant_blocks` containing
+  the matching block hashes found so far during a scan.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2365,9 +2365,17 @@ public:
         return true;
     }
 
+    void release() {
+        if (!m_could_reserve) {
+            throw std::runtime_error("Attempt to release unreserved BlockFiltersScanReserver");
+        }
+        g_scanfilter_in_progress = false;
+        m_could_reserve = false;
+    }
+
     ~BlockFiltersScanReserver() {
         if (m_could_reserve) {
-            g_scanfilter_in_progress = false;
+            release();
         }
     }
 };
@@ -2427,6 +2435,9 @@ static RPCHelpMan scanblocks()
             RPCResult{"when action=='status' and a scan is currently in progress", RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::NUM, "progress", "Approximate percent complete"},
                     {RPCResult::Type::NUM, "current_height", "Height of the block currently being scanned"},
+                    {RPCResult::Type::ARR, "relevant_blocks", "Blocks that may have matched a scanobject.", {
+                        {RPCResult::Type::STR_HEX, "blockhash", "A relevant blockhash"},
+                    }},
                 },
             },
             scan_result_abort,
@@ -2441,15 +2452,20 @@ static RPCHelpMan scanblocks()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    static GlobalMutex cs_relevant_blocks;
+    static UniValue relevant_blocks GUARDED_BY(cs_relevant_blocks);
+
     UniValue ret(UniValue::VOBJ);
     if (request.params[0].get_str() == "status") {
         BlockFiltersScanReserver reserver;
+        LOCK(cs_relevant_blocks);
         if (reserver.reserve()) {
             // no scan in progress
             return NullUniValue;
         }
         ret.pushKV("progress", g_scanfilter_progress.load());
         ret.pushKV("current_height", g_scanfilter_progress_height.load());
+        ret.pushKV("relevant_blocks", relevant_blocks);
         return ret;
     } else if (request.params[0].get_str() == "abort") {
         BlockFiltersScanReserver reserver;
@@ -2461,6 +2477,11 @@ static RPCHelpMan scanblocks()
         g_scanfilter_should_abort_scan = true;
         return true;
     } else if (request.params[0].get_str() == "start") {
+        {
+            LOCK(cs_relevant_blocks);
+            relevant_blocks = UniValue(UniValue::VARR);
+        }
+
         BlockFiltersScanReserver reserver;
         if (!reserver.reserve()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Scan already in progress, use action \"abort\" or \"status\"");
@@ -2516,7 +2537,7 @@ static RPCHelpMan scanblocks()
                 needle_set.emplace(script.begin(), script.end());
             }
         }
-        UniValue blocks(UniValue::VARR);
+
         const int amount_per_chunk = 10000;
         std::vector<BlockFilter> filters;
         int start_block_height = start_index->nHeight; // for progress reporting
@@ -2554,7 +2575,8 @@ static RPCHelpMan scanblocks()
                             }
                         }
 
-                        blocks.push_back(filter.GetBlockHash().GetHex());
+                        LOCK(cs_relevant_blocks);
+                        relevant_blocks.push_back(filter.GetBlockHash().GetHex());
                     }
                 }
             }
@@ -2574,8 +2596,10 @@ static RPCHelpMan scanblocks()
 
         ret.pushKV("from_height", start_block_height);
         ret.pushKV("to_height", start_index->nHeight); // start_index is always the last scanned block here
-        ret.pushKV("relevant_blocks", std::move(blocks));
+        LOCK(cs_relevant_blocks);
+        ret.pushKV("relevant_blocks", std::move(relevant_blocks));
         ret.pushKV("completed", completed);
+        reserver.release(); // ensure this is before cs_relevant_blocks is released, so status doesn't try to use moved relevant_blocks
     }
     else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));


### PR DESCRIPTION
Currently, after starting a scan with `scanblocks` the user must wait until the scan is complete to see the associated/relevant block hashes.
This updates the `scanblocks status` result object to provide the `relevant_blocks` found so far.
This enables earlier subsequent lookup within matching blocks (e.g. to run `getdescriptoractivity` in PR #30708)

Below is an example tested on signet by starting and obtaining status of a scan for an address that has received many coinbase outputs (so there are matches over many blocks, showing the increase in `relevant_blocks` results in `scanblocks status` over the life of the scan).  Also tested on mainnet (see https://github.com/bitcoin/bitcoin/pull/30713#pullrequestreview-2296520203).

```
build/src/bitcoin-cli -signet scanblocks start '["addr(tb1qsygnet2jdqm8n2p7wmmklp9yel3k7agpnycv4f)"]'
```
```
build/src/bitcoin-cli -signet scanblocks status
{
  "progress": 14,
  "current_height": 30002,
  "relevant_blocks": [
    "0000012aee246273622a8fb3546454a1d6c11cb468dfb1cd536a3058b0590cba",
    "0000002e043f797a967fca25c18fd2b0f66ddce76b443e540327d2e19928d0aa",
...
    "000000f7626bb9f7917f48d0c63a9c30a4692232e5cd96366192a62c7d1a89a4",
    "000000db94d6817657bd9184ad5f6232981cfe60177b7395485260a339b32571"
  ]
}
```
or (to show snapshots over time)
```
for i in `seq 1 20`; do sleep 1; src/bitcoin-cli -signet scanblocks status > test$i.txt; done
```

`-deprecatedrpc` seems like overkill for the addition of a key (not a data type change). Release notes have been added (affecting user interface).

If testing, be sure to enable the block filter index feature (e.g. adding `blockfilterindex=1` to bitcoin.conf), and allow time for the index to build:
```
2024-09-11T12:17:49Z Config file arg: signet="1"
2024-09-11T12:17:49Z Config file arg: [signet] blockfilterindex="1"
2024-09-11T12:17:51Z Syncing basic block filter index with block chain from height 0
...
2024-09-11T12:19:41Z basic block filter index is enabled at height 212758
2024-09-11T12:19:41Z basic block filter index thread exit
```