### PR TITLE
test: Print CompletedProcess object on error

### DIFF
--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -83,13 +83,11 @@ def bctest(testDir, testObj, buildenv):
     execrun = [execprog] + execargs
 
     # Read the input data (if there is any)
-    stdinCfg = None
     inputData = None
     if "input" in testObj:
         filename = os.path.join(testDir, testObj["input"])
         with open(filename, encoding="utf8") as f:
             inputData = f.read()
-        stdinCfg = subprocess.PIPE
 
     # Read the expected output data (if there is any)
     outputFn = None
@@ -112,9 +110,8 @@ def bctest(testDir, testObj, buildenv):
             raise Exception
 
     # Run the test
-    proc = subprocess.Popen(execrun, stdin=stdinCfg, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     try:
-        outs = proc.communicate(input=inputData)
+        res = subprocess.run(execrun, capture_output=True, text=True, input=inputData)
     except OSError:
         logging.error("OSError, Failed to execute " + execprog)
         raise
@@ -123,9 +120,9 @@ def bctest(testDir, testObj, buildenv):
         data_mismatch, formatting_mismatch = False, False
         # Parse command output and expected output
         try:
-            a_parsed = parse_output(outs[0], outputType)
+            a_parsed = parse_output(res.stdout, outputType)
         except Exception as e:
-            logging.error('Error parsing command output as %s: %s' % (outputType, e))
+            logging.error(f"Error parsing command output as {outputType}: '{str(e)}'; res: {str(res)}")
             raise
         try:
             b_parsed = parse_output(outputData, outputType)
@@ -134,13 +131,13 @@ def bctest(testDir, testObj, buildenv):
             raise
         # Compare data
         if a_parsed != b_parsed:
-            logging.error("Output data mismatch for " + outputFn + " (format " + outputType + ")")
+            logging.error(f"Output data mismatch for {outputFn} (format {outputType}); res: {str(res)}")
             data_mismatch = True
         # Compare formatting
-        if outs[0] != outputData:
-            error_message = "Output formatting mismatch for " + outputFn + ":\n"
+        if res.stdout != outputData:
+            error_message = f"Output formatting mismatch for {outputFn}:\nres: {str(res)}\n"
             error_message += "".join(difflib.context_diff(outputData.splitlines(True),
-                                                          outs[0].splitlines(True),
+                                                          res.stdout.splitlines(True),
                                                           fromfile=outputFn,
                                                           tofile="returned"))
             logging.error(error_message)
@@ -152,8 +149,8 @@ def bctest(testDir, testObj, buildenv):
     wantRC = 0
     if "return_code" in testObj:
         wantRC = testObj['return_code']
-    if proc.returncode != wantRC:
-        logging.error("Return code mismatch for " + outputFn)
+    if res.returncode != wantRC:
+        logging.error(f"Return code mismatch for {outputFn}; res: {str(res)}")
         raise Exception
 
     if "error_txt" in testObj:
@@ -164,8 +161,8 @@ def bctest(testDir, testObj, buildenv):
         # emits DISPLAY errors when running as a windows application on
         # linux through wine. Just assert that the expected error text appears
         # somewhere in stderr.
-        if want_error not in outs[1]:
-            logging.error("Error mismatch:\n" + "Expected: " + want_error + "\nReceived: " + outs[1].rstrip())
+        if want_error not in res.stderr:
+            logging.error(f"Error mismatch:\nExpected: {want_error}\nReceived: {res.stderr.rstrip()}\nres: {str(res)}")
             raise Exception
 
 def parse_output(a, fmt):


### PR DESCRIPTION
It would be good to know the output on `Error parsing command output`. Otherwise test failures are meaningless: https://github.com/bitcoin/bitcoin/issues/30792#issuecomment-2325911157

Fix it by just printing the full `CompletedProcess` object.

Also, use the modern `subprocess.run` to simplify the code.