### PR TITLE
refactor: include the proper header rather than forward-declaring RemovalReasonToString

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <kernel/chain.h>
 #include <kernel/mempool_entry.h>
+#include <kernel/mempool_removal_reason.h>
 #include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -18,8 +19,6 @@
 #include <future>
 #include <unordered_map>
 #include <utility>
-
-std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
 
 /**
  * ValidationSignalsImpl manages a list of shared_ptr<CValidationInterface> callbacks.


### PR DESCRIPTION
Trivial no-op fixup.

This was pointed out by #31053, which causes the include order to be shuffled around:

```
[21:49:26.130] /ci_container_base/src/validationinterface.cpp:22:13: error: redundant 'RemovalReasonToString' declaration [readability-redundant-declaration,-warnings-as-errors]
[21:49:26.130]    22 | std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
[21:49:26.130]       | ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[21:49:26.130] /ci_container_base/src/kernel/mempool_removal_reason.h:22:13: note: previously declared here
[21:49:26.130]    22 | std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
[21:49:26.130]       |             ^
```


I don't see any reason why the include shouldn't just be used.