### PR TITLE
blockstorage: Avoid potential Memory Leak

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -387,9 +387,14 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     }
 
     const auto [mi, inserted]{m_block_index.try_emplace(hash)};
-    CBlockIndex* pindex = &(*mi).second;
+    CBlockIndex* pindex = nullptr;
     if (inserted) {
+        pindex = &(*mi).second;
         pindex->phashBlock = &((*mi).first);
+    } else {
+        // Log error or handle failure
+        LogError("%s: Failed to emplace block index for hash %s\n", __func__, hash.ToString());
+        return nullptr;
     }
     return pindex;
 }


### PR DESCRIPTION
Issue: 
-> Potential Memory Leak in BlockManager::InsertBlockIndex
Reason: 
-> The InsertBlockIndex function creates a new CBlockIndex when try_emplace is successful, but doesn't guarantee that the object will be released if an error occurs later. This can lead to memory leaks potentially.