### PR TITLE
depends: fix for llvm-ranlib (etc): 'No such file or directory' macOS 15.0

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -16,6 +16,11 @@ OSX_SDK=$(SDK_PATH)/Xcode-$(XCODE_VERSION)-$(XCODE_BUILD_ID)-extracted-SDK-with-
 clang_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang")
 clangxx_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang++")
 
+# Setting make flags early because xcode does not
+ifeq ($(build_os), darwin)
+	.SHELLFLAGS=-c
+endif
+
 darwin_AR=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ar")
 darwin_DSYMUTIL=$(shell $(SHELL) $(.SHELLFLAGS) "command -v dsymutil")
 darwin_NM=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-nm")


### PR DESCRIPTION
This is an attempt to fix the issue https://github.com/bitcoin/bitcoin/issues/30978 .

To briefly summarize, @Sjors found that while compiling dependencies on macOS 15.0 the following "No such file or directory" are generated while these tools are installed.

```
$ cd depends
$ make
/bin/sh: command -v llvm-ranlib: No such file or directory
/bin/sh: command -v llvm-strip: No such file or directory
/bin/sh: command -v llvm-nm: No such file or directory
/bin/sh: command -v llvm-objdump: No such file or directory
/bin/sh: command -v dsymutil: No such file or directory
```

~~The proposed fix conditionally defines the necessary variables for these tools in the `./depends/Makefile` when building on macOS. The rationale is described in more detail in https://github.com/bitcoin/bitcoin/issues/30978#issuecomment-2379782629 as the Solution number 3.~~

### Update 1:

It turns out that Xcode's make is not setting the flags that Gnu does as @hebasto described in https://github.com/bitcoin/bitcoin/issues/30978#issuecomment-2582535849. So, to avoid any architectural changes in the `depends` directory that may lead to more confusion, the current patch manually sets the required flag in order for the above errors to be resolved. 

cc @hebasto 
