### PR TITLE
fuzz: reduce number of iterations in `crypto_aeadchacha20poly1305` target

### DIFF
--- a/src/test/fuzz/crypto_chacha20poly1305.cpp
+++ b/src/test/fuzz/crypto_chacha20poly1305.cpp
@@ -39,7 +39,7 @@ FUZZ_TARGET(crypto_aeadchacha20poly1305)
     // data).
     InsecureRandomContext rng(provider.ConsumeIntegral<uint64_t>());
 
-    LIMITED_WHILE(provider.ConsumeBool(), 10000)
+    LIMITED_WHILE(provider.ConsumeBool(), 100)
     {
         // Mode:
         // - Bit 0: whether to use single-plain Encrypt/Decrypt; otherwise use a split at prefix.


### PR DESCRIPTION
By reducing the number of iterations we improve the performance of this target and may increase coverage. 

Running with `-runs=100000` from qa-assets I noticed a significant performance improvement and an increase on cov:
master:
```
#100000 DONE   cov: 567 ft: 4078 corp: 124/33Kb lim: 4096 exec/s: 793 rss: 499Mb
```

PR:
```
#100000 DONE   cov: 568 ft: 3833 corp: 113/15188b lim: 1746 exec/s: 1250 rss: 544Mb
```
