### PR TITLE
doc: update Fedora build instructions for cmake

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -96,7 +96,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 
 Build requirements:
 
-    sudo dnf install gcc-c++ libtool make autoconf automake python3
+    sudo dnf install gcc-c++ cmake make python3
 
 Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
@@ -108,8 +108,7 @@ SQLite is required for the descriptor wallet:
 
 Berkeley DB is only required for the legacy wallet. Fedora releases have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
 Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
-are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
-pass `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
+are based on Berkeley DB 4.8. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 


### PR DESCRIPTION
Update Fedora build instructions for cmake:

- update the Fedora build requirements
- remove old configure instruction

This was forgotten to update