### PR TITLE
depends: add *FLAGS to gen_id

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -141,8 +141,16 @@ include packages/packages.mk
 #     2. Before including packages/*.mk (excluding packages/packages.mk), since
 #        they rely on the build_id variables
 #
-build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' AR='$(build_AR)' NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
-$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(host_CXX)' CXX_STANDARD='$(CXX_STANDARD)' AR='$(host_AR)' NM='$(host_NM)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
+                      AR='$(build_AR)' NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
+                      DEBUG='$(DEBUG)' NO_HARDEN='$(NO_HARDEN)' \
+                      ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+
+$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(host_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
+                                        CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' \
+                                        AR='$(host_AR)' NM='$(host_NM)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
+                                        DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' \
+                                        ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
 boost_packages_$(NO_BOOST) = $(boost_packages)
 

--- a/depends/gen_id
+++ b/depends/gen_id
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Usage: env [ CC=... ] [ C_STANDARD=...] [ CXX=... ] [CXX_STANDARD=...] \
+#            [ CPPFLAGS=... ] [CFLAGS=...] [CXXFLAGS=...] [LDFLAGS=...] \
 #            [ AR=... ] [ NM=... ] [ RANLIB=... ] [ STRIP=... ] [ DEBUG=... ] \
-#            [ LTO=... ] [ NO_HARDEN=... ] ./build-id [ID_SALT]...
+#            [ LTO=... ] [ NO_HARDEN=... ] ./gen_id [ID_SALT]...
 #
 # Prints to stdout a SHA256 hash representing the current toolset, used by
 # depends/Makefile as a build id for caching purposes (detecting when the
@@ -33,6 +34,13 @@
     echo "BEGIN ID SALT"
     echo "$@"
     echo "END ID SALT"
+
+    echo "BEGIN FLAGS"
+    echo "CPPFLAGS=${CPPFLAGS}"
+    echo "CFLAGS=${CFLAGS}"
+    echo "CXXFLAGS=${CXXFLAGS}"
+    echo "LDFLAGS=${LDFLAGS}"
+    echo "END FLAGS"
 
     # GCC only prints COLLECT_LTO_WRAPPER when invoked with just "-v", but we want
     # the information from "-v -E -" as well, so just include both.

--- a/depends/gen_id
+++ b/depends/gen_id
@@ -58,6 +58,17 @@
     echo "CXX_STANDARD=${CXX_STANDARD}"
     echo "END CXX"
 
+    # We use lld when cross-compiling for macOS, and it's version should
+    # be tied to LLVM. However someone compiling with GCC and -fuse-ld=lld
+    # would not see a cache bust if the LLVM toolchain was updated.
+    echo "BEGIN lld"
+    bash -c "ld.lld --version"
+    echo "END lld"
+
+    echo "BEGIN mold"
+    bash -c "mold --version"
+    echo "END mold"
+
     echo "BEGIN AR"
     bash -c "${AR} --version"
     env | grep '^AR_'


### PR DESCRIPTION
The depends cache should be busted when flags change, the same as any other tooling change. I'd also like to start passing `*FLAGS` into depends inside the Guix env, which, without this change, doesn't bust the cache.