### PR TITLE
depends: build libevent with `-D_GNU_SOURCE`

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -14,6 +14,7 @@ define $(package)_set_vars
   $(package)_config_opts=-DEVENT__DISABLE_BENCHMARK=ON -DEVENT__DISABLE_OPENSSL=ON
   $(package)_config_opts+=-DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON
   $(package)_config_opts+=-DEVENT__DISABLE_TESTS=ON -DEVENT__LIBRARY_TYPE=STATIC
+  $(package)_cppflags += -D_GNU_SOURCE
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 
   ifeq ($(NO_HARDEN),)


### PR DESCRIPTION
Currently, builds of libevent in depends, using CMake, fail on some systems, like Alpine, with the following:
```bash
/bitcoin/depends/work/build/aarch64-unknown-linux-musl/libevent/2.1.12-stable-1516ed47ea8/evmap.c: In function 'evmap_signal_add_':
/bitcoin/depends/work/build/aarch64-unknown-linux-musl/libevent/2.1.12-stable-1516ed47ea8/evmap.c:456:31: error: 'NSIG' undeclared (first use in this function)
  456 |         if (sig < 0 || sig >= NSIG)
```

From what I can tell the `GNU_SOURCE` "detection" in libevents CMake build system, never? really worked, primarily relies on looking for a deprecated define, and it's not clear what a nice fix is. For now, always build with `_GNU_SOURCE`, to match the autotools behaviour.