### PR TITLE
cluster mempool: Implement changeset interface for mempool

### DIFF
--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -245,14 +245,15 @@ Arguments passed:
 2. Replaced transaction virtual size as `int32`
 3. Replaced transaction fee as `int64`
 4. Replaced transaction mempool entry time (epoch) as `uint64`
-5. Replacement transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+5. Replacement transaction ID or package hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
 6. Replacement transaction virtual size as `int32`
 7. Replacement transaction fee as `int64`
+8. `bool` indicating if the argument 5. is a transaction ID or package hash (true if it's a transaction ID)
 
-Note: In cases where a single replacement transaction replaces multiple
+Note: In cases where a replacement transaction or package replaces multiple
 existing transactions in the mempool, the tracepoint is called once for each
-replaced transaction, with data of the replacement transaction being the same
-in each call.
+replaced transaction, with data of the replacement transaction or package
+being the same in each call.
 
 #### Tracepoint `mempool:rejected`
 

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -11,6 +11,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/check.h>
 
@@ -28,7 +29,7 @@ static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_R
     unsigned int sigOpCost{4};
     uint64_t fee{0};
     LockPoints lp;
-    pool.addUnchecked(CTxMemPoolEntry(
+    AddToMempool(pool, CTxMemPoolEntry(
         tx, fee, nTime, nHeight, sequence,
         spendsCoinbase, sigOpCost, lp));
 }

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/check.h>
 
@@ -26,7 +27,7 @@ static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& po
     bool spendsCoinbase = false;
     unsigned int sigOpCost = 4;
     LockPoints lp;
-    pool.addUnchecked(CTxMemPoolEntry(
+    AddToMempool(pool, CTxMemPoolEntry(
         tx, nFee, nTime, nHeight, sequence,
         spendsCoinbase, sigOpCost, lp));
 }

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <validation.h>
 
@@ -28,7 +29,7 @@ static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_R
     bool spendsCoinbase = false;
     unsigned int sigOpCost = 4;
     LockPoints lp;
-    pool.addUnchecked(CTxMemPoolEntry(tx, 1000, nTime, nHeight, sequence, spendsCoinbase, sigOpCost, lp));
+    AddToMempool(pool, CTxMemPoolEntry(tx, 1000, nTime, nHeight, sequence, spendsCoinbase, sigOpCost, lp));
 }
 
 struct Available {

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <univalue.h>
 #include <util/check.h>
@@ -21,7 +22,7 @@
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     LockPoints lp;
-    pool.addUnchecked(CTxMemPoolEntry(tx, fee, /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
+    AddToMempool(pool, CTxMemPoolEntry(tx, fee, /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
 }
 
 static void RpcMempool(benchmark::Bench& bench)

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -191,7 +191,7 @@ std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(
                                                 int64_t replacement_vsize)
 {
     // Require that the replacement strictly improves the mempool's feerate diagram.
-    const auto chunk_results{pool.CalculateChunksForRBF(replacement_fees, replacement_vsize, direct_conflicts, all_conflicts)};
+    const auto chunk_results{pool.CalculateChunksForRBF(replacement_fees, replacement_vsize, all_conflicts, all_conflicts)};
 
     if (!chunk_results.has_value()) {
         return std::make_pair(DiagramCheckError::UNCALCULABLE, util::ErrorString(chunk_results).original);

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -184,14 +184,10 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
     return std::nullopt;
 }
 
-std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(CTxMemPool& pool,
-                                                const CTxMemPool::setEntries& direct_conflicts,
-                                                const CTxMemPool::setEntries& all_conflicts,
-                                                CAmount replacement_fees,
-                                                int64_t replacement_vsize)
+std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(CTxMemPool::ChangeSet& changeset)
 {
     // Require that the replacement strictly improves the mempool's feerate diagram.
-    const auto chunk_results{pool.CalculateChunksForRBF(replacement_fees, replacement_vsize, all_conflicts, all_conflicts)};
+    const auto chunk_results{changeset.CalculateChunksForRBF()};
 
     if (!chunk_results.has_value()) {
         return std::make_pair(DiagramCheckError::UNCALCULABLE, util::ErrorString(chunk_results).original);

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -117,19 +117,9 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
 
 /**
  * The replacement transaction must improve the feerate diagram of the mempool.
- * @param[in]   pool                The mempool.
- * @param[in]   direct_conflicts    Set of in-mempool txids corresponding to the direct conflicts i.e.
- *                                  input double-spends with the proposed transaction
- * @param[in]   all_conflicts       Set of mempool entries corresponding to all transactions to be evicted
- * @param[in]   replacement_fees    Fees of proposed replacement package
- * @param[in]   replacement_vsize   Size of proposed replacement package
+ * @param[in]   changeset           The changeset containing proposed additions/removals
  * @returns error type and string if mempool diagram doesn't improve, otherwise std::nullopt.
  */
-std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(CTxMemPool& pool,
-                                                const CTxMemPool::setEntries& direct_conflicts,
-                                                const CTxMemPool::setEntries& all_conflicts,
-                                                CAmount replacement_fees,
-                                                int64_t replacement_vsize)
-                                                EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
+std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(CTxMemPool::ChangeSet& changeset);
 
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
     CBlock block(BuildBlockTestCase(rand_ctx));
 
     LOCK2(cs_main, pool.cs);
-    pool.addUnchecked(entry.FromTx(block.vtx[2]));
+    AddToMempool(pool, entry.FromTx(block.vtx[2]));
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     // Do a simple ShortTxIDs RT
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
     CBlock block(BuildBlockTestCase(rand_ctx));
 
     LOCK2(cs_main, pool.cs);
-    pool.addUnchecked(entry.FromTx(block.vtx[2]));
+    AddToMempool(pool, entry.FromTx(block.vtx[2]));
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     uint256 txhash;
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
     CBlock block(BuildBlockTestCase(rand_ctx));
 
     LOCK2(cs_main, pool.cs);
-    pool.addUnchecked(entry.FromTx(block.vtx[1]));
+    AddToMempool(pool, entry.FromTx(block.vtx[1]));
     BOOST_CHECK_EQUAL(pool.get(block.vtx[1]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     uint256 txhash;
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     extra_txn.resize(10);
 
     LOCK2(cs_main, pool.cs);
-    pool.addUnchecked(entry.FromTx(block.vtx[2]));
+    AddToMempool(pool, entry.FromTx(block.vtx[2]));
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
     // Ensure the non_block_tx is actually not in the block
     for (const auto &block_tx : block.vtx) {

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -59,7 +59,7 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
         TestMemPoolEntryHelper entry;
         const CAmount fee{ConsumeMoney(fuzzed_data_provider, /*max=*/MAX_MONEY/100000)};
         assert(MoneyRange(fee));
-        pool.addUnchecked(entry.Fee(fee).FromTx(tx));
+        AddToMempool(pool, entry.Fee(fee).FromTx(tx));
 
         // All outputs are available to spend
         for (uint32_t n{0}; n < num_outputs; ++n) {
@@ -154,7 +154,7 @@ FUZZ_TARGET(mini_miner_selection, .init = initialize_miner)
         TestMemPoolEntryHelper entry;
         const CAmount fee{ConsumeMoney(fuzzed_data_provider, /*max=*/MAX_MONEY/100000)};
         assert(MoneyRange(fee));
-        pool.addUnchecked(entry.Fee(fee).FromTx(tx));
+        AddToMempool(pool, entry.Fee(fee).FromTx(tx));
         transactions.push_back(tx);
     }
     std::vector<COutPoint> outpoints;

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -78,7 +78,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
 
         if (add_to_mempool && !pool.exists(GenTxid::Txid(tx->GetHash()))) {
             LOCK2(cs_main, pool.cs);
-            pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx));
+            AddToMempool(pool, ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx));
             available.insert(i);
         }
     }

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -73,12 +73,12 @@ FUZZ_TARGET(rbf, .init = initialize_rbf)
             mtx->vin[0].prevout = COutPoint{another_tx.GetHash(), 0};
         }
         LOCK2(cs_main, pool.cs);
-        pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, another_tx));
+        AddToMempool(pool, ConsumeTxMemPoolEntry(fuzzed_data_provider, another_tx));
     }
     const CTransaction tx{*mtx};
     if (fuzzed_data_provider.ConsumeBool()) {
         LOCK2(cs_main, pool.cs);
-        pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
+        AddToMempool(pool, ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
     }
     {
         LOCK(pool.cs);
@@ -129,7 +129,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
             mempool_txs.pop_back();
             break;
         }
-        pool.addUnchecked(parent_entry);
+        AddToMempool(pool, parent_entry);
         if (fuzzed_data_provider.ConsumeBool()) {
             child.vin[0].prevout = COutPoint{mempool_txs.back().GetHash(), 0};
         }
@@ -141,7 +141,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
             mempool_txs.pop_back();
             break;
         }
-        pool.addUnchecked(child_entry);
+        AddToMempool(pool, child_entry);
 
         if (fuzzed_data_provider.ConsumeBool()) {
             pool.PrioritiseTransaction(mempool_txs.back().GetHash().ToUint256(), fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(-100000, 100000));

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(miniminer_negative, TestChain100Setup)
     const CAmount negative_modified_fees{positive_base_fee + negative_fee_delta};
     BOOST_CHECK(negative_modified_fees < 0);
     const auto tx_mod_negative = make_tx({COutPoint{m_coinbase_txns[4]->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(positive_base_fee).FromTx(tx_mod_negative));
+    AddToMempool(pool, entry.Fee(positive_base_fee).FromTx(tx_mod_negative));
     pool.PrioritiseTransaction(tx_mod_negative->GetHash(), negative_fee_delta);
     const COutPoint only_outpoint{tx_mod_negative->GetHash(), 0};
 
@@ -114,21 +114,21 @@ BOOST_FIXTURE_TEST_CASE(miniminer_1p1c, TestChain100Setup)
 
     // Create a parent tx0 and child tx1 with normal fees:
     const auto tx0 = make_tx({COutPoint{m_coinbase_txns[0]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(med_fee).FromTx(tx0));
+    AddToMempool(pool, entry.Fee(med_fee).FromTx(tx0));
     const auto tx1 = make_tx({COutPoint{tx0->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(med_fee).FromTx(tx1));
+    AddToMempool(pool, entry.Fee(med_fee).FromTx(tx1));
 
     // Create a low-feerate parent tx2 and high-feerate child tx3 (cpfp)
     const auto tx2 = make_tx({COutPoint{m_coinbase_txns[1]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx2));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx2));
     const auto tx3 = make_tx({COutPoint{tx2->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx3));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx3));
 
     // Create a parent tx4 and child tx5 where both have low fees
     const auto tx4 = make_tx({COutPoint{m_coinbase_txns[2]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx4));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx4));
     const auto tx5 = make_tx({COutPoint{tx4->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx5));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx5));
     const CAmount tx5_delta{CENT/100};
     // Make tx5's modified fee much higher than its base fee. This should cause it to pass
     // the fee-related checks despite being low-feerate.
@@ -137,9 +137,9 @@ BOOST_FIXTURE_TEST_CASE(miniminer_1p1c, TestChain100Setup)
 
     // Create a high-feerate parent tx6, low-feerate child tx7
     const auto tx6 = make_tx({COutPoint{m_coinbase_txns[3]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx6));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx6));
     const auto tx7 = make_tx({COutPoint{tx6->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx7));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx7));
 
     std::vector<COutPoint> all_unspent_outpoints({
         COutPoint{tx0->GetHash(), 1},
@@ -405,23 +405,23 @@ BOOST_FIXTURE_TEST_CASE(miniminer_overlap, TestChain100Setup)
 
     // Create 3 parents of different feerates, and 1 child spending outputs from all 3 parents.
     const auto tx0 = make_tx({COutPoint{m_coinbase_txns[0]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx0));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx0));
     const auto tx1 = make_tx({COutPoint{m_coinbase_txns[1]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(med_fee).FromTx(tx1));
+    AddToMempool(pool, entry.Fee(med_fee).FromTx(tx1));
     const auto tx2 = make_tx({COutPoint{m_coinbase_txns[2]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx2));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx2));
     const auto tx3 = make_tx({COutPoint{tx0->GetHash(), 0}, COutPoint{tx1->GetHash(), 0}, COutPoint{tx2->GetHash(), 0}}, /*num_outputs=*/3);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx3));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx3));
 
     // Create 1 grandparent and 1 parent, then 2 children.
     const auto tx4 = make_tx({COutPoint{m_coinbase_txns[3]->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx4));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx4));
     const auto tx5 = make_tx({COutPoint{tx4->GetHash(), 0}}, /*num_outputs=*/3);
-    pool.addUnchecked(entry.Fee(low_fee).FromTx(tx5));
+    AddToMempool(pool, entry.Fee(low_fee).FromTx(tx5));
     const auto tx6 = make_tx({COutPoint{tx5->GetHash(), 0}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(med_fee).FromTx(tx6));
+    AddToMempool(pool, entry.Fee(med_fee).FromTx(tx6));
     const auto tx7 = make_tx({COutPoint{tx5->GetHash(), 1}}, /*num_outputs=*/2);
-    pool.addUnchecked(entry.Fee(high_fee).FromTx(tx7));
+    AddToMempool(pool, entry.Fee(high_fee).FromTx(tx7));
 
     std::vector<CTransactionRef> all_transactions{tx0, tx1, tx2, tx3, tx4, tx5, tx6, tx7};
     std::vector<int64_t> tx_vsizes;
@@ -604,7 +604,7 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
     auto& lasttx = m_coinbase_txns[0];
     for (auto i{0}; i < 500; ++i) {
         const auto tx = make_tx({COutPoint{lasttx->GetHash(), 0}}, /*num_outputs=*/1);
-        pool.addUnchecked(entry.Fee(CENT).FromTx(tx));
+        AddToMempool(pool, entry.Fee(CENT).FromTx(tx));
         chain_txids.push_back(tx->GetHash());
         lasttx = tx;
     }
@@ -616,7 +616,7 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
 
     // GatherClusters stops at 500 transactions.
     const auto tx_501 = make_tx({COutPoint{lasttx->GetHash(), 0}}, /*num_outputs=*/1);
-    pool.addUnchecked(entry.Fee(CENT).FromTx(tx_501));
+    AddToMempool(pool, entry.Fee(CENT).FromTx(tx_501));
     const auto cluster_501 = pool.GatherClusters({tx_501->GetHash()});
     BOOST_CHECK_EQUAL(cluster_501.size(), 0);
 
@@ -629,12 +629,12 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
     std::vector<Txid> zigzag_txids;
     for (auto p{0}; p < 50; ++p) {
         const auto txp = make_tx({COutPoint{Txid::FromUint256(GetRandHash()), 0}}, /*num_outputs=*/2);
-        pool.addUnchecked(entry.Fee(CENT).FromTx(txp));
+        AddToMempool(pool, entry.Fee(CENT).FromTx(txp));
         zigzag_txids.push_back(txp->GetHash());
     }
     for (auto c{0}; c < 49; ++c) {
         const auto txc = make_tx({COutPoint{zigzag_txids[c], 1}, COutPoint{zigzag_txids[c+1], 0}}, /*num_outputs=*/1);
-        pool.addUnchecked(entry.Fee(CENT).FromTx(txc));
+        AddToMempool(pool, entry.Fee(CENT).FromTx(txc));
         zigzag_txids.push_back(txc->GetHash());
     }
     const auto vec_iters_zigzag = pool.GetIterVec(convert_to_uint256_vec(zigzag_txids));

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -63,9 +63,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k; // make transaction unique
                 {
                     LOCK2(cs_main, mpool.cs);
-                    mpool.addUnchecked(entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
+                    AddToMempool(mpool, entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
                     // Since TransactionAddedToMempool callbacks are generated in ATMP,
-                    // not addUnchecked, we cheat and create one manually here
+                    // not AddToMempool, we cheat and create one manually here
                     const int64_t virtual_size = GetVirtualTransactionSize(*MakeTransactionRef(tx));
                     const NewMempoolTransactionInfo tx_info{NewMempoolTransactionInfo(MakeTransactionRef(tx),
                                                                                       feeV[j],
@@ -164,9 +164,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
                 {
                     LOCK2(cs_main, mpool.cs);
-                    mpool.addUnchecked(entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
+                    AddToMempool(mpool, entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
                     // Since TransactionAddedToMempool callbacks are generated in ATMP,
-                    // not addUnchecked, we cheat and create one manually here
+                    // not AddToMempool, we cheat and create one manually here
                     const int64_t virtual_size = GetVirtualTransactionSize(*MakeTransactionRef(tx));
                     const NewMempoolTransactionInfo tx_info{NewMempoolTransactionInfo(MakeTransactionRef(tx),
                                                                                       feeV[j],
@@ -228,9 +228,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
                 {
                     LOCK2(cs_main, mpool.cs);
-                    mpool.addUnchecked(entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
+                    AddToMempool(mpool, entry.Fee(feeV[j]).Time(Now<NodeSeconds>()).Height(blocknum).FromTx(tx));
                     // Since TransactionAddedToMempool callbacks are generated in ATMP,
-                    // not addUnchecked, we cheat and create one manually here
+                    // not AddToMempool, we cheat and create one manually here
                     const int64_t virtual_size = GetVirtualTransactionSize(*MakeTransactionRef(tx));
                     const NewMempoolTransactionInfo tx_info{NewMempoolTransactionInfo(MakeTransactionRef(tx),
                                                                                       feeV[j],

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -402,7 +402,7 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     const auto res3 = ImprovesFeerateDiagram(pool, {entry1}, {entry1, entry2}, tx1_fee + tx2_fee + 1, tx1_size + tx2_size);
     BOOST_CHECK(res3.has_value());
     BOOST_CHECK(res3.value().first == DiagramCheckError::UNCALCULABLE);
-    BOOST_CHECK(res3.value().second == strprintf("%s has 2 descendants, max 1 allowed", tx1->GetHash().GetHex()));
+    BOOST_CHECK(res3.value().second == strprintf("%s has both ancestor and descendant, exceeding cluster limit of 2", tx2->GetHash().GetHex()));
 
 }
 

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -362,7 +362,7 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     const CAmount normal_fee{CENT/10};
 
     // low feerate parent with normal feerate child
-    const auto tx1 = make_tx(/*inputs=*/ {m_coinbase_txns[0]}, /*output_values=*/ {10 * COIN});
+    const auto tx1 = make_tx(/*inputs=*/ {m_coinbase_txns[0], m_coinbase_txns[1]}, /*output_values=*/ {10 * COIN});
     AddToMempool(pool, entry.Fee(low_fee).FromTx(tx1));
     const auto tx2 = make_tx(/*inputs=*/ {tx1}, /*output_values=*/ {995 * CENT});
     AddToMempool(pool, entry.Fee(normal_fee).FromTx(tx2));
@@ -373,6 +373,9 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     const auto entry2 = pool.GetIter(tx2->GetHash()).value();
     const auto tx2_fee = entry2->GetModifiedFee();
     const auto tx2_size = entry2->GetTxSize();
+
+    // conflicting transactions
+    const auto tx1_conflict = make_tx(/*inputs=*/ {m_coinbase_txns[0], m_coinbase_txns[2]}, /*output_values=*/ {10 * COIN});
 
     // Now test ImprovesFeerateDiagram with various levels of "package rbf" feerates
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -1078,7 +1078,25 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
         BOOST_CHECK_EQUAL(it_child_3->second.m_effective_feerate.value().GetFee(package3_total_vsize), 199 + 1300);
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-    }
 
+        // Finally, check that we can prioritise tx_child_1 to get package1 into the mempool.
+        // It should not be possible to resubmit package1 and get it in without prioritisation.
+        const auto submit4 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        if (auto err_4{CheckPackageMempoolAcceptResult(package1, submit4, /*expect_valid=*/false, m_node.mempool.get())}) {
+            BOOST_ERROR(err_4.value());
+        }
+        m_node.mempool->PrioritiseTransaction(tx_child_1->GetHash(), 1363);
+        const auto submit5 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false, std::nullopt);
+        if (auto err_5{CheckPackageMempoolAcceptResult(package1, submit5, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_5.value());
+        }
+        it_parent_1 = submit5.m_tx_results.find(tx_parent_1->GetWitnessHash());
+        it_child_1 = submit5.m_tx_results.find(tx_child_1->GetWitnessHash());
+        BOOST_CHECK_EQUAL(it_parent_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(it_child_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        LOCK(m_node.mempool->cs);
+        BOOST_CHECK(m_node.mempool->GetIter(tx_parent_1->GetHash()).has_value());
+        BOOST_CHECK(m_node.mempool->GetIter(tx_child_1->GetHash()).has_value());
+    }
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -180,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(ephemeral_tests, RegTestingSetup)
     BOOST_CHECK(!CheckEphemeralSpends({grandparent_tx_1}, minrelay, pool).has_value());
 
     // Add first grandparent to mempool and fetch entry
-    pool.addUnchecked(entry.FromTx(grandparent_tx_1));
+    AddToMempool(pool, entry.FromTx(grandparent_tx_1));
 
     // Ignores ancestors that aren't direct parents
     BOOST_CHECK(!CheckEphemeralSpends({child_no_dust}, minrelay, pool).has_value());
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE(ephemeral_tests, RegTestingSetup)
     BOOST_CHECK(!CheckEphemeralSpends({grandparent_tx_2, parent_with_dust}, minrelay, pool).has_value());
 
     // Add second grandparent to mempool
-    pool.addUnchecked(entry.FromTx(grandparent_tx_2));
+    AddToMempool(pool, entry.FromTx(grandparent_tx_2));
 
     // Only spends single dust out of two direct parents
     BOOST_CHECK(CheckEphemeralSpends({dust_non_spend_both_parents}, minrelay, pool).has_value());
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE(ephemeral_tests, RegTestingSetup)
     BOOST_CHECK(!CheckEphemeralSpends({parent_with_dust}, minrelay, pool).has_value());
 
     // Now add dusty parent to mempool
-    pool.addUnchecked(entry.FromTx(parent_with_dust));
+    AddToMempool(pool, entry.FromTx(parent_with_dust));
 
     // Passes dust checks even with non-parent ancestors
     BOOST_CHECK(!CheckEphemeralSpends({child_no_dust}, minrelay, pool).has_value());
@@ -219,9 +219,9 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
     CTxMemPool::setEntries empty_ancestors;
 
     auto mempool_tx_v3 = make_tx(random_outpoints(1), /*version=*/3);
-    pool.addUnchecked(entry.FromTx(mempool_tx_v3));
+    AddToMempool(pool, entry.FromTx(mempool_tx_v3));
     auto mempool_tx_v2 = make_tx(random_outpoints(1), /*version=*/2);
-    pool.addUnchecked(entry.FromTx(mempool_tx_v2));
+    AddToMempool(pool, entry.FromTx(mempool_tx_v2));
     // Default values.
     CTxMemPool::Limits m_limits{};
 
@@ -331,7 +331,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
         package_multi_parents.emplace_back(mempool_tx_v3);
         for (size_t i{0}; i < 2; ++i) {
             auto mempool_tx = make_tx(random_outpoints(i + 1), /*version=*/3);
-            pool.addUnchecked(entry.FromTx(mempool_tx));
+            AddToMempool(pool, entry.FromTx(mempool_tx));
             mempool_outpoints.emplace_back(mempool_tx->GetHash(), 0);
             package_multi_parents.emplace_back(mempool_tx);
         }
@@ -356,7 +356,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
         auto last_outpoint{random_outpoints(1)[0]};
         for (size_t i{0}; i < 2; ++i) {
             auto mempool_tx = make_tx({last_outpoint}, /*version=*/3);
-            pool.addUnchecked(entry.FromTx(mempool_tx));
+            AddToMempool(pool, entry.FromTx(mempool_tx));
             last_outpoint = COutPoint{mempool_tx->GetHash(), 0};
             package_multi_gen.emplace_back(mempool_tx);
             if (i == 1) middle_tx = mempool_tx;
@@ -443,7 +443,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
         BOOST_CHECK(GetTransactionWeight(*tx_mempool_v3_child) <= TRUC_CHILD_MAX_VSIZE * WITNESS_SCALE_FACTOR);
         auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_mempool_v3_child), m_limits)};
         BOOST_CHECK(SingleTRUCChecks(tx_mempool_v3_child, *ancestors, empty_conflicts_set, GetVirtualTransactionSize(*tx_mempool_v3_child)) == std::nullopt);
-        pool.addUnchecked(entry.FromTx(tx_mempool_v3_child));
+        AddToMempool(pool, entry.FromTx(tx_mempool_v3_child));
 
         Package package_v3_1p1c{mempool_tx_v3, tx_mempool_v3_child};
         BOOST_CHECK(PackageTRUCChecks(tx_mempool_v3_child, GetVirtualTransactionSize(*tx_mempool_v3_child), package_v3_1p1c, empty_ancestors) == std::nullopt);
@@ -471,7 +471,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
                           expected_error_str);
 
         // Configuration where parent already has 2 other children in mempool (no sibling eviction allowed). This may happen as the result of a reorg.
-        pool.addUnchecked(entry.FromTx(tx_v3_child2));
+        AddToMempool(pool, entry.FromTx(tx_v3_child2));
         auto tx_v3_child3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 24}}, /*version=*/3);
         auto entry_mempool_parent = pool.GetIter(mempool_tx_v3->GetHash().ToUint256()).value();
         BOOST_CHECK_EQUAL(entry_mempool_parent->GetCountWithDescendants(), 3);
@@ -490,9 +490,9 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
         auto tx_mempool_nibling = make_tx({COutPoint{tx_mempool_sibling->GetHash(), 0}}, /*version=*/3);
         auto tx_to_submit = make_tx({COutPoint{tx_mempool_grandparent->GetHash(), 1}}, /*version=*/3);
 
-        pool.addUnchecked(entry.FromTx(tx_mempool_grandparent));
-        pool.addUnchecked(entry.FromTx(tx_mempool_sibling));
-        pool.addUnchecked(entry.FromTx(tx_mempool_nibling));
+        AddToMempool(pool, entry.FromTx(tx_mempool_grandparent));
+        AddToMempool(pool, entry.FromTx(tx_mempool_sibling));
+        AddToMempool(pool, entry.FromTx(tx_mempool_nibling));
 
         auto ancestors_3gen{pool.CalculateMemPoolAncestors(entry.FromTx(tx_to_submit), m_limits)};
         const auto expected_error_str{strprintf("tx %s (wtxid=%s) would exceed descendant count limit",

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -539,9 +539,11 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
         if (submit) {
             LOCK2(cs_main, m_node.mempool->cs);
             LockPoints lp;
-            m_node.mempool->addUnchecked(CTxMemPoolEntry(ptx, /*fee=*/(total_in - num_outputs * amount_per_output),
-                                                         /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
-                                                         /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
+            auto changeset = m_node.mempool->GetChangeSet();
+            changeset->StageAddition(ptx, /*fee=*/(total_in - num_outputs * amount_per_output),
+                    /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
+                    /*spends_coinbase=*/false, /*sigops_cost=*/4, lp);
+            changeset->Apply();
         }
         --num_transactions;
     }
@@ -569,9 +571,13 @@ void TestChain100Setup::MockMempoolMinFee(const CFeeRate& target_feerate)
     // The new mempool min feerate is equal to the removed package's feerate + incremental feerate.
     const auto tx_fee = target_feerate.GetFee(GetVirtualTransactionSize(*tx)) -
         m_node.mempool->m_opts.incremental_relay_feerate.GetFee(GetVirtualTransactionSize(*tx));
-    m_node.mempool->addUnchecked(CTxMemPoolEntry(tx, /*fee=*/tx_fee,
-                                                 /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
-                                                 /*spends_coinbase=*/true, /*sigops_cost=*/1, lp));
+    {
+        auto changeset = m_node.mempool->GetChangeSet();
+        changeset->StageAddition(tx, /*fee=*/tx_fee,
+                /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
+                /*spends_coinbase=*/true, /*sigops_cost=*/1, lp);
+        changeset->Apply();
+    }
     m_node.mempool->TrimToSize(0);
     assert(m_node.mempool->GetMinFee() == target_feerate);
 }

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -219,3 +219,13 @@ void CheckMempoolTRUCInvariants(const CTxMemPool& tx_pool)
         }
     }
 }
+
+void AddToMempool(CTxMemPool& tx_pool, const CTxMemPoolEntry& entry)
+{
+    LOCK2(cs_main, tx_pool.cs);
+    auto changeset = tx_pool.GetChangeSet();
+    changeset->StageAddition(entry.GetSharedTx(), entry.GetFee(),
+            entry.GetTime().count(), entry.GetHeight(), entry.GetSequence(),
+            entry.GetSpendsCoinbase(), entry.GetSigOpCost(), entry.GetLockPoints());
+    changeset->Apply();
+}

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -68,4 +68,8 @@ std::vector<uint32_t> GetDustIndexes(const CTransactionRef& tx_ref, CFeeRate dus
  *   */
 void CheckMempoolTRUCInvariants(const CTxMemPool& tx_pool);
 
+/** One-line wrapper for creating a mempool changeset with a single transaction
+ *  and applying it. */
+void AddToMempool(CTxMemPool& tx_pool, const CTxMemPoolEntry& entry);
+
 #endif // BITCOIN_TEST_UTIL_TXMEMPOOL_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1383,9 +1383,16 @@ void CTxMemPool::ChangeSet::Apply()
     m_pool->RemoveStaged(m_to_remove, false, MemPoolRemovalReason::REPLACED);
     for (size_t i=0; i<m_entry_vec.size(); ++i) {
         auto tx_entry = m_entry_vec[i];
-        m_pool->addUnchecked(*tx_entry);
+        if (i == 0 && m_ancestors.count(tx_entry)) {
+            m_pool->addUnchecked(*tx_entry, m_ancestors[tx_entry]);
+        } else {
+            // We always recalculate ancestors from scratch if we're dealing
+            // with transactions which may have parents in the same package.
+            m_pool->addUnchecked(*tx_entry);
+        }
     }
     m_to_add.clear();
     m_to_remove.clear();
     m_entry_vec.clear();
+    m_ancestors.clear();
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1411,6 +1411,7 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
 
 CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
 {
+    Assume(m_to_add.find(tx->GetHash()) == m_to_add.end());
     auto newit = m_to_add.emplace(tx, fee, time, entry_height, entry_sequence, spends_coinbase, sigops_cost, lp).first;
     m_entry_vec.push_back(newit);
     return newit;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -606,6 +606,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 {
     // Remove transaction from memory pool
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
         setEntries txToRemove;
         txiter origit = mapTx.find(origTx.GetHash());
         if (origit != mapTx.end()) {
@@ -637,6 +638,7 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
     AssertLockHeld(cs);
     AssertLockHeld(::cs_main);
+    Assume(!m_have_changeset);
 
     setEntries txToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
@@ -675,6 +677,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
 void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight)
 {
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
     std::vector<RemovedMempoolTransactionInfo> txs_removed_for_block;
     txs_removed_for_block.reserve(vtx.size());
     for (const auto& tx : vtx)
@@ -1093,6 +1096,7 @@ void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPool
 int CTxMemPool::Expire(std::chrono::seconds time)
 {
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
     indexed_transaction_set::index<entry_time>::type::iterator it = mapTx.get<entry_time>().begin();
     setEntries toremove;
     while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
@@ -1163,6 +1167,7 @@ void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
 
 void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining) {
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1369,3 +1369,23 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
     std::sort(new_chunks.begin(), new_chunks.end(), std::greater());
     return std::make_pair(old_chunks, new_chunks);
 }
+
+CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
+{
+    auto newit = m_to_add.emplace(tx, fee, time, entry_height, entry_sequence, spends_coinbase, sigops_cost, lp).first;
+    m_entry_vec.push_back(newit);
+    return newit;
+}
+
+void CTxMemPool::ChangeSet::Apply()
+{
+    LOCK(m_pool->cs);
+    m_pool->RemoveStaged(m_to_remove, false, MemPoolRemovalReason::REPLACED);
+    for (size_t i=0; i<m_entry_vec.size(); ++i) {
+        auto tx_entry = m_entry_vec[i];
+        m_pool->addUnchecked(*tx_entry);
+    }
+    m_to_add.clear();
+    m_to_remove.clear();
+    m_entry_vec.clear();
+}

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -260,13 +260,13 @@ struct TxMempoolInfo
  *
  * Usually when a new transaction is added to the mempool, it has no in-mempool
  * children (because any such children would be an orphan).  So in
- * addUnchecked(), we:
- * - update a new entry's setMemPoolParents to include all in-mempool parents
- * - update the new entry's direct parents to include the new tx as a child
+ * addNewTransaction(), we:
+ * - update a new entry's m_parents to include all in-mempool parents
+ * - update each of those parent entries to include the new tx as a child
  * - update all ancestors of the transaction to include the new tx's size/fee
  *
  * When a transaction is removed from the mempool, we must:
- * - update all in-mempool parents to not track the tx in setMemPoolChildren
+ * - update all in-mempool parents to not track the tx in their m_children
  * - update all ancestors to not include the tx's size/fees in descendant state
  * - update all in-mempool children to not include it as a parent
  *
@@ -283,7 +283,7 @@ struct TxMempoolInfo
  * unreachable from just looking at transactions in the mempool (the linking
  * transactions may also be in the disconnected block, waiting to be added).
  * Because of this, there's not much benefit in trying to search for in-mempool
- * children in addUnchecked().  Instead, in the special case of transactions
+ * children in addNewTransaction().  Instead, in the special case of transactions
  * being added from a disconnected block, we require the caller to clean up the
  * state, to account for in-mempool, out-of-block descendants for all the
  * in-block transactions by calling UpdateTransactionsFromBlock().  Note that
@@ -453,15 +453,6 @@ public:
      */
     void check(const CCoinsViewCache& active_coins_tip, int64_t spendheight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    // addUnchecked must updated state for all ancestors of a given transaction,
-    // to track size/count of descendant transactions.  First version of
-    // addUnchecked can be used to have it call CalculateMemPoolAncestors(), and
-    // then invoke the second version.
-    // Note that addUnchecked is ONLY called from ATMP outside of tests
-    // and any other callers may break wallet's in-mempool tracking (due to
-    // lack of CValidationInterface::TransactionAddedToMempool callbacks).
-    void addUnchecked(const CTxMemPoolEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** After reorg, filter the entries that would no longer be valid in the next block, and update
@@ -791,7 +782,7 @@ private:
     /** Before calling removeUnchecked for a given transaction,
      *  UpdateForRemoveFromMempool must be called on the entire (dependent) set
      *  of transactions being removed at the same time.  We use each
-     *  CTxMemPoolEntry's setMemPoolParents in order to walk ancestors of a
+     *  CTxMemPoolEntry's m_parents in order to walk ancestors of a
      *  given transaction that is removed, so we can't remove intermediate
      *  transactions in a chain before we've updated all the state for the
      *  removal.
@@ -865,9 +856,29 @@ public:
         // map from the m_to_add index to the ancestors for the transaction
         std::map<CTxMemPool::txiter, CTxMemPool::setEntries, CompareIteratorByHash> m_ancestors;
         CTxMemPool::setEntries m_to_remove;
+
+        friend class CTxMemPool;
     };
 
     std::unique_ptr<ChangeSet> GetChangeSet() EXCLUSIVE_LOCKS_REQUIRED(cs) { return std::make_unique<ChangeSet>(this); }
+
+    friend class CTxMemPool::ChangeSet;
+
+private:
+    // Apply the given changeset to the mempool, by removing transactions in
+    // the to_remove set and adding transactions in the to_add set.
+    void Apply(CTxMemPool::ChangeSet* changeset) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    // addNewTransaction must update state for all ancestors of a given transaction,
+    // to track size/count of descendant transactions.  First version of
+    // addNewTransaction can be used to have it call CalculateMemPoolAncestors(), and
+    // then invoke the second version.
+    // Note that addNewTransaction is ONLY called (via Apply()) from ATMP
+    // outside of tests and any other callers may break wallet's in-mempool
+    // tracking (due to lack of CValidationInterface::TransactionAddedToMempool
+    // callbacks).
+    void addNewTransaction(CTxMemPool::txiter it) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void addNewTransaction(CTxMemPool::txiter it, CTxMemPool::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -791,6 +791,34 @@ public:
         return !it || visited(*it);
     }
 
+    /*
+     * CTxMemPool::ChangeSet:
+     *
+     * This class is used for all mempool additions and associated removals (eg
+     * due to rbf). Removals that don't need to be evaluated for acceptance,
+     * such as removing transactions that appear in a block, or due to reorg,
+     * or removals related to mempool limiting or expiry do not need to use
+     * this.
+     *
+     * Callers can interleave calls to StageAddition()/StageRemoval(), and
+     * removals may be invoked in any order, but additions must be done in a
+     * topological order in the case of transaction packages (ie, parents must
+     * be added before children).
+     *
+     * CalculateChunksForRBF() can be used to calculate the feerate diagram of
+     * the proposed set of new transactions and compare with the existing
+     * mempool.
+     *
+     * CalculateMemPoolAncestors() calculates the in-mempool (not including
+     * what is in the change set itself) ancestors of a given transacion.
+     *
+     * Apply() will apply the removals and additions that are staged into the
+     * mempool.
+     *
+     * Only one changeset may exist at a time. While a changeset is
+     * outstanding, no removals or additions may be made directly to the
+     * mempool.
+     */
     class ChangeSet {
     public:
         explicit ChangeSet(CTxMemPool* pool) : m_pool(pool) {}

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -510,15 +510,6 @@ public:
      * don't actually exist in the mempool, returns an empty vector. */
     std::vector<txiter> GetIterVec(const std::vector<uint256>& txids) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Remove a set of transactions from the mempool.
-     *  If a transaction is in this set, then all in-mempool descendants must
-     *  also be in the set, unless this transaction is being removed for being
-     *  in a block.
-     *  Set updateDescendants to true when removing a tx that was in a block, so
-     *  that any in-mempool descendants have their ancestor state updated.
-     */
-    void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
-
     /** UpdateTransactionsFromBlock is called when adding transactions from a
      * disconnected block back to the mempool, new mempool entries may have
      * children in the mempool (which is generally not the case when otherwise
@@ -738,6 +729,15 @@ public:
     std::optional<std::string> CheckConflictTopology(const setEntries& direct_conflicts);
 
 private:
+    /** Remove a set of transactions from the mempool.
+     *  If a transaction is in this set, then all in-mempool descendants must
+     *  also be in the set, unless this transaction is being removed for being
+     *  in a block.
+     *  Set updateDescendants to true when removing a tx that was in a block, so
+     *  that any in-mempool descendants have their ancestor state updated.
+     */
+    void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the
      *  mempool but may have child transactions in the mempool, eg during a

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -844,6 +844,18 @@ public:
             return ret;
         }
 
+        std::vector<CTransactionRef> GetAddedTxns() const {
+            std::vector<CTransactionRef> ret;
+            ret.reserve(m_entry_vec.size());
+            for (const auto& entry : m_entry_vec) {
+                ret.emplace_back(entry->GetSharedTx());
+            }
+            return ret;
+        }
+
+        size_t GetTxCount() const { return m_entry_vec.size(); }
+        const CTransaction& GetAddedTxn(size_t index) const { return m_entry_vec.at(index)->GetTx(); }
+
         void Apply() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     private:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -804,6 +804,8 @@ public:
         TxHandle StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp);
         void StageRemoval(CTxMemPool::txiter it) { m_to_remove.insert(it); }
 
+        const CTxMemPool::setEntries& GetRemovals() const { return m_to_remove; }
+
         util::Result<CTxMemPool::setEntries> CalculateMemPoolAncestors(TxHandle tx, const Limits& limits)
         {
             // Look up transaction in our cache first

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -706,23 +706,6 @@ public:
         return m_sequence_number;
     }
 
-    /**
-     * Calculate the sorted chunks for the old and new mempool relating to the
-     * clusters that would be affected by a potential replacement transaction.
-     * (replacement_fees, replacement_vsize) values are gathered from a
-     * proposed set of replacement transactions that are considered as a single
-     * chunk, and represent their complete cluster. In other words, they have no
-     * in-mempool ancestors.
-     *
-     * @param[in] replacement_fees    Package fees
-     * @param[in] replacement_vsize   Package size (must be greater than 0)
-     * @param[in] direct_conflicts    All transactions that would be removed directly by
-     *                                having a conflicting input with a proposed transaction
-     * @param[in] all_conflicts       All transactions that would be removed
-     * @return old and new diagram pair respectively, or an error string if the conflicts don't match a calculable topology
-     */
-    util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateChunksForRBF(CAmount replacement_fees, int64_t replacement_vsize, const setEntries& direct_conflicts, const setEntries& all_conflicts) EXCLUSIVE_LOCKS_REQUIRED(cs);
-
     /* Check that all direct conflicts are in a cluster size of two or less. Each
      * direct conflict may be in a separate cluster.
      */
@@ -843,6 +826,14 @@ public:
             }
             return ret;
         }
+
+        /**
+         * Calculate the sorted chunks for the old and new mempool relating to the
+         * clusters that would be affected by a potential replacement transaction.
+         *
+         * @return old and new diagram pair respectively, or an error string if the conflicts don't match a calculable topology
+         */
+        util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateChunksForRBF();
 
         size_t GetTxCount() const { return m_entry_vec.size(); }
         const CTransaction& GetAddedTxn(size_t index) const { return m_entry_vec.at(index)->GetTx(); }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1205,9 +1205,10 @@ bool MemPoolAccept::PackageMempoolChecks(const std::vector<CTransactionRef>& txn
                                      "package RBF failed: " + err_tup.value().second, "");
     }
 
-    LogDebug(BCLog::TXPACKAGES, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s)\n",
+    LogDebug(BCLog::TXPACKAGES, "package RBF checks passed: parent %s (wtxid=%s), child %s (wtxid=%s), package hash (%s)\n",
         txns.front()->GetHash().ToString(), txns.front()->GetWitnessHash().ToString(),
-        txns.back()->GetHash().ToString(), txns.back()->GetWitnessHash().ToString());
+        txns.back()->GetHash().ToString(), txns.back()->GetWitnessHash().ToString(),
+        GetPackageHash(txns).ToString());
 
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -889,10 +889,6 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     int64_t nSigOpsCost = GetTransactionSigOpCost(tx, m_view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-    // ws.m_modified_fees includes any fee deltas from PrioritiseTransaction
-    ws.m_modified_fees = ws.m_base_fees;
-    m_pool.ApplyDelta(hash, ws.m_modified_fees);
-
     // Keep track of transactions that spend a coinbase, which we re-scan
     // during reorgs to ensure COINBASE_MATURITY is still met.
     bool fSpendsCoinbase = false;
@@ -911,6 +907,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         m_subpackage.m_changeset = m_pool.GetChangeSet();
     }
     ws.m_tx_handle = m_subpackage.m_changeset->StageAddition(ptx, ws.m_base_fees, nAcceptTime, m_active_chainstate.m_chain.Height(), entry_sequence, fSpendsCoinbase, nSigOpsCost, lock_points.value());
+
+    // ws.m_modified_fees includes any fee deltas from PrioritiseTransaction
+    ws.m_modified_fees = ws.m_tx_handle->GetModifiedFee();
 
     ws.m_vsize = ws.m_tx_handle->GetTxSize();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1820,6 +1820,11 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
         AcceptSubPackage(txns_package_eval, args);
     PackageValidationState& package_state_final = multi_submission_result.m_state;
 
+    // This is invoked by AcceptSubPackage() already, so this is just here for
+    // clarity (since it's not permitted to invoke LimitMempoolSize() while a
+    // changeset is outstanding).
+    ClearSubPackageState();
+
     // Make sure we haven't exceeded max mempool size.
     // Package transactions that were submitted to mempool or already in mempool may be evicted.
     LimitMempoolSize(m_pool, m_active_chainstate.CoinsTip());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -324,7 +324,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         }
     }
 
-    // AcceptToMemoryPool/addUnchecked all assume that new mempool entries have
+    // AcceptToMemoryPool/addNewTransaction all assume that new mempool entries have
     // no in-mempool children, which is generally not true when adding
     // previously-confirmed transactions back to the mempool.
     // UpdateTransactionsFromBlock finds descendants of any transactions in

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1299,7 +1299,8 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                                       it->GetTxSize());
         FeeFrac feerate{m_subpackage.m_total_modified_fees, int32_t(m_subpackage.m_total_vsize)};
         uint256 tx_or_package_hash{};
-        if (m_subpackage.m_changeset->GetTxCount() == 1) {
+        const bool replaced_with_tx{m_subpackage.m_changeset->GetTxCount() == 1};
+        if (replaced_with_tx) {
             const CTransaction& tx = m_subpackage.m_changeset->GetAddedTxn(0);
             tx_or_package_hash = tx.GetHash();
             log_string += strprintf("New tx %s (wtxid=%s, fees=%s, vsize=%s)",
@@ -1324,7 +1325,8 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                 std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count(),
                 tx_or_package_hash.data(),
                 feerate.size,
-                feerate.fee
+                feerate.fee,
+                replaced_with_tx
         );
         m_subpackage.m_replaced_transactions.push_back(it->GetSharedTx());
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1207,7 +1207,7 @@ bool MemPoolAccept::PackageMempoolChecks(const std::vector<CTransactionRef>& txn
 
     // Check if it's economically rational to mine this package rather than the ones it replaces.
     // This takes the place of ReplacementChecks()'s PaysMoreThanConflicts() in the package RBF setting.
-    if (const auto err_tup{ImprovesFeerateDiagram(m_pool, direct_conflict_iters, m_subpackage.m_all_conflicts, m_subpackage.m_total_modified_fees, m_subpackage.m_total_vsize)}) {
+    if (const auto err_tup{ImprovesFeerateDiagram(*m_subpackage.m_changeset)}) {
         return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
                                      "package RBF failed: " + err_tup.value().second, "");
     }

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -391,11 +391,11 @@ class PackageRBFTest(BitcoinTestFramework):
         # Now make conflicting packages for each coin
         package_hex1, _package_txns1 = self.create_simple_package(coin1, DEFAULT_FEE, DEFAULT_CHILD_FEE)
         package_result = node.submitpackage(package_hex1)
-        assert_equal(f"package RBF failed: {parent1_result['tx'].rehash()} is not the only parent of child {child_result['tx'].rehash()}", package_result["package_msg"])
+        assert_equal(f"package RBF failed: {child_result['tx'].rehash()} has 2 ancestors, max 1 allowed", package_result["package_msg"])
 
         package_hex2, _package_txns2 = self.create_simple_package(coin2, DEFAULT_FEE, DEFAULT_CHILD_FEE)
         package_result = node.submitpackage(package_hex2)
-        assert_equal(f"package RBF failed: {parent2_result['tx'].rehash()} is not the only parent of child {child_result['tx'].rehash()}", package_result["package_msg"])
+        assert_equal(f"package RBF failed: {child_result['tx'].rehash()} has 2 ancestors, max 1 allowed", package_result["package_msg"])
 
         package_hex3, _package_txns3 = self.create_simple_package(coin3, DEFAULT_FEE, DEFAULT_CHILD_FEE)
         package_result = node.submitpackage(package_hex3)
@@ -445,7 +445,7 @@ class PackageRBFTest(BitcoinTestFramework):
         # Now make conflicting packages for each coin
         package_hex1, _package_txns1 = self.create_simple_package(coin1, DEFAULT_FEE, DEFAULT_CHILD_FEE)
         package_result = node.submitpackage(package_hex1)
-        assert_equal(f"package RBF failed: {parent_result['tx'].rehash()} has 2 descendants, max 1 allowed", package_result["package_msg"])
+        assert_equal(f"package RBF failed: {child2_result['tx'].rehash()} is not the only child of parent {parent_result['tx'].rehash()}", package_result["package_msg"])
 
         package_hex2, _package_txns2 = self.create_simple_package(coin2, DEFAULT_FEE, DEFAULT_CHILD_FEE)
         package_result = node.submitpackage(package_hex2)


### PR DESCRIPTION
part of cluster mempool: #30289 

It became clear while working on cluster mempool that it would be helpful for transaction validation if we could consider a full set of proposed changes to the mempool -- consisting of a set of transactions to add, and a set of transactions (ie conflicts) to simultaneously remove -- and perform calculations on what the mempool would look like if the proposed changes were to be applied.  Two specific examples of where we'd like to do this:

- Determining if ancestor/descendant/TRUC limits would be violated (in the future, cluster limits) if either a single transaction or a package of transactions were to be accepted
- Determining if an RBF would make the mempool "better", however that idea is defined, both in the single transaction and package of transaction cases

In preparation for cluster mempool, I have pulled this reworking of the mempool interface out of #28676 so it can be reviewed on its own.  I have not re-implemented ancestor/descendant limits to be run through the changeset, since with cluster mempool those limits will be going away, so this seems like wasted effort.  However, I have rebased #28676 on top of this branch so reviewers can see what the new mempool interface could look like in the cluster mempool setting.

There are some minor behavior changes here, which I believe are inconsequential:
- In the package validation setting, transactions would be added to the mempool before the `ConsensusScriptChecks()` are run. In theory, `ConsensusScriptChecks()` should always pass if the `PolicyScriptChecks()` have passed and it's just a belt-and-suspenders for us, but if somehow they were to diverge then there could be some small behavior change from adding transactions and then removing them, versus never adding them at all.
- The error reporting on `CheckConflictTopology()` has slightly changed due to no longer distinguishing between direct conflicts and indirect conflicts. I believe this should be entirely inconsequential because there shouldn't be a logical difference between those two ideas from the perspective of this function, but I did have to update some error strings in some tests.
- Because, in a package setting, RBFs now happen as part of the entire package being accepted, the logging has changed slightly because we do not know which transaction specifically evicted a given removed transaction. 
  -  Specifically, the "package hash" is now used to reference the set of transactions that are being accepted, rather than any single txid. The log message relating to package RBF that happen in the `TXPACKAGES` category has been updated as well to include the package hash, so that it's possible to see which specific set of transactions are being referenced by that package hash.
  - Relatedly, the tracepoint logging in the package rbf case has been updated as well to reference the package hash, rather than a transaction hash.