### PR TITLE
build: Disallow building fuzz binary without -DBUILD_FOR_FUZZING

### DIFF
--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -145,3 +145,11 @@ target_link_libraries(fuzz
 if(ENABLE_WALLET)
   add_subdirectory(${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz wallet)
 endif()
+
+if(BUILD_FOR_FUZZING)
+    # List of fuzz targets
+    add_fuzz_test(p2p_message ...)
+    # Other fuzz targets
+else()
+    message(FATAL_ERROR "Fuzz binaries require BUILD_FOR_FUZZING=ON")
+endif()


### PR DESCRIPTION
This pull request addresses [issue #31057](https://github.com/bitcoin/bitcoin/issues/31057).

Build System:
  - Modified `CMakeLists.txt` to prevent building the fuzz binary unless `BUILD_FOR_FUZZING` is enabled.
  - Added a fatal error message if an attempt is made to build the fuzz binary without `BUILD_FOR_FUZZING`.

Building the fuzz binary without `-DBUILD_FOR_FUZZING` results in a binary that is less effective for testing because it won't crash on `Assume` statements and won't bypass fuzz blockers with `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`.

By enforcing `-DBUILD_FOR_FUZZING`, we ensure that:

- The fuzz binary is correctly configured for fuzz testing.
- Compile failures are caught early in the CI on all platforms.
- Workarounds like #31028 are no longer necessary.

