### PR TITLE
test: Prove+document ConstevalFormatString/tinyformat parity

### DIFF
--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -126,6 +126,15 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)
     FailFmtWithError<2>("%1$.*2$", err_term);
     FailFmtWithError<2>("%1$9.*2$", err_term);
 
+    // Non-parity between tinyformat and ConstevalFormatString.
+    // tinyformat throws but ConstevalFormatString does not.
+    BOOST_CHECK_EXCEPTION(tfm::format(ConstevalFormatString<1>{"%n"}, 0), tfm::format_error,
+        HasReason{"tinyformat: %n conversion spec not supported"});
+    BOOST_CHECK_EXCEPTION(tfm::format(ConstevalFormatString<2>{"%*s"}, "hi", "hi"), tfm::format_error,
+        HasReason{"tinyformat: Cannot convert from argument type to integer for use as variable width or precision"});
+    BOOST_CHECK_EXCEPTION(tfm::format(ConstevalFormatString<2>{"%.*s"}, "hi", "hi"), tfm::format_error,
+        HasReason{"tinyformat: Cannot convert from argument type to integer for use as variable width or precision"});
+
     // Ensure that tinyformat throws if format string contains wrong number
     // of specifiers. PassFmt relies on this to verify tinyformat successfully
     // formats the strings, and will need to be updated if tinyformat is changed

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -45,6 +45,7 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)
     PassFmt<0>("");
     PassFmt<0>("%%");
     PassFmt<1>("%s");
+    PassFmt<1>("%c");
     PassFmt<0>("%%s");
     PassFmt<0>("s%%");
     PassFmt<1>("%%%s");

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -8,21 +8,22 @@
 #include <test/util/setup_common.h>
 
 using namespace util;
+using util::detail::CheckNumFormatSpecifiers;
 
 BOOST_AUTO_TEST_SUITE(util_string_tests)
 
 // Helper to allow compile-time sanity checks while providing the number of
 // args directly. Normally PassFmt<sizeof...(Args)> would be used.
 template <unsigned NumArgs>
-inline void PassFmt(util::ConstevalFormatString<NumArgs> fmt)
+void PassFmt(ConstevalFormatString<NumArgs> fmt)
 {
     // Execute compile-time check again at run-time to get code coverage stats
-    util::detail::CheckNumFormatSpecifiers<NumArgs>(fmt.fmt);
+    BOOST_CHECK_NO_THROW(CheckNumFormatSpecifiers<NumArgs>(fmt.fmt));
 }
 template <unsigned WrongNumArgs>
-inline void FailFmtWithError(const char* wrong_fmt, std::string_view error)
+void FailFmtWithError(const char* wrong_fmt, std::string_view error)
 {
-    BOOST_CHECK_EXCEPTION(util::detail::CheckNumFormatSpecifiers<WrongNumArgs>(wrong_fmt), const char*, HasReason{error});
+    BOOST_CHECK_EXCEPTION(CheckNumFormatSpecifiers<WrongNumArgs>(wrong_fmt), const char*, HasReason{error});
 }
 
 BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -15,6 +15,8 @@ import sys
 FALSE_POSITIVES = [
     ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
+    ("src/test/util_string_tests.cpp", 'tfm::format(ConstevalFormatString<2>{"%*s"}, "hi", "hi")'),
+    ("src/test/util_string_tests.cpp", 'tfm::format(ConstevalFormatString<2>{"%.*s"}, "hi", "hi")'),
 ]
 
 


### PR DESCRIPTION
Clarifies and puts the extent of parity under test.

Broken out from #30546 based on https://github.com/bitcoin/bitcoin/pull/30546#discussion_r1755013263 and https://github.com/bitcoin/bitcoin/pull/30546#discussion_r1756495304.