### PR TITLE
cmake: scope Boost Test check to `vcpkg`

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -64,9 +64,9 @@ function(add_boost_if_needed)
     set(CMAKE_REQUIRED_DEFINITIONS)
   endif()
 
-  if(BUILD_TESTS)
-    # Some package managers, such as vcpkg, vendor Boost.Test separately
-    # from the rest of the headers, so we have to check for it individually.
+  # Some package managers, such as vcpkg, vendor Boost.Test separately
+  # from the rest of the headers, so we have to check for it individually.
+  if(BUILD_TESTS AND DEFINED VCPKG_TARGET_TRIPLET)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -DBOOST_TEST_NO_MAIN)
     include(CheckIncludeFileCXX)
     check_include_file_cxx(boost/test/included/unit_test.hpp HAVE_BOOST_INCLUDED_UNIT_TEST_H)


### PR DESCRIPTION
This check was added for `vcpkg`, given how it packages Boost. However, we don't need to run the check for other platforms, and it's quite slow. So, scope it to just `vcpkg`. 

On my machine, this reduces the time to run `time cmake -B build` from ~12 seconds, to ~6 seconds.

Fixes: #30787.