### PR TITLE
ci: add `LLVM_SYMBOLIZER_PATH` to Valgrind fuzz job

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -21,3 +21,4 @@ export BITCOIN_CONFIG="\
  -DCMAKE_C_COMPILER=clang-16 \
  -DCMAKE_CXX_COMPILER=clang++-16 \
 "
+export LLVM_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-16"


### PR DESCRIPTION
Otherwise:
```bash
	NEW_FUNC[1/23]: ==4710==WARNING: invalid path to external symbolizer!
==4710==WARNING: Failed to use and restart external symbolizer!
0xb72010  (/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/src/test/fuzz/fuzz+0xa6a010) (BuildId: 2087ad415cb752eea259ed750f3b78a7fcb0b43b)
	NEW_FUNC[2/23]: 0xb72240  (/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/src/test/fuzz/fuzz+0xa6a240) (BuildId: 2087ad415cb752eea259ed750f3b78a7fcb0b43b)

```