### PR TITLE
RPC: improve SFFO arg parsing, error catching and coverage

### DIFF
--- a/test/functional/wallet_sendmany.py
+++ b/test/functional/wallet_sendmany.py
@@ -5,16 +5,16 @@
 """Test the sendmany RPC command."""
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
 
 class SendmanyTest(BitcoinTestFramework):
     # Setup and helpers
     def add_options(self, parser):
         self.add_wallet_options(parser)
 
-
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
-
 
     def set_test_params(self):
         self.num_nodes = 1
@@ -26,9 +26,19 @@ class SendmanyTest(BitcoinTestFramework):
         addr_3 = self.wallet.getnewaddress()
 
         self.log.info("Test using duplicate address in SFFO argument")
-        self.def_wallet.sendmany(dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[addr_1, addr_1, addr_1])
+        assert_raises_rpc_error(-8, "Invalid parameter 'subtract fee from output', duplicated position: 0", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[addr_1, addr_1, addr_1])
         self.log.info("Test using address not present in tx.vout in SFFO argument")
-        self.def_wallet.sendmany(dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[addr_3])
+        assert_raises_rpc_error(-8, f"Invalid parameter 'subtract fee from output', destination {addr_3} not found in tx outputs", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[addr_3])
+        self.log.info("Test using negative index in SFFO argument")
+        assert_raises_rpc_error(-8, "Invalid parameter 'subtract fee from output', negative position: -5", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[-5])
+        self.log.info("Test using an out of bounds index in SFFO argument")
+        assert_raises_rpc_error(-8, "Invalid parameter 'subtract fee from output', position too large: 5", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[5])
+        self.log.info("Test using an unexpected type in SFFO argument")
+        assert_raises_rpc_error(-8, "Invalid parameter 'subtract fee from output', invalid value type: bool", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[False])
+        self.log.info("Test duplicates in SFFO argument, mix string destinations with numeric indexes")
+        assert_raises_rpc_error(-8, "Invalid parameter 'subtract fee from output', duplicated position: 0", self.def_wallet.sendmany, dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[0, addr_1])
+        self.log.info("Test valid mixing of string destinations with numeric indexes in SFFO argument")
+        self.def_wallet.sendmany(dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[0, addr_2])
 
     def run_test(self):
         self.nodes[0].createwallet("activewallet")


### PR DESCRIPTION
Following changes were made:

1) Catch and signal error for duplicate string destinations.
2) Catch and signal error for invalid value type.
3) Catch and signal error for string destination not found in tx outputs.
4) Improved `InterpretSubtractFeeFromOutputInstructions()` code organization.
5) Added test coverage for all possible error failures.

Also, fixed two PEP 8 warnings at the 'wallet_sendmany.py' file:
- PEP 8: E302 expected 2 blank lines, found 1 at the SendmanyTest class declaration.
- PEP 8: E303 too many blank lines (2) at skip_test_if_missing_module() and set_test_params()