### PR TITLE
Add waitFeesChanged() to Mining interface

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -75,9 +75,9 @@ public:
      * Waits for fees in the next block to rise, a new tip or the timeout.
      *
      * @param[in] current_tip   block hash that the most recent template builds on
-     * @param[in] fee_threshold how far total fees for the next block should rise (currently ignored)
+     * @param[in] fee_threshold how far total fees for the next block should rise
      * @param[in] options       options for creating the block, should match those
-     *                          passed to createNewBlock (currently ignored)
+     *                          passed to createNewBlock
      *
      * @returns true if fees increased, false if a new tip arrives or the timeout occurs
      */

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -71,6 +71,18 @@ public:
      */
     virtual BlockRef waitTipChanged(uint256 current_tip, MillisecondsDouble timeout = MillisecondsDouble::max()) = 0;
 
+    /**
+     * Waits for fees in the next block to rise, a new tip or the timeout.
+     *
+     * @param[in] current_tip   block hash that the most recent template builds on
+     * @param[in] fee_threshold how far total fees for the next block should rise (currently ignored)
+     * @param[in] options       options for creating the block, should match those
+     *                          passed to createNewBlock (currently ignored)
+     *
+     * @returns true if fees increased, false if a new tip arrives or the timeout occurs
+     */
+    virtual bool waitFeesChanged(uint256 current_tip, CAmount fee_threshold, const node::BlockCreateOptions& options = {}, MillisecondsDouble timeout = MillisecondsDouble::max()) = 0;
+
    /**
      * Construct a new block template
      *

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -17,10 +17,11 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     isInitialBlockDownload @1 (context :Proxy.Context) -> (result: Bool);
     getTip @2 (context :Proxy.Context) -> (result: Common.BlockRef, hasResult: Bool);
     waitTipChanged @3 (context :Proxy.Context, currentTip: Data, timeout: Float64) -> (result: Common.BlockRef);
-    createNewBlock @4 (scriptPubKey: Data, options: BlockCreateOptions) -> (result: BlockTemplate);
-    processNewBlock @5 (context :Proxy.Context, block: Data) -> (newBlock: Bool, result: Bool);
-    getTransactionsUpdated @6 (context :Proxy.Context) -> (result: UInt32);
-    testBlockValidity @7 (context :Proxy.Context, block: Data, checkMerkleRoot: Bool) -> (state: BlockValidationState, result: Bool);
+    waitFeesChanged @4 (context :Proxy.Context, currentTip: Data, feeThreshold: Int64, options: BlockCreateOptions, timeout: Float64) -> (result: Bool);
+    createNewBlock @5 (scriptPubKey: Data, options: BlockCreateOptions) -> (result: BlockTemplate);
+    processNewBlock @6 (context :Proxy.Context, block: Data) -> (newBlock: Bool, result: Bool);
+    getTransactionsUpdated @7 (context :Proxy.Context) -> (result: UInt32);
+    testBlockValidity @8 (context :Proxy.Context, block: Data, checkMerkleRoot: Bool) -> (state: BlockValidationState, result: Bool);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -968,6 +968,9 @@ public:
 
         BlockAssembler::Options assemble_options{options};
         ApplyArgsManOptions(*Assert(m_node.args), assemble_options);
+        // It's not necessary to verify the template, since we don't return it.
+        // This is also faster.
+        assemble_options.test_block_validity = false;
 
         while (!chainman().m_interrupt) {
             now = std::chrono::steady_clock::now();
@@ -977,9 +980,18 @@ public:
                 return false;
             }
 
-            // TODO: when cluster mempool is available, actually calculate
-            // fees for the next block. This is currently too expensive.
-            if (context()->mempool->GetTransactionsUpdated() > last_mempool_update) return true;
+            // Did anything change at all?
+            if (context()->mempool->GetTransactionsUpdated() != last_mempool_update) {
+                auto block_template{BlockAssembler{chainman().ActiveChainstate(), context()->mempool.get(), assemble_options}.CreateNewBlock(CScript())};
+
+                CAmount fees = 0;
+                for (CAmount fee : block_template->vTxFees) {
+                    // Skip coinbase
+                    if (fee < 0) continue;
+                    fees += fee;
+                    if (fees >= fee_threshold) return true;
+                }
+            }
 
             std::this_thread::sleep_until(std::min(deadline, now + tick));
         }


### PR DESCRIPTION
The Stratum v2 protocol allows pushing out templates as fees in the mempool increase. This interface lets us know when it's time to do so.

I split the implementation into two parts because I'm not sure if we should include the second commit now, or wait until cluster mempool #30289 is merged.

The first commit contains a mock implementation very similiar to how longpolling in `getblocktemplate` works. It calls `getTransactionsUpdated` once per second. This returns `true` anytime a transaction is added to the mempool, even if it has no impact on fees in the best block.

The second commit creates a new block template so it can actually measure the fees. It's slightly faster `getNewBlock()` because it skips verification.

On my 2019 Intel MacBook Pro it takes about 20ms to generate a block template. The `waitFeesChanged()` waits 1 second between each `CreateNewBlock` call so as to not burden the node too much. But on (very) low end hardware this may still be problematic.

The second commit does not change the interface, so it could be left out if people prefer that. I'm not sure what performance increase to expect from cluster mempool.

The interface intentionally does not return the resulting template, so that the implementation can be optimized further. Downside is that the caller needs to do another `getNewBlock()`.

The changes here can use to make longpolling `getblocktemplate` more efficient, by only returning the RPC call when template fees actually increased. However this PR does not touch that RPC code.