### PR TITLE
cluster mempool: extend DepGraph functionality

### DIFF
--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -28,7 +28,7 @@ DepGraph<SetType> MakeLinearGraph(ClusterIndex ntx)
     DepGraph<SetType> depgraph;
     for (ClusterIndex i = 0; i < ntx; ++i) {
         depgraph.AddTransaction({-int32_t(i), 1});
-        if (i > 0) depgraph.AddDependency(i - 1, i);
+        if (i > 0) depgraph.AddDependencies(SetType::Singleton(i - 1), i);
     }
     return depgraph;
 }
@@ -43,7 +43,7 @@ DepGraph<SetType> MakeWideGraph(ClusterIndex ntx)
     DepGraph<SetType> depgraph;
     for (ClusterIndex i = 0; i < ntx; ++i) {
         depgraph.AddTransaction({int32_t(i) + 1, 1});
-        if (i > 0) depgraph.AddDependency(0, i);
+        if (i > 0) depgraph.AddDependencies(SetType::Singleton(0), i);
     }
     return depgraph;
 }
@@ -70,19 +70,19 @@ DepGraph<SetType> MakeHardGraph(ClusterIndex ntx)
                 depgraph.AddTransaction({1, 2});
             } else if (i == 1) {
                 depgraph.AddTransaction({14, 2});
-                depgraph.AddDependency(0, 1);
+                depgraph.AddDependencies(SetType::Singleton(0), 1);
             } else if (i == 2) {
                 depgraph.AddTransaction({6, 1});
-                depgraph.AddDependency(2, 1);
+                depgraph.AddDependencies(SetType::Singleton(2), 1);
             } else if (i == 3) {
                 depgraph.AddTransaction({5, 1});
-                depgraph.AddDependency(2, 3);
+                depgraph.AddDependencies(SetType::Singleton(2), 3);
             } else if ((i & 1) == 0) {
                 depgraph.AddTransaction({7, 1});
-                depgraph.AddDependency(i - 1, i);
+                depgraph.AddDependencies(SetType::Singleton(i - 1), i);
             } else {
                 depgraph.AddTransaction({5, 1});
-                depgraph.AddDependency(i, 4);
+                depgraph.AddDependencies(SetType::Singleton(i), 4);
             }
         } else {
             // Even cluster size.
@@ -98,16 +98,16 @@ DepGraph<SetType> MakeHardGraph(ClusterIndex ntx)
                 depgraph.AddTransaction({1, 1});
             } else if (i == 1) {
                 depgraph.AddTransaction({3, 1});
-                depgraph.AddDependency(0, 1);
+                depgraph.AddDependencies(SetType::Singleton(0), 1);
             } else if (i == 2) {
                 depgraph.AddTransaction({1, 1});
-                depgraph.AddDependency(0, 2);
+                depgraph.AddDependencies(SetType::Singleton(0), 2);
             } else if (i & 1) {
                 depgraph.AddTransaction({4, 1});
-                depgraph.AddDependency(i - 1, i);
+                depgraph.AddDependencies(SetType::Singleton(i - 1), i);
             } else {
                 depgraph.AddTransaction({0, 1});
-                depgraph.AddDependency(i, 3);
+                depgraph.AddDependencies(SetType::Singleton(i), 3);
             }
         }
     }
@@ -195,7 +195,7 @@ void BenchMergeLinearizationsWorstCase(ClusterIndex ntx, benchmark::Bench& bench
     DepGraph<SetType> depgraph;
     for (ClusterIndex i = 0; i < ntx; ++i) {
         depgraph.AddTransaction({i, 1});
-        if (i) depgraph.AddDependency(0, i);
+        if (i) depgraph.AddDependencies(SetType::Singleton(0), i);
     }
     std::vector<ClusterIndex> lin1;
     std::vector<ClusterIndex> lin2;

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -184,6 +184,48 @@ public:
         }
     }
 
+    /** Compute the (reduced) set of parents of node i in this graph.
+     *
+     * This returns the minimal subset of the parents of i whose ancestors together equal all of
+     * i's ancestors (unless i is part of a cycle of dependencies). Note that DepGraph does not
+     * store the set of parents; this information is inferred from the ancestor sets.
+     *
+     * Complexity: O(N) where N=Ancestors(i).Count() (which is bounded by TxCount()).
+     */
+    SetType GetReducedParents(ClusterIndex i) const noexcept
+    {
+        SetType parents = Ancestors(i);
+        parents.Reset(i);
+        for (auto parent : parents) {
+            if (parents[parent]) {
+                parents -= Ancestors(parent);
+                parents.Set(parent);
+            }
+        }
+        return parents;
+    }
+
+    /** Compute the (reduced) set of children of node i in this graph.
+     *
+     * This returns the minimal subset of the children of i whose descendants together equal all of
+     * i's descendants (unless i is part of a cycle of dependencies). Note that DepGraph does not
+     * store the set of children; this information is inferred from the descendant sets.
+     *
+     * Complexity: O(N) where N=Descendants(i).Count() (which is bounded by TxCount()).
+     */
+    SetType GetReducedChildren(ClusterIndex i) const noexcept
+    {
+        SetType children = Descendants(i);
+        children.Reset(i);
+        for (auto child : children) {
+            if (children[child]) {
+                children -= Descendants(child);
+                children.Set(child);
+            }
+        }
+        return children;
+    }
+
     /** Compute the aggregate feerate of a set of nodes in this graph.
      *
      * Complexity: O(N) where N=elems.Count().

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -23,17 +23,17 @@ namespace {
 constexpr std::pair<FeeFrac, TestBitSet> HOLE{FeeFrac{0, 0x3FFFFF}, {}};
 
 template<typename SetType>
-void TestDepGraphSerialization(const Cluster<SetType>& cluster, const std::string& hexenc)
+void TestDepGraphSerialization(const std::vector<std::pair<FeeFrac, SetType>>& cluster, const std::string& hexenc)
 {
-    DepGraph depgraph(cluster);
-
-    // Run normal sanity and correspondence checks, which includes a round-trip test.
-    VerifyDepGraphFromCluster(cluster, depgraph);
-
-    // Remove holes (which are expected to be present as HOLE entries in cluster).
+    // Construct DepGraph from cluster argument.
+    DepGraph<SetType> depgraph;
     SetType holes;
     for (ClusterIndex i = 0; i < cluster.size(); ++i) {
+        depgraph.AddTransaction(cluster[i].first);
         if (cluster[i] == HOLE) holes.Set(i);
+    }
+    for (ClusterIndex i = 0; i < cluster.size(); ++i) {
+        depgraph.AddDependencies(cluster[i].second, i);
     }
     depgraph.RemoveTransactions(holes);
 

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac sum{1500, 400};
     FeeFrac diff{500, -200};
     FeeFrac empty{0, 0};
-    FeeFrac zero_fee{0, 1}; // zero-fee allowed
+    [[maybe_unused]] FeeFrac zero_fee{0, 1}; // zero-fee allowed
 
     BOOST_CHECK(empty == FeeFrac{}); // same as no-args
 

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -896,24 +896,12 @@ FUZZ_TARGET(clusterlin_postlinearize_tree)
     }
     if (direction & 1) {
         for (ClusterIndex i = 0; i < depgraph_gen.TxCount(); ++i) {
-            auto children = depgraph_gen.Descendants(i) - TestBitSet::Singleton(i);
-            // Remove descendants that are children of other descendants.
-            for (auto j : children) {
-                if (!children[j]) continue;
-                children -= depgraph_gen.Descendants(j);
-                children.Set(j);
-            }
+            auto children = depgraph_gen.GetReducedChildren(i);
             if (children.Any()) depgraph_tree.AddDependency(i, children.First());
          }
     } else {
         for (ClusterIndex i = 0; i < depgraph_gen.TxCount(); ++i) {
-            auto parents = depgraph_gen.Ancestors(i) - TestBitSet::Singleton(i);
-            // Remove ancestors that are parents of other ancestors.
-            for (auto j : parents) {
-                if (!parents[j]) continue;
-                parents -= depgraph_gen.Ancestors(j);
-                parents.Set(j);
-            }
+            auto parents = depgraph_gen.GetReducedParents(i);
             if (parents.Any()) depgraph_tree.AddDependency(parents.First(), i);
         }
     }

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -234,7 +234,7 @@ struct DepGraphFormatter
             if (new_feerate.IsEmpty()) break;
             assert(reordering.size() < SetType::Size());
             auto topo_idx = topo_depgraph.AddTransaction(new_feerate);
-            for (auto parent : new_ancestors) topo_depgraph.AddDependency(parent, topo_idx);
+            topo_depgraph.AddDependencies(new_ancestors, topo_idx);
             diff %= total_size + 1;
             // Insert the new transaction at distance diff back from the end.
             for (auto& pos : reordering) {

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -40,7 +40,7 @@ void assertion_fail(std::string_view file, int line, std::string_view func, std:
 
 /** Helper for Assert()/Assume() */
 template <bool IS_ASSERT, typename T>
-T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
+constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
     if constexpr (IS_ASSERT
 #ifdef ABORT_ON_FAILED_ASSUME

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -64,13 +64,13 @@ struct FeeFrac
     int32_t size;
 
     /** Construct an IsEmpty() FeeFrac. */
-    inline FeeFrac() noexcept : fee{0}, size{0} {}
+    constexpr inline FeeFrac() noexcept : fee{0}, size{0} {}
 
     /** Construct a FeeFrac with specified fee and size. */
-    inline FeeFrac(int64_t f, int32_t s) noexcept : fee{f}, size{s} {}
+    constexpr inline FeeFrac(int64_t f, int32_t s) noexcept : fee{f}, size{s} {}
 
-    inline FeeFrac(const FeeFrac&) noexcept = default;
-    inline FeeFrac& operator=(const FeeFrac&) noexcept = default;
+    constexpr inline FeeFrac(const FeeFrac&) noexcept = default;
+    constexpr inline FeeFrac& operator=(const FeeFrac&) noexcept = default;
 
     /** Check if this is empty (size and fee are 0). */
     bool inline IsEmpty() const noexcept {


### PR DESCRIPTION
Part of cluster mempool: #30289 

This adds:
* `DepGraph::AddDependencies` to add 0 or more dependencies to a single transaction at once (identical to calling `DepGraph::AddDependency` once for each, but more efficient).
* `DepGraph::RemoveTransactions` to remove 0 or more transactions from a depgraph.
* `DepGraph::GetReducedParents` (and `DepGraph::GetReducedChildren`) to get the (reduced) direct parents and children of a transaction in a depgraph.

After which, the `Cluster` type is removed.

This is the result of fleshing out the design for the "intermediate layer" ("TxGraph", no PR yet) between the cluster linearization layer and the mempool layer. My earlier thinking was that TxGraph would store `Cluster` objects (vectors of pairs of `FeeFrac`s and sets of parents), and convert them to `DepGraph` on the fly whenever needed. However, after more consideration, it seems better to have TxGraph store `DepGraph` objects, and manipulate them directly without constantly re-creating them. This requires `DepGraph` to have some additional functionality.

The bulk of the complexity here is the addition of `DepGraph::RemoveTransactions`, which leaves the remaining transactions' positions within the `DepGraph` untouched (we want existing identifiers to remain valid), so this implies that graphs can now have "holes" (positions that are unused, but followed by positions that are used). To enable that, an extension of the fuzz/test serialization format `DepGraphFormatter` is included to deal with such holes.
