### PR TITLE
test: Wait for local services to update in feature_assumeutxo

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -314,9 +314,9 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.sync_blocks(nodes=(miner, snapshot_node))
         # Check the base snapshot block was stored and ensure node signals full-node service support
         self.wait_until(lambda: not try_rpc(-1, "Block not found", snapshot_node.getblock, snapshot_block_hash))
-        assert 'NETWORK' in snapshot_node.getnetworkinfo()['localservicesnames']
+        self.wait_until(lambda: 'NETWORK' in snapshot_node.getnetworkinfo()['localservicesnames'])
 
-        # Now the snapshot_node is sync, verify the ibd_node can sync from it
+        # Now that the snapshot_node is synced, verify the ibd_node can sync from it
         self.connect_nodes(snapshot_node.index, ibd_node.index)
         assert 'NETWORK' in ibd_node.getpeerinfo()[0]['servicesnames']
         self.sync_blocks(nodes=(ibd_node, snapshot_node))
@@ -698,7 +698,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.wait_until(lambda: len(n2.getchainstates()['chainstates']) == 1)
 
         # Once background chain sync completes, the full node must start offering historical blocks again.
-        assert {'NETWORK', 'NETWORK_LIMITED'}.issubset(n2.getnetworkinfo()['localservicesnames'])
+        self.wait_until(lambda: {'NETWORK', 'NETWORK_LIMITED'}.issubset(n2.getnetworkinfo()['localservicesnames']))
 
         completed_idx_state = {
             'basic block filter index': COMPLETE_IDX,


### PR DESCRIPTION
Closes #30878

It seems like there is a race where the block is stored locally and `getblock` does not error anymore, but `ActivateBestChain` has not finished yet, so the local services are not updated yet either. Fix this by waiting for the local services to update.

Can be reproduced locally by adding the sleep here:

```cpp
──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
src/validation.cpp:3567: bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr< │
──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
        }

        if (WITH_LOCK(::cs_main, return m_disabled)) {
            std::this_thread::sleep_for(std::chrono::seconds(10));
            // Background chainstate has reached the snapshot base block, so exit.

            // Restart indexes to resume indexing for all blocks unique to the snapshot
```