### PR TITLE
test: switch MiniWallet padding unit from weight to vsize

### DIFF
--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -31,7 +31,7 @@ class BlocksXORTest(BitcoinTestFramework):
         node = self.nodes[0]
         wallet = MiniWallet(node)
         for _ in range(5):
-            wallet.send_self_transfer(from_node=node, target_weight=80000)
+            wallet.send_self_transfer(from_node=node, target_vsize=20000)
             self.generate(wallet, 1)
 
         block_files = list(node.blocks_path.glob('blk[0-9][0-9][0-9][0-9][0-9].dat'))

--- a/test/functional/feature_framework_miniwallet.py
+++ b/test/functional/feature_framework_miniwallet.py
@@ -9,7 +9,7 @@ import string
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_greater_than_or_equal,
+    assert_equal,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -22,17 +22,15 @@ class FeatureFrameworkMiniWalletTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def test_tx_padding(self):
-        """Verify that MiniWallet's transaction padding (`target_weight` parameter)
-           works accurately enough (i.e. at most 3 WUs higher) with all modes."""
+        """Verify that MiniWallet's transaction padding (`target_vsize` parameter)
+           works accurately with all modes."""
         for mode_name, wallet in self.wallets:
             self.log.info(f"Test tx padding with MiniWallet mode {mode_name}...")
             utxo = wallet.get_utxo(mark_as_spent=False)
-            for target_weight in [1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 4000000,
-                                  989,  2001, 4337, 13371, 23219, 49153, 102035, 223419, 3999989]:
-                tx = wallet.create_self_transfer(utxo_to_spend=utxo, target_weight=target_weight)["tx"]
-                self.log.debug(f"-> target weight: {target_weight}, actual weight: {tx.get_weight()}")
-                assert_greater_than_or_equal(tx.get_weight(), target_weight)
-                assert_greater_than_or_equal(target_weight + 3, tx.get_weight())
+            for target_vsize in [250, 500, 1250, 2500, 5000, 12500, 25000, 50000, 1000000,
+                                 248, 501, 1085, 3343, 5805, 12289, 25509, 55855,  999998]:
+                tx = wallet.create_self_transfer(utxo_to_spend=utxo, target_vsize=target_vsize)["tx"]
+                assert_equal(tx.get_vsize(), target_vsize)
 
     def test_wallet_tagging(self):
         """Verify that tagged wallet instances are able to send funds."""

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -4,9 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test logic for limiting mempool and package ancestors/descendants."""
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.messages import (
-    WITNESS_SCALE_FACTOR,
-)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -290,19 +287,18 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         parent_utxos = []
         target_vsize = 30_000
         high_fee = 10 * target_vsize  # 10 sats/vB
-        target_weight = target_vsize * WITNESS_SCALE_FACTOR
         self.log.info("Check that in-mempool and in-package ancestor size limits are calculated properly in packages")
         # Mempool transactions A and B
         for _ in range(2):
-            bulked_tx = self.wallet.create_self_transfer(target_weight=target_weight)
+            bulked_tx = self.wallet.create_self_transfer(target_vsize=target_vsize)
             self.wallet.sendrawtransaction(from_node=node, tx_hex=bulked_tx["hex"])
             parent_utxos.append(bulked_tx["new_utxo"])
 
         # Package transaction C
-        pc_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=high_fee, target_weight=target_weight)
+        pc_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=high_fee, target_vsize=target_vsize)
 
         # Package transaction D
-        pd_tx = self.wallet.create_self_transfer(utxo_to_spend=pc_tx["new_utxos"][0], target_weight=target_weight)
+        pd_tx = self.wallet.create_self_transfer(utxo_to_spend=pc_tx["new_utxos"][0], target_vsize=target_vsize)
 
         assert_equal(2, node.getmempoolinfo()["size"])
         return [pc_tx["hex"], pd_tx["hex"]]
@@ -321,20 +317,19 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         node = self.nodes[0]
         target_vsize = 21_000
         high_fee = 10 * target_vsize  # 10 sats/vB
-        target_weight = target_vsize * WITNESS_SCALE_FACTOR
         self.log.info("Check that in-mempool and in-package descendant sizes are calculated properly in packages")
         # Top parent in mempool, Ma
-        ma_tx = self.wallet.create_self_transfer_multi(num_outputs=2, fee_per_output=high_fee // 2, target_weight=target_weight)
+        ma_tx = self.wallet.create_self_transfer_multi(num_outputs=2, fee_per_output=high_fee // 2, target_vsize=target_vsize)
         self.wallet.sendrawtransaction(from_node=node, tx_hex=ma_tx["hex"])
 
         package_hex = []
         for j in range(2): # Two legs (left and right)
             # Mempool transaction (Mb and Mc)
-            mempool_tx = self.wallet.create_self_transfer(utxo_to_spend=ma_tx["new_utxos"][j], target_weight=target_weight)
+            mempool_tx = self.wallet.create_self_transfer(utxo_to_spend=ma_tx["new_utxos"][j], target_vsize=target_vsize)
             self.wallet.sendrawtransaction(from_node=node, tx_hex=mempool_tx["hex"])
 
             # Package transaction (Pd and Pe)
-            package_tx = self.wallet.create_self_transfer(utxo_to_spend=mempool_tx["new_utxo"], target_weight=target_weight)
+            package_tx = self.wallet.create_self_transfer(utxo_to_spend=mempool_tx["new_utxo"], target_vsize=target_vsize)
             package_hex.append(package_tx["hex"])
 
         assert_equal(3, node.getmempoolinfo()["size"])

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -22,6 +22,7 @@ from test_framework.wallet import (
 
 MAX_REPLACEMENT_CANDIDATES = 100
 TRUC_MAX_VSIZE = 10000
+TRUC_CHILD_MAX_VSIZE = 1000
 
 def cleanup(extra_args=None):
     def decorator(func):
@@ -72,10 +73,10 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v3_parent_normal["txid"]])
         tx_v3_child_heavy = self.wallet.create_self_transfer(
             utxo_to_spend=tx_v3_parent_normal["new_utxo"],
-            target_vsize=1001,
+            target_vsize=TRUC_CHILD_MAX_VSIZE + 1,
             version=3
         )
-        assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), 1000)
+        assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), TRUC_CHILD_MAX_VSIZE)
         expected_error_child_heavy = f"TRUC-violation, version=3 child tx {tx_v3_child_heavy['txid']} (wtxid={tx_v3_child_heavy['wtxid']}) is too big"
         assert_raises_rpc_error(-26, expected_error_child_heavy, node.sendrawtransaction, tx_v3_child_heavy["hex"])
         self.check_mempool([tx_v3_parent_normal["txid"]])
@@ -87,10 +88,10 @@ class MempoolTRUC(BitcoinTestFramework):
             from_node=node,
             fee_rate=DEFAULT_FEE,
             utxo_to_spend=tx_v3_parent_normal["new_utxo"],
-            target_vsize=997,
+            target_vsize=TRUC_CHILD_MAX_VSIZE - 3,
             version=3
         )
-        assert_greater_than_or_equal(1000, tx_v3_child_almost_heavy["tx"].get_vsize())
+        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_almost_heavy["tx"].get_vsize())
         self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy["txid"]])
         assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
         tx_v3_child_almost_heavy_rbf = self.wallet.send_self_transfer(
@@ -100,7 +101,8 @@ class MempoolTRUC(BitcoinTestFramework):
             target_vsize=875,
             version=3
         )
-        assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(), 1000)
+        assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(),
+                                     TRUC_CHILD_MAX_VSIZE)
         self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy_rbf["txid"]])
         assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
 
@@ -199,7 +201,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v2_from_v3 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block["new_utxo"], version=2)
         tx_v3_from_v2 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v2_block["new_utxo"], version=3)
         tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_vsize=1250, version=3)
-        assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], 1000)
+        assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], TRUC_CHILD_MAX_VSIZE)
         self.check_mempool([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]])
         node.invalidateblock(block[0])
         self.check_mempool([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"], tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]])
@@ -231,7 +233,7 @@ class MempoolTRUC(BitcoinTestFramework):
 
         # Parent and child are within v3 limits, but parent's 10kvB descendant limit is exceeded
         assert_greater_than_or_equal(TRUC_MAX_VSIZE, tx_v3_parent_large1["tx"].get_vsize())
-        assert_greater_than_or_equal(1000, tx_v3_child_large1["tx"].get_vsize())
+        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large1["tx"].get_vsize())
         assert_greater_than(tx_v3_parent_large1["tx"].get_vsize() + tx_v3_child_large1["tx"].get_vsize(), 10000)
 
         assert_raises_rpc_error(-26, f"too-long-mempool-chain, exceeds descendant size limit for tx {tx_v3_parent_large1['txid']}", node.sendrawtransaction, tx_v3_child_large1["hex"])
@@ -254,7 +256,7 @@ class MempoolTRUC(BitcoinTestFramework):
 
         # Parent and child are within TRUC limits
         assert_greater_than_or_equal(TRUC_MAX_VSIZE, tx_v3_parent_large2["tx"].get_vsize())
-        assert_greater_than_or_equal(1000, tx_v3_child_large2["tx"].get_vsize())
+        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large2["tx"].get_vsize())
         assert_greater_than(tx_v3_parent_large2["tx"].get_vsize() + tx_v3_child_large2["tx"].get_vsize(), 10000)
 
         assert_raises_rpc_error(-26, f"too-long-mempool-chain, exceeds ancestor size limit", node.sendrawtransaction, tx_v3_child_large2["hex"])
@@ -281,7 +283,7 @@ class MempoolTRUC(BitcoinTestFramework):
         )
         tx_v3_child_heavy = self.wallet.create_self_transfer_multi(
             utxos_to_spend=[tx_v3_parent_normal["new_utxo"]],
-            target_vsize=1001,
+            target_vsize=TRUC_CHILD_MAX_VSIZE + 1,
             fee_per_output=10000,
             version=3
         )

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
-    WITNESS_SCALE_FACTOR,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -55,14 +54,14 @@ class MempoolTRUC(BitcoinTestFramework):
     def test_truc_max_vsize(self):
         node = self.nodes[0]
         self.log.info("Test TRUC-specific maximum transaction vsize")
-        tx_v3_heavy = self.wallet.create_self_transfer(target_weight=(TRUC_MAX_VSIZE + 1) * WITNESS_SCALE_FACTOR, version=3)
+        tx_v3_heavy = self.wallet.create_self_transfer(target_vsize=TRUC_MAX_VSIZE + 1, version=3)
         assert_greater_than_or_equal(tx_v3_heavy["tx"].get_vsize(), TRUC_MAX_VSIZE)
         expected_error_heavy = f"TRUC-violation, version=3 tx {tx_v3_heavy['txid']} (wtxid={tx_v3_heavy['wtxid']}) is too big"
         assert_raises_rpc_error(-26, expected_error_heavy, node.sendrawtransaction, tx_v3_heavy["hex"])
         self.check_mempool([])
 
         # Ensure we are hitting the TRUC-specific limit and not something else
-        tx_v2_heavy = self.wallet.send_self_transfer(from_node=node, target_weight=(TRUC_MAX_VSIZE + 1) * WITNESS_SCALE_FACTOR, version=2)
+        tx_v2_heavy = self.wallet.send_self_transfer(from_node=node, target_vsize=TRUC_MAX_VSIZE + 1, version=2)
         self.check_mempool([tx_v2_heavy["txid"]])
 
     @cleanup(extra_args=["-datacarriersize=1000"])
@@ -73,7 +72,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v3_parent_normal["txid"]])
         tx_v3_child_heavy = self.wallet.create_self_transfer(
             utxo_to_spend=tx_v3_parent_normal["new_utxo"],
-            target_weight=4004,
+            target_vsize=1001,
             version=3
         )
         assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), 1000)
@@ -88,7 +87,7 @@ class MempoolTRUC(BitcoinTestFramework):
             from_node=node,
             fee_rate=DEFAULT_FEE,
             utxo_to_spend=tx_v3_parent_normal["new_utxo"],
-            target_weight=3987,
+            target_vsize=997,
             version=3
         )
         assert_greater_than_or_equal(1000, tx_v3_child_almost_heavy["tx"].get_vsize())
@@ -98,7 +97,7 @@ class MempoolTRUC(BitcoinTestFramework):
             from_node=node,
             fee_rate=DEFAULT_FEE * 2,
             utxo_to_spend=tx_v3_parent_normal["new_utxo"],
-            target_weight=3500,
+            target_vsize=875,
             version=3
         )
         assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(), 1000)
@@ -199,7 +198,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([])
         tx_v2_from_v3 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block["new_utxo"], version=2)
         tx_v3_from_v2 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v2_block["new_utxo"], version=3)
-        tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_weight=5000, version=3)
+        tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_vsize=1250, version=3)
         assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], 1000)
         self.check_mempool([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]])
         node.invalidateblock(block[0])
@@ -217,16 +216,16 @@ class MempoolTRUC(BitcoinTestFramework):
         """
         node = self.nodes[0]
         self.log.info("Test that a decreased limitdescendantsize also applies to TRUC child")
-        parent_target_weight = 9990 * WITNESS_SCALE_FACTOR
-        child_target_weight = 500 * WITNESS_SCALE_FACTOR
+        parent_target_vsize = 9990
+        child_target_vsize = 500
         tx_v3_parent_large1 = self.wallet.send_self_transfer(
             from_node=node,
-            target_weight=parent_target_weight,
+            target_vsize=parent_target_vsize,
             version=3
         )
         tx_v3_child_large1 = self.wallet.create_self_transfer(
             utxo_to_spend=tx_v3_parent_large1["new_utxo"],
-            target_weight=child_target_weight,
+            target_vsize=child_target_vsize,
             version=3
         )
 
@@ -244,12 +243,12 @@ class MempoolTRUC(BitcoinTestFramework):
         self.restart_node(0, extra_args=["-limitancestorsize=10", "-datacarriersize=40000"])
         tx_v3_parent_large2 = self.wallet.send_self_transfer(
             from_node=node,
-            target_weight=parent_target_weight,
+            target_vsize=parent_target_vsize,
             version=3
         )
         tx_v3_child_large2 = self.wallet.create_self_transfer(
             utxo_to_spend=tx_v3_parent_large2["new_utxo"],
-            target_weight=child_target_weight,
+            target_vsize=child_target_vsize,
             version=3
         )
 
@@ -267,12 +266,12 @@ class MempoolTRUC(BitcoinTestFramework):
         node = self.nodes[0]
         tx_v3_parent_normal = self.wallet.create_self_transfer(
             fee_rate=0,
-            target_weight=4004,
+            target_vsize=1001,
             version=3
         )
         tx_v3_parent_2_normal = self.wallet.create_self_transfer(
             fee_rate=0,
-            target_weight=4004,
+            target_vsize=1001,
             version=3
         )
         tx_v3_child_multiparent = self.wallet.create_self_transfer_multi(
@@ -282,7 +281,7 @@ class MempoolTRUC(BitcoinTestFramework):
         )
         tx_v3_child_heavy = self.wallet.create_self_transfer_multi(
             utxos_to_spend=[tx_v3_parent_normal["new_utxo"]],
-            target_weight=4004,
+            target_vsize=1001,
             fee_per_output=10000,
             version=3
         )
@@ -294,7 +293,7 @@ class MempoolTRUC(BitcoinTestFramework):
 
         self.check_mempool([])
         result = node.submitpackage([tx_v3_parent_normal["hex"], tx_v3_child_heavy["hex"]])
-        # tx_v3_child_heavy is heavy based on weight, not sigops.
+        # tx_v3_child_heavy is heavy based on vsize, not sigops.
         assert_equal(result['package_msg'], f"TRUC-violation, version=3 child tx {tx_v3_child_heavy['txid']} (wtxid={tx_v3_child_heavy['wtxid']}) is too big: {tx_v3_child_heavy['tx'].get_vsize()} > 1000 virtual bytes")
         self.check_mempool([])
 
@@ -416,7 +415,7 @@ class MempoolTRUC(BitcoinTestFramework):
         node = self.nodes[0]
         tx_v3_parent = self.wallet.create_self_transfer(
             fee_rate=0,
-            target_weight=4004,
+            target_vsize=1001,
             version=3
         )
         tx_v2_child = self.wallet.create_self_transfer_multi(


### PR DESCRIPTION
This PR is a late follow-up for #30162, where I retrospectively consider the padding unit of choice as a mistake. The weight unit is merely a consensus rule detail and is largely irrelevant from a user's perspective w.r.t. fee-rate calculations and mempool policy rules (e.g. for package relay and TRUC limits), so there doesn't seem to be any value of using a granularity that we can't even guarantee to reach exactly anyway.

Switch to the more natural unit of vsize instead, which simplifies both the padding implementation (no "round up to the next multiple of 4" anymore) and the current tests that take use of this padding. The rather annoying multiplications by `WITNESS_SCALE_FACTOR` can then be removed and weird-looking magic numbers like `4004` can be replaced by numbers that are more connected to actual policy limit constants from the codebase, e.g. `1001` for exceeding `TRUC_CHILD_MAX_VSIZE` by one. The second commits introduces a constant for that.