### PR TITLE
CI: Add label to scripted-diffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,25 @@ jobs:
           # Use clang++, because it is a bit faster and uses less memory than g++
           git rebase --exec "echo Running test-one-commit on \$( git log -1 ) && CC=clang CXX=clang++ cmake -B build -DWERROR=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWITH_BDB=ON -DWITH_MINIUPNPC=ON -DWITH_USDT=ON && cmake --build build -j $(nproc) && ctest --test-dir build -j $(nproc) && ./build/test/functional/test_runner.py -j $(( $(nproc) * 2 ))" ${{ env.TEST_BASE }}
 
+  label-scripted-diff:
+    name: 'label scripted diff'
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Check for scripted-diff commits and label PR # See: test/lint/commit-script-check.sh
+        run: |
+          if git rev-list --pretty="%s" -n ${{ github.event.pull_request.commits }} HEAD | grep -q "^scripted-diff:"; then
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "scripted-diff"
+            echo "Added 'scripted-diff' label to PR."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   macos-native-arm64:
     name: 'macOS 14 native, arm64, no depends, sqlite only, gui'
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -671,7 +671,7 @@ public:
         m_sorted_to_original(depgraph.TxCount()),
         m_original_to_sorted(depgraph.PositionRange())
     {
-        // Determine reordering mapping, by sorting by decreasing feerate. Unusued positions are
+        // Determine reordering mapping, by sorting by decreasing feerate. Unused positions are
         // not included, as they will never be looked up anyway.
         ClusterIndex sorted_pos{0};
         for (auto i : depgraph.Positions()) {

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -54,7 +54,7 @@ public:
     //! The optional `ready_fn` callback will be called after the event loop is
     //! created but before it is started. This can be useful in tests to trigger
     //! client connections from another thread as soon as the event loop is
-    //! available, but should not be neccessary in normal code which starts
+    //! available, but should not be necessary in normal code which starts
     //! clients and servers independently.
     virtual void serve(int fd, const char* exe_name, interfaces::Init& init, const std::function<void()>& ready_fn = {}) = 0;
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -135,7 +135,7 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
 }
 
 // Bypasses the actual proof of work check during fuzz testing with a simplified validation checking whether
-// the most signficant bit of the last byte of the hash is set.
+// the most significant bit of the last byte of the hash is set.
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -31,7 +31,7 @@ RET=0
 PREV_BRANCH=$(git name-rev --name-only HEAD)
 PREV_HEAD=$(git rev-parse HEAD)
 for commit in $(git rev-list --reverse "$1"); do
-    if git rev-list -n 1 --pretty="%s" "$commit" | grep -q "^scripted-diff:"; then
+    if git rev-list -n 1 --pretty="%s" "$commit" | grep -q "^scripted-diff:"; then # See: .github/workflows/ci.yml
         git checkout --quiet "$commit"^ || exit
         SCRIPT="$(git rev-list --format=%b -n1 "$commit" | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
         if test -z "$SCRIPT"; then


### PR DESCRIPTION
Add a `scripted-diff` label for pull requests that contain `scripted-diff:` commits, to make sure that CI is running them properly.
Inspired by https://github.com/bitcoin/bitcoin/issues/29692

Note that I've used https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows instead of e.g. `actions-ecosystem/action-add-labels` since it's a lot simpler, can be tried locally and documents a lot better what we're doing (it's also what their example uses in https://docs.github.com/en/actions/use-cases-and-examples/project-management/adding-labels-to-issues).