### PR TITLE
miner: Reorg Testnet4 minimum difficulty blocks

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -14,6 +14,7 @@
 #include <common/settings.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
+#include <consensus/params.h>
 #include <consensus/validation.h>
 #include <external_signer.h>
 #include <httprpc.h>
@@ -50,6 +51,7 @@
 #include <policy/fees/block_policy_estimator.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
+#include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
@@ -976,6 +978,86 @@ public:
         return WaitTipChanged(chainman(), notifications(), current_tip, timeout, m_interrupt_mining);
     }
 
+    // Collect all blocks in the block index that are not on the active chain
+    // and are above the given height.
+    std::vector<CBlockIndex*> GetAllForkBlocksAboveHeight(int height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        CChain& active_chain = chainman().ActiveChain();
+        std::vector<CBlockIndex*> forks;
+        for (auto& [_, block_index] : chainman().BlockIndex()) {
+            if (!active_chain.Contains(block_index) && block_index.nHeight > height) {
+                forks.push_back(&block_index);
+            }
+        }
+        return forks;
+    }
+
+    // Temporarily invalidate min-difficulty blocks and competing forks on
+    // Testnet4 so that a block template can be built on top of the last
+    // actual-difficulty block. Returns the list of invalidated block indexes
+    // so they can be reconsidered later.
+    std::vector<CBlockIndex*> RollbackTestnet4MinDiffBlocks()
+    {
+        std::vector<CBlockIndex*> invalids;
+
+        // Collect all min-difficulty blocks from the current tip backwards,
+        // stopping at the first actual-difficulty block.
+        {
+            LOCK(::cs_main);
+            CBlockIndex* tip{chainman().ActiveChain().Tip()};
+            if (!tip) return {};
+
+            CBlockIndex* walk{tip};
+            while (walk->nBits == 0x1d00ffff) {
+                invalids.push_back(walk);
+                walk = walk->pprev;
+                if (!walk) return {};
+            }
+
+            // No min-difficulty blocks found at the tip
+            if (invalids.empty()) return {};
+
+            // Insert forks first so the actual-difficulty block remains the
+            // tip when invalidating.
+            std::vector<CBlockIndex*> forks = GetAllForkBlocksAboveHeight(walk->nHeight);
+            invalids.insert(invalids.end(), forks.begin(), forks.end());
+        }
+
+        // Invalidate min-difficulty blocks, starting with forks first.
+        for (auto it = invalids.rbegin(); it != invalids.rend(); ++it) {
+            BlockValidationState state;
+            chainman().ActiveChainstate().InvalidateBlock(state, *it);
+            if (state.IsValid()) {
+                chainman().ActiveChainstate().ActivateBestChain(state);
+            }
+            if (!state.IsValid()) {
+                LogWarning("testnet4 rollback: failed to invalidate block %s: %s\n",
+                           (*it)->GetBlockHash().ToString(), state.ToString());
+            }
+        }
+
+        return invalids;
+    }
+
+    // Undo the temporary invalidation of min-difficulty blocks.
+    void ReconsiderTestnet4Blocks(const std::vector<CBlockIndex*>& invalids)
+    {
+        for (CBlockIndex* index : invalids) {
+            {
+                LOCK(::cs_main);
+                chainman().ActiveChainstate().ResetBlockFailureFlags(index);
+                chainman().RecalculateBestHeader();
+            }
+            BlockValidationState state;
+            chainman().ActiveChainstate().ActivateBestChain(state);
+            if (!state.IsValid()) {
+                LogWarning("testnet4 rollback: failed to reconsider block %s: %s\n",
+                           index->GetBlockHash().ToString(), state.ToString());
+            }
+        }
+    }
+
     std::unique_ptr<BlockTemplate> createNewBlock(const BlockCreateOptions& options, bool cooldown) override
     {
         // Ensure m_tip_block is set so consumers of BlockTemplate can rely on that.
@@ -997,14 +1079,35 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
         }
+
+        // On testnet4, temporarily roll back any min-difficulty blocks at the
+        // tip so that the template builds on the last actual-difficulty block.
+        // This lets a miner produce a block that re-orgs the min-difficulty
+        // chain. The rollback is undone after the template is created.
+        std::vector<CBlockIndex*> testnet4_invalids;
+        if (chainman().GetConsensus().enforce_BIP94 && !chainman().IsInitialBlockDownload()) {
+            testnet4_invalids = RollbackTestnet4MinDiffBlocks();
+        }
+
         const BlockCreateOptions create_options{MergeMiningOptions(options, m_node.mining_args)};
-        return std::make_unique<BlockTemplateImpl>(create_options,
-                                                   BlockAssembler{
-                                                       chainman().ActiveChainstate(),
-                                                       m_node.mempool.get(),
-                                                       create_options,
-                                                   }.CreateNewBlock(),
-                                                   m_node);
+        std::unique_ptr<CBlockTemplate> block_template{
+            BlockAssembler{chainman().ActiveChainstate(), m_node.mempool.get(), create_options}.CreateNewBlock()};
+
+        if (!testnet4_invalids.empty()) {
+            const CBlockIndex* prev{WITH_LOCK(::cs_main,
+                return chainman().m_blockman.LookupBlockIndex(block_template->block.hashPrevBlock))};
+            if (prev && block_template->block.nTime > prev->nTime + 1200) {
+                // Set block time 18 min ahead of the prev block, assuming that the
+                // template should be refreshed roughly once every minute
+                block_template->block.nTime = prev->nTime + 1080;
+                block_template->block.nBits = GetNextWorkRequired(prev, &block_template->block,
+                                                                  chainman().GetConsensus());
+            }
+
+            ReconsiderTestnet4Blocks(testnet4_invalids);
+        }
+
+        return std::make_unique<BlockTemplateImpl>(create_options, std::move(block_template), m_node);
     }
 
     void interrupt() override

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -915,6 +915,13 @@ static RPCMethod getblocktemplate()
     CHECK_NONFATAL(pindexPrev);
     CBlock block{block_template->getBlock()};
 
+    if (consensusParams.enforce_BIP94) {
+        // createNewBlock() may have built the template on a rolled-back tip, i.e.
+        // the last block not using the min-difficulty exception. In that case
+        // derive the actual prev block from the template rather than pindexPrev.
+        pindexPrev = CHECK_NONFATAL(chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock));
+    }
+
     // Update nTime
     UpdateTime(&block, consensusParams, pindexPrev);
     block.nNonce = 0;


### PR DESCRIPTION
Note: This is just a proof of concept put here for discussion/feedback/brainstorming/improvement. I am not sure if we want to merge this into core at all since it can be dealt with externally as well. But this was the simplest way for me to make it work and it's probably also simpler for many miners to run this branch rather than another external software.

### Context

Testnet4 fixes block storms but it kept the minimum-difficulty exception in place. The rationale was that this would be the only way developers could still get their non-standard transactions into the blockchain. However, probably due to the public discussion of this feature, this has attracted the attention of people whose motivation might be A) grab as many testnet coins as possible or B) to annoy developers. There are currently one or more actors who just max out the min-difficulty exception as much as possible and as quickly as possible, see https://mempool.space/testnet4. There are always several min-difficulty blocks appearing instantly after a normal difficulty mined block.

There are several implications to this:
- Developers can not get their non-standard transactions into the blockchain using the min-exception blocks, unless they put in significant effort to outrace the spammers
- The actual difficulty is artificially raised
- Less coins are going to faucets (though this is a very minor issue)

### Solution

The solution to this problem was already briefly discussed in the original pull request for Testnet4: The min-difficulty blocks can all be easily re-orged by a single block with the actual difficulty. The code here implements this functionality within the `getblocktemplate` RPC. All blocks with min-difficulty (including forks) are temporarily marked invalid while the template is created. The blocks are only temporarily marked invalid since another miner might find an actual difficulty block on top of the min-difficulty blocks and we don't want to create a fork in the chain in that case.

We do want to keep the transactions from the blocks and include them in the block template. That should work with this solution via the orphan pool but I haven't done extensive testing on this yet. In reality it seems like there are several transactions in these min-difficulty blocks with a minimum block height and these can not be included in the re-org block (except the ones that are in the first one). However, given that these transactions appear in almost every block it might just be self-transfers created by the spammer.

### Mining Pool

The follow-up to this would be to run a public (solo) pool with this enabled so that we can get some more hash rate behind this without requiring any effort on the side of those with hash rate and demotivate the spammers.

### Acknowledgement

I worked on this at Bitcoin++ in Berlin a week ago together with Emzy and Sjors. Together we were able to demo a pool running a previous version of this PR and connected a miner to it. That pool isn't public yet though.

### Demo

Here are some log outputs showing how first the orphan blocks are invalidated and then the actual chain is rolled back. Then, after the template was constructed, the blocks are reconsidered.

<details><summary>Logs</summary>

```
2024-10-19T13:14:29Z InvalidChainFound: invalid block=00000000004967e9a55121ced9a1b5df2bbf794edef6eaeca56985180dca178a  height=50944  log2_work=71.373305  date=2024-10-19T13:58:13Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=000000000097f5f8174415729790d2d83b90af466564ddf416247a050681caee  height=50947  log2_work=71.373305  date=2024-10-19T14:58:16Z
2024-10-19T13:14:29Z InvalidChainFound: invalid block=00000000002663fc47b4f47626296cc2d3118320581c4ff0eaa6317812bffdb2  height=50945  log2_work=71.373305  date=2024-10-19T14:18:14Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=000000000097f5f8174415729790d2d83b90af466564ddf416247a050681caee  height=50947  log2_work=71.373305  date=2024-10-19T14:58:16Z
2024-10-19T13:14:29Z InvalidChainFound: invalid block=000000000062e7e0743d4e97085a1696c7352096ea53e58daad468fc8995f397  height=50946  log2_work=71.373305  date=2024-10-19T14:38:15Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=000000000097f5f8174415729790d2d83b90af466564ddf416247a050681caee  height=50947  log2_work=71.373305  date=2024-10-19T14:58:16Z
2024-10-19T13:14:29Z UpdateTip: new best=0000000000638927100cc5578d750a9fcb763020fdab55bf27ba39ba26a57000 height=50946 version=0x2840e000 log2_work=71.373305 tx=862937 date='2024-10-19T14:38:15Z' progress=1.000000 cache=0.6MiB(2838txo)
2024-10-19T13:14:29Z InvalidChainFound: invalid block=000000000097f5f8174415729790d2d83b90af466564ddf416247a050681caee  height=50947  log2_work=71.373305  date=2024-10-19T14:58:16Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=0000000000638927100cc5578d750a9fcb763020fdab55bf27ba39ba26a57000  height=50946  log2_work=71.373305  date=2024-10-19T14:38:15Z
2024-10-19T13:14:29Z UpdateTip: new best=0000000000d35f958ad057b68c5822990b8b91325f6e549a2386b578e231a8b0 height=50945 version=0x27b82000 log2_work=71.373305 tx=862933 date='2024-10-19T14:18:14Z' progress=1.000000 cache=0.6MiB(2834txo)
2024-10-19T13:14:29Z InvalidChainFound: invalid block=0000000000638927100cc5578d750a9fcb763020fdab55bf27ba39ba26a57000  height=50946  log2_work=71.373305  date=2024-10-19T14:38:15Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=0000000000d35f958ad057b68c5822990b8b91325f6e549a2386b578e231a8b0  height=50945  log2_work=71.373305  date=2024-10-19T14:18:14Z
2024-10-19T13:14:29Z UpdateTip: new best=0000000000c0704c802da78900f465ea3eaeba55719b76c88bc9f2a43bacb58c height=50944 version=0x22de4000 log2_work=71.373305 tx=862930 date='2024-10-19T13:58:13Z' progress=1.000000 cache=0.6MiB(2832txo)
2024-10-19T13:14:29Z InvalidChainFound: invalid block=0000000000d35f958ad057b68c5822990b8b91325f6e549a2386b578e231a8b0  height=50945  log2_work=71.373305  date=2024-10-19T14:18:14Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=0000000000c0704c802da78900f465ea3eaeba55719b76c88bc9f2a43bacb58c  height=50944  log2_work=71.373305  date=2024-10-19T13:58:13Z
2024-10-19T13:14:29Z UpdateTip: new best=0000000000f6f9d3588bbc15a2bd5da43c4470301b4361104a9781e530830bfb height=50943 version=0x224c4000 log2_work=71.373305 tx=862929 date='2024-10-19T13:38:12Z' progress=1.000000 cache=0.6MiB(2832txo)
2024-10-19T13:14:29Z InvalidChainFound: invalid block=0000000000c0704c802da78900f465ea3eaeba55719b76c88bc9f2a43bacb58c  height=50944  log2_work=71.373305  date=2024-10-19T13:58:13Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=0000000000f6f9d3588bbc15a2bd5da43c4470301b4361104a9781e530830bfb  height=50943  log2_work=71.373305  date=2024-10-19T13:38:12Z
2024-10-19T13:14:29Z UpdateTip: new best=0000000000000005a8ae7897cfd4a0a9f1f45c89bf9f4dc090d7074b2b7a4586 height=50942 version=0x20000000 log2_work=71.373305 tx=862928 date='2024-10-19T13:18:11Z' progress=1.000000 cache=0.6MiB(2832txo)
2024-10-19T13:14:29Z InvalidChainFound: invalid block=0000000000f6f9d3588bbc15a2bd5da43c4470301b4361104a9781e530830bfb  height=50943  log2_work=71.373305  date=2024-10-19T13:38:12Z
2024-10-19T13:14:29Z InvalidChainFound:  current best=0000000000000005a8ae7897cfd4a0a9f1f45c89bf9f4dc090d7074b2b7a4586  height=50942  log2_work=71.373305  date=2024-10-19T13:18:11Z
2024-10-19T13:14:29Z CreateNewBlock(): block weight: 14069 txs: 18 fees: 35293 sigops 412
2024-10-19T13:14:29Z UpdateTip: new best=0000000000f6f9d3588bbc15a2bd5da43c4470301b4361104a9781e530830bfb height=50943 version=0x224c4000 log2_work=71.373305 tx=862929 date='2024-10-19T13:38:12Z' progress=1.000000 cache=0.6MiB(2832txo)
2024-10-19T13:14:29Z UpdateTip: new best=0000000000c0704c802da78900f465ea3eaeba55719b76c88bc9f2a43bacb58c height=50944 version=0x22de4000 log2_work=71.373305 tx=862930 date='2024-10-19T13:58:13Z' progress=1.000000 cache=0.6MiB(2832txo)
2024-10-19T13:14:29Z UpdateTip: new best=0000000000d35f958ad057b68c5822990b8b91325f6e549a2386b578e231a8b0 height=50945 version=0x27b82000 log2_work=71.373305 tx=862933 date='2024-10-19T14:18:14Z' progress=1.000000 cache=0.6MiB(2834txo)
2024-10-19T13:14:29Z UpdateTip: new best=0000000000638927100cc5578d750a9fcb763020fdab55bf27ba39ba26a57000 height=50946 version=0x2840e000 log2_work=71.373305 tx=862937 date='2024-10-19T14:38:15Z' progress=1.000000 cache=0.6MiB(2838txo)
2024-10-19T13:14:29Z UpdateTip: new best=000000000097f5f8174415729790d2d83b90af466564ddf416247a050681caee height=50947 version=0x25f34000 log2_work=71.373305 tx=862947 date='2024-10-19T14:58:16Z' progress=1.000000 cache=0.6MiB(2853txo)
```

</details>