### PR TITLE
guix: Drop unused autotools packages

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -1,5 +1,4 @@
 (use-modules (gnu packages)
-             (gnu packages autotools)
              ((gnu packages bash) #:select (bash-minimal))
              (gnu packages bison)
              ((gnu packages certs) #:select (nss-certs))
@@ -511,9 +510,6 @@ inspecting signatures in Mach-O binaries.")
         gcc-toolchain-12
         cmake-minimal
         gnu-make
-        libtool
-        autoconf-2.71
-        automake
         pkg-config
         ;; Scripting
         python-minimal ;; (3.10)


### PR DESCRIPTION
This PR implements https://github.com/hebasto/bitcoin/pull/294.

From https://github.com/hebasto/bitcoin/pull/294#issuecomment-2317292100:
> I think guix was already bumped to cmake, so this can be done in a separate pull already today?