### PR TITLE
contrib: skip missing binaries in gen-manpages

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import argparse
 
 BINARIES = [
 'src/bitcoind',
@@ -15,6 +16,18 @@ BINARIES = [
 'src/bitcoin-util',
 'src/qt/bitcoin-qt',
 ]
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+parser.add_argument(
+    "-s",
+    "--skip-missing-binaries",
+    action="store_true",
+    default=False,
+    help="skip generation for binaries that are not found in the build path",
+)
+args = parser.parse_args()
 
 # Paths to external utilities.
 git = os.getenv('GIT', 'git')
@@ -38,8 +51,12 @@ for relpath in BINARIES:
     try:
         r = subprocess.run([abspath, "--version"], stdout=subprocess.PIPE, check=True, text=True)
     except IOError:
-        print(f'{abspath} not found or not an executable', file=sys.stderr)
-        sys.exit(1)
+        if(args.skip_missing_binaries):
+            print(f'{abspath} not found or not an executable. Skipping...', file=sys.stderr)
+            continue
+        else:
+            print(f'{abspath} not found or not an executable', file=sys.stderr)
+            sys.exit(1)
     # take first line (which must contain version)
     verstr = r.stdout.splitlines()[0]
     # last word of line is the actual version e.g. v22.99.0-5c6b3d5b3508

--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -68,6 +68,10 @@ for relpath in BINARIES:
 
     versions.append((abspath, verstr, copyright))
 
+if not versions:
+    print(f'No binaries found in {builddir}. Please ensure the binaries are present in {builddir}, or set another build path using the BUILDDIR env variable.')
+    sys.exit(1)
+
 if any(verstr.endswith('-dirty') for (_, verstr, _) in versions):
     print("WARNING: Binaries were built from a dirty tree.")
     print('man pages generated from dirty binaries should NOT be committed.')


### PR DESCRIPTION
Instead of stopping the execution of gen-manpages.py when a binary is not found, continue generating manpages for the available binaries and skip the missing ones.

A new argument, `--skip-missing-binaries`, has been added to enable this behavior.

```sh
➜  bitcoin git:(fix-gen-manpages) ✗ ./contrib/devtools/gen-manpages.py --help
usage: gen-manpages.py [-h] [-s]

options:
  -h, --help            show this help message and exit
  -s, --skip-missing-binaries
                        skip generation for binaries that are not found

```

closes #30985

This PR also includes an error prompt if no binaries are found in the build path.