### PR TITLE
doc: Add xz-utils to the general dependencies for windows build

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -32,7 +32,7 @@ First, install the general dependencies:
 
     sudo apt update
     sudo apt upgrade
-    sudo apt install cmake curl g++ git make pkg-config
+    sudo apt install cmake curl g++ git make pkg-config xz-utils
 
 A host toolchain (`g++`) is necessary because some dependency
 packages need to build host utilities that are used in the build process.


### PR DESCRIPTION
The `xz-utils` package is not always installed by default on WSL. So when compiling bitcoin core for windows following the [doc](https://github.com/bitcoin/bitcoin/blob/master/doc/build-windows.md) the compilation of `qt` causes a critical error. `xz-utils` must then be installed afterwards. The bug creates a folder `/bitcoin/depends/work/build/x86_64-w64-mingw32/qt` which blocks the compilation process. You need to manually delete this folder to continue compiling.

`xz-utils`, installed by default, avoids this inconvenience.