### PR TITLE
build: have "make test" depend on "make all"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,12 @@ endif()
 if(BUILD_TESTS)
   enable_testing()
 endif()
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+  # have "make test" depend on "make all"
+  set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
+endif()
+
 # TODO: The `CMAKE_SKIP_BUILD_RPATH` variable setting can be deleted
 #       in the future after reordering Guix script commands to
 #       perform binary checks after the installation step.


### PR DESCRIPTION
See [Upstream docs](https://cmake.org/cmake/help/latest/variable/CMAKE_SKIP_TEST_ALL_DEPENDENCY.html) for specifics.

Unfortunately, this **seems to have no effect when directly executing `ctest`** :(

This brings the test -> hack -> test cycle more inline with how it worked with autotools.

With `CMAKE_SKIP_TEST_ALL_DEPENDENCY` set to FALSE, `make test` will trigger a rebuild, ensuring that test binaries are current before running them.

To test:
```
cmake -S . -B build
make -C build -j24
touch src/primitives/transaction.cpp
make -C build test ARGS=-j24
```

Without this commit, the above will not rebuild before running tests.