### PR TITLE
util: Check bilingual_str format strings at compile time

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -207,14 +207,14 @@ util::Result<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgro
         DumpPeerAddresses(args, *addrman);
     } catch (const InvalidAddrManVersionError&) {
         if (!RenameOver(path_addr, (fs::path)path_addr + ".bak")) {
-            return util::Error{strprintf(_("Failed to rename invalid peers.dat file. Please move or delete it and try again."))};
+            return util::Error{strprintf(_<"Failed to rename invalid peers.dat file. Please move or delete it and try again.">())};
         }
         // Addrman can be in an inconsistent state after failure, reset it
         addrman = std::make_unique<AddrMan>(netgroupman, deterministic, /*consistency_check_ratio=*/check_addrman);
         LogPrintf("Creating new peers.dat because the file version was not compatible (%s). Original backed up to peers.dat.bak\n", fs::quoted(fs::PathToString(path_addr)));
         DumpPeerAddresses(args, *addrman);
     } catch (const std::exception& e) {
-        return util::Error{strprintf(_("Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start."),
+        return util::Error{strprintf(_<"Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.">(),
                                      e.what(), PACKAGE_BUGREPORT, fs::quoted(fs::PathToString(path_addr)))};
     }
     return addrman;

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -71,7 +71,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 
 std::string CopyrightHolders(const std::string& strPrefix)
 {
-    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION);
+    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
     std::string strCopyrightHolders = strPrefix + copyright_devs;
 
     // Make sure Bitcoin Core copyright is not removed by accident
@@ -85,15 +85,17 @@ std::string LicenseInfo()
 {
     const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
 
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
+    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
            "\n" +
            strprintf(_("Please contribute if you find %s useful. "
-                       "Visit %s for further information about the software.").translated, PACKAGE_NAME, "<" PACKAGE_URL ">") +
+                       "Visit %s for further information about the software."),
+                     PACKAGE_NAME, "<" PACKAGE_URL ">")
+               .translated +
            "\n" +
-           strprintf(_("The source code is available from %s.").translated, URL_SOURCE_CODE) +
+           strprintf(_("The source code is available from %s."), URL_SOURCE_CODE).translated +
            "\n" +
            "\n" +
            _("This is experimental software.").translated + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s").translated, "COPYING", "<https://opensource.org/licenses/MIT>") +
+           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/licenses/MIT>").translated +
            "\n";
 }

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -71,7 +71,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 
 std::string CopyrightHolders(const std::string& strPrefix)
 {
-    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
+    const auto copyright_devs = strprintf(_<COPYRIGHT_HOLDERS>(), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
     std::string strCopyrightHolders = strPrefix + copyright_devs;
 
     // Make sure Bitcoin Core copyright is not removed by accident
@@ -85,17 +85,17 @@ std::string LicenseInfo()
 {
     const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
 
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
+    return CopyrightHolders(strprintf(_<"Copyright (C) %i-%i">(), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
            "\n" +
-           strprintf(_("Please contribute if you find %s useful. "
-                       "Visit %s for further information about the software."),
+           strprintf(_<"Please contribute if you find %s useful. "
+                       "Visit %s for further information about the software.">(),
                      PACKAGE_NAME, "<" PACKAGE_URL ">")
                .translated +
            "\n" +
-           strprintf(_("The source code is available from %s."), URL_SOURCE_CODE).translated +
+           strprintf(_<"The source code is available from %s.">(), URL_SOURCE_CODE).translated +
            "\n" +
            "\n" +
            _("This is experimental software.").translated + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/licenses/MIT>").translated +
+           strprintf(_<"Distributed under the MIT software license, see the accompanying file %s or %s">(), "COPYING", "<https://opensource.org/licenses/MIT>").translated +
            "\n";
 }

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -19,7 +19,7 @@ std::optional<ConfigError> InitConfig(ArgsManager& args, SettingsAbortFn setting
 {
     try {
         if (!CheckDataDirOption(args)) {
-            return ConfigError{ConfigStatus::FAILED, strprintf(_("Specified data directory \"%s\" does not exist."), args.GetArg("-datadir", ""))};
+            return ConfigError{ConfigStatus::FAILED, strprintf(_<"Specified data directory \"%s\" does not exist.">(), args.GetArg("-datadir", ""))};
         }
 
         // Record original datadir and config paths before parsing the config
@@ -36,7 +36,7 @@ std::optional<ConfigError> InitConfig(ArgsManager& args, SettingsAbortFn setting
 
         std::string error;
         if (!args.ReadConfigFiles(error, true)) {
-            return ConfigError{ConfigStatus::FAILED, strprintf(_("Error reading configuration file: %s"), error)};
+            return ConfigError{ConfigStatus::FAILED, strprintf(_<"Error reading configuration file: %s">(), error)};
         }
 
         // Check for chain settings (Params() calls are only valid after this clause)

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -147,21 +147,21 @@ bilingual_str TransactionErrorString(const TransactionError err)
 
 bilingual_str ResolveErrMsg(const std::string& optname, const std::string& strBind)
 {
-    return strprintf(_("Cannot resolve -%s address: '%s'"), optname, strBind);
+    return strprintf(_<"Cannot resolve -%s address: '%s'">(), optname, strBind);
 }
 
 bilingual_str InvalidPortErrMsg(const std::string& optname, const std::string& invalid_value)
 {
-    return strprintf(_("Invalid port specified in %s: '%s'"), optname, invalid_value);
+    return strprintf(_<"Invalid port specified in %s: '%s'">(), optname, invalid_value);
 }
 
 bilingual_str AmountHighWarn(const std::string& optname)
 {
-    return strprintf(_("%s is set very high!"), optname);
+    return strprintf(_<"%s is set very high!">(), optname);
 }
 
 bilingual_str AmountErrMsg(const std::string& optname, const std::string& strValue)
 {
-    return strprintf(_("Invalid amount for -%s=<amount>: '%s'"), optname, strValue);
+    return strprintf(_<"Invalid amount for -%s=<amount>: '%s'">(), optname, strValue);
 }
 } // namespace common

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -229,7 +229,7 @@ static bool InitHTTPAllowList()
         const CSubNet subnet{LookupSubNet(strAllow)};
         if (!subnet.IsValid()) {
             uiInterface.ThreadSafeMessageBox(
-                strprintf(Untranslated("Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24)."), strAllow),
+                strprintf(Untranslated<"Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).">(), strAllow),
                 "", CClientUIInterface::MSG_ERROR);
             return false;
         }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -106,7 +106,7 @@ bool BaseIndex::Init()
         // best chain, we will rewind to the fork point during index sync
         const CBlockIndex* locator_index{m_chainstate->m_blockman.LookupBlockIndex(locator.vHave.at(0))};
         if (!locator_index) {
-            return InitError(strprintf(Untranslated("%s: best block of the index not found. Please rebuild the index."), GetName()));
+            return InitError(strprintf(Untranslated<"%s: best block of the index not found. Please rebuild the index.">(), GetName()));
         }
         SetBestBlockIndex(locator_index);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -894,7 +894,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
     bilingual_str errors;
     for (const auto& arg : args.GetUnsuitableSectionOnlyArgs()) {
-        errors += strprintf(_("Config setting for %s only applied on %s network when in [%s] section.") + Untranslated("\n"), arg, ChainTypeToString(chain), ChainTypeToString(chain));
+        errors += strprintf(_("Config setting for %s only applied on %s network when in [%s] section."), arg, ChainTypeToString(chain), ChainTypeToString(chain)) + Untranslated("\n");
     }
 
     if (!errors.empty()) {
@@ -909,7 +909,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Warn if unrecognized section name are present in the config file.
     bilingual_str warnings;
     for (const auto& section : args.GetUnrecognizedSections()) {
-        warnings += strprintf(Untranslated("%s:%i ") + _("Section [%s] is not recognized.") + Untranslated("\n"), section.m_file, section.m_line, section.m_name);
+        warnings += Untranslated(strprintf("%s:%i ", section.m_file, section.m_line)) + strprintf(_("Section [%s] is not recognized."), section.m_name) + Untranslated("\n");
     }
 
     if (!warnings.empty()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -185,7 +185,7 @@ static fs::path GetPidFile(const ArgsManager& args)
         g_generated_pid = true;
         return true;
     } else {
-        return InitError(strprintf(_("Unable to create the PID file '%s': %s"), fs::PathToString(GetPidFile(args)), SysErrorString(errno)));
+        return InitError(strprintf(_<"Unable to create the PID file '%s': %s">(), fs::PathToString(GetPidFile(args)), SysErrorString(errno)));
     }
 }
 
@@ -894,7 +894,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
     bilingual_str errors;
     for (const auto& arg : args.GetUnsuitableSectionOnlyArgs()) {
-        errors += strprintf(_("Config setting for %s only applied on %s network when in [%s] section."), arg, ChainTypeToString(chain), ChainTypeToString(chain)) + Untranslated("\n");
+        errors += strprintf(_<"Config setting for %s only applied on %s network when in [%s] section.">(), arg, ChainTypeToString(chain), ChainTypeToString(chain)) + Untranslated("\n");
     }
 
     if (!errors.empty()) {
@@ -909,7 +909,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Warn if unrecognized section name are present in the config file.
     bilingual_str warnings;
     for (const auto& section : args.GetUnrecognizedSections()) {
-        warnings += Untranslated(strprintf("%s:%i ", section.m_file, section.m_line)) + strprintf(_("Section [%s] is not recognized."), section.m_name) + Untranslated("\n");
+        warnings += Untranslated(strprintf("%s:%i ", section.m_file, section.m_line)) + strprintf(_<"Section [%s] is not recognized.">(), section.m_name) + Untranslated("\n");
     }
 
     if (!warnings.empty()) {
@@ -917,7 +917,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     if (!fs::is_directory(args.GetBlocksDirPath())) {
-        return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist."), args.GetArg("-blocksdir", "")));
+        return InitError(strprintf(_<"Specified blocks directory \"%s\" does not exist.">(), args.GetArg("-blocksdir", "")));
     }
 
     // parse and validate enabled filter types
@@ -929,7 +929,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         for (const auto& name : names) {
             BlockFilterType filter_type;
             if (!BlockFilterTypeByName(name, filter_type)) {
-                return InitError(strprintf(_("Unknown -blockfilterindex value %s."), name));
+                return InitError(strprintf(_<"Unknown -blockfilterindex value %s.">(), name));
             }
             g_enabled_filter_types.insert(filter_type);
         }
@@ -993,13 +993,13 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     available_fds = std::min(FD_SETSIZE, available_fds);
 #endif
     if (available_fds < min_required_fds)
-        return InitError(strprintf(_("Not enough file descriptors available. %d available, %d required."), available_fds, min_required_fds));
+        return InitError(strprintf(_<"Not enough file descriptors available. %d available, %d required.">(), available_fds, min_required_fds));
 
     // Trim requested connection counts, to fit into system limitations
     nMaxConnections = std::min(available_fds - min_required_fds, user_max_connection);
 
     if (nMaxConnections < user_max_connection)
-        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."), user_max_connection, nMaxConnections));
+        InitWarning(strprintf(_<"Reducing -maxconnections from %d to %d, because of system limitations.">(), user_max_connection, nMaxConnections));
 
     // ********************************************************* Step 3: parameter-to-internal-flags
     if (auto result{init::SetLoggingCategories(args)}; !result) return InitError(util::ErrorString(result));
@@ -1044,7 +1044,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
                 return (pos != std::string::npos) && (doc_option.substr(0, pos) == option);
             });
             if (it == TEST_OPTIONS_DOC.end()) {
-                InitWarning(strprintf(_("Unrecognised option \"%s\" provided in -test=<option>."), option));
+                InitWarning(strprintf(_<"Unrecognised option \"%s\" provided in -test=<option>.">(), option));
             }
         }
     }
@@ -1088,9 +1088,9 @@ static bool LockDataDirectory(bool probeOnly)
     const fs::path& datadir = gArgs.GetDataDirNet();
     switch (util::LockDirectory(datadir, ".lock", probeOnly)) {
     case util::LockResult::ErrorWrite:
-        return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), fs::PathToString(datadir)));
+        return InitError(strprintf(_<"Cannot write to data directory '%s'; check permissions.">(), fs::PathToString(datadir)));
     case util::LockResult::ErrorLock:
-        return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), fs::PathToString(datadir), PACKAGE_NAME));
+        return InitError(strprintf(_<"Cannot obtain a lock on data directory %s. %s is probably already running.">(), fs::PathToString(datadir), PACKAGE_NAME));
     case util::LockResult::Success: return true;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
@@ -1102,11 +1102,11 @@ bool AppInitSanityChecks(const kernel::Context& kernel)
     auto result{kernel::SanityChecks(kernel)};
     if (!result) {
         InitError(util::ErrorString(result));
-        return InitError(strprintf(_("Initialization sanity check failed. %s is shutting down."), PACKAGE_NAME));
+        return InitError(strprintf(_<"Initialization sanity check failed. %s is shutting down.">(), PACKAGE_NAME));
     }
 
     if (!ECC_InitSanityCheck()) {
-        return InitError(strprintf(_("Elliptic curve cryptography sanity check failure. %s is shutting down."), PACKAGE_NAME));
+        return InitError(strprintf(_<"Elliptic curve cryptography sanity check failure. %s is shutting down.">(), PACKAGE_NAME));
     }
 
     // Probe the data directory lock to give an early error message, if possible
@@ -1218,7 +1218,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     try {
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown), chainman_opts, blockman_opts);
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, strprintf(Untranslated("Failed to initialize ChainstateManager: %s"), e.what())};
+        return {ChainstateLoadStatus::FAILURE_FATAL, strprintf(Untranslated<"Failed to initialize ChainstateManager: %s">(), e.what())};
     }
     ChainstateManager& chainman = *node.chainman;
     // This is defined and set here instead of inline in validation.h to avoid a hard
@@ -1286,7 +1286,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     auto opt_max_upload = ParseByteUnits(args.GetArg("-maxuploadtarget", DEFAULT_MAX_UPLOAD_TARGET), ByteUnit::M);
     if (!opt_max_upload) {
-        return InitError(strprintf(_("Unable to parse -maxuploadtarget: '%s'"), args.GetArg("-maxuploadtarget", "")));
+        return InitError(strprintf(_<"Unable to parse -maxuploadtarget: '%s'">(), args.GetArg("-maxuploadtarget", "")));
     }
 
     // ********************************************************* Step 4a: application initialization
@@ -1349,7 +1349,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             try {
                 ipc->listenAddress(address);
             } catch (const std::exception& e) {
-                return InitError(strprintf(Untranslated("Unable to bind to IPC address '%s'. %s"), address, e.what()));
+                return InitError(strprintf(Untranslated<"Unable to bind to IPC address '%s'. %s">(), address, e.what()));
             }
             LogPrintf("Listening for IPC requests on address %s\n", address);
         }
@@ -1409,12 +1409,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 asmap_path = args.GetDataDirNet() / asmap_path;
             }
             if (!fs::exists(asmap_path)) {
-                InitError(strprintf(_("Could not find asmap file %s"), fs::quoted(fs::PathToString(asmap_path))));
+                InitError(strprintf(_<"Could not find asmap file %s">(), fs::quoted(fs::PathToString(asmap_path))));
                 return false;
             }
             asmap = DecodeAsmap(asmap_path);
             if (asmap.size() == 0) {
-                InitError(strprintf(_("Could not parse asmap file %s"), fs::quoted(fs::PathToString(asmap_path))));
+                InitError(strprintf(_<"Could not parse asmap file %s">(), fs::quoted(fs::PathToString(asmap_path))));
                 return false;
             }
             const uint256 asmap_version = (HashWriter{} << asmap).GetHash();
@@ -1449,7 +1449,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (!peerman_opts.ignore_incoming_txs) {
         bool read_stale_estimates = args.GetBoolArg("-acceptstalefeeestimates", DEFAULT_ACCEPT_STALE_FEE_ESTIMATES);
         if (read_stale_estimates && (chainparams.GetChainType() != ChainType::REGTEST)) {
-            return InitError(strprintf(_("acceptstalefeeestimates is not supported on %s chain."), chainparams.GetChainTypeString()));
+            return InitError(strprintf(_<"acceptstalefeeestimates is not supported on %s chain.">(), chainparams.GetChainTypeString()));
         }
         node.fee_estimator = std::make_unique<CBlockPolicyEstimator>(FeeestPath(args), read_stale_estimates);
 
@@ -1472,12 +1472,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     std::vector<std::string> uacomments;
     for (const std::string& cmt : args.GetArgs("-uacomment")) {
         if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
-            return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
+            return InitError(strprintf(_<"User Agent comment (%s) contains unsafe characters.">(), cmt));
         uacomments.push_back(cmt);
     }
     strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
     if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
-        return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
+        return InitError(strprintf(_<"Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.">(),
             strSubVersion.size(), MAX_SUBVERSION_LENGTH));
     }
 
@@ -1486,7 +1486,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         for (const std::string& snet : args.GetArgs("-onlynet")) {
             enum Network net = ParseNetwork(snet);
             if (net == NET_UNROUTABLE)
-                return InitError(strprintf(_("Unknown network specified in -onlynet: '%s'"), snet));
+                return InitError(strprintf(_<"Unknown network specified in -onlynet: '%s'">(), snet));
             g_reachable_nets.Add(net);
         }
     }
@@ -1508,7 +1508,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // If -dnsseed=1 is explicitly specified, abort. If it's left unspecified by the user, we skip
     // the DNS seeds by adjusting -dnsseed in InitParameterInteraction.
     if (args.GetBoolArg("-dnsseed") == true && !g_reachable_nets.Contains(NET_IPV4) && !g_reachable_nets.Contains(NET_IPV6)) {
-        return InitError(strprintf(_("Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6")));
+        return InitError(strprintf(_<"Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6">()));
     };
 
     // Check for host lookup allowed before parsing any network related parameters
@@ -1527,14 +1527,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         } else {
             const std::optional<CService> proxyAddr{Lookup(proxyArg, 9050, fNameLookup)};
             if (!proxyAddr.has_value()) {
-                return InitError(strprintf(_("Invalid -proxy address or hostname: '%s'"), proxyArg));
+                return InitError(strprintf(_<"Invalid -proxy address or hostname: '%s'">(), proxyArg));
             }
 
             addrProxy = Proxy(proxyAddr.value(), proxyRandomize);
         }
 
         if (!addrProxy.IsValid())
-            return InitError(strprintf(_("Invalid -proxy address or hostname: '%s'"), proxyArg));
+            return InitError(strprintf(_<"Invalid -proxy address or hostname: '%s'">(), proxyArg));
 
         SetProxy(NET_IPV4, addrProxy);
         SetProxy(NET_IPV6, addrProxy);
@@ -1563,7 +1563,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             } else {
                 const std::optional<CService> addr{Lookup(onionArg, 9050, fNameLookup)};
                 if (!addr.has_value() || !addr->IsValid()) {
-                    return InitError(strprintf(_("Invalid -onion address or hostname: '%s'"), onionArg));
+                    return InitError(strprintf(_<"Invalid -onion address or hostname: '%s'">(), onionArg));
                 }
 
                 onion_proxy = Proxy(addr.value(), proxyRandomize);
@@ -1732,11 +1732,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 11: import blocks
 
     if (!CheckDiskSpace(args.GetDataDirNet())) {
-        InitError(strprintf(_("Error: Disk space is low for %s"), fs::quoted(fs::PathToString(args.GetDataDirNet()))));
+        InitError(strprintf(_<"Error: Disk space is low for %s">(), fs::quoted(fs::PathToString(args.GetDataDirNet()))));
         return false;
     }
     if (!CheckDiskSpace(args.GetBlocksDirPath())) {
-        InitError(strprintf(_("Error: Disk space is low for %s"), fs::quoted(fs::PathToString(args.GetBlocksDirPath()))));
+        InitError(strprintf(_<"Error: Disk space is low for %s">(), fs::quoted(fs::PathToString(args.GetBlocksDirPath()))));
         return false;
     }
 
@@ -1751,10 +1751,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 assumed_chain_bytes};
 
         if (!CheckDiskSpace(args.GetBlocksDirPath(), additional_bytes_needed)) {
-            InitWarning(strprintf(_(
+            InitWarning(strprintf(_<
                     "Disk space for %s may not accommodate the block files. " \
                     "Approximately %u GB of data will be stored in this directory."
-                ),
+                >(),
                 fs::quoted(fs::PathToString(args.GetBlocksDirPath())),
                 chainparams.AssumedBlockchainSize()
             ));
@@ -1873,9 +1873,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         static_cast<uint16_t>(args.GetIntArg("-port", Params().GetDefaultPort()));
 
     const auto BadPortWarning = [](const char* prefix, uint16_t port) {
-        return strprintf(_("%s request to listen on port %u. This port is considered \"bad\" and "
+        return strprintf(_<"%s request to listen on port %u. This port is considered \"bad\" and "
                            "thus it is unlikely that any peer will connect to it. See "
-                           "doc/p2p-bad-ports.md for details and a full list."),
+                           "doc/p2p-bad-ports.md for details and a full list.">(),
                          prefix,
                          port);
     };
@@ -1938,8 +1938,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     if (args.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION)) {
         if (connOptions.onion_binds.size() > 1) {
-            InitWarning(strprintf(_("More than one onion bind address is provided. Using %s "
-                                    "for the automatically created Tor onion service."),
+            InitWarning(strprintf(_<"More than one onion bind address is provided. Using %s "
+                                    "for the automatically created Tor onion service.">(),
                                   onion_service_target.ToStringAddrPort()));
         }
         StartTorControl(onion_service_target);
@@ -1986,7 +1986,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (!i2psam_arg.empty()) {
         const std::optional<CService> addr{Lookup(i2psam_arg, 7656, fNameLookup)};
         if (!addr.has_value() || !addr->IsValid()) {
-            return InitError(strprintf(_("Invalid -i2psam address or hostname: '%s'"), i2psam_arg));
+            return InitError(strprintf(_<"Invalid -i2psam address or hostname: '%s'">(), i2psam_arg));
         }
         SetProxy(NET_I2P, Proxy{addr.value()});
     } else {
@@ -2068,7 +2068,7 @@ bool StartIndexBackgroundSync(NodeContext& node)
         const CBlockIndex* start_block = *indexes_start_block;
         if (!start_block) start_block = chainman.ActiveChain().Genesis();
         if (!chainman.m_blockman.CheckBlockDataAvailability(*index_chain.Tip(), *Assert(start_block))) {
-            return InitError(strprintf(Untranslated("%s best block of the index goes beyond pruned data. Please disable the index or reindex (which will download the whole blockchain again)"), older_index_name));
+            return InitError(strprintf(Untranslated<"%s best block of the index goes beyond pruned data. Please disable the index or reindex (which will download the whole blockchain again)">(), older_index_name));
         }
     }
 

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -62,13 +62,13 @@ util::Result<void> SetLoggingLevel(const ArgsManager& args)
             if (level_str.find_first_of(':', 3) == std::string::npos) {
                 // user passed a global log level, i.e. -loglevel=<level>
                 if (!LogInstance().SetLogLevel(level_str)) {
-                    return util::Error{strprintf(_("Unsupported global logging level %s=%s. Valid values: %s."), "-loglevel", level_str, LogInstance().LogLevelsString())};
+                    return util::Error{strprintf(_<"Unsupported global logging level %s=%s. Valid values: %s.">(), "-loglevel", level_str, LogInstance().LogLevelsString())};
                 }
             } else {
                 // user passed a category-specific log level, i.e. -loglevel=<category>:<level>
                 const auto& toks = SplitString(level_str, ':');
                 if (!(toks.size() == 2 && LogInstance().SetCategoryLogLevel(toks[0], toks[1]))) {
-                    return util::Error{strprintf(_("Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=<category>:<loglevel>. Valid categories: %3$s. Valid loglevels: %4$s."), "-loglevel", level_str, LogInstance().LogCategoriesString(), LogInstance().LogLevelsString())};
+                    return util::Error{strprintf(_<"Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=<category>:<loglevel>. Valid categories: %3$s. Valid loglevels: %4$s.">(), "-loglevel", level_str, LogInstance().LogCategoriesString(), LogInstance().LogLevelsString())};
                 }
             }
         }
@@ -86,7 +86,7 @@ util::Result<void> SetLoggingCategories(const ArgsManager& args)
             [](std::string cat){return cat == "0" || cat == "none";})) {
             for (const auto& cat : categories) {
                 if (!LogInstance().EnableCategory(cat)) {
-                    return util::Error{strprintf(_("Unsupported logging category %s=%s."), "-debug", cat)};
+                    return util::Error{strprintf(_<"Unsupported logging category %s=%s.">(), "-debug", cat)};
                 }
             }
         }
@@ -95,7 +95,7 @@ util::Result<void> SetLoggingCategories(const ArgsManager& args)
     // Now remove the logging categories which were explicitly excluded
     for (const std::string& cat : args.GetArgs("-debugexclude")) {
         if (!LogInstance().DisableCategory(cat)) {
-            return util::Error{strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat)};
+            return util::Error{strprintf(_<"Unsupported logging category %s=%s.">(), "-debugexclude", cat)};
         }
     }
     return {};
@@ -111,7 +111,7 @@ bool StartLogging(const ArgsManager& args)
         }
     }
     if (!LogInstance().StartLogging()) {
-            return InitError(strprintf(Untranslated("Could not open debug log file %s"),
+            return InitError(strprintf(Untranslated<"Could not open debug log file %s">(),
                 fs::PathToString(LogInstance().m_file_path)));
     }
 
@@ -126,7 +126,7 @@ bool StartLogging(const ArgsManager& args)
         LogPrintf("Config file: %s\n", fs::PathToString(config_file_path));
     } else if (args.IsArgSet("-conf")) {
         // Warn if no conf file exists at path provided by user
-        InitWarning(strprintf(_("The specified config file %s does not exist"), fs::PathToString(config_file_path)));
+        InitWarning(strprintf(_<"The specified config file %s does not exist">(), fs::PathToString(config_file_path)));
     } else {
         // Not categorizing as "Warning" because it's the default behavior
         LogPrintf("Config file: %s (not found, skipping)\n", fs::PathToString(config_file_path));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3054,14 +3054,14 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     socklen_t len = sizeof(sockaddr);
     if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
     {
-        strError = strprintf(Untranslated("Bind address family for %s not supported"), addrBind.ToStringAddrPort());
+        strError = strprintf(Untranslated<"Bind address family for %s not supported">(), addrBind.ToStringAddrPort());
         LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
         return false;
     }
 
     std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
     if (!sock) {
-        strError = strprintf(Untranslated("Couldn't open socket for incoming connections (socket returned error %s)"), NetworkErrorString(WSAGetLastError()));
+        strError = strprintf(Untranslated<"Couldn't open socket for incoming connections (socket returned error %s)">(), NetworkErrorString(WSAGetLastError()));
         LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
         return false;
     }
@@ -3069,7 +3069,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.
     if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, (sockopt_arg_type)&nOne, sizeof(int)) == SOCKET_ERROR) {
-        strError = strprintf(Untranslated("Error setting SO_REUSEADDR on socket: %s, continuing anyway"), NetworkErrorString(WSAGetLastError()));
+        strError = strprintf(Untranslated<"Error setting SO_REUSEADDR on socket: %s, continuing anyway">(), NetworkErrorString(WSAGetLastError()));
         LogPrintf("%s\n", strError.original);
     }
 
@@ -3078,14 +3078,14 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     if (addrBind.IsIPv6()) {
 #ifdef IPV6_V6ONLY
         if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, (sockopt_arg_type)&nOne, sizeof(int)) == SOCKET_ERROR) {
-            strError = strprintf(Untranslated("Error setting IPV6_V6ONLY on socket: %s, continuing anyway"), NetworkErrorString(WSAGetLastError()));
+            strError = strprintf(Untranslated<"Error setting IPV6_V6ONLY on socket: %s, continuing anyway">(), NetworkErrorString(WSAGetLastError()));
             LogPrintf("%s\n", strError.original);
         }
 #endif
 #ifdef WIN32
         int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
         if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, (const char*)&nProtLevel, sizeof(int)) == SOCKET_ERROR) {
-            strError = strprintf(Untranslated("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway"), NetworkErrorString(WSAGetLastError()));
+            strError = strprintf(Untranslated<"Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway">(), NetworkErrorString(WSAGetLastError()));
             LogPrintf("%s\n", strError.original);
         }
 #endif
@@ -3094,9 +3094,9 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), PACKAGE_NAME);
+            strError = strprintf(_<"Unable to bind to %s on this computer. %s is probably already running.">(), addrBind.ToStringAddrPort(), PACKAGE_NAME);
         else
-            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
+            strError = strprintf(_<"Unable to bind to %s on this computer (bind returned error %s)">(), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
         LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
         return false;
     }
@@ -3105,7 +3105,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     // Listen for incoming connections
     if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
     {
-        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
+        strError = strprintf(_<"Listening for incoming connections failed (listen returned error %s)">(), NetworkErrorString(WSAGetLastError()));
         LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
         return false;
     }

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -66,7 +66,7 @@ static bool TryParsePermissionFlags(const std::string& str, NetPermissionFlags& 
             }
             else if (permission.length() == 0); // Allow empty entries
             else {
-                error = strprintf(_("Invalid P2P permission: '%s'"), permission);
+                error = strprintf(_<"Invalid P2P permission: '%s'">(), permission);
                 return false;
             }
         }
@@ -77,7 +77,7 @@ static bool TryParsePermissionFlags(const std::string& str, NetPermissionFlags& 
     if (connection_direction == ConnectionDirection::None) {
         connection_direction = ConnectionDirection::In;
     } else if (flags == NetPermissionFlags::None) {
-        error = strprintf(_("Only direction was set, no permissions: '%s'"), str);
+        error = strprintf(_<"Only direction was set, no permissions: '%s'">(), str);
         return false;
     }
 
@@ -115,7 +115,7 @@ bool NetWhitebindPermissions::TryParse(const std::string& str, NetWhitebindPermi
         return false;
     }
     if (addrBind.value().GetPort() == 0) {
-        error = strprintf(_("Need to specify a port with -whitebind: '%s'"), strBind);
+        error = strprintf(_<"Need to specify a port with -whitebind: '%s'">(), strBind);
         return false;
     }
 
@@ -135,7 +135,7 @@ bool NetWhitelistPermissions::TryParse(const std::string& str, NetWhitelistPermi
     const std::string net = str.substr(offset);
     const CSubNet subnet{LookupSubNet(net)};
     if (!subnet.IsValid()) {
-        error = strprintf(_("Invalid netmask specified in -whitelist: '%s'"), net);
+        error = strprintf(_<"Invalid netmask specified in -whitelist: '%s'">(), net);
         return false;
     }
 

--- a/src/node/blockmanager_args.cpp
+++ b/src/node/blockmanager_args.cpp
@@ -27,7 +27,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, BlockManager::Op
         nPruneTarget = BlockManager::PRUNE_TARGET_MANUAL;
     } else if (nPruneTarget) {
         if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES) {
-            return util::Error{strprintf(_("Prune configured below the minimum of %d MiB.  Please use a higher number."), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024)};
+            return util::Error{strprintf(_<"Prune configured below the minimum of %d MiB.  Please use a higher number.">(), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024)};
         }
     }
     opts.prune_target = nPruneTarget;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -404,7 +404,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
     if (snapshot_blockhash) {
         const std::optional<AssumeutxoData> maybe_au_data = GetParams().AssumeutxoForBlockhash(*snapshot_blockhash);
         if (!maybe_au_data) {
-            m_opts.notifications.fatalError(strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString()));
+            m_opts.notifications.fatalError(strprintf(_<"Assumeutxo data not found for the given blockhash '%s'.">(), snapshot_blockhash->ToString()));
             return false;
         }
         const AssumeutxoData& au_data = *Assert(maybe_au_data);
@@ -1259,7 +1259,7 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
     for (Chainstate* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
         BlockValidationState state;
         if (!chainstate->ActivateBestChain(state, nullptr)) {
-            chainman.GetNotifications().fatalError(strprintf(_("Failed to connect best block (%s)."), state.ToString()));
+            chainman.GetNotifications().fatalError(strprintf(_<"Failed to connect best block (%s).">(), state.ToString()));
             return;
         }
     }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -146,7 +146,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         auto chainstates{chainman.GetAll()};
         if (std::any_of(chainstates.begin(), chainstates.end(),
                         [](const Chainstate* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-            return {ChainstateLoadStatus::FAILURE, strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+            return {ChainstateLoadStatus::FAILURE, strprintf(_<"Witness data for blocks after height %d requires validation. Please restart with -reindex.">(),
                                                              chainman.GetConsensus().SegwitHeight)};
         };
     }

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -35,7 +35,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
         if (auto min_work{uint256::FromUserHex(*value)}) {
             opts.minimum_chain_work = UintToArith256(*min_work);
         } else {
-            return util::Error{strprintf(Untranslated("Invalid minimum work specified (%s), must be up to %d hex digits"), *value, uint256::size() * 2)};
+            return util::Error{strprintf(Untranslated<"Invalid minimum work specified (%s), must be up to %d hex digits">(), *value, uint256::size() * 2)};
         }
     }
 
@@ -43,7 +43,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
         if (auto block_hash{uint256::FromUserHex(*value)}) {
             opts.assumed_valid_block = *block_hash;
         } else {
-            return util::Error{strprintf(Untranslated("Invalid assumevalid block hash specified (%s), must be up to %d hex digits (or 0 to disable)"), *value, uint256::size() * 2)};
+            return util::Error{strprintf(Untranslated<"Invalid assumevalid block hash specified (%s), must be up to %d hex digits (or 0 to disable)">(), *value, uint256::size() * 2)};
         }
     }
 

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -74,7 +74,7 @@ bool InitError(const bilingual_str& str, const std::vector<std::string>& details
     // functions which provide error details are ones that run during early init
     // before the GUI uiInterface is registered, so there's no point passing
     // main messages and details separately to uiInterface yet.
-    return InitError(details.empty() ? str : strprintf(Untranslated("%s:\n%s"), str, MakeUnorderedList(details)));
+    return InitError(details.empty() ? str : strprintf(Untranslated<"%s:\n%s">(), str, MakeUnorderedList(details)));
 }
 
 void InitWarning(const bilingual_str& str)

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -89,7 +89,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", DEFAULT_ACCEPT_NON_STD_TXN);
     if (!chainparams.IsTestChain() && !mempool_opts.require_standard) {
-        return util::Error{strprintf(Untranslated("acceptnonstdtxn is not currently supported for %s chain"), chainparams.GetChainTypeString())};
+        return util::Error{strprintf(Untranslated<"acceptnonstdtxn is not currently supported for %s chain">(), chainparams.GetChainTypeString())};
     }
 
     mempool_opts.full_rbf = argsman.GetBoolArg("-mempoolfullrbf", mempool_opts.full_rbf);

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -52,14 +52,14 @@ bool TimeOffsets::WarnIfOutOfSync() const
         return false;
     }
 
-    bilingual_str msg{strprintf(_(
+    bilingual_str msg{strprintf(_<
         "Your computer's date and time appear to be more than %d minutes out of sync with the network, "
         "this may lead to consensus failure. After you've confirmed your computer's clock, this message "
         "should no longer appear when you restart your node. Without a restart, it should stop showing "
         "automatically after you've connected to a sufficient number of new outbound peers, which may "
         "take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` "
         "RPC methods to get more info."
-    ), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
+    >(), Ticks<std::chrono::minutes>(WARN_THRESHOLD))};
     LogWarning("%s\n", msg.original);
     m_warnings.Set(node::Warning::CLOCK_OUT_OF_SYNC, msg);
     return true;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -529,7 +529,7 @@ int GuiMain(int argc, char* argv[])
     SetupUIArgs(gArgs);
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {
-        InitError(strprintf(Untranslated("Error parsing command line arguments: %s"), error));
+        InitError(strprintf(Untranslated<"Error parsing command line arguments: %s">(), error));
         // Create a message box, because the gui has neither been created nor has subscribed to core signals
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             // message cannot be translated because translations have not been initialized

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -53,27 +53,27 @@ FUZZ_TARGET(str_printf)
             fuzzed_data_provider,
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeRandomLengthString(32));
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<signed char>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<char>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeBool());
             });
     } catch (const tinyformat::format_error&) {
     }
@@ -99,35 +99,35 @@ FUZZ_TARGET(str_printf)
             fuzzed_data_provider,
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeFloatingPoint<float>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeFloatingPoint<double>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<int16_t>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<int32_t>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<int64_t>());
             },
             [&] {
                 (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+                (void)tinyformat::format(bilingual_lit<"%s">{bilingual_string}, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
             });
     } catch (const tinyformat::format_error&) {
     }

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -42,7 +42,7 @@ util::Result<int> IntFn(int i, bool success)
 util::Result<bilingual_str> StrFn(bilingual_str s, bool success)
 {
     if (success) return s;
-    return util::Error{strprintf(Untranslated("str %s error."), s.original)};
+    return util::Error{strprintf(Untranslated<"str %s error.">(), s.original)};
 }
 
 util::Result<NoCopy> NoCopyFn(int i, bool success)

--- a/src/test/translation_tests.cpp
+++ b/src/test/translation_tests.cpp
@@ -12,7 +12,8 @@ BOOST_AUTO_TEST_SUITE(translation_tests)
 BOOST_AUTO_TEST_CASE(translation_namedparams)
 {
     bilingual_str arg{"original", "translated"};
-    bilingual_str format{"original [%s]", "translated [%s]"};
+    auto format{Untranslated<"original [%s]">()};
+    format.translated = "translated [%s]";
     bilingual_str result{strprintf(format, arg)};
     BOOST_CHECK_EQUAL(result.original, "original [original]");
     BOOST_CHECK_EQUAL(result.translated, "translated [translated]");

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -16,13 +16,13 @@ BOOST_AUTO_TEST_SUITE(util_string_tests)
 template <unsigned NumArgs>
 inline void PassFmt(util::ConstevalFormatString<NumArgs> fmt)
 {
-    // This was already executed at compile-time, but is executed again at run-time to avoid -Wunused.
-    decltype(fmt)::Detail_CheckNumFormatSpecifiers(fmt.fmt);
+    // Execute compile-time check again at run-time to get code coverage stats
+    util::detail::CheckNumFormatSpecifiers<NumArgs>(fmt.fmt);
 }
 template <unsigned WrongNumArgs>
 inline void FailFmtWithError(std::string_view wrong_fmt, std::string_view error)
 {
-    BOOST_CHECK_EXCEPTION(util::ConstevalFormatString<WrongNumArgs>::Detail_CheckNumFormatSpecifiers(wrong_fmt), const char*, HasReason(error));
+    BOOST_CHECK_EXCEPTION(util::detail::CheckNumFormatSpecifiers<WrongNumArgs>(wrong_fmt), const char*, HasReason{error});
 }
 
 BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -403,7 +403,7 @@ static CTxMemPool::Options&& Flatten(CTxMemPool::Options&& opts, bilingual_str& 
     opts.check_ratio = std::clamp<int>(opts.check_ratio, 0, 1'000'000);
     int64_t descendant_limit_bytes = opts.limits.descendant_size_vbytes * 40;
     if (opts.max_size_bytes < 0 || opts.max_size_bytes < descendant_limit_bytes) {
-        error = strprintf(_("-maxmempool must be at least %d MB"), std::ceil(descendant_limit_bytes / 1'000'000.0));
+        error = strprintf(_<"-maxmempool must be at least %d MB">(), std::ceil(descendant_limit_bytes / 1'000'000.0));
     }
     return std::move(opts);
 }

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -18,6 +18,51 @@
 #include <vector>
 
 namespace util {
+namespace detail {
+template <unsigned num_params>
+constexpr static void CheckNumFormatSpecifiers(std::string_view str)
+{
+    unsigned count_normal{0}; // Number of "normal" specifiers, like %s
+    unsigned count_pos{0};    // Max number in positional specifier, like %8$s
+    for (auto it{str.begin()}; it < str.end();) {
+        if (*it != '%') {
+            ++it;
+            continue;
+        }
+
+        if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
+        if (*it == '%') {
+            // Percent escape: %%
+            ++it;
+            continue;
+        }
+
+        unsigned maybe_num{0};
+        while ('0' <= *it && *it <= '9') {
+            maybe_num *= 10;
+            maybe_num += *it - '0';
+            ++it;
+        };
+
+        if (*it == '$') {
+            // Positional specifier, like %8$s
+            if (maybe_num == 0) throw "Positional format specifier must have position of at least 1";
+            count_pos = std::max(count_pos, maybe_num);
+            if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
+        } else {
+            // Non-positional specifier, like %s
+            ++count_normal;
+            ++it;
+        }
+        // The remainder "[flags][width][.precision][length]type" of the
+        // specifier is not checked. Parsing continues with the next '%'.
+    }
+    if (count_normal && count_pos) throw "Format specifiers must be all positional or all non-positional!";
+    unsigned count{count_normal | count_pos};
+    if (num_params != count) throw "Format specifier count must match the argument count!";
+}
+} // namespace detail
+
 /**
  * @brief A wrapper for a compile-time partially validated format string
  *
@@ -35,48 +80,7 @@ namespace util {
 template <unsigned num_params>
 struct ConstevalFormatString {
     const char* const fmt;
-    consteval ConstevalFormatString(const char* str) : fmt{str} { Detail_CheckNumFormatSpecifiers(fmt); }
-    constexpr static void Detail_CheckNumFormatSpecifiers(std::string_view str)
-    {
-        unsigned count_normal{0}; // Number of "normal" specifiers, like %s
-        unsigned count_pos{0};    // Max number in positional specifier, like %8$s
-        for (auto it{str.begin()}; it < str.end();) {
-            if (*it != '%') {
-                ++it;
-                continue;
-            }
-
-            if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
-            if (*it == '%') {
-                // Percent escape: %%
-                ++it;
-                continue;
-            }
-
-            unsigned maybe_num{0};
-            while ('0' <= *it && *it <= '9') {
-                maybe_num *= 10;
-                maybe_num += *it - '0';
-                ++it;
-            };
-
-            if (*it == '$') {
-                // Positional specifier, like %8$s
-                if (maybe_num == 0) throw "Positional format specifier must have position of at least 1";
-                count_pos = std::max(count_pos, maybe_num);
-                if (++it >= str.end()) throw "Format specifier incorrectly terminated by end of string";
-            } else {
-                // Non-positional specifier, like %s
-                ++count_normal;
-                ++it;
-            }
-            // The remainder "[flags][width][.precision][length]type" of the
-            // specifier is not checked. Parsing continues with the next '%'.
-        }
-        if (count_normal && count_pos) throw "Format specifiers must be all positional or all non-positional!";
-        unsigned count{count_normal | count_pos};
-        if (num_params != count) throw "Format specifier count must match the argument count!";
-    }
+    consteval ConstevalFormatString(const char* str) : fmt{str} { detail::CheckNumFormatSpecifiers<num_params>(fmt); }
 };
 
 void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -19,6 +19,15 @@
 
 namespace util {
 namespace detail {
+/** Helper allowing literal strings to be passed as template parameters. */
+template<size_t N>
+struct StringLiteral {
+    constexpr StringLiteral(const char (&str)[N]) {
+        std::copy_n(str, N, value);
+    }
+    char value[N];
+};
+
 template <unsigned num_params>
 constexpr static void CheckNumFormatSpecifiers(std::string_view str)
 {

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -10,6 +10,9 @@
 #include <functional>
 #include <string>
 
+/** Translate a message to the native language of the user. */
+const extern std::function<std::string(const char*)> G_TRANSLATION_FUN;
+
 /**
  * Bilingual messages:
  *   - in GUI: user's native language + untranslated (i.e. English)
@@ -63,9 +66,6 @@ bilingual_str format(const bilingual_str& fmt, const Args&... args)
                          tfm::format(fmt.translated, translate_arg(args, true)...)};
 }
 } // namespace tinyformat
-
-/** Translate a message to the native language of the user. */
-const extern std::function<std::string(const char*)> G_TRANSLATION_FUN;
 
 struct ConstevalStringLiteral {
     const char* const lit;

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -67,9 +67,11 @@ inline bilingual_lit<lit> Untranslated() { return Untranslated(lit.value); }
 
 // Provide an overload of tinyformat::format which can take bilingual_str arguments.
 namespace tinyformat {
-template <typename... Args>
-bilingual_str format(const bilingual_str& fmt, const Args&... args)
+template <util::detail::StringLiteral lit, typename... Args>
+bilingual_str format(const bilingual_lit<lit>& fmt, const Args&... args)
 {
+    constexpr util::ConstevalFormatString<sizeof...(args)> check{lit.value};
+    (void)check;
     const auto translate_arg{[](const auto& arg, bool translated) -> const auto& {
         if constexpr (std::is_same_v<decltype(arg), const bilingual_str&>) {
             return translated ? arg.translated : arg.original;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2919,7 +2919,7 @@ bool Chainstate::FlushStateToDisk(
         m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), m_chain.GetLocator());
     }
     } catch (const std::runtime_error& e) {
-        return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));
+        return FatalError(m_chainman.GetNotifications(), state, strprintf(_<"System error while flushing: %s">(), e.what()));
     }
     return true;
 }
@@ -2992,7 +2992,7 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
             WarningBitsConditionChecker checker(m_chainman, bit);
             ThresholdState state = checker.GetStateFor(pindex, params.GetConsensus(), m_chainman.m_warningcache.at(bit));
             if (state == ThresholdState::ACTIVE || state == ThresholdState::LOCKED_IN) {
-                const bilingual_str warning = strprintf(_("Unknown new rules activated (versionbit %i)"), bit);
+                const bilingual_str warning = strprintf(_<"Unknown new rules activated (versionbit %i)">(), bit);
                 if (state == ThresholdState::ACTIVE) {
                     m_chainman.GetNotifications().warningSet(kernel::Warning::UNKNOWN_NEW_RULES_ACTIVATED, warning);
                 } else {
@@ -4516,7 +4516,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return FatalError(GetNotifications(), state, strprintf(_("System error while saving block to disk: %s"), e.what()));
+        return FatalError(GetNotifications(), state, strprintf(_<"System error while saving block to disk: %s">(), e.what()));
     }
 
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate
@@ -5187,7 +5187,7 @@ void ChainstateManager::LoadExternalBlockFile(
             }
         }
     } catch (const std::runtime_error& e) {
-        GetNotifications().fatalError(strprintf(_("System error while loading external block file: %s"), e.what()));
+        GetNotifications().fatalError(strprintf(_<"System error while loading external block file: %s">(), e.what()));
     }
     LogPrintf("Loaded %i blocks from external file in %dms\n", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 }
@@ -5668,20 +5668,20 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         if (!GetParams().AssumeutxoForBlockhash(base_blockhash).has_value()) {
             auto available_heights = GetParams().GetAvailableSnapshotHeights();
             std::string heights_formatted = util::Join(available_heights, ", ", [&](const auto& i) { return util::ToString(i); });
-            return util::Error{strprintf(Untranslated("assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s"),
+            return util::Error{strprintf(Untranslated<"assumeutxo block hash in snapshot metadata not recognized (hash: %s). The following snapshot heights are available: %s">(),
                 base_blockhash.ToString(),
                 heights_formatted)};
         }
 
         snapshot_start_block = m_blockman.LookupBlockIndex(base_blockhash);
         if (!snapshot_start_block) {
-            return util::Error{strprintf(Untranslated("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again"),
+            return util::Error{strprintf(Untranslated<"The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call loadtxoutset again">(),
                           base_blockhash.ToString())};
         }
 
         bool start_block_invalid = snapshot_start_block->nStatus & BLOCK_FAILED_MASK;
         if (start_block_invalid) {
-            return util::Error{strprintf(Untranslated("The base block header (%s) is part of an invalid chain"), base_blockhash.ToString())};
+            return util::Error{strprintf(Untranslated<"The base block header (%s) is part of an invalid chain">(), base_blockhash.ToString())};
         }
 
         if (!m_best_header || m_best_header->GetAncestor(snapshot_start_block->nHeight) != snapshot_start_block) {
@@ -5751,8 +5751,8 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
             snapshot_chainstate.reset();
             bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
-                GetNotifications().fatalError(strprintf(_("Failed to remove snapshot chainstate dir (%s). "
-                    "Manually remove it before restarting.\n"), fs::PathToString(*snapshot_datadir)));
+                GetNotifications().fatalError(strprintf(_<"Failed to remove snapshot chainstate dir (%s). "
+                    "Manually remove it before restarting.\n">(), fs::PathToString(*snapshot_datadir)));
             }
         }
         return util::Error{std::move(reason)};
@@ -5760,7 +5760,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     if (auto res{this->PopulateAndValidateSnapshot(*snapshot_chainstate, coins_file, metadata)}; !res) {
         LOCK(::cs_main);
-        return cleanup_bad_snapshot(strprintf(Untranslated("Population failed: %s"), util::ErrorString(res)));
+        return cleanup_bad_snapshot(strprintf(Untranslated<"Population failed: %s">(), util::ErrorString(res)));
     }
 
     LOCK(::cs_main);  // cs_main required for rest of snapshot activation.
@@ -5841,7 +5841,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     if (!snapshot_start_block) {
         // Needed for ComputeUTXOStats to determine the
         // height and to avoid a crash when base_blockhash.IsNull()
-        return util::Error{strprintf(Untranslated("Did not find snapshot start blockheader %s"),
+        return util::Error{strprintf(Untranslated<"Did not find snapshot start blockheader %s">(),
                   base_blockhash.ToString())};
     }
 
@@ -5849,8 +5849,8 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     const auto& maybe_au_data = GetParams().AssumeutxoForHeight(base_height);
 
     if (!maybe_au_data) {
-        return util::Error{strprintf(Untranslated("Assumeutxo height in snapshot metadata not recognized "
-                  "(%d) - refusing to load snapshot"), base_height)};
+        return util::Error{strprintf(Untranslated<"Assumeutxo height in snapshot metadata not recognized "
+                  "(%d) - refusing to load snapshot">(), base_height)};
     }
 
     const AssumeutxoData& au_data = *maybe_au_data;
@@ -5888,11 +5888,11 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 if (coin.nHeight > base_height ||
                     outpoint.n >= std::numeric_limits<decltype(outpoint.n)>::max() // Avoid integer wrap-around in coinstats.cpp:ApplyHash
                 ) {
-                    return util::Error{strprintf(Untranslated("Bad snapshot data after deserializing %d coins"),
+                    return util::Error{strprintf(Untranslated<"Bad snapshot data after deserializing %d coins">(),
                               coins_count - coins_left)};
                 }
                 if (!MoneyRange(coin.out.nValue)) {
-                    return util::Error{strprintf(Untranslated("Bad snapshot data after deserializing %d coins - bad tx out value"),
+                    return util::Error{strprintf(Untranslated<"Bad snapshot data after deserializing %d coins - bad tx out value">(),
                               coins_count - coins_left)};
                 }
                 coins_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
@@ -5931,7 +5931,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 }
             }
         } catch (const std::ios_base::failure&) {
-            return util::Error{strprintf(Untranslated("Bad snapshot format or truncated snapshot after deserializing %d coins"),
+            return util::Error{strprintf(Untranslated<"Bad snapshot format or truncated snapshot after deserializing %d coins">(),
                       coins_processed)};
         }
     }
@@ -5952,7 +5952,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
         out_of_coins = true;
     }
     if (!out_of_coins) {
-        return util::Error{strprintf(Untranslated("Bad snapshot - coins left over after deserializing %d coins"),
+        return util::Error{strprintf(Untranslated<"Bad snapshot - coins left over after deserializing %d coins">(),
             coins_count)};
     }
 
@@ -5984,7 +5984,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 
     // Assert that the deserialized chainstate contents match the expected assumeutxo value.
     if (AssumeutxoHash{maybe_stats->hashSerialized} != au_data.hash_serialized) {
-        return util::Error{strprintf(Untranslated("Bad snapshot content hash: expected %s, got %s"),
+        return util::Error{strprintf(Untranslated<"Bad snapshot content hash: expected %s, got %s">(),
             au_data.hash_serialized.ToString(), maybe_stats->hashSerialized.ToString())};
     }
 
@@ -6066,7 +6066,7 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
     uint256 snapshot_blockhash = *Assert(SnapshotBlockhash());
 
     auto handle_invalid_snapshot = [&]() EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
-        bilingual_str user_error = strprintf(_(
+        bilingual_str user_error = strprintf(_<
             "%s failed to validate the -assumeutxo snapshot state. "
             "This indicates a hardware problem, or a bug in the software, or a "
             "bad software modification that allowed an invalid snapshot to be "
@@ -6077,7 +6077,7 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
             "without using any snapshot data. "
             "Please report this incident to %s, including how you obtained the snapshot. "
             "The invalid snapshot chainstate will be left on disk in case it is "
-            "helpful in diagnosing the issue that caused this error."),
+            "helpful in diagnosing the issue that caused this error.">(),
             PACKAGE_NAME, snapshot_tip_height, snapshot_base_height, snapshot_base_height, PACKAGE_BUGREPORT
         );
 
@@ -6091,7 +6091,7 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
 
         auto rename_result = m_snapshot_chainstate->InvalidateCoinsDBOnDisk();
         if (!rename_result) {
-            user_error = strprintf(Untranslated("%s\n%s"), user_error, util::ErrorString(rename_result));
+            user_error = strprintf(Untranslated<"%s\n%s">(), user_error, util::ErrorString(rename_result));
         }
 
         GetNotifications().fatalError(user_error);
@@ -6338,11 +6338,11 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
 
         LogPrintf("%s: error renaming file '%s' -> '%s': %s\n",
                 __func__, src_str, dest_str, e.what());
-        return util::Error{strprintf(_(
+        return util::Error{strprintf(_<
             "Rename of '%s' -> '%s' failed. "
             "You should resolve this by manually moving or deleting the invalid "
             "snapshot directory %s, otherwise you will encounter the same error again "
-            "on the next startup."),
+            "on the next startup.">(),
             src_str, dest_str, src_str)};
     }
     return {};
@@ -6437,9 +6437,9 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
                                    const fs::filesystem_error& err) {
         LogError("[snapshot] Error renaming path (%s) -> (%s): %s\n",
                   fs::PathToString(p_old), fs::PathToString(p_new), err.what());
-        GetNotifications().fatalError(strprintf(_(
+        GetNotifications().fatalError(strprintf(_<
             "Rename of '%s' -> '%s' failed. "
-            "Cannot clean up the background chainstate leveldb directory."),
+            "Cannot clean up the background chainstate leveldb directory.">(),
             fs::PathToString(p_old), fs::PathToString(p_new)));
     };
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -153,7 +153,7 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
     TryCreateDirectories(pathIn);
     if (util::LockDirectory(pathIn, ".walletlock") != util::LockResult::Success) {
         LogPrintf("Cannot obtain a lock on wallet directory %s. Another instance may be using it.\n", strPath);
-        err = strprintf(_("Error initializing wallet database environment %s!"), fs::quoted(fs::PathToString(Directory())));
+        err = strprintf(_<"Error initializing wallet database environment %s!">(), fs::quoted(fs::PathToString(Directory())));
         return false;
     }
 
@@ -194,7 +194,7 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
             LogPrintf("BerkeleyEnvironment::Open: Error %d closing failed database environment: %s\n", ret2, DbEnv::strerror(ret2));
         }
         Reset();
-        err = strprintf(_("Error initializing wallet database environment %s!"), fs::quoted(fs::PathToString(Directory())));
+        err = strprintf(_<"Error initializing wallet database environment %s!">(), fs::quoted(fs::PathToString(Directory())));
         if (ret == DB_RUNRECOVERY) {
             err += Untranslated(" ") + _("This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet");
         }
@@ -332,7 +332,7 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
         const std::string strFile = fs::PathToString(m_filename);
         int result = db.verify(strFile.c_str(), nullptr, nullptr, 0);
         if (result != 0) {
-            errorStr = strprintf(_("%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup."), fs::quoted(fs::PathToString(file_path)));
+            errorStr = strprintf(_<"%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.">(), fs::quoted(fs::PathToString(file_path)));
             return false;
         }
     }

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -33,13 +33,13 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
     fs::path path = fs::PathFromString(dump_filename);
     path = fs::absolute(path);
     if (fs::exists(path)) {
-        error = strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path));
+        error = strprintf(_<"File %s already exists. If you are sure this is what you want, move it out of the way first.">(), fs::PathToString(path));
         return false;
     }
     std::ofstream dump_file;
     dump_file.open(path);
     if (dump_file.fail()) {
-        error = strprintf(_("Unable to open %s for writing"), fs::PathToString(path));
+        error = strprintf(_<"Unable to open %s for writing">(), fs::PathToString(path));
         return false;
     }
 
@@ -131,7 +131,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     fs::path dump_path = fs::PathFromString(dump_filename);
     dump_path = fs::absolute(dump_path);
     if (!fs::exists(dump_path)) {
-        error = strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path));
+        error = strprintf(_<"Dump file %s does not exist.">(), fs::PathToString(dump_path));
         return false;
     }
     std::ifstream dump_file{dump_path};
@@ -146,19 +146,19 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string version_value;
     std::getline(dump_file, version_value, '\n');
     if (magic_key != DUMP_MAGIC) {
-        error = strprintf(_("Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."), magic_key, DUMP_MAGIC);
+        error = strprintf(_<"Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\".">(), magic_key, DUMP_MAGIC);
         dump_file.close();
         return false;
     }
     // Check the version number (value of first record)
     uint32_t ver;
     if (!ParseUInt32(version_value, &ver)) {
-        error =strprintf(_("Error: Unable to parse version %u as a uint32_t"), version_value);
+        error =strprintf(_<"Error: Unable to parse version %u as a uint32_t">(), version_value);
         dump_file.close();
         return false;
     }
     if (ver != DUMP_VERSION) {
-        error = strprintf(_("Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s"), version_value);
+        error = strprintf(_<"Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s">(), version_value);
         dump_file.close();
         return false;
     }
@@ -171,7 +171,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string format_value;
     std::getline(dump_file, format_value, '\n');
     if (format_key != "format") {
-        error = strprintf(_("Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."), format_key);
+        error = strprintf(_<"Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\".">(), format_key);
         dump_file.close();
         return false;
     }
@@ -189,11 +189,11 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     } else if (file_format == "bdb_swap") {
         data_format = DatabaseFormat::BERKELEY_SWAP;
     } else {
-        error = strprintf(_("Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or \"sqlite\"."), file_format);
+        error = strprintf(_<"Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or \"sqlite\".">(), file_format);
         return false;
     }
     if (file_format != format_value) {
-        warnings.push_back(strprintf(_("Warning: Dumpfile wallet format \"%s\" does not match command line specified format \"%s\"."), format_value, file_format));
+        warnings.push_back(strprintf(_<"Warning: Dumpfile wallet format \"%s\" does not match command line specified format \"%s\".">(), format_value, file_format));
     }
     std::string format_hasher_line = strprintf("%s,%s\n", format_key, format_value);
     hasher << Span{format_hasher_line};
@@ -213,7 +213,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
         LOCK(wallet->cs_wallet);
         DBErrors load_wallet_ret = wallet->LoadWallet();
         if (load_wallet_ret != DBErrors::LOAD_OK) {
-            error = strprintf(_("Error creating %s"), name);
+            error = strprintf(_<"Error creating %s">(), name);
             return false;
         }
 
@@ -248,12 +248,12 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             }
 
             if (!IsHex(key)) {
-                error = strprintf(_("Error: Got key that was not hex: %s"), key);
+                error = strprintf(_<"Error: Got key that was not hex: %s">(), key);
                 ret = false;
                 break;
             }
             if (!IsHex(value)) {
-                error = strprintf(_("Error: Got value that was not hex: %s"), value);
+                error = strprintf(_<"Error: Got value that was not hex: %s">(), value);
                 ret = false;
                 break;
             }
@@ -261,7 +261,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             std::vector<unsigned char> k = ParseHex(key);
             std::vector<unsigned char> v = ParseHex(value);
             if (!batch->Write(Span{k}, Span{v})) {
-                error = strprintf(_("Error: Unable to write record to new wallet"));
+                error = strprintf(_<"Error: Unable to write record to new wallet">());
                 ret = false;
                 break;
             }
@@ -273,7 +273,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
                 error = _("Error: Missing checksum");
                 ret = false;
             } else if (checksum != comp_checksum) {
-                error = strprintf(_("Error: Dumpfile checksum does not match. Computed %s, expected %s"), HexStr(comp_checksum), HexStr(checksum));
+                error = strprintf(_<"Error: Dumpfile checksum does not match. Computed %s, expected %s">(), HexStr(comp_checksum), HexStr(checksum));
                 ret = false;
             }
         }

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -66,13 +66,13 @@ util::Result<void> ExternalSignerScriptPubKeyMan::DisplayAddress(const CTxDestin
     const UniValue& result = signer.DisplayAddress(descriptor->ToString());
 
     const UniValue& error = result.find_value("error");
-    if (error.isStr()) return util::Error{strprintf(_("Signer returned error: %s"), error.getValStr())};
+    if (error.isStr()) return util::Error{strprintf(_<"Signer returned error: %s">(), error.getValStr())};
 
     const UniValue& ret_address = result.find_value("address");
     if (!ret_address.isStr()) return util::Error{_("Signer did not echo address")};
 
     if (ret_address.getValStr() != EncodeDestination(dest)) {
-        return util::Error{strprintf(_("Signer echoed unexpected address %s"), ret_address.getValStr())};
+        return util::Error{strprintf(_<"Signer echoed unexpected address %s">(), ret_address.getValStr())};
     }
 
     return util::Result<void>();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -46,7 +46,7 @@ static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWallet
     }
 
     if (wtx.mapValue.count("replaced_by_txid")) {
-        errors.push_back(strprintf(Untranslated("Cannot bump transaction %s which was already bumped by transaction %s"), wtx.GetHash().ToString(), wtx.mapValue.at("replaced_by_txid")));
+        errors.push_back(strprintf(Untranslated<"Cannot bump transaction %s which was already bumped by transaction %s">(), wtx.GetHash().ToString(), wtx.mapValue.at("replaced_by_txid")));
         return feebumper::Result::WALLET_ERROR;
     }
 
@@ -75,7 +75,7 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
 
     if (newFeerate.GetFeePerK() < minMempoolFeeRate.GetFeePerK()) {
         errors.push_back(strprintf(
-            Untranslated("New fee rate (%s) is lower than the minimum fee rate (%s) to get into the mempool -- "),
+            Untranslated<"New fee rate (%s) is lower than the minimum fee rate (%s) to get into the mempool -- ">(),
             FormatMoney(newFeerate.GetFeePerK()),
             FormatMoney(minMempoolFeeRate.GetFeePerK())));
         return feebumper::Result::WALLET_ERROR;
@@ -89,7 +89,7 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
 
     std::optional<CAmount> combined_bump_fee = wallet.chain().calculateCombinedBumpFee(reused_inputs, newFeerate);
     if (!combined_bump_fee.has_value()) {
-        errors.push_back(strprintf(Untranslated("Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.")));
+        errors.push_back(strprintf(Untranslated<"Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.">()));
     }
     CAmount new_total_fee = newFeerate.GetFee(maxTxSize) + combined_bump_fee.value();
 
@@ -99,14 +99,14 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
     CAmount minTotalFee = old_fee + incrementalRelayFee.GetFee(maxTxSize);
 
     if (new_total_fee < minTotalFee) {
-        errors.push_back(strprintf(Untranslated("Insufficient total fee %s, must be at least %s (oldFee %s + incrementalFee %s)"),
+        errors.push_back(strprintf(Untranslated<"Insufficient total fee %s, must be at least %s (oldFee %s + incrementalFee %s)">(),
             FormatMoney(new_total_fee), FormatMoney(minTotalFee), FormatMoney(old_fee), FormatMoney(incrementalRelayFee.GetFee(maxTxSize))));
         return feebumper::Result::INVALID_PARAMETER;
     }
 
     CAmount requiredFee = GetRequiredFee(wallet, maxTxSize);
     if (new_total_fee < requiredFee) {
-        errors.push_back(strprintf(Untranslated("Insufficient total fee (cannot be less than required fee %s)"),
+        errors.push_back(strprintf(Untranslated<"Insufficient total fee (cannot be less than required fee %s)">(),
             FormatMoney(requiredFee)));
         return feebumper::Result::INVALID_PARAMETER;
     }
@@ -114,7 +114,7 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
     // Check that in all cases the new fee doesn't violate maxTxFee
     const CAmount max_tx_fee = wallet.m_default_max_tx_fee;
     if (new_total_fee > max_tx_fee) {
-        errors.push_back(strprintf(Untranslated("Specified or calculated fee %s is too high (cannot be higher than -maxtxfee %s)"),
+        errors.push_back(strprintf(Untranslated<"Specified or calculated fee %s is too high (cannot be higher than -maxtxfee %s)">(),
             FormatMoney(new_total_fee), FormatMoney(max_tx_fee)));
         return feebumper::Result::WALLET_ERROR;
     }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -37,14 +37,14 @@ bool VerifyWallets(WalletContext& context)
         // if a path has trailing slashes, and it strips trailing slashes.
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
         if (error || !fs::exists(canonical_wallet_dir)) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), fs::PathToString(wallet_dir)));
+            chain.initError(strprintf(_<"Specified -walletdir \"%s\" does not exist">(), fs::PathToString(wallet_dir)));
             return false;
         } else if (!fs::is_directory(canonical_wallet_dir)) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), fs::PathToString(wallet_dir)));
+            chain.initError(strprintf(_<"Specified -walletdir \"%s\" is not a directory">(), fs::PathToString(wallet_dir)));
             return false;
         // The canonical path transforms relative paths into absolute ones, so we check the non-canonical version
         } else if (!wallet_dir.is_absolute()) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" is a relative path"), fs::PathToString(wallet_dir)));
+            chain.initError(strprintf(_<"Specified -walletdir \"%s\" is a relative path">(), fs::PathToString(wallet_dir)));
             return false;
         }
         args.ForceSetArg("-walletdir", fs::PathToString(canonical_wallet_dir));
@@ -86,7 +86,7 @@ bool VerifyWallets(WalletContext& context)
         const fs::path path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(wallet_file));
 
         if (!wallet_paths.insert(path).second) {
-            chain.initWarning(strprintf(_("Ignoring duplicate -wallet %s."), wallet_file));
+            chain.initWarning(strprintf(_<"Ignoring duplicate -wallet %s.">(), wallet_file));
             continue;
         }
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -534,7 +534,7 @@ RPCHelpMan importwallet()
 
         // Use uiInterface.ShowProgress instead of pwallet.ShowProgress because pwallet.ShowProgress has a cancel button tied to AbortRescan which
         // we don't want for this progress bar showing the import progress. uiInterface.ShowProgress does not have a cancel button.
-        pwallet->chain().showProgress(strprintf("%s " + _("Importing…").translated, pwallet->GetDisplayName()), 0, false); // show progress dialog in GUI
+        pwallet->chain().showProgress(strprintf("%s %s", pwallet->GetDisplayName(), _("Importing…").translated), 0, false); // show progress dialog in GUI
         std::vector<std::tuple<CKey, int64_t, bool, std::string>> keys;
         std::vector<std::pair<CScript, int64_t>> scripts;
         while (file.good()) {

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -99,7 +99,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
                                        newFilename.c_str(), DB_AUTO_COMMIT);
     if (result != 0)
     {
-        error = strprintf(Untranslated("Failed to rename %s to %s"), filename, newFilename);
+        error = strprintf(Untranslated<"Failed to rename %s to %s">(), filename, newFilename);
         return false;
     }
 
@@ -119,7 +119,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
         warnings.push_back(Untranslated("Salvage: Database salvage found errors, all data may not be recoverable."));
     }
     if (result != 0 && result != DB_VERIFY_BAD) {
-        error = strprintf(Untranslated("Salvage: Database salvage failed with result %d."), result);
+        error = strprintf(Untranslated<"Salvage: Database salvage failed with result %d.">(), result);
         return false;
     }
 
@@ -160,7 +160,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
 
     if (salvagedData.empty())
     {
-        error = strprintf(Untranslated("Salvage(aggressive) found no records in %s."), newFilename);
+        error = strprintf(Untranslated<"Salvage(aggressive) found no records in %s.">(), newFilename);
         return false;
     }
 
@@ -172,7 +172,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
                             DB_CREATE,          // Flags
                             0);
     if (ret > 0) {
-        error = strprintf(Untranslated("Cannot create database file %s"), filename);
+        error = strprintf(Untranslated<"Cannot create database file %s">(), filename);
         pdbCopy->close(0);
         return false;
     }
@@ -203,7 +203,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
 
         if (!fReadOK)
         {
-            warnings.push_back(strprintf(Untranslated("WARNING: WalletBatch::Recover skipping %s: %s"), strType, strErr));
+            warnings.push_back(strprintf(Untranslated<"WARNING: WalletBatch::Recover skipping %s: %s">(), strType, strErr));
             continue;
         }
         Dbt datKey(row.first.data(), row.first.size());

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -274,7 +274,7 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
         if (auto ptr_wtx = wallet.GetWalletTx(outpoint.hash)) {
             // Clearly invalid input, fail
             if (ptr_wtx->tx->vout.size() <= outpoint.n) {
-                return util::Error{strprintf(_("Invalid pre-selected input %s"), outpoint.ToString())};
+                return util::Error{strprintf(_<"Invalid pre-selected input %s">(), outpoint.ToString())};
             }
             txout = ptr_wtx->tx->vout.at(outpoint.n);
             if (input_bytes == -1) {
@@ -284,7 +284,7 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
             // The input is external. We did not find the tx in mapWallet.
             const auto out{coin_control.GetExternalOutput(outpoint)};
             if (!out) {
-                return util::Error{strprintf(_("Not found pre-selected input %s"), outpoint.ToString())};
+                return util::Error{strprintf(_<"Not found pre-selected input %s">(), outpoint.ToString())};
             }
 
             txout = *out;
@@ -295,7 +295,7 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
         }
 
         if (input_bytes == -1) {
-            return util::Error{strprintf(_("Not solvable pre-selected input %s"), outpoint.ToString())}; // Not solvable, can't estimate size for fee
+            return util::Error{strprintf(_<"Not solvable pre-selected input %s">(), outpoint.ToString())}; // Not solvable, can't estimate size for fee
         }
 
         /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
@@ -1024,7 +1024,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     coin_selection_params.m_max_tx_weight = coin_control.m_max_tx_weight.value_or(MAX_STANDARD_TX_WEIGHT);
     int minimum_tx_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR;
     if (coin_selection_params.m_max_tx_weight.value() < minimum_tx_weight || coin_selection_params.m_max_tx_weight.value() > MAX_STANDARD_TX_WEIGHT) {
-        return util::Error{strprintf(_("Maximum transaction weight must be between %d and %d"), minimum_tx_weight, MAX_STANDARD_TX_WEIGHT)};
+        return util::Error{strprintf(_<"Maximum transaction weight must be between %d and %d">(), minimum_tx_weight, MAX_STANDARD_TX_WEIGHT)};
     }
     // Set the long term feerate estimate to the wallet's consolidate feerate
     coin_selection_params.m_long_term_feerate = wallet.m_consolidate_feerate;
@@ -1102,11 +1102,11 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // Do not, ever, assume that it's fine to change the fee rate if the user has explicitly
     // provided one
     if (coin_control.m_feerate && coin_selection_params.m_effective_feerate > *coin_control.m_feerate) {
-        return util::Error{strprintf(_("Fee rate (%s) is lower than the minimum fee rate setting (%s)"), coin_control.m_feerate->ToString(FeeEstimateMode::SAT_VB), coin_selection_params.m_effective_feerate.ToString(FeeEstimateMode::SAT_VB))};
+        return util::Error{strprintf(_<"Fee rate (%s) is lower than the minimum fee rate setting (%s)">(), coin_control.m_feerate->ToString(FeeEstimateMode::SAT_VB), coin_selection_params.m_effective_feerate.ToString(FeeEstimateMode::SAT_VB))};
     }
     if (feeCalc.reason == FeeReason::FALLBACK && !wallet.m_allow_fallback_fee) {
         // eventually allow a fallback fee
-        return util::Error{strprintf(_("Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s."), "-fallbackfee")};
+        return util::Error{strprintf(_<"Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.">(), "-fallbackfee")};
     }
 
     // Calculate the cost of change

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -197,7 +197,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     uint32_t app_id = static_cast<uint32_t>(read_result.value());
     uint32_t net_magic = ReadBE32(Params().MessageStart().data());
     if (app_id != net_magic) {
-        error = strprintf(_("SQLiteDatabase: Unexpected application id. Expected %u, got %u"), net_magic, app_id);
+        error = strprintf(_<"SQLiteDatabase: Unexpected application id. Expected %u, got %u">(), net_magic, app_id);
         return false;
     }
 
@@ -206,7 +206,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     if (!read_result.has_value()) return false;
     int32_t user_ver = read_result.value();
     if (user_ver != WALLET_SCHEMA_VERSION) {
-        error = strprintf(_("SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported"), user_ver, WALLET_SCHEMA_VERSION);
+        error = strprintf(_<"SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported">(), user_ver, WALLET_SCHEMA_VERSION);
         return false;
     }
 
@@ -214,7 +214,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     int ret = sqlite3_prepare_v2(m_db, "PRAGMA integrity_check", -1, &stmt, nullptr);
     if (ret != SQLITE_OK) {
         sqlite3_finalize(stmt);
-        error = strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret));
+        error = strprintf(_<"SQLiteDatabase: Failed to prepare statement to verify database: %s">(), sqlite3_errstr(ret));
         return false;
     }
     while (true) {
@@ -223,12 +223,12 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
             break;
         }
         if (ret != SQLITE_ROW) {
-            error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
+            error = strprintf(_<"SQLiteDatabase: Failed to execute statement to verify database: %s">(), sqlite3_errstr(ret));
             break;
         }
         const char* msg = (const char*)sqlite3_column_text(stmt, 0);
         if (!msg) {
-            error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
+            error = strprintf(_<"SQLiteDatabase: Failed to read database verification error: %s">(), sqlite3_errstr(ret));
             break;
         }
         std::string str_msg(msg);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1891,7 +1891,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     fAbortRescan = false;
-    ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
+    ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
     uint256 tip_hash = WITH_LOCK(cs_wallet, return GetLastBlockHash());
     uint256 end_hash = tip_hash;
     if (max_height) chain().findAncestorByHeight(tip_hash, *max_height, FoundBlock().hash(end_hash));
@@ -1906,7 +1906,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
             m_scanning_progress = 0;
         }
         if (block_height % 100 == 0 && progress_end - progress_begin > 0.0) {
-            ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
+            ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
         }
 
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;
@@ -2003,7 +2003,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         WalletLogPrintf("Scanning current mempool transactions.\n");
         WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
     }
-    ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), 100); // hide progress dialog in GUI
+    ShowProgress(strprintf("%s %s", GetDisplayName(), _("Rescanning…").translated), 100); // hide progress dialog in GUI
     if (block_height && fAbortRescan) {
         WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -519,7 +519,7 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
     } catch (const std::exception& e) {
         assert(!wallet);
         if (!error.empty()) error += Untranslated("\n");
-        error += strprintf(Untranslated("Unexpected exception: %s"), e.what());
+        error += strprintf(Untranslated<"Unexpected exception: %s">(), e.what());
     }
     if (!wallet) {
         fs::remove_all(wallet_path);
@@ -2392,11 +2392,11 @@ util::Result<void> CWallet::RemoveTxs(std::vector<uint256>& txs_to_remove)
     for (const uint256& hash : txs_to_remove) {
         auto it_wtx = mapWallet.find(hash);
         if (it_wtx == mapWallet.end()) {
-            str_err = strprintf(_("Transaction %s does not belong to this wallet"), hash.GetHex());
+            str_err = strprintf(_<"Transaction %s does not belong to this wallet">(), hash.GetHex());
             break;
         }
         if (!batch.EraseTx(hash)) {
-            str_err = strprintf(_("Failure removing transaction: %s"), hash.GetHex());
+            str_err = strprintf(_<"Failure removing transaction: %s">(), hash.GetHex());
             break;
         }
         erased_txs.emplace_back(it_wtx);
@@ -2557,7 +2557,7 @@ util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType type, c
     LOCK(cs_wallet);
     auto spk_man = GetScriptPubKeyMan(type, /*internal=*/false);
     if (!spk_man) {
-        return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
+        return util::Error{strprintf(_<"Error: No %s addresses available.">(), FormatOutputType(type))};
     }
 
     auto op_dest = spk_man->GetNewDestination(type);
@@ -2650,7 +2650,7 @@ util::Result<CTxDestination> ReserveDestination::GetReservedDestination(bool int
 {
     m_spk_man = pwallet->GetScriptPubKeyMan(type, internal);
     if (!m_spk_man) {
-        return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
+        return util::Error{strprintf(_<"Error: No %s addresses available.">(), FormatOutputType(type))};
     }
 
     if (nIndex == -1) {
@@ -2987,42 +2987,42 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     DBErrors nLoadWalletRet = walletInstance->LoadWallet();
     if (nLoadWalletRet != DBErrors::LOAD_OK) {
         if (nLoadWalletRet == DBErrors::CORRUPT) {
-            error = strprintf(_("Error loading %s: Wallet corrupted"), walletFile);
+            error = strprintf(_<"Error loading %s: Wallet corrupted">(), walletFile);
             return nullptr;
         }
         else if (nLoadWalletRet == DBErrors::NONCRITICAL_ERROR)
         {
-            warnings.push_back(strprintf(_("Error reading %s! All keys read correctly, but transaction data"
-                                           " or address metadata may be missing or incorrect."),
+            warnings.push_back(strprintf(_<"Error reading %s! All keys read correctly, but transaction data"
+                                           " or address metadata may be missing or incorrect.">(),
                 walletFile));
         }
         else if (nLoadWalletRet == DBErrors::TOO_NEW) {
-            error = strprintf(_("Error loading %s: Wallet requires newer version of %s"), walletFile, PACKAGE_NAME);
+            error = strprintf(_<"Error loading %s: Wallet requires newer version of %s">(), walletFile, PACKAGE_NAME);
             return nullptr;
         }
         else if (nLoadWalletRet == DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED) {
-            error = strprintf(_("Error loading %s: External signer wallet being loaded without external signer support compiled"), walletFile);
+            error = strprintf(_<"Error loading %s: External signer wallet being loaded without external signer support compiled">(), walletFile);
             return nullptr;
         }
         else if (nLoadWalletRet == DBErrors::NEED_REWRITE)
         {
-            error = strprintf(_("Wallet needed to be rewritten: restart %s to complete"), PACKAGE_NAME);
+            error = strprintf(_<"Wallet needed to be rewritten: restart %s to complete">(), PACKAGE_NAME);
             return nullptr;
         } else if (nLoadWalletRet == DBErrors::NEED_RESCAN) {
-            warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
-                                           " Rescanning wallet."), walletFile));
+            warnings.push_back(strprintf(_<"Error reading %s! Transaction data may be missing or incorrect."
+                                           " Rescanning wallet.">(), walletFile));
             rescan_required = true;
         } else if (nLoadWalletRet == DBErrors::UNKNOWN_DESCRIPTOR) {
-            error = strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
+            error = strprintf(_<"Unrecognized descriptor found. Loading wallet %s\n\n"
                                 "The wallet might had been created on a newer version.\n"
-                                "Please try running the latest software version.\n"), walletFile);
+                                "Please try running the latest software version.\n">(), walletFile);
             return nullptr;
         } else if (nLoadWalletRet == DBErrors::UNEXPECTED_LEGACY_ENTRY) {
-            error = strprintf(_("Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
-                                "The wallet might have been tampered with or created with malicious intent.\n"), walletFile);
+            error = strprintf(_<"Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
+                                "The wallet might have been tampered with or created with malicious intent.\n">(), walletFile);
             return nullptr;
         } else {
-            error = strprintf(_("Error loading %s"), walletFile);
+            error = strprintf(_<"Error loading %s">(), walletFile);
             return nullptr;
         }
     }
@@ -3064,12 +3064,12 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         }
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
-        error = strprintf(_("Error loading %s: Private keys can only be disabled during creation"), walletFile);
+        error = strprintf(_<"Error loading %s: Private keys can only be disabled during creation">(), walletFile);
         return nullptr;
     } else if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {
-                warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+                warnings.push_back(strprintf(_<"Warning: Private keys detected in wallet {%s} with disabled private keys">(), walletFile));
                 break;
             }
         }
@@ -3078,7 +3078,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     if (!args.GetArg("-addresstype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-addresstype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown address type '%s'"), args.GetArg("-addresstype", ""));
+            error = strprintf(_<"Unknown address type '%s'">(), args.GetArg("-addresstype", ""));
             return nullptr;
         }
         walletInstance->m_default_address_type = parsed.value();
@@ -3087,7 +3087,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     if (!args.GetArg("-changetype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-changetype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown change type '%s'"), args.GetArg("-changetype", ""));
+            error = strprintf(_<"Unknown change type '%s'">(), args.GetArg("-changetype", ""));
             return nullptr;
         }
         walletInstance->m_default_change_type = parsed.value();
@@ -3125,7 +3125,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     if (args.IsArgSet("-fallbackfee")) {
         std::optional<CAmount> fallback_fee = ParseMoney(args.GetArg("-fallbackfee", ""));
         if (!fallback_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", args.GetArg("-fallbackfee", ""));
+            error = strprintf(_<"Invalid amount for %s=<amount>: '%s'">(), "-fallbackfee", args.GetArg("-fallbackfee", ""));
             return nullptr;
         } else if (fallback_fee.value() > HIGH_TX_FEE_PER_KB) {
             warnings.push_back(AmountHighWarn("-fallbackfee") + Untranslated(" ") +
@@ -3140,7 +3140,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     if (args.IsArgSet("-discardfee")) {
         std::optional<CAmount> discard_fee = ParseMoney(args.GetArg("-discardfee", ""));
         if (!discard_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", args.GetArg("-discardfee", ""));
+            error = strprintf(_<"Invalid amount for %s=<amount>: '%s'">(), "-discardfee", args.GetArg("-discardfee", ""));
             return nullptr;
         } else if (discard_fee.value() > HIGH_TX_FEE_PER_KB) {
             warnings.push_back(AmountHighWarn("-discardfee") + Untranslated(" ") +
@@ -3162,7 +3162,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         walletInstance->m_pay_tx_fee = CFeeRate{pay_tx_fee.value(), 1000};
 
         if (chain && walletInstance->m_pay_tx_fee < chain->relayMinFee()) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least %s)"),
+            error = strprintf(_<"Invalid amount for %s=<amount>: '%s' (must be at least %s)">(),
                 "-paytxfee", args.GetArg("-paytxfee", ""), chain->relayMinFee().ToString());
             return nullptr;
         }
@@ -3174,11 +3174,11 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
             error = AmountErrMsg("maxtxfee", args.GetArg("-maxtxfee", ""));
             return nullptr;
         } else if (max_fee.value() > HIGH_MAX_TX_FEE) {
-            warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
+            warnings.push_back(strprintf(_<"%s is set very high! Fees this large could be paid on a single transaction.">(), "-maxtxfee"));
         }
 
         if (chain && CFeeRate{max_fee.value(), 1000} < chain->relayMinFee()) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
+            error = strprintf(_<"Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)">(),
                 "-maxtxfee", args.GetArg("-maxtxfee", ""), chain->relayMinFee().ToString());
             return nullptr;
         }
@@ -3326,12 +3326,12 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
 
                 error = chain.havePruned() ?
                      _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)") :
-                     strprintf(_(
+                     strprintf(_<
                         "Error loading wallet. Wallet requires blocks to be downloaded, "
                         "and software does not currently support loading wallets while "
                         "blocks are being downloaded out of order when using assumeutxo "
                         "snapshots. Wallet should be able to load successfully after "
-                        "node sync reaches height %s"), block_height);
+                        "node sync reaches height %s">(), block_height);
                 return false;
             }
         }
@@ -3375,7 +3375,7 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
         WalletLogPrintf("Allowing wallet upgrade up to %i\n", version);
     }
     if (version < prev_version) {
-        error = strprintf(_("Cannot downgrade wallet from version %i to version %i. Wallet version unchanged."), prev_version, version);
+        error = strprintf(_<"Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.">(), prev_version, version);
         return false;
     }
 
@@ -3383,7 +3383,7 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
 
     // Do not upgrade versions to any version between HD_SPLIT and FEATURE_PRE_SPLIT_KEYPOOL unless already supporting HD_SPLIT
     if (!CanSupportFeature(FEATURE_HD_SPLIT) && version >= FEATURE_HD_SPLIT && version < FEATURE_PRE_SPLIT_KEYPOOL) {
-        error = strprintf(_("Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified."), prev_version, version, FEATURE_PRE_SPLIT_KEYPOOL);
+        error = strprintf(_<"Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.">(), prev_version, version, FEATURE_PRE_SPLIT_KEYPOOL);
         return false;
     }
 
@@ -4152,7 +4152,7 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
                     ins_wtx.CopyFrom(to_copy_wtx);
                     return true;
                 })) {
-                    error = strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex());
+                    error = strprintf(_<"Error: Could not add watchonly tx %s to watchonly wallet">(), wtx->GetHash().GetHex());
                     return false;
                 }
                 watchonly_batch->WriteTx(data.watchonly_wallet->mapWallet.at(hash));
@@ -4165,7 +4165,7 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
         }
         if (!is_mine) {
             // Both not ours and not in the watchonly wallet
-            error = strprintf(_("Error: Transaction %s in wallet cannot be identified to belong to migrated wallets"), wtx->GetHash().GetHex());
+            error = strprintf(_<"Error: Transaction %s in wallet cannot be identified to belong to migrated wallets">(), wtx->GetHash().GetHex());
             return false;
         }
     }
@@ -4185,7 +4185,7 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
 
         std::unique_ptr<WalletBatch> batch = std::make_unique<WalletBatch>(ext_wallet->GetDatabase());
         if (!batch->TxnBegin()) {
-            error = strprintf(_("Error: database transaction cannot be executed for wallet %s"), ext_wallet->GetName());
+            error = strprintf(_<"Error: database transaction cannot be executed for wallet %s">(), ext_wallet->GetName());
             return false;
         }
         wallets_vec.emplace_back(ext_wallet, std::move(batch));
@@ -4244,7 +4244,7 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
     // Persist external wallets address book entries
     for (auto& [wallet, batch] : wallets_vec) {
         if (!batch->TxnCommit()) {
-            error = strprintf(_("Error: address book copy failed for wallet %s"), wallet->GetName());
+            error = strprintf(_<"Error: address book copy failed for wallet %s">(), wallet->GetName());
             return false;
         }
     }
@@ -4310,7 +4310,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             std::string wallet_name = wallet.GetName() + "_watchonly";
             std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
+                error = strprintf(_<"Wallet file creation failed: %s">(), error);
                 return false;
             }
 
@@ -4347,7 +4347,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             std::string wallet_name = wallet.GetName() + "_solvables";
             std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
+                error = strprintf(_<"Wallet file creation failed: %s">(), error);
                 return false;
             }
 

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 FALSE_POSITIVES = [
-    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
+    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
 ]
 

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 FALSE_POSITIVES = [
-    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
+    ("src/clientversion.cpp", "strprintf(_<COPYRIGHT_HOLDERS>(), COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
 ]
 


### PR DESCRIPTION
Check translated `strprintf` calls at compile time to prevent `tinyformat::format_error` exceptions when the original string does not contain format specifiers matching the number of formatted arguments. Exceptions are still thrown if the translated strings do not contain the right number of format specifiers.

Most of the commits in this PR are code cleanup needed to make the compile time checks apply, but the relevant commits implementing the checks are simple:

- [`c49aaff65280` util: Add bilingual_lit type](https://github.com/bitcoin/bitcoin/pull/31074/commits/c49aaff652808017345736f72b0ee9c87ff44874)
- [`2b4668ec6877` scripted-diff: Replace _() with _<>() for compile time format checking](https://github.com/bitcoin/bitcoin/pull/31074/commits/2b4668ec68776294412d21b8cd74e373867bed11)
- [`649b9b62ecfc` util: Check bilingual_str format strings at compile time](https://github.com/bitcoin/bitcoin/pull/31074/commits/649b9b62ecfc079e693920af933cf3e541fa7fd5)

---

This PR is alternative to #31061, that has messier syntax than #31061, but a cleaner implementation and a less confusing API. Unlike #31061, the `_` and `Untranslated` functions continue to return `bilingual_str` structs with `original` and `translated` members instead of returning different structs with `lit` and `translate()` members. This approach is less confusing because it means there's a single type for representing bilingual values, and means that unlike #31061, code that is not doing string formatting does not need to change. Only code actually using tinyformat changes in this PR.

A drawback to this change compared to #31061 is that syntax for translated format strings is messier:

```diff
-    return strprintf(_("%s is set very high!"), optname);
+    return strprintf(_<"%s is set very high!">(), optname);
```
But that's also a good way of showing that the string is used at compile time, and without this, there's no way to get the `_` function to return a type that is compatible with bilingual_str.

Marking this as a draft because I need to think about differences of the two approaches. But I am inclined to think this approach is better because it is not fighting with compiler to be able evaluate function arguments at compile time, when this is supposed to be what template arguments are for https://old.reddit.com/r/cpp/comments/lxmv2z/allowing_parameters_of_consteval_function_to_be/gpp40lf/
