### PR TITLE
rest: Support transaction broadcast in REST interface

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -36,6 +36,12 @@ Responds with 404 if the transaction doesn't exist.
 By default, this endpoint will only search the mempool.
 To query for a confirmed transaction, enable the transaction index via "txindex=1" command line / configuration option.
 
+`POST /rest/broadcast.hex`
+
+Broadcasts a transaction.
+The transaction hex must be passed in the body of the request.
+Returns the txid if the transaction was broadcasted correctly, responds with 400 if the transaction hex can't be parsed or if broadcasting failed.
+
 #### Blocks
 - `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 - `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`

--- a/doc/release-notes-31065.md
+++ b/doc/release-notes-31065.md
@@ -1,0 +1,4 @@
+Updated REST APIs
+-----------------------
+
+- A new `/rest/broadcast/` endpoint has been added to allow broadcasting a transaction from the REST interface. (#31065)

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -33,9 +33,9 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
 
 TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
-    // BroadcastTransaction can be called by RPC or by the wallet.
-    // chainman, mempool and peerman are initialized before the RPC server and wallet are started
-    // and reset after the RPC sever and wallet are stopped.
+    // BroadcastTransaction can be called by RPC, REST, or by the wallet.
+    // chainman, mempool and peerman are initialized before the RPC/REST servers and wallet are started
+    // and reset after the RPC/REST servers and wallet are stopped.
     assert(node.chainman);
     assert(node.mempool);
     assert(node.peerman);


### PR DESCRIPTION
This adds a REST endpoint to allow broadcasting a transaction:
`POST /rest/broadcast.hex`

This would make it possible to build electrum indexers that access
the REST interface only, eliminating the need of accessing the RPC interface.
This would improve UX (no need to authenticate) and security
(only a small subset of methods are available from the REST interface).
See also https://github.com/bitcoin/bitcoin/pull/31065#issuecomment-2417141803

The transaction hex must be passed in the body of the request;
on success, the txid of the broadcasted transaction will be returned.

Fixes #31017