### PR TITLE
test: add check that too large txs aren't put into orphanage

### DIFF
--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <consensus/validation.h>
 #include <script/signingprovider.h>
 #include <test/util/transaction_utils.h>
 
@@ -68,4 +69,24 @@ std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keyst
     AddCoins(coinsRet, CTransaction(dummyTransactions[1]), 0);
 
     return dummyTransactions;
+}
+
+void BulkTransaction(CMutableTransaction& tx, int32_t target_weight)
+{
+    tx.vout.emplace_back(0, CScript() << OP_RETURN);
+    auto unpadded_weight{GetTransactionWeight(CTransaction(tx))};
+    assert(target_weight >= unpadded_weight);
+
+    // determine number of needed padding bytes by converting weight difference to vbytes
+    auto dummy_vbytes = (target_weight - unpadded_weight + (WITNESS_SCALE_FACTOR - 1)) / WITNESS_SCALE_FACTOR;
+    // compensate for the increase of the compact-size encoded script length
+    // (note that the length encoding of the unpadded output script needs one byte)
+    dummy_vbytes -= GetSizeOfCompactSize(dummy_vbytes) - 1;
+
+    // pad transaction by repeatedly appending a dummy opcode to the output script
+    tx.vout[0].scriptPubKey.insert(tx.vout[0].scriptPubKey.end(), dummy_vbytes, OP_1);
+
+    // actual weight should be at most 3 higher than target weight
+    assert(GetTransactionWeight(CTransaction(tx)) >= target_weight);
+    assert(GetTransactionWeight(CTransaction(tx)) <= target_weight + 3);
 }

--- a/src/test/util/transaction_utils.h
+++ b/src/test/util/transaction_utils.h
@@ -26,4 +26,8 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
 // the second nValues[2] and nValues[3] outputs paid to a TxoutType::PUBKEYHASH.
 std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues);
 
+// bulk transaction to reach a certain target weight,
+// by appending a single output with padded output script
+void BulkTransaction(CMutableTransaction& tx, int32_t target_weight);
+
 #endif // BITCOIN_TEST_UTIL_TRANSACTION_UTILS_H


### PR DESCRIPTION
This PR adds test coverage for the following check in `TxOrphanage::AddTx`, where large orphan txs are ignored in order to avoid memory exhaustion attacks:
https://github.com/bitcoin/bitcoin/blob/5abb9b1af49be9024f95fa2f777285c531785d85/src/txorphanage.cpp#L22-L34
Note that this code-path isn't reachable under normal circumstances, as txs larger than `MAX_STANDARD_TX_WEIGHT` are already rejected earlier in the course of doing the mempool standardness checks (see `MemPoolAccept::PreChecks` -> `IsStandardTx` -> `reason = "tx-size";`), so this is only relevant if tx standardness rules are disabled via `-acceptnonstdtxns=1`. The ignore path is checked ~~by asserting the debug log, which is ugly, but as far as I know there is currently no way to access the orphanage entries from the outside~~ via unit test that checks the return value of `AddTx`. As an alternative to adding test coverage, one might consider removing this check altogether (or replacing it with an `Assume`), as it's redundant as explained above.