### PR TITLE
test: Remove dead code from interface_zmq test

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -489,13 +489,8 @@ class ZMQTest (BitcoinTestFramework):
         mempool_snapshot = self.nodes[0].getrawmempool(mempool_sequence=True)
         mempool_view = set(mempool_snapshot["txids"])
         get_raw_seq = mempool_snapshot["mempool_sequence"]
-        assert_equal(get_raw_seq, 6)
-        # Snapshot may be too old compared to zmq message we read off latest
-        while zmq_mem_seq >= get_raw_seq:
-            sleep(2)
-            mempool_snapshot = self.nodes[0].getrawmempool(mempool_sequence=True)
-            mempool_view = set(mempool_snapshot["txids"])
-            get_raw_seq = mempool_snapshot["mempool_sequence"]
+        assert_equal(get_raw_seq, num_txs + 1)
+        assert zmq_mem_seq < get_raw_seq
 
         # Things continue to happen in the "interim" while waiting for snapshot results
         # We have node 0 do all these to avoid p2p races with RBF announcements


### PR DESCRIPTION
The loop removed here appears to be effectively dead code: In case `get_raw_seq` is behind `zmq_mem_seq` the loop runs and tries to get a more recent (higher) number for `get_raw_seq`. However, the exact number of `get_raw_seq` is asserted in the line above: `assert_equal(get_raw_seq, 6)`. If the loop would actually achieve its purpose this assert would need to be racy. This does not seem to be the case and 6 appears to be the final number. `zmq_mem_seq` however does take some time to catch up (if it were continue to be updated). But this is not handled by the loop and does not seem to be relevant at this point in the test. The backlog is consumed a bit later in another loop that handles this correctly already.