### PR TITLE
test: Fix RANDOM_CTX_SEED use with parallel tests

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -29,7 +29,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
-const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+static std::string g_bench_name;
+const std::function<std::string()> G_TEST_GET_FULL_NAME = []{ return g_bench_name; };
 
 namespace {
 
@@ -117,6 +118,7 @@ void BenchRunner::RunAll(const Args& args)
             bench.output(nullptr);
         }
         bench.name(name);
+        g_bench_name = name;
         if (args.min_time > 0ms) {
             // convert to nanos before dividing to reduce rounding errors
             std::chrono::nanoseconds min_time_ns = args.min_time;

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -35,8 +35,6 @@ __AFL_FUZZ_INIT();
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
-const std::function<std::string()> G_TEST_GET_FULL_NAME{};
-
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.
@@ -80,6 +78,7 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 static std::string_view g_fuzz_target;
 static const TypeTestOneInput* g_test_one_input{nullptr};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME = []{ return std::string{g_fuzz_target}; };
 
 #if defined(__clang__) && defined(__linux__)
 extern "C" void __llvm_profile_reset_counters(void) __attribute__((weak));

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -31,6 +31,10 @@ def get_fuzz_env(*, target, source_dir):
     if platform.system() == "Windows":
         # On Windows, `env` option must include valid `SystemRoot`.
         fuzz_env = {**fuzz_env, 'SystemRoot': os.environ.get('SystemRoot')}
+    random_seed = os.environ.get('RANDOM_CTX_SEED')
+    if random_seed:
+        fuzz_env['RANDOM_CTX_SEED'] = random_seed
+
     return fuzz_env
 
 


### PR DESCRIPTION
To fix the issue with test directories clashing when running in parallel with the env var `RANDOM_CTX_SEED` set, we now mix in the test name.

Issue was introduced by 97e16f57042cab07e5e73f6bed19feec2006e4f7, and comment for `g_insecure_rand_ctx_temp_path` became invalid with that commit. Make the determinism clear through removing the no longer useful `g_insecure_rand_ctx_temp_path`.

Fixes #30696.