### PR TITLE
contrib: Update asmap link in seeds readme

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -9,7 +9,7 @@ changes its default return value, as those are the services which seeds are adde
 to addrman with).
 
 The seeds compiled into the release are created from sipa's, achow101's and luke-jr's
-DNS seed, virtu's crawler, and fjahr's community AS map data. Run the following commands
+DNS seed, virtu's crawler, and asmap community AS map data. Run the following commands
 from the `/contrib/seeds` directory:
 
 ```
@@ -18,7 +18,7 @@ curl https://mainnet.achownodes.xyz/seeds.txt.gz | gzip -dc >> seeds_main.txt
 curl https://21.ninja/seeds.txt.gz | gzip -dc >> seeds_main.txt
 curl https://luke.dashjr.org/programs/bitcoin/files/charts/seeds.txt >> seeds_main.txt
 curl https://testnet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_test.txt
-curl https://raw.githubusercontent.com/fjahr/asmap-data/main/latest_asmap.dat > asmap-filled.dat
+curl https://raw.githubusercontent.com/asmap/asmap-data/main/latest_asmap.dat > asmap-filled.dat
 python3 makeseeds.py -a asmap-filled.dat -s seeds_main.txt > nodes_main.txt
 python3 makeseeds.py -a asmap-filled.dat -s seeds_test.txt > nodes_test.txt
 # TODO: Uncomment when a seeder publishes seeds.txt.gz for testnet4


### PR DESCRIPTION
I am moving all my ASMap related repositories to an asmap org. While there is a redirect in place that works for now, GitHub doesn't guarantee that it will keep working in the long term. So we should still fix the links.