### PR TITLE
doc: clarify 'filename' argument in 'loadwallet' RPC

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -216,11 +216,15 @@ static RPCHelpMan listwallets()
 static RPCHelpMan loadwallet()
 {
     return RPCHelpMan{"loadwallet",
-                "\nLoads a wallet from a wallet file or directory."
-                "\nNote that all wallet command-line options used when starting bitcoind will be"
-                "\napplied to the new wallet.\n",
-                {
-                    {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet directory or .dat file."},
+               "\nLoads a wallet from a wallet file or directory.\n"
+               "\nThe 'filename' should be specified as a path relative to the wallets directory (e.g., `~/.bitcoin/wallets`).\n"
+               "\nExamples:\n"
+               "  Load a wallet named 'mywallet':\n"
+               "    bitcoin-cli loadwallet \"mywallet\"\n"
+               "  Load a wallet from a subdirectory:\n"
+               "    bitcoin-cli loadwallet \"subdir/mywallet\"\n",
+               {
+                    {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The **relative** path to the wallet directory or .dat file."},
                     {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
                 },
                 RPCResult{


### PR DESCRIPTION
Update the 'loadwallet' RPC help text to specify that the 'filename' should be provided as a path relative to the wallets directory. Add examples showing how to load a wallet from a different directory.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
