### PR TITLE
test: Drop no longer needed workarounds

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -199,7 +199,7 @@ function(add_boost_test source_file)
       COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no
     )
     set_property(TEST ${test_suite_name} PROPERTY
-      SKIP_REGULAR_EXPRESSION "no test cases matching filter" "Skipping"
+      SKIP_REGULAR_EXPRESSION "no test cases matching filter"
     )
   endif()
 endfunction()

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -86,14 +86,6 @@ BOOST_AUTO_TEST_CASE(raii_event_order)
     event_set_mem_functions(malloc, realloc, free);
 }
 
-#else
-
-BOOST_AUTO_TEST_CASE(raii_event_tests_SKIPPED)
-{
-    // It would probably be ideal to report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
-    BOOST_TEST_MESSAGE("Skipping raii_event_tess: libevent doesn't support event_set_mem_functions");
-}
-
 #endif  // EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -16,13 +16,6 @@
 
 BOOST_FIXTURE_TEST_SUITE(system_tests, BasicTestingSetup)
 
-// At least one test is required (in case ENABLE_EXTERNAL_SIGNER is not defined).
-// Workaround for https://github.com/bitcoin/bitcoin/issues/19128
-BOOST_AUTO_TEST_CASE(dummy)
-{
-    BOOST_CHECK(true);
-}
-
 #ifdef ENABLE_EXTERNAL_SIGNER
 
 BOOST_AUTO_TEST_CASE(run_command)


### PR DESCRIPTION
This PR deletes the workarounds introduced in https://github.com/bitcoin/bitcoin/pull/16564 and https://github.com/bitcoin/bitcoin/pull/15382, as `ctest` skips these cases gracefully: https://github.com/bitcoin/bitcoin/blob/5c80192ff6b982ee3a75be4142fe942b8206f2cd/src/test/CMakeLists.txt#L201-L203