### PR TITLE
build: Enhance Ccache performance across worktrees and build trees

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -19,8 +19,17 @@ if(CMAKE_GENERATOR MATCHES "Make|Ninja")
       )
       set(WITH_CCACHE ON)
     elseif(WITH_CCACHE)
-      list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
-      list(APPEND CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
+      foreach(lang IN ITEMS C CXX OBJCXX)
+        if(DEFINED CMAKE_${lang}_COMPILER_LAUNCHER)
+          list(APPEND configure_warnings
+            "CMAKE_${lang}_COMPILER_LAUNCHER is already set. Skipping built-in ccache support for ${lang}."
+          )
+        else()
+          # Use `cmake -E env` as a cross-platform way to set the CCACHE_NOHASHDIR environment variable,
+          # increasing ccache hit rate e.g. in case of multiple build directories or git worktrees.
+          set(CMAKE_${lang}_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env CCACHE_NOHASHDIR=1 ${CCACHE_EXECUTABLE})
+        endif()
+      endforeach()
     endif()
   else()
     set(WITH_CCACHE OFF)

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -2,7 +2,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-if(NOT MSVC)
+# The <LANG>_COMPILER_LAUNCHER target property, used to integrate
+# ccache, is supported only by the Makefile and Ninja generators.
+if(CMAKE_GENERATOR MATCHES "Make|Ninja")
   find_program(CCACHE_EXECUTABLE ccache)
   if(CCACHE_EXECUTABLE)
     execute_process(
@@ -23,6 +25,8 @@ if(NOT MSVC)
   else()
     set(WITH_CCACHE OFF)
   endif()
+else()
+  set(WITH_CCACHE "Built-in ccache support for the '${CMAKE_GENERATOR}' generator is not available.")
 endif()
 
 mark_as_advanced(CCACHE_EXECUTABLE)


### PR DESCRIPTION
To maximize performance, it is essential to follow the [recommendations](https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md#cache-compilations-with-ccache) in the Productivity Notes: set the `base_dir` Ccache configuration option or use the `CCACHE_BASEDIR` environment variable:
```
$ export CCACHE_BASEDIR=$HOME
```

Here are examples of usage on Ubuntu 24.04:

1. Across different worktrees:
```
$ export CCACHE_DIR=$(mktemp -d)
$ git worktree add ../wt_1 4d3f360e2af94f4ed46dc0943196d548da82003e
$ pushd ../wt_1
$ cmake -B build -DWITH_CCACHE=ON
$ cmake --build build -t bitcoind -j $(nproc)
$ popd
$ git worktree add ../wt_2 4d3f360e2af94f4ed46dc0943196d548da82003e
$ pushd ../wt_2
$ cmake -B build -DWITH_CCACHE=ON
$ ccache --zero-stats
$ cmake --build build -t bitcoind -j $(nproc)
$ popd
$ ccache --show-stats
Cacheable calls:    302 / 302 (100.0%)
  Hits:             302 / 302 (100.0%)
    Direct:         302 / 302 (100.0%)
    Preprocessed:     0 / 302 ( 0.00%)
  Misses:             0 / 302 ( 0.00%)
Local storage:
  Cache size (GiB): 0.2 / 5.0 ( 3.31%)
  Hits:             302 / 302 (100.0%)
  Misses:             0 / 302 ( 0.00%)
```

2. Across different build trees:
```
$ export CCACHE_DIR=$(mktemp -d)
$ cmake -B build_1 -DWITH_CCACHE=ON
$ cmake --build build_1 -t bitcoind -j $(nproc)
$ cmake -B build_2 -DWITH_CCACHE=ON
$ ccache --zero-stats
$ cmake --build build_2 -t bitcoind -j $(nproc)
$ ccache --show-stats
Cacheable calls:    302 / 302 (100.0%)
  Hits:             302 / 302 (100.0%)
    Direct:         302 / 302 (100.0%)
    Preprocessed:     0 / 302 ( 0.00%)
  Misses:             0 / 302 ( 0.00%)
Local storage:
  Cache size (GiB): 0.2 / 5.0 ( 3.31%)
  Hits:             302 / 302 (100.0%)
  Misses:             0 / 302 ( 0.00%)
```

This PR addresses this [comment](https://github.com/bitcoin/bitcoin/pull/30811#issuecomment-2331096969):
> However, ccache does _not_ hit across two different build dirs, compiling the same commit.

---

Fixes https://github.com/bitcoin/bitcoin/issues/31771.

Form https://github.com/bitcoin/bitcoin/actions/runs/13215680798/job/36894673006:
```
...
Treat compiler warnings as errors ..... ON
Use ccache for compiling .............. Built-in ccache support for the 'Visual Studio 17 2022' generator is not available.


-- Configuring done (300.1s)
-- Generating done (1.2s)
-- Build files have been written to: D:/a/bitcoin/bitcoin/build
```