### PR TITLE
Split CConnman

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/run_command.cpp
   common/settings.cpp
   common/signmessage.cpp
+  common/sockman.cpp
   common/system.cpp
   common/url.cpp
   compressor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   core_write.cpp
   deploymentinfo.cpp
   external_signer.cpp
+  i2p.cpp
   init/common.cpp
   kernel/chainparams.cpp
   key.cpp
@@ -190,7 +191,6 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   headerssync.cpp
   httprpc.cpp
   httpserver.cpp
-  i2p.cpp
   index/base.cpp
   index/blockfilterindex.cpp
   index/coinstatsindex.cpp

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -88,6 +88,27 @@ bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
     return true;
 }
 
+std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)
+{
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+    auto sock = listen_sock.Accept((struct sockaddr*)&sockaddr, &len);
+
+    if (!sock) {
+        const int nErr = WSAGetLastError();
+        if (nErr != WSAEWOULDBLOCK) {
+            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
+        }
+        return {};
+    }
+
+    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
+    }
+
+    return sock;
+}
+
 void SockMan::StopListening()
 {
     m_listen.clear();

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -90,19 +90,23 @@ bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
 
 std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)
 {
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    auto sock = listen_sock.Accept((struct sockaddr*)&sockaddr, &len);
+    sockaddr_storage storage;
+    socklen_t len{sizeof(storage)};
+
+    auto sock{listen_sock.Accept(reinterpret_cast<sockaddr*>(&storage), &len)};
 
     if (!sock) {
-        const int nErr = WSAGetLastError();
-        if (nErr != WSAEWOULDBLOCK) {
-            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
+        const int err{WSAGetLastError()};
+        if (err != WSAEWOULDBLOCK) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Error,
+                          "Cannot accept new connection: %s\n",
+                          NetworkErrorString(err));
         }
         return {};
     }
 
-    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
+    if (!addr.SetSockAddr(reinterpret_cast<sockaddr*>(&storage), len)) {
         LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
     }
 

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -10,6 +10,20 @@
 #include <util/sock.h>
 #include <util/thread.h>
 
+/** Get the bind address for a socket as CService. */
+CService GetBindAddress(const Sock& sock)
+{
+    CService addr_bind;
+    struct sockaddr_storage sockaddr_bind;
+    socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
+    if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
+        addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind, sockaddr_bind_len);
+    } else {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
+    }
+    return addr_bind;
+}
+
 SockMan::SockMan(std::shared_ptr<CThreadInterrupt> interrupt_net) : m_interrupt_net{interrupt_net} {}
 
 bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
@@ -107,6 +121,83 @@ void SockMan::JoinSocketsThreads()
     if (m_thread_i2p_accept.joinable()) {
         m_thread_i2p_accept.join();
     }
+}
+
+std::optional<SockMan::Id>
+SockMan::ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
+                          bool is_important,
+                          std::optional<Proxy> proxy,
+                          bool& proxy_failed,
+                          CService& me,
+                          std::unique_ptr<Sock>& sock,
+                          std::unique_ptr<i2p::sam::Session>& i2p_transient_session)
+{
+    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+
+    Assume(!me.IsValid());
+
+    if (std::holds_alternative<CService>(to)) {
+        const CService& addr_to{std::get<CService>(to)};
+        if (addr_to.IsI2P()) {
+            if (!Assume(proxy.has_value())) {
+                return std::nullopt;
+            }
+
+            i2p::Connection conn;
+            bool connected{false};
+
+            if (m_i2p_sam_session) {
+                connected = m_i2p_sam_session->Connect(addr_to, conn, proxy_failed);
+            } else {
+                {
+                    LOCK(m_unused_i2p_sessions_mutex);
+                    if (m_unused_i2p_sessions.empty()) {
+                        i2p_transient_session = std::make_unique<i2p::sam::Session>(proxy.value(), m_interrupt_net);
+                    } else {
+                        i2p_transient_session.swap(m_unused_i2p_sessions.front());
+                        m_unused_i2p_sessions.pop();
+                    }
+                }
+                connected = i2p_transient_session->Connect(addr_to, conn, proxy_failed);
+                if (!connected) {
+                    LOCK(m_unused_i2p_sessions_mutex);
+                    if (m_unused_i2p_sessions.size() < MAX_UNUSED_I2P_SESSIONS_SIZE) {
+                        m_unused_i2p_sessions.emplace(i2p_transient_session.release());
+                    }
+                }
+            }
+
+            if (connected) {
+                sock = std::move(conn.sock);
+                me = conn.me;
+            }
+        } else if (proxy.has_value()) {
+            sock = ConnectThroughProxy(proxy.value(), addr_to.ToStringAddr(), addr_to.GetPort(), proxy_failed);
+        } else {
+            sock = ConnectDirectly(addr_to, is_important);
+        }
+    } else {
+        if (!Assume(proxy.has_value())) {
+            return std::nullopt;
+        }
+
+        const auto& hostport{std::get<StringHostIntPort>(to)};
+
+        bool dummy_proxy_failed;
+        sock = ConnectThroughProxy(proxy.value(), hostport.host, hostport.port, dummy_proxy_failed);
+    }
+
+    if (!sock) {
+        return std::nullopt;
+    }
+
+    if (!me.IsValid()) {
+        me = GetBindAddress(*sock);
+    }
+
+    const Id id{GetNewId()};
+
+    return id;
 }
 
 std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -8,6 +8,9 @@
 #include <logging.h>
 #include <netbase.h>
 #include <util/sock.h>
+#include <util/thread.h>
+
+SockMan::SockMan(std::shared_ptr<CThreadInterrupt> interrupt_net) : m_interrupt_net{interrupt_net} {}
 
 bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
 {
@@ -88,6 +91,24 @@ bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
     return true;
 }
 
+void SockMan::StartSocketsThreads(const Options& options)
+{
+    if (options.i2p.has_value()) {
+        m_i2p_sam_session = std::make_unique<i2p::sam::Session>(
+            options.i2p->private_key_file, options.i2p->sam_proxy, m_interrupt_net);
+
+        m_thread_i2p_accept =
+            std::thread(&util::TraceThread, options.i2p->accept_thread_name, [this] { ThreadI2PAccept(); });
+    }
+}
+
+void SockMan::JoinSocketsThreads()
+{
+    if (m_thread_i2p_accept.joinable()) {
+        m_thread_i2p_accept.join();
+    }
+}
+
 std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)
 {
     sockaddr_storage storage;
@@ -124,3 +145,39 @@ void SockMan::StopListening()
 }
 
 void SockMan::EventI2PStatus(const CService&, I2PStatus) {}
+
+void SockMan::ThreadI2PAccept()
+{
+    static constexpr auto err_wait_begin = 1s;
+    static constexpr auto err_wait_cap = 5min;
+    auto err_wait = err_wait_begin;
+
+    i2p::Connection conn;
+
+    auto SleepOnFailure = [&]() {
+        m_interrupt_net->sleep_for(err_wait);
+        if (err_wait < err_wait_cap) {
+            err_wait += 1s;
+        }
+    };
+
+    while (!m_interrupt_net->interrupted()) {
+
+        if (!m_i2p_sam_session->Listen(conn)) {
+            EventI2PStatus(conn.me, SockMan::I2PStatus::STOP_LISTENING);
+            SleepOnFailure();
+            continue;
+        }
+
+        EventI2PStatus(conn.me, SockMan::I2PStatus::START_LISTENING);
+
+        if (!m_i2p_sam_session->Accept(conn)) {
+            SleepOnFailure();
+            continue;
+        }
+
+        EventNewConnectionAccepted(std::move(conn.sock), conn.me, conn.peer);
+
+        err_wait = err_wait_begin;
+    }
+}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -148,6 +148,10 @@ bool SockMan::ShouldTryToSend(Id id) const { return true; }
 
 bool SockMan::ShouldTryToRecv(Id id) const { return true; }
 
+void SockMan::EventIOLoopCompletedForOne(Id id) {}
+
+void SockMan::EventIOLoopCompletedForAll() {}
+
 void SockMan::EventI2PStatus(const CService&, I2PStatus) {}
 
 void SockMan::ThreadI2PAccept()

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -122,3 +122,5 @@ void SockMan::StopListening()
 {
     m_listen.clear();
 }
+
+void SockMan::EventI2PStatus(const CService&, I2PStatus) {}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -225,6 +225,26 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
     return sock;
 }
 
+void SockMan::NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
+{
+    if (!sock->IsSelectable()) {
+        LogPrintf("connection from %s dropped: non-selectable socket\n", them.ToStringAddrPort());
+        return;
+    }
+
+    // According to the internet TCP_NODELAY is not carried into accepted sockets
+    // on all platforms.  Set it again here just to be sure.
+    const int on{1};
+    if (sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) == SOCKET_ERROR) {
+        LogDebug(BCLog::NET, "connection from %s: unable to set TCP_NODELAY, continuing anyway\n",
+                 them.ToStringAddrPort());
+    }
+
+    const Id id{GetNewId()};
+
+    EventNewConnectionAccepted(id, std::move(sock), me, them);
+}
+
 SockMan::Id SockMan::GetNewId()
 {
     return m_next_id.fetch_add(1, std::memory_order_relaxed);
@@ -275,7 +295,10 @@ void SockMan::ThreadI2PAccept()
             continue;
         }
 
-        EventNewConnectionAccepted(std::move(conn.sock), conn.me, conn.peer);
+        Assume(conn.me.IsI2P());
+        Assume(conn.peer.IsI2P());
+
+        NewSockAccepted(std::move(conn.sock), conn.me, conn.peer);
 
         err_wait = err_wait_begin;
     }

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <common/sockman.h>
+#include <logging.h>
+#include <netbase.h>
+#include <util/sock.h>
+
+bool SockMan::BindListenPort(const CService& addrBind, bilingual_str& strError)
+{
+    int nOne = 1;
+
+    // Create socket for listening for incoming connections
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
+    {
+        strError = Untranslated(strprintf("Bind address family for %s not supported", addrBind.ToStringAddrPort()));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    if (!sock) {
+        strError = Untranslated(strprintf("Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError())));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    // Allow binding if the port is still in TIME_WAIT state after
+    // the program was closed and restarted.
+    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &nOne, sizeof(int)) == SOCKET_ERROR) {
+        strError = Untranslated(strprintf("Error setting SO_REUSEADDR on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+        LogPrintf("%s\n", strError.original);
+    }
+
+    // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
+    // and enable it by default or not. Try to enable it, if possible.
+    if (addrBind.IsIPv6()) {
+#ifdef IPV6_V6ONLY
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &nOne, sizeof(int)) == SOCKET_ERROR) {
+            strError = Untranslated(strprintf("Error setting IPV6_V6ONLY on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+            LogPrintf("%s\n", strError.original);
+        }
+#endif
+#ifdef WIN32
+        int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &nProtLevel, sizeof(int)) == SOCKET_ERROR) {
+            strError = Untranslated(strprintf("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+            LogPrintf("%s\n", strError.original);
+        }
+#endif
+    }
+
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
+        int nErr = WSAGetLastError();
+        if (nErr == WSAEADDRINUSE)
+            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), CLIENT_NAME);
+        else
+            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+    LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
+
+    // Listen for incoming connections
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
+    {
+        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    m_listen.emplace_back(std::move(sock));
+
+    return true;
+}
+
+void SockMan::StopListening()
+{
+    m_listen.clear();
+}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -9,68 +9,77 @@
 #include <netbase.h>
 #include <util/sock.h>
 
-bool SockMan::BindListenPort(const CService& addrBind, bilingual_str& strError)
+bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
 {
-    int nOne = 1;
-
     // Create socket for listening for incoming connections
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
-    {
-        strError = Untranslated(strprintf("Bind address family for %s not supported", addrBind.ToStringAddrPort()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+    sockaddr_storage storage;
+    socklen_t len{sizeof(storage)};
+    if (!to.GetSockAddr(reinterpret_cast<sockaddr*>(&storage), &len)) {
+        err_msg = Untranslated(strprintf("Bind address family for %s not supported", to.ToStringAddrPort()));
         return false;
     }
 
-    std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    std::unique_ptr<Sock> sock{CreateSock(to.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP)};
     if (!sock) {
-        strError = Untranslated(strprintf("Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError())));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        err_msg = Untranslated(strprintf("Cannot create %s listen socket: %s",
+                                         to.ToStringAddrPort(),
+                                         NetworkErrorString(WSAGetLastError())));
         return false;
     }
+
+    int one{1};
 
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.
-    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &nOne, sizeof(int)) == SOCKET_ERROR) {
-        strError = Untranslated(strprintf("Error setting SO_REUSEADDR on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-        LogPrintf("%s\n", strError.original);
+    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) == SOCKET_ERROR) {
+        LogPrintLevel(BCLog::NET,
+                      BCLog::Level::Info,
+                      "Cannot set SO_REUSEADDR on %s listen socket: %s, continuing anyway\n",
+                      to.ToStringAddrPort(),
+                      NetworkErrorString(WSAGetLastError()));
     }
 
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) {
+    if (to.IsIPv6()) {
 #ifdef IPV6_V6ONLY
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &nOne, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_V6ONLY on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one)) == SOCKET_ERROR) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Info,
+                          "Cannot set IPV6_V6ONLY on %s listen socket: %s, continuing anyway\n",
+                          to.ToStringAddrPort(),
+                          NetworkErrorString(WSAGetLastError()));
         }
 #endif
 #ifdef WIN32
-        int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &nProtLevel, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
+        int prot_level{PROTECTION_LEVEL_UNRESTRICTED};
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &prot_level, sizeof(prot_level)) == SOCKET_ERROR) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Info,
+                          "Cannot set IPV6_PROTECTION_LEVEL on %s listen socket: %s, continuing anyway\n",
+                          to.ToStringAddrPort(),
+                          NetworkErrorString(WSAGetLastError()));
         }
 #endif
     }
 
-    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
-        int nErr = WSAGetLastError();
-        if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), CLIENT_NAME);
-        else
-            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+    if (sock->Bind(reinterpret_cast<sockaddr*>(&storage), len) == SOCKET_ERROR) {
+        const int err{WSAGetLastError()};
+        if (err == WSAEADDRINUSE) {
+            err_msg = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."),
+                                to.ToStringAddrPort(),
+                                CLIENT_NAME);
+        } else {
+            err_msg = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"),
+                                to.ToStringAddrPort(),
+                                NetworkErrorString(err));
+        }
         return false;
     }
-    LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
 
     // Listen for incoming connections
-    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
-    {
-        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR) {
+        err_msg = strprintf(_("Cannot listen on %s: %s"), to.ToStringAddrPort(), NetworkErrorString(WSAGetLastError()));
         return false;
     }
 

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -10,8 +10,14 @@
 #include <util/sock.h>
 #include <util/thread.h>
 
+#include <cassert>
+
+// The set of sockets cannot be modified while waiting
+// The sleep time needs to be small to avoid new sockets stalling
+static constexpr auto SELECT_TIMEOUT{50ms};
+
 /** Get the bind address for a socket as CService. */
-CService GetBindAddress(const Sock& sock)
+static CService GetBindAddress(const Sock& sock)
 {
     CService addr_bind;
     struct sockaddr_storage sockaddr_bind;
@@ -107,6 +113,9 @@ bool SockMan::BindAndStartListening(const CService& to, bilingual_str& err_msg)
 
 void SockMan::StartSocketsThreads(const Options& options)
 {
+    m_thread_socket_handler = std::thread(
+        &util::TraceThread, options.socket_handler_thread_name, [this] { ThreadSocketHandler(); });
+
     if (options.i2p.has_value()) {
         m_i2p_sam_session = std::make_unique<i2p::sam::Session>(
             options.i2p->private_key_file, options.i2p->sam_proxy, m_interrupt_net);
@@ -121,6 +130,10 @@ void SockMan::JoinSocketsThreads()
     if (m_thread_i2p_accept.joinable()) {
         m_thread_i2p_accept.join();
     }
+
+    if (m_thread_socket_handler.joinable()) {
+        m_thread_socket_handler.join();
+    }
 }
 
 std::optional<SockMan::Id>
@@ -128,11 +141,13 @@ SockMan::ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
                           bool is_important,
                           std::optional<Proxy> proxy,
                           bool& proxy_failed,
-                          CService& me,
-                          std::unique_ptr<Sock>& sock,
-                          std::unique_ptr<i2p::sam::Session>& i2p_transient_session)
+                          CService& me)
 {
+    AssertLockNotHeld(m_connected_mutex);
     AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+
+    std::unique_ptr<Sock> sock;
+    std::unique_ptr<i2p::sam::Session> i2p_transient_session;
 
     Assume(!me.IsValid());
 
@@ -197,6 +212,12 @@ SockMan::ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
 
     const Id id{GetNewId()};
 
+    {
+        LOCK(m_connected_mutex);
+        m_connected.emplace(id, std::make_shared<ConnectionSockets>(std::move(sock),
+                                                                    std::move(i2p_transient_session)));
+    }
+
     return id;
 }
 
@@ -227,6 +248,8 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
 
 void SockMan::NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
 {
+    AssertLockNotHeld(m_connected_mutex);
+
     if (!sock->IsSelectable()) {
         LogPrintf("connection from %s dropped: non-selectable socket\n", them.ToStringAddrPort());
         return;
@@ -242,12 +265,63 @@ void SockMan::NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, 
 
     const Id id{GetNewId()};
 
-    EventNewConnectionAccepted(id, std::move(sock), me, them);
+    {
+        LOCK(m_connected_mutex);
+        m_connected.emplace(id, std::make_shared<ConnectionSockets>(std::move(sock)));
+    }
+
+    if (!EventNewConnectionAccepted(id, me, them)) {
+        CloseConnection(id);
+    }
 }
 
 SockMan::Id SockMan::GetNewId()
 {
     return m_next_id.fetch_add(1, std::memory_order_relaxed);
+}
+
+bool SockMan::CloseConnection(Id id)
+{
+    LOCK(m_connected_mutex);
+    return m_connected.erase(id) > 0;
+}
+
+ssize_t SockMan::SendBytes(Id id,
+                           std::span<const unsigned char> data,
+                           bool will_send_more,
+                           std::string& errmsg) const
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    if (data.empty()) {
+        return 0;
+    }
+
+    auto sockets{GetConnectionSockets(id)};
+    if (!sockets) {
+        // Bail out immediately and just leave things in the caller's send queue.
+        return 0;
+    }
+
+    int flags{MSG_NOSIGNAL | MSG_DONTWAIT};
+#ifdef MSG_MORE
+    if (will_send_more) {
+        flags |= MSG_MORE;
+    }
+#endif
+
+    const ssize_t sent{WITH_LOCK(sockets->mutex, return sockets->sock->Send(data.data(), data.size(), flags);)};
+
+    if (sent >= 0) {
+        return sent;
+    }
+
+    const int err{WSAGetLastError()};
+    if (err == WSAEWOULDBLOCK || err == WSAEMSGSIZE || err == WSAEINTR || err == WSAEINPROGRESS) {
+        return 0;
+    }
+    errmsg = NetworkErrorString(err);
+    return -1;
 }
 
 void SockMan::StopListening()
@@ -265,8 +339,17 @@ void SockMan::EventIOLoopCompletedForAll() {}
 
 void SockMan::EventI2PStatus(const CService&, I2PStatus) {}
 
+void SockMan::TestOnlyAddExistentConnection(Id id, std::unique_ptr<Sock>&& sock)
+{
+    LOCK(m_connected_mutex);
+    const auto result{m_connected.emplace(id, std::make_shared<ConnectionSockets>(std::move(sock)))};
+    assert(result.second);
+}
+
 void SockMan::ThreadI2PAccept()
 {
+    AssertLockNotHeld(m_connected_mutex);
+
     static constexpr auto err_wait_begin = 1s;
     static constexpr auto err_wait_cap = 5min;
     auto err_wait = err_wait_begin;
@@ -302,4 +385,148 @@ void SockMan::ThreadI2PAccept()
 
         err_wait = err_wait_begin;
     }
+}
+
+void SockMan::ThreadSocketHandler()
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    while (!m_interrupt_net->interrupted()) {
+        EventIOLoopCompletedForAll();
+
+        // Check for the readiness of the already connected sockets and the
+        // listening sockets in one call ("readiness" as in poll(2) or
+        // select(2)). If none are ready, wait for a short while and return
+        // empty sets.
+        auto io_readiness{GenerateWaitSockets()};
+        if (io_readiness.events_per_sock.empty() ||
+            // WaitMany() may as well be a static method, the context of the first Sock in the vector is not relevant.
+            !io_readiness.events_per_sock.begin()->first->WaitMany(SELECT_TIMEOUT,
+                                                                   io_readiness.events_per_sock)) {
+            m_interrupt_net->sleep_for(SELECT_TIMEOUT);
+        }
+
+        // Service (send/receive) each of the already connected sockets.
+        SocketHandlerConnected(io_readiness);
+
+        // Accept new connections from listening sockets.
+        SocketHandlerListening(io_readiness.events_per_sock);
+    }
+}
+
+SockMan::IOReadiness SockMan::GenerateWaitSockets()
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    IOReadiness io_readiness;
+
+    for (const auto& sock : m_listen) {
+        io_readiness.events_per_sock.emplace(sock, Sock::Events{Sock::RECV});
+    }
+
+    auto connected_snapshot{WITH_LOCK(m_connected_mutex, return m_connected;)};
+
+    for (const auto& [id, sockets] : connected_snapshot) {
+        const bool select_recv{ShouldTryToRecv(id)};
+        const bool select_send{ShouldTryToSend(id)};
+        if (!select_recv && !select_send) continue;
+
+        Sock::Event event = (select_send ? Sock::SEND : 0) | (select_recv ? Sock::RECV : 0);
+        io_readiness.events_per_sock.emplace(sockets->sock, Sock::Events{event});
+        io_readiness.ids_per_sock.emplace(sockets->sock, id);
+    }
+
+    return io_readiness;
+}
+
+void SockMan::SocketHandlerConnected(const IOReadiness& io_readiness)
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    for (const auto& [sock, events] : io_readiness.events_per_sock) {
+        if (m_interrupt_net->interrupted()) {
+            return;
+        }
+
+        auto it{io_readiness.ids_per_sock.find(sock)};
+        if (it == io_readiness.ids_per_sock.end()) {
+            continue;
+        }
+        const Id id{it->second};
+
+        bool send_ready = events.occurred & Sock::SEND; // Sock::SEND could only be set if ShouldTryToSend() has returned true in GenerateWaitSockets().
+        bool recv_ready = events.occurred & Sock::RECV; // Sock::RECV could only be set if ShouldTryToRecv() has returned true in GenerateWaitSockets().
+        bool err_ready = events.occurred & Sock::ERR;
+
+        if (send_ready) {
+            bool cancel_recv;
+
+            EventReadyToSend(id, cancel_recv);
+
+            if (cancel_recv) {
+                recv_ready = false;
+            }
+        }
+
+        if (recv_ready || err_ready) {
+            uint8_t buf[0x10000]; // typical socket buffer is 8K-64K
+
+            auto sockets{GetConnectionSockets(id)};
+            if (!sockets) {
+                continue;
+            }
+
+            const ssize_t nrecv{WITH_LOCK(
+                sockets->mutex,
+                return sockets->sock->Recv(buf, sizeof(buf), MSG_DONTWAIT);)};
+
+            if (nrecv < 0) { // In all cases (including -1 and 0) EventIOLoopCompletedForOne() should be executed after this, don't change the code to skip it.
+                const int err = WSAGetLastError();
+                if (err != WSAEWOULDBLOCK && err != WSAEMSGSIZE && err != WSAEINTR && err != WSAEINPROGRESS) {
+                    EventGotPermanentReadError(id, NetworkErrorString(err));
+                }
+            } else if (nrecv == 0) {
+                EventGotEOF(id);
+            } else {
+                EventGotData(id, {buf, static_cast<size_t>(nrecv)});
+            }
+        }
+
+        EventIOLoopCompletedForOne(id);
+    }
+}
+
+void SockMan::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock)
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    for (const auto& sock : m_listen) {
+        if (m_interrupt_net->interrupted()) {
+            return;
+        }
+        const auto it = events_per_sock.find(sock);
+        if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
+            CService addr_accepted;
+
+            auto sock_accepted{AcceptConnection(*sock, addr_accepted)};
+
+            if (sock_accepted) {
+                NewSockAccepted(std::move(sock_accepted), GetBindAddress(*sock), addr_accepted);
+            }
+        }
+    }
+}
+
+std::shared_ptr<SockMan::ConnectionSockets> SockMan::GetConnectionSockets(Id id) const
+{
+    LOCK(m_connected_mutex);
+
+    auto it{m_connected.find(id)};
+    if (it == m_connected.end()) {
+        // There is no socket in case we've already disconnected, or in test cases without
+        // real connections.
+        return {};
+    }
+
+    return it->second;
 }

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -144,6 +144,10 @@ void SockMan::StopListening()
     m_listen.clear();
 }
 
+bool SockMan::ShouldTryToSend(Id id) const { return true; }
+
+bool SockMan::ShouldTryToRecv(Id id) const { return true; }
+
 void SockMan::EventI2PStatus(const CService&, I2PStatus) {}
 
 void SockMan::ThreadI2PAccept()

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -113,6 +113,11 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
     return sock;
 }
 
+SockMan::Id SockMan::GetNewId()
+{
+    return m_next_id.fetch_add(1, std::memory_order_relaxed);
+}
+
 void SockMan::StopListening()
 {
     m_listen.clear();

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_COMMON_SOCKMAN_H
+#define BITCOIN_COMMON_SOCKMAN_H
+
+#include <netaddress.h>
+#include <util/sock.h>
+#include <util/translation.h>
+
+#include <memory>
+#include <vector>
+
+/**
+ * A socket manager class which handles socket operations.
+ * To use this class, inherit from it and implement the pure virtual methods.
+ * Handled operations:
+ * - binding and listening on sockets
+ */
+class SockMan
+{
+public:
+    /**
+     * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
+     * @param[in] addrBind Where to bind.
+     * @param[out] strError Error string if an error occurs.
+     * @retval true Success.
+     * @retval false Failure, `strError` will be set.
+     */
+    bool BindListenPort(const CService& addrBind, bilingual_str& strError);
+
+    /**
+     * Stop listening by closing all listening sockets.
+     */
+    void StopListening();
+
+    /**
+     * List of listening sockets.
+     */
+    std::vector<std::shared_ptr<Sock>> m_listen;
+};
+
+#endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -17,6 +17,7 @@
  * To use this class, inherit from it and implement the pure virtual methods.
  * Handled operations:
  * - binding and listening on sockets
+ * - accepting incoming connections
  */
 class SockMan
 {
@@ -29,6 +30,14 @@ public:
      * @retval false Failure, `err_msg` will be set.
      */
     bool BindAndStartListening(const CService& to, bilingual_str& err_msg);
+
+    /**
+     * Accept a connection.
+     * @param[in] listen_sock Socket on which to accept the connection.
+     * @param[out] addr Address of the peer that was accepted.
+     * @return Newly created socket for the accepted connection.
+     */
+    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
 
     /**
      * Stop listening by closing all listening sockets.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -29,6 +29,23 @@ public:
     using Id = int64_t;
 
     /**
+     * Possible status changes that can be passed to `EventI2PStatus()`.
+     */
+    enum class I2PStatus : uint8_t {
+        /// The listen succeeded and we are now listening for incoming I2P connections.
+        START_LISTENING,
+
+        /// The listen failed and now we are not listening (even if START_LISTENING was signaled before).
+        STOP_LISTENING,
+    };
+
+    virtual ~SockMan() = default;
+
+    //
+    // Non-virtual functions, to be reused by children classes.
+    //
+
+    /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
      * @param[in] to Where to bind.
      * @param[out] err_msg Error string if an error occurs.
@@ -61,6 +78,23 @@ public:
     std::vector<std::shared_ptr<Sock>> m_listen;
 
 private:
+
+    //
+    // Pure virtual functions must be implemented by children classes.
+    //
+
+    //
+    // Non-pure virtual functions can be overridden by children classes or left
+    // alone to use the default implementation from SockMan.
+    //
+
+    /**
+     * Be notified of a change in the state of the I2P connectivity.
+     * The default behavior, implemented by `SockMan`, is to ignore this event.
+     * @param[in] addr The address we started or stopped listening on.
+     * @param[in] new_status New status.
+     */
+    virtual void EventI2PStatus(const CService& addr, I2PStatus new_status);
 
     /**
      * The id to assign to the next created connection. Used to generate ids of connections.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -9,6 +9,7 @@
 #include <util/sock.h>
 #include <util/translation.h>
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -22,6 +23,11 @@
 class SockMan
 {
 public:
+    /**
+     * Each connection is assigned an unique id of this type.
+     */
+    using Id = int64_t;
+
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
      * @param[in] to Where to bind.
@@ -40,6 +46,11 @@ public:
     std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
 
     /**
+     * Generate an id for a newly created connection.
+     */
+    Id GetNewId();
+
+    /**
      * Stop listening by closing all listening sockets.
      */
     void StopListening();
@@ -48,6 +59,13 @@ public:
      * List of listening sockets.
      */
     std::vector<std::shared_ptr<Sock>> m_listen;
+
+private:
+
+    /**
+     * The id to assign to the next created connection. Used to generate ids of connections.
+     */
+    std::atomic<Id> m_next_id{0};
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -23,12 +23,12 @@ class SockMan
 public:
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
-     * @param[in] addrBind Where to bind.
-     * @param[out] strError Error string if an error occurs.
+     * @param[in] to Where to bind.
+     * @param[out] err_msg Error string if an error occurs.
      * @retval true Success.
-     * @retval false Failure, `strError` will be set.
+     * @retval false Failure, `err_msg` will be set.
      */
-    bool BindListenPort(const CService& addrBind, bilingual_str& strError);
+    bool BindAndStartListening(const CService& to, bilingual_str& err_msg);
 
     /**
      * Stop listening by closing all listening sockets.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -144,6 +144,15 @@ public:
     std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
 
     /**
+     * After a new socket with a peer has been created, configure its flags,
+     * make a new connection id and call `EventNewConnectionAccepted()`.
+     * @param[in] sock The newly created socket.
+     * @param[in] me Address at our end of the connection.
+     * @param[in] them Address of the new peer.
+     */
+    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them);
+
+    /**
      * Generate an id for a newly created connection.
      */
     Id GetNewId();
@@ -185,11 +194,13 @@ private:
 
     /**
      * Be notified when a new connection has been accepted.
+     * @param[in] id Id of the newly accepted connection.
      * @param[in] sock Connected socket to communicate with the peer.
      * @param[in] me The address and port at our side of the connection.
      * @param[in] them The address and port at the peer's side of the connection.
      */
-    virtual void EventNewConnectionAccepted(std::unique_ptr<Sock>&& sock,
+    virtual void EventNewConnectionAccepted(Id id,
+                                            std::unique_ptr<Sock>&& sock,
                                             const CService& me,
                                             const CService& them) = 0;
 

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -150,6 +150,38 @@ private:
                                             const CService& me,
                                             const CService& them) = 0;
 
+    /**
+     * Called when the socket is ready to send data and `ShouldTryToSend()` has
+     * returned true. This is where the higher level code serializes its messages
+     * and calls `SockMan::SendBytes()`.
+     * @param[in] id Id of the connection whose socket is ready to send.
+     * @param[out] cancel_recv Should always be set upon return and if it is true,
+     * then the next attempt to receive data from that connection will be omitted.
+     */
+    virtual void EventReadyToSend(Id id, bool& cancel_recv) = 0;
+
+    /**
+     * Called when new data has been received.
+     * @param[in] id Connection for which the data arrived.
+     * @param[in] data Received data.
+     */
+    virtual void EventGotData(Id id, std::span<const uint8_t> data) = 0;
+
+    /**
+     * Called when the remote peer has sent an EOF on the socket. This is a graceful
+     * close of their writing side, we can still send and they will receive, if it
+     * makes sense at the application level.
+     * @param[in] id Connection whose socket got EOF.
+     */
+    virtual void EventGotEOF(Id id) = 0;
+
+    /**
+     * Called when we get an irrecoverable error trying to read from a socket.
+     * @param[in] id Connection whose socket got an error.
+     * @param[in] errmsg Message describing the error.
+     */
+    virtual void EventGotPermanentReadError(Id id, const std::string& errmsg) = 0;
+
     //
     // Non-pure virtual functions can be overridden by children classes or left
     // alone to use the default implementation from SockMan.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -171,6 +171,23 @@ private:
     virtual bool ShouldTryToRecv(Id id) const;
 
     /**
+     * SockMan has completed the current send+recv iteration for a given connection.
+     * It will do another send+recv for this connection after processing all other connections.
+     * Can be used to execute periodic tasks for a given connection.
+     * The implementation in SockMan does nothing.
+     * @param[in] id Connection for which send+recv has been done.
+     */
+    virtual void EventIOLoopCompletedForOne(Id id);
+
+    /**
+     * SockMan has completed send+recv for all connections.
+     * Can be used to execute periodic tasks for all connections, like closing
+     * connections due to higher level logic.
+     * The implementation in SockMan does nothing.
+     */
+    virtual void EventIOLoopCompletedForAll();
+
+    /**
      * Be notified of a change in the state of the I2P connectivity.
      * The default behavior, implemented by `SockMan`, is to ignore this event.
      * @param[in] addr The address we started or stopped listening on.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -135,29 +135,6 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex, !m_unused_i2p_sessions_mutex);
 
     /**
-     * Accept a connection.
-     * @param[in] listen_sock Socket on which to accept the connection.
-     * @param[out] addr Address of the peer that was accepted.
-     * @return Newly created socket for the accepted connection.
-     */
-    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
-
-    /**
-     * After a new socket with a peer has been created, configure its flags,
-     * make a new connection id and call `EventNewConnectionAccepted()`.
-     * @param[in] sock The newly created socket.
-     * @param[in] me Address at our end of the connection.
-     * @param[in] them Address of the new peer.
-     */
-    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
-
-    /**
-     * Generate an id for a newly created connection.
-     */
-    Id GetNewId();
-
-    /**
      * Destroy a given connection by closing its socket and release resources occupied by it.
      * @param[in] id Connection to destroy.
      * @return Whether the connection existed and its socket was closed by this call.
@@ -193,19 +170,12 @@ public:
      */
     const std::shared_ptr<CThreadInterrupt> m_interrupt_net;
 
-    /**
-     * I2P SAM session.
-     * Used to accept incoming and make outgoing I2P connections from a persistent
-     * address.
-     */
-    std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
-
-    /**
-     * List of listening sockets.
-     */
-    std::vector<std::shared_ptr<Sock>> m_listen;
-
 protected:
+
+    /**
+     * Generate an id for a newly created connection.
+     */
+    Id GetNewId();
 
     /**
      * During some tests mocked sockets are created outside of `SockMan`, make it
@@ -396,6 +366,24 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
 
     /**
+     * Accept a connection.
+     * @param[in] listen_sock Socket on which to accept the connection.
+     * @param[out] addr Address of the peer that was accepted.
+     * @return Newly created socket for the accepted connection.
+     */
+    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
+
+    /**
+     * After a new socket with a peer has been created, configure its flags,
+     * make a new connection id and call `EventNewConnectionAccepted()`.
+     * @param[in] sock The newly created socket.
+     * @param[in] me Address at our end of the connection.
+     * @param[in] them Address of the new peer.
+     */
+    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
      * Generate a collection of sockets to check for IO readiness.
      * @return Sockets to check for readiness plus an aux map to find the
      * corresponding connection id given a socket.
@@ -453,6 +441,18 @@ private:
      * a host fails, then the created session is put to this pool for reuse.
      */
     std::queue<std::unique_ptr<i2p::sam::Session>> m_unused_i2p_sessions GUARDED_BY(m_unused_i2p_sessions_mutex);
+
+    /**
+     * I2P SAM session.
+     * Used to accept incoming and make outgoing I2P connections from a persistent
+     * address.
+     */
+    std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
+
+    /**
+     * List of listening sockets.
+     */
+    std::vector<std::shared_ptr<Sock>> m_listen;
 
     mutable Mutex m_connected_mutex;
 

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -156,6 +156,21 @@ private:
     //
 
     /**
+     * Can be used to temporarily pause sends on a connection.
+     * The implementation in SockMan always returns true.
+     * @param[in] id Connection for which to confirm or omit the next send.
+     */
+    virtual bool ShouldTryToSend(Id id) const;
+
+    /**
+     * SockMan would only call Recv() on a connection's socket if this returns true.
+     * Can be used to temporarily pause receives on a connection.
+     * The implementation in SockMan always returns true.
+     * @param[in] id Connection for which to confirm or omit the next receive.
+     */
+    virtual bool ShouldTryToRecv(Id id) const;
+
+    /**
      * Be notified of a change in the state of the I2P connectivity.
      * The default behavior, implemented by `SockMan`, is to ignore this event.
      * @param[in] addr The address we started or stopped listening on.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -14,8 +14,13 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
+#include <queue>
 #include <thread>
+#include <variant>
 #include <vector>
+
+CService GetBindAddress(const Sock& sock);
 
 /**
  * A socket manager class which handles socket operations.
@@ -24,6 +29,7 @@
  * - binding and listening on sockets
  * - starting of necessary threads to process socket operations
  * - accepting incoming connections
+ * - making outbound connections
  */
 class SockMan
 {
@@ -99,6 +105,37 @@ public:
     void JoinSocketsThreads();
 
     /**
+     * A more readable std::tuple<std::string, uint16_t> for host and port.
+     */
+    struct StringHostIntPort {
+        const std::string& host;
+        uint16_t port;
+    };
+
+    /**
+     * Make an outbound connection, save the socket internally and return a newly generated connection id.
+     * @param[in] to The address to connect to, either as CService or a host as string and port as
+     * an integer, if the later is used, then `proxy` must be valid.
+     * @param[in] is_important If true, then log failures with higher severity.
+     * @param[in] proxy Proxy to connect through, if set.
+     * @param[out] proxy_failed If `proxy` is valid and the connection failed because of the
+     * proxy, then it will be set to true.
+     * @param[out] me If the connection was successful then this is set to the address on the
+     * local side of the socket.
+     * @param[out] sock Connected socket, if the operation is successful.
+     * @param[out] i2p_transient_session I2P session, if the operation is successful.
+     * @return Newly generated id, or std::nullopt if the operation fails.
+     */
+    std::optional<SockMan::Id> ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
+                                                bool is_important,
+                                                std::optional<Proxy> proxy,
+                                                bool& proxy_failed,
+                                                CService& me,
+                                                std::unique_ptr<Sock>& sock,
+                                                std::unique_ptr<i2p::sam::Session>& i2p_transient_session)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+
+    /**
      * Accept a connection.
      * @param[in] listen_sock Socket on which to accept the connection.
      * @param[out] addr Address of the peer that was accepted.
@@ -135,6 +172,12 @@ public:
     std::vector<std::shared_ptr<Sock>> m_listen;
 
 private:
+
+    /**
+     * Cap on the size of `m_unused_i2p_sessions`, to ensure it does not
+     * unexpectedly use too much memory.
+     */
+    static constexpr size_t MAX_UNUSED_I2P_SESSIONS_SIZE{10};
 
     //
     // Pure virtual functions must be implemented by children classes.
@@ -242,6 +285,20 @@ private:
      * Thread that accepts incoming I2P connections in a loop, can be stopped via `m_interrupt_net`.
      */
     std::thread m_thread_i2p_accept;
+
+    /**
+     * Mutex protecting m_unused_i2p_sessions.
+     */
+    Mutex m_unused_i2p_sessions_mutex;
+
+    /**
+     * A pool of created I2P SAM transient sessions that should be used instead
+     * of creating new ones in order to reduce the load on the I2P network.
+     * Creating a session in I2P is not cheap, thus if this is not empty, then
+     * pick an entry from it instead of creating a new session. If connecting to
+     * a host fails, then the created session is put to this pool for reuse.
+     */
+    std::queue<std::unique_ptr<i2p::sam::Session>> m_unused_i2p_sessions GUARDED_BY(m_unused_i2p_sessions_mutex);
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -16,11 +16,10 @@
 #include <memory>
 #include <optional>
 #include <queue>
+#include <span>
 #include <thread>
 #include <variant>
 #include <vector>
-
-CService GetBindAddress(const Sock& sock);
 
 /**
  * A socket manager class which handles socket operations.
@@ -30,6 +29,8 @@ CService GetBindAddress(const Sock& sock);
  * - starting of necessary threads to process socket operations
  * - accepting incoming connections
  * - making outbound connections
+ * - closing connections
+ * - waiting for IO readiness on sockets and doing send/recv accordingly
  */
 class SockMan
 {
@@ -76,6 +77,8 @@ public:
      * Options to influence `StartSocketsThreads()`.
      */
     struct Options {
+        std::string_view socket_handler_thread_name;
+
         struct I2P {
             explicit I2P(const fs::path& file, const Proxy& proxy, std::string_view accept_thread_name)
                 : private_key_file{file},
@@ -122,18 +125,14 @@ public:
      * proxy, then it will be set to true.
      * @param[out] me If the connection was successful then this is set to the address on the
      * local side of the socket.
-     * @param[out] sock Connected socket, if the operation is successful.
-     * @param[out] i2p_transient_session I2P session, if the operation is successful.
      * @return Newly generated id, or std::nullopt if the operation fails.
      */
     std::optional<SockMan::Id> ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
                                                 bool is_important,
                                                 std::optional<Proxy> proxy,
                                                 bool& proxy_failed,
-                                                CService& me,
-                                                std::unique_ptr<Sock>& sock,
-                                                std::unique_ptr<i2p::sam::Session>& i2p_transient_session)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+                                                CService& me)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex, !m_unused_i2p_sessions_mutex);
 
     /**
      * Accept a connection.
@@ -150,12 +149,38 @@ public:
      * @param[in] me Address at our end of the connection.
      * @param[in] them Address of the new peer.
      */
-    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them);
+    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
 
     /**
      * Generate an id for a newly created connection.
      */
     Id GetNewId();
+
+    /**
+     * Destroy a given connection by closing its socket and release resources occupied by it.
+     * @param[in] id Connection to destroy.
+     * @return Whether the connection existed and its socket was closed by this call.
+     */
+    bool CloseConnection(Id id)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Try to send some data over the given connection.
+     * @param[in] id Identifier of the connection.
+     * @param[in] data The data to send, it might happen that only a prefix of this is sent.
+     * @param[in] will_send_more Used as an optimization if the caller knows that they will
+     * be sending more data soon after this call.
+     * @param[out] errmsg If <0 is returned then this will contain a human readable message
+     * explaining the error.
+     * @retval >=0 The number of bytes actually sent.
+     * @retval <0 A permanent error has occurred.
+     */
+    ssize_t SendBytes(Id id,
+                      std::span<const unsigned char> data,
+                      bool will_send_more,
+                      std::string& errmsg) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
 
     /**
      * Stop listening by closing all listening sockets.
@@ -180,6 +205,17 @@ public:
      */
     std::vector<std::shared_ptr<Sock>> m_listen;
 
+protected:
+
+    /**
+     * During some tests mocked sockets are created outside of `SockMan`, make it
+     * possible to add those so that send/recv can be exercised.
+     * @param[in] id Connection id to add.
+     * @param[in,out] sock Socket to associate with the added connection.
+     */
+    void TestOnlyAddExistentConnection(Id id, std::unique_ptr<Sock>&& sock)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
 private:
 
     /**
@@ -195,12 +231,13 @@ private:
     /**
      * Be notified when a new connection has been accepted.
      * @param[in] id Id of the newly accepted connection.
-     * @param[in] sock Connected socket to communicate with the peer.
      * @param[in] me The address and port at our side of the connection.
      * @param[in] them The address and port at the peer's side of the connection.
+     * @retval true The new connection was accepted at the higher level.
+     * @retval false The connection was refused at the higher level, so the
+     * associated socket and id should be discarded by `SockMan`.
      */
-    virtual void EventNewConnectionAccepted(Id id,
-                                            std::unique_ptr<Sock>&& sock,
+    virtual bool EventNewConnectionAccepted(Id id,
                                             const CService& me,
                                             const CService& them) = 0;
 
@@ -243,8 +280,9 @@ private:
 
     /**
      * Can be used to temporarily pause sends on a connection.
+     * SockMan would only call EventReadyToSend() if this returns true.
      * The implementation in SockMan always returns true.
-     * @param[in] id Connection for which to confirm or omit the next send.
+     * @param[in] id Connection for which to confirm or omit the next call to EventReadyToSend().
      */
     virtual bool ShouldTryToSend(Id id) const;
 
@@ -282,15 +320,120 @@ private:
     virtual void EventI2PStatus(const CService& addr, I2PStatus new_status);
 
     /**
+     * The sockets used by a connection - a data socket and an optional I2P session socket.
+     */
+    struct ConnectionSockets {
+        explicit ConnectionSockets(std::unique_ptr<Sock>&& s)
+            : sock{std::move(s)}
+        {
+        }
+
+        explicit ConnectionSockets(std::shared_ptr<Sock>&& s, std::unique_ptr<i2p::sam::Session>&& sess)
+            : sock{std::move(s)},
+              i2p_transient_session{std::move(sess)}
+        {
+        }
+
+        /**
+         * Mutex that serializes the Send() and Recv() calls on `sock`.
+         */
+        Mutex mutex;
+
+        /**
+         * Underlying socket.
+         * `shared_ptr` (instead of `unique_ptr`) is used to avoid premature close of the
+         * underlying file descriptor by one thread while another thread is poll(2)-ing
+         * it for activity.
+         * @see https://github.com/bitcoin/bitcoin/issues/21744 for details.
+         */
+        std::shared_ptr<Sock> sock;
+
+        /**
+         * When transient I2P sessions are used, then each connection has its own session, otherwise
+         * all connections use the session from `m_i2p_sam_session` and share the same I2P address.
+         * I2P sessions involve a data/transport socket (in `sock`) and a control socket
+         * (in `i2p_transient_session`). For transient sessions, once the data socket `sock` is
+         * closed, the control socket is not going to be used anymore and would be just taking
+         * resources. Storing it here makes its deletion together with `sock` automatic.
+         */
+        std::unique_ptr<i2p::sam::Session> i2p_transient_session;
+    };
+
+    /**
+     * Info about which socket has which event ready and its connection id.
+     */
+    struct IOReadiness {
+        /**
+         * Map of socket -> socket events. For example:
+         * socket1 -> { requested = SEND|RECV, occurred = RECV }
+         * socket2 -> { requested = SEND, occurred = SEND }
+         */
+        Sock::EventsPerSock events_per_sock;
+
+        /**
+         * Map of socket -> connection id (in `m_connected`). For example
+         * socket1 -> id=23
+         * socket2 -> id=56
+         */
+        std::unordered_map<Sock::EventsPerSock::key_type,
+                           SockMan::Id,
+                           Sock::HashSharedPtrSock,
+                           Sock::EqualSharedPtrSock>
+            ids_per_sock;
+    };
+
+    /**
      * Accept incoming I2P connections in a loop and call
      * `EventNewConnectionAccepted()` for each new connection.
      */
-    void ThreadI2PAccept();
+    void ThreadI2PAccept()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Check connected and listening sockets for IO readiness and process them accordingly.
+     */
+    void ThreadSocketHandler()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Generate a collection of sockets to check for IO readiness.
+     * @return Sockets to check for readiness plus an aux map to find the
+     * corresponding connection id given a socket.
+     */
+    IOReadiness GenerateWaitSockets()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Do the read/write for connected sockets that are ready for IO.
+     * @param[in] io_readiness Which sockets are ready and their connection ids.
+     */
+    void SocketHandlerConnected(const IOReadiness& io_readiness)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Accept incoming connections, one from each read-ready listening socket.
+     * @param[in] events_per_sock Sockets that are ready for IO.
+     */
+    void SocketHandlerListening(const Sock::EventsPerSock& events_per_sock)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Retrieve an entry from m_connected.
+     * @param[in] id Connection id to search for.
+     * @return ConnectionSockets for the given connection id or empty shared_ptr if not found.
+     */
+    std::shared_ptr<ConnectionSockets> GetConnectionSockets(Id id) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
 
     /**
      * The id to assign to the next created connection. Used to generate ids of connections.
      */
     std::atomic<Id> m_next_id{0};
+
+    /**
+     * Thread that sends to and receives from sockets and accepts connections.
+     */
+    std::thread m_thread_socket_handler;
 
     /**
      * Thread that accepts incoming I2P connections in a loop, can be stopped via `m_interrupt_net`.
@@ -310,6 +453,15 @@ private:
      * a host fails, then the created session is put to this pool for reuse.
      */
     std::queue<std::unique_ptr<i2p::sam::Session>> m_unused_i2p_sessions GUARDED_BY(m_unused_i2p_sessions_mutex);
+
+    mutable Mutex m_connected_mutex;
+
+    /**
+     * Sockets for existent connections.
+     * The `shared_ptr` makes it possible to create a snapshot of this by simply copying
+     * it (under `m_connected_mutex`).
+     */
+    std::unordered_map<Id, std::shared_ptr<ConnectionSockets>> m_connected GUARDED_BY(m_connected_mutex);
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -5,12 +5,16 @@
 #ifndef BITCOIN_COMMON_SOCKMAN_H
 #define BITCOIN_COMMON_SOCKMAN_H
 
+#include <i2p.h>
 #include <netaddress.h>
+#include <netbase.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/translation.h>
 
 #include <atomic>
 #include <memory>
+#include <thread>
 #include <vector>
 
 /**
@@ -18,6 +22,7 @@
  * To use this class, inherit from it and implement the pure virtual methods.
  * Handled operations:
  * - binding and listening on sockets
+ * - starting of necessary threads to process socket operations
  * - accepting incoming connections
  */
 class SockMan
@@ -39,6 +44,12 @@ public:
         STOP_LISTENING,
     };
 
+    /**
+     * Constructor.
+     * @param[in] interrupt_net Singal this to tell SockMan to cease network activity.
+     */
+    explicit SockMan(std::shared_ptr<CThreadInterrupt> interrupt_net);
+
     virtual ~SockMan() = default;
 
     //
@@ -47,12 +58,45 @@ public:
 
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
+     * Should be called before `StartSocketsThreads()`.
      * @param[in] to Where to bind.
      * @param[out] err_msg Error string if an error occurs.
      * @retval true Success.
      * @retval false Failure, `err_msg` will be set.
      */
     bool BindAndStartListening(const CService& to, bilingual_str& err_msg);
+
+    /**
+     * Options to influence `StartSocketsThreads()`.
+     */
+    struct Options {
+        struct I2P {
+            explicit I2P(const fs::path& file, const Proxy& proxy, std::string_view accept_thread_name)
+                : private_key_file{file},
+                  sam_proxy{proxy},
+                  accept_thread_name{accept_thread_name}
+            {}
+
+            const fs::path private_key_file;
+            const Proxy sam_proxy;
+            const std::string_view accept_thread_name;
+        };
+
+        /**
+         * I2P options. If set then a thread will be started that will accept incoming I2P connections.
+         */
+        std::optional<I2P> i2p;
+    };
+
+    /**
+     * Start the necessary threads for sockets IO.
+     */
+    void StartSocketsThreads(const Options& options);
+
+    /**
+     * Join (wait for) the threads started by `StartSocketsThreads()` to exit.
+     */
+    void JoinSocketsThreads();
 
     /**
      * Accept a connection.
@@ -73,6 +117,19 @@ public:
     void StopListening();
 
     /**
+     * This is signaled when network activity should cease.
+     * A copy of this is saved in `m_i2p_sam_session`.
+     */
+    const std::shared_ptr<CThreadInterrupt> m_interrupt_net;
+
+    /**
+     * I2P SAM session.
+     * Used to accept incoming and make outgoing I2P connections from a persistent
+     * address.
+     */
+    std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
+
+    /**
      * List of listening sockets.
      */
     std::vector<std::shared_ptr<Sock>> m_listen;
@@ -82,6 +139,16 @@ private:
     //
     // Pure virtual functions must be implemented by children classes.
     //
+
+    /**
+     * Be notified when a new connection has been accepted.
+     * @param[in] sock Connected socket to communicate with the peer.
+     * @param[in] me The address and port at our side of the connection.
+     * @param[in] them The address and port at the peer's side of the connection.
+     */
+    virtual void EventNewConnectionAccepted(std::unique_ptr<Sock>&& sock,
+                                            const CService& me,
+                                            const CService& them) = 0;
 
     //
     // Non-pure virtual functions can be overridden by children classes or left
@@ -97,9 +164,20 @@ private:
     virtual void EventI2PStatus(const CService& addr, I2PStatus new_status);
 
     /**
+     * Accept incoming I2P connections in a loop and call
+     * `EventNewConnectionAccepted()` for each new connection.
+     */
+    void ThreadI2PAccept();
+
+    /**
      * The id to assign to the next created connection. Used to generate ids of connections.
      */
     std::atomic<Id> m_next_id{0};
+
+    /**
+     * Thread that accepts incoming I2P connections in a loop, can be stopped via `m_interrupt_net`.
+     */
+    std::thread m_thread_i2p_accept;
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1727,43 +1727,17 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
-void CConnman::AcceptConnection(const Sock& listen_sock) {
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    auto sock = listen_sock.Accept((struct sockaddr*)&sockaddr, &len);
-
-    if (!sock) {
-        const int nErr = WSAGetLastError();
-        if (nErr != WSAEWOULDBLOCK) {
-            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
-        }
-        return;
-    }
-
-    CService addr;
-    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
-    } else {
-        addr = MaybeFlipIPv6toCJDNS(addr);
-    }
-
-    const CService addr_bind{MaybeFlipIPv6toCJDNS(GetBindAddress(*sock))};
+void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
+                                            const CService& addr_bind,
+                                            const CService& addr)
+{
+    int nInbound = 0;
 
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
     auto it{m_listen_permissions.find(addr_bind)};
     if (it != m_listen_permissions.end()) {
         NetPermissions::AddFlag(permission_flags, it->second);
     }
-
-    CreateNodeFromAcceptedSocket(std::move(sock), permission_flags, addr_bind, addr);
-}
-
-void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
-                                            NetPermissionFlags permission_flags,
-                                            const CService& addr_bind,
-                                            const CService& addr)
-{
-    int nInbound = 0;
 
     const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
 
@@ -2225,7 +2199,16 @@ void CConnman::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock
         }
         const auto it = events_per_sock.find(sock);
         if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
-            AcceptConnection(*sock);
+            CService addr_accepted;
+
+            auto sock_accepted{AcceptConnection(*sock, addr_accepted)};
+
+            if (sock_accepted) {
+                addr_accepted = MaybeFlipIPv6toCJDNS(addr_accepted);
+                const CService addr_bind{MaybeFlipIPv6toCJDNS(GetBindAddress(*sock))};
+
+                CreateNodeFromAcceptedSocket(std::move(sock_accepted), addr_bind, addr_accepted);
+            }
         }
     }
 }
@@ -3126,7 +3109,7 @@ void CConnman::ThreadI2PAcceptIncoming()
             continue;
         }
 
-        CreateNodeFromAcceptedSocket(std::move(conn.sock), NetPermissionFlags::None, conn.me, conn.peer);
+        CreateNodeFromAcceptedSocket(std::move(conn.sock), conn.me, conn.peer);
 
         err_wait = err_wait_begin;
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3200,12 +3200,15 @@ bool CConnman::Bind(const CService& addr_, unsigned int flags, NetPermissionFlag
     const CService addr{MaybeFlipIPv6toCJDNS(addr_)};
 
     bilingual_str strError;
-    if (!BindListenPort(addr, strError)) {
+    if (!BindAndStartListening(addr, strError)) {
+        LogError("%s", strError.original);
         if ((flags & BF_REPORT_ERROR) && m_client_interface) {
             m_client_interface->ThreadSafeMessageBox(strError, "", CClientUIInterface::MSG_ERROR);
         }
         return false;
     }
+
+    LogPrintLevel(BCLog::NET, BCLog::Level::Info, "Bound to and listening on %s", addr.ToStringAddrPort());
 
     m_listen_permissions.emplace(addr, permissions);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -99,10 +99,6 @@ enum BindFlags {
     BF_DONT_ADVERTISE = (1U << 1),
 };
 
-// The set of sockets cannot be modified while waiting
-// The sleep time needs to be small to avoid new sockets stalling
-static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 50;
-
 const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
 
 static const uint64_t RANDOMIZER_ID_NETGROUP = 0x6c0edd8036ef4036ULL; // SHA256("netgroup")[0:8]
@@ -420,9 +416,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
     }
 
     // Connect
-    std::unique_ptr<Sock> sock;
     Proxy proxy;
-    std::unique_ptr<i2p::sam::Session> i2p_transient_session;
 
     std::optional<NodeId> node_id;
     CService me;
@@ -446,9 +440,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                                        /*is_important=*/conn_type == ConnectionType::MANUAL,
                                        use_proxy ? std::optional<Proxy>{proxy} : std::nullopt,
                                        proxyConnectionFailed,
-                                       me,
-                                       sock,
-                                       i2p_transient_session);
+                                       me);
 
             if (!proxyConnectionFailed) {
                 // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to
@@ -465,9 +457,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                                        /*is_important=*/conn_type == ConnectionType::MANUAL,
                                        proxy,
                                        dummy,
-                                       me,
-                                       sock,
-                                       i2p_transient_session);
+                                       me);
         }
         // Check any other resolved address (if any) if we fail to connect
         if (!node_id.has_value()) {
@@ -487,7 +477,6 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                             .Write(0)
                             .Finalize();
         CNode* pnode = new CNode(node_id.value(),
-                                std::move(sock),
                                 target_addr,
                                 CalculateKeyedNetGroup(target_addr),
                                 nonce,
@@ -498,7 +487,6 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                                 network_id,
                                 CNodeOptions{
                                     .permission_flags = permission_flags,
-                                    .i2p_sam_session = std::move(i2p_transient_session),
                                     .recv_flood_size = nReceiveFloodSize,
                                     .use_v2transport = use_v2transport,
                                 });
@@ -511,24 +499,6 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
     }
 
     return nullptr;
-}
-
-void CNode::CloseSocketDisconnect()
-{
-    fDisconnect = true;
-    LOCK(m_sock_mutex);
-    if (m_sock) {
-        LogDebug(BCLog::NET, "Resetting socket for peer=%d%s", GetId(), LogIP(fLogIPs));
-        m_sock.reset();
-
-        TRACEPOINT(net, closed_connection,
-            GetId(),
-            m_addr_name.c_str(),
-            ConnectionTypeAsString().c_str(),
-            ConnectedThroughNetwork(),
-            Ticks<std::chrono::seconds>(m_connected));
-    }
-    m_i2p_sam_session.reset();
 }
 
 void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, std::optional<CNetAddr> addr, const std::vector<NetWhitelistPermissions>& ranges) const {
@@ -1554,7 +1524,7 @@ Transport::Info V2Transport::GetInfo() const noexcept
     return info;
 }
 
-std::pair<size_t, bool> CConnman::SocketSendData(CNode& node)
+std::pair<size_t, bool> CConnman::SendMessagesAsBytes(CNode& node)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
@@ -1582,45 +1552,27 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node)
         if (expected_more.has_value()) Assume(!data.empty() == *expected_more);
         expected_more = more;
         data_left = !data.empty(); // will be overwritten on next loop if all of data gets sent
-        int nBytes = 0;
-        if (!data.empty()) {
-            LOCK(node.m_sock_mutex);
-            // There is no socket in case we've already disconnected, or in test cases without
-            // real connections. In these cases, we bail out immediately and just leave things
-            // in the send queue and transport.
-            if (!node.m_sock) {
-                break;
-            }
-            int flags = MSG_NOSIGNAL | MSG_DONTWAIT;
-#ifdef MSG_MORE
-            if (more) {
-                flags |= MSG_MORE;
-            }
-#endif
-            nBytes = node.m_sock->Send(data.data(), data.size(), flags);
-        }
-        if (nBytes > 0) {
+
+        std::string errmsg;
+        const ssize_t sent{SendBytes(node.GetId(), data, more, errmsg)};
+        if (sent > 0) {
             node.m_last_send = GetTime<std::chrono::seconds>();
-            node.nSendBytes += nBytes;
+            node.nSendBytes += sent;
             // Notify transport that bytes have been processed.
-            node.m_transport->MarkBytesSent(nBytes);
+            node.m_transport->MarkBytesSent(sent);
             // Update statistics per message type.
             if (!msg_type.empty()) { // don't report v2 handshake bytes for now
-                node.AccountForSentBytes(msg_type, nBytes);
+                node.AccountForSentBytes(msg_type, sent);
             }
-            nSentSize += nBytes;
-            if ((size_t)nBytes != data.size()) {
+            nSentSize += sent;
+            if (static_cast<size_t>(sent) != data.size()) {
                 // could not send full message; stop sending more
                 break;
             }
         } else {
-            if (nBytes < 0) {
-                // error
-                int nErr = WSAGetLastError();
-                if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS) {
-                    LogDebug(BCLog::NET, "socket send error, %s: %s\n", node.DisconnectMsg(fLogIPs), NetworkErrorString(nErr));
-                    node.CloseSocketDisconnect();
-                }
+            if (sent < 0) {
+                LogDebug(BCLog::NET, "socket send error, %s: %s\n", node.DisconnectMsg(fLogIPs), errmsg);
+                MarkAsDisconnectAndCloseConnection(node);
             }
             break;
         }
@@ -1707,8 +1659,7 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
-void CConnman::EventNewConnectionAccepted(SockMan::Id id,
-                                          std::unique_ptr<Sock>&& sock,
+bool CConnman::EventNewConnectionAccepted(SockMan::Id id,
                                           const CService& me,
                                           const CService& them)
 {
@@ -1738,7 +1689,7 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
 
     if (!fNetworkActive) {
         LogDebug(BCLog::NET, "connection from %s dropped: not accepting new connections\n", addr.ToStringAddrPort());
-        return;
+        return false;
     }
 
     // Don't accept connections from banned peers.
@@ -1746,7 +1697,7 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
     if (!NetPermissions::HasFlag(permission_flags, NetPermissionFlags::NoBan) && banned)
     {
         LogDebug(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToStringAddrPort());
-        return;
+        return false;
     }
 
     // Only accept connections from discouraged peers if our inbound slots aren't (almost) full.
@@ -1754,7 +1705,7 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
     if (!NetPermissions::HasFlag(permission_flags, NetPermissionFlags::NoBan) && nInbound + 1 >= m_max_inbound && discouraged)
     {
         LogDebug(BCLog::NET, "connection from %s dropped (discouraged)\n", addr.ToStringAddrPort());
-        return;
+        return false;
     }
 
     if (nInbound >= m_max_inbound)
@@ -1762,7 +1713,7 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
         if (!AttemptToEvictConnection()) {
             // No connection to evict, disconnect the new connection
             LogDebug(BCLog::NET, "failed to find an eviction candidate - connection dropped (full)\n");
-            return;
+            return false;
         }
     }
 
@@ -1779,7 +1730,6 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
                         .Write(addr_bind.GetPort()) // inbound connections use bind port
                         .Finalize();
     CNode* pnode = new CNode(id,
-                             std::move(sock),
                              CAddress{addr, NODE_NONE},
                              CalculateKeyedNetGroup(addr),
                              nonce,
@@ -1810,6 +1760,8 @@ void CConnman::EventNewConnectionAccepted(SockMan::Id id,
 
     // We received a new connection, harvest entropy from the time (and our peer count)
     RandAddEvent((uint32_t)id);
+
+    return true;
 }
 
 bool CConnman::AddConnection(const std::string& address, ConnectionType conn_type, bool use_v2transport = false)
@@ -1849,6 +1801,20 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
 
     OpenNetworkConnection(CAddress(), false, std::move(grant), address.c_str(), conn_type, /*use_v2transport=*/use_v2transport);
     return true;
+}
+
+void CConnman::MarkAsDisconnectAndCloseConnection(CNode& node)
+{
+    node.fDisconnect = true;
+    if (CloseConnection(node.GetId())) {
+        LogDebug(BCLog::NET, "Closed sockets for peer=%d%s", node.GetId(), node.LogIP(fLogIPs));
+        TRACEPOINT(net, closed_connection,
+            node.GetId(),
+            node.m_addr_name.c_str(),
+            node.ConnectionTypeAsString().c_str(),
+            node.ConnectedThroughNetwork(),
+            Ticks<std::chrono::seconds>(node.m_connected));
+    }
 }
 
 void CConnman::DisconnectNodes()
@@ -1902,8 +1868,7 @@ void CConnman::DisconnectNodes()
             // release outbound grant (if any)
             pnode->grantOutbound.Release();
 
-            // close socket and cleanup
-            pnode->CloseSocketDisconnect();
+            MarkAsDisconnectAndCloseConnection(*pnode);
 
             // update connection count by network
             if (pnode->IsManualOrFullOutboundConn()) --m_network_conn_counts[pnode->addr.GetNetwork()];
@@ -2016,7 +1981,7 @@ void CConnman::EventReadyToSend(SockMan::Id id, bool& cancel_recv)
         return;
     }
 
-    const auto [bytes_sent, data_left] = WITH_LOCK(node->cs_vSend, return SocketSendData(*node););
+    const auto [bytes_sent, data_left] = WITH_LOCK(node->cs_vSend, return SendMessagesAsBytes(*node););
 
     // If both receiving and (non-optimistic) sending were possible, we first attempt
     // sending. If that succeeds, but does not fully drain the send queue, do not
@@ -2044,7 +2009,7 @@ void CConnman::EventGotData(SockMan::Id id, std::span<const uint8_t> data)
             "receiving message bytes failed, %s\n",
             node->DisconnectMsg(fLogIPs)
         );
-        node->CloseSocketDisconnect();
+        MarkAsDisconnectAndCloseConnection(*node);
     }
     RecordBytesRecv(data.size());
     if (notify) {
@@ -2065,7 +2030,7 @@ void CConnman::EventGotEOF(SockMan::Id id)
     if (!node->fDisconnect) {
         LogDebug(BCLog::NET, "socket closed for peer=%d\n", id);
     }
-    node->CloseSocketDisconnect();
+    MarkAsDisconnectAndCloseConnection(*node);
 }
 
 void CConnman::EventGotPermanentReadError(SockMan::Id id, const std::string& errmsg)
@@ -2080,7 +2045,7 @@ void CConnman::EventGotPermanentReadError(SockMan::Id id, const std::string& err
     if (!node->fDisconnect) {
         LogDebug(BCLog::NET, "socket recv error for peer=%d: %s\n", id, errmsg);
     }
-    node->CloseSocketDisconnect();
+    MarkAsDisconnectAndCloseConnection(*node);
 }
 
 bool CConnman::ShouldTryToSend(SockMan::Id id) const
@@ -2131,164 +2096,6 @@ void CConnman::EventIOLoopCompletedForAll()
 
     DisconnectNodes();
     NotifyNumConnectionsChanged();
-}
-
-Sock::EventsPerSock CConnman::GenerateWaitSockets(std::span<CNode* const> nodes)
-{
-    AssertLockNotHeld(m_nodes_mutex);
-
-    Sock::EventsPerSock events_per_sock;
-
-    for (const auto& sock : m_listen) {
-        events_per_sock.emplace(sock, Sock::Events{Sock::RECV});
-    }
-
-    for (CNode* pnode : nodes) {
-        const bool select_recv{ShouldTryToRecv(pnode->GetId())};
-        const bool select_send{ShouldTryToSend(pnode->GetId())};
-        if (!select_recv && !select_send) continue;
-
-        LOCK(pnode->m_sock_mutex);
-        if (pnode->m_sock) {
-            Sock::Event event = (select_send ? Sock::SEND : 0) | (select_recv ? Sock::RECV : 0);
-            events_per_sock.emplace(pnode->m_sock, Sock::Events{event});
-        }
-    }
-
-    return events_per_sock;
-}
-
-void CConnman::SocketHandler()
-{
-    AssertLockNotHeld(m_total_bytes_sent_mutex);
-
-    Sock::EventsPerSock events_per_sock;
-
-    {
-        const NodesSnapshot snap{*this, /*shuffle=*/false};
-
-        const auto timeout = std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS);
-
-        // Check for the readiness of the already connected sockets and the
-        // listening sockets in one call ("readiness" as in poll(2) or
-        // select(2)). If none are ready, wait for a short while and return
-        // empty sets.
-        events_per_sock = GenerateWaitSockets(snap.Nodes());
-        if (events_per_sock.empty() || !events_per_sock.begin()->first->WaitMany(timeout, events_per_sock)) {
-            m_interrupt_net->sleep_for(timeout);
-        }
-
-        // Service (send/receive) each of the already connected nodes.
-        SocketHandlerConnected(snap.Nodes(), events_per_sock);
-    }
-
-    // Accept new connections from listening sockets.
-    SocketHandlerListening(events_per_sock);
-}
-
-void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
-                                      const Sock::EventsPerSock& events_per_sock)
-{
-    AssertLockNotHeld(m_nodes_mutex);
-    AssertLockNotHeld(m_total_bytes_sent_mutex);
-
-    for (CNode* pnode : nodes) {
-        if (m_interrupt_net->interrupted()) {
-            return;
-        }
-
-        //
-        // Receive
-        //
-        bool recvSet = false;
-        bool sendSet = false;
-        bool errorSet = false;
-        {
-            LOCK(pnode->m_sock_mutex);
-            if (!pnode->m_sock) {
-                continue;
-            }
-            const auto it = events_per_sock.find(pnode->m_sock);
-            if (it != events_per_sock.end()) {
-                recvSet = it->second.occurred & Sock::RECV; // Sock::RECV could only be set if ShouldTryToRecv() has returned true in GenerateWaitSockets().
-                sendSet = it->second.occurred & Sock::SEND; // Sock::SEND could only be set if ShouldTryToSend() has returned true in GenerateWaitSockets().
-                errorSet = it->second.occurred & Sock::ERR;
-            }
-        }
-
-        if (sendSet) {
-            bool cancel_recv;
-
-            EventReadyToSend(pnode->GetId(), cancel_recv);
-
-            if (cancel_recv) {
-                recvSet = false;
-            }
-        }
-
-        if (recvSet || errorSet)
-        {
-            // typical socket buffer is 8K-64K
-            uint8_t pchBuf[0x10000];
-            int nBytes = 0;
-            {
-                LOCK(pnode->m_sock_mutex);
-                if (!pnode->m_sock) {
-                    continue;
-                }
-                nBytes = pnode->m_sock->Recv(pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
-            }
-            if (nBytes > 0)
-            {
-                EventGotData(pnode->GetId(), {pchBuf, static_cast<size_t>(nBytes)});
-            }
-            else if (nBytes == 0)
-            {
-                EventGotEOF(pnode->GetId());
-            }
-            else if (nBytes < 0)
-            {
-                // error
-                int nErr = WSAGetLastError();
-                if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
-                {
-                    EventGotPermanentReadError(pnode->GetId(), NetworkErrorString(nErr));
-                }
-            }
-        }
-
-        EventIOLoopCompletedForOne(pnode->GetId());
-    }
-}
-
-void CConnman::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock)
-{
-    for (const auto& sock : m_listen) {
-        if (m_interrupt_net->interrupted()) {
-            return;
-        }
-        const auto it = events_per_sock.find(sock);
-        if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
-            CService addr_accepted;
-
-            auto sock_accepted{AcceptConnection(*sock, addr_accepted)};
-
-            if (sock_accepted) {
-                NewSockAccepted(std::move(sock_accepted), GetBindAddress(*sock), addr_accepted);
-            }
-        }
-    }
-}
-
-void CConnman::ThreadSocketHandler()
-{
-    AssertLockNotHeld(m_nodes_mutex);
-    AssertLockNotHeld(m_total_bytes_sent_mutex);
-
-    while (!m_interrupt_net->interrupted()) {
-        EventIOLoopCompletedForAll();
-        SocketHandler();
-    }
 }
 
 void CConnman::WakeMessageHandler()
@@ -3325,10 +3132,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         fMsgProcWake = false;
     }
 
-    // Send and receive from sockets, accept connections
-    threadSocketHandler = std::thread(&util::TraceThread, "net", [this] { ThreadSocketHandler(); });
-
     SockMan::Options sockman_options;
+
+    sockman_options.socket_handler_thread_name = "net";
 
     Proxy i2p_sam;
     if (GetProxy(NET_I2P, i2p_sam) && connOptions.m_i2p_accept_incoming) {
@@ -3425,8 +3231,6 @@ void CConnman::StopThreads()
         threadOpenAddedConnections.join();
     if (threadDNSAddressSeed.joinable())
         threadDNSAddressSeed.join();
-    if (threadSocketHandler.joinable())
-        threadSocketHandler.join();
 }
 
 void CConnman::StopNodes()
@@ -3450,7 +3254,7 @@ void CConnman::StopNodes()
     WITH_LOCK(m_nodes_mutex, nodes.swap(m_nodes));
     for (auto& [_, pnode] : nodes) {
         LogDebug(BCLog::NET, "Stopping node, %s", pnode->DisconnectMsg(fLogIPs));
-        pnode->CloseSocketDisconnect();
+        MarkAsDisconnectAndCloseConnection(*pnode);
         DeleteNode(pnode);
     }
 
@@ -3764,7 +3568,6 @@ static std::unique_ptr<Transport> MakeTransport(NodeId id, bool use_v2transport,
 }
 
 CNode::CNode(NodeId idIn,
-             std::shared_ptr<Sock> sock,
              const CAddress& addrIn,
              uint64_t nKeyedNetGroupIn,
              uint64_t nLocalHostNonceIn,
@@ -3776,7 +3579,6 @@ CNode::CNode(NodeId idIn,
              CNodeOptions&& node_opts)
     : m_transport{MakeTransport(idIn, node_opts.use_v2transport, conn_type_in == ConnectionType::INBOUND)},
       m_permission_flags{node_opts.permission_flags},
-      m_sock{sock},
       m_connected{GetTime<std::chrono::seconds>()},
       addr{addrIn},
       addrBind{addrBindIn},
@@ -3789,8 +3591,7 @@ CNode::CNode(NodeId idIn,
       m_conn_type{conn_type_in},
       id{idIn},
       nLocalHostNonce{nLocalHostNonceIn},
-      m_recv_flood_size{node_opts.recv_flood_size},
-      m_i2p_sam_session{std::move(node_opts.i2p_sam_session)}
+      m_recv_flood_size{node_opts.recv_flood_size}
 {
     if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);
 
@@ -3876,13 +3677,13 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 
         // If there was nothing to send before, and there is now (predicted by the "more" value
         // returned by the GetBytesToSend call above), attempt "optimistic write":
-        // because the poll/select loop may pause for SELECT_TIMEOUT_MILLISECONDS before actually
+        // because the poll/select loop may pause for a while before actually
         // doing a send, try sending from the calling thread if the queue was empty before.
         // With a V1Transport, more will always be true here, because adding a message always
         // results in sendable bytes there, but with V2Transport this is not the case (it may
         // still be in the handshake).
         if (queue_was_empty && more) {
-            SocketSendData(*pnode);
+            SendMessagesAsBytes(*pnode);
         }
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2074,6 +2074,29 @@ bool CConnman::ShouldTryToRecv(SockMan::Id id) const
     return !node->fPauseRecv;
 }
 
+void CConnman::EventIOLoopCompletedForOne(SockMan::Id id)
+{
+    AssertLockNotHeld(m_nodes_mutex);
+
+    CNode* node{GetNodeById(id)};
+    if (node == nullptr) {
+        return;
+    }
+
+    if (InactivityCheck(*node)) {
+        node->fDisconnect = true;
+    }
+}
+
+void CConnman::EventIOLoopCompletedForAll()
+{
+    AssertLockNotHeld(m_nodes_mutex);
+    AssertLockNotHeld(m_reconnections_mutex);
+
+    DisconnectNodes();
+    NotifyNumConnectionsChanged();
+}
+
 Sock::EventsPerSock CConnman::GenerateWaitSockets(std::span<CNode* const> nodes)
 {
     AssertLockNotHeld(m_nodes_mutex);
@@ -2130,6 +2153,7 @@ void CConnman::SocketHandler()
 void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                                       const Sock::EventsPerSock& events_per_sock)
 {
+    AssertLockNotHeld(m_nodes_mutex);
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
     for (CNode* pnode : nodes) {
@@ -2223,7 +2247,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
             }
         }
 
-        if (InactivityCheck(*pnode)) pnode->fDisconnect = true;
+        EventIOLoopCompletedForOne(pnode->GetId());
     }
 }
 
@@ -2255,8 +2279,7 @@ void CConnman::ThreadSocketHandler()
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
     while (!m_interrupt_net->interrupted()) {
-        DisconnectNodes();
-        NotifyNumConnectionsChanged();
+        EventIOLoopCompletedForAll();
         SocketHandler();
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -511,7 +511,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
         AddWhitelistPermissionFlags(permission_flags, target_addr, whitelist_permissions);
 
         // Add node
-        NodeId id = GetNewNodeId();
+        NodeId id = GetNewId();
         uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
         if (!addr_bind.IsValid()) {
             addr_bind = GetBindAddress(*sock);
@@ -1795,7 +1795,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
         }
     }
 
-    NodeId id = GetNewNodeId();
+    NodeId id = GetNewId();
     uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
 
     // The V2Transport transparently falls back to V1 behavior when an incoming V1 connection is
@@ -3160,11 +3160,6 @@ CConnman::CConnman(uint64_t nSeed0In,
     Options connOptions;
     Init(connOptions);
     SetNetworkActive(network_active);
-}
-
-NodeId CConnman::GetNewNodeId()
-{
-    return nLastNodeId.fetch_add(1, std::memory_order_relaxed);
 }
 
 uint16_t CConnman::GetDefaultPort(Network net) const

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1591,8 +1591,10 @@ Transport::Info V2Transport::GetInfo() const noexcept
     return info;
 }
 
-std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
+std::pair<size_t, bool> CConnman::SocketSendData(CNode& node)
 {
+    AssertLockNotHeld(m_total_bytes_sent_mutex);
+
     auto it = node.vSendMsg.begin();
     size_t nSentSize = 0;
     bool data_left{false}; //!< second return value (whether unsent data remains)
@@ -1667,6 +1669,11 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
         assert(node.m_send_memusage == 0);
     }
     node.vSendMsg.erase(node.vSendMsg.begin(), it);
+
+    if (nSentSize > 0) {
+        RecordBytesSent(nSentSize);
+    }
+
     return {nSentSize, data_left};
 }
 
@@ -2047,6 +2054,83 @@ bool CConnman::InactivityCheck(const CNode& node) const
     return false;
 }
 
+void CConnman::EventReadyToSend(SockMan::Id id, bool& cancel_recv)
+{
+    AssertLockNotHeld(m_nodes_mutex);
+
+    CNode* node{GetNodeById(id)};
+    if (node == nullptr) {
+        cancel_recv = true;
+        return;
+    }
+
+    const auto [bytes_sent, data_left] = WITH_LOCK(node->cs_vSend, return SocketSendData(*node););
+
+    // If both receiving and (non-optimistic) sending were possible, we first attempt
+    // sending. If that succeeds, but does not fully drain the send queue, do not
+    // attempt to receive. This avoids needlessly queueing data if the remote peer
+    // is slow at receiving data, by means of TCP flow control. We only do this when
+    // sending actually succeeded to make sure progress is always made; otherwise a
+    // deadlock would be possible when both sides have data to send, but neither is
+    // receiving.
+    cancel_recv = bytes_sent > 0 && data_left;
+}
+
+void CConnman::EventGotData(SockMan::Id id, std::span<const uint8_t> data)
+{
+    AssertLockNotHeld(mutexMsgProc);
+    AssertLockNotHeld(m_nodes_mutex);
+
+    CNode* node{GetNodeById(id)};
+    if (node == nullptr) {
+        return;
+    }
+
+    bool notify = false;
+    if (!node->ReceiveMsgBytes(data, notify)) {
+        LogDebug(BCLog::NET,
+            "receiving message bytes failed, %s\n",
+            node->DisconnectMsg(fLogIPs)
+        );
+        node->CloseSocketDisconnect();
+    }
+    RecordBytesRecv(data.size());
+    if (notify) {
+        node->MarkReceivedMsgsForProcessing();
+        WakeMessageHandler();
+    }
+}
+
+void CConnman::EventGotEOF(SockMan::Id id)
+{
+    AssertLockNotHeld(m_nodes_mutex);
+
+    CNode* node{GetNodeById(id)};
+    if (node == nullptr) {
+        return;
+    }
+
+    if (!node->fDisconnect) {
+        LogDebug(BCLog::NET, "socket closed for peer=%d\n", id);
+    }
+    node->CloseSocketDisconnect();
+}
+
+void CConnman::EventGotPermanentReadError(SockMan::Id id, const std::string& errmsg)
+{
+    AssertLockNotHeld(m_nodes_mutex);
+
+    CNode* node{GetNodeById(id)};
+    if (node == nullptr) {
+        return;
+    }
+
+    if (!node->fDisconnect) {
+        LogDebug(BCLog::NET, "socket recv error for peer=%d: %s\n", id, errmsg);
+    }
+    node->CloseSocketDisconnect();
+}
+
 bool CConnman::ShouldTryToSend(SockMan::Id id) const
 {
     AssertLockNotHeld(m_nodes_mutex);
@@ -2181,19 +2265,12 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
         }
 
         if (sendSet) {
-            // Send data
-            auto [bytes_sent, data_left] = WITH_LOCK(pnode->cs_vSend, return SocketSendData(*pnode));
-            if (bytes_sent) {
-                RecordBytesSent(bytes_sent);
+            bool cancel_recv;
 
-                // If both receiving and (non-optimistic) sending were possible, we first attempt
-                // sending. If that succeeds, but does not fully drain the send queue, do not
-                // attempt to receive. This avoids needlessly queueing data if the remote peer
-                // is slow at receiving data, by means of TCP flow control. We only do this when
-                // sending actually succeeded to make sure progress is always made; otherwise a
-                // deadlock would be possible when both sides have data to send, but neither is
-                // receiving.
-                if (data_left) recvSet = false;
+            EventReadyToSend(pnode->GetId(), cancel_recv);
+
+            if (cancel_recv) {
+                recvSet = false;
             }
         }
 
@@ -2211,27 +2288,11 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
             }
             if (nBytes > 0)
             {
-                bool notify = false;
-                if (!pnode->ReceiveMsgBytes({pchBuf, (size_t)nBytes}, notify)) {
-                    LogDebug(BCLog::NET,
-                        "receiving message bytes failed, %s\n",
-                        pnode->DisconnectMsg(fLogIPs)
-                    );
-                    pnode->CloseSocketDisconnect();
-                }
-                RecordBytesRecv(nBytes);
-                if (notify) {
-                    pnode->MarkReceivedMsgsForProcessing();
-                    WakeMessageHandler();
-                }
+                EventGotData(pnode->GetId(), {pchBuf, static_cast<size_t>(nBytes)});
             }
             else if (nBytes == 0)
             {
-                // socket closed gracefully
-                if (!pnode->fDisconnect) {
-                    LogDebug(BCLog::NET, "socket closed, %s\n", pnode->DisconnectMsg(fLogIPs));
-                }
-                pnode->CloseSocketDisconnect();
+                EventGotEOF(pnode->GetId());
             }
             else if (nBytes < 0)
             {
@@ -2239,10 +2300,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    if (!pnode->fDisconnect) {
-                        LogDebug(BCLog::NET, "socket recv error, %s: %s\n", pnode->DisconnectMsg(fLogIPs), NetworkErrorString(nErr));
-                    }
-                    pnode->CloseSocketDisconnect();
+                    EventGotPermanentReadError(pnode->GetId(), NetworkErrorString(nErr));
                 }
             }
         }
@@ -3857,7 +3915,6 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         msg.data.data()
     );
 
-    size_t nBytesSent = 0;
     {
         LOCK(pnode->cs_vSend);
         // Check if the transport still has unsent bytes, and indicate to it that we're about to
@@ -3880,10 +3937,9 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         // results in sendable bytes there, but with V2Transport this is not the case (it may
         // still be in the handshake).
         if (queue_was_empty && more) {
-            std::tie(nBytesSent, std::ignore) = SocketSendData(*pnode);
+            SocketSendData(*pnode);
         }
     }
-    if (nBytesSent) RecordBytesSent(nBytesSent);
 }
 
 bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1727,9 +1727,9 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
-void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
-                                            const CService& addr_bind,
-                                            const CService& addr)
+void CConnman::EventNewConnectionAccepted(std::unique_ptr<Sock>&& sock,
+                                          const CService& addr_bind,
+                                          const CService& addr)
 {
     int nInbound = 0;
 
@@ -2207,7 +2207,7 @@ void CConnman::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock
                 addr_accepted = MaybeFlipIPv6toCJDNS(addr_accepted);
                 const CService addr_bind{MaybeFlipIPv6toCJDNS(GetBindAddress(*sock))};
 
-                CreateNodeFromAcceptedSocket(std::move(sock_accepted), addr_bind, addr_accepted);
+                EventNewConnectionAccepted(std::move(sock_accepted), addr_bind, addr_accepted);
             }
         }
     }
@@ -3090,42 +3090,6 @@ void CConnman::EventI2PStatus(const CService& addr, SockMan::I2PStatus new_statu
     }
 }
 
-void CConnman::ThreadI2PAcceptIncoming()
-{
-    static constexpr auto err_wait_begin = 1s;
-    static constexpr auto err_wait_cap = 5min;
-    auto err_wait = err_wait_begin;
-
-    i2p::Connection conn;
-
-    auto SleepOnFailure = [&]() {
-        m_interrupt_net->sleep_for(err_wait);
-        if (err_wait < err_wait_cap) {
-            err_wait += 1s;
-        }
-    };
-
-    while (!m_interrupt_net->interrupted()) {
-
-        if (!m_i2p_sam_session->Listen(conn)) {
-            EventI2PStatus(conn.me, SockMan::I2PStatus::STOP_LISTENING);
-            SleepOnFailure();
-            continue;
-        }
-
-        EventI2PStatus(conn.me, SockMan::I2PStatus::START_LISTENING);
-
-        if (!m_i2p_sam_session->Accept(conn)) {
-            SleepOnFailure();
-            continue;
-        }
-
-        CreateNodeFromAcceptedSocket(std::move(conn.sock), conn.me, conn.peer);
-
-        err_wait = err_wait_begin;
-    }
-}
-
 void Discover()
 {
     if (!fDiscover)
@@ -3159,11 +3123,11 @@ CConnman::CConnman(uint64_t nSeed0In,
                    const CChainParams& params,
                    bool network_active,
                    std::shared_ptr<CThreadInterrupt> interrupt_net)
-    : addrman(addrman_in)
+    : SockMan{interrupt_net}
+    , addrman(addrman_in)
     , m_netgroupman{netgroupman}
     , nSeed0(nSeed0In)
     , nSeed1(nSeed1In)
-    , m_interrupt_net{interrupt_net}
     , m_params(params)
 {
     SetTryNewOutboundPeer(false);
@@ -3256,12 +3220,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         return false;
     }
 
-    Proxy i2p_sam;
-    if (GetProxy(NET_I2P, i2p_sam) && connOptions.m_i2p_accept_incoming) {
-        m_i2p_sam_session = std::make_unique<i2p::sam::Session>(gArgs.GetDataDirNet() / "i2p_private_key",
-                                                                i2p_sam, m_interrupt_net);
-    }
-
     // Randomize the order in which we may query seednode to potentially prevent connecting to the same one every restart (and signal that we have restarted)
     std::vector<std::string> seed_nodes = connOptions.vSeedNodes;
     if (!seed_nodes.empty()) {
@@ -3307,6 +3265,15 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     // Send and receive from sockets, accept connections
     threadSocketHandler = std::thread(&util::TraceThread, "net", [this] { ThreadSocketHandler(); });
 
+    SockMan::Options sockman_options;
+
+    Proxy i2p_sam;
+    if (GetProxy(NET_I2P, i2p_sam) && connOptions.m_i2p_accept_incoming) {
+        sockman_options.i2p.emplace(gArgs.GetDataDirNet() / "i2p_private_key", i2p_sam, "i2paccept");
+    }
+
+    StartSocketsThreads(sockman_options);
+
     if (!gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED))
         LogPrintf("DNS seeding disabled\n");
     else
@@ -3331,11 +3298,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     // Process messages
     threadMessageHandler = std::thread(&util::TraceThread, "msghand", [this] { ThreadMessageHandler(); });
-
-    if (m_i2p_sam_session) {
-        threadI2PAcceptIncoming =
-            std::thread(&util::TraceThread, "i2paccept", [this] { ThreadI2PAcceptIncoming(); });
-    }
 
     // Dump network addresses
     scheduler.scheduleEvery([this] { DumpAddresses(); }, DUMP_PEERS_INTERVAL);
@@ -3390,9 +3352,8 @@ void CConnman::Interrupt()
 
 void CConnman::StopThreads()
 {
-    if (threadI2PAcceptIncoming.joinable()) {
-        threadI2PAcceptIncoming.join();
-    }
+    JoinSocketsThreads();
+
     if (threadMessageHandler.joinable())
         threadMessageHandler.join();
     if (threadOpenConnections.joinable())

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3,8 +3,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
-
 #include <net.h>
 
 #include <addrdb.h>
@@ -3134,76 +3132,6 @@ void CConnman::ThreadI2PAcceptIncoming()
     }
 }
 
-bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError)
-{
-    int nOne = 1;
-
-    // Create socket for listening for incoming connections
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
-    {
-        strError = Untranslated(strprintf("Bind address family for %s not supported", addrBind.ToStringAddrPort()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
-    }
-
-    std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
-    if (!sock) {
-        strError = Untranslated(strprintf("Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError())));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
-    }
-
-    // Allow binding if the port is still in TIME_WAIT state after
-    // the program was closed and restarted.
-    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &nOne, sizeof(int)) == SOCKET_ERROR) {
-        strError = Untranslated(strprintf("Error setting SO_REUSEADDR on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-        LogPrintf("%s\n", strError.original);
-    }
-
-    // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
-    // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) {
-#ifdef IPV6_V6ONLY
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &nOne, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_V6ONLY on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
-        }
-#endif
-#ifdef WIN32
-        int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &nProtLevel, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
-        }
-#endif
-    }
-
-    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
-        int nErr = WSAGetLastError();
-        if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), CLIENT_NAME);
-        else
-            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
-    }
-    LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
-
-    // Listen for incoming connections
-    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
-    {
-        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
-    }
-
-    m_listen.emplace_back(std::move(sock));
-
-    return true;
-}
-
 void Discover()
 {
     if (!fDiscover)
@@ -3515,7 +3443,7 @@ void CConnman::StopNodes()
     }
     m_nodes_disconnected.clear();
     m_listen_permissions.clear();
-    m_listen.clear();
+    StopListening();
     semOutbound.reset();
     semAddnode.reset();
 }

--- a/src/net.h
+++ b/src/net.h
@@ -97,7 +97,7 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
 static constexpr bool DEFAULT_V2_TRANSPORT{true};
 
-typedef int64_t NodeId;
+using NodeId = SockMan::Id;
 
 struct AddedNodeParams {
     std::string m_added_node;
@@ -1428,8 +1428,6 @@ private:
 
     void DeleteNode(CNode* pnode);
 
-    NodeId GetNewNodeId();
-
     /** (Try to) send data from node's vSendMsg. Returns (bytes_sent, data_left). */
     std::pair<size_t, bool> SocketSendData(CNode& node) const EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
 
@@ -1509,7 +1507,6 @@ private:
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
     std::list<CNode*> m_nodes_disconnected;
     mutable RecursiveMutex m_nodes_mutex;
-    std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};
 
     // Stores number of full-tx connections (outbound and manual) per network

--- a/src/net.h
+++ b/src/net.h
@@ -1337,18 +1337,15 @@ private:
 
     virtual void EventI2PStatus(const CService& addr, SockMan::I2PStatus new_status) override;
 
-    void ThreadI2PAcceptIncoming();
-
     /**
-     * Create a `CNode` object from a socket that has just been accepted and add the node to
-     * the `m_nodes` member.
+     * Create a `CNode` object and add it to the `m_nodes` member.
      * @param[in] sock Connected socket to communicate with the peer.
-     * @param[in] addr_bind The address and port at our side of the connection.
-     * @param[in] addr The address and port at the peer's side of the connection.
+     * @param[in] me The address and port at our side of the connection.
+     * @param[in] them The address and port at the peer's side of the connection.
      */
-    void CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
-                                      const CService& addr_bind,
-                                      const CService& addr);
+    virtual void EventNewConnectionAccepted(std::unique_ptr<Sock>&& sock,
+                                            const CService& me,
+                                            const CService& them) override;
 
     void DisconnectNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_nodes_mutex);
     void NotifyNumConnectionsChanged();
@@ -1607,25 +1604,11 @@ private:
     Mutex mutexMsgProc;
     std::atomic<bool> flagInterruptMsgProc{false};
 
-    /**
-     * This is signaled when network activity should cease.
-     * A copy of this is saved in `m_i2p_sam_session`.
-     */
-    const std::shared_ptr<CThreadInterrupt> m_interrupt_net;
-
-    /**
-     * I2P SAM session.
-     * Used to accept incoming and make outgoing I2P connections from a persistent
-     * address.
-     */
-    std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
-
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
-    std::thread threadI2PAcceptIncoming;
 
     /** flag for deciding to connect to an extra outbound peer,
      *  in excess of m_max_outbound_full_relay

--- a/src/net.h
+++ b/src/net.h
@@ -1353,17 +1353,25 @@ private:
     /** Return true if the peer is inactive and should be disconnected. */
     bool InactivityCheck(const CNode& node) const;
 
+    virtual bool ShouldTryToSend(SockMan::Id id) const override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
+    virtual bool ShouldTryToRecv(SockMan::Id id) const override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
     /**
      * Generate a collection of sockets to check for IO readiness.
      * @param[in] nodes Select from these nodes' sockets.
      * @return sockets to check for readiness
      */
-    Sock::EventsPerSock GenerateWaitSockets(std::span<CNode* const> nodes);
+    Sock::EventsPerSock GenerateWaitSockets(std::span<CNode* const> nodes)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
     /**
      * Check connected and listening sockets for IO readiness and process them accordingly.
      */
-    void SocketHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc);
+    void SocketHandler()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_total_bytes_sent_mutex, !mutexMsgProc);
 
     /**
      * Do the read/write for connected sockets that are ready for IO.
@@ -1506,6 +1514,8 @@ private:
 
     // connection string and whether to use v2 p2p
     std::vector<AddedNodeParams> m_added_node_params GUARDED_BY(m_added_nodes_mutex);
+
+    CNode* GetNodeById(NodeId node_id) const EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
     mutable Mutex m_added_nodes_mutex;
     std::unordered_map<NodeId, CNode*> m_nodes GUARDED_BY(m_nodes_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1332,18 +1332,15 @@ private:
     void ThreadOpenConnections(std::vector<std::string> connect, std::span<const std::string> seed_nodes) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex, !m_unused_i2p_sessions_mutex, !m_reconnections_mutex);
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     void ThreadI2PAcceptIncoming();
-    void AcceptConnection(const Sock& listen_sock);
 
     /**
      * Create a `CNode` object from a socket that has just been accepted and add the node to
      * the `m_nodes` member.
      * @param[in] sock Connected socket to communicate with the peer.
-     * @param[in] permission_flags The peer's permissions.
      * @param[in] addr_bind The address and port at our side of the connection.
      * @param[in] addr The address and port at the peer's side of the connection.
      */
     void CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
-                                      NetPermissionFlags permission_flags,
                                       const CService& addr_bind,
                                       const CService& addr);
 

--- a/src/net.h
+++ b/src/net.h
@@ -9,6 +9,7 @@
 #include <bip324.h>
 #include <chainparams.h>
 #include <common/bloom.h>
+#include <common/sockman.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>
 #include <crypto/siphash.h>
@@ -1056,7 +1057,7 @@ protected:
     ~NetEventsInterface() = default;
 };
 
-class CConnman
+class CConnman : private SockMan
 {
 public:
 
@@ -1322,7 +1323,6 @@ private:
     //! in case of no limit, it will always return 0
     std::chrono::seconds GetMaxOutboundTimeLeftInCycle_() const EXCLUSIVE_LOCKS_REQUIRED(m_total_bytes_sent_mutex);
 
-    bool BindListenPort(const CService& bindAddr, bilingual_str& strError);
     bool Bind(const CService& addr, unsigned int flags, NetPermissionFlags permissions);
     bool InitBinds(const Options& options);
 
@@ -1492,11 +1492,6 @@ private:
 
     unsigned int nSendBufferMaxSize{0};
     unsigned int nReceiveFloodSize{0};
-
-    /**
-     * List of listening sockets.
-     */
-    std::vector<std::shared_ptr<Sock>> m_listen;
 
     /**
      * Permissions that incoming peers get based on our listening address they connected to.

--- a/src/net.h
+++ b/src/net.h
@@ -1359,6 +1359,12 @@ private:
     virtual bool ShouldTryToRecv(SockMan::Id id) const override
         EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
+    virtual void EventIOLoopCompletedForOne(SockMan::Id id) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
+    virtual void EventIOLoopCompletedForAll() override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex);
+
     /**
      * Generate a collection of sockets to check for IO readiness.
      * @param[in] nodes Select from these nodes' sockets.
@@ -1380,7 +1386,7 @@ private:
      */
     void SocketHandlerConnected(const std::vector<CNode*>& nodes,
                                 const Sock::EventsPerSock& events_per_sock)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_total_bytes_sent_mutex, !mutexMsgProc);
 
     /**
      * Accept incoming connections, one from each read-ready listening socket.

--- a/src/net.h
+++ b/src/net.h
@@ -1318,15 +1318,6 @@ public:
     bool MultipleManualOrFullOutboundConns(Network net) const EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
 
 private:
-    struct ListenSocket {
-    public:
-        std::shared_ptr<Sock> sock;
-        ListenSocket(std::shared_ptr<Sock> sock_)
-            : sock{sock_}
-        {
-        }
-    };
-
     //! returns the time left in the current max outbound cycle
     //! in case of no limit, it will always return 0
     std::chrono::seconds GetMaxOutboundTimeLeftInCycle_() const EXCLUSIVE_LOCKS_REQUIRED(m_total_bytes_sent_mutex);
@@ -1341,7 +1332,7 @@ private:
     void ThreadOpenConnections(std::vector<std::string> connect, std::span<const std::string> seed_nodes) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex, !m_unused_i2p_sessions_mutex, !m_reconnections_mutex);
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     void ThreadI2PAcceptIncoming();
-    void AcceptConnection(const ListenSocket& hListenSocket);
+    void AcceptConnection(const Sock& listen_sock);
 
     /**
      * Create a `CNode` object from a socket that has just been accepted and add the node to
@@ -1502,7 +1493,10 @@ private:
     unsigned int nSendBufferMaxSize{0};
     unsigned int nReceiveFloodSize{0};
 
-    std::vector<ListenSocket> vhListenSocket;
+    /**
+     * List of listening sockets.
+     */
+    std::vector<std::shared_ptr<Sock>> m_listen;
 
     /**
      * Permissions that incoming peers get based on our listening address they connected to.

--- a/src/net.h
+++ b/src/net.h
@@ -1338,11 +1338,13 @@ private:
 
     /**
      * Create a `CNode` object and add it to the `m_nodes` member.
+     * @param[in] id Id of the newly accepted connection.
      * @param[in] sock Connected socket to communicate with the peer.
      * @param[in] me The address and port at our side of the connection.
      * @param[in] them The address and port at the peer's side of the connection.
      */
-    virtual void EventNewConnectionAccepted(std::unique_ptr<Sock>&& sock,
+    virtual void EventNewConnectionAccepted(SockMan::Id id,
+                                            std::unique_ptr<Sock>&& sock,
                                             const CService& me,
                                             const CService& them) override;
 

--- a/src/net.h
+++ b/src/net.h
@@ -1353,6 +1353,18 @@ private:
     /** Return true if the peer is inactive and should be disconnected. */
     bool InactivityCheck(const CNode& node) const;
 
+    void EventReadyToSend(SockMan::Id id, bool& cancel_recv) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
+    virtual void EventGotData(SockMan::Id id, std::span<const uint8_t> data) override
+        EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc, !m_nodes_mutex);
+
+    virtual void EventGotEOF(SockMan::Id id) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
+    virtual void EventGotPermanentReadError(SockMan::Id id, const std::string& errmsg) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
     virtual bool ShouldTryToSend(SockMan::Id id) const override
         EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
@@ -1447,7 +1459,8 @@ private:
     void DeleteNode(CNode* pnode);
 
     /** (Try to) send data from node's vSendMsg. Returns (bytes_sent, data_left). */
-    std::pair<size_t, bool> SocketSendData(CNode& node) const EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
+    std::pair<size_t, bool> SocketSendData(CNode& node)
+        EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend, !m_total_bytes_sent_mutex);
 
     void DumpAddresses();
 

--- a/src/net.h
+++ b/src/net.h
@@ -1321,21 +1321,17 @@ private:
     struct ListenSocket {
     public:
         std::shared_ptr<Sock> sock;
-        inline void AddSocketPermissionFlags(NetPermissionFlags& flags) const { NetPermissions::AddFlag(flags, m_permissions); }
-        ListenSocket(std::shared_ptr<Sock> sock_, NetPermissionFlags permissions_)
-            : sock{sock_}, m_permissions{permissions_}
+        ListenSocket(std::shared_ptr<Sock> sock_)
+            : sock{sock_}
         {
         }
-
-    private:
-        NetPermissionFlags m_permissions;
     };
 
     //! returns the time left in the current max outbound cycle
     //! in case of no limit, it will always return 0
     std::chrono::seconds GetMaxOutboundTimeLeftInCycle_() const EXCLUSIVE_LOCKS_REQUIRED(m_total_bytes_sent_mutex);
 
-    bool BindListenPort(const CService& bindAddr, bilingual_str& strError, NetPermissionFlags permissions);
+    bool BindListenPort(const CService& bindAddr, bilingual_str& strError);
     bool Bind(const CService& addr, unsigned int flags, NetPermissionFlags permissions);
     bool InitBinds(const Options& options);
 
@@ -1507,6 +1503,12 @@ private:
     unsigned int nReceiveFloodSize{0};
 
     std::vector<ListenSocket> vhListenSocket;
+
+    /**
+     * Permissions that incoming peers get based on our listening address they connected to.
+     */
+    std::unordered_map<CService, NetPermissionFlags, CServiceHash> m_listen_permissions;
+
     std::atomic<bool> fNetworkActive{true};
     bool fAddressesInitialized{false};
     AddrMan& addrman;

--- a/src/net.h
+++ b/src/net.h
@@ -666,7 +666,6 @@ public:
 struct CNodeOptions
 {
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
-    std::unique_ptr<i2p::sam::Session> i2p_sam_session = nullptr;
     bool prefer_evict = false;
     size_t recv_flood_size{DEFAULT_MAXRECEIVEBUFFER * 1000};
     bool use_v2transport = false;
@@ -682,16 +681,6 @@ public:
 
     const NetPermissionFlags m_permission_flags;
 
-    /**
-     * Socket used for communication with the node.
-     * May not own a Sock object (after `CloseSocketDisconnect()` or during tests).
-     * `shared_ptr` (instead of `unique_ptr`) is used to avoid premature close of
-     * the underlying file descriptor by one thread while another thread is
-     * poll(2)-ing it for activity.
-     * @see https://github.com/bitcoin/bitcoin/issues/21744 for details.
-     */
-    std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
-
     /** Sum of GetMemoryUsage of all vSendMsg entries. */
     size_t m_send_memusage GUARDED_BY(cs_vSend){0};
     /** Total number of bytes sent on the wire to this peer. */
@@ -699,7 +688,6 @@ public:
     /** Messages still to be fed to m_transport->SetMessageToSend. */
     std::deque<CSerializedNetMsg> vSendMsg GUARDED_BY(cs_vSend);
     Mutex cs_vSend;
-    Mutex m_sock_mutex;
     Mutex cs_vRecv;
 
     uint64_t nRecvBytes GUARDED_BY(cs_vRecv){0};
@@ -887,7 +875,6 @@ public:
     std::atomic<std::chrono::microseconds> m_min_ping_time{std::chrono::microseconds::max()};
 
     CNode(NodeId id,
-          std::shared_ptr<Sock> sock,
           const CAddress& addrIn,
           uint64_t nKeyedNetGroupIn,
           uint64_t nLocalHostNonceIn,
@@ -950,8 +937,6 @@ public:
         nRefCount--;
     }
 
-    void CloseSocketDisconnect() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
-
     void CopyStats(CNodeStats& stats) EXCLUSIVE_LOCKS_REQUIRED(!m_subver_mutex, !m_addr_local_mutex, !cs_vSend, !cs_vRecv);
 
     std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }
@@ -996,18 +981,6 @@ private:
 
     mapMsgTypeSize mapSendBytesPerMsgType GUARDED_BY(cs_vSend);
     mapMsgTypeSize mapRecvBytesPerMsgType GUARDED_BY(cs_vRecv);
-
-    /**
-     * If an I2P session is created per connection (for outbound transient I2P
-     * connections) then it is stored here so that it can be destroyed when the
-     * socket is closed. I2P sessions involve a data/transport socket (in `m_sock`)
-     * and a control socket (in `m_i2p_sam_session`). For transient sessions, once
-     * the data socket is closed, the control socket is not going to be used anymore
-     * and is just taking up resources. So better close it as soon as `m_sock` is
-     * closed.
-     * Otherwise this unique_ptr is empty.
-     */
-    std::unique_ptr<i2p::sam::Session> m_i2p_sam_session GUARDED_BY(m_sock_mutex);
 };
 
 /**
@@ -1339,14 +1312,20 @@ private:
     /**
      * Create a `CNode` object and add it to the `m_nodes` member.
      * @param[in] id Id of the newly accepted connection.
-     * @param[in] sock Connected socket to communicate with the peer.
      * @param[in] me The address and port at our side of the connection.
      * @param[in] them The address and port at the peer's side of the connection.
+     * @retval true on success
+     * @retval false on failure, meaning that the associated socket and node_id should be discarded
      */
-    virtual void EventNewConnectionAccepted(SockMan::Id id,
-                                            std::unique_ptr<Sock>&& sock,
+    virtual bool EventNewConnectionAccepted(SockMan::Id id,
                                             const CService& me,
                                             const CService& them) override;
+
+    /**
+     * Mark a node as disconnected and close its connection with the peer.
+     * @param[in] node Node to disconnect.
+     */
+    void MarkAsDisconnectAndCloseConnection(CNode& node);
 
     void DisconnectNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_nodes_mutex);
     void NotifyNumConnectionsChanged();
@@ -1377,36 +1356,6 @@ private:
     virtual void EventIOLoopCompletedForAll() override
         EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex);
 
-    /**
-     * Generate a collection of sockets to check for IO readiness.
-     * @param[in] nodes Select from these nodes' sockets.
-     * @return sockets to check for readiness
-     */
-    Sock::EventsPerSock GenerateWaitSockets(std::span<CNode* const> nodes)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
-
-    /**
-     * Check connected and listening sockets for IO readiness and process them accordingly.
-     */
-    void SocketHandler()
-        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_total_bytes_sent_mutex, !mutexMsgProc);
-
-    /**
-     * Do the read/write for connected sockets that are ready for IO.
-     * @param[in] nodes Nodes to process. The socket of each node is checked against `what`.
-     * @param[in] events_per_sock Sockets that are ready for IO.
-     */
-    void SocketHandlerConnected(const std::vector<CNode*>& nodes,
-                                const Sock::EventsPerSock& events_per_sock)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_total_bytes_sent_mutex, !mutexMsgProc);
-
-    /**
-     * Accept incoming connections, one from each read-ready listening socket.
-     * @param[in] events_per_sock Sockets that are ready for IO.
-     */
-    void SocketHandlerListening(const Sock::EventsPerSock& events_per_sock);
-
-    void ThreadSocketHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc, !m_nodes_mutex, !m_reconnections_mutex);
     void ThreadDNSAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
 
     uint64_t CalculateKeyedNetGroup(const CNetAddr& ad) const;
@@ -1458,8 +1407,8 @@ private:
     void DeleteNode(CNode* pnode);
 
     /** (Try to) send data from node's vSendMsg. Returns (bytes_sent, data_left). */
-    std::pair<size_t, bool> SocketSendData(CNode& node)
-        EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend, !m_total_bytes_sent_mutex);
+    std::pair<size_t, bool> SendMessagesAsBytes(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
 
     void DumpAddresses();
 
@@ -1634,7 +1583,6 @@ private:
     std::atomic<bool> flagInterruptMsgProc{false};
 
     std::thread threadDNSAddressSeed;
-    std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;

--- a/src/net.h
+++ b/src/net.h
@@ -1331,6 +1331,12 @@ private:
     void ProcessAddrFetch() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_unused_i2p_sessions_mutex);
     void ThreadOpenConnections(std::vector<std::string> connect, std::span<const std::string> seed_nodes) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex, !m_unused_i2p_sessions_mutex, !m_reconnections_mutex);
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
+
+    /// Whether we are currently advertising our I2P address (via `AddLocal()`).
+    bool m_i2p_advertising_listen_addr{false};
+
+    virtual void EventI2PStatus(const CService& addr, SockMan::I2PStatus new_status) override;
+
     void ThreadI2PAcceptIncoming();
 
     /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5130,10 +5130,15 @@ void PeerManagerImpl::EvictExtraOutboundPeers(std::chrono::seconds now)
 
         m_connman.ForEachNode([&](CNode* pnode) {
             if (!pnode->IsBlockOnlyConn() || pnode->fDisconnect) return;
-            if (pnode->GetId() > youngest_peer.first) {
-                next_youngest_peer = youngest_peer;
-                youngest_peer.first = pnode->GetId();
-                youngest_peer.second = pnode->m_last_block_time;
+            if (pnode->GetId() > next_youngest_peer.first) {
+                if (pnode->GetId() > youngest_peer.first) {
+                    next_youngest_peer = youngest_peer;
+                    youngest_peer.first = pnode->GetId();
+                    youngest_peer.second = pnode->m_last_block_time;
+                } else {
+                    next_youngest_peer.first = pnode->GetId();
+                    next_youngest_peer.second = pnode->m_last_block_time;
+                }
             }
         });
         NodeId to_disconnect = youngest_peer.first;

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -87,7 +87,7 @@ public:
         LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Pre-register peer=%d\n", peer_id);
         const uint64_t local_salt{FastRandomContext().rand64()};
 
-        // We do this exactly once per peer (which are unique by NodeId, see GetNewNodeId) so it's
+        // We do this exactly once per peer (which are unique by id, see SockMan::GetNewId()) so it's
         // safe to assume we don't have this record yet.
         Assume(m_states.emplace(peer_id, local_salt).second);
         return local_salt;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -210,6 +210,10 @@ static RPCHelpMan getpeerinfo()
     std::vector<CNodeStats> vstats;
     connman.GetNodeStats(vstats);
 
+    std::sort(vstats.begin(), vstats.end(), [](const CNodeStats& a, const CNodeStats& b) {
+        return a.nodeid < b.nodeid;
+    });
+
     UniValue ret(UniValue::VARR);
 
     for (const CNodeStats& stats : vstats) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -55,7 +55,6 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     NodeId id{0};
     CNode dummyNode1{id++,
-                     /*sock=*/nullptr,
                      addr1,
                      /*nKeyedNetGroupIn=*/0,
                      /*nLocalHostNonceIn=*/0,
@@ -122,7 +121,6 @@ void AddRandomOutboundPeer(NodeId& id, std::vector<CNode*>& vNodes, PeerManager&
     }
 
     vNodes.emplace_back(new CNode{id++,
-                                  /*sock=*/nullptr,
                                   addr,
                                   /*nKeyedNetGroupIn=*/0,
                                   /*nLocalHostNonceIn=*/0,
@@ -322,7 +320,6 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     banman->ClearBanned();
     NodeId id{0};
     nodes[0] = new CNode{id++,
-                         /*sock=*/nullptr,
                          addr[0],
                          /*nKeyedNetGroupIn=*/0,
                          /*nLocalHostNonceIn=*/0,
@@ -343,7 +340,6 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     BOOST_CHECK(!banman->IsDiscouraged(other_addr)); // Different address, not discouraged
 
     nodes[1] = new CNode{id++,
-                         /*sock=*/nullptr,
                          addr[1],
                          /*nKeyedNetGroupIn=*/1,
                          /*nLocalHostNonceIn=*/1,
@@ -374,7 +370,6 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     // Make sure non-IP peers are discouraged and disconnected properly.
 
     nodes[2] = new CNode{id++,
-                         /*sock=*/nullptr,
                          addr[2],
                          /*nKeyedNetGroupIn=*/1,
                          /*nLocalHostNonceIn=*/1,
@@ -417,7 +412,6 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
     NodeId id{0};
     CNode dummyNode{id++,
-                    /*sock=*/nullptr,
                     addr,
                     /*nKeyedNetGroupIn=*/4,
                     /*nLocalHostNonceIn=*/4,

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -186,7 +186,6 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 const auto peer = ConsumeAddress(fuzzed_data_provider);
                 connman.CreateNodeFromAcceptedSocketPublic(
                     /*sock=*/CreateSock(AF_INET, SOCK_STREAM, IPPROTO_TCP),
-                    /*permissions=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS),
                     /*addr_bind=*/ConsumeAddress(fuzzed_data_provider),
                     /*addr_peer=*/peer);
             },

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -83,12 +83,12 @@ FUZZ_TARGET(connman, .init = initialize_connman)
 
     CNetAddr random_netaddr;
     CAddress random_address;
-    CNode random_node = ConsumeNode(fuzzed_data_provider);
+    CNode random_node = ConsumeNode(fuzzed_data_provider, connman.GetNewIdPublic());
     CSubNet random_subnet;
     std::string random_string;
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100) {
-        CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider).release()};
+        CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider, connman.GetNewIdPublic()).release()};
         connman.AddTestNode(p2p_node);
     }
 

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -185,6 +185,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
                 const auto peer = ConsumeAddress(fuzzed_data_provider);
                 connman.EventNewConnectionAcceptedPublic(
+                    /*id=*/connman.GetNewIdPublic(),
                     /*sock=*/CreateSock(AF_INET, SOCK_STREAM, IPPROTO_TCP),
                     /*me=*/ConsumeAddress(fuzzed_data_provider),
                     /*them=*/peer);

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -184,10 +184,10 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             [&] {
                 connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
                 const auto peer = ConsumeAddress(fuzzed_data_provider);
-                connman.CreateNodeFromAcceptedSocketPublic(
+                connman.EventNewConnectionAcceptedPublic(
                     /*sock=*/CreateSock(AF_INET, SOCK_STREAM, IPPROTO_TCP),
-                    /*addr_bind=*/ConsumeAddress(fuzzed_data_provider),
-                    /*addr_peer=*/peer);
+                    /*me=*/ConsumeAddress(fuzzed_data_provider),
+                    /*them=*/peer);
             },
             [&] {
                 CConnman::Options options;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -83,13 +83,14 @@ FUZZ_TARGET(connman, .init = initialize_connman)
 
     CNetAddr random_netaddr;
     CAddress random_address;
-    CNode random_node = ConsumeNode(fuzzed_data_provider, connman.GetNewIdPublic());
+    CNode& random_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider, connman.GetNewIdPublic()).release()};
+    connman.AddTestNode(random_node, std::make_unique<FuzzedSock>(fuzzed_data_provider));
     CSubNet random_subnet;
     std::string random_string;
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100) {
         CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider, connman.GetNewIdPublic()).release()};
-        connman.AddTestNode(p2p_node);
+        connman.AddTestNode(p2p_node, std::make_unique<FuzzedSock>(fuzzed_data_provider));
     }
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
@@ -124,6 +125,15 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             },
             [&] {
                 connman.DisconnectNode(random_subnet);
+            },
+            [&] {
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    auto nonexistent_node{ConsumeNodeAsUniquePtr(fuzzed_data_provider, connman.GetNewIdPublic())};
+                    connman.MarkAsDisconnectAndCloseConnection(*nonexistent_node);
+                } else {
+                    CNode& existent_node{*connman.TestNodes().begin()->second};
+                    connman.MarkAsDisconnectAndCloseConnection(existent_node);
+                }
             },
             [&] {
                 connman.ForEachNode([](auto) {});
@@ -186,7 +196,6 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 const auto peer = ConsumeAddress(fuzzed_data_provider);
                 connman.EventNewConnectionAcceptedPublic(
                     /*id=*/connman.GetNewIdPublic(),
-                    /*sock=*/CreateSock(AF_INET, SOCK_STREAM, IPPROTO_TCP),
                     /*me=*/ConsumeAddress(fuzzed_data_provider),
                     /*them=*/peer);
             },
@@ -208,9 +217,6 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                                       options.onion_binds.empty();
 
                 connman.InitBindsPublic(options);
-            },
-            [&] {
-                connman.SocketHandlerPublic();
             });
     }
     (void)connman.GetAddedNodeInfo(fuzzed_data_provider.ConsumeBool());

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -43,9 +43,6 @@ FUZZ_TARGET(net, .init = initialize_net)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                node.CloseSocketDisconnect();
-            },
-            [&] {
                 CNodeStats stats;
                 node.CopyStats(stats);
             },

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -65,7 +65,7 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
     const auto num_peers_to_add = fuzzed_data_provider.ConsumeIntegralInRange(1, 3);
     for (int i = 0; i < num_peers_to_add; ++i) {
         peers.push_back(ConsumeNodeAsUniquePtr(fuzzed_data_provider, i).release());
-        connman.AddTestNode(*peers.back());
+        connman.AddTestNode(*peers.back(), std::make_unique<FuzzedSock>(fuzzed_data_provider));
         peerman->InitializeNode(
             *peers.back(),
             static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()));

--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -70,7 +70,7 @@ void HeadersSyncSetup::ResetAndInitialize()
 
     for (auto conn_type : conn_types) {
         CAddress addr{};
-        m_connections.push_back(new CNode(id++, nullptr, addr, 0, 0, addr, "", conn_type, false, 0));
+        m_connections.push_back(new CNode(id++, addr, 0, 0, addr, "", conn_type, false, 0));
         CNode& p2p_node = *m_connections.back();
 
         connman.Handshake(

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -96,7 +96,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     }
     CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();
 
-    connman.AddTestNode(p2p_node);
+    connman.AddTestNode(p2p_node, std::make_unique<FuzzedSock>(fuzzed_data_provider));
     FillNode(fuzzed_data_provider, connman, p2p_node);
 
     const auto mock_time = ConsumeTime(fuzzed_data_provider);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -88,7 +88,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 
         FillNode(fuzzed_data_provider, connman, p2p_node);
 
-        connman.AddTestNode(p2p_node);
+        connman.AddTestNode(p2p_node, std::make_unique<FuzzedSock>(fuzzed_data_provider));
     }
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 30)

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -267,7 +267,6 @@ template <bool ReturnUniquePtr = false>
 auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<NodeId>& node_id_in = std::nullopt) noexcept
 {
     const NodeId node_id = node_id_in.value_or(fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, std::numeric_limits<NodeId>::max()));
-    const auto sock = std::make_shared<FuzzedSock>(fuzzed_data_provider);
     const CAddress address = ConsumeAddress(fuzzed_data_provider);
     const uint64_t keyed_net_group = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
     const uint64_t local_host_nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
@@ -280,7 +279,6 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
     NetPermissionFlags permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
     if constexpr (ReturnUniquePtr) {
         return std::make_unique<CNode>(node_id,
-                                       sock,
                                        address,
                                        keyed_net_group,
                                        local_host_nonce,
@@ -292,7 +290,6 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                                        CNodeOptions{ .permission_flags = permission_flags });
     } else {
         return CNode{node_id,
-                     sock,
                      address,
                      keyed_net_group,
                      local_host_nonce,

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -65,7 +65,6 @@ void AddPeer(NodeId& id, std::vector<CNode*>& nodes, PeerManager& peerman, Connm
     const bool inbound_onion{onion_peer && conn_type == ConnectionType::INBOUND};
 
     nodes.emplace_back(new CNode{++id,
-                                 /*sock=*/nullptr,
                                  addr,
                                  /*nKeyedNetGroupIn=*/0,
                                  /*nLocalHostNonceIn=*/0,

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -118,9 +118,9 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     BOOST_CHECK_EQUAL(nodes.back()->ConnectedThroughNetwork(), Network::NET_CJDNS);
 
     BOOST_TEST_MESSAGE("Call AddNode() for all the peers");
-    for (auto node : connman->TestNodes()) {
+    for (const auto& [id, node] : connman->TestNodes()) {
         BOOST_CHECK(connman->AddNode({/*m_added_node=*/node->addr.ToStringAddrPort(), /*m_use_v2transport=*/true}));
-        BOOST_TEST_MESSAGE(strprintf("peer id=%s addr=%s", node->GetId(), node->addr.ToStringAddrPort()));
+        BOOST_TEST_MESSAGE(strprintf("peer id=%s addr=%s", id, node->addr.ToStringAddrPort()));
     }
 
     BOOST_TEST_MESSAGE("\nCall AddNode() with 2 addrs resolving to existing localhost addnode entry; neither should be added");
@@ -135,7 +135,7 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     BOOST_CHECK(connman->GetAddedNodeInfo(/*include_connected=*/false).empty());
 
     // Test AddedNodesContain()
-    for (auto node : connman->TestNodes()) {
+    for (const auto& [_, node] : connman->TestNodes()) {
         BOOST_CHECK(connman->AddedNodesContain(node->addr));
     }
     AddPeer(id, nodes, *peerman, *connman, ConnectionType::OUTBOUND_FULL_RELAY);
@@ -152,12 +152,12 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     }
 
     BOOST_TEST_MESSAGE("\nCheck that all connected peers are correctly detected as connected");
-    for (const auto& node : connman->TestNodes()) {
+    for (const auto& [_, node] : connman->TestNodes()) {
         BOOST_CHECK(connman->AlreadyConnectedToAddressPublic(node->addr));
     }
 
     // Clean up
-    for (auto node : connman->TestNodes()) {
+    for (const auto& [_, node] : connman->TestNodes()) {
         peerman->FinalizeNode(*node);
     }
     connman->ClearTestNodes();

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -60,7 +60,6 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     std::string pszDest;
 
     std::unique_ptr<CNode> pnode1 = std::make_unique<CNode>(id++,
-                                                            /*sock=*/nullptr,
                                                             addr,
                                                             /*nKeyedNetGroupIn=*/0,
                                                             /*nLocalHostNonceIn=*/0,
@@ -79,7 +78,6 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK_EQUAL(pnode1->ConnectedThroughNetwork(), Network::NET_IPV4);
 
     std::unique_ptr<CNode> pnode2 = std::make_unique<CNode>(id++,
-                                                            /*sock=*/nullptr,
                                                             addr,
                                                             /*nKeyedNetGroupIn=*/1,
                                                             /*nLocalHostNonceIn=*/1,
@@ -98,7 +96,6 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK_EQUAL(pnode2->ConnectedThroughNetwork(), Network::NET_IPV4);
 
     std::unique_ptr<CNode> pnode3 = std::make_unique<CNode>(id++,
-                                                            /*sock=*/nullptr,
                                                             addr,
                                                             /*nKeyedNetGroupIn=*/0,
                                                             /*nLocalHostNonceIn=*/0,
@@ -117,7 +114,6 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK_EQUAL(pnode3->ConnectedThroughNetwork(), Network::NET_IPV4);
 
     std::unique_ptr<CNode> pnode4 = std::make_unique<CNode>(id++,
-                                                            /*sock=*/nullptr,
                                                             addr,
                                                             /*nKeyedNetGroupIn=*/1,
                                                             /*nLocalHostNonceIn=*/1,
@@ -610,7 +606,6 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     ipv4AddrPeer.s_addr = 0xa0b0c001;
     CAddress addr = CAddress(CService(ipv4AddrPeer, 7777), NODE_NETWORK);
     std::unique_ptr<CNode> pnode = std::make_unique<CNode>(/*id=*/0,
-                                                           /*sock=*/nullptr,
                                                            addr,
                                                            /*nKeyedNetGroupIn=*/0,
                                                            /*nLocalHostNonceIn=*/0,
@@ -665,7 +660,6 @@ BOOST_AUTO_TEST_CASE(get_local_addr_for_peer_port)
     in_addr peer_out_in_addr;
     peer_out_in_addr.s_addr = htonl(0x01020304);
     CNode peer_out{/*id=*/0,
-                   /*sock=*/nullptr,
                    /*addrIn=*/CAddress{CService{peer_out_in_addr, 8333}, NODE_NETWORK},
                    /*nKeyedNetGroupIn=*/0,
                    /*nLocalHostNonceIn=*/0,
@@ -687,7 +681,6 @@ BOOST_AUTO_TEST_CASE(get_local_addr_for_peer_port)
     in_addr peer_in_in_addr;
     peer_in_in_addr.s_addr = htonl(0x05060708);
     CNode peer_in{/*id=*/0,
-                  /*sock=*/nullptr,
                   /*addrIn=*/CAddress{CService{peer_in_in_addr, 8333}, NODE_NETWORK},
                   /*nKeyedNetGroupIn=*/0,
                   /*nLocalHostNonceIn=*/0,
@@ -825,7 +818,6 @@ BOOST_AUTO_TEST_CASE(initial_advertise_from_version_message)
     in_addr peer_in_addr;
     peer_in_addr.s_addr = htonl(0x01020304);
     CNode peer{/*id=*/0,
-               /*sock=*/nullptr,
                /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
                /*nKeyedNetGroupIn=*/0,
                /*nLocalHostNonceIn=*/0,
@@ -901,7 +893,6 @@ BOOST_AUTO_TEST_CASE(advertise_local_address)
 {
     auto CreatePeer = [](const CAddress& addr) {
         return std::make_unique<CNode>(/*id=*/0,
-                                       /*sock=*/nullptr,
                                        addr,
                                        /*nKeyedNetGroupIn=*/0,
                                        /*nLocalHostNonceIn=*/0,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -115,8 +115,7 @@ struct ConnmanTestMsg : public CConnman {
 
     bool AlreadyConnectedToAddressPublic(const CNetAddr& addr) { return AlreadyConnectedToAddress(addr); };
 
-    CNode* ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+    CNode* ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type);
 };
 
 constexpr ServiceFlags ALL_SERVICE_FLAGS[]{

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -35,6 +35,7 @@ class FastRandomContext;
 
 struct ConnmanTestMsg : public CConnman {
     using CConnman::CConnman;
+    using CConnman::MarkAsDisconnectAndCloseConnection;
 
     void SetMsgProc(NetEventsInterface* msgproc)
     {
@@ -53,6 +54,12 @@ struct ConnmanTestMsg : public CConnman {
     {
         LOCK(m_nodes_mutex);
         return m_nodes;
+    }
+
+    void AddTestNode(CNode& node, std::unique_ptr<Sock>&& sock)
+    {
+        TestOnlyAddExistentConnection(node.GetId(), std::move(sock));
+        AddTestNode(node);
     }
 
     void AddTestNode(CNode& node)
@@ -74,21 +81,15 @@ struct ConnmanTestMsg : public CConnman {
     }
 
     void EventNewConnectionAcceptedPublic(SockMan::Id id,
-                                          std::unique_ptr<Sock> sock,
                                           const CAddress& me,
                                           const CAddress& them)
     {
-        EventNewConnectionAccepted(id, std::move(sock), me, them);
+        EventNewConnectionAccepted(id, me, them);
     }
 
     bool InitBindsPublic(const CConnman::Options& options)
     {
         return InitBinds(options);
-    }
-
-    void SocketHandlerPublic()
-    {
-        SocketHandler();
     }
 
     Id GetNewIdPublic()

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -72,11 +72,10 @@ struct ConnmanTestMsg : public CConnman {
     }
 
     void CreateNodeFromAcceptedSocketPublic(std::unique_ptr<Sock> sock,
-                                            NetPermissionFlags permissions,
                                             const CAddress& addr_bind,
                                             const CAddress& addr_peer)
     {
-        CreateNodeFromAcceptedSocket(std::move(sock), permissions, addr_bind, addr_peer);
+        CreateNodeFromAcceptedSocket(std::move(sock), addr_bind, addr_peer);
     }
 
     bool InitBindsPublic(const CConnman::Options& options)

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -71,11 +71,11 @@ struct ConnmanTestMsg : public CConnman {
         m_nodes.clear();
     }
 
-    void CreateNodeFromAcceptedSocketPublic(std::unique_ptr<Sock> sock,
-                                            const CAddress& addr_bind,
-                                            const CAddress& addr_peer)
+    void EventNewConnectionAcceptedPublic(std::unique_ptr<Sock> sock,
+                                            const CAddress& me,
+                                            const CAddress& them)
     {
-        CreateNodeFromAcceptedSocket(std::move(sock), addr_bind, addr_peer);
+        EventNewConnectionAccepted(std::move(sock), me, them);
     }
 
     bool InitBindsPublic(const CConnman::Options& options)

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -73,11 +73,12 @@ struct ConnmanTestMsg : public CConnman {
         m_nodes.clear();
     }
 
-    void EventNewConnectionAcceptedPublic(std::unique_ptr<Sock> sock,
-                                            const CAddress& me,
-                                            const CAddress& them)
+    void EventNewConnectionAcceptedPublic(SockMan::Id id,
+                                          std::unique_ptr<Sock> sock,
+                                          const CAddress& me,
+                                          const CAddress& them)
     {
-        EventNewConnectionAccepted(std::move(sock), me, them);
+        EventNewConnectionAccepted(id, std::move(sock), me, them);
     }
 
     bool InitBindsPublic(const CConnman::Options& options)

--- a/test/functional/feature_port.py
+++ b/test/functional/feature_port.py
@@ -29,23 +29,23 @@ class PortTest(BitcoinTestFramework):
         port2 = p2p_port(self.num_nodes + 5)
 
         self.log.info("When starting with -port, bitcoind binds to it and uses port + 1 for an onion bind")
-        with node.assert_debug_log(expected_msgs=[f'Bound to 0.0.0.0:{port1}', f'Bound to 127.0.0.1:{port1 + 1}']):
+        with node.assert_debug_log(expected_msgs=[f'Bound to and listening on 0.0.0.0:{port1}', f'Bound to and listening on 127.0.0.1:{port1 + 1}']):
             self.restart_node(0, extra_args=["-listen", f"-port={port1}"])
 
         self.log.info("When specifying -port multiple times, only the last one is taken")
-        with node.assert_debug_log(expected_msgs=[f'Bound to 0.0.0.0:{port2}', f'Bound to 127.0.0.1:{port2 + 1}'], unexpected_msgs=[f'Bound to 0.0.0.0:{port1}']):
+        with node.assert_debug_log(expected_msgs=[f'Bound to and listening on 0.0.0.0:{port2}', f'Bound to and listening on 127.0.0.1:{port2 + 1}'], unexpected_msgs=[f'Bound to and listening on 0.0.0.0:{port1}']):
             self.restart_node(0, extra_args=["-listen", f"-port={port1}", f"-port={port2}"])
 
         self.log.info("When specifying ports with both -port and -bind, the one from -port is ignored")
-        with node.assert_debug_log(expected_msgs=[f'Bound to 0.0.0.0:{port2}'], unexpected_msgs=[f'Bound to 0.0.0.0:{port1}']):
+        with node.assert_debug_log(expected_msgs=[f'Bound to and listening on 0.0.0.0:{port2}'], unexpected_msgs=[f'Bound to and listening on 0.0.0.0:{port1}']):
             self.restart_node(0, extra_args=["-listen", f"-port={port1}", f"-bind=0.0.0.0:{port2}"])
 
         self.log.info("When -bind specifies no port, the values from -port and -bind are combined")
-        with self.nodes[0].assert_debug_log(expected_msgs=[f'Bound to 0.0.0.0:{port1}']):
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'Bound to and listening on 0.0.0.0:{port1}']):
             self.restart_node(0, extra_args=["-listen", f"-port={port1}", "-bind=0.0.0.0"])
 
         self.log.info("When an onion bind specifies no port, the value from -port, incremented by 1, is taken")
-        with self.nodes[0].assert_debug_log(expected_msgs=[f'Bound to 127.0.0.1:{port1 + 1}']):
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'Bound to and listening on 127.0.0.1:{port1 + 1}']):
             self.restart_node(0, extra_args=["-listen", f"-port={port1}", "-bind=127.0.0.1=onion"])
 
         self.log.info("Invalid values for -port raise errors")


### PR DESCRIPTION
Currently `CConnman` is a mixture of:
* low level socket handling, e.g. send, recv, poll, bind, listen, connect, and
* higher level logic that is specific to the Bitcoin P2P protocol, e.g. V1/V2 transport, choosing which address to connect to, if we manage to connect mark the address good in `AddrMan`, maintaining the number of inbound and outbound connections, banning of peers, interacting with `PeerManager`.

---

This PR splits the socket handling into a new class which makes the code more modular and reusable. Having more modular and reusable code is a good thing on its own, even if the code is not reused. Stratum V2 and libevent-less RPC/HTTP server could benefit from this, but it makes sense on its own, even without those projects.

---

The socket operations are driven by the new class `SockMan` which informs the higher level via provided methods when e.g. new data arrives on the socket or a new connection is accepted. For this, `SockMan` provides some non-virtual methods to start it rolling and then it calls pure virtual methods which are implemented by the higher level (e.g. `CConnman`) on certain events, for example "got this new data on this node's socket".

The interface of `SockMan` is:

```cpp
/**
 * A socket manager class which handles socket operations.
 * To use this class, inherit from it and implement the pure virtual methods.
 * Handled operations:
 * - binding and listening on sockets
 * - starting of necessary threads to process socket operations
 * - accepting incoming connections
 * - making outbound connections
 * - closing connections
 * - waiting for IO readiness on sockets and doing send/recv accordingly
 */
class SockMan
{
public:

    //
    // Non-virtual functions, to be reused by children classes.
    //

    /**
     * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
     * Should be called before `StartSocketsThreads()`.
     * @param[in] to Where to bind.
     * @param[out] err_msg Error string if an error occurs.
     * @retval true Success.
     * @retval false Failure, `err_msg` will be set.
     */
    bool BindAndStartListening(const CService& to, bilingual_str& err_msg);

    /**
     * Start the necessary threads for sockets IO.
     */
    void StartSocketsThreads(const Options& options);

    /**
     * Join (wait for) the threads started by `StartSocketsThreads()` to exit.
     */
    void JoinSocketsThreads();

    /**
     * Make an outbound connection, save the socket internally and return a newly generated connection id.
     * @param[in] to The address to connect to, either as CService or a host as string and port as
     * an integer, if the later is used, then `proxy` must be valid.
     * @param[in] is_important If true, then log failures with higher severity.
     * @param[in] proxy Proxy to connect through, if set.
     * @param[out] proxy_failed If `proxy` is valid and the connection failed because of the
     * proxy, then it will be set to true.
     * @param[out] me If the connection was successful then this is set to the address on the
     * local side of the socket.
     * @return Newly generated id, or std::nullopt if the operation fails.
     */
    std::optional<SockMan::Id> ConnectAndMakeId(const std::variant<CService, StringHostIntPort>& to,
                                                bool is_important,
                                                std::optional<Proxy> proxy,
                                                bool& proxy_failed,
                                                CService& me)
        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex, !m_unused_i2p_sessions_mutex);

    /**
     * Destroy a given connection by closing its socket and release resources occupied by it.
     * @param[in] id Connection to destroy.
     * @return Whether the connection existed and its socket was closed by this call.
     */
    bool CloseConnection(Id id)
        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);

    /**
     * Try to send some data over the given connection.
     * @param[in] id Identifier of the connection.
     * @param[in] data The data to send, it might happen that only a prefix of this is sent.
     * @param[in] will_send_more Used as an optimization if the caller knows that they will
     * be sending more data soon after this call.
     * @param[out] errmsg If <0 is returned then this will contain a human readable message
     * explaining the error.
     * @retval >=0 The number of bytes actually sent.
     * @retval <0 A permanent error has occurred.
     */
    ssize_t SendBytes(Id id,
                      std::span<const unsigned char> data,
                      bool will_send_more,
                      std::string& errmsg) const
        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);

    /**
     * Stop listening by closing all listening sockets.
     */
    void StopListening();

    //
    // Pure virtual functions must be implemented by children classes.
    //

    /**
     * Be notified when a new connection has been accepted.
     * @param[in] id Id of the newly accepted connection.
     * @param[in] me The address and port at our side of the connection.
     * @param[in] them The address and port at the peer's side of the connection.
     * @retval true The new connection was accepted at the higher level.
     * @retval false The connection was refused at the higher level, so the
     * associated socket and id should be discarded by `SockMan`.
     */
    virtual bool EventNewConnectionAccepted(Id id,
                                            const CService& me,
                                            const CService& them) = 0;

    /**
     * Called when the socket is ready to send data and `ShouldTryToSend()` has
     * returned true. This is where the higher level code serializes its messages
     * and calls `SockMan::SendBytes()`.
     * @param[in] id Id of the connection whose socket is ready to send.
     * @param[out] cancel_recv Should always be set upon return and if it is true,
     * then the next attempt to receive data from that connection will be omitted.
     */
    virtual void EventReadyToSend(Id id, bool& cancel_recv) = 0;

    /**
     * Called when new data has been received.
     * @param[in] id Connection for which the data arrived.
     * @param[in] data Received data.
     */
    virtual void EventGotData(Id id, std::span<const uint8_t> data) = 0;

    /**
     * Called when the remote peer has sent an EOF on the socket. This is a graceful
     * close of their writing side, we can still send and they will receive, if it
     * makes sense at the application level.
     * @param[in] id Connection whose socket got EOF.
     */
    virtual void EventGotEOF(Id id) = 0;

    /**
     * Called when we get an irrecoverable error trying to read from a socket.
     * @param[in] id Connection whose socket got an error.
     * @param[in] errmsg Message describing the error.
     */
    virtual void EventGotPermanentReadError(Id id, const std::string& errmsg) = 0;
};
```

Resolves: https://github.com/bitcoin/bitcoin/issues/30694

---

Review hint: this PR moves some code around, so reviewers may find this helpful: `git show --color-moved --color-moved-ws=allow-indentation-change`.