### PR TITLE
doc: fix compiler flags for macOS configuration

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -60,7 +60,7 @@ brew install llvm
 And append the following to the configure commands below:
 
 ``` bash
-CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++
+-DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++"
 ```
 
 Try `llvm@17` if compilation fails with the default version of llvm.


### PR DESCRIPTION
Small CMake correction in the macOS build docs. My Mac will actually use AppleClang if I don't specify the compiler flags.
```bash
% cmake -B testbuild
-- The CXX compiler identification is AppleClang 15.0.0.15000309
```

```bash
% cmake -B testbuild -DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++"
-- The CXX compiler identification is Clang 18.1.8
```