### PR TITLE
build: fix version number post CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # Project / Package metadata
 #=============================
 set(PACKAGE_NAME "Bitcoin Core")
-set(CLIENT_VERSION_MAJOR 27)
+set(CLIENT_VERSION_MAJOR 28)
 set(CLIENT_VERSION_MINOR 99)
 set(CLIENT_VERSION_BUILD 0)
 set(CLIENT_VERSION_RC 0)


### PR DESCRIPTION
CMake was merged after branching-off for `28.x`.