### PR TITLE
doc: macOS 15 ships llvm 16

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -51,7 +51,7 @@ To install, run the following from your terminal:
 brew install cmake boost pkg-config libevent
 ```
 
-For macOS 11 (Big Sur) and 12 (Monterey) you need to install a more recent version of llvm.
+For macOS 11 (Big Sur) through 14 (Sonoma) you need to install a more recent version of llvm.
 
 ``` bash
 brew install llvm


### PR DESCRIPTION
#30263 bumped the minimum clang to 16

macOS versions before 15 ship older versions, see https://en.wikipedia.org/wiki/Xcode#Xcode_15.0_-_(since_visionOS_support)

Updating macOS build instructions to reflect this.