### PR TITLE
ci: add timestamps to cirrus jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
 env:  # Global defaults
   CIRRUS_CLONE_DEPTH: 1
+  CIRRUS_LOG_TIMESTAMP: true
   PACKAGE_MANAGER_INSTALL: "apt-get update && apt-get install -y"
   MAKEJOBS: "-j10"
   TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache


### PR DESCRIPTION
Currently, debugging where time is spent in the cirrus jobs feels annoying, e.g. trying to see where time may be spent in https://github.com/bitcoin/bitcoin/issues/30969

Enable timestamps in the logs for more information.