### PR TITLE
depends: Print ready-to-use `--toolchain` option for CMake invocation

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -189,6 +189,7 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 	echo copying packages: $^
 	echo to: $(@D)
 	cd $(@D); $(foreach package,$^, $(build_TAR) xf $($(package)_cached); )
+	echo To build Bitcoin Core with these packages, pass \'--toolchain $(@D)/toolchain.cmake\' to the first CMake invocation.
 	touch $@
 
 ifeq ($(host),$(build))


### PR DESCRIPTION
Requested in https://github.com/bitcoin/bitcoin/pull/30997#issuecomment-2385057317:
> P.S. it would be nice if `make` in `depends` provides the incantation needed for the configure stage.

An example of a build log with this PR:
```
$ make --no-print-directory -C depends -j16 NO_QT=1 NO_WALLET=1 NO_UPNP=1 NO_NATPMP=1 NO_ZMQ=1 NO_USDT=1 LOG=1
Extracting boost...
/home/hebasto/git/bitcoin/depends/sources/boost_1_81_0.tar.gz: OK
Preprocessing boost...
Configuring boost...
Building boost...
Staging boost...
Postprocessing boost...
Caching boost...
Extracting libevent...
/home/hebasto/git/bitcoin/depends/sources/libevent-2.1.12-stable.tar.gz: OK
Preprocessing libevent...
Configuring libevent...
Building libevent...
Staging libevent...
Postprocessing libevent...
Caching libevent...
copying packages: boost libevent
to: /home/hebasto/git/bitcoin/depends/x86_64-pc-linux-gnu
To build Bitcoin Core with these packages, pass '--toolchain /home/hebasto/git/bitcoin/depends/x86_64-pc-linux-gnu/toolchain.cmake' to the first CMake invocation.
```