### PR TITLE
Follow-up after AutoFile position caching: remove unused code

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -684,10 +684,6 @@ bool BlockManager::UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos
 
     // Write undo data
     long fileOutPos = fileout.tell();
-    if (fileOutPos < 0) {
-        LogError("%s: ftell failed\n", __func__);
-        return false;
-    }
     pos.nPos = (unsigned int)fileOutPos;
     fileout << blockundo;
 
@@ -982,10 +978,6 @@ bool BlockManager::WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const
 
     // Write block
     long fileOutPos = fileout.tell();
-    if (fileOutPos < 0) {
-        LogError("%s: ftell failed\n", __func__);
-        return false;
-    }
     pos.nPos = (unsigned int)fileOutPos;
     fileout << TX_WITH_WITNESS(block);
 

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -77,8 +77,6 @@ std::optional<uint256> ReadSnapshotBaseBlockhash(fs::path chaindir)
     afile.seek(0, SEEK_END);
     if (position != afile.tell()) {
         LogPrintf("[snapshot] warning: unexpected trailing data in %s\n", read_from_str);
-    } else if (afile.IsError()) {
-        LogPrintf("[snapshot] warning: i/o error reading %s\n", read_from_str);
     }
     return base_blockhash;
 }

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -106,11 +106,6 @@ bool AutoFile::Commit()
     return ::FileCommit(m_file);
 }
 
-bool AutoFile::IsError()
-{
-    return ferror(m_file);
-}
-
 bool AutoFile::Truncate(unsigned size)
 {
     return ::TruncateFile(m_file, size);

--- a/src/streams.h
+++ b/src/streams.h
@@ -455,7 +455,6 @@ public:
     }
 
     bool Commit();
-    bool IsError();
     bool Truncate(unsigned size);
 };
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -430,8 +430,17 @@ public:
     /** Implementation detail, only used internally. */
     std::size_t detail_fread(Span<std::byte> dst);
 
+    /** Wrapper around fseek(). Will throw if seeking is not possible. */
     void seek(int64_t offset, int origin);
+
+    /** Find position within the file. Will throw if unknown. */
     int64_t tell();
+
+    /** Wrapper around FileCommit(). */
+    bool Commit();
+
+    /** Wrapper around TruncateFile(). */
+    bool Truncate(unsigned size);
 
     //
     // Stream subset
@@ -453,9 +462,6 @@ public:
         ::Unserialize(*this, obj);
         return *this;
     }
-
-    bool Commit();
-    bool Truncate(unsigned size);
 };
 
 /** Wrapper around an AutoFile& that implements a ring buffer to


### PR DESCRIPTION
This is a follow-up to #30884.

Remove a number of dead code paths, and improve the code organization and documentation, in `AutoFile`.