### PR TITLE
Disable RBF Rule 2

### DIFF
--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -17,14 +17,7 @@ other consensus and policy rules, each of the following conditions are met:
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).
 
-2. The replacement transaction only include an unconfirmed input if that input was included in
-   one of the directly conflicting transactions. An unconfirmed input spends an output from a
-   currently-unconfirmed transaction.
-
-   *Rationale*: When RBF was originally implemented, the mempool did not keep track of
-   ancestor feerates yet. This rule was suggested as a temporary restriction.
-
-3. The replacement transaction pays an absolute fee of at least the sum paid by the original
+2. The replacement transaction pays an absolute fee of at least the sum paid by the original
    transactions.
 
    *Rationale*: Only requiring the replacement transaction to have a higher feerate could allow an
@@ -34,7 +27,7 @@ other consensus and policy rules, each of the following conditions are met:
    rational miner, a replacement policy allowing the replacement transaction to decrease the absolute
    fees in the next block would be incentive-incompatible.
 
-4. The additional fees (difference between absolute fee paid by the replacement transaction and the
+3. The additional fees (difference between absolute fee paid by the replacement transaction and the
    sum paid by the original transactions) pays for the replacement transaction's bandwidth at or
    above the rate set by the node's incremental relay feerate. For example, if the incremental relay
    feerate is 1 satoshi/vB and the replacement transaction is 500 virtual bytes total, then the
@@ -43,7 +36,7 @@ other consensus and policy rules, each of the following conditions are met:
    *Rationale*: Try to prevent DoS attacks where an attacker causes the network to repeatedly relay
    transactions each paying a tiny additional amount in fees, e.g. just 1 satoshi.
 
-5. The number of original transactions does not exceed 100. More precisely, the sum of all
+4. The number of original transactions does not exceed 100. More precisely, the sum of all
    directly conflicting transactions' descendant counts (number of transactions inclusive of itself
    and its descendants) must not exceed 100; it is possible that this overestimates the true number
    of original transactions.
@@ -52,7 +45,7 @@ other consensus and policy rules, each of the following conditions are met:
    significant portions of the node's mempool using replacements with multiple directly conflicting
    transactions, each with large descendant sets.
 
-6. The replacement transaction's feerate is greater than the feerates of all directly conflicting
+5. The replacement transaction's feerate is greater than the feerates of all directly conflicting
    transactions.
 
    *Rationale*: This rule was originally intended to ensure that the replacement transaction is

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -71,14 +71,6 @@ std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx, CTxMem
                                                   CTxMemPool::setEntries& all_conflicts)
     EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 
-/** The replacement transaction may only include an unconfirmed input if that input was included in
- * one of the original transactions.
- * @returns error message if tx spends unconfirmed inputs not also spent by iters_conflicting,
- * otherwise std::nullopt. */
-std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx, const CTxMemPool& pool,
-                                               const CTxMemPool::setEntries& iters_conflicting)
-    EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
-
 /** Check the intersection between two sets of transactions (a set of mempool entries and a set of
  * txids) to make sure they are disjoint.
  * @param[in]   ancestors           Set of mempool entries corresponding to ancestors of the

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -289,25 +289,6 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     add_descendants(tx8, 1, pool);
     BOOST_CHECK(GetEntriesForConflicts(*conflicts_with_parents.get(), pool, all_parents, all_conflicts).has_value());
 
-    // Tests for HasNoNewUnconfirmed
-    const auto spends_unconfirmed = make_tx({tx1}, {36 * CENT});
-    for (const auto& input : spends_unconfirmed->vin) {
-        // Spends unconfirmed inputs.
-        BOOST_CHECK(pool.exists(GenTxid::Txid(input.prevout.hash)));
-    }
-    BOOST_CHECK(HasNoNewUnconfirmed(/*tx=*/ *spends_unconfirmed.get(),
-                                    /*pool=*/ pool,
-                                    /*iters_conflicting=*/ all_entries) == std::nullopt);
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_unconfirmed.get(), pool, {entry2_normal}) == std::nullopt);
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_unconfirmed.get(), pool, empty_set).has_value());
-
-    const auto spends_new_unconfirmed = make_tx({tx1, tx8}, {36 * CENT});
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_new_unconfirmed.get(), pool, {entry2_normal}).has_value());
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_new_unconfirmed.get(), pool, all_entries).has_value());
-
-    const auto spends_conflicting_confirmed = make_tx({m_coinbase_txns[0], m_coinbase_txns[1]}, {45 * CENT});
-    BOOST_CHECK(HasNoNewUnconfirmed(*spends_conflicting_confirmed.get(), pool, {entry1_normal, entry3_low}) == std::nullopt);
-
     // Tests for CheckConflictTopology
 
     // Tx4 has 23 descendants

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1105,13 +1105,6 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY,
                              strprintf("too many potential replacements%s", ws.m_sibling_eviction ? " (including sibling eviction)" : ""), *err_string);
     }
-    // Enforce Rule #2.
-    if (const auto err_string{HasNoNewUnconfirmed(tx, m_pool, m_subpackage.m_all_conflicts)}) {
-        // Sibling eviction is only done for TRUC transactions, which cannot have multiple ancestors.
-        Assume(!ws.m_sibling_eviction);
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY,
-                             strprintf("replacement-adds-unconfirmed%s", ws.m_sibling_eviction ? " (including sibling eviction)" : ""), *err_string);
-    }
 
     // Check if it's economically rational to mine this transaction rather than the ones it
     // replaces and pays for its own relay fees. Enforce Rules #3 and #4.

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -318,7 +318,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, 0)
 
     def test_new_unconfirmed_inputs(self):
-        """Replacements that add new unconfirmed inputs are rejected"""
+        """Replacements that add new unconfirmed inputs are not rejected"""
         confirmed_utxo = self.make_utxo(self.nodes[0], int(1.1 * COIN))
         unconfirmed_utxo = self.make_utxo(self.nodes[0], int(0.1 * COIN), confirmed=False)
 
@@ -335,8 +335,13 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             amount_per_output=1 * COIN,
         )["hex"]
 
-        # This will raise an exception
-        assert_raises_rpc_error(-26, "replacement-adds-unconfirmed", self.nodes[0].sendrawtransaction, tx2_hex, 0)
+        # Works when enabled
+        tx2_txid = self.nodes[0].sendrawtransaction(tx2_hex, 0)
+
+        mempool = self.nodes[0].getrawmempool()
+        assert tx2_txid in mempool
+
+        assert_equal(tx2_hex, self.nodes[0].getrawtransaction(tx2_txid))
 
     def test_too_many_replacements(self):
         """Replacements that evict too many transactions are rejected"""


### PR DESCRIPTION
One of the current RBF acceptance criteria is the prohibition of new unconfirmed inputs in the replacement transaction. That means that all replacement inputs must either be confirmed, or have unconfirmed spends that would get evicted.

However, that limitation is trivially circumvented. If one wanted to spend an unconfirmed UTXO in the replacement transaction, all one would need to do is create a temporary, independent low-fee-rate transaction that spends that input, and then simply add that transaction to the replacement's eviction set. @glozow has documented that [here](https://gist.github.com/glozow/25d9662c52453bd08b4b4b1d3783b9ff) back in early 2022, and I imagine there's other literature out there documenting this same phenomenon.

One interesting thing to note with this approach of circumventing rule 2 is that the broadcasting of the temporary transaction and the broadcasting of the actually intended replacement transaction ought to be staggered, lest some nodes see only the final replacement transaction and reject it. I think it's fair to say that that makes the propagation somewhat nondeterministic. Given that any motivated actor can trivially craft such a dummy transaction and then simply wait 30 seconds (maybe less?) before broadcasting the replacement, removing the pretense of rule 2 would reduce network traffic for this scenario.

In light of all the work on the cluster mempool that's been ongoing recently, a question for this PR might be: "why now?" My answer would be that due to the easy circumvention of rule 2, and it therefore arguably not being a "real" rule, removing it is somewhat independent of future, even near-term, mempool policy improvements.

All that being said, the basis of this PR might be due to a glaring misunderstanding on my part of how bitcoin works, in which case feel free to close it, and my apologies for the noise.