### PR TITLE
Wallet: "listreceivedby*" fix

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -135,8 +135,12 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
         if (is_change) return; // no change addresses
 
         auto it = mapTally.find(address);
-        if (it == mapTally.end() && !fIncludeEmpty)
+        if (it == mapTally.end() && !fIncludeEmpty) {
             return;
+        } else if (it == mapTally.end()) {
+            LOCK(wallet.cs_wallet);
+            if (!wallet.IsMine(address)) return; // no send addresses
+        }
 
         CAmount nAmount = 0;
         int nConf = std::numeric_limits<int>::max();


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/16159, 

This PR builds on https://github.com/bitcoin/bitcoin/pull/25973, fixing `listreceivedby*` RPCs by filtering out `send` addresses using `IsMine` (see https://github.com/bitcoin/bitcoin/pull/25973#discussion_r1269477246). It also breaks down the `listreceivedby` tests into subtests and adds a test to verify 'listreceivedby*' does not return `send` addresses