### PR TITLE
build: Add more cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,6 +35,63 @@
         "BUILD_GUI": "ON",
         "WITH_QRENCODE": "OFF"
       }
+    },
+    {
+      "name": "libfuzzer",
+      "displayName": "Build for fuzzing with libfuzzer, and sanitizers enabled",
+      "binaryDir": "${sourceDir}/build_fuzz",
+      "cacheVariables": {
+        "BUILD_FOR_FUZZING": "ON",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_C_FLAGS": "-ftrivial-auto-var-init=pattern",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS": "-ftrivial-auto-var-init=pattern",
+        "SANITIZERS": "undefined,address,fuzzer"
+      }
+    },
+    {
+      "name": "libfuzzer-nosan",
+      "displayName": "Build for fuzzing with libfuzzer, and sanitizers disabled",
+      "binaryDir": "${sourceDir}/build_fuzz_nosan",
+      "cacheVariables": {
+        "BUILD_FOR_FUZZING": "ON",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "SANITIZERS": "fuzzer"
+      }
+    },
+    {
+      "name": "dev-mode",
+      "displayName": "Developer mode, with all features/dependencies enabled",
+      "binaryDir": "${sourceDir}/build_dev_mode",
+      "cacheVariables": {
+        "BUILD_BENCH": "ON",
+        "BUILD_CLI": "ON",
+        "BUILD_DAEMON": "ON",
+        "BUILD_FUZZ_BINARY": "ON",
+        "BUILD_GUI": "ON",
+        "BUILD_GUI_TESTS": "ON",
+        "BUILD_KERNEL_LIB": "ON",
+        "BUILD_SHARED_LIBS": "ON",
+        "BUILD_TESTING": "ON",
+        "BUILD_TESTS": "ON",
+        "BUILD_TX": "ON",
+        "BUILD_UTIL": "ON",
+        "BUILD_UTIL_CHAINSTATE": "ON",
+        "BUILD_WALLET_TOOL": "ON",
+        "ENABLE_EXTERNAL_SIGNER": "ON",
+        "ENABLE_HARDENING": "ON",
+        "ENABLE_WALLET": "ON",
+        "WARN_INCOMPATIBLE_BDB": "OFF",
+        "WITH_BDB": "ON",
+        "WITH_MINIUPNPC": "ON",
+        "WITH_MULTIPROCESS": "ON",
+        "WITH_NATPMP": "ON",
+        "WITH_QRENCODE": "ON",
+        "WITH_SQLITE": "ON",
+        "WITH_USDT": "ON",
+        "WITH_ZMQ": "ON"
+      }
     }
   ]
 }

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -7,17 +7,16 @@ To quickly get started fuzzing Bitcoin Core using [libFuzzer](https://llvm.org/d
 ```sh
 $ git clone https://github.com/bitcoin/bitcoin
 $ cd bitcoin/
-$ cmake -B build_fuzz \
-   -DCMAKE_C_COMPILER="clang" \
-   -DCMAKE_CXX_COMPILER="clang++" \
-   -DBUILD_FOR_FUZZING=ON \
-   -DSANITIZERS=undefined,address,fuzzer
+$ cmake --preset=libfuzzer
 # macOS users: If you have problem with this step then make sure to read "macOS hints for
 # libFuzzer" on https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md#macos-hints-for-libfuzzer
 $ cmake --build build_fuzz
 $ FUZZ=process_message build_fuzz/src/test/fuzz/fuzz
 # abort fuzzing using ctrl-c
 ```
+
+One can use `--prefix=libfuzzer-nosan` to do the same without common sanitizers enabled.
+See [further](#run-without-sanitizers-for-increased-throughput) for more information.
 
 There is also a runner script to execute all fuzz targets. Refer to
 `./test/fuzz/test_runner.py --help` for more details.
@@ -107,8 +106,8 @@ INFO: seed corpus: files: 991 min: 1b max: 1858b total: 288291b rss: 150Mb
 Fuzzing on a harness compiled with `-DSANITIZERS=address,fuzzer,undefined` is
 good for finding bugs. However, the very slow execution even under libFuzzer
 will limit the ability to find new coverage. A good approach is to perform
-occasional long runs without the additional bug-detectors (just
-`-DSANITIZERS=fuzzer`) and then merge new inputs into a corpus as described in
+occasional long runs without the additional bug-detectors
+(`--preset=libfuzzer-nosan`) and then merge new inputs into a corpus as described in
 the qa-assets repo
 (https://github.com/bitcoin-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 Patience is useful; even with improved throughput, libFuzzer may need days and
@@ -145,11 +144,9 @@ You may also need to take care of giving the correct path for `clang` and
 Full configuration step that was tested on macOS with `brew` installed `llvm`:
 
 ```sh
-$ cmake -B build_fuzz \
+$ cmake --preset=libfuzzer \
    -DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" \
    -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++" \
-   -DBUILD_FOR_FUZZING=ON \
-   -DSANITIZERS=undefined,address,fuzzer \
    -DAPPEND_LDFLAGS=-Wl,-no_warn_duplicate_libraries
 ```
 


### PR DESCRIPTION
Add three more cmake presets to the project-wide `CMakePresets.json` file:
* `dev-mode`: enables all features and dependencies
* `libfuzzer`: builds for fuzzing with libfuzzer and the typical sanitizers (but not the optional ones that require suppressions) enabled.
* `libfuzzer-nosan`: builds for fuzzing with libfuzzer and no (other) sanitizers

... and then uses these in some documentation.