### PR TITLE
test: Remove 0.16.3 test from wallet_backwards_compatibility.py

### DIFF
--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -33,7 +33,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 12
+        self.num_nodes = 11
         # Add new version after each release:
         self.extra_args = [
             ["-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to mine blocks. noban for immediate tx relay
@@ -47,7 +47,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.19.1
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=127.0.0.1"], # v0.18.1
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=127.0.0.1"], # v0.17.2
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=127.0.0.1", "-wallet=wallet.dat"], # v0.16.3
         ]
         self.wallet_names = [self.default_wallet_name]
 
@@ -68,7 +67,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             190100,
             180100,
             170200,
-            160300,
         ])
 
         self.start_nodes()
@@ -133,18 +131,17 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
     def run_test(self):
         node_miner = self.nodes[0]
         node_master = self.nodes[1]
-        node_v21 = self.nodes[self.num_nodes - 6]
-        node_v17 = self.nodes[self.num_nodes - 2]
-        node_v16 = self.nodes[self.num_nodes - 1]
+        node_v21 = self.nodes[self.num_nodes - 5]
+        node_v17 = self.nodes[self.num_nodes - 1]
 
         legacy_nodes = self.nodes[2:] # Nodes that support legacy wallets
-        legacy_only_nodes = self.nodes[-5:] # Nodes that only support legacy wallets
-        descriptors_nodes = self.nodes[2:-5] # Nodes that support descriptor wallets
+        legacy_only_nodes = self.nodes[-4:] # Nodes that only support legacy wallets
+        descriptors_nodes = self.nodes[2:-4] # Nodes that support descriptor wallets
 
         self.generatetoaddress(node_miner, COINBASE_MATURITY + 1, node_miner.getnewaddress())
 
         # Sanity check the test framework:
-        res = node_v16.getblockchaininfo()
+        res = node_v17.getblockchaininfo()
         assert_equal(res['blocks'], COINBASE_MATURITY + 1)
 
         self.log.info("Test wallet backwards compatibility...")
@@ -215,9 +212,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         # In descriptors wallet mode, run this test on the nodes that support descriptor wallets
         # In legacy wallets mode, run this test on the nodes that support legacy wallets
         for node in descriptors_nodes if self.options.descriptors else legacy_nodes:
-            if self.major_version_less_than(node, 17):
-                # loadwallet was introduced in v0.17.0
-                continue
             self.log.info(f"- {node.version}")
             for wallet_name in ["w1", "w2", "w3"]:
                 if self.major_version_less_than(node, 18) and wallet_name == "w3":
@@ -289,15 +283,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             self.log.info("Test blank wallet incompatibility with v17")
             node_v17.assert_start_raises_init_error(["-wallet=w3"], "Error: Error loading w3: Wallet requires newer version of Bitcoin Core")
         self.start_node(node_v17.index)
-
-        # No wallet created in master can be opened in 0.16
-        self.log.info("Test that wallets created in master are too new for 0.16")
-        self.stop_node(node_v16.index)
-        for wallet_name in ["w1", "w2", "w3"]:
-            if self.options.descriptors:
-                node_v16.assert_start_raises_init_error([f"-wallet={wallet_name}"], f"Error: {wallet_name} corrupt, salvage failed")
-            else:
-                node_v16.assert_start_raises_init_error([f"-wallet={wallet_name}"], f"Error: Error loading {wallet_name}: Wallet requires newer version of Bitcoin Core")
 
         # When descriptors are enabled, w1 cannot be opened by 0.21 since it contains a taproot descriptor
         if self.options.descriptors:

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -185,6 +185,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         self.restart_node(0)
         copy_v16()
         wallet = node_master.get_wallet_rpc(self.default_wallet_name)
+        assert_equal(wallet.getbalance(), v16_3_balance)
         self.log.info("Test upgradewallet without a version argument")
         self.test_upgradewallet(wallet, previous_version=159900, expected_version=169900)
         # wallet should still contain the same balance


### PR DESCRIPTION
The test checks that any wallet created with current master can not be loaded with `v0.16.3`. This is interesting documentation, however it is probably not something to keep as a test, because:

* It seems like an extremely unlikely (and unsupported) edge case that someone creates a wallet with master and then goes ahead to open it with a long EOL software version.
* A better test would be the inverse: Create a wallet with `v0.16.3` and open it with current master. This is already tested in `wallet_upgradewallet.py`, where I've added an additional balance check before upgrading the `v0.16.3` wallet.
* The test is intermittently failing when shutting down the `v0.16.3` node, for example in https://github.com/bitcoin/bitcoin/pull/30875#issuecomment-2357565564. The exact cause is unclear, but given that the test isn't worthy to keep, removing it will ensure that the error disappears.