### PR TITLE
p2p: rpc: add `tx_reconciliation` to `getpeerinfo`

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1902,6 +1902,9 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         stats.m_fee_filter_received = 0;
     }
 
+    if (m_txreconciliation) {
+        stats.m_tx_reconciliation = m_txreconciliation->IsPeerRegistered(nodeid);
+    }
     stats.m_ping_wait = ping_wait;
     stats.m_addr_processed = peer->m_addr_processed.load();
     stats.m_addr_rate_limited = peer->m_addr_rate_limited.load();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1925,6 +1925,7 @@ PeerManagerInfo PeerManagerImpl::GetInfo() const
     return PeerManagerInfo{
         .median_outbound_time_offset = m_outbound_time_offsets.Median(),
         .ignores_incoming_txs = m_opts.ignore_incoming_txs,
+        .reconcile_txs = m_opts.reconcile_txs
     };
 }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -49,6 +49,7 @@ struct CNodeStateStats {
     ServiceFlags their_services;
     int64_t presync_height{-1};
     std::chrono::seconds time_offset{0};
+    bool m_tx_reconciliation{false};
 };
 
 struct PeerManagerInfo {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -55,6 +55,7 @@ struct CNodeStateStats {
 struct PeerManagerInfo {
     std::chrono::seconds median_outbound_time_offset{0s};
     bool ignores_incoming_txs{false};
+    bool reconcile_txs{DEFAULT_TXRECONCILIATION_ENABLE};
 };
 
 class PeerManager : public CValidationInterface, public NetEventsInterface

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -187,6 +187,7 @@ static RPCHelpMan getpeerinfo()
                                                               "best capture connection behaviors."},
                     {RPCResult::Type::STR, "transport_protocol_type", "Type of transport protocol: \n" + Join(TRANSPORT_TYPE_DOC, ",\n") + ".\n"},
                     {RPCResult::Type::STR, "session_id", "The session ID for this connection, or \"\" if there is none (\"v2\" transport protocol only).\n"},
+                    {RPCResult::Type::BOOL, "tx_reconciliation", /*optional=*/true, "Whether peer is registered for transaction reconciliation"}
                 }},
             }},
         },
@@ -199,6 +200,9 @@ static RPCHelpMan getpeerinfo()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     const CConnman& connman = EnsureConnman(node);
     const PeerManager& peerman = EnsurePeerman(node);
+
+    const auto& peerman_info{peerman.GetInfo()};
+    const bool reconcile_txs{peerman_info.reconcile_txs};
 
     std::vector<CNodeStats> vstats;
     connman.GetNodeStats(vstats);
@@ -293,6 +297,9 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("connection_type", ConnectionTypeAsString(stats.m_conn_type));
         obj.pushKV("transport_protocol_type", TransportTypeAsString(stats.m_transport_type));
         obj.pushKV("session_id", stats.m_session_id);
+        if (reconcile_txs) {
+            obj.pushKV("tx_reconciliation", statestats.m_tx_reconciliation);
+        }
 
         ret.push_back(std::move(obj));
     }

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -195,6 +195,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(['Register peer=1']):
             peer.send_message(sendtxrcncl_higher_version)
+        assert_equal(self.nodes[0].getpeerinfo()[0]['tx_reconciliation'], True)
         self.nodes[0].disconnect_p2ps()
 
         self.log.info('unexpected SENDTXRCNCL is ignored')
@@ -220,6 +221,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(['Forget txreconciliation state of peer']):
             peer.send_message(create_sendtxrcncl_msg())
             peer.send_message(msg_verack())
+        assert_equal(self.nodes[0].getpeerinfo()[0]['tx_reconciliation'], False)
         self.nodes[0].disconnect_p2ps()
 
         # Now, *receiving* from *outbound*.

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -146,19 +146,16 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_outbound_p2p_connection(
             SendTxrcnclReceiver(), wait_for_verack=True, p2p_idx=0, connection_type="addr-fetch")
         assert not peer.sendtxrcncl_msg_received
-        self.nodes[0].disconnect_p2ps()
 
         self.log.info('SENDTXRCNCL not sent if -txreconciliation flag is not set')
         self.restart_node(0, [])
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=True, wait_for_verack=True)
         assert not peer.sendtxrcncl_msg_received
-        self.nodes[0].disconnect_p2ps()
 
         self.log.info('SENDTXRCNCL not sent if blocksonly is set')
         self.restart_node(0, ["-txreconciliation", "-blocksonly"])
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=True, wait_for_verack=True)
         assert not peer.sendtxrcncl_msg_received
-        self.nodes[0].disconnect_p2ps()
 
         # Check everything concerning *receiving* SENDTXRCNCL
         # First, receiving from *inbound*.
@@ -177,7 +174,6 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(['ignored, as our node does not have txreconciliation enabled']):
             peer.send_message(create_sendtxrcncl_msg())
-        self.nodes[0].disconnect_p2ps()
 
         self.restart_node(0, ["-txreconciliation"])
 


### PR DESCRIPTION
This PR adds a new field in `getpeerinfo` RPC to know whether a peer is registered for transaction reconciliation (we register it when receiving a `SENDTXRCNCL` msg).  

- The field `tx_reconciliation` is optional for in case you do not support tx reconciliation.
- With this field, we can improve `p2p_sendtxrcncl` tests by checking whether a peer is registered for transaction reconciliation instead of simply rely on logs message.
- d660df07d756ba5e06b74e4b51a7287620ae306b - Just remove unnecessary `disconnect_p2ps` (we're calling it right before restarting the node) calls in `p2p_sendtxrcncl`.