### PR TITLE
Improve loadwallet doc

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -235,6 +235,8 @@ static RPCHelpMan loadwallet()
                 },
                 RPCExamples{
                     HelpExampleCli("loadwallet", "\"test.dat\"")
+                  + HelpExampleCli("loadwallet", "\"subdirectory/test.dat\"") 
+                  + HelpExampleCli("loadwallet", "\"../otherdir/testwallet.dat\"") 
                   + HelpExampleRpc("loadwallet", "\"test.dat\"")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -220,7 +220,7 @@ static RPCHelpMan loadwallet()
                 "\nNote that all wallet command-line options used when starting bitcoind will be"
                 "\napplied to the new wallet.\n",
                 {
-                    {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet directory or .dat file."},
+                    {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet directory or .dat file. The filename should be the relative path from the wallet directory (~/.bitcoin/regtest/wallets)."},
                     {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
                 },
                 RPCResult{
@@ -235,7 +235,7 @@ static RPCHelpMan loadwallet()
                 },
                 RPCExamples{
                     HelpExampleCli("loadwallet", "\"test.dat\"")
-            + HelpExampleRpc("loadwallet", "\"test.dat\"")
+                  + HelpExampleRpc("loadwallet", "\"test.dat\"")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
Title: Improve documentation of the filename parameter in loadwallet RPC

This PR addresses issue #30269 . The documentation for the loadwallet RPC has been improved to clarify that the filename parameter should be provided as a relative path from the wallet directory (~/.bitcoin/regtest/wallets). Additionally, two examples were added to demonstrate how to load a wallet from a different directory.

These changes aim to make the usage of the filename parameter more intuitive and prevent potential confusion for users. Please review the modifications and let me know if any further adjustments are needed. Thanks!