### PR TITLE
Cover remaining tinyformat usages in CheckFormatSpecifiers

### DIFF
--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -7,79 +7,79 @@
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 
+#include <limits>
+
 using namespace util;
 
 BOOST_AUTO_TEST_SUITE(util_string_tests)
 
-// Helper to allow compile-time sanity checks while providing the number of
-// args directly. Normally PassFmt<sizeof...(Args)> would be used.
-template <unsigned NumArgs>
-inline void PassFmt(util::ConstevalFormatString<NumArgs> fmt)
+constexpr unsigned INVALID = std::numeric_limits<unsigned>::max();
+
+// Helper to allow compile-time sanity checks
+consteval void ValidFormatSpecifiers(std::string_view str, int num_params)
 {
-    // This was already executed at compile-time, but is executed again at run-time to avoid -Wunused.
-    decltype(fmt)::Detail_CheckNumFormatSpecifiers(fmt.fmt);
-}
-template <unsigned WrongNumArgs>
-inline void FailFmtWithError(std::string_view wrong_fmt, std::string_view error)
-{
-    BOOST_CHECK_EXCEPTION(util::ConstevalFormatString<WrongNumArgs>::Detail_CheckNumFormatSpecifiers(wrong_fmt), const char*, HasReason(error));
+    // Execute compile-time check again at run-time to get code coverage stats
+    CheckFormatSpecifiers(str, num_params);
 }
 
-BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)
+BOOST_AUTO_TEST_CASE(ConstevalFormatString_CompileTimePass)
 {
-    PassFmt<0>("");
-    PassFmt<0>("%%");
-    PassFmt<1>("%s");
-    PassFmt<0>("%%s");
-    PassFmt<0>("s%%");
-    PassFmt<1>("%%%s");
-    PassFmt<1>("%s%%");
-    PassFmt<0>(" 1$s");
-    PassFmt<1>("%1$s");
-    PassFmt<1>("%1$s%1$s");
-    PassFmt<2>("%2$s");
-    PassFmt<2>("%2$s 4$s %2$s");
-    PassFmt<129>("%129$s 999$s %2$s");
-    PassFmt<1>("%02d");
-    PassFmt<1>("%+2s");
-    PassFmt<1>("%.6i");
-    PassFmt<1>("%5.2f");
-    PassFmt<1>("%#x");
-    PassFmt<1>("%1$5i");
-    PassFmt<1>("%1$-5i");
-    PassFmt<1>("%1$.5i");
+    ValidFormatSpecifiers("", 0);
+    ValidFormatSpecifiers("%%", 0);
+    ValidFormatSpecifiers("%s", 1);
+    ValidFormatSpecifiers("%%s", 0);
+    ValidFormatSpecifiers("s%%", 0);
+    ValidFormatSpecifiers("%%%s", 1);
+    ValidFormatSpecifiers("%s%%", 1);
+    ValidFormatSpecifiers(" 1$s", 0);
+    ValidFormatSpecifiers("%1$s", 1);
+    ValidFormatSpecifiers("%1$s%1$s", 1);
+    ValidFormatSpecifiers("%2$s", 2);
+    ValidFormatSpecifiers("%2$s 4$s %2$s", 2);
+    ValidFormatSpecifiers("%129$s 999$s %2$s", 129);
+    ValidFormatSpecifiers("%02d", 1);
+    ValidFormatSpecifiers("%+2s", 1);
+    ValidFormatSpecifiers("%.6i", 1);
+    ValidFormatSpecifiers("%5.2f", 1);
+    ValidFormatSpecifiers("%#x", 1);
+    ValidFormatSpecifiers("%1$5i", 1);
+    ValidFormatSpecifiers("%1$-5i", 1);
+    ValidFormatSpecifiers("%1$.5i", 1);
     // tinyformat accepts almost any "type" spec, even '%', or '_', or '\n'.
-    PassFmt<1>("%123%");
-    PassFmt<1>("%123%s");
-    PassFmt<1>("%_");
-    PassFmt<1>("%\n");
+    ValidFormatSpecifiers("%123%", 1);
+    ValidFormatSpecifiers("%123%s", 1);
+    ValidFormatSpecifiers("%_", 1);
+    ValidFormatSpecifiers("%\n", 1);
 
     // The `*` specifier behavior is unsupported and can lead to runtime
     // errors when used in a ConstevalFormatString. Please refer to the
     // note in the ConstevalFormatString docs.
-    PassFmt<1>("%*c");
-    PassFmt<2>("%2$*3$d");
-    PassFmt<1>("%.*f");
+    ValidFormatSpecifiers("%*c", 1);
+    ValidFormatSpecifiers("%2$*3$d", 2);
+    ValidFormatSpecifiers("%.*f", 1);
+}
 
-    auto err_mix{"Format specifiers must be all positional or all non-positional!"};
-    FailFmtWithError<1>("%s%1$s", err_mix);
+BOOST_AUTO_TEST_CASE(ConstevalFormatString_RuntimeFail)
+{
+    HasReason err_mix{"Format specifiers must be all positional or all non-positional!"};
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%s%1$s", 1), const char*, err_mix);
 
-    auto err_num{"Format specifier count must match the argument count!"};
-    FailFmtWithError<1>("", err_num);
-    FailFmtWithError<0>("%s", err_num);
-    FailFmtWithError<2>("%s", err_num);
-    FailFmtWithError<0>("%1$s", err_num);
-    FailFmtWithError<2>("%1$s", err_num);
+    HasReason err_num{"Format specifier count must match the argument count!"};
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("", 1), const char*, err_num);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%s", 0), const char*, err_num);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%s", 2), const char*, err_num);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$s", 0), const char*, err_num);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$s", 2), const char*, err_num);
 
-    auto err_0_pos{"Positional format specifier must have position of at least 1"};
-    FailFmtWithError<1>("%$s", err_0_pos);
-    FailFmtWithError<1>("%$", err_0_pos);
-    FailFmtWithError<0>("%0$", err_0_pos);
-    FailFmtWithError<0>("%0$s", err_0_pos);
+    HasReason err_0_pos{"Positional format specifier must have position of at least 1"};
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%$s", INVALID), const char*, err_0_pos);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%$", INVALID), const char*, err_0_pos);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%0$", INVALID), const char*, err_0_pos);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%0$s", INVALID), const char*, err_0_pos);
 
-    auto err_term{"Format specifier incorrectly terminated by end of string"};
-    FailFmtWithError<1>("%", err_term);
-    FailFmtWithError<1>("%1$", err_term);
+    HasReason err_term{"Format specifier incorrectly terminated by end of string"};
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%", INVALID), const char*, err_term);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", INVALID), const char*, err_term);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -54,7 +54,6 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_CompileTimePass)
     // The `*` specifier behavior is unsupported and can lead to runtime
     // errors when used in a ConstevalFormatString. Please refer to the
     // note in the ConstevalFormatString docs.
-    ValidFormatSpecifiers("%*c", 1);
     ValidFormatSpecifiers("%2$*3$d", 2);
     ValidFormatSpecifiers("%.*f", 1);
 }
@@ -80,7 +79,18 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_RuntimeFail)
     HasReason err_term{"Format specifier incorrectly terminated by end of string!"};
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%", INVALID), const char*, err_term);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1", INVALID), const char*, err_term);
-    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", 1), const char*, err_term);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", INVALID), const char*, err_term);
+}
+
+BOOST_AUTO_TEST_CASE(ConstevalFormatString_SpecificUsageTests)
+{
+    // Example usages from bitcoin-cli
+    CheckFormatSpecifiers("<->   type   net  v  mping   ping send recv  txn  blk  hb %*s%*s%*s ", 6);
+    CheckFormatSpecifiers("%*s %-*s%s\n", 5);
+    CheckFormatSpecifiers("%3s %6s %5s %2s%7s%7s%5s%5s%5s%5s  %2s %*s%*s%*s%*i %*s %-*s%s\n", 24);
+    CheckFormatSpecifiers("                        ms     ms  sec  sec  min  min                %*s\n\n", 2);
+    CheckFormatSpecifiers("\n%-*s    port %6i    score %6i", 4);
+    CheckFormatSpecifiers("%*s %s\n", 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -80,6 +80,9 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_RuntimeFail)
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%", INVALID), const char*, err_term);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1", INVALID), const char*, err_term);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", INVALID), const char*, err_term);
+
+    HasReason err_n_specifier{"Conversion spec not supported"};
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%n", 0), const char*, err_n_specifier);
 }
 
 BOOST_AUTO_TEST_CASE(ConstevalFormatString_SpecificUsageTests)

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -79,7 +79,8 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_RuntimeFail)
 
     HasReason err_term{"Format specifier incorrectly terminated by end of string!"};
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%", INVALID), const char*, err_term);
-    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", INVALID), const char*, err_term);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1", INVALID), const char*, err_term);
+    BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", 1), const char*, err_term);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -71,13 +71,13 @@ BOOST_AUTO_TEST_CASE(ConstevalFormatString_RuntimeFail)
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$s", 0), const char*, err_num);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$s", 2), const char*, err_num);
 
-    HasReason err_0_pos{"Positional format specifier must have position of at least 1"};
+    HasReason err_0_pos{"Positional format specifier must have position of at least 1!"};
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%$s", INVALID), const char*, err_0_pos);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%$", INVALID), const char*, err_0_pos);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%0$", INVALID), const char*, err_0_pos);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%0$s", INVALID), const char*, err_0_pos);
 
-    HasReason err_term{"Format specifier incorrectly terminated by end of string"};
+    HasReason err_term{"Format specifier incorrectly terminated by end of string!"};
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%", INVALID), const char*, err_term);
     BOOST_CHECK_EXCEPTION(CheckFormatSpecifiers("%1$", INVALID), const char*, err_term);
 }

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -42,7 +42,7 @@ constexpr static void CheckFormatSpecifiers(std::string_view str, unsigned num_p
             continue;
         }
 
-        if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
+        if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string!";
         if (*it == '%') {
             // Percent escape: %%
             ++it;
@@ -58,9 +58,9 @@ constexpr static void CheckFormatSpecifiers(std::string_view str, unsigned num_p
 
         if (*it == '$') {
             // Positional specifier, like %8$s
-            if (maybe_num == 0) throw "Positional format specifier must have position of at least 1";
+            if (maybe_num == 0) throw "Positional format specifier must have position of at least 1!";
             count_pos = std::max(count_pos, maybe_num);
-            if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
+            if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string!";
         } else {
             // Non-positional specifier, like %s
             ++count_normal;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -26,7 +26,7 @@ namespace util {
  * run-time. Validation is partial to try and prevent the most common errors
  * while avoiding re-implementing the entire parsing logic.
  *
- * @note Counting of `*` dynamic width and precision fields (such as `%*c`,
+ * @note Counting of `*` dynamic width and precision fields (such as
  * `%2$*3$d`, `%.*f`) is not implemented to minimize code complexity as long as
  * they are not used in the codebase. Usage of these fields is not counted and
  * can lead to run-time exceptions. Code wanting to use the `*` specifier can
@@ -46,6 +46,11 @@ constexpr static void CheckFormatSpecifiers(std::string_view str, unsigned num_p
         if (*it == '%') {
             // Percent escape: %%
             ++it;
+            continue;
+        }
+        if (*it == '*' || ((*it == '_' || *it == '-') && *std::next(it) == '*')) {
+            count_normal += 2; // width + value
+            it += 2;
             continue;
         }
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -51,9 +51,8 @@ constexpr static void CheckFormatSpecifiers(std::string_view str, unsigned num_p
 
         unsigned maybe_num{0};
         while ('0' <= *it && *it <= '9') {
-            maybe_num *= 10;
-            maybe_num += *it - '0';
-            ++it;
+            maybe_num = maybe_num * 10 + (*it - '0');
+            if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string!";
         };
 
         if (*it == '$') {

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -66,6 +66,7 @@ constexpr static void CheckFormatSpecifiers(std::string_view str, unsigned num_p
             count_pos = std::max(count_pos, maybe_num);
             if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string!";
         } else {
+            if (*it == 'n') throw "Conversion spec not supported";
             // Non-positional specifier, like %s
             ++count_normal;
             ++it;


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/30928#discussion_r1779584565

The current string formatter couldn't validate every string format template that we were using.
Extended it with dynamic widths, fixed a number parsing bug that could go over the string's content and added a `%n` validation.