### PR TITLE
docs: Add instructions on how to self-sign bitcoin-core binaries for macOS

### DIFF
--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -32,6 +32,13 @@ Upgrading directly from a version of Bitcoin Core that has reached its EOL is
 possible, but it might take some time if the data directory needs to be migrated. Old
 wallet versions of Bitcoin Core are generally supported.
 
+Running Bitcoin Core binaries on macOS requires self signing.
+```
+cd /path/to/bitcoin-core/bin
+xattr -d com.apple.quarantine bitcoin-cli bitcoin-qt bitcoin-tx bitcoin-util bitcoin-wallet bitcoind test_bitcoin
+codesign -s - bitcoin-cli bitcoin-qt bitcoin-tx bitcoin-util bitcoin-wallet bitcoind test_bitcoin
+```
+
 Compatibility
 ==============
 


### PR DESCRIPTION
Related to #15774

This PR adds instructions to the release notes to tell users how to self sign bitcoin core binaries so they are executable on macOS.

Tested on
```
Darwin Chriss-MacBook-Pro.local 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:46 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6031 arm64
```

These commands do not appear to require 'phoning home'. I tested these commands when disconnected from a network connection and things worked.