### PR TITLE
guix: Drop no longer needed `PATH` modification

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -230,8 +230,6 @@ case "$HOST" in
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 
-# Make $HOST-specific native binaries from depends available in $PATH
-export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 mkdir -p "$DISTSRC"
 (
     cd "$DISTSRC"


### PR DESCRIPTION
I don't see any reason why this would be necessary in the master branch @ d812cf11896a2214467b6fa72d7b763bac6077c5.

Additionally, from https://github.com/bitcoin/bitcoin/pull/30940#pullrequestreview-2322355196:
>    2. I don't understand why "In the Guix environment, `${BASEPREFIX}/${HOST}/native/bin` is added to the `PATH` environment variable," according to the description. Setting this seems indiscriminate, like a sledgehammer approach, something that would cause the guix build to behave differently from normal depends builds and lead to confusing issues like this one.

My Guix build:
```
aarch64
015b853d60c742120b88f1501ce241c8b7b3e874eca9ab150ba2ec282ecb9572  guix-build-f1daa80521ec/output/aarch64-linux-gnu/SHA256SUMS.part
2a8ed51f02046a73dc9a391b8939528c2e506d545274c934202a5643f26b102b  guix-build-f1daa80521ec/output/aarch64-linux-gnu/bitcoin-f1daa80521ec-aarch64-linux-gnu-debug.tar.gz
0ce7a6c81b657cfcbd2edf1e18cca8f66bd7bbe15a12b90dd60ddb1218b72254  guix-build-f1daa80521ec/output/aarch64-linux-gnu/bitcoin-f1daa80521ec-aarch64-linux-gnu.tar.gz
de6cb71e37a1c2e9a9a9952d4456a7fde407b38f95a1447928ded3f592b2e47f  guix-build-f1daa80521ec/output/arm-linux-gnueabihf/SHA256SUMS.part
c91be594ad4d02a2cb4cea2f57e91ebeae9a1cda66ec49e05ecc3a793e767f24  guix-build-f1daa80521ec/output/arm-linux-gnueabihf/bitcoin-f1daa80521ec-arm-linux-gnueabihf-debug.tar.gz
eb8ea448df1734009129d88cdf28a1ae5918bff19a58fa9525c0b1dde0dfd987  guix-build-f1daa80521ec/output/arm-linux-gnueabihf/bitcoin-f1daa80521ec-arm-linux-gnueabihf.tar.gz
6d558c036b66c81fb5843b1918f24fec6bd901098a0dfb15100b497e12e8fdc3  guix-build-f1daa80521ec/output/arm64-apple-darwin/SHA256SUMS.part
23691ecaf5d23c72f06fe81054a84e2549d8e89582317b6d3e14276aeba0b07f  guix-build-f1daa80521ec/output/arm64-apple-darwin/bitcoin-f1daa80521ec-arm64-apple-darwin-unsigned.tar.gz
8965a32937894d6dd75e6b04809bdc925187967c2547a795dec2e11a75262624  guix-build-f1daa80521ec/output/arm64-apple-darwin/bitcoin-f1daa80521ec-arm64-apple-darwin-unsigned.zip
ec0b2f35f498537ca6eb8b306a1e26cf97b7f1bdf140f3c4ca8b18c643fc4599  guix-build-f1daa80521ec/output/arm64-apple-darwin/bitcoin-f1daa80521ec-arm64-apple-darwin.tar.gz
d46d8117efdbfe90be13bcf36ba2ddcfa7c53ba01762a53c72a1b48f2cac569c  guix-build-f1daa80521ec/output/dist-archive/bitcoin-f1daa80521ec.tar.gz
facf7bbec0e9324e9ed58b8da07c5b1df2f120bd9090f7d124613ed62092dd46  guix-build-f1daa80521ec/output/powerpc64-linux-gnu/SHA256SUMS.part
c065b222f60ec19b7585daf197dadcb529fa588de1b26e767e4ebd43d6345562  guix-build-f1daa80521ec/output/powerpc64-linux-gnu/bitcoin-f1daa80521ec-powerpc64-linux-gnu-debug.tar.gz
4e837a86ce6adbd595dc31d2b584c3322acd30b6f18b57144f18fc09289fec65  guix-build-f1daa80521ec/output/powerpc64-linux-gnu/bitcoin-f1daa80521ec-powerpc64-linux-gnu.tar.gz
f4362984a846e97c6a388366bb2922294c66bb3f78adf71064f97ab5a346e4ed  guix-build-f1daa80521ec/output/riscv64-linux-gnu/SHA256SUMS.part
427fc7fdac244c6dd4fdf0312486e3bcf8372c68fd3570bdb815734544b8369e  guix-build-f1daa80521ec/output/riscv64-linux-gnu/bitcoin-f1daa80521ec-riscv64-linux-gnu-debug.tar.gz
ae9a07f7e2e656efbba99246be5767798028c13fcf5d172a595b734f5e1241c4  guix-build-f1daa80521ec/output/riscv64-linux-gnu/bitcoin-f1daa80521ec-riscv64-linux-gnu.tar.gz
8ff7494e648fe5744efd4522a003d94b531dcab28cb8c2fea05a09897be111ce  guix-build-f1daa80521ec/output/x86_64-apple-darwin/SHA256SUMS.part
9845e894fc6b0dd339dc4f62f3bc4e37f76935f309887798ca488fb5465b2b6c  guix-build-f1daa80521ec/output/x86_64-apple-darwin/bitcoin-f1daa80521ec-x86_64-apple-darwin-unsigned.tar.gz
fa0e07573ae977ef6bb3ecaa07b1e434c52041865e2def9de6a041fb3749d27d  guix-build-f1daa80521ec/output/x86_64-apple-darwin/bitcoin-f1daa80521ec-x86_64-apple-darwin-unsigned.zip
cd99cda53a8fbcc5380333058426055977cd39d3bdc0da571b3f64d293787719  guix-build-f1daa80521ec/output/x86_64-apple-darwin/bitcoin-f1daa80521ec-x86_64-apple-darwin.tar.gz
a6beac93eb8f9516a13ab7451b0c45b2898fd56315a066cc6470ba84226bba27  guix-build-f1daa80521ec/output/x86_64-linux-gnu/SHA256SUMS.part
f50e03971274371ef0ec5710de4879670f75cb29a8eacd5c02f0d622740d026a  guix-build-f1daa80521ec/output/x86_64-linux-gnu/bitcoin-f1daa80521ec-x86_64-linux-gnu-debug.tar.gz
97dcd833014cccaac1b228f438ac49aec94603f0317c606e9344d9709302dbbd  guix-build-f1daa80521ec/output/x86_64-linux-gnu/bitcoin-f1daa80521ec-x86_64-linux-gnu.tar.gz
7c2ea5572f9f137523b88f6a0f1ac711abd6a7ef8aa361ceea35d01e700a3778  guix-build-f1daa80521ec/output/x86_64-w64-mingw32/SHA256SUMS.part
c64d33e04dfc8adfe5a48d6ed17579a69e0b8938e2973bd1810bcaefe5dc9506  guix-build-f1daa80521ec/output/x86_64-w64-mingw32/bitcoin-f1daa80521ec-win64-debug.zip
87d81e11510ffef0082e3be80ce3f8f5e7d9f5c3cdb1dae887d4341cf678af31  guix-build-f1daa80521ec/output/x86_64-w64-mingw32/bitcoin-f1daa80521ec-win64-setup-unsigned.exe
d46887ef5d23fe19ce23dd356dc3a1c03a1164778f78466b4ef415038b42e3eb  guix-build-f1daa80521ec/output/x86_64-w64-mingw32/bitcoin-f1daa80521ec-win64-unsigned.tar.gz
c1a54433d0849548734e8962590e3a33b529665cd610f2ed5acbb1a52c02ae23  guix-build-f1daa80521ec/output/x86_64-w64-mingw32/bitcoin-f1daa80521ec-win64.zip
```