### PR TITLE
fuzz: Add fuzz-only build mode option for targets

### DIFF
--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -133,7 +133,7 @@ void initialize()
 }
 } // namespace
 
-FUZZ_TARGET(p2p_headers_presync, .init = initialize)
+FUZZ_TARGET(p2p_headers_presync, .init = initialize, .require_build_for_fuzzing = true)
 {
     ChainstateManager& chainman = *g_testing_setup->m_node.chainman;
 


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bitcoin/issues/30950.

Any targets that require BUILD_ON_FUZZING=ON (currently only `p2p_headers_presync`) to work properly can now set `require_build_for_fuzzing` as an option. If BUILD_FOR_FUZZING is not on and you try to run a target that has this option, then there's a message printed upon exit.

With this change, the CI will be able to run the fuzz test runner without any timeouts/failures.




