### PR TITLE
doc: add testnet4 section header for config file

### DIFF
--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -72,8 +72,11 @@ cat >> "${EXAMPLE_CONF_FILE}" << 'EOF'
 # Options for mainnet
 [main]
 
-# Options for testnet
+# Options for testnet3
 [test]
+
+# Options for testnet4
+[testnet4]
 
 # Options for signet
 [signet]

--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -31,7 +31,7 @@ Comments may appear in two ways:
 ### Network specific options
 
 Network specific options can be:
-- placed into sections with headers `[main]` (not `[mainnet]`), `[test]` (not `[testnet]`), `[signet]` or `[regtest]`;
+- placed into sections with headers `[main]` (not `[mainnet]`), `[test]` (not `[testnet]`, for testnet3), `[testnet4]`, `[signet]` or `[regtest]`;
 - prefixed with a chain name; e.g., `regtest.maxmempool=100`.
 
 Network specific options take precedence over non-network specific options.


### PR DESCRIPTION
This PR adds the missing `testnet4` config section header documentation for the config file.