### PR TITLE
build: Add missing USDT header dependency to kernel

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(bitcoinkernel
     bitcoin_crypto
     leveldb
     secp256k1
+    $<TARGET_NAME_IF_EXISTS:USDT::headers>
   PUBLIC
     Boost::headers
 )


### PR DESCRIPTION
Noticed while testing a branch that replaces `boost::multi_index` with a custom replacement.

Currently depends builds pick up usdt and boost from the same path, and because boost always exists, the usdt path is implicitly included. So without boost, USDT isn't found.

An alternative to this would be to disable USDT for the kernel. I'd be open to either approach.