### PR TITLE
test: simplify timewarp test

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -160,9 +160,8 @@ class MiningTest(BitcoinTestFramework):
         bad_block.solve()
         assert_raises_rpc_error(-25, 'time-timewarp-attack', lambda: node.submitheader(hexdata=CBlockHeader(bad_block).serialize().hex()))
 
-        bad_block.nTime = t + MAX_FUTURE_BLOCK_TIME - MAX_TIMEWARP
-        bad_block.solve()
-        node.submitheader(hexdata=CBlockHeader(bad_block).serialize().hex())
+        block.solve()
+        node.submitheader(hexdata=CBlockHeader(block).serialize().hex())
 
     def run_test(self):
         node = self.nodes[0]


### PR DESCRIPTION
Follow up from PR #30698 (comment https://github.com/bitcoin/bitcoin/pull/30698#discussion_r1729632270).

`mining_basic` checks that a block with wall time is rejected when the previous block is `MAX_FUTURE_BLOCK_TIME` in the future, then checks that a block just beyond the `MAX_TIMEWARP` is also rejected.

This PR removes the first check, since they seem to be essentially checking the same thing twice.
Also incorporates the suggestion in https://github.com/bitcoin/bitcoin/pull/30698#discussion_r1730946634 to reuse `block`.