### PR TITLE
test: generalize HasReason and use it in FailFmtWithError

### DIFF
--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -274,11 +274,9 @@ std::ostream& operator<<(std::ostream& os, const uint256& num);
 class HasReason
 {
 public:
-    explicit HasReason(const std::string& reason) : m_reason(reason) {}
-    bool operator()(const std::exception& e) const
-    {
-        return std::string(e.what()).find(m_reason) != std::string::npos;
-    };
+    explicit HasReason(std::string_view reason) : m_reason(reason) {}
+    bool operator()(std::string_view s) const { return s.find(m_reason) != std::string_view::npos; }
+    bool operator()(const std::exception& e) const { return (*this)(e.what()); }
 
 private:
     const std::string m_reason;

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -5,6 +5,7 @@
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
+#include <test/util/setup_common.h>
 
 using namespace util;
 
@@ -21,9 +22,7 @@ inline void PassFmt(util::ConstevalFormatString<NumArgs> fmt)
 template <unsigned WrongNumArgs>
 inline void FailFmtWithError(std::string_view wrong_fmt, std::string_view error)
 {
-    using ErrType = const char*;
-    auto check_throw{[error](const ErrType& str) { return str == error; }};
-    BOOST_CHECK_EXCEPTION(util::ConstevalFormatString<WrongNumArgs>::Detail_CheckNumFormatSpecifiers(wrong_fmt), ErrType, check_throw);
+    BOOST_CHECK_EXCEPTION(util::ConstevalFormatString<WrongNumArgs>::Detail_CheckNumFormatSpecifiers(wrong_fmt), const char*, HasReason(error));
 }
 
 BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)


### PR DESCRIPTION
Standardized boost exception checking in recent tests introduced in https://github.com/bitcoin/bitcoin/pull/30546#discussion_r1756493521 by extending `HasReason` to accept `const char*` through `string_view` in `operator()`.

Note that `HasReason` only checks partial matches - but since we're specifying the whole error string, it doesn't affect us in this case.