### PR TITLE
 bench: Remove redundant logging benchmarks 

### DIFF
--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -64,21 +64,21 @@ static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
     });
 }
 
-static void LogPrintfWithThreadNames(benchmark::Bench& bench)
+static void LogWithThreadNames(benchmark::Bench& bench)
 {
-    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
+    Logging(bench, {"-logthreadnames=1"}, [] { LogInfo("%s\n", "test"); });
 }
 
-static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
+static void LogWithoutThreadNames(benchmark::Bench& bench)
 {
-    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
+    Logging(bench, {"-logthreadnames=0"}, [] { LogInfo("%s\n", "test"); });
 }
 
 static void LogWithoutWriteToFile(benchmark::Bench& bench)
 {
     // Disable writing the log to a file, as used for unit tests and fuzzing in `MakeNoLogFileContext`.
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
-        LogPrintf("%s\n", "test");
+        LogInfo("%s\n", "test");
         LogDebug(BCLog::NET, "%s\n", "test");
     });
 }
@@ -89,6 +89,6 @@ BENCHMARK(LogWithDebug, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutDebug, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintfCategoryWithThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintfCategoryWithoutThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintfWithThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintfWithoutThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogWithThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutWriteToFile, benchmark::PriorityLevel::HIGH);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -28,18 +28,6 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
-static void LogPrintLevelWithThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=1", "-debug=net"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
-}
-
-static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
-}
-
 static void LogWithDebug(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogDebug(BCLog::NET, "%s\n", "test"); });
@@ -48,20 +36,6 @@ static void LogWithDebug(benchmark::Bench& bench)
 static void LogWithoutDebug(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogDebug(BCLog::NET, "%s\n", "test"); });
-}
-
-static void LogPrintfCategoryWithThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=1", "-debug=net"}, [] {
-        LogPrintfCategory(BCLog::NET, "%s\n", "test");
-    });
-}
-
-static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] {
-        LogPrintfCategory(BCLog::NET, "%s\n", "test");
-    });
 }
 
 static void LogWithThreadNames(benchmark::Bench& bench)
@@ -83,12 +57,8 @@ static void LogWithoutWriteToFile(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(LogPrintLevelWithThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintLevelWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithDebug, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutDebug, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintfCategoryWithThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintfCategoryWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutWriteToFile, benchmark::PriorityLevel::HIGH);

--- a/src/logging.h
+++ b/src/logging.h
@@ -273,7 +273,6 @@ static inline void LogPrintf_(std::string_view logging_function, std::string_vie
 
 // Deprecated unconditional logging.
 #define LogPrintf(...) LogInfo(__VA_ARGS__)
-#define LogPrintfCategory(category, ...) LogPrintLevel_(category, BCLog::Level::Info, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -116,7 +116,6 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacrosDeprecated, LogSetup)
     LogPrintLevel(BCLog::NET, BCLog::Level::Info, "foo8: %s\n", "bar8");
     LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "foo9: %s\n", "bar9");
     LogPrintLevel(BCLog::NET, BCLog::Level::Error, "foo10: %s\n", "bar10");
-    LogPrintfCategory(BCLog::VALIDATION, "foo11: %s\n", "bar11");
     std::ifstream file{tmp_log_path};
     std::vector<std::string> log_lines;
     for (std::string log; std::getline(file, log);) {
@@ -128,7 +127,6 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacrosDeprecated, LogSetup)
         "[net:info] foo8: bar8",
         "[net:warning] foo9: bar9",
         "[net:error] foo10: bar10",
-        "[validation:info] foo11: bar11",
     };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -26,7 +26,6 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
     'LogDebug,1',
     'LogTrace,1',
     'LogPrintf,0',
-    'LogPrintfCategory,1',
     'LogPrintLevel,2',
     'printf,0',
     'snprintf,2',


### PR DESCRIPTION
`LogPrint*ThreadNames` is redundant with `LogWith(out)ThreadNames`,
because they all measure toggling the thread names (and check that it
has no effect on performance).

Fix it by removing the redundant ones. This also allows to drop a deprecated logging alias.