### PR TITLE
test: Fix copy-paste in wallet/test/db_tests ostream operator

### DIFF
--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -28,7 +28,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<const Serializ
 {
     Span key{kv.first}, value{kv.second};
     os << "(\"" << std::string_view{reinterpret_cast<const char*>(key.data()), key.size()} << "\", \""
-       << std::string_view{reinterpret_cast<const char*>(key.data()), key.size()} << "\")";
+       << std::string_view{reinterpret_cast<const char*>(value.data()), value.size()} << "\")";
     return os;
 }
 


### PR DESCRIPTION
Fix accidentally remaining copy-pasted variable name.

Example output when intentionally adding `expected.erase(expected.begin());` before `BOOST_CHECK_EQUAL_COLLECTIONS` in *db_tests.cpp*/`CheckPrefix`:

Before fix:
```
src/wallet/test/db_tests.cpp(61): error: in "db_tests/db_cursor_prefix_byte_test": check { actual.begin(), actual.end() } == { expected.begin(), expected.end() } has failed. 
Mismatch at position 0: ("�", "�") != ("�suffix", "�suffix")
Mismatch at position 1: ("�suffix", "�suffix") != ("��", "��")
Mismatch at position 2: ("��", "��") != ("��suffix", "��suffix")
Collections size mismatch: 4 != 3
```

After fix:
```
src/wallet/test/db_tests.cpp(61): error: in "db_tests/db_cursor_prefix_byte_test": check { actual.begin(), actual.end() } == { expected.begin(), expected.end() } has failed. 
Mismatch at position 0: ("�", "f") != ("�suffix", "fs")
Mismatch at position 1: ("�suffix", "fs") != ("��", "ff")
Mismatch at position 2: ("��", "ff") != ("��suffix", "ffs")
Collections size mismatch: 4 != 3
```

Super-minor issue only uncovered when tests fail, but might as well correct it.