### PR TITLE
build: optimize .h generation in GenerateHeaderFrom{Raw,Json}.cmake

### DIFF
--- a/cmake/script/GenerateHeaderFromJson.cmake
+++ b/cmake/script/GenerateHeaderFromJson.cmake
@@ -2,25 +2,21 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+cmake_path(GET JSON_SOURCE_PATH STEM json_source_basename)
+
 file(READ ${JSON_SOURCE_PATH} hex_content HEX)
-string(REGEX MATCHALL "([A-Za-z0-9][A-Za-z0-9])" bytes "${hex_content}")
+string(REGEX REPLACE "................" "\\0\n" formatted_bytes "${hex_content}")
+string(REGEX REPLACE "[^\n][^\n]" "0x\\0, " formatted_bytes "${formatted_bytes}")
 
-file(WRITE ${HEADER_PATH} "#include <string_view>\n")
-file(APPEND ${HEADER_PATH} "namespace json_tests{\n")
-get_filename_component(json_source_basename ${JSON_SOURCE_PATH} NAME_WE)
-file(APPEND ${HEADER_PATH} "inline constexpr char detail_${json_source_basename}_bytes[]{\n")
+set(header_content
+"#include <string_view>
 
-set(i 0)
-foreach(byte ${bytes})
-  math(EXPR i "${i} + 1")
-  math(EXPR remainder "${i} % 8")
-  if(remainder EQUAL 0)
-    file(APPEND ${HEADER_PATH} "0x${byte},\n")
-  else()
-    file(APPEND ${HEADER_PATH} "0x${byte}, ")
-  endif()
-endforeach()
+namespace json_tests {
+inline constexpr char detail_${json_source_basename}_bytes[] {
+${formatted_bytes}
+};
 
-file(APPEND ${HEADER_PATH} "\n};\n")
-file(APPEND ${HEADER_PATH} "inline constexpr std::string_view ${json_source_basename}{std::begin(detail_${json_source_basename}_bytes), std::end(detail_${json_source_basename}_bytes)};")
-file(APPEND ${HEADER_PATH} "\n}")
+inline constexpr std::string_view ${json_source_basename}{std::begin(detail_${json_source_basename}_bytes), std::end(detail_${json_source_basename}_bytes)};
+}
+")
+file(WRITE ${HEADER_PATH} "${header_content}")

--- a/cmake/script/GenerateHeaderFromRaw.cmake
+++ b/cmake/script/GenerateHeaderFromRaw.cmake
@@ -2,26 +2,22 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+cmake_path(GET RAW_SOURCE_PATH STEM raw_source_basename)
+
 file(READ ${RAW_SOURCE_PATH} hex_content HEX)
-string(REGEX MATCHALL "([A-Za-z0-9][A-Za-z0-9])" bytes "${hex_content}")
+string(REGEX REPLACE "................" "\\0\n" formatted_bytes "${hex_content}")
+string(REGEX REPLACE "[^\n][^\n]" "std::byte{0x\\0}, " formatted_bytes "${formatted_bytes}")
 
-file(WRITE ${HEADER_PATH} "#include <cstddef>\n")
-file(APPEND ${HEADER_PATH} "#include <span>\n")
-file(APPEND ${HEADER_PATH} "namespace ${RAW_NAMESPACE} {\n")
-get_filename_component(raw_source_basename ${RAW_SOURCE_PATH} NAME_WE)
-file(APPEND ${HEADER_PATH} "inline constexpr std::byte detail_${raw_source_basename}_raw[]{\n")
+set(header_content
+"#include <cstddef>
+#include <span>
 
-set(i 0)
-foreach(byte ${bytes})
-  math(EXPR i "${i} + 1")
-  math(EXPR remainder "${i} % 8")
-  if(remainder EQUAL 0)
-    file(APPEND ${HEADER_PATH} "std::byte{0x${byte}},\n")
-  else()
-    file(APPEND ${HEADER_PATH} "std::byte{0x${byte}}, ")
-  endif()
-endforeach()
+namespace ${RAW_NAMESPACE} {
+inline constexpr std::byte detail_${raw_source_basename}_raw[] {
+${formatted_bytes}
+};
 
-file(APPEND ${HEADER_PATH} "\n};\n")
-file(APPEND ${HEADER_PATH} "inline constexpr std::span ${raw_source_basename}{detail_${raw_source_basename}_raw};\n")
-file(APPEND ${HEADER_PATH} "}")
+inline constexpr std::span ${raw_source_basename}{detail_${raw_source_basename}_raw};
+}
+")
+file(WRITE ${HEADER_PATH} "${header_content}")


### PR DESCRIPTION
Follow up of the https://github.com/bitcoin/bitcoin/pull/30883 revert.

Replaced multiple file writes with a single string template write.
The raw content is first grouped into 8 byte chunks, followed by another regex replace which wraps them in `std::byte` or just the raw bytes, prefixed with `0x`.

Tested the output with `diff -w` and they're the same - only whitespace differences because slightly different source formatting.

----

Tested the `Raw` performance with:
```bash
time cmake -DRAW_SOURCE_PATH=src/bench/data/block413567.raw -DHEADER_PATH=build/after/block413567.raw.h -DRAW_NAMESPACE=benchmark::data -P cmake/script/GenerateHeaderFromRaw.cmake
```

Before:
> 15.41s user 23.06s system 97% cpu 39.593 total

After:
> 0.77s user 0.06s system 97% cpu 0.849 total

----

Tested the `Json` performance with:
```bash
time cmake -DJSON_SOURCE_PATH=src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json -DHEADER_PATH=build/after/ecdsa_secp256k1_sha256_bitcoin_test.json -P cmake/script/GenerateHeaderFromJson.cmake
````

Before:
> 3.57s user 6.01s system 94% cpu 10.136 total

After:
> 0.17s user 0.01s system 98% cpu 0.187 total
