### PR TITLE
test: Assert that when we add the max orphan amount that we cannot add anymore and that a random orphan gets dropped

### DIFF
--- a/test/functional/rpc_getorphantxs.py
+++ b/test/functional/rpc_getorphantxs.py
@@ -125,6 +125,5 @@ class GetOrphanTxsTest(BitcoinTestFramework):
             self.log.info("Check the transaction hex of orphan")
             assert_equal(orphan["hex"], tx["hex"])
 
-
 if __name__ == '__main__':
     GetOrphanTxsTest(__file__).main()


### PR DESCRIPTION
After joining the bitcoin pr review club about https://github.com/bitcoin/bitcoin/pull/30793

I learned about [`CVE-2012-3789`](https://github.com/bitcoin/bitcoin/blob/master/src/net_processing.cpp#L4693)

So I was motivated to write a functional test that covers this part of the code,

This test should add the max number of orphans to a nodes orphanage and then attempt to add another, then asserts that the number of orphans is still at the max amount