### PR TITLE
Don't wipe coins cache when full and instead evict LRU clean entries

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -282,6 +282,17 @@ bool CCoinsViewCache::Sync()
     return fOk;
 }
 
+void CCoinsViewCache::MaybeShrinkCache(size_t size_to_fit) noexcept
+{
+    auto it{m_clean_sentinel.second.Next()};
+    while (it != &m_clean_sentinel && static_cast<int64_t>(DynamicMemoryUsage()) - DynamicMemoryAvailableSpace() >= size_to_fit) {
+        auto next{it->second.Next()};
+        cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
+        cacheCoins.erase(it->first);
+        it = next;
+    }
+}
+
 void CCoinsViewCache::Uncache(const COutPoint& hash)
 {
     CCoinsMap::iterator it = cacheCoins.find(hash);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -42,6 +42,10 @@ size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }
 
+size_t CCoinsViewCache::DynamicMemoryAvailableSpace() const {
+    return cacheCoins.get_allocator().resource()->FreeListBytes();
+}
+
 CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {
     const auto [ret, inserted] = cacheCoins.try_emplace(outpoint);
     if (inserted) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -141,8 +141,8 @@ private:
     inline void RemoveFromLinkedList() noexcept
     {
         if (m_next == nullptr) return;
-            m_next->second.m_prev = m_prev;
-            m_prev->second.m_next = m_next;
+        m_next->second.m_prev = m_prev;
+        m_prev->second.m_next = m_next;
     }
 
 public:
@@ -466,6 +466,12 @@ public:
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
     bool Sync();
+
+    /**
+     * Try shrinking the cache's memory usage minus free space by evicting clean
+     * cache entries from the clean linked list.
+     */
+    void MaybeShrinkCache(size_t size_to_fit) noexcept;
 
     /**
      * Removes the UTXO with the given outpoint from the cache, if it is

--- a/src/coins.h
+++ b/src/coins.h
@@ -460,8 +460,11 @@ public:
     //! Calculate the size of the cache (in number of transaction outputs)
     unsigned int GetCacheSize() const;
 
-    //! Calculate the size of the cache (in bytes)
+    //! Calculate the total size of the cache in memory (in bytes)
     size_t DynamicMemoryUsage() const;
+
+    //! Calculate the size of the available space in the cache (in bytes)
+    size_t DynamicMemoryAvailableSpace() const;
 
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;

--- a/src/malloc_usage.h
+++ b/src/malloc_usage.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MALLOC_USAGE_H
+#define BITCOIN_MALLOC_USAGE_H
+
+#include <cassert>
+#include <cstddef>
+
+namespace memusage {
+
+/** Compute the total memory used by allocating alloc bytes. */
+static inline size_t MallocUsage(size_t alloc)
+{
+    // Measured on libc6 2.19 on Linux.
+    if (alloc == 0) {
+        return 0;
+    } else if (sizeof(void*) == 8) {
+        return ((alloc + 31) >> 4) << 4;
+    } else if (sizeof(void*) == 4) {
+        return ((alloc + 15) >> 3) << 3;
+    } else {
+        assert(0);
+    }
+}
+
+} // namespace memusage
+
+#endif // BITCOIN_MALLOC_USAGE_H

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -175,14 +175,7 @@ static inline size_t DynamicUsage(const std::unordered_map<Key,
                                                                          MAX_BLOCK_SIZE_BYTES,
                                                                          ALIGN_BYTES>>& m)
 {
-    auto* pool_resource = m.get_allocator().resource();
-
-    // The allocated chunks are stored in a std::list. Size per node should
-    // therefore be 3 pointers: next, previous, and a pointer to the chunk.
-    size_t estimated_list_node_size = MallocUsage(sizeof(void*) * 3);
-    size_t usage_resource = estimated_list_node_size * pool_resource->NumAllocatedChunks();
-    size_t usage_chunks = MallocUsage(pool_resource->ChunkSizeBytes()) * pool_resource->NumAllocatedChunks();
-    return usage_resource + usage_chunks + MallocUsage(sizeof(void*) * m.bucket_count());
+    return m.get_allocator().resource()->DynamicMemoryUsage();
 }
 
 } // namespace memusage

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -6,10 +6,10 @@
 #define BITCOIN_MEMUSAGE_H
 
 #include <indirectmap.h>
+#include <malloc_usage.h>
 #include <prevector.h>
 #include <support/allocators/pool.h>
 
-#include <cassert>
 #include <cstdlib>
 #include <list>
 #include <map>
@@ -22,9 +22,6 @@
 
 namespace memusage
 {
-
-/** Compute the total memory used by allocating alloc bytes. */
-static size_t MallocUsage(size_t alloc);
 
 /** Dynamic memory usage for built-in types is zero. */
 static inline size_t DynamicUsage(const int8_t& v) { return 0; }
@@ -47,20 +44,6 @@ template<typename X> static inline size_t DynamicUsage(const X * const &v) { ret
  *  application data structures require more accurate inner accounting, they should
  *  iterate themselves, or use more efficient caching + updating on modification.
  */
-
-static inline size_t MallocUsage(size_t alloc)
-{
-    // Measured on libc6 2.19 on Linux.
-    if (alloc == 0) {
-        return 0;
-    } else if (sizeof(void*) == 8) {
-        return ((alloc + 31) >> 4) << 4;
-    } else if (sizeof(void*) == 4) {
-        return ((alloc + 15) >> 3) << 3;
-    } else {
-        assert(0);
-    }
-}
 
 // STL data structures
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -625,10 +625,12 @@ void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
     CoinsCachePair sentinel{};
     sentinel.second.SelfRef(sentinel);
+    CoinsCachePair clean_sentinel{};
+    clean_sentinel.second.SelfRef(clean_sentinel);
     CCoinsMapMemoryResource resource;
     CCoinsMap map{0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, &resource};
     auto usage{InsertCoinsMapEntry(map, sentinel, value, flags)};
-    auto cursor{CoinsViewCacheCursor(usage, sentinel, map, /*will_erase=*/true)};
+    auto cursor{CoinsViewCacheCursor(usage, sentinel, clean_sentinel, map, /*will_erase=*/true)};
     BOOST_CHECK(view.BatchWrite(cursor, {}));
 }
 

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -48,12 +48,14 @@ BOOST_AUTO_TEST_CASE(linked_list_iteration)
     BOOST_CHECK_EQUAL(node, &sentinel);
 
     // Check iterating through pairs is identical to iterating through a list
-    // Clear the flags during iteration
+    // Set clean during iteration
+    CoinsCachePair clean_sentinel;
+    clean_sentinel.second.SelfRef(clean_sentinel);
     node = sentinel.second.Next();
     for (const auto& expected : nodes) {
         BOOST_CHECK_EQUAL(&expected, node);
         auto next = node->second.Next();
-        node->second.ClearFlags();
+        node->second.SetClean(*node, clean_sentinel);
         node = next;
     }
     BOOST_CHECK_EQUAL(node, &sentinel);
@@ -184,16 +186,18 @@ BOOST_AUTO_TEST_CASE(linked_list_add_flags)
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
 
-    // Check that we can clear flags then re-add them
-    n1.second.ClearFlags();
+    CoinsCachePair clean_sentinel;
+    clean_sentinel.second.SelfRef(clean_sentinel);
+    // Check that we can set clean then re-add to flagged list
+    n1.second.SetClean(n1, clean_sentinel);
     BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
 
-    // Check that calling `ClearFlags` with 0 flags has no effect
-    n1.second.ClearFlags();
+    // Check that calling `SetClean` has no effect
+    n1.second.SetClean(n1, clean_sentinel);
     BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -122,6 +122,8 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
             [&] {
                 CoinsCachePair sentinel{};
                 sentinel.second.SelfRef(sentinel);
+                CoinsCachePair clean_sentinel{};
+                clean_sentinel.second.SelfRef(clean_sentinel);
                 size_t usage{0};
                 CCoinsMapMemoryResource resource;
                 CCoinsMap coins_map{0, SaltedOutpointHasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
@@ -145,7 +147,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 }
                 bool expected_code_path = false;
                 try {
-                    auto cursor{CoinsViewCacheCursor(usage, sentinel, coins_map, /*will_erase=*/true)};
+                    auto cursor{CoinsViewCacheCursor(usage, sentinel, clean_sentinel, coins_map, /*will_erase=*/true)};
                     coins_view_cache.BatchWrite(cursor, fuzzed_data_provider.ConsumeBool() ? ConsumeUInt256(fuzzed_data_provider) : coins_view_cache.GetBestBlock());
                     expected_code_path = true;
                 } catch (const std::logic_error& e) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -484,7 +484,9 @@ public:
 enum class CoinsCacheSizeState
 {
     //! The coins cache is in immediate need of a flush.
-    CRITICAL = 2,
+    CRITICAL = 3,
+    //! The coins cache is at >= 99% capacity.
+    NEAR_CRITICAL = 2,
     //! The cache is at >= 90% capacity.
     LARGE = 1,
     OK = 0
@@ -752,14 +754,16 @@ public:
     /** Update the chain tip based on database information, i.e. CoinsTip()'s best block. */
     bool LoadChainTip() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    size_t GetCoinsCacheSizeTotalSpace(
+        size_t max_coins_cache_size_bytes,
+        size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     //! Dictates whether we need to flush the cache to disk or not.
     //!
     //! @return the state of the size of the coins cache.
     CoinsCacheSizeState GetCoinsCacheSizeState() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    CoinsCacheSizeState GetCoinsCacheSizeState(
-        size_t max_coins_cache_size_bytes,
-        size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    CoinsCacheSizeState GetCoinsCacheSizeState(size_t total_space_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 


### PR DESCRIPTION
Depends on #28939.

This only wipes the coins cache if memory usage is greater than total allowed cache size. Instead, it does a non-wiping sync to disk and keeps all unspent coins in the cache. These are tracked in a linked list of clean entries, and when spent are removed from the clean linked list and appended to the dirty linked list. This results in the head of the clean linked list containing the oldest clean entry.

When the cache grows to above the large size threshold, clean entries beginning from the head of the linked list are evicted until the cache is below the threshold. This lets the cache maintain a size at or below the large threshold as long as clean entries exist in the cache. When there are no more clean entries, the non-wiping sync removes all spent entries and cleans all non-spent entries. This reduces the size of the cache and allows the previously dirty unspent entries to be evicted as needed.

The pool allocator is modified to add an accounting field to track the amount of free bytes. However, if the in-memory footprint of the cache grows larger than allowed it will wipe and reallocate the cache. This will happen if the mempool fills up and the cache was using the unused mempool space. It will also be reallocated when resizing caches during assumeutxo syncing.