### PR TITLE
doc: Add `nproc` support for Mac through `coreutils`

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -223,9 +223,12 @@ After configuration, you are ready to compile.
 Run the following in your terminal to compile Bitcoin Core:
 
 ``` bash
-cmake --build build     # Use "-j N" here for N parallel jobs.
-ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build -j$(nproc)
+ctest --test-dir build -j$(nproc) # Some tests are disabled if Python 3 is not available.
 ```
+
+Note: On macOS, the `nproc` command is not available by default.
+You can install it by running `brew install coreutils`.
 
 ### 3. Deploy (optional)
 

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -62,6 +62,9 @@ If you have multiple threads on your machine, you can utilize all of them with:
 cmake --build build -j$(nproc)
 ```
 
+Note: On macOS, the `nproc` command is not available by default.
+You can install it by running `brew install coreutils`.
+
 ### Only build what you need
 
 When rebuilding during development, note that running `cmake --build build`, without giving a target, will do a lot of work you probably don't need. It will build the GUI (if you've enabled it) and all the tests (which take much longer to build than the app does).

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -59,7 +59,7 @@ If you do need the wallet enabled (`-DENABLE_WALLET=ON`), it is common for devs 
 If you have multiple threads on your machine, you can utilize all of them with:
 
 ```sh
-cmake --build build -j "$(($(nproc)+1))"
+cmake --build build -j$(nproc)
 ```
 
 ### Only build what you need


### PR DESCRIPTION
See: https://www.gnu.org/software/coreutils/manual/html_node/nproc-invocation.html

Revival of a failed attempt in https://github.com/bitcoin/bitcoin/pull/30619

You can test on your mac via:
```bash
% echo $(nproc)
command not found: nproc
```
```bash
% brew install coreutils
...
% echo $(nproc)
10
```