### PR TITLE
test: Check already deactivated network stays suspended after dumptxoutset

### DIFF
--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -19,6 +19,17 @@ class DumptxoutsetTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
+    def check_expected_network(self, node, active):
+        rev_file = node.blocks_path / "rev00000.dat"
+        bogus_file = node.blocks_path / "bogus.dat"
+        rev_file.rename(bogus_file)
+        assert_raises_rpc_error(
+            -1, 'Could not roll back to requested height.', node.dumptxoutset, 'utxos.dat', rollback=99)
+        assert_equal(node.getnetworkinfo()['networkactive'], active)
+
+        # Cleanup
+        bogus_file.rename(rev_file)
+
     def run_test(self):
         """Test a trivial usage of the dumptxoutset RPC command."""
         node = self.nodes[0]
@@ -60,16 +71,14 @@ class DumptxoutsetTest(BitcoinTestFramework):
         assert_raises_rpc_error(
             -8, 'Invalid snapshot type "bogus" specified. Please specify "rollback" or "latest"', node.dumptxoutset, 'utxos.dat', "bogus")
 
-        self.log.info(f"Test that dumptxoutset failure does not leave the network activity suspended")
-        rev_file = node.blocks_path / "rev00000.dat"
-        bogus_file = node.blocks_path / "bogus.dat"
-        rev_file.rename(bogus_file)
-        assert_raises_rpc_error(
-            -1, 'Could not roll back to requested height.', node.dumptxoutset, 'utxos.dat', rollback=99)
-        assert_equal(node.getnetworkinfo()['networkactive'], True)
+        self.log.info(f"Test that dumptxoutset failure does not leave the network activity suspended when it was on previously")
+        self.check_expected_network(node, True)
 
-        # Cleanup
-        bogus_file.rename(rev_file)
+        self.log.info(f"Test that dumptxoutset failure leaves the network activity suspended when it was off")
+        node.setnetworkactive(False)
+        self.check_expected_network(node, False)
+        node.setnetworkactive(True)
+
 
 if __name__ == '__main__':
     DumptxoutsetTest(__file__).main()


### PR DESCRIPTION
Follow-up to #30817 which covered the robustness of `dumptxoutset`: network is deactivated during the run but re-activated even when an issue was encountered. But it did not cover the case if the user had deactivated the network themselves before. In that case the user may want the network to stay off so the network is not reactivated after `dumptxoutset` finishes. A test for this behavior is added here.