### PR TITLE
fuzz: fix timeout in `crypto_fschacha20poly1305`

### DIFF
--- a/src/test/fuzz/crypto_chacha20poly1305.cpp
+++ b/src/test/fuzz/crypto_chacha20poly1305.cpp
@@ -130,7 +130,7 @@ FUZZ_TARGET(crypto_fschacha20poly1305)
     // data).
     InsecureRandomContext rng(provider.ConsumeIntegral<uint64_t>());
 
-    LIMITED_WHILE(provider.ConsumeBool(), 10000)
+    LIMITED_WHILE(provider.ConsumeBool(), 100)
     {
         // Mode:
         // - Bit 0: whether to use single-plain Encrypt/Decrypt; otherwise use a split at prefix.


### PR DESCRIPTION
Fixes #30505

This PR fixes a timeout in `crypto_fschacha20poly1305` by reducing the number of iterations. I left it running for a while and noticed it speeds up the target and do not impact coverage.