### PR TITLE
bench: [refactor] iwyu

### DIFF
--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -4,12 +4,18 @@
 
 #include <addrman.h>
 #include <bench/bench.h>
+#include <compat/compat.h>
+#include <netaddress.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <protocol.h>
 #include <random.h>
+#include <span.h>
+#include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>
 
+#include <cstring>
 #include <optional>
 #include <vector>
 

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bench/bench.h>
-
 #include <base58.h>
+#include <bench/bench.h>
+#include <span.h>
 
 #include <array>
+#include <cstring>
 #include <vector>
 
 

--- a/src/bench/bech32.cpp
+++ b/src/bench/bech32.cpp
@@ -2,12 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bench/bench.h>
-
 #include <bech32.h>
+#include <bench/bench.h>
 #include <util/strencodings.h>
 
-#include <string>
 #include <vector>
 
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -4,16 +4,21 @@
 
 #include <bench/bench.h>
 
-#include <test/util/setup_common.h>
+#include <test/util/setup_common.h> // IWYU pragma: keep
+#include <tinyformat.h>
 #include <util/fs.h>
 #include <util/string.h>
 
 #include <chrono>
+#include <compare>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
+#include <ratio>
 #include <regex>
+#include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,16 +5,17 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
+#include <bench/nanobench.h> // IWYU pragma: export
 #include <util/fs.h>
 #include <util/macros.h>
 
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
-
-#include <bench/nanobench.h> // IWYU pragma: export
 
 /*
  * Usage:

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -3,15 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
-#include <clientversion.h>
 #include <common/args.h>
 #include <crypto/sha256.h>
+#include <tinyformat.h>
 #include <util/fs.h>
-#include <util/strencodings.h>
+#include <util/string.h>
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <sstream>
 #include <vector>

--- a/src/bench/bip324_ecdh.cpp
+++ b/src/bench/bip324_ecdh.cpp
@@ -3,12 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
 #include <key.h>
 #include <pubkey.h>
 #include <random.h>
 #include <span.h>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -3,17 +3,21 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <consensus/validation.h>
-#include <crypto/sha256.h>
+#include <consensus/consensus.h>
 #include <node/miner.h>
+#include <primitives/transaction.h>
 #include <random.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/mining.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
-#include <txmempool.h>
 #include <validation.h>
 
-
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <memory>
 #include <vector>
 
 static void AssembleBlock(benchmark::Bench& bench)

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -4,10 +4,15 @@
 
 #include <bench/bench.h>
 #include <coins.h>
+#include <consensus/amount.h>
+#include <key.h>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
 #include <script/signingprovider.h>
 #include <test/util/transaction_utils.h>
 
+#include <cassert>
 #include <vector>
 
 // Microbenchmark for simple accesses to a CCoinsViewCache database. Note from

--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -6,6 +6,11 @@
 #include <bench/bench.h>
 #include <crypto/chacha20.h>
 #include <crypto/chacha20poly1305.h>
+#include <span.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
 /* Number of bytes to process per iteration */
 static const uint64_t BUFFER_SIZE_TINY  = 64;

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -4,13 +4,22 @@
 
 #include <bench/bench.h>
 #include <bench/data.h>
-
 #include <chainparams.h>
 #include <common/args.h>
 #include <consensus/validation.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+#include <span.h>
 #include <streams.h>
 #include <util/chaintype.h>
 #include <validation.h>
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <vector>
 
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using

--- a/src/bench/checkblockindex.cpp
+++ b/src/bench/checkblockindex.cpp
@@ -6,6 +6,8 @@
 #include <test/util/setup_common.h>
 #include <validation.h>
 
+#include <memory>
+
 static void CheckBlockIndex(benchmark::Bench& bench)
 {
     auto testing_setup{MakeNoLogFileContext<TestChain100Setup>()};

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -7,9 +7,11 @@
 #include <common/system.h>
 #include <key.h>
 #include <prevector.h>
-#include <pubkey.h>
 #include <random.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <utility>
 #include <vector>
 
 static const size_t BATCHES = 101;

--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -3,9 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
-#include <util/bitset.h>
 #include <cluster_linearize.h>
+#include <util/bitset.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <vector>
 
 using namespace cluster_linearize;
 

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -3,15 +3,28 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <consensus/amount.h>
 #include <interfaces/chain.h>
 #include <node/context.h>
+#include <outputtype.h>
+#include <policy/feerate.h>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <sync.h>
+#include <util/result.h>
 #include <wallet/coinselection.h>
 #include <wallet/spend.h>
-#include <wallet/wallet.h>
 #include <wallet/test/util.h>
+#include <wallet/transaction.h>
+#include <wallet/wallet.h>
 
+#include <cassert>
+#include <map>
+#include <memory>
 #include <set>
+#include <utility>
+#include <vector>
 
 using node::NodeContext;
 using wallet::AttemptSelection;

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -11,10 +11,13 @@
 #include <crypto/sha3.h>
 #include <crypto/sha512.h>
 #include <crypto/siphash.h>
-#include <hash.h>
 #include <random.h>
+#include <span.h>
 #include <tinyformat.h>
 #include <uint256.h>
+
+#include <cstdint>
+#include <vector>
 
 /* Number of bytes to hash per iteration */
 static const uint64_t BUFFER_SIZE = 1000*1000;

--- a/src/bench/data.cpp
+++ b/src/bench/data.cpp
@@ -4,6 +4,8 @@
 
 #include <bench/data.h>
 
+#include <iterator>
+
 namespace benchmark {
 namespace data {
 

--- a/src/bench/descriptors.cpp
+++ b/src/bench/descriptors.cpp
@@ -4,11 +4,16 @@
 
 #include <bench/bench.h>
 #include <key.h>
-#include <pubkey.h>
 #include <script/descriptor.h>
+#include <script/script.h>
+#include <script/signingprovider.h>
 
+#include <cassert>
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 static void ExpandDescriptor(benchmark::Bench& bench)
 {

--- a/src/bench/disconnected_transactions.cpp
+++ b/src/bench/disconnected_transactions.cpp
@@ -5,8 +5,17 @@
 #include <bench/bench.h>
 #include <kernel/disconnected_transactions.h>
 #include <primitives/block.h>
-#include <test/util/random.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
 #include <test/util/setup_common.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <vector>
 
 constexpr size_t BLOCK_VTX_COUNT{4000};
 constexpr size_t BLOCK_VTX_COUNT_10PERCENT{400};

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -3,14 +3,27 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <chain.h>
 #include <chainparams.h>
+#include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <pow.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <random.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
-#include <txmempool.h>
+#include <uint256.h>
 #include <validation.h>
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 
 static void DuplicateInputs(benchmark::Bench& bench)

--- a/src/bench/ellswift.cpp
+++ b/src/bench/ellswift.cpp
@@ -3,9 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
 #include <key.h>
+#include <pubkey.h>
 #include <random.h>
+#include <span.h>
+#include <uint256.h>
+
+#include <algorithm>
+#include <cassert>
 
 static void EllSwiftCreate(benchmark::Bench& bench)
 {

--- a/src/bench/gcs_filter.cpp
+++ b/src/bench/gcs_filter.cpp
@@ -4,6 +4,11 @@
 
 #include <bench/bench.h>
 #include <blockfilter.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
 
 static GCSFilter::ElementSet GenerateGCSTestElements()
 {

--- a/src/bench/hashpadding.cpp
+++ b/src/bench/hashpadding.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <hash.h>
+#include <crypto/sha256.h>
 #include <random.h>
 #include <uint256.h>
 

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -2,14 +2,28 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <bench/bench.h>
-
 #include <addresstype.h>
+#include <bench/bench.h>
+#include <blockfilter.h>
+#include <chain.h>
+#include <index/base.h>
 #include <index/blockfilterindex.h>
-#include <node/chainstate.h>
-#include <node/context.h>
+#include <interfaces/chain.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <span.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
 #include <util/strencodings.h>
+#include <util/time.h>
+#include <validation.h>
+
+#include <cassert>
+#include <memory>
+#include <vector>
 
 // Very simple block filter index sync benchmark, only using coinbase outputs.
 static void BlockFilterIndexSync(benchmark::Bench& bench)

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -5,10 +5,21 @@
 #include <bench/bench.h>
 #include <bench/data.h>
 #include <chainparams.h>
-#include <clientversion.h>
+#include <flatfile.h>
+#include <node/blockstorage.h>
+#include <span.h>
+#include <streams.h>
 #include <test/util/setup_common.h>
-#include <util/chaintype.h>
+#include <uint256.h>
+#include <util/fs.h>
 #include <validation.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <vector>
 
 /**
  * The LoadExternalBlockFile() function is used during -reindex and -loadblock.

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -3,9 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
 #include <support/lockedpool.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #define ASIZE 2048

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -5,7 +5,9 @@
 #include <bench/bench.h>
 #include <logging.h>
 #include <test/util/setup_common.h>
-#include <util/chaintype.h>
+
+#include <functional>
+#include <vector>
 
 // All but 2 of the benchmarks should have roughly similar performance:
 //

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -3,10 +3,19 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <kernel/mempool_entry.h>
+#include <consensus/amount.h>
+#include <kernel/cs_main.h>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <util/check.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -3,15 +3,22 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <kernel/mempool_entry.h>
+#include <consensus/amount.h>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
 #include <random.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
-#include <util/chaintype.h>
 #include <validation.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <vector>
+
+class CCoinsViewCache;
 
 static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {

--- a/src/bench/merkle_root.cpp
+++ b/src/bench/merkle_root.cpp
@@ -3,10 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
 #include <consensus/merkle.h>
 #include <random.h>
 #include <uint256.h>
+
+#include <vector>
 
 static void MerkleRoot(benchmark::Bench& bench)
 {

--- a/src/bench/peer_eviction.cpp
+++ b/src/bench/peer_eviction.cpp
@@ -3,13 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <net.h>
 #include <netaddress.h>
+#include <node/eviction.h>
 #include <random.h>
 #include <test/util/net.h>
-#include <test/util/setup_common.h>
 
-#include <algorithm>
+#include <chrono>
 #include <functional>
 #include <vector>
 

--- a/src/bench/poly1305.cpp
+++ b/src/bench/poly1305.cpp
@@ -5,8 +5,11 @@
 
 #include <bench/bench.h>
 #include <crypto/poly1305.h>
-
 #include <span.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
 /* Number of bytes to process per iteration */
 static constexpr uint64_t BUFFER_SIZE_TINY  = 64;

--- a/src/bench/pool.cpp
+++ b/src/bench/pool.cpp
@@ -5,7 +5,11 @@
 #include <bench/bench.h>
 #include <support/allocators/pool.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <unordered_map>
+#include <utility>
 
 template <typename Map>
 void BenchFillClearMap(benchmark::Bench& bench, Map& map)

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -3,11 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <prevector.h>
-#include <serialize.h>
-#include <streams.h>
-#include <type_traits>
 
 #include <bench/bench.h>
+#include <serialize.h>
+#include <streams.h>
+
+#include <type_traits>
+#include <vector>
 
 struct nontrivial_t {
     int x{-1};

--- a/src/bench/random.cpp
+++ b/src/bench/random.cpp
@@ -5,7 +5,9 @@
 #include <bench/bench.h>
 #include <random.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 
 namespace {

--- a/src/bench/readblock.cpp
+++ b/src/bench/readblock.cpp
@@ -4,13 +4,20 @@
 
 #include <bench/bench.h>
 #include <bench/data.h>
-
-#include <consensus/validation.h>
+#include <flatfile.h>
 #include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+#include <span.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
-#include <util/chaintype.h>
 #include <validation.h>
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 static FlatFilePos WriteBlockToDisk(ChainstateManager& chainman)
 {

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -6,7 +6,9 @@
 #include <bench/bench.h>
 #include <common/bloom.h>
 #include <crypto/common.h>
+#include <span.h>
 
+#include <cstdint>
 #include <vector>
 
 static void RollingBloom(benchmark::Bench& bench)

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -4,14 +4,22 @@
 
 #include <bench/bench.h>
 #include <bench/data.h>
-
+#include <chain.h>
+#include <core_io.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <rpc/blockchain.h>
+#include <serialize.h>
+#include <span.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
-#include <util/chaintype.h>
+#include <uint256.h>
+#include <univalue.h>
 #include <validation.h>
 
-#include <univalue.h>
+#include <cstddef>
+#include <memory>
+#include <vector>
 
 namespace {
 

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -3,14 +3,19 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <consensus/amount.h>
 #include <kernel/cs_main.h>
-#include <kernel/mempool_entry.h>
+#include <primitives/transaction.h>
 #include <rpc/mempool.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
-#include <util/chaintype.h>
-
 #include <univalue.h>
+#include <util/check.h>
+
+#include <memory>
+#include <vector>
 
 
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)

--- a/src/bench/sign_transaction.cpp
+++ b/src/bench/sign_transaction.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bench/bench.h>
 #include <addresstype.h>
+#include <bench/bench.h>
 #include <coins.h>
 #include <key.h>
 #include <primitives/transaction.h>
@@ -11,9 +11,15 @@
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/sign.h>
-#include <uint256.h>
+#include <script/signingprovider.h>
+#include <span.h>
 #include <test/util/random.h>
+#include <uint256.h>
 #include <util/translation.h>
+
+#include <cassert>
+#include <map>
+#include <vector>
 
 enum class InputType {
     P2WPKH, // segwitv0, witness-pubkey-hash (ECDSA signature)

--- a/src/bench/strencodings.cpp
+++ b/src/bench/strencodings.cpp
@@ -4,7 +4,10 @@
 
 #include <bench/bench.h>
 #include <bench/data.h>
+#include <span.h>
 #include <util/strencodings.h>
+
+#include <vector>
 
 static void HexStrBench(benchmark::Bench& bench)
 {

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -3,13 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <hash.h>
 #include <key.h>
-#include <script/script.h>
+#include <primitives/transaction.h>
+#include <pubkey.h>
 #include <script/interpreter.h>
-#include <streams.h>
+#include <script/script.h>
+#include <span.h>
 #include <test/util/transaction_utils.h>
+#include <uint256.h>
 
 #include <array>
+#include <cassert>
+#include <cstdint>
+#include <vector>
 
 // Microbenchmark for verification of a basic P2WPKH script. Can be easily
 // modified to measure performance of other types of scripts.

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -4,16 +4,24 @@
 
 #include <bench/bench.h>
 #include <interfaces/chain.h>
-#include <node/chainstate.h>
-#include <node/context.h>
+#include <kernel/chainparams.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <sync.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
-#include <wallet/test/util.h>
-#include <validationinterface.h>
+#include <uint256.h>
+#include <util/time.h>
+#include <validation.h>
 #include <wallet/receive.h>
+#include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
 
+#include <cassert>
+#include <memory>
 #include <optional>
+#include <string>
 
 namespace wallet {
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine)

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -2,14 +2,25 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #include <bench/bench.h>
-#include <node/context.h>
+#include <config/bitcoin-config.h> // IWYU pragma: keep
 #include <random.h>
+#include <support/allocators/secure.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/fs.h>
+#include <util/translation.h>
 #include <wallet/context.h>
+#include <wallet/db.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace wallet {
 static void WalletCreate(benchmark::Bench& bench, bool encrypted)

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -2,17 +2,42 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
 #include <bench/bench.h>
+#include <chain.h>
 #include <chainparams.h>
-#include <wallet/coincontrol.h>
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <consensus/merkle.h>
+#include <interfaces/chain.h>
 #include <kernel/chain.h>
-#include <node/context.h>
+#include <node/blockstorage.h>
+#include <outputtype.h>
+#include <policy/feerate.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/result.h>
+#include <util/time.h>
 #include <validation.h>
+#include <versionbits.h>
+#include <wallet/coincontrol.h>
+#include <wallet/coinselection.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
+
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
 using wallet::CWallet;
 using wallet::CreateMockableWalletDatabase;

--- a/src/bench/wallet_ismine.cpp
+++ b/src/bench/wallet_ismine.cpp
@@ -2,19 +2,28 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
+#include <addresstype.h>
 #include <bench/bench.h>
-#include <interfaces/chain.h>
+#include <config/bitcoin-config.h> // IWYU pragma: keep
 #include <key.h>
 #include <key_io.h>
-#include <node/context.h>
+#include <script/descriptor.h>
+#include <script/script.h>
+#include <script/signingprovider.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
-#include <util/translation.h>
-#include <validationinterface.h>
 #include <wallet/context.h>
+#include <wallet/db.h>
 #include <wallet/test/util.h>
+#include <wallet/types.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
 
 namespace wallet {
 static void WalletIsMine(benchmark::Bench& bench, bool legacy_wallet, int num_combo = 0)

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -2,21 +2,25 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
+#include <addresstype.h>
 #include <bench/bench.h>
-#include <interfaces/chain.h>
-#include <node/context.h>
-#include <test/util/mining.h>
+#include <config/bitcoin-config.h> // IWYU pragma: keep
+#include <consensus/amount.h>
+#include <outputtype.h>
+#include <primitives/transaction.h>
 #include <test/util/setup_common.h>
-#include <wallet/test/util.h>
-#include <util/translation.h>
-#include <validationinterface.h>
+#include <util/check.h>
 #include <wallet/context.h>
-#include <wallet/receive.h>
+#include <wallet/db.h>
+#include <wallet/test/util.h>
+#include <wallet/transaction.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
 
-#include <optional>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace wallet{
 static void AddTx(CWallet& wallet)

--- a/src/bench/xor.cpp
+++ b/src/bench/xor.cpp
@@ -3,8 +3,8 @@
 // file COPYING or https://opensource.org/license/mit/.
 
 #include <bench/bench.h>
-
 #include <random.h>
+#include <span.h>
 #include <streams.h>
 
 #include <cstddef>


### PR DESCRIPTION
Missing includes are problematic, because:

* Upcoming releases of a C++ standard library implementation often minimize their internal header dependencies. For example, `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` (https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html). This can lead to compile failures, which are easy to fix for developers, but may not be for users. For example, commit 138f8671569f7ebb8c84e9d80c44cddeda9e3845 had to add missing includes to accommodate GCC 15 (and the commit had to be backported).
* A Bitcoin Core developer removing a feature from a module and wanting to drop the now unused includes may not be able to do so without touching other unrelated files, because those files rely on the transitive includes.

Moreover, missing or extraneous includes are problematic, because they may be confusing the code reader as to what the real dependencies are.

Finally, extraneous includes may slow down the build.

Fix all issues in `bench`, by applying the rule include-what-you-use (iwyu).

Follow-up pull requests will handle the other places.