### PR TITLE
cmake: Avoid hardcoding Qt's major version in Find module / variable names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if(BUILD_GUI)
   if(BUILD_GUI_TESTS)
     list(APPEND qt_components Test)
   endif()
-  find_package(Qt5 5.11.3 MODULE REQUIRED
+  find_package(Qt 5.11.3 MODULE REQUIRED
     COMPONENTS ${qt_components}
   )
   unset(qt_components)

--- a/cmake/module/FindQt.cmake
+++ b/cmake/module/FindQt.cmake
@@ -3,10 +3,10 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 #[=======================================================================[
-FindQt5
--------
+FindQt
+------
 
-Finds the Qt 5 headers and libraries.
+Finds the Qt headers and libraries.
 
 This is a wrapper around find_package() command that:
  - facilitates searching in various build environments
@@ -19,7 +19,7 @@ if(CMAKE_HOST_APPLE)
   find_program(HOMEBREW_EXECUTABLE brew)
   if(HOMEBREW_EXECUTABLE)
     execute_process(
-      COMMAND ${HOMEBREW_EXECUTABLE} --prefix qt@5
+      COMMAND ${HOMEBREW_EXECUTABLE} --prefix qt@${Qt_FIND_VERSION_MAJOR}
       OUTPUT_VARIABLE _qt_homebrew_prefix
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -40,10 +40,10 @@ endif()
 # /usr/x86_64-w64-mingw32/lib/libm.a or /usr/arm-linux-gnueabihf/lib/libm.a.
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 
-find_package(Qt5 ${Qt5_FIND_VERSION}
-  COMPONENTS ${Qt5_FIND_COMPONENTS}
+find_package(Qt${Qt_FIND_VERSION_MAJOR} ${Qt_FIND_VERSION}
+  COMPONENTS ${Qt_FIND_COMPONENTS}
   HINTS ${_qt_homebrew_prefix}
-  PATH_SUFFIXES Qt5  # Required on OpenBSD systems.
+  PATH_SUFFIXES Qt${Qt_FIND_VERSION_MAJOR}  # Required on OpenBSD systems.
 )
 unset(_qt_homebrew_prefix)
 
@@ -56,11 +56,11 @@ else()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Qt5
-  REQUIRED_VARS Qt5_DIR
-  VERSION_VAR Qt5_VERSION
+find_package_handle_standard_args(Qt
+  REQUIRED_VARS Qt${Qt_FIND_VERSION_MAJOR}_DIR
+  VERSION_VAR Qt${Qt_FIND_VERSION_MAJOR}_VERSION
 )
 
-foreach(component IN LISTS Qt5_FIND_COMPONENTS ITEMS "")
-  mark_as_advanced(Qt5${component}_DIR)
+foreach(component IN LISTS Qt_FIND_COMPONENTS ITEMS "")
+  mark_as_advanced(Qt${Qt_FIND_VERSION_MAJOR}${component}_DIR)
 endforeach()


### PR DESCRIPTION
This PR facilitates future migration to Qt 6 and is a prerequisite for https://github.com/bitcoin/bitcoin/pull/30997.

No behaviour change.