### PR TITLE
rpc: Disallow non-matching transactions in combinerawtransaction

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -652,9 +652,15 @@ static RPCHelpMan combinerawtransaction()
     UniValue txs = request.params[0].get_array();
     std::vector<CMutableTransaction> txVariants(txs.size());
 
+    std::optional<Txid> txid;
     for (unsigned int idx = 0; idx < txs.size(); idx++) {
         if (!DecodeHexTx(txVariants[idx], txs[idx].get_str())) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed for tx %d. Make sure the tx has at least one input.", idx));
+        }
+        if (txid.has_value() && txid.value() != txVariants[idx].GetHash()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Transactions to be combine do not match."));
+        } else {
+            txid = txVariants[idx].GetHash();
         }
     }
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -610,6 +610,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), bal + Decimal('50.00000000') + Decimal('2.19000000'))  # block reward + tx
         assert_raises_rpc_error(-25, "Input not found or already spent", self.nodes[0].combinerawtransaction, [rawTxPartialSigned1['hex'], rawTxPartialSigned2['hex']])
 
+        self.logging.info("Reject non-matching txids when calling combinerawtransaction")
+        rawtx1 = self.nodes[0].createrawtransaction(inputs=[], outputs={self.nodes[0].getnewaddress(): 1})
+        rawtx2 = self.nodes[0].createrawtransaction(inputs=[], outputs={self.nodes[0].getnewaddress(): 1})
+        assert_raises_rpc_error(-25, "Transactions to be combine do not match.", self.nodes[0].combinerawtransaction, [rawtx1, rawtx2])
+
+        self.logging.info("Accept duplicate transactions in combinerawtransaction")
+        rawtx3 = self.nodes[0].combinerawtransaction([rawtx1, rawtx1])
+        assert_equal(rawtx1, rawtx3)
 
 if __name__ == '__main__':
     RawTransactionsTest(__file__).main()


### PR DESCRIPTION
Resolves #25980 by disallowing obviously broken usage. If txid doesn't match, we can't sensibly combine it.