### PR TITLE
interfaces: #30697 follow ups

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -361,7 +361,7 @@ public:
     virtual bool updateRwSetting(const std::string& name, const SettingsUpdate& update_function) = 0;
 
     //! Replace a setting in <datadir>/settings.json with a new value.
-    virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue& value, bool write = true) = 0;
+    virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue value, bool write = true) = 0;
 
     //! Delete a given setting in <datadir>/settings.json.
     virtual bool deleteRwSettings(const std::string& name, bool write = true) = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -356,6 +356,8 @@ public:
     virtual common::SettingsValue getRwSetting(const std::string& name) = 0;
 
     //! Updates a setting in <datadir>/settings.json.
+    //! Null can be passed to erase the setting. There is intentionally no
+    //! support for writing null values to settings.json.
     //! Depending on the action returned by the update function, this will either
     //! update the setting in memory or write the updated settings to disk.
     virtual bool updateRwSetting(const std::string& name, const SettingsUpdate& update_function) = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -363,6 +363,9 @@ public:
     virtual bool updateRwSetting(const std::string& name, const SettingsUpdate& update_function) = 0;
 
     //! Replace a setting in <datadir>/settings.json with a new value.
+    //! Null can be passed to erase the setting.
+    //! This method provides a simpler alternative to updateRwSetting when
+    //! atomically reading and updating the setting is not required.
     virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue value, SettingsAction action = SettingsAction::WRITE) = 0;
 
     //! Delete a given setting in <datadir>/settings.json.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -369,6 +369,8 @@ public:
     virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue value, SettingsAction action = SettingsAction::WRITE) = 0;
 
     //! Delete a given setting in <datadir>/settings.json.
+    //! This method provides a simpler alternative to overwriteRwSetting when
+    //! erasing a setting, for ease of use and readability.
     virtual bool deleteRwSettings(const std::string& name, SettingsAction action = SettingsAction::WRITE) = 0;
 
     //! Synchronously send transactionAddedToMempool notifications about all

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -361,10 +361,10 @@ public:
     virtual bool updateRwSetting(const std::string& name, const SettingsUpdate& update_function) = 0;
 
     //! Replace a setting in <datadir>/settings.json with a new value.
-    virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue value, bool write = true) = 0;
+    virtual bool overwriteRwSetting(const std::string& name, common::SettingsValue value, SettingsAction action = SettingsAction::WRITE) = 0;
 
     //! Delete a given setting in <datadir>/settings.json.
-    virtual bool deleteRwSettings(const std::string& name, bool write = true) = 0;
+    virtual bool deleteRwSettings(const std::string& name, SettingsAction action = SettingsAction::WRITE) = 0;
 
     //! Synchronously send transactionAddedToMempool notifications about all
     //! current mempool transactions to the specified handler and return after

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -826,22 +826,22 @@ public:
         });
         if (!action) return false;
         // Now dump value to disk if requested
-        return *action == interfaces::SettingsAction::SKIP_WRITE || args().WriteSettingsFile();
+        return *action != interfaces::SettingsAction::WRITE || args().WriteSettingsFile();
     }
-    bool overwriteRwSetting(const std::string& name, common::SettingsValue value, bool write) override
+    bool overwriteRwSetting(const std::string& name, common::SettingsValue value, interfaces::SettingsAction action) override
     {
-        if (value.isNull()) return deleteRwSettings(name, write);
+        if (value.isNull()) return deleteRwSettings(name, action);
         return updateRwSetting(name, [&](common::SettingsValue& settings) {
             settings = std::move(value);
-            return write ? interfaces::SettingsAction::WRITE : interfaces::SettingsAction::SKIP_WRITE;
+            return action;
         });
     }
-    bool deleteRwSettings(const std::string& name, bool write) override
+    bool deleteRwSettings(const std::string& name, interfaces::SettingsAction action) override
     {
         args().LockSettings([&](common::Settings& settings) {
             settings.rw_settings.erase(name);
         });
-        return !write || args().WriteSettingsFile();
+        return action != interfaces::SettingsAction::WRITE || args().WriteSettingsFile();
     }
     void requestMempoolTransactions(Notifications& notifications) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -828,7 +828,7 @@ public:
         // Now dump value to disk if requested
         return *action == interfaces::SettingsAction::SKIP_WRITE || args().WriteSettingsFile();
     }
-    bool overwriteRwSetting(const std::string& name, common::SettingsValue& value, bool write) override
+    bool overwriteRwSetting(const std::string& name, common::SettingsValue value, bool write) override
     {
         if (value.isNull()) return deleteRwSettings(name, write);
         return updateRwSetting(name, [&](common::SettingsValue& settings) {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -841,10 +841,7 @@ public:
     }
     bool deleteRwSettings(const std::string& name, interfaces::SettingsAction action) override
     {
-        args().LockSettings([&](common::Settings& settings) {
-            settings.rw_settings.erase(name);
-        });
-        return action != interfaces::SettingsAction::WRITE || args().WriteSettingsFile();
+        return overwriteRwSetting(name, {}, action);
     }
     void requestMempoolTransactions(Notifications& notifications) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -834,7 +834,6 @@ public:
     }
     bool overwriteRwSetting(const std::string& name, common::SettingsValue value, interfaces::SettingsAction action) override
     {
-        if (value.isNull()) return deleteRwSettings(name, action);
         return updateRwSetting(name, [&](common::SettingsValue& settings) {
             settings = std::move(value);
             return action;

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -69,7 +69,7 @@ bool VerifyWallets(WalletContext& context)
             // Pass write=false because no need to write file and probably
             // better not to. If unnamed wallet needs to be added next startup
             // and the setting is empty, this code will just run again.
-            chain.overwriteRwSetting("wallet", std::move(wallets), /*write=*/false);
+            chain.overwriteRwSetting("wallet", std::move(wallets), interfaces::SettingsAction::SKIP_WRITE);
         }
     }
 

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -69,7 +69,7 @@ bool VerifyWallets(WalletContext& context)
             // Pass write=false because no need to write file and probably
             // better not to. If unnamed wallet needs to be added next startup
             // and the setting is empty, this code will just run again.
-            chain.overwriteRwSetting("wallet", wallets, /*write=*/false);
+            chain.overwriteRwSetting("wallet", std::move(wallets), /*write=*/false);
         }
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -334,12 +334,11 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 // concurrently, ensuring no race conditions occur during either process.
 BOOST_FIXTURE_TEST_CASE(write_wallet_settings_concurrently, TestingSetup)
 {
-    WalletContext context;
-    context.chain = m_node.chain.get();
+    auto chain = m_node.chain.get();
     const auto NUM_WALLETS{5};
 
     // Since we're counting the number of wallets, ensure we start without any.
-    BOOST_REQUIRE(context.chain->getRwSetting("wallet").isNull());
+    BOOST_REQUIRE(chain->getRwSetting("wallet").isNull());
 
     const auto& check_concurrent_wallet = [&](const auto& settings_function, int num_expected_wallets) {
         std::vector<std::thread> threads;
@@ -347,19 +346,19 @@ BOOST_FIXTURE_TEST_CASE(write_wallet_settings_concurrently, TestingSetup)
         for (auto i{0}; i < NUM_WALLETS; ++i) threads.emplace_back(settings_function, i);
         for (auto& t : threads) t.join();
 
-        auto wallets = context.chain->getRwSetting("wallet");
+        auto wallets = chain->getRwSetting("wallet");
         BOOST_CHECK_EQUAL(wallets.getValues().size(), num_expected_wallets);
     };
 
     // Add NUM_WALLETS wallets concurrently, ensure we end up with NUM_WALLETS stored.
-    check_concurrent_wallet([&context](int i) {
-        Assert(AddWalletSetting(*context.chain, strprintf("wallet_%d", i)));
+    check_concurrent_wallet([&chain](int i) {
+        Assert(AddWalletSetting(*chain, strprintf("wallet_%d", i)));
     },
                             /*num_expected_wallets=*/NUM_WALLETS);
 
     // Remove NUM_WALLETS wallets concurrently, ensure we end up with 0 wallets.
-    check_concurrent_wallet([&context](int i) {
-        Assert(RemoveWalletSetting(*context.chain, strprintf("wallet_%d", i)));
+    check_concurrent_wallet([&chain](int i) {
+        Assert(RemoveWalletSetting(*chain, strprintf("wallet_%d", i)));
     },
                             /*num_expected_wallets=*/0);
 }


### PR DESCRIPTION

This PR addresses the remaining review comments from #30697

1. Disallowed overwriting settings values with a `null` value.
2. Uniformly used the `SettingsAction` enum in all settings methods instead of a boolean parameter.
3. Updated `overwriteRwSetting` to receive the `common::SettingsValue` parameter by value, enabling it to be moved safely.
4. Removed wallet context from the `write_wallet_settings_concurrently` unit test, as it is not needed.

