### PR TITLE
refactor: move util/pcp and util/netif to common/

### DIFF
--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -194,7 +194,10 @@ cd "$BUILD_DIR/src"
 extract_symbols "$TEMP_DIR"
 if check_libraries "$TEMP_DIR"; then
     echo "Success! No unexpected dependencies were detected."
+    RET=0
 else
     echo >&2 "Error: Unexpected dependencies were detected. Check previous output."
+    RET=1
 fi
 rm -r "$TEMP_DIR"
+exit $RET

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,8 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/init.cpp
   common/interfaces.cpp
   common/messages.cpp
+  common/netif.cpp
+  common/pcp.cpp
   common/run_command.cpp
   common/settings.cpp
   common/signmessage.cpp

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -4,7 +4,7 @@
 
 #include <config/bitcoin-config.h> // IWYU pragma: keep
 
-#include <util/netif.h>
+#include <common/netif.h>
 
 #include <logging.h>
 #include <netbase.h>

--- a/src/common/netif.h
+++ b/src/common/netif.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_NETIF_H
-#define BITCOIN_UTIL_NETIF_H
+#ifndef BITCOIN_COMMON_NETIF_H
+#define BITCOIN_COMMON_NETIF_H
 
 #include <netaddress.h>
 
@@ -16,4 +16,4 @@ std::optional<CNetAddr> QueryDefaultGateway(Network network);
 //! Return all local non-loopback IPv4 and IPv6 network addresses.
 std::vector<CNetAddr> GetLocalAddresses();
 
-#endif // BITCOIN_UTIL_NETIF_H
+#endif // BITCOIN_COMMON_NETIF_H

--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <util/pcp.h>
+#include <common/pcp.h>
 
+#include <common/netif.h>
 #include <crypto/common.h>
 #include <logging.h>
 #include <netaddress.h>
@@ -11,7 +12,6 @@
 #include <random.h>
 #include <span.h>
 #include <util/check.h>
-#include <util/netif.h>
 #include <util/readwritefile.h>
 #include <util/sock.h>
 #include <util/strencodings.h>

--- a/src/common/pcp.h
+++ b/src/common/pcp.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_PCP_H
-#define BITCOIN_UTIL_PCP_H
+#ifndef BITCOIN_COMMON_PCP_H
+#define BITCOIN_COMMON_PCP_H
 
 #include <netaddress.h>
 
@@ -65,4 +65,4 @@ std::variant<MappingResult, MappingError> NATPMPRequestPortMap(const CNetAddr &g
 //! Returns the external_ip:external_port of the mapping if successful, otherwise a MappingError.
 std::variant<MappingResult, MappingError> PCPRequestPortMap(const PCPMappingNonce &nonce, const CNetAddr &gateway, const CNetAddr &bind, uint16_t port, uint32_t lifetime, int num_tries = 3, std::chrono::milliseconds timeout_per_try = std::chrono::milliseconds(1000));
 
-#endif // BITCOIN_UTIL_PCP_H
+#endif // BITCOIN_COMMON_PCP_H

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -7,14 +7,14 @@
 #include <mapport.h>
 
 #include <clientversion.h>
+#include <common/netif.h>
+#include <common/pcp.h>
 #include <common/system.h>
 #include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <random.h>
-#include <util/netif.h>
-#include <util/pcp.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -12,6 +12,7 @@
 #include <banman.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/netif.h>
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
@@ -28,7 +29,6 @@
 #include <random.h>
 #include <scheduler.h>
 #include <util/fs.h>
-#include <util/netif.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/thread.h>

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,8 +15,6 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs_helpers.cpp
   hasher.cpp
   moneystr.cpp
-  netif.cpp
-  pcp.cpp
   rbf.cpp
   readwritefile.cpp
   serfloat.cpp


### PR DESCRIPTION
Move util/pcp.cpp and util/netif.cpp to common/ because they depend on netaddress.cpp which is part of the common library. This was causing check-deps.sh script to fail as reported by _fanquake_ in https://github.com/bitcoin/bitcoin/pull/30415#issuecomment-2385475097.

Also make CI fail when the `check-deps.sh` script fails. Previously it would output errors but not cause the job to fail (which was not intended).