### PR TITLE
Add NODE_TXRELAY_V2.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -329,6 +329,9 @@ enum ServiceFlags : uint64_t {
     // NODE_P2P_V2 means the node supports BIP324 transport
     NODE_P2P_V2 = (1 << 11),
 
+    // NODE_TXRELAY_V2 means the node supports BIPXXX transaction-relay v2 protocol
+    NODE_TXRELAY_V2 = (1 << 12),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just


### PR DESCRIPTION
This is the top commit from #30572, where the new node service bit support commit is extracted on its own.

See the corresponding BIP draft for motivation: https://github.com/bitcoin/bips/pull/1663

Dissociating this change from halting the processing of unrequested transaction, allow the node service bit support to be used for further policies and mechanisms, beyond this mechanism only.