### PR TITLE
Update libmultiprocess library

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=015e95f7ebaa47619a213a19801e7fffafc56864
+$(package)_version=abe254b9734f2e2b220d1456de195532d6e6ac1e
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=4b1266b121337f3f6f37e1863fba91c1a5ee9ad126bcffc6fe6b9ca47ad050a1
+$(package)_sha256_hash=85777073259fdc75d24ac5777a19991ec1156c5f12db50b252b861c95dcb4f46
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds

--- a/src/test/ipc_test.cpp
+++ b/src/test/ipc_test.cpp
@@ -62,7 +62,7 @@ void IpcPipeTest()
 
         auto connection_client = std::make_unique<mp::Connection>(loop, kj::mv(pipe.ends[0]));
         auto foo_client = std::make_unique<mp::ProxyClient<gen::FooInterface>>(
-            connection_client->m_rpc_system.bootstrap(mp::ServerVatId().vat_id).castAs<gen::FooInterface>(),
+            connection_client->m_rpc_system->bootstrap(mp::ServerVatId().vat_id).castAs<gen::FooInterface>(),
             connection_client.get(), /* destroy_connection= */ false);
         foo_promise.set_value(std::move(foo_client));
         disconnect_client = [&] { loop.sync([&] { connection_client.reset(); }); };


### PR DESCRIPTION
Add recent changes and fixes for shutdown bugs.

https://github.com/chaincodelabs/libmultiprocess/pull/111: doc: Add internal design section
https://github.com/chaincodelabs/libmultiprocess/pull/113: Add missing include to util.h
https://github.com/chaincodelabs/libmultiprocess/pull/116: shutdown bugfix: destroy RPC system before running cleanup callbacks
https://github.com/chaincodelabs/libmultiprocess/pull/118: shutdown bugfix: Prevent segfault in server if connection is broken during long function call
https://github.com/chaincodelabs/libmultiprocess/pull/119: cmake: avoid libatomic not found error on debian