### PR TITLE
doc: fix minor typo

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -1,6 +1,6 @@
 # Windows / MSVC Build Guide
 
-This guide describes how to build bitcoind, command-line utilities, and GUI on Windows using Micsrosoft Visual Studio.
+This guide describes how to build bitcoind, command-line utilities, and GUI on Windows using Microsoft Visual Studio.
 
 For cross-compiling options, please see [`build-windows.md`](./build-windows.md).
 


### PR DESCRIPTION
Fix typo in doc/build-windows-msvc.md:
- "Micsrosoft" -> Microsoft

No test required.