### PR TITLE
ci: Add missed configuration options to "Win64 native" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build --preset vs2022-static -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON
+          cmake -B build --preset vs2022-static -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DBUILD_GUI=ON -DWITH_BDB=ON -DWITH_MINIUPNPC=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,8 +16,7 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "BUILD_GUI": "ON",
-        "WITH_QRENCODE": "OFF",
-        "WITH_NATPMP": "OFF"
+        "WITH_QRENCODE": "OFF"
       }
     },
     {
@@ -34,8 +33,7 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "BUILD_GUI": "ON",
-        "WITH_QRENCODE": "OFF",
-        "WITH_NATPMP": "OFF"
+        "WITH_QRENCODE": "OFF"
       }
     }
   ]

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -42,27 +42,31 @@ Available presets can be listed as follows:
 cmake --list-presets
 ```
 
+By default, all presets:
+- Set `BUILD_GUI` to `ON`.
+- Set `WITH_QRENCODE` to `OFF`, due to known build issues when using vcpkg's `libqrencode` package.
+
 ## Building
 
 CMake will put the resulting object files, libraries, and executables into a dedicated build directory.
 
 In the following instructions, the "Debug" configuration can be specified instead of the "Release" one.
 
-### 4. Building with Dynamic Linking with GUI
-
-```
-cmake -B build --preset vs2022 -DBUILD_GUI=ON  # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
-cmake --build build --config Release           # Use "-j N" for N parallel jobs.
-ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
-```
-
-### 5. Building with Static Linking without GUI
+### 4. Building with Static Linking with GUI
 
 ```
 cmake -B build --preset vs2022-static          # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
 cmake --build build --config Release           # Use "-j N" for N parallel jobs.
 ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 cmake --install build --config Release         # Optional.
+```
+
+### 5. Building with Dynamic Linking without GUI
+
+```
+cmake -B build --preset vs2022 -DBUILD_GUI=OFF # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
+cmake --build build --config Release           # Use "-j N" for N parallel jobs.
+ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ## Performance Notes


### PR DESCRIPTION
Some build options were overlooked when the CMake staging branch dropped package autodetection.

This PR restores them. Similar to https://github.com/bitcoin/bitcoin/pull/30740.