### PR TITLE
build: improve cxx and linker flag caching

### DIFF
--- a/cmake/module/TryAppendCXXFlags.cmake
+++ b/cmake/module/TryAppendCXXFlags.cmake
@@ -40,10 +40,10 @@ In configuration output, this function prints a string by the following pattern:
 ]=]
 function(try_append_cxx_flags flags)
   cmake_parse_arguments(PARSE_ARGV 1
-    TACXXF                            # prefix
-    "SKIP_LINK"                       # options
-    "TARGET;VAR;SOURCE;RESULT_VAR"    # one_value_keywords
-    "IF_CHECK_PASSED"                 # multi_value_keywords
+    TACXXF                  # prefix
+    "SKIP_LINK"             # options
+    "TARGET;VAR;RESULT_VAR" # one_value_keywords
+    "IF_CHECK_PASSED"       # multi_value_keywords
   )
 
   set(flags_as_string "${flags}")
@@ -53,12 +53,6 @@ function(try_append_cxx_flags flags)
   string(TOUPPER "${id_string}" id_string)
 
   set(source "int main() { return 0; }")
-  if(DEFINED TACXXF_SOURCE AND NOT TACXXF_SOURCE STREQUAL source)
-    set(source "${TACXXF_SOURCE}")
-    string(SHA256 source_hash "${source}")
-    string(SUBSTRING ${source_hash} 0 4 source_hash_head)
-    string(APPEND id_string _${source_hash_head})
-  endif()
 
   # This avoids running a linker.
   set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)

--- a/cmake/module/TryAppendLinkerFlag.cmake
+++ b/cmake/module/TryAppendLinkerFlag.cmake
@@ -25,24 +25,24 @@ function(try_append_linker_flag flag)
     "IF_CHECK_PASSED"                 # multi_value_keywords
   )
 
-  string(MAKE_C_IDENTIFIER "${flag}" result)
-  string(TOUPPER "${result}" result)
-  string(PREPEND result LINKER_SUPPORTS_)
+  string(MAKE_C_IDENTIFIER "${flag}" linker_result)
+  string(TOUPPER "${linker_result}" linker_result)
+  string(PREPEND linker_result LINKER_SUPPORTS_)
 
   set(source "int main() { return 0; }")
   if(DEFINED TALF_SOURCE AND NOT TALF_SOURCE STREQUAL source)
     set(source "${TALF_SOURCE}")
     string(SHA256 source_hash "${source}")
     string(SUBSTRING ${source_hash} 0 4 source_hash_head)
-    string(APPEND result _${source_hash_head})
+    string(APPEND linker_result _${source_hash_head})
   endif()
 
   # This forces running a linker.
   set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
   set(CMAKE_REQUIRED_LINK_OPTIONS ${flag} ${working_linker_werror_flag})
-  check_cxx_source_compiles("${source}" ${result})
+  check_cxx_source_compiles("${source}" ${linker_result})
 
-  if(${result})
+  if(${linker_result})
     if(DEFINED TALF_IF_CHECK_PASSED)
       if(DEFINED TALF_TARGET)
         target_link_options(${TALF_TARGET} INTERFACE ${TALF_IF_CHECK_PASSED})
@@ -65,7 +65,7 @@ function(try_append_linker_flag flag)
   endif()
 
   if(DEFINED TALF_RESULT_VAR)
-    set(${TALF_RESULT_VAR} "${${result}}" PARENT_SCOPE)
+    set(${TALF_RESULT_VAR} "${${linker_result}}" PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/cmake/module/TryAppendLinkerFlag.cmake
+++ b/cmake/module/TryAppendLinkerFlag.cmake
@@ -31,10 +31,11 @@ function(try_append_linker_flag flag)
 
   set(source "int main() { return 0; }")
   if(DEFINED TALF_SOURCE AND NOT TALF_SOURCE STREQUAL source)
+    # If a custom source code is provided, use it and append its hash to the cache key to ensure uniqueness.
     set(source "${TALF_SOURCE}")
     string(SHA256 source_hash "${source}")
-    string(SUBSTRING ${source_hash} 0 4 source_hash_head)
-    string(APPEND linker_result _${source_hash_head})
+    string(TOUPPER "${source_hash}" upper_hash)
+    string(APPEND linker_result "_${upper_hash}")
   endif()
 
   # This forces running a linker.

--- a/cmake/module/TryAppendLinkerFlag.cmake
+++ b/cmake/module/TryAppendLinkerFlag.cmake
@@ -25,9 +25,10 @@ function(try_append_linker_flag flag)
     "IF_CHECK_PASSED"                 # multi_value_keywords
   )
 
-  string(MAKE_C_IDENTIFIER "${flag}" linker_result)
+  # Create a unique identifier based on the flag and a global linker setting
+  string(MAKE_C_IDENTIFIER "${flag} ${working_linker_werror_flag}" linker_result)
   string(TOUPPER "${linker_result}" linker_result)
-  string(PREPEND linker_result LINKER_SUPPORTS_)
+  string(PREPEND linker_result "LINKER_SUPPORTS_")
 
   set(source "int main() { return 0; }")
   if(DEFINED TALF_SOURCE AND NOT TALF_SOURCE STREQUAL source)


### PR DESCRIPTION
Migration of https://github.com/hebasto/bitcoin/pull/340

`try_append_cxx_flags` and `try_append_linker_flag` are CMake functions used to test and conditionally apply compiler and linker flags to ensure compatibility with the build environment.

Currently the only case when the `SOURCE` parameter was overwritten was [bitcoin/bitcoin@8b6f1c4/CMakeLists.txt#L383-L389](https://github.com/bitcoin/bitcoin/blob/8b6f1c4353836bae6aa683cbc65251165bd031ba/CMakeLists.txt#L383-L389).
So currently the values would be unique without the hash, but overwriting a source in the future would cause a false hit, so I kept the full (uppercase) hash - and also added the `werror_flag` to the cache key, since the result of the compilation depends on it as well.

After this change we will have logs such as:
```
-- Performing Test CXX_SUPPORTS__FSANITIZE_UNDEFINED_ADDRESS_FUZZER
-- Performing Test CXX_SUPPORTS__FSANITIZE_UNDEFINED_ADDRESS_FUZZER - Success
-- Performing Test LINKER_SUPPORTS__FSANITIZE_UNDEFINED_ADDRESS_FUZZER__WL__FATAL_WARNINGS_A797852B32447D9D3594B7F06EFE65790DAAEFCBEFCE4144D7B1F480F6FA4B6A
-- Performing Test LINKER_SUPPORTS__FSANITIZE_UNDEFINED_ADDRESS_FUZZER__WL__FATAL_WARNINGS_A797852B32447D9D3594B7F06EFE65790DAAEFCBEFCE4144D7B1F480F6FA4B6A - Success
-- Performing Test FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION
-- Performing Test FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION - Success
```

On top of that, `try_append_cxx_flags` currently doesn't even need a `SOURCE` parameter - I've removed it for now, we can add it back once we need it.