### PR TITLE
build: Fix kernel static lib component install

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -123,7 +123,7 @@ if(NOT BUILD_SHARED_LIBS)
   # LIBS_PRIVATE is substituted in the pkg-config file.
   set(LIBS_PRIVATE "")
   foreach(lib ${all_kernel_static_link_libs})
-    install(TARGETS ${lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(TARGETS ${lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Kernel)
     string(APPEND LIBS_PRIVATE " -l${lib}")
   endforeach()
 
@@ -131,7 +131,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT Kernel)
 
 include(GNUInstallDirs)
 install(TARGETS bitcoinkernel

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -120,14 +120,10 @@ if(NOT BUILD_SHARED_LIBS)
   set(all_kernel_static_link_libs "")
   get_target_static_link_libs(bitcoinkernel all_kernel_static_link_libs)
 
+  install(TARGETS ${all_kernel_static_link_libs} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Kernel)
+  list(TRANSFORM all_kernel_static_link_libs PREPEND "-l")
   # LIBS_PRIVATE is substituted in the pkg-config file.
-  set(LIBS_PRIVATE "")
-  foreach(lib ${all_kernel_static_link_libs})
-    install(TARGETS ${lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Kernel)
-    string(APPEND LIBS_PRIVATE " -l${lib}")
-  endforeach()
-
-  string(STRIP "${LIBS_PRIVATE}" LIBS_PRIVATE)
+  list(JOIN all_kernel_static_link_libs " " LIBS_PRIVATE)
 endif()
 
 configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)


### PR DESCRIPTION
Fixes the installation of the pkgconfig file and the static library when installing only the `Kernel` component.

This is a followup to fix #30835 and #30814, which were merged shortly after one another, but are interrelated. Can be tested with:
```
cmake -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_KERNEL_LIB=ON
cmake --build build --target bitcoinkernel
cmake --install build --component Kernel
```
