### PR TITLE
wallet: Fix error messages telling user to specify wallet

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -950,7 +950,7 @@ static void ParseError(const UniValue& error, std::string& strPrint, int& nRet)
             strPrint += ("error message:\n" + err_msg.get_str());
         }
         if (err_code.isNum() && err_code.getInt<int>() == RPC_WALLET_NOT_SPECIFIED) {
-            strPrint += "\nTry adding \"-rpcwallet=<filename>\" option to bitcoin-cli command line.";
+            strPrint += "\nTry adding \"-rpcwallet=<walletname>\" option to bitcoin-cli command line.";
         }
     } else {
         strPrint = "error: " + error.write();

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& reques
             RPC_WALLET_NOT_FOUND, "No wallet is loaded. Load a wallet using loadwallet or create a new one with createwallet. (Note: A default wallet is no longer automatically created)");
     }
     throw JSONRPCError(RPC_WALLET_NOT_SPECIFIED,
-        "Wallet file not specified (must request wallet RPC through /wallet/<filename> uri-path).");
+        "Wallet file not specified (must request wallet RPC through /wallet/<walletname> uri-path).");
 }
 
 void EnsureWalletIsUnlocked(const CWallet& wallet)


### PR DESCRIPTION
I'm not very familiar with the wallet and got confused by the error messages

`Wallet file not specified (must request wallet RPC through /wallet/<filename> uri-path).`
`Try adding "-rpcwallet=<filename>" option to bitcoin-cli command line.`

not knowing which filename to put here (some `wallet.dat` in the wallet's directory?), when actually, at least for newer wallets, just the wallet name is expected.