### PR TITLE
refactor: prohibit direct flags access in CCoinsCacheEntry and remove invalid tests

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -49,7 +49,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
             cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
             if (ret->second.coin.IsSpent()) { // TODO GetCoin cannot return spent coins
                 // The parent only has an empty entry for this outpoint; we can consider our version as fresh.
-                ret->second.AddFlags(CCoinsCacheEntry::FRESH, *ret, m_sentinel);
+                CCoinsCacheEntry::SetFresh(*ret, m_sentinel);
             }
         } else {
             cacheCoins.erase(ret);
@@ -95,7 +95,8 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         fresh = !it->second.IsDirty();
     }
     it->second.coin = std::move(coin);
-    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0), *it, m_sentinel);
+    CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+    if (fresh) CCoinsCacheEntry::SetFresh(*it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACE5(utxocache, add,
            outpoint.hash.data(),
@@ -107,13 +108,8 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
     cachedCoinsUsage += coin.DynamicMemoryUsage();
-    auto [it, inserted] = cacheCoins.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(std::move(outpoint)),
-        std::forward_as_tuple(std::move(coin)));
-    if (inserted) {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
-    }
+    auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
+    if (inserted) CCoinsCacheEntry::SetDirty(*it, m_sentinel);
 }
 
 void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check_for_overwrite) {
@@ -143,7 +139,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (it->second.IsFresh()) {
         cacheCoins.erase(it);
     } else {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
+        CCoinsCacheEntry::SetDirty(*it, m_sentinel);
         it->second.coin.Clear();
     }
     return true;
@@ -203,13 +199,11 @@ bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &ha
                     entry.coin = it->second.coin;
                 }
                 cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                entry.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
+                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
-                if (it->second.IsFresh()) {
-                    entry.AddFlags(CCoinsCacheEntry::FRESH, *itUs, m_sentinel);
-                }
+                if (it->second.IsFresh()) CCoinsCacheEntry::SetFresh(*itUs, m_sentinel);
             }
         } else {
             // Found the entry in the parent cache
@@ -237,7 +231,7 @@ bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &ha
                     itUs->second.coin = it->second.coin;
                 }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
+                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent
                 // cache. If it already existed and was spent in the parent
                 // cache then marking it FRESH would prevent that spentness

--- a/src/coins.h
+++ b/src/coins.h
@@ -162,20 +162,19 @@ public:
     //! Adding a flag also requires a self reference to the pair that contains
     //! this entry in the CCoinsCache map and a reference to the sentinel of the
     //! flagged pair linked list.
-    void AddFlags(uint8_t flags, CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept
+    static void AddFlags(uint8_t flags, CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept
     {
         Assume(flags & (DIRTY | FRESH));
-        Assume(&pair.second == this);
-        if (!m_flags) {
-            m_prev = sentinel.second.m_prev;
-            m_next = &sentinel;
+        if (!pair.second.m_flags) {
+            pair.second.m_prev = sentinel.second.m_prev;
+            pair.second.m_next = &sentinel;
             sentinel.second.m_prev = &pair;
-            m_prev->second.m_next = &pair;
+            pair.second.m_prev->second.m_next = &pair;
         }
-        m_flags |= flags;
+        pair.second.m_flags |= flags;
     }
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { pair.second.AddFlags(DIRTY, pair, sentinel); }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { pair.second.AddFlags(FRESH, pair, sentinel); }
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(DIRTY, pair, sentinel); }
+    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); }
 
     void SetClean() noexcept
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -166,11 +166,13 @@ public:
     {
         Assume(flags & (DIRTY | FRESH));
         if (!pair.second.m_flags) {
+            Assume(!pair.second.m_prev && !pair.second.m_next);
             pair.second.m_prev = sentinel.second.m_prev;
             pair.second.m_next = &sentinel;
             sentinel.second.m_prev = &pair;
             pair.second.m_prev->second.m_next = &pair;
         }
+        Assume(pair.second.m_prev && pair.second.m_next);
         pair.second.m_flags |= flags;
     }
     static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(DIRTY, pair, sentinel); }
@@ -182,6 +184,7 @@ public:
         m_next->second.m_prev = m_prev;
         m_prev->second.m_next = m_next;
         m_flags = 0;
+        m_prev = m_next = nullptr;
     }
     uint8_t GetFlags() const noexcept { return m_flags; }
     bool IsDirty() const noexcept { return m_flags & DIRTY; }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -596,7 +596,8 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, CAmo
     SetCoinsValue(value, entry.coin);
     auto inserted = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted.second);
-    inserted.first->second.AddFlags(flags, *inserted.first, sentinel);
+    if (flags & DIRTY) CCoinsCacheEntry::SetDirty(*inserted.first, sentinel);
+    if (flags & FRESH) CCoinsCacheEntry::SetFresh(*inserted.first, sentinel);
     return inserted.first->second.coin.DynamicMemoryUsage();
 }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -674,7 +674,8 @@ public:
 static void CheckAccessCoin(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
 {
     SingleEntryCacheTest test{base_value, cache_coin};
-    test.cache.AccessCoin(OUTPOINT);
+    auto& coin = test.cache.AccessCoin(OUTPOINT);
+    BOOST_CHECK_EQUAL(coin.IsSpent(), !test.cache.GetCoin(OUTPOINT));
     test.cache.SelfTest(/*sanity_check=*/false);
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(test.cache.map()), expected);
 }
@@ -684,37 +685,21 @@ BOOST_AUTO_TEST_CASE(ccoins_access)
     /* Check AccessCoin behavior, requesting a coin from a cache view layered on
      * top of a base view, and checking the resulting entry in the cache after
      * the access.
-     *              Base    Cache               Expected
+     *                  Base        Cache               Expected
      */
-    CheckAccessCoin(ABSENT, MISSING,            MISSING           );
-    CheckAccessCoin(ABSENT, SPENT_CLEAN,        SPENT_CLEAN       );
-    CheckAccessCoin(ABSENT, SPENT_FRESH,        SPENT_FRESH       );
-    CheckAccessCoin(ABSENT, SPENT_DIRTY,        SPENT_DIRTY       );
-    CheckAccessCoin(ABSENT, SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
-    CheckAccessCoin(ABSENT, VALUE2_CLEAN,       VALUE2_CLEAN      );
-    CheckAccessCoin(ABSENT, VALUE2_FRESH,       VALUE2_FRESH      );
-    CheckAccessCoin(ABSENT, VALUE2_DIRTY,       VALUE2_DIRTY      );
-    CheckAccessCoin(ABSENT, VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
+    for (auto base_value : {ABSENT, SPENT, VALUE1}) {
+        CheckAccessCoin(base_value, MISSING,            base_value == VALUE1 ? VALUE1_CLEAN : MISSING);
 
-    CheckAccessCoin(SPENT,  MISSING,            MISSING           );
-    CheckAccessCoin(SPENT,  SPENT_CLEAN,        SPENT_CLEAN       );
-    CheckAccessCoin(SPENT,  SPENT_FRESH,        SPENT_FRESH       );
-    CheckAccessCoin(SPENT,  SPENT_DIRTY,        SPENT_DIRTY       );
-    CheckAccessCoin(SPENT,  SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
-    CheckAccessCoin(SPENT,  VALUE2_CLEAN,       VALUE2_CLEAN      );
-    CheckAccessCoin(SPENT,  VALUE2_FRESH,       VALUE2_FRESH      );
-    CheckAccessCoin(SPENT,  VALUE2_DIRTY,       VALUE2_DIRTY      );
-    CheckAccessCoin(SPENT,  VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
+        CheckAccessCoin(base_value, SPENT_CLEAN,        SPENT_CLEAN       );
+        CheckAccessCoin(base_value, SPENT_FRESH,        SPENT_FRESH       );
+        CheckAccessCoin(base_value, SPENT_DIRTY,        SPENT_DIRTY       );
+        CheckAccessCoin(base_value, SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
 
-    CheckAccessCoin(VALUE1, MISSING,            VALUE1_CLEAN      );
-    CheckAccessCoin(VALUE1, SPENT_CLEAN,        SPENT_CLEAN       );
-    CheckAccessCoin(VALUE1, SPENT_FRESH,        SPENT_FRESH       );
-    CheckAccessCoin(VALUE1, SPENT_DIRTY,        SPENT_DIRTY       );
-    CheckAccessCoin(VALUE1, SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
-    CheckAccessCoin(VALUE1, VALUE2_CLEAN,       VALUE2_CLEAN      );
-    CheckAccessCoin(VALUE1, VALUE2_FRESH,       VALUE2_FRESH      );
-    CheckAccessCoin(VALUE1, VALUE2_DIRTY,       VALUE2_DIRTY      );
-    CheckAccessCoin(VALUE1, VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
+        CheckAccessCoin(base_value, VALUE2_CLEAN,       VALUE2_CLEAN      );
+        CheckAccessCoin(base_value, VALUE2_FRESH,       VALUE2_FRESH      );
+        CheckAccessCoin(base_value, VALUE2_DIRTY,       VALUE2_DIRTY      );
+        CheckAccessCoin(base_value, VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
+    }
 }
 
 static void CheckSpendCoins(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
@@ -730,37 +715,21 @@ BOOST_AUTO_TEST_CASE(ccoins_spend)
     /* Check SpendCoin behavior, requesting a coin from a cache view layered on
      * top of a base view, spending, and then checking
      * the resulting entry in the cache after the modification.
-     *              Base    Cache               Expected
+     *                  Base        Cache               Expected
      */
-    CheckSpendCoins(ABSENT, MISSING,            MISSING    );
-    CheckSpendCoins(ABSENT, SPENT_CLEAN,        SPENT_DIRTY);
-    CheckSpendCoins(ABSENT, SPENT_FRESH,        MISSING    );
-    CheckSpendCoins(ABSENT, SPENT_DIRTY,        SPENT_DIRTY);
-    CheckSpendCoins(ABSENT, SPENT_DIRTY_FRESH,  MISSING    );
-    CheckSpendCoins(ABSENT, VALUE2_CLEAN,       SPENT_DIRTY);
-    CheckSpendCoins(ABSENT, VALUE2_FRESH,       MISSING    );
-    CheckSpendCoins(ABSENT, VALUE2_DIRTY,       SPENT_DIRTY);
-    CheckSpendCoins(ABSENT, VALUE2_DIRTY_FRESH, MISSING    );
+    for (auto base_value : {ABSENT, SPENT, VALUE1}) {
+        CheckSpendCoins(base_value, MISSING,            base_value == VALUE1 ? SPENT_DIRTY : MISSING);
 
-    CheckSpendCoins(SPENT,  MISSING,            MISSING    );
-    CheckSpendCoins(SPENT,  SPENT_CLEAN,        SPENT_DIRTY);
-    CheckSpendCoins(SPENT,  SPENT_FRESH,        MISSING    );
-    CheckSpendCoins(SPENT,  SPENT_DIRTY,        SPENT_DIRTY);
-    CheckSpendCoins(SPENT,  SPENT_DIRTY_FRESH,  MISSING    );
-    CheckSpendCoins(SPENT,  VALUE2_CLEAN,       SPENT_DIRTY);
-    CheckSpendCoins(SPENT,  VALUE2_FRESH,       MISSING    );
-    CheckSpendCoins(SPENT,  VALUE2_DIRTY,       SPENT_DIRTY);
-    CheckSpendCoins(SPENT,  VALUE2_DIRTY_FRESH, MISSING    );
+        CheckSpendCoins(base_value, SPENT_CLEAN,        SPENT_DIRTY);
+        CheckSpendCoins(base_value, SPENT_FRESH,        MISSING    );
+        CheckSpendCoins(base_value, SPENT_DIRTY,        SPENT_DIRTY);
+        CheckSpendCoins(base_value, SPENT_DIRTY_FRESH,  MISSING    );
 
-    CheckSpendCoins(VALUE1, MISSING,            SPENT_DIRTY);
-    CheckSpendCoins(VALUE1, SPENT_CLEAN,        SPENT_DIRTY);
-    CheckSpendCoins(VALUE1, SPENT_FRESH,        MISSING    );
-    CheckSpendCoins(VALUE1, SPENT_DIRTY,        SPENT_DIRTY);
-    CheckSpendCoins(VALUE1, SPENT_DIRTY_FRESH,  MISSING    );
-    CheckSpendCoins(VALUE1, VALUE2_CLEAN,       SPENT_DIRTY);
-    CheckSpendCoins(VALUE1, VALUE2_FRESH,       MISSING    );
-    CheckSpendCoins(VALUE1, VALUE2_DIRTY,       SPENT_DIRTY);
-    CheckSpendCoins(VALUE1, VALUE2_DIRTY_FRESH, MISSING    );
+        CheckSpendCoins(base_value, VALUE2_CLEAN,       SPENT_DIRTY);
+        CheckSpendCoins(base_value, VALUE2_FRESH,       MISSING    );
+        CheckSpendCoins(base_value, VALUE2_DIRTY,       SPENT_DIRTY);
+        CheckSpendCoins(base_value, VALUE2_DIRTY_FRESH, MISSING    );
+    }
 }
 
 static void CheckAddCoin(const CAmount base_value, const MaybeCoin& cache_coin, const CAmount modify_value, const CoinOrError& expected, const bool coinbase)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -613,7 +613,9 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags, const C
         } else {
             value = it->second.coin.out.nValue;
         }
-        flags = it->second.GetFlags();
+        flags = 0;
+        if (it->second.IsDirty()) flags |= DIRTY;
+        if (it->second.IsFresh()) flags |= FRESH;
         assert(flags != NO_ENTRY);
     }
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -128,7 +128,8 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    const auto flags{fuzzed_data_provider.ConsumeIntegral<uint8_t>()};
+                    const auto dirty{fuzzed_data_provider.ConsumeBool()};
+                    const auto fresh{fuzzed_data_provider.ConsumeBool()};
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {
@@ -140,7 +141,8 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                         coins_cache_entry.coin = *opt_coin;
                     }
                     auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
-                    it->second.AddFlags(flags, *it, sentinel);
+                    if (dirty) CCoinsCacheEntry::SetDirty(*it, sentinel);
+                    if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
                     usage += it->second.coin.DynamicMemoryUsage();
                 }
                 bool expected_code_path = false;


### PR DESCRIPTION
Similarly to https://github.com/bitcoin/bitcoin/pull/30849, this cleanup is intended to de-risk https://github.com/bitcoin/bitcoin/pull/30673#discussion_r1739909068 by simplifying the coin cache public interface.

`CCoinsCacheEntry` provided general access to its internal flags state, even though, in reality, it could only be `clean`, `fresh`, `dirty`, or `fresh|dirty` (in the follow-up, we will remove `fresh` without `dirty`).

Once it was marked as `dirty`, we couldn’t set the state back to clean with `AddFlags(0)`—tests explicitly checked against that.

This PR refines the public interface to make this distinction clearer and to make invalid behavior impossible, rather than just checked by tests. We don't need extensive access to the internals of `CCoinsCacheEntry`, as many tests were simply validating invalid combinations in this way.

The last few commits contain significant test refactorings to make `coins_tests` easier to change in follow-ups.