### PR TITLE
Optimize: convert trusted keys list to a set for better performance

### DIFF
--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -83,17 +83,17 @@ def main():
     dirname = os.path.dirname(os.path.abspath(__file__))
     print("Using verify-commits data from " + dirname)
     with open(dirname + "/trusted-git-root", "r", encoding="utf8") as f:
-        verified_root = f.read().splitlines()[0]
+        verified_root = set(f.read().splitlines())[0]
     with open(dirname + "/trusted-sha512-root-commit", "r", encoding="utf8") as f:
-        verified_sha512_root = f.read().splitlines()[0]
+        verified_sha512_root = set(f.read().splitlines())[0]
     with open(dirname + "/allow-revsig-commits", "r", encoding="utf8") as f:
-        revsig_allowed = f.read().splitlines()
+        revsig_allowed = set(f.read().splitlines())
     with open(dirname + "/allow-unclean-merge-commits", "r", encoding="utf8") as f:
-        unclean_merge_allowed = f.read().splitlines()
+        unclean_merge_allowed = set(f.read().splitlines())
     with open(dirname + "/allow-incorrect-sha512-commits", "r", encoding="utf8") as f:
-        incorrect_sha512_allowed = f.read().splitlines()
+        incorrect_sha512_allowed = set(f.read().splitlines())
     with open(dirname + "/trusted-keys", "r", encoding="utf8") as f:
-        trusted_keys = f.read().splitlines()
+        trusted_keys = set(f.read().splitlines())
 
     # Set commit and variables
     current_commit = args.commit


### PR DESCRIPTION
# PR:

This pull request optimizes the handling of trusted keys by converting lists to sets. This change improves performance for membership checks, making them faster.

# Tests

No new tests were added, as this is a refactor that does not change the business logic.