### PR TITLE
tinyformat: refactor: increase compile-time checks and don't throw for tfm::format_error

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -950,7 +950,9 @@ Strings and formatting
 
   - Do not use it when passing strings to `tfm::format`, `strprintf`, `LogInfo`, `LogDebug`, etc.
 
-    - *Rationale*: This is redundant. Tinyformat handles strings.
+    - *Rationale*: Tinyformat handles string parameters. Format strings
+      should be known at compile-time, so using a string literal or
+      `constexpr const char*` allows for compile-time validation.
 
   - Do not use it to convert to `QString`. Use `QString::fromStdString()`.
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -540,15 +540,15 @@ public:
         // Report detailed peer connections list sorted by direction and minimum ping time.
         if (DetailsRequested() && !m_peers.empty()) {
             std::sort(m_peers.begin(), m_peers.end());
-            result += strprintf("<->   type   net  v  mping   ping send recv  txn  blk  hb %*s%*s%*s ",
-                                m_max_addr_processed_length, "addrp",
-                                m_max_addr_rate_limited_length, "addrl",
-                                m_max_age_length, "age");
+            result += tfm::format_raw("<->   type   net  v  mping   ping send recv  txn  blk  hb %*s%*s%*s ",
+                                      m_max_addr_processed_length, "addrp",
+                                      m_max_addr_rate_limited_length, "addrl",
+                                      m_max_age_length, "age");
             if (m_is_asmap_on) result += " asmap ";
-            result += strprintf("%*s %-*s%s\n", m_max_id_length, "id", IsAddressSelected() ? m_max_addr_length : 0, IsAddressSelected() ? "address" : "", IsVersionSelected() ? "version" : "");
+            result += tfm::format_raw("%*s %-*s%s\n", m_max_id_length, "id", IsAddressSelected() ? m_max_addr_length : 0, IsAddressSelected() ? "address" : "", IsVersionSelected() ? "version" : "");
             for (const Peer& peer : m_peers) {
                 std::string version{ToString(peer.version) + peer.sub_version};
-                result += strprintf(
+                result += tfm::format_raw(
                     "%3s %6s %5s %2s%7s%7s%5s%5s%5s%5s  %2s %*s%*s%*s%*i %*s %-*s%s\n",
                     peer.is_outbound ? "out" : "in",
                     ConnectionTypeForNetinfo(peer.conn_type),
@@ -575,7 +575,7 @@ public:
                     IsAddressSelected() ? peer.addr : "",
                     IsVersionSelected() && version != "0" ? version : "");
             }
-            result += strprintf("                        ms     ms  sec  sec  min  min                %*s\n\n", m_max_age_length, "min");
+            result += tfm::format_raw("                        ms     ms  sec  sec  min  min                %*s\n\n", m_max_age_length, "min");
         }
 
         // Report peer connection totals by type.
@@ -624,7 +624,7 @@ public:
                 max_addr_size = std::max(addr["address"].get_str().length() + 1, max_addr_size);
             }
             for (const UniValue& addr : local_addrs) {
-                result += strprintf("\n%-*s    port %6i    score %6i", max_addr_size, addr["address"].get_str(), addr["port"].getInt<int>(), addr["score"].getInt<int>());
+                result += tfm::format_raw("\n%-*s    port %6i    score %6i", max_addr_size, addr["address"].get_str(), addr["port"].getInt<int>(), addr["score"].getInt<int>());
             }
         }
 
@@ -1117,10 +1117,10 @@ static void ParseGetInfoResult(UniValue& result)
         }
 
         for (const std::string& wallet : result["balances"].getKeys()) {
-            result_string += strprintf("%*s %s\n",
-                                       max_balance_length,
-                                       result["balances"][wallet].getValStr(),
-                                       wallet.empty() ? "\"\"" : wallet);
+            result_string += tfm::format_raw("%*s %s\n",
+                                             max_balance_length,
+                                             result["balances"][wallet].getValStr(),
+                                             wallet.empty() ? "\"\"" : wallet);
         }
         result_string += "\n";
     }

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -71,7 +71,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 
 std::string CopyrightHolders(const std::string& strPrefix)
 {
-    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION);
+    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
     std::string strCopyrightHolders = strPrefix + copyright_devs;
 
     // Make sure Bitcoin Core copyright is not removed by accident
@@ -85,15 +85,17 @@ std::string LicenseInfo()
 {
     const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
 
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
+    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
            "\n" +
            strprintf(_("Please contribute if you find %s useful. "
-                       "Visit %s for further information about the software.").translated, PACKAGE_NAME, "<" PACKAGE_URL ">") +
+                       "Visit %s for further information about the software."),
+                     PACKAGE_NAME, "<" PACKAGE_URL ">")
+               .translated +
            "\n" +
-           strprintf(_("The source code is available from %s.").translated, URL_SOURCE_CODE) +
+           strprintf(_("The source code is available from %s."), URL_SOURCE_CODE).translated +
            "\n" +
            "\n" +
            _("This is experimental software.").translated + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s").translated, "COPYING", "<https://opensource.org/licenses/MIT>") +
+           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/licenses/MIT>").translated +
            "\n";
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -617,7 +617,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)",
                              Ticks<std::chrono::seconds>(DEFAULT_MAX_TIP_AGE)),
                    ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-printpriority", strprintf("Log transaction fee rate in " + CURRENCY_UNIT + "/kvB when mining blocks (default: %u)", DEFAULT_PRINT_MODIFIED_FEE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-printpriority", strprintf("Log transaction fee rate in %s/kvB when mining blocks (default: %u)", CURRENCY_UNIT, DEFAULT_PRINT_MODIFIED_FEE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-uacomment=<cmt>", "Append comment to the user agent string", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 
     SetupChainParamsBaseOptions(argsman);

--- a/src/logging.h
+++ b/src/logging.h
@@ -242,12 +242,7 @@ template <typename... Args>
 inline void LogPrintFormatInternal(std::string_view logging_function, std::string_view source_file, const int source_line, const BCLog::LogFlags flag, const BCLog::Level level, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
     if (LogInstance().Enabled()) {
-        std::string log_msg;
-        try {
-            log_msg = tfm::format(fmt, args...);
-        } catch (tinyformat::format_error& fmterr) {
-            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
-        }
+        const auto log_msg{tfm::format(fmt, args...)};
         LogInstance().LogPrintStr(log_msg, logging_function, source_file, source_line, flag, level);
     }
 }

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -48,35 +48,32 @@ FUZZ_TARGET(str_printf)
     //
     // Upstream bug report: https://github.com/c42f/tinyformat/issues/70
 
-    try {
-        CallOneOf(
-            fuzzed_data_provider,
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32));
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<signed char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<unsigned char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeBool());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
-            });
-    } catch (const tinyformat::format_error&) {
-    }
+    CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32));
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<signed char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeBool());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
+        });
 
     if (format_string.find('%') != std::string::npos && format_string.find('c') != std::string::npos) {
         // Avoid triggering the following:
@@ -94,41 +91,38 @@ FUZZ_TARGET(str_printf)
         return;
     }
 
-    try {
-        CallOneOf(
-            fuzzed_data_provider,
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<float>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<double>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int16_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint16_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int32_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint32_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int64_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
-            },
-            [&] {
-                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            });
-    } catch (const tinyformat::format_error&) {
-    }
+    CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<float>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<double>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int16_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int64_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+        },
+        [&] {
+            (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+        });
 }

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -52,27 +52,27 @@ FUZZ_TARGET(str_printf)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32));
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32));
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<signed char>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<signed char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<unsigned char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<char>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeBool());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeBool());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
             });
     } catch (const tinyformat::format_error&) {
@@ -98,35 +98,35 @@ FUZZ_TARGET(str_printf)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<float>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<float>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<double>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<double>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int16_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int16_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint16_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int32_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int32_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint32_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int64_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int64_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
             },
             [&] {
-                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+                (void)tinyformat::format_raw(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint64_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
             });
     } catch (const tinyformat::format_error&) {

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -52,27 +52,27 @@ FUZZ_TARGET(str_printf)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32));
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<signed char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<unsigned char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<char>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeBool());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
             });
     } catch (const tinyformat::format_error&) {
@@ -98,35 +98,35 @@ FUZZ_TARGET(str_printf)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<float>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeFloatingPoint<double>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int16_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint16_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int32_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint32_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<int64_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
             },
             [&] {
-                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+                (void)strprintf(format_string.c_str(), fuzzed_data_provider.ConsumeIntegral<uint64_t>());
                 (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
             });
     } catch (const tinyformat::format_error&) {

--- a/src/test/txrequest_tests.cpp
+++ b/src/test/txrequest_tests.cpp
@@ -178,10 +178,10 @@ public:
             size_t real_total = runner.txrequest.Count(peer);
             size_t real_candidates = runner.txrequest.CountCandidates(peer);
             size_t real_inflight = runner.txrequest.CountInFlight(peer);
-            BOOST_CHECK_MESSAGE(real_total == total, strprintf("[" + comment + "] total %i (%i expected)", real_total, total));
-            BOOST_CHECK_MESSAGE(real_inflight == inflight, strprintf("[" + comment + "] inflight %i (%i expected)", real_inflight, inflight));
-            BOOST_CHECK_MESSAGE(real_candidates == candidates, strprintf("[" + comment + "] candidates %i (%i expected)", real_candidates, candidates));
-            BOOST_CHECK_MESSAGE(ret == expected, "[" + comment + "] mismatching requestables");
+            BOOST_CHECK_MESSAGE(real_total == total, strprintf("[%s] total %i (%i expected)", comment, real_total, total));
+            BOOST_CHECK_MESSAGE(real_inflight == inflight, strprintf("[%s] inflight %i (%i expected)", comment, real_inflight, inflight));
+            BOOST_CHECK_MESSAGE(real_candidates == candidates, strprintf("[%s] candidates %i (%i expected)", comment, real_candidates, candidates));
+            BOOST_CHECK_MESSAGE(ret == expected, strprintf("[%s] mismatching requestables", comment));
         });
     }
 

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -2,10 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <tinyformat.h>
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
+
+#include <sstream>
 
 using namespace util;
 
@@ -81,5 +84,18 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)
     FailFmtWithError<1>("%", err_term);
     FailFmtWithError<1>("%1$", err_term);
 }
+
+BOOST_AUTO_TEST_CASE(tinyformat_ConstevalFormatString)
+{
+    // Ensure invalid format strings don't throw at run-time, when not in DEBUG
+#ifndef DEBUG
+    BOOST_CHECK_EQUAL(tfm::format("%*c", "dummy"), R"(Error "tinyformat: Cannot convert from argument type to integer for use as variable width or precision" while formatting: %*c)");
+    BOOST_CHECK_EQUAL(tfm::format("%2$*3$d", "dummy", "value"), R"(Error "tinyformat: Positional argument out of range" while formatting: %2$*3$d)");
+    std::ostringstream oss;
+    tfm::format(oss, "%.*f", 5);
+    BOOST_CHECK_EQUAL(oss.str(), R"(Error "tinyformat: Too many conversion specifiers in format string" while formatting: %.*f)");
+#endif
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -145,6 +145,7 @@ namespace tfm = tinyformat;
 #include <iostream>
 #include <sstream>
 #include <stdexcept> // Added for Bitcoin Core
+#include <util/string.h> // Added for Bitcoin Core
 
 #ifndef TINYFORMAT_ASSERT
 #   include <cassert>
@@ -1153,7 +1154,11 @@ std::string format(const std::string &fmt, const Args&... args)
     format(oss, fmt.c_str(), args...);
     return oss.str();
 }
-
+template <typename... Args>
+std::string format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    return format(fmt.fmt, args...);
+}
 } // namespace tinyformat
 
 // Added for Bitcoin Core:

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1056,33 +1056,33 @@ inline void vformat(std::ostream& out, const char* fmt, FormatListRef list)
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
 
 /// Format list of arguments to the stream according to given format string.
-template<typename... Args>
-void format(std::ostream& out, const char* fmt, const Args&... args)
+template <typename... Args>
+void format_raw(std::ostream& out, const char* fmt, const Args&... args) // Renamed for Bitcoin Core
 {
     vformat(out, fmt, makeFormatList(args...));
 }
 
 /// Format list of arguments according to the given format string and return
 /// the result as a string.
-template<typename... Args>
-std::string format(const char* fmt, const Args&... args)
+template <typename... Args>
+std::string format_raw(const char* fmt, const Args&... args) // Renamed for Bitcoin Core
 {
     std::ostringstream oss;
-    format(oss, fmt, args...);
+    format_raw(oss, fmt, args...);
     return oss.str();
 }
 
 /// Format list of arguments to std::cout, according to the given format string
-template<typename... Args>
-void printf(const char* fmt, const Args&... args)
+template <typename... Args>
+void printf_raw(const char* fmt, const Args&... args) // Renamed for Bitcoin Core
 {
-    format(std::cout, fmt, args...);
+    format_raw(std::cout, fmt, args...);
 }
 
-template<typename... Args>
-void printfln(const char* fmt, const Args&... args)
+template <typename... Args>
+void printfln_raw(const char* fmt, const Args&... args) // Renamed for Bitcoin Core
 {
-    format(std::cout, fmt, args...);
+    format_raw(std::cout, fmt, args...);
     std::cout << '\n';
 }
 
@@ -1150,7 +1150,12 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 template <typename... Args>
 std::string format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    return format(fmt.fmt, args...);
+    return format_raw(fmt.fmt, args...);
+}
+template <typename... Args>
+void format(std::ostream& out, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    return format_raw(out, fmt.fmt, args...);
 }
 } // namespace tinyformat
 

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1147,13 +1147,6 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 #endif
 
 // Added for Bitcoin Core
-template<typename... Args>
-std::string format(const std::string &fmt, const Args&... args)
-{
-    std::ostringstream oss;
-    format(oss, fmt.c_str(), args...);
-    return oss.str();
-}
 template <typename... Args>
 std::string format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1049,7 +1049,15 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_MAKEFORMATLIST)
 /// list of format arguments is held in a single function argument.
 inline void vformat(std::ostream& out, const char* fmt, FormatListRef list)
 {
-    detail::formatImpl(out, fmt, list.m_args, list.m_N);
+    // Modified for Bitcoin Core to not throw for formatting errors
+    try {
+        detail::formatImpl(out, fmt, list.m_args, list.m_N);
+    } catch (tinyformat::format_error& fmterr) {
+        out << "Error \"" + std::string{fmterr.what()} + "\" while formatting: " + fmt;
+#ifdef DEBUG
+        throw;
+#endif
+    }
 }
 
 
@@ -1150,12 +1158,12 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 template <typename... Args>
 std::string format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    return format_raw(fmt.fmt, args...);
+    return tfm::format_raw(fmt.fmt, args...);
 }
 template <typename... Args>
 void format(std::ostream& out, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
-    return format_raw(out, fmt.fmt, args...);
+    tfm::format_raw(out, fmt.fmt, args...);
 }
 } // namespace tinyformat
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -6,7 +6,6 @@
 #define BITCOIN_UTIL_STRING_H
 
 #include <span.h>
-#include <tinyformat.h>
 
 #include <array>
 #include <cstdint>
@@ -234,13 +233,5 @@ template <typename T1, size_t PREFIX_LEN>
            std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
 } // namespace util
-
-namespace tinyformat {
-template <typename... Args>
-std::string format(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    return format(fmt.fmt, args...);
-}
-} // namespace tinyformat
 
 #endif // BITCOIN_UTIL_STRING_H

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -59,8 +59,8 @@ bilingual_str format(const bilingual_str& fmt, const Args&... args)
             return arg;
         }
     }};
-    return bilingual_str{tfm::format(fmt.original.c_str(), translate_arg(args, false)...),
-                         tfm::format(fmt.translated.c_str(), translate_arg(args, true)...)};
+    return bilingual_str{tfm::format_raw(fmt.original.c_str(), translate_arg(args, false)...),
+                         tfm::format_raw(fmt.translated.c_str(), translate_arg(args, true)...)};
 }
 } // namespace tinyformat
 

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -59,8 +59,8 @@ bilingual_str format(const bilingual_str& fmt, const Args&... args)
             return arg;
         }
     }};
-    return bilingual_str{tfm::format(fmt.original, translate_arg(args, false)...),
-                         tfm::format(fmt.translated, translate_arg(args, true)...)};
+    return bilingual_str{tfm::format(fmt.original.c_str(), translate_arg(args, false)...),
+                         tfm::format(fmt.translated.c_str(), translate_arg(args, true)...)};
 }
 } // namespace tinyformat
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -534,7 +534,7 @@ RPCHelpMan importwallet()
 
         // Use uiInterface.ShowProgress instead of pwallet.ShowProgress because pwallet.ShowProgress has a cancel button tied to AbortRescan which
         // we don't want for this progress bar showing the import progress. uiInterface.ShowProgress does not have a cancel button.
-        pwallet->chain().showProgress(strprintf("%s " + _("Importing…").translated, pwallet->GetDisplayName()), 0, false); // show progress dialog in GUI
+        pwallet->chain().showProgress(strprintf("%s %s", pwallet->GetDisplayName(), _("Importing…").translated), 0, false); // show progress dialog in GUI
         std::vector<std::tuple<CKey, int64_t, bool, std::string>> keys;
         std::vector<std::pair<CScript, int64_t>> scripts;
         while (file.good()) {

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -64,7 +64,7 @@ void ImportDescriptors(CWallet& wallet, const std::string& seed_insecure)
 
     for (const std::string& desc_fmt : DESCS) {
         for (bool internal : {true, false}) {
-            const auto descriptor{(strprintf)(desc_fmt, "[5aa9973a/66h/4h/2h]" + seed_insecure, int{internal})};
+            const auto descriptor{(strprintf)(desc_fmt.c_str(), "[5aa9973a/66h/4h/2h]" + seed_insecure, int{internal})};
 
             FlatSigningProvider keys;
             std::string error;

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -64,7 +64,7 @@ void ImportDescriptors(CWallet& wallet, const std::string& seed_insecure)
 
     for (const std::string& desc_fmt : DESCS) {
         for (bool internal : {true, false}) {
-            const auto descriptor{(strprintf)(desc_fmt.c_str(), "[5aa9973a/66h/4h/2h]" + seed_insecure, int{internal})};
+            const auto descriptor{tfm::format_raw(desc_fmt.c_str(), "[5aa9973a/66h/4h/2h]" + seed_insecure, int{internal})};
 
             FlatSigningProvider keys;
             std::string error;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1891,7 +1891,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     fAbortRescan = false;
-    ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
+    ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
     uint256 tip_hash = WITH_LOCK(cs_wallet, return GetLastBlockHash());
     uint256 end_hash = tip_hash;
     if (max_height) chain().findAncestorByHeight(tip_hash, *max_height, FoundBlock().hash(end_hash));
@@ -1906,7 +1906,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
             m_scanning_progress = 0;
         }
         if (block_height % 100 == 0 && progress_end - progress_begin > 0.0) {
-            ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
+            ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
         }
 
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;
@@ -2003,7 +2003,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         WalletLogPrintf("Scanning current mempool transactions.\n");
         WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
     }
-    ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), 100); // hide progress dialog in GUI
+    ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), 100); // hide progress dialog in GUI
     if (block_height && fAbortRescan) {
         WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 FALSE_POSITIVES = [
-    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
+    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
 ]
 

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -15,6 +15,9 @@ import sys
 FALSE_POSITIVES = [
     ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
+    ("src/test/util_string_tests.cpp", r'tfm::format("%*c", "dummy")'),
+    ("src/test/util_string_tests.cpp", r'tfm::format("%2$*3$d", "dummy", "value")'),
+    ("src/test/util_string_tests.cpp", r'tfm::format(oss, "%.*f", 5)'),
 ]
 
 


### PR DESCRIPTION
Avoid unexpected run-time crashes from string formatting by enforcing compile-time format string checks for most* `tfm::format` and `strprintf` usage, and by returning an error string instead of throwing for a run-time tfm::format_error so callsites don't need to implement this error handling.

This PR should introduce no behaviour change.
The main changes are:
- remove the `const std::string&` `tfm::format` overload since it's not necessary. Usage of this overload is removed by one of:
  - replacing string concatenation in the format string with just an extra parameter
  - using the `bilingual_str` overload
  - using the `tfm::format_raw` functions (only for tinyformat implementation or tests)
- rename the non-compile-time-validated `tfm::format` overloads to `tfm::format_raw`, so existing callsites by default use the safer `util::ConstevalFormatString` `tfm::format` overloads. Callsites that for some reason don't pass the compile-time checks (such as in `bitcoin-cli.cpp`) can use `tfm::format_raw`.
- make `tfm::format_error` internal to `tinyformat` and just return error strings instead, so callsites don't need to implement error handling to prevent crashing. 

*The `bilingual_str format(const bilingual_str& fmt, const Args&... args)` is not yet compile-time checked, which means the `lint-format-strings.py` test can't be removed yet.

 Follow-up on https://github.com/bitcoin/bitcoin/pull/30889#discussion_r1766633746, an alternative to #15926.