### PR TITLE
code style: update .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,17 +10,17 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Source code files
-[*.{h,cpp,py,sh}]
+[*.{h,cpp,rs,py,sh}]
 indent_size = 4
 
-# .cirrus.yml, .fuzzbuzz.yml, etc.
+# .cirrus.yml, etc.
 [*.yml]
 indent_size = 2
 
-# Makefiles
-[{*.am,Makefile.*.include}]
+# Makefiles (only relevant for depends build)
+[Makefile]
 indent_style = tab
 
-# Autoconf scripts
-[configure.ac]
+# CMake files
+[{CMakeLists.txt,*.cmake,*.cmake.in}]
 indent_size = 2


### PR DESCRIPTION
Updates the .editorconfig file, first introduced in 2021 (see PR #21123, commit 7a135d57) w.r.t. following changes:
- consider Rust .rs files (relevant since #28076, commit bbbbdb0c)
- reflect build system change to CMake (#30454, #30664)
- add setting for bare Makefile still used for depends builds

Can be tested e.g. by using the editorconfig-vim plugin (https://github.com/editorconfig/editorconfig-vim). The PR is made under the assumption that the file is still considered useful, especially for new contributors. If people feel like that's not the case anymore, the alternative is to delete it, obviously.