### PR TITLE
rpc: dumptxoutset height parameter follow-ups (29553)

### DIFF
--- a/doc/assumeutxo.md
+++ b/doc/assumeutxo.md
@@ -17,7 +17,7 @@ Once you've obtained the snapshot, you can use the RPC command `loadtxoutset` to
 load it.
 
 ```
-$ bitcoin-cli loadtxoutset /path/to/input
+$ bitcoin-cli -rpcclienttimeout=0 loadtxoutset /path/to/input
 ```
 
 After the snapshot has loaded, the syncing process of both the snapshot chain

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3005,7 +3005,7 @@ static RPCHelpMan loadtxoutset()
                 }
         },
         RPCExamples{
-            HelpExampleCli("loadtxoutset", "utxo.dat")
+            HelpExampleCli("loadtxoutset -rpcclienttimeout=0", "utxo.dat")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
First, this addresses two left-over comments in #29553:

- When running `dumptxoutset` the network gets disabled in the beginning and then re-enabled at the end. The network would be re-enabled even if the user had already disabled the network themself before running `dumptxoutset`. The network is now not re-enabled anymore since that might not be what the user wants.
- The `-rpcclienttimeout=0` option is added to `loadtxoutset` examples in documentation

Additionally, pablomartin4btc notified me that he found his node stuck at the invalidated height after some late testing after #29553 was merged. We could not find the actual source of the issue since his logs got lost. However, it seems likely that some kind of disruption stopped the process before the node could roll forward again. We fixed this issue for network disablement with a RAII class previously and it seems logical that this can happen the same way for the rollback part so I suggest to also fix it the same way.

An example to reproduce the issue described above as I think it happened: Remove the `!` in the following line in `PrepareUTXOSnapshot()` to simulate an issue occurring during `GetUTXOStats()`.

```
if (!maybe_stats) {
```

This leaves the node in the following state on master:

```
$ build/src/bitcoin-cli -rpcclienttimeout=0 -named dumptxoutset utxo-859750.dat rollback=859750
error code: -32603
error message:
Unable to read UTXO set
$ build/src/bitcoin-cli getchaintips
[
  {
    "height": 859762,
    "hash": "00000000000000000002ec7a0fcca3aeca5b35545b52eb925766670aacc704ad",
    "branchlen": 12,
    "status": "headers-only"
  },
  {
    "height": 859750,
    "hash": "0000000000000000000010897b6b88a18f9478050200d8d048013c58bfd6229e",
    "branchlen": 0,
    "status": "active"
  },
```

(Note that the first tip is `headers-only` and not `invalid` only because I started `dumptxoutset` before my node had fully synced to the tip. pablomartin4btc saw it as `invalid`.)