### PR TITLE
Introduce `g_fuzzing` global for fuzzing checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,11 +240,6 @@ if(BUILD_FOR_FUZZING)
   set(BUILD_GUI_TESTS OFF)
   set(BUILD_BENCH OFF)
   set(BUILD_FUZZ_BINARY ON)
-
-  target_compile_definitions(core_interface INTERFACE
-    ABORT_ON_FAILED_ASSUME
-    FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-  )
 endif()
 
 include(ProcessConfigurations)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -9,6 +9,7 @@
 #include <chain.h>
 #include <primitives/block.h>
 #include <uint256.h>
+#include <util/check.h>
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
@@ -138,11 +139,8 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
 // the most signficant bit of the last byte of the hash is set.
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    return (hash.data()[31] & 0x80) == 0;
-#else
+    if (g_fuzzing) return (hash.data()[31] & 0x80) == 0;
     return CheckProofOfWorkImpl(hash, nBits, params);
-#endif
 }
 
 bool CheckProofOfWorkImpl(uint256 hash, unsigned int nBits, const Consensus::Params& params)

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -102,6 +102,8 @@ void ResetCoverageCounters() {}
 
 void initialize()
 {
+    g_fuzzing = true;
+
     // By default, make the RNG deterministic with a fixed seed. This will affect all
     // randomness during the fuzz test, except:
     // - GetStrongRandBytes(), which is used for the creation of private key material.

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <string_view>
 
+bool g_fuzzing = false;
+
 std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func)
 {
     return strprintf("Internal bug detected: %s\n%s:%d (%s)\n"

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -13,6 +13,8 @@
 #include <string_view>
 #include <utility>
 
+extern bool g_fuzzing;
+
 std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func);
 
 class NonFatalCheckError : public std::runtime_error
@@ -42,7 +44,7 @@ void assertion_fail(std::string_view file, int line, std::string_view func, std:
 template <bool IS_ASSERT, typename T>
 constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
-    if (IS_ASSERT || std::is_constant_evaluated()
+    if (IS_ASSERT || std::is_constant_evaluated() || g_fuzzing
 #ifdef ABORT_ON_FAILED_ASSUME
         || true
 #endif


### PR DESCRIPTION
This PR introduces a global `g_fuzzing` that indicates if we are fuzzing.

If `g_fuzzing` is `true` then:

* Assume checks are enabled
* Special fuzzing paths are taken (e.g. pow check is reduced to one bit)

Closes #30950 #31057