### PR TITLE
test: Use shell builtins in run_command test case

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, with error message for stderr
-        const std::string command{"python3 -c 'import sys; print(\"err\", file=sys.stderr); sys.exit(2)'"};
+        const std::string command{"sh -c 'echo err 1>&2 && false'"};
         const std::string expected{"err"};
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             const std::string what(e.what());


### PR DESCRIPTION
Uses the [suggested command](https://github.com/bitcoin/bitcoin/issues/30938#issuecomment-2363906135)

Fixes #30938