### PR TITLE
ci: Post CMake-migration fixes and amendments

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -121,7 +121,7 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   BITCOIN_CONFIG_ALL="$BITCOIN_CONFIG_ALL -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
-bash -c "cmake -S $BASE_ROOT_DIR $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (cat CMakeFiles/CMakeOutput.log CMakeFiles/CMakeError.log) && false)"
+bash -c "cmake -S $BASE_ROOT_DIR $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (cat $(cmake -P "${BASE_ROOT_DIR}/ci/test/GetCMakeLogFiles.cmake")) && false)"
 
 bash -c "make $MAKEJOBS all $GOAL" || ( echo "Build failure. Verbose build follows." && make all "$GOAL" V=1 ; false )
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -123,7 +123,7 @@ fi
 
 bash -c "cmake -S $BASE_ROOT_DIR $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (cat $(cmake -P "${BASE_ROOT_DIR}/ci/test/GetCMakeLogFiles.cmake")) && false)"
 
-bash -c "make $MAKEJOBS all $GOAL" || ( echo "Build failure. Verbose build follows." && make all "$GOAL" V=1 ; false )
+bash -c "cmake --build . $MAKEJOBS --target all $GOAL" || ( echo "Build failure. Verbose build follows." && cmake --build . --target all "$GOAL" --verbose ; false )
 
 bash -c "${PRINT_CCACHE_STATISTICS}"
 du -sh "${DEPENDS_DIR}"/*/

--- a/ci/test/GetCMakeLogFiles.cmake
+++ b/ci/test/GetCMakeLogFiles.cmake
@@ -1,0 +1,11 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+  set(log_files "CMakeFiles/CMakeConfigureLog.yaml")
+else()
+  set(log_files "CMakeFiles/CMakeOutput.log CMakeFiles/CMakeError.log")
+endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E echo ${log_files})


### PR DESCRIPTION
This PR addresses the change in logging that [happened](https://cmake.org/cmake/help/latest/release/3.26.html#configure-log) in CMake 3.26.

Additionally, the `make` invocation replaced with `cmake --build`.

Here are examples of the CI logs:
- for a an error during the build system generation: https://cirrus-ci.com/build/5210987156996096
- for a compiler error: https://cirrus-ci.com/build/4617660913156096