### PR TITLE
net: option to disallow v1 connection on ipv4 and ipv6 peers

### DIFF
--- a/doc/release-notes-30951.md
+++ b/doc/release-notes-30951.md
@@ -1,0 +1,11 @@
+New settings
+------------
+
+- A new `-v2onlyclearnet` option ensures every outbound connection to an IPv4/IPv6
+  peer is encrypted (v2/BIP324); connections to Tor/I2P/CJDNS peers are
+  unaffected, being already encrypted. It requires `-listen=0`, which takes
+  valuable listening capacity away from the network, so enable it only if
+  avoiding unencrypted clearnet traffic is a genuine concern. This guards message
+  contents against passive on-path observers (ISPs, firewalls); it does not hide
+  that you run a Bitcoin node (default port 8333 and traffic patterns still reveal
+  that) and offers no protection against active adversaries. (#30951)

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -297,7 +297,7 @@ std::optional<CNetAddr> QueryDefaultGatewayImpl(sa_family_t)
 
 std::optional<CNetAddr> QueryDefaultGateway(Network network)
 {
-    Assume(network == NET_IPV4 || network == NET_IPV6);
+    Assume(IsClearnet(network));
 
     sa_family_t family;
     if (network == NET_IPV4) {

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -296,7 +296,7 @@ std::optional<CNetAddr> QueryDefaultGatewayImpl(sa_family_t)
 
 std::optional<CNetAddr> QueryDefaultGateway(Network network)
 {
-    Assume(network == NET_IPV4 || network == NET_IPV6);
+    Assume(IsClearnet(network));
 
     sa_family_t family;
     if (network == NET_IPV4) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -569,6 +569,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-i2pacceptincoming", strprintf("Whether to accept inbound I2P connections (default: %i). Ignored if -i2psam is not set. Listening for inbound I2P connections is done through the SAM proxy, not by binding to a local address and port.", DEFAULT_I2P_ACCEPT_INCOMING), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-onlynet=<net>", "Make automatic outbound connections only to network <net> (" + Join(GetNetworkNames(), ", ") + "). Inbound and manual connections are not affected by this option. It can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-v2transport", strprintf("Support v2 transport (default: %u)", DEFAULT_V2_TRANSPORT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-v2onlyclearnet", strprintf("Ensure all outbound IPv4/IPv6 peers use encrypted network traffic (default: %u). Using this option requires -listen=0 and takes valuable listening capacity away from the network. Enable this option only if passive network observers like ISPs, firewalls, etc. pose a threat and unencrypted network traffic must be avoided. Note: Encryption protects message contents but does not obscure that you are running a Bitcoin node. Observers can still identify Bitcoin activity from your outbound connection attempts to the default port (8333) or by analysing traffic patterns.", DEFAULT_V2_ONLY_CLEARNET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
@@ -987,6 +988,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Signal NODE_P2P_V2 if BIP324 v2 transport is enabled.
     if (args.GetBoolArg("-v2transport", DEFAULT_V2_TRANSPORT)) {
         g_local_services = ServiceFlags(g_local_services | NODE_P2P_V2);
+    } else if (args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET)) {
+        return InitError(_("Cannot set -v2onlyclearnet to true when v2transport is disabled."));
     }
 
     // Signal NODE_COMPACT_FILTERS if peerblockfilters and basic filters index are both enabled.
@@ -1022,6 +1025,12 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // if listen=0, then disallow listenonion=1
     if (!args.GetBoolArg("-listen", DEFAULT_LISTEN) && args.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION)) {
         return InitError(Untranslated("Cannot set -listen=0 together with -listenonion=1"));
+    }
+
+    if (args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET)) {
+        if (args.GetBoolArg("-listen", DEFAULT_LISTEN)) {
+            return InitError(_("Cannot set -v2onlyclearnet=1 with listen=1. See -help for details on -v2onlyclearnet."));
+        }
     }
 
     // Make sure enough file descriptors are available. We need to reserve enough FDs to account for the bare minimum,
@@ -2110,6 +2119,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.whitelist_forcerelay = args.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY);
     connOptions.whitelist_relay = args.GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY);
     connOptions.m_capture_messages = args.GetBoolArg("-capturemessages", false);
+    connOptions.m_v2only_clearnet = args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET);
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
     const uint16_t default_bind_port =

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -836,7 +836,7 @@ void InitParameterInteraction(ArgsManager& args)
     if (!onlynets.empty()) {
         bool clearnet_reachable = std::any_of(onlynets.begin(), onlynets.end(), [](const auto& net) {
             const auto n = ParseNetwork(net);
-            return n == NET_IPV4 || n == NET_IPV6;
+            return IsClearnet(n);
         });
         if (!clearnet_reachable && args.SoftSetBoolArg("-dnsseed", false)) {
             LogInfo("parameter interaction: -onlynet excludes IPv4 and IPv6 -> setting -dnsseed=0\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -873,7 +873,7 @@ void InitParameterInteraction(ArgsManager& args)
     if (!onlynets.empty()) {
         bool clearnet_reachable = std::any_of(onlynets.begin(), onlynets.end(), [](const auto& net) {
             const auto n = ParseNetwork(net);
-            return n == NET_IPV4 || n == NET_IPV6;
+            return IsClearnet(n);
         });
         if (!clearnet_reachable && args.SoftSetBoolArg("-dnsseed", false)) {
             LogInfo("parameter interaction: -onlynet excludes IPv4 and IPv6 -> setting -dnsseed=0\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -602,6 +602,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-i2pacceptincoming", strprintf("Whether to accept inbound I2P connections (default: %i). Ignored if -i2psam is not set. Listening for inbound I2P connections is done through the SAM proxy, not by binding to a local address and port.", DEFAULT_I2P_ACCEPT_INCOMING), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-onlynet=<net>", "Make automatic outbound connections only to network <net> (" + Join(GetNetworkNames(), ", ") + "). Inbound and manual connections are not affected by this option. It can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-v2transport", strprintf("Support v2 transport (default: %u)", DEFAULT_V2_TRANSPORT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-v2onlyclearnet", strprintf("Ensure all outbound IPv4/IPv6 peers use encrypted network traffic (default: %u). Using this option requires -listen=0 and takes valuable listening capacity away from the network. Enable this option only if passive network observers like ISPs, firewalls, etc. pose a threat and unencrypted network traffic must be avoided. Note: Encryption protects message contents but does not obscure that you are running a Bitcoin node. Observers can still identify Bitcoin activity from your outbound connection attempts to the default port (8333) or by analysing traffic patterns.", DEFAULT_V2_ONLY_CLEARNET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
@@ -1024,6 +1025,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Signal NODE_P2P_V2 if BIP324 v2 transport is enabled.
     if (args.GetBoolArg("-v2transport", DEFAULT_V2_TRANSPORT)) {
         g_local_services = ServiceFlags(g_local_services | NODE_P2P_V2);
+    } else if (args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET)) {
+        return InitError(_("Cannot set -v2onlyclearnet to true when v2transport is disabled."));
     }
 
     // Signal NODE_COMPACT_FILTERS if peerblockfilters and basic filters index are both enabled.
@@ -1059,6 +1062,12 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // if listen=0, then disallow listenonion=1
     if (!args.GetBoolArg("-listen", DEFAULT_LISTEN) && args.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION)) {
         return InitError(Untranslated("Cannot set -listen=0 together with -listenonion=1"));
+    }
+
+    if (args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET)) {
+        if (args.GetBoolArg("-listen", DEFAULT_LISTEN)) {
+            return InitError(_("Cannot set -v2onlyclearnet=1 with listen=1. See -help for details on -v2onlyclearnet."));
+        }
     }
 
     // Make sure enough file descriptors are available. We need to reserve enough FDs to account for the bare minimum,
@@ -2158,6 +2167,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.whitelist_forcerelay = args.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY);
     connOptions.whitelist_relay = args.GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY);
     connOptions.m_capture_messages = args.GetBoolArg("-capturemessages", false);
+    connOptions.m_v2only_clearnet = args.GetBoolArg("-v2onlyclearnet", DEFAULT_V2_ONLY_CLEARNET);
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
     const uint16_t default_bind_port =

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2511,6 +2511,13 @@ bool CConnman::MultipleManualOrFullOutboundConns(Network net) const
     return m_network_conn_counts[net] > 1;
 }
 
+bool CConnman::RequiresV2ForOutbound(const CNetAddr& addr, std::string_view dest_name) const
+{
+    if (!m_v2only_clearnet) return false;
+    if (IsClearnet(addr.GetNetClass())) return true;
+    return !addr.IsValid() && !dest_name.empty();
+}
+
 bool CConnman::MaybePickPreferredNetwork(std::optional<Network>& network)
 {
     std::array<Network, 5> nets{NET_IPV4, NET_IPV6, NET_ONION, NET_I2P, NET_CJDNS};

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3083,7 +3083,7 @@ std::optional<Network> CConnman::PrivateBroadcast::PickNetwork(std::optional<Pro
     }
 
     const Network net{nets[FastRandomContext{}.randrange(nets.size())]};
-    if (net == NET_IPV4 || net == NET_IPV6) {
+    if (IsClearnet(net)) {
         proxy = clearnet_proxy;
     }
     return net;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -444,6 +444,10 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
     std::unique_ptr<i2p::sam::Session> i2p_transient_session;
 
     for (auto& target_addr : connect_to) {
+        if (RequiresV2ForOutbound(target_addr, pszDest ? pszDest : "") && !use_v2transport) {
+            LogDebug(BCLog::NET, "skipping v1 connection to %s (-v2onlyclearnet)\n", target_addr.ToStringAddrPort());
+            continue;
+        }
         if (target_addr.IsValid()) {
             const std::optional<Proxy> use_proxy{
                 proxy_override.has_value() ? proxy_override : GetProxy(target_addr.GetNetwork()),
@@ -1946,7 +1950,7 @@ void CConnman::DisconnectNodes()
                 // Add to reconnection list if appropriate. We don't reconnect right here, because
                 // the creation of a connection is a blocking operation (up to several seconds),
                 // and we don't want to hold up the socket handler thread for that long.
-                if (network_active && pnode->m_transport->ShouldReconnectV1()) {
+                if (network_active && !RequiresV2ForOutbound(pnode->addr, pnode->m_dest) && pnode->m_transport->ShouldReconnectV1()) {
                     reconnections_to_add.push_back({
                         .addr_connect = pnode->addr,
                         .grant = std::move(pnode->grantOutbound),

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -446,6 +446,10 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
     std::unique_ptr<i2p::sam::Session> i2p_transient_session;
 
     for (auto& target_addr : connect_to) {
+        if (RequiresV2ForOutbound(target_addr, pszDest ? pszDest : "") && !use_v2transport) {
+            LogDebug(BCLog::NET, "skipping v1 connection to %s (-v2onlyclearnet)\n", target_addr.ToStringAddrPort());
+            continue;
+        }
         if (target_addr.IsValid()) {
             const std::optional<Proxy> use_proxy{
                 proxy_override.has_value() ? proxy_override : GetProxy(target_addr.GetNetwork()),
@@ -1970,7 +1974,7 @@ void CConnman::DisconnectNodes()
                 // Add to reconnection list if appropriate. We don't reconnect right here, because
                 // the creation of a connection is a blocking operation (up to several seconds),
                 // and we don't want to hold up the socket handler thread for that long.
-                if (network_active && pnode->m_transport->ShouldReconnectV1()) {
+                if (network_active && !RequiresV2ForOutbound(pnode->addr, pnode->m_dest) && pnode->m_transport->ShouldReconnectV1()) {
                     reconnections_to_add.push_back({
                         .proxy_override = pnode->m_proxy_override,
                         .addr_connect = pnode->addr,

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3169,7 +3169,7 @@ std::optional<Network> CConnman::PrivateBroadcast::PickNetwork(std::optional<Pro
     }
 
     const Network net{nets[FastRandomContext{}.randrange(nets.size())]};
-    if (net == NET_IPV4 || net == NET_IPV6) {
+    if (IsClearnet(net)) {
         proxy = clearnet_proxy;
     }
     return net;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2571,6 +2571,13 @@ bool CConnman::MultipleManualOrFullOutboundConns(Network net) const
     return m_network_conn_counts[net] > 1;
 }
 
+bool CConnman::RequiresV2ForOutbound(const CNetAddr& addr, std::string_view dest_name) const
+{
+    if (!m_v2only_clearnet) return false;
+    if (IsClearnet(addr.GetNetClass())) return true;
+    return !addr.IsValid() && !dest_name.empty();
+}
+
 bool CConnman::MaybePickPreferredNetwork(std::optional<Network>& network)
 {
     AssertLockNotHeld(m_nodes_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -77,6 +77,8 @@ static const int MAX_FEELER_CONNECTIONS = 1;
 static constexpr size_t MAX_PRIVATE_BROADCAST_CONNECTIONS{64};
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
+/** -v2onlyclearnet default */
+static constexpr bool DEFAULT_V2_ONLY_CLEARNET{false};
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -1096,6 +1098,7 @@ public:
         bool whitelist_forcerelay = DEFAULT_WHITELISTFORCERELAY;
         bool whitelist_relay = DEFAULT_WHITELISTRELAY;
         bool m_capture_messages = false;
+        bool m_v2only_clearnet = DEFAULT_V2_ONLY_CLEARNET;
     };
 
     void Init(const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_total_bytes_sent_mutex)
@@ -1134,6 +1137,7 @@ public:
         whitelist_forcerelay = connOptions.whitelist_forcerelay;
         whitelist_relay = connOptions.whitelist_relay;
         m_capture_messages = connOptions.m_capture_messages;
+        m_v2only_clearnet = connOptions.m_v2only_clearnet;
     }
 
     // test only
@@ -1560,6 +1564,24 @@ private:
      */
     bool MaybePickPreferredNetwork(std::optional<Network>& network);
 
+    /**
+     * Whether an outbound connection to this destination must be v2 only.
+     *
+     * Returns true when -v2onlyclearnet is set AND either:
+     *   - the resolved address is clearnet (IPv4/IPv6) OR
+     *   - the address is unresolved and a destination string was supplied.
+     *     if bitcoind delegates DNS to a name proxy (ex: Tor), we can't tell
+     *     locally whether the name resolves to clearnet or not, so we assume
+     *     the worst case and require v2 to avoid sending plaintext.
+     *
+     * Connections to non-routable (local/loopback) addresses can be v1 since
+     * their traffic never leaves the LAN.
+     *
+     * @param addr      target address (maybe unresolved)
+     * @param dest_name destination string (or empty if connecting by resolved address)
+     */
+    bool RequiresV2ForOutbound(const CNetAddr& addr, std::string_view dest_name) const;
+
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);
 
@@ -1752,6 +1774,13 @@ private:
      * flag for whether messages are captured
      */
     bool m_capture_messages{false};
+
+    /**
+     * option for restricting outbound clearnet connections (IPv4/IPv6) to v2 only.
+     * outbound connections to IPv4/IPv6 need to be v2 connections.
+     * outbound connections to Tor/I2P/CJDNS can be v1 or v2 connections.
+     */
+    bool m_v2only_clearnet{DEFAULT_V2_ONLY_CLEARNET};
 
     /**
      * Mutex protecting m_i2p_sam_sessions.

--- a/src/net.h
+++ b/src/net.h
@@ -77,6 +77,8 @@ static const int MAX_FEELER_CONNECTIONS = 1;
 static constexpr size_t MAX_PRIVATE_BROADCAST_CONNECTIONS{64};
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
+/** -v2onlyclearnet default */
+static constexpr bool DEFAULT_V2_ONLY_CLEARNET{false};
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS{200};
 /** Default percentage of inbound connection slots that tx-relaying peers can use */
@@ -1113,6 +1115,7 @@ public:
         bool whitelist_forcerelay = DEFAULT_WHITELISTFORCERELAY;
         bool whitelist_relay = DEFAULT_WHITELISTRELAY;
         bool m_capture_messages = false;
+        bool m_v2only_clearnet = DEFAULT_V2_ONLY_CLEARNET;
     };
 
     void Init(const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_total_bytes_sent_mutex)
@@ -1152,6 +1155,7 @@ public:
         whitelist_forcerelay = connOptions.whitelist_forcerelay;
         whitelist_relay = connOptions.whitelist_relay;
         m_capture_messages = connOptions.m_capture_messages;
+        m_v2only_clearnet = connOptions.m_v2only_clearnet;
     }
 
     // test only
@@ -1619,6 +1623,24 @@ private:
      */
     bool MaybePickPreferredNetwork(std::optional<Network>& network) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
+    /**
+     * Whether an outbound connection to this destination must be v2 only.
+     *
+     * Returns true when -v2onlyclearnet is set AND either:
+     *   - the resolved address is clearnet (IPv4/IPv6) OR
+     *   - the address is unresolved and a destination string was supplied.
+     *     if bitcoind delegates DNS to a name proxy (ex: Tor), we can't tell
+     *     locally whether the name resolves to clearnet or not, so we assume
+     *     the worst case and require v2 to avoid sending plaintext.
+     *
+     * Connections to non-routable (local/loopback) addresses can be v1 since
+     * their traffic never leaves the LAN.
+     *
+     * @param addr      target address (maybe unresolved)
+     * @param dest_name destination string (or empty if connecting by resolved address)
+     */
+    bool RequiresV2ForOutbound(const CNetAddr& addr, std::string_view dest_name) const;
+
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);
 
@@ -1812,6 +1834,13 @@ private:
      * flag for whether messages are captured
      */
     bool m_capture_messages{false};
+
+    /**
+     * option for restricting outbound clearnet connections (IPv4/IPv6) to v2 only.
+     * outbound connections to IPv4/IPv6 need to be v2 connections.
+     * outbound connections to Tor/I2P/CJDNS can be v1 or v2 connections.
+     */
+    bool m_v2only_clearnet{DEFAULT_V2_ONLY_CLEARNET};
 
     /**
      * Mutex protecting m_i2p_sam_sessions.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -141,6 +141,8 @@ std::vector<std::string> GetNetworkNames(bool append_unroutable)
     return names;
 }
 
+bool IsClearnet(const enum Network net) { return net == NET_IPV4 || net == NET_IPV6; }
+
 static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
     if (!ContainsNoNUL(name)) return {};

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -179,6 +179,8 @@ enum Network ParseNetwork(const std::string& net);
 std::string GetNetworkName(enum Network net);
 /** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
 std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
+/** Returns true if the network is IPv4 or IPv6 (as opposed to Tor/I2P/CJDNS). */
+bool IsClearnet(enum Network net);
 bool SetProxy(enum Network net, const Proxy &addrProxy);
 std::optional<Proxy> GetProxy(enum Network net);
 bool IsProxy(const CNetAddr &addr);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -180,6 +180,8 @@ enum Network ParseNetwork(const std::string& net);
 std::string GetNetworkName(enum Network net);
 /** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
 std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
+/** Returns true if the network is IPv4 or IPv6 (as opposed to Tor/I2P/CJDNS). */
+bool IsClearnet(enum Network net);
 bool SetProxy(enum Network net, const Proxy &addrProxy);
 std::optional<Proxy> GetProxy(enum Network net);
 bool IsProxy(const CNetAddr &addr);

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -434,6 +434,15 @@ class ConfArgsTest(BitcoinTestFramework):
             "-proxyrandomize is disabled. Tor circuits for private broadcast connections may "
             "be correlated to other connections over Tor. For maximum privacy set -proxyrandomize=1."))
 
+    def test_v2onlyclearnet(self):
+        self.log.info('Test -v2onlyclearnet startup options')
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-v2onlyclearnet=1', '-v2transport=0'],
+            expected_msg='Error: Cannot set -v2onlyclearnet to true when v2transport is disabled.')
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-v2onlyclearnet=1', '-v2transport=1', '-listen=1'],
+            expected_msg='Error: Cannot set -v2onlyclearnet=1 with listen=1. See -help for details on -v2onlyclearnet.')
+
     def test_ignored_conf(self):
         self.log.info('Test error is triggered when the datadir in use contains a bitcoin.conf file that would be ignored '
                       'because a conflicting -conf file argument is passed.')
@@ -520,6 +529,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_networkactive()
         self.test_connect_with_seednode()
         self.test_privatebroadcast()
+        self.test_v2onlyclearnet()
 
         self.test_dir_config()
         self.test_negated_config()

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -451,6 +451,15 @@ class ConfArgsTest(BitcoinTestFramework):
             "-proxyrandomize is disabled. Tor circuits for private broadcast connections may "
             "be correlated to other connections over Tor. For maximum privacy set -proxyrandomize=1."))
 
+    def test_v2onlyclearnet(self):
+        self.log.info('Test -v2onlyclearnet startup options')
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-v2onlyclearnet=1', '-v2transport=0'],
+            expected_msg='Error: Cannot set -v2onlyclearnet to true when v2transport is disabled.')
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-v2onlyclearnet=1', '-v2transport=1', '-listen=1'],
+            expected_msg='Error: Cannot set -v2onlyclearnet=1 with listen=1. See -help for details on -v2onlyclearnet.')
+
     def test_ignored_conf(self):
         self.log.info('Test error is triggered when the datadir in use contains a bitcoin.conf file that would be ignored '
                       'because a conflicting -conf file argument is passed.')
@@ -538,6 +547,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_networkactive()
         self.test_connect_with_seednode()
         self.test_privatebroadcast()
+        self.test_v2onlyclearnet()
 
         self.test_dir_config()
         self.test_negated_config()

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -17,8 +17,10 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     check_node_connections,
+    p2p_port,
 )
 from test_framework.crypto.chacha20 import REKEY_INTERVAL
+from test_framework.socks5 import Socks5Configuration, Socks5Server
 
 
 class P2PEncrypted(BitcoinTestFramework):
@@ -127,6 +129,29 @@ class P2PEncrypted(BitcoinTestFramework):
         assert not peer1.supports_v2_p2p
         assert_equal(node0.getpeerinfo()[-1]["transport_protocol_type"], "v1")
         check_node_connections(node=node0, num_in=1, num_out=0)
+
+        conf = Socks5Configuration()
+        conf.auth = True
+        conf.unauth = True
+        conf.addr = ('127.0.0.1', p2p_port(self.num_nodes))
+        conf.keep_alive = True
+        proxy = Socks5Server(conf)
+        proxy.start()
+        args = ['-listen=0', '-nobind', f'-proxy={conf.addr[0]}:{conf.addr[1]}', '-proxyrandomize=0', '-v2onlyclearnet=1', '-v2transport=1']
+        self.restart_node(0, extra_args=args)
+        self.log.info("Test -v2onlyclearnet=1 behaviour")
+        self.log.info("Check that outbound v2 connection to an ipv4 peer is successful")
+        node0.addnode("15.61.23.23:1234", "onetry", v2transport=True)
+        assert_equal(node0.getpeerinfo()[-1]["addr"], "15.61.23.23:1234")
+        self.log.info("Check that outbound v1 connection to an ipv4 peer is unsuccessful")
+        with node0.assert_debug_log(expected_msgs=["skipping v1 connection to 8.8.8.8:1234"]):
+            node0.addnode("8.8.8.8:1234", "onetry", v2transport=False)
+        assert all(peer["addr"] != "8.8.8.8:1234" for peer in node0.getpeerinfo())
+        self.log.info("Check that outbound v1 connection to an onion peer is successful")
+        addr = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion:8333"
+        node0.addnode(addr, "onetry", False)
+        assert_equal(node0.getpeerinfo()[-1]["addr"], addr)
+        proxy.stop()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -18,8 +18,10 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     check_node_connections,
+    p2p_port,
 )
 from test_framework.crypto.chacha20 import REKEY_INTERVAL
+from test_framework.socks5 import Socks5Configuration, Socks5Server
 
 
 class P2PEncrypted(BitcoinTestFramework):
@@ -128,6 +130,29 @@ class P2PEncrypted(BitcoinTestFramework):
         assert not peer1.supports_v2_p2p
         assert_equal(node0.getpeerinfo()[-1]["transport_protocol_type"], "v1")
         check_node_connections(node=node0, num_in=1, num_out=0)
+
+        conf = Socks5Configuration()
+        conf.auth = True
+        conf.unauth = True
+        conf.addr = ('127.0.0.1', p2p_port(self.num_nodes))
+        conf.keep_alive = True
+        proxy = Socks5Server(conf)
+        proxy.start()
+        args = ['-listen=0', '-nobind', f'-proxy={conf.addr[0]}:{conf.addr[1]}', '-proxyrandomize=0', '-v2onlyclearnet=1', '-v2transport=1']
+        self.restart_node(0, extra_args=args)
+        self.log.info("Test -v2onlyclearnet=1 behaviour")
+        self.log.info("Check that outbound v2 connection to an ipv4 peer is successful")
+        node0.addnode("15.61.23.23:1234", "onetry", v2transport=True)
+        assert_equal(node0.getpeerinfo()[-1]["addr"], "15.61.23.23:1234")
+        self.log.info("Check that outbound v1 connection to an ipv4 peer is unsuccessful")
+        with node0.assert_debug_log(expected_msgs=["skipping v1 connection to 8.8.8.8:1234"]):
+            node0.addnode("8.8.8.8:1234", "onetry", v2transport=False)
+        assert all(peer["addr"] != "8.8.8.8:1234" for peer in node0.getpeerinfo())
+        self.log.info("Check that outbound v1 connection to an onion peer is successful")
+        addr = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion:8333"
+        node0.addnode(addr, "onetry", False)
+        assert_equal(node0.getpeerinfo()[-1]["addr"], addr)
+        proxy.stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
resolves #29618.

This PR adds a config flag option `-v2onlyclearnet` which disallows outbound v1 connections on ipv4 and ipv6 networks since they're unencrypted. outbound v1 connections are still possible from tor/i2p/cjdns peers since they're encrypted networks.

- v1 outbound connections to peers are not attempted
- v1 reconnections are not attempted (if peer is falsely advertised as v2 peer and we attempt a v2 connection but it fails, we do not attempt a v1 reconnection when `-v2onlyclearnet` is switched on)

Currently 70% of reachable nodes in network supporting v2 (according to https://21.ninja/reachable-nodes/node-service-share/ and https://bitnodes.io/nodes). Also found 81% of addresses supporting v2 in the addrman of nodes I checked - personal node and the nodes in [peer.observer](https://peer.observer/addrman/alice). (You can use [this branch ](https://github.com/stratospher/bitcoin/commits/addrinfo_service_display/)to check the % of v2 addresses in a node's addrman.)

EDIT: see [summary](https://github.com/bitcoin/bitcoin/pull/30951#issuecomment-4346061700) on pros and cons for whether to allow v2 inbounds or not for `-v2onlyclearnet`.