### PR TITLE
doc: add `-DWITH_BDB=ON` to unix build docs

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -118,7 +118,7 @@ Run `cmake -B build -LH` to see the full list of available options.
 This enables support for both wallet types, assuming
 `sqlite3` and `db4` are both installed.
 ```bash
-cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include"
+cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include" -DWITH_BDB=ON
 ```
 
 ##### No Wallet or GUI

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -112,7 +112,7 @@ Run `cmake -B build -LH` to see the full list of available options.
 This enables support for both wallet types:
 
 ```bash
-cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include"
+cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include" -DWITH_BDB=ON
 ```
 
 ### 2. Compile

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -90,7 +90,7 @@ There is an included test suite that is useful for testing code changes when dev
 To run the test suite (recommended), you will need to have Python 3 installed:
 
 ```bash
-pkg_add install python  # Select the newest version of the package.
+pkg_add python  # Select the newest version of the package.
 ```
 
 ## Building Bitcoin Core

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -162,7 +162,7 @@ and configure using the following:
 ```bash
 export BDB_PREFIX="/path/to/bitcoin/depends/x86_64-pc-linux-gnu"
 
-cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include"
+cmake -B build -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include" -DWITH_BDB=ON
 ```
 
 **Note**: Make sure that `BDB_PREFIX` is an absolute path.


### PR DESCRIPTION
Existing instructions for building legacy wallet support omit `-DWITH_BDB=ON`, which results in:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    BerkeleyDB_INCLUDE_DIR
```

and a build without BDB support.

This PR updates the docs to include `-DWITH_BDB=ON`.
Also adds a minor correction to the OpenBSD build doc.

Checked by building on Linux (Debian 12.7), FreeBSD 14.1, and OpenBSD 7.5 and attempting to create a legacy wallet with the `createwallet` rpc (with `-deprecatedrpc=create_bdb`).


