### PR TITLE
chainparams: Re-add seed.bitcoinstats.com

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -147,6 +147,7 @@ public:
         vSeeds.emplace_back("seed.bitcoin.sipa.be."); // Pieter Wuille, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("dnsseed.bluematt.me."); // Matt Corallo, only supports x9
         vSeeds.emplace_back("dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us."); // Luke Dashjr
+        vSeeds.emplace_back("seed.bitcoinstats.com."); // Christian Decker, supports x1 - xf
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch."); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.net."); // Peter Todd, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.bitcoin.sprovoost.nl."); // Sjors Provoost


### PR DESCRIPTION
Following the removal in https://github.com/bitcoin/bitcoin/pull/30720, `seed.bitcoinstats.com` has been rebuilt from scratch and has been working correctly for the last couple of weeks. If desired we can re-enable it in the list of available seeds.

This reverts commit c88a7dc53e3be7489605c3326cf768df5437393a.