### PR TITLE
kernel: Create usable static kernel library

### DIFF
--- a/libbitcoinkernel.pc.in
+++ b/libbitcoinkernel.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PACKAGE_NAME@ kernel library
+Description: Experimental library for the Bitcoin Core validation engine.
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbitcoinkernel
+Libs.private: -L${libdir} @LIBS_PRIVATE@
+Cflags: -I${includedir}

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -98,6 +98,32 @@ set_target_properties(bitcoinkernel PROPERTIES
   CXX_VISIBILITY_PRESET default
 )
 
+# When building the static library, install all static libraries the
+# bitcoinkernel depends on.
+if(NOT BUILD_SHARED_LIBS)
+  # Recursively get all the static libraries a target depends on and put them in libs_out
+  function(get_target_static_link_libs target libs_out)
+    get_target_property(linked_libraries ${target} LINK_LIBRARIES)
+    foreach(dep ${linked_libraries})
+      if(TARGET ${dep})
+        get_target_property(dep_type ${dep} TYPE)
+        if(dep_type STREQUAL "STATIC_LIBRARY")
+          list(APPEND ${libs_out} ${dep})
+          get_target_static_link_libs(${dep} ${libs_out})
+        endif()
+      endif()
+    endforeach()
+    set(${libs_out} ${${libs_out}} PARENT_SCOPE)
+  endfunction()
+
+  set(all_kernel_static_link_libs "")
+  get_target_static_link_libs(bitcoinkernel all_kernel_static_link_libs)
+
+  foreach(lib ${all_kernel_static_link_libs})
+    install(TARGETS ${lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endforeach()
+endif()
+
 include(GNUInstallDirs)
 install(TARGETS bitcoinkernel
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -119,10 +119,18 @@ if(NOT BUILD_SHARED_LIBS)
   set(all_kernel_static_link_libs "")
   get_target_static_link_libs(bitcoinkernel all_kernel_static_link_libs)
 
+  # LIBS_PRIVATE is substituted in the pkg-config file.
+  set(LIBS_PRIVATE "")
   foreach(lib ${all_kernel_static_link_libs})
     install(TARGETS ${lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    string(APPEND LIBS_PRIVATE " -l${lib}")
   endforeach()
+
+  string(STRIP "${LIBS_PRIVATE}" LIBS_PRIVATE)
 endif()
+
+configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 include(GNUInstallDirs)
 install(TARGETS bitcoinkernel


### PR DESCRIPTION
Since the move to cmake, the kernel static library that is installed after a cmake --install build is unusable. It lacks symbols for the internal libraries, besides those defined in the kernel library target.

Fix this by explicitly installing all the required internal static libraries. To make usage of these installed libraries easy, add a pkg-config file that can be used during linking.

This patch can be tested with:

```
cmake -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_KERNEL_LIB=ON
cmake --build build
cmake --install build
g++ -std=c++20 -o test_chainstate src/bitcoin-chainstate.cpp -I/home/drgrid/bitcoin/src $(pkg-config --libs --static libbitcoinkernel)
```

Attempts to solve #30801
