### PR TITLE
lint: commit-script-check.sh: echo to stderr

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -35,20 +35,20 @@ for commit in $(git rev-list --reverse "$1"); do
         git checkout --quiet "$commit"^ || exit
         SCRIPT="$(git rev-list --format=%b -n1 "$commit" | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
         if test -z "$SCRIPT"; then
-            echo "Error: missing script for: $commit"
-            echo "Failed"
+            echo "Error: missing script for: $commit" >&2
+            echo "Failed" >&2
             RET=1
         else
-            echo "Running script for: $commit"
-            echo "$SCRIPT"
+            echo "Running script for: $commit" >&2
+            echo "$SCRIPT" >&2
             (eval "$SCRIPT")
-            git --no-pager diff --exit-code "$commit" && echo "OK" || (echo "Failed"; false) || RET=1
+            git --no-pager diff --exit-code "$commit" && echo "OK" >&2 || (echo "Failed" >&2; false) || RET=1
         fi
         git reset --quiet --hard HEAD
      else
         if git rev-list "--format=%b" -n1 "$commit" | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
-            echo "Error: script block marker but no scripted-diff in title of commit $commit"
-            echo "Failed"
+            echo "Error: script block marker but no scripted-diff in title of commit $commit" >&2
+            echo "Failed" >&2
             RET=1
         fi
     fi


### PR DESCRIPTION
This makes it easier to redirect the produced `git diff` on failure. On success, it shouldn't hurt, because the same output is still present, just on stderr.

Can be tested by introducing a fault in any scripted diff and then calling `commit-script-check.sh HEAD~..HEAD > any_file.txt`. Previously the file contained the full output, now it contains just the diff.