### PR TITLE
ci: Delete no longer needed workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Remove non-MSVC tool installations
-        run: |
-          Remove-Item -Path "$env:ProgramFiles/CMake" -Recurse -Force
-
       - name: Configure Developer Command Prompt for Microsoft Visual C++
         # Using microsoft/setup-msbuild is not enough.
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
This PR removes a workaround that was necessary at some point during the development of the CMake staging branch.