### PR TITLE
test: Add explicit onion bind to p2p_permissions

### DIFF
--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -14,8 +14,10 @@ from test_framework.p2p import P2PDataStore
 from test_framework.test_node import ErrorMatch
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    append_config,
     assert_equal,
     p2p_port,
+    tor_port,
 )
 from test_framework.wallet import MiniWallet
 
@@ -57,11 +59,14 @@ class P2PPermissionsTests(BitcoinTestFramework):
         # by modifying the configuration file.
         ip_port = "127.0.0.1:{}".format(p2p_port(1))
         self.nodes[1].replace_in_config([("bind=127.0.0.1", "whitebind=bloomfilter,forcerelay@" + ip_port)])
+        # Explicitly bind the tor port to prevent collisions with the default tor port
+        append_config(self.nodes[1].datadir_path, [f"bind=127.0.0.1:{tor_port(self.nodes[1].index)}=onion"])
         self.checkpermission(
             ["-whitelist=noban@127.0.0.1"],
             # Check parameter interaction forcerelay should activate relay
             ["noban", "bloomfilter", "forcerelay", "relay", "download"])
         self.nodes[1].replace_in_config([("whitebind=bloomfilter,forcerelay@" + ip_port, "bind=127.0.0.1")])
+        self.nodes[1].replace_in_config([(f"bind=127.0.0.1:{tor_port(self.nodes[1].index)}=onion", "")])
 
         self.checkpermission(
             # legacy whitelistrelay should be ignored


### PR DESCRIPTION
When the bind option is replaced in the bitcoin.conf, bitcoind will attempd to bind to the default tor listening port. If another bitcoind is running that is already bound to that port, the bind will fail which, since #22729, causes the test to fail.

This failure can be avoided by explicitly binding the tor port when the bind is removed.