### PR TITLE
doc: update signet documentation related to build directories

### DIFF
--- a/contrib/signet/README.md
+++ b/contrib/signet/README.md
@@ -23,9 +23,8 @@ miner
 
 You will first need to pick a difficulty target. Since signet chains are primarily protected by a signature rather than proof of work, there is no need to spend as much energy as possible mining, however you may wish to choose to spend more time than the absolute minimum. The calibrate subcommand can be used to pick a target appropriate for your hardware, eg:
 
-    cd src/
-    MINER="../contrib/signet/miner"
-    GRIND="./bitcoin-util grind"
+    MINER="./contrib/signet/miner"
+    GRIND="./build/src/bitcoin-util grind"
     $MINER calibrate --grind-cmd="$GRIND"
     nbits=1e00f403 for 25s average mining time
 
@@ -33,7 +32,7 @@ It defaults to estimating an nbits value resulting in 25s average time to find a
 
 To mine the first block in your custom chain, you can run:
 
-    CLI="./bitcoin-cli -conf=mysignet.conf"
+    CLI="./build/src/bitcoin-cli -conf=mysignet.conf"
     ADDR=$($CLI -signet getnewaddress)
     NBITS=1e00f403
     $MINER --cli="$CLI" generate --grind-cmd="$GRIND" --address="$ADDR" --nbits=$NBITS


### PR DESCRIPTION
While setting up my own signet I noticed that the binary paths in the documentation for this is out of date, after build artifacts moved to the `build` directory. This PR mimics what happened in #30741
