### PR TITLE
wip: Split fuzz binary (take 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ endif()
 option(BUILD_BENCH "Build bench_bitcoin executable." OFF)
 option(BUILD_FUZZ_BINARY "Build fuzz binary." OFF)
 option(BUILD_FOR_FUZZING "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF)
+cmake_dependent_option(BUILD_INDIVIDUAL_FUZZ_BINARIES "Build individual fuzz binaries for each harness." OFF "BUILD_FOR_FUZZING" OFF)
 
 option(INSTALL_MAN "Install man pages." ON)
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -31,6 +31,8 @@ const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
 const std::function<std::string()> G_TEST_GET_FULL_NAME{};
 
+std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 namespace {
 
 void GenerateTemplateResults(const std::vector<ankerl::nanobench::Result>& benchmarkResults, const fs::path& file, const char* tpl)

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -34,6 +34,8 @@ const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
 const std::function<std::string()> G_TEST_GET_FULL_NAME{};
 
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 // This is all you need to run all the tests
 int main(int argc, char* argv[])
 {

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 add_subdirectory(util)
 
-add_executable(fuzz
+set(HARNESS_SOURCES
   addition_overflow.cpp
   addrman.cpp
   asmap.cpp
@@ -128,9 +128,9 @@ add_executable(fuzz
   vecdeque.cpp
   versionbits.cpp
 )
-target_link_libraries(fuzz
+
+set(HARNESS_LIBS
   core_interface
-  test_fuzz
   bitcoin_cli
   bitcoin_common
   bitcoin_util
@@ -142,6 +142,30 @@ target_link_libraries(fuzz
   $<TARGET_NAME_IF_EXISTS:libevent::libevent>
 )
 
+if(BUILD_INDIVIDUAL_FUZZ_BINARIES)
+  # bash command produces list of harnesses: <harness name> <source file>
+  execute_process(
+      COMMAND bash -c "grep -H \"^FUZZ_TARGET\" src/test/fuzz/*.cpp | sed -E 's/.*\\/([^/]+\\.cpp):FUZZ_TARGET(_DESERIALIZE)?\\(([a-zA-Z0-9_]+).*/\\3 \\1/'"
+      OUTPUT_VARIABLE FUZZ_HARNESSES
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REPLACE "\n" ";" FUZZ_HARNESS_LIST "${FUZZ_HARNESSES}")
+  message(STATUS ${FUZZ_HARNESSES})
+
+  foreach(HARNESS_INFO ${FUZZ_HARNESS_LIST})
+    string(REPLACE " " ";" HARNESS_PARTS ${HARNESS_INFO})
+    list(GET HARNESS_PARTS 0 HARNESS_NAME)
+    list(GET HARNESS_PARTS 1 HARNESS_FILE)
+
+    add_executable(fuzz_${HARNESS_NAME} ${HARNESS_FILE})
+    target_link_libraries(fuzz_${HARNESS_NAME} ${HARNESS_LIBS} test_fuzz_${HARNESS_NAME})
+    target_compile_definitions(fuzz_${HARNESS_NAME} PUBLIC FUZZ_HARNESS=${HARNESS_NAME})
+  endforeach()
+else()
+  add_executable(fuzz ${HARNESS_SOURCES})
+  target_link_libraries(fuzz ${HARNESS_LIBS} test_fuzz)
+endif()
+
 if(ENABLE_WALLET)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz wallet)
+    #add_subdirectory(${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz wallet)
 endif()

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -75,13 +75,29 @@ auto& FuzzTargets()
 
 void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, FuzzTargetOptions opts)
 {
+#ifndef FUZZ_HARNESS
     const auto [it, ins]{FuzzTargets().try_emplace(name, FuzzTarget /* temporary can be dropped after Apple-Clang-16 ? */ {std::move(target), std::move(opts)})};
     Assert(ins);
+#endif
 }
 
 static std::string_view g_fuzz_target;
-static const TypeTestOneInput* g_test_one_input{nullptr};
 
+#ifdef FUZZ_HARNESS
+void PASTE2(FUZZ_HARNESS, _fuzz_target)(FuzzBufferType);
+extern const FuzzTargetOptions PASTE2(FUZZ_HARNESS, _fuzz_opts);
+#else
+static const TypeTestOneInput* g_test_one_input{nullptr};
+#endif
+
+inline void test_one_input(FuzzBufferType buffer)
+{
+#ifdef FUZZ_HARNESS
+    PASTE2(FUZZ_HARNESS,_fuzz_target)(buffer);
+#else
+    (*Assert(g_test_one_input))(buffer);
+#endif
+}
 
 #if defined(__clang__) && defined(__linux__)
 extern "C" void __llvm_profile_reset_counters(void) __attribute__((weak));
@@ -122,6 +138,9 @@ void initialize()
         return WrappedGetAddrInfo(name, false);
     };
 
+#ifdef FUZZ_HARNESS
+    PASTE2(FUZZ_HARNESS, _fuzz_opts).init();
+#else
     bool should_exit{false};
     if (std::getenv("PRINT_ALL_FUZZ_TARGETS_AND_ABORT")) {
         for (const auto& [name, t] : FuzzTargets()) {
@@ -151,6 +170,7 @@ void initialize()
         std::cerr << "Hint: Set the PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 env var to see all compiled targets." << std::endl;
         std::exit(EXIT_FAILURE);
     }
+
     const auto it = FuzzTargets().find(g_fuzz_target);
     if (it == FuzzTargets().end()) {
         std::cerr << "No fuzz target compiled for " << g_fuzz_target << "." << std::endl;
@@ -159,6 +179,7 @@ void initialize()
     Assert(!g_test_one_input);
     g_test_one_input = &it->second.test_one_input;
     it->second.opts.init();
+#endif
 
     ResetCoverageCounters();
 }
@@ -207,7 +228,6 @@ void signal_handler(int signal)
 // This function is used by libFuzzer
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    static const auto& test_one_input = *Assert(g_test_one_input);
     test_one_input({data, size});
     return 0;
 }
@@ -224,7 +244,6 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
 int main(int argc, char** argv)
 {
     initialize();
-    static const auto& test_one_input = *Assert(g_test_one_input);
 #ifdef __AFL_LOOP
     // Enable AFL persistent mode. Requires compilation using afl-clang-fast++.
     // See fuzzing.md for details.

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -37,6 +37,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::string()> G_TEST_GET_FULL_NAME{};
 
+std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -36,10 +36,11 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 
 #define DETAIL_FUZZ(name, ...)                                                        \
     void name##_fuzz_target(FuzzBufferType);                                          \
+    FuzzTargetOptions name##_fuzz_opts{__VA_ARGS__};                                  \
     struct name##_Before_Main {                                                       \
         name##_Before_Main()                                                          \
         {                                                                             \
-            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, {__VA_ARGS__});    \
+            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, name##_fuzz_opts); \
         }                                                                             \
     } const static g_##name##_before_main;                                            \
     void name##_fuzz_target(FuzzBufferType buffer)

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -30,6 +30,7 @@ void initialize_miner()
         g_available_coins.emplace_back(Txid::FromUint256(uint256::ZERO), i);
     }
 }
+} // namespace
 
 // Test that the MiniMiner can run with various outpoints and feerates.
 FUZZ_TARGET(mini_miner, .init = initialize_miner)
@@ -196,4 +197,3 @@ FUZZ_TARGET(mini_miner_selection, .init = initialize_miner)
         assert(mock_template_txids.count(tx->GetHash()));
     }
 }
-} // namespace

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -136,6 +136,7 @@ std::unique_ptr<CTxMemPool> MakeMempool(FuzzedDataProvider& fuzzed_data_provider
     Assert(error.empty() || error.original.starts_with("-maxmempool must be at least "));
     return mempool;
 }
+} // namespace
 
 FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
 {
@@ -327,4 +328,3 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
 
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
 }
-} // namespace

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -186,9 +186,9 @@ void Test(const std::string& str)
     }
 }
 
-void test_init() {}
+} // namespace
 
-FUZZ_TARGET(script_assets_test_minimizer, .init = test_init, .hidden = true)
+FUZZ_TARGET(script_assets_test_minimizer, .hidden = true)
 {
     if (buffer.size() < 2 || buffer.back() != '\n' || buffer[buffer.size() - 2] != ',') return;
     const std::string str((const char*)buffer.data(), buffer.size() - 2);
@@ -197,5 +197,3 @@ FUZZ_TARGET(script_assets_test_minimizer, .init = test_init, .hidden = true)
     } catch (const std::runtime_error&) {
     }
 }
-
-} // namespace

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -26,6 +26,7 @@ std::string GetArgumentName(const std::string& name)
     }
     return name.substr(0, idx);
 }
+} // namespace
 
 FUZZ_TARGET(system, .init = initialize_system)
 {
@@ -127,4 +128,3 @@ FUZZ_TARGET(system, .init = initialize_system)
 
     (void)HelpRequested(args_manager);
 }
-} // namespace

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -184,6 +184,7 @@ void CheckATMPInvariants(const MempoolAcceptResult& res, bool txid_in_mempool, b
     }
     }
 }
+} // namespace
 
 FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 {
@@ -418,4 +419,3 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
     }
     Finish(fuzzed_data_provider, tx_pool, chainstate);
 }
-} // namespace

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -2,22 +2,61 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
-  descriptor.cpp
-  mempool.cpp
-  net.cpp
-  ../fuzz.cpp
-  ../util.cpp
-)
+if(BUILD_INDIVIDUAL_FUZZ_BINARIES)
+  # bash command produces list of harnesses: <harness name> <source file>
+  execute_process(
+      COMMAND bash -c "grep -H \"^FUZZ_TARGET\" src/test/fuzz/*.cpp | sed -E 's/.*\\/([^/]+\\.cpp):FUZZ_TARGET(_DESERIALIZE)?\\(([a-zA-Z0-9_]+).*/\\3 \\1/'"
+      OUTPUT_VARIABLE FUZZ_HARNESSES
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REPLACE "\n" ";" FUZZ_HARNESS_LIST "${FUZZ_HARNESSES}")
+  message(STATUS ${FUZZ_HARNESSES})
 
-target_link_libraries(test_fuzz
-  PRIVATE
-    core_interface
-    test_util
-    bitcoin_node
-    Boost::headers
-)
+  foreach(HARNESS_INFO ${FUZZ_HARNESS_LIST})
+    string(REPLACE " " ";" HARNESS_PARTS ${HARNESS_INFO})
+    list(GET HARNESS_PARTS 0 HARNESS_NAME)
+    list(GET HARNESS_PARTS 1 HARNESS_FILE)
 
-if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
-  target_compile_definitions(test_fuzz PRIVATE PROVIDE_FUZZ_MAIN_FUNCTION)
+    add_library(test_fuzz_${HARNESS_NAME} STATIC EXCLUDE_FROM_ALL
+      descriptor.cpp
+      mempool.cpp
+      net.cpp
+      ../fuzz.cpp
+      ../util.cpp
+    )
+
+    target_link_libraries(test_fuzz_${HARNESS_NAME}
+      PRIVATE
+        core_interface
+        test_util
+        bitcoin_node
+        Boost::headers
+    )
+
+    target_compile_definitions(test_fuzz_${HARNESS_NAME} PUBLIC FUZZ_HARNESS=${HARNESS_NAME})
+
+    if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
+      target_compile_definitions(test_fuzz_${HARNESS_NAME} PRIVATE PROVIDE_FUZZ_MAIN_FUNCTION)
+    endif()
+  endforeach()
+else()
+  add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
+    descriptor.cpp
+    mempool.cpp
+    net.cpp
+    ../fuzz.cpp
+    ../util.cpp
+  )
+
+  target_link_libraries(test_fuzz
+    PRIVATE
+      core_interface
+      test_util
+      bitcoin_node
+      Boost::headers
+  )
+
+  if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
+    target_compile_definitions(test_fuzz PRIVATE PROVIDE_FUZZ_MAIN_FUNCTION)
+  endif()
 endif()

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -184,6 +184,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         setup.LoadVerifyActivateChainstate();
     }
 }
+} // namespace
 
 // There are two fuzz targets:
 //
@@ -196,5 +197,3 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
 // expensive state to be reset.
 FUZZ_TARGET(utxo_snapshot /*valid*/, .init = initialize_chain<false>) { utxo_snapshot_fuzz<false>(buffer); }
 FUZZ_TARGET(utxo_snapshot_invalid, .init = initialize_chain<true>) { utxo_snapshot_fuzz<true>(buffer); }
-
-} // namespace

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -110,6 +110,7 @@ void initialize()
 }
 
 constexpr uint32_t MAX_START_TIME = 4102444800; // 2100-01-01
+} // namespace
 
 FUZZ_TARGET(versionbits, .init = initialize)
 {
@@ -362,4 +363,3 @@ FUZZ_TARGET(versionbits, .init = initialize)
         assert(exp_since > 0 || exp_state == ThresholdState::DEFINED);
     }
 }
-} // namespace

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -46,3 +46,5 @@ const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS = 
 const std::function<std::string()> G_TEST_GET_FULL_NAME = []() {
     return boost::unit_test::framework::current_test_case().full_name();
 };
+
+std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -72,8 +72,6 @@ using node::LoadChainstate;
 using node::RegenerateCommitments;
 using node::VerifyLoadedChainstate;
 
-const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
-
 constexpr inline auto TEST_DIR_PATH_ELEMENT{"test_common bitcoin"}; // Includes a space to catch possible path escape issues.
 /** Random context to get unique temp data dirs. Separate from m_rng, which can be seeded from a const env var */
 static FastRandomContext g_rng_temp_path;


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/28971

In addition to the benefits listed in #28971, this should also enable us to use https://github.com/ossf/fuzz-introspector provided by oss-fuzz. Our current runtime harness selection blocks introspector's static analysis from working properly (e.g. it can't statically determine which functions are reachable by a given harness).

This PR uses the approach suggested here: https://github.com/bitcoin/bitcoin/pull/29010#issuecomment-1846204744. The list of available harnesses is determined (prior to compiling) by grepping for harness names in `FUZZ_TARGET` invocations. When compiling with `-DBUILD_INDIVIDUAL_FUZZ_BINARIES=ON`, individual binaries for each harness are produced that no longer include the runtime lookup via the `FUZZ` environment variable.

```
cmake -B build_fuzz \
  -DBUILD_FOR_FUZZING=ON \
  -DBUILD_INDIVIDUAL_FUZZ_BINARIES=ON \
  -DSANITIZERS=fuzzer
cmake --build build_fuzz
```

`build_fuzz/src/test/fuzz` will contain the individual binaries, which are prefixed with `fuzz_*`.

I'm opening this now to get some early feedback, there are still a few things to address:
- [ ] mention `-DBUILD_INDIVIDUAL_FUZZ_BINARIES` in the docs
- [ ] include wallet harnesses
- [ ] CI job that builds individual binaries (perhaps verify that the list of produced harnesses matches the monolithic binary)