### PR TITLE
validation: fetch block inputs on parallel threads

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -565,13 +565,63 @@ private:
 };
 
 /**
- * CCoinsViewCache overlay that avoids populating/mutating parent cache layers on cache misses.
+ * CCoinsViewCache subclass that asynchronously fetches all block inputs in parallel during ConnectBlock without
+ * mutating the base cache.
  *
- * This is achieved by fetching coins from the base view using PeekCoin() instead of GetCoin(),
- * so intermediate CCoinsViewCache layers are not filled.
+ * Only used in ConnectBlock to pass as an ephemeral view that can be reset if the block is invalid.
+ * It provides the same interface as CCoinsViewCache. It overrides all methods that mutate base,
+ * stopping threads before calling superclass.
+ * It adds an additional StartFetching method to provide the block.
  *
- * Used during ConnectBlock() as an ephemeral, resettable top-level view that is flushed only
- * on success, so invalid blocks don't pollute the underlying cache.
+ * When a block is passed to StartFetching, the inputs of the block are flattened into a vector of InputToFetch
+ * objects. StartFetching then submits worker tasks to a ThreadPool and keeps the returned futures alive until fetching
+ * is stopped.
+ *
+ * ProcessInput() atomically fetches and increments m_input_head, so each thread can only access a single element of the
+ * m_inputs vector at a time. Workers race to claim inputs, so they may fetch elements in any order. If the fetched
+ * index is greater than the size of m_inputs, no more inputs can be fetched and false is returned.
+ *
+ * The worker claims the InputToFetch at this index, fetches the coin from the base cache and moves it into the
+ * InputToFetch object. The ready flag is then set with a release memory order. This allows the ready flag to be
+ * used as a memory fence, guaranteeing the coin being written to the object will have happened before another
+ * thread tests the flag with an acquire memory order.
+ * This assumes all base->PeekCoin() paths are safe for concurrent readers and do not mutate lower cache layers.
+ *
+ * When a coin is requested from the cache on the main thread and is not already in cacheCoins map, FetchCoinFromBase
+ * checks whether the next unconsumed entry in m_inputs has the requested outpoint. On a match, m_input_tail is advanced
+ * and the entry's ready flag is tested with an acquire memory order. If the worker has already completed, the coin is
+ * moved out and returned. Otherwise the main thread calls ProcessInput() to make progress (by fetching other inputs)
+ * rather than blocking on a specific worker.
+ *
+ * StopFetching() is called before mutating operations (Flush/Sync/Reset/SetBackend). It stops fetching by moving
+ * m_input_head to the end of m_inputs (so workers quickly exit), then waits for all futures to complete and clears
+ * the per-block state (m_inputs and the head/tail counters).
+ *
+ *       Workers advance m_input_head to fetch inputs. Main thread advances m_input_tail to consume.
+ *
+ *       Before workers start:
+ *
+ *                 m_input_head
+ *                 m_input_tail
+ *                      │
+ *                      ▼
+ *                 ┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
+ *       m_inputs: │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │
+ *                 │         │         │         │         │         │         │         │         │         │
+ *                 └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+ *
+ *       After workers start:
+ *
+ *                                       Worker 2            Worker 0  Worker 3  Worker 1  m_input_head
+ *                                          │                   │         │         │         │
+ *                                          ▼                   ▼         ▼         ▼         ▼
+ *                 ┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
+ *       m_inputs: │  ready  │  ready  │fetching │  ready  │fetching │fetching │fetching │ waiting │ waiting │
+ *                 │consumed │    ✓    │    ●    │    ✓    │    ●    │    ●    │    ●    │         │         │
+ *                 └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+ *                                ▲
+ *                                │
+ *                           m_input_tail
  */
 class CoinsViewOverlay : public CCoinsViewCache
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -12,6 +12,7 @@
 #include <memusage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
 #include <serialize.h>
 #include <support/allocators/pool.h>
 #include <uint256.h>
@@ -27,6 +28,7 @@
 #include <optional>
 #include <ranges>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -572,6 +574,8 @@ class CoinsViewOverlay : public CCoinsViewCache
 private:
     //! The latest input not yet being fetched. Workers atomically increment this when fetching.
     mutable std::atomic_uint32_t m_input_head{0};
+    //! The latest input not yet accessed by a consumer. Only the main thread increments this.
+    mutable uint32_t m_input_tail{0};
 
     //! The inputs of the block which is being fetched.
     struct InputToFetch {
@@ -605,15 +609,18 @@ private:
     {
         m_inputs.clear();
         m_input_head.store(0, std::memory_order_relaxed);
+        m_input_tail = 0;
     }
 
     std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
     {
-        // TODO: linear scan; replaced with O(1) m_input_tail lookup in a follow-up commit.
-        for (const auto i : std::views::iota(0U, m_inputs.size())) {
-            auto& input{m_inputs[i]};
-            if (input.outpoint != outpoint) continue;
-            return input.coin;
+        // This assumes ConnectBlock accesses all inputs in the same order as
+        // they are added to m_inputs in StartFetching.
+        if (m_input_tail < m_inputs.size() && m_inputs[m_input_tail].outpoint == outpoint) {
+            // We advance the tail since the input is cached and not accessed through this method again.
+            auto& input{m_inputs[m_input_tail++]};
+            // We can move the coin since we won't access this input again.
+            return std::move(input.coin);
         }
 
         // We will only get here for BIP30 checks.
@@ -635,11 +642,16 @@ public:
     {
         Assume(m_inputs.empty());
         Assume(m_input_head.load(std::memory_order_relaxed) == 0);
+        Assume(m_input_tail == 0);
         // Loop through the inputs of the block and set them in the queue.
+        // Filter txs that are spending inputs created earlier in the same block.
+        std::unordered_set<Txid, SaltedTxidHasher> txids;
+        txids.reserve(block.vtx.size());
         for (const auto& tx : block.vtx | std::views::drop(1)) {
             for (const auto& input : tx->vin) {
-                m_inputs.emplace_back(input.prevout);
+                if (!txids.contains(input.prevout.hash)) m_inputs.emplace_back(input.prevout);
             }
+            txids.emplace(tx->GetHash());
         }
         while (ProcessInput()) {}
         return CreateResetGuard();

--- a/src/coins.h
+++ b/src/coins.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <functional>
+#include <future>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -593,6 +594,7 @@ private:
         InputToFetch(InputToFetch&& other) noexcept : outpoint{other.outpoint} { Assert(false); }
         explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
     };
+    //! Must only be mutated when m_futures is empty. Elements may be mutated when m_futures is not empty.
     std::vector<InputToFetch> m_inputs{};
 
     /**
@@ -614,9 +616,20 @@ private:
         return true;
     }
 
-    //! Clear fetching data.
+    //! Stop all worker threads and clear fetching data.
     void StopFetching() noexcept
     {
+        if (m_futures.empty()) {
+            Assume(m_inputs.empty());
+            Assume(m_input_head.load(std::memory_order_relaxed) == 0);
+            Assume(m_input_tail == 0);
+            return;
+        }
+        // Skip fetching the rest of the inputs by moving the head to the end.
+        m_input_head.store(m_inputs.size(), std::memory_order_relaxed);
+        // Wait for all threads to stop.
+        for (auto& future : m_futures) future.wait();
+        m_futures.clear();
         m_inputs.clear();
         m_input_head.store(0, std::memory_order_relaxed);
         m_input_tail = 0;
@@ -648,6 +661,7 @@ private:
 
     //! Non-null. May have zero workers when input fetching is disabled.
     std::shared_ptr<ThreadPool> m_thread_pool;
+    std::vector<std::future<void>> m_futures{};
 
 protected:
     void Reset() noexcept override
@@ -666,23 +680,36 @@ public:
         m_inputs.reserve(MAX_INPUTS_PER_BLOCK);
     }
 
-    //! Start fetching inputs from block.
+    //! Start fetching inputs from block in background.
     [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept
     {
+        Assume(m_futures.empty());
         Assume(m_inputs.empty());
         Assume(m_input_head.load(std::memory_order_relaxed) == 0);
         Assume(m_input_tail == 0);
-        // Loop through the inputs of the block and set them in the queue.
-        // Filter txs that are spending inputs created earlier in the same block.
-        std::unordered_set<Txid, SaltedTxidHasher> txids;
-        txids.reserve(block.vtx.size());
-        for (const auto& tx : block.vtx | std::views::drop(1)) {
-            for (const auto& input : tx->vin) {
-                if (!txids.contains(input.prevout.hash)) m_inputs.emplace_back(input.prevout);
+        if (const auto workers_count{m_thread_pool->WorkersCount()}; workers_count > 0) {
+            // Loop through the inputs of the block and set them in the queue.
+            // Filter txs that are spending inputs created earlier in the same block.
+            std::unordered_set<Txid, SaltedTxidHasher> txids;
+            txids.reserve(block.vtx.size());
+            for (const auto& tx : block.vtx | std::views::drop(1)) {
+                for (const auto& input : tx->vin) {
+                    if (!txids.contains(input.prevout.hash)) m_inputs.emplace_back(input.prevout);
+                }
+                txids.emplace(tx->GetHash());
             }
-            txids.emplace(tx->GetHash());
+            // Only start threads if we have something to fetch.
+            if (!m_inputs.empty()) {
+                std::vector<std::function<void()>> tasks(workers_count, [this] {
+                    while (ProcessInput()) {}
+                });
+                if (auto futures{m_thread_pool->Submit(std::move(tasks))}; futures.has_value()) {
+                    m_futures = std::move(*futures);
+                } else {
+                    m_inputs.clear();
+                }
+            }
         }
-        while (ProcessInput()) {}
         return CreateResetGuard();
     }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -385,7 +385,7 @@ protected:
 public:
     explicit CCoinsViewBacked(CCoinsView* in_view) : base{Assert(in_view)} {}
 
-    void SetBackend(CCoinsView& in_view) { base = &in_view; }
+    virtual void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override { return base->GetCoin(outpoint); }
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
@@ -496,7 +496,7 @@ public:
      * If reallocate_cache is false, the cache will retain the same memory footprint
      * after flushing and should be destroyed to deallocate.
      */
-    void Flush(bool reallocate_cache = true);
+    virtual void Flush(bool reallocate_cache = true);
 
     /**
      * Push the modifications applied to this cache to its base while retaining
@@ -504,7 +504,7 @@ public:
      * Failure to call this method or Flush() before destruction will cause the changes
      * to be forgotten.
      */
-    void Sync();
+    virtual void Sync();
 
     /**
      * Removes the UTXO with the given outpoint from the cache, if it is
@@ -677,6 +677,24 @@ public:
         }
         while (ProcessInput()) {}
         return CreateResetGuard();
+    }
+
+    void SetBackend(CCoinsView& view) override
+    {
+        StopFetching();
+        CCoinsViewCache::SetBackend(view);
+    }
+
+    void Flush(bool reallocate_cache = true) override
+    {
+        StopFetching();
+        CCoinsViewCache::Flush(reallocate_cache);
+    }
+
+    void Sync() override
+    {
+        StopFetching();
+        CCoinsViewCache::Sync();
     }
 };
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -10,6 +10,7 @@
 #include <compressor.h>
 #include <core_memusage.h>
 #include <memusage.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <support/allocators/pool.h>
@@ -21,8 +22,13 @@
 #include <cassert>
 #include <cstdint>
 
+#include <atomic>
 #include <functional>
+#include <optional>
+#include <ranges>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 /**
  * A UTXO entry.
@@ -415,7 +421,7 @@ protected:
      * Discard all modifications made to this cache without flushing to the base view.
      * This can be used to efficiently reuse a cache instance across multiple operations.
      */
-    void Reset() noexcept;
+    virtual void Reset() noexcept;
 
     /* Fetch the coin from base. Used for cache misses in FetchCoin. */
     virtual std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const;
@@ -564,13 +570,80 @@ private:
 class CoinsViewOverlay : public CCoinsViewCache
 {
 private:
+    //! The latest input not yet being fetched. Workers atomically increment this when fetching.
+    mutable std::atomic_uint32_t m_input_head{0};
+
+    //! The inputs of the block which is being fetched.
+    struct InputToFetch {
+        //! The outpoint of the input to fetch.
+        const COutPoint& outpoint;
+        //! The coin that workers will fetch and main thread will insert into cache.
+        mutable std::optional<Coin> coin{std::nullopt};
+
+        explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
+    };
+    std::vector<InputToFetch> m_inputs{};
+
+    /**
+     * Claim and fetch the next input in the queue.
+     *
+     * @return true if there are more inputs in the queue to fetch
+     * @return false if there are no more inputs in the queue to fetch
+     */
+    bool ProcessInput() const noexcept
+    {
+        const auto i{m_input_head.fetch_add(1, std::memory_order_relaxed)};
+        if (i >= m_inputs.size()) return false;
+
+        auto& input{m_inputs[i]};
+        input.coin = base->PeekCoin(input.outpoint);
+        return true;
+    }
+
+    //! Clear fetching data.
+    void StopFetching() noexcept
+    {
+        m_inputs.clear();
+        m_input_head.store(0, std::memory_order_relaxed);
+    }
+
     std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
     {
+        // TODO: linear scan; replaced with O(1) m_input_tail lookup in a follow-up commit.
+        for (const auto i : std::views::iota(0U, m_inputs.size())) {
+            auto& input{m_inputs[i]};
+            if (input.outpoint != outpoint) continue;
+            return input.coin;
+        }
+
+        // We will only get here for BIP30 checks.
         return base->PeekCoin(outpoint);
+    }
+
+protected:
+    void Reset() noexcept override
+    {
+        StopFetching();
+        CCoinsViewCache::Reset();
     }
 
 public:
     using CCoinsViewCache::CCoinsViewCache;
+
+    //! Start fetching inputs from block.
+    [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept
+    {
+        Assume(m_inputs.empty());
+        Assume(m_input_head.load(std::memory_order_relaxed) == 0);
+        // Loop through the inputs of the block and set them in the queue.
+        for (const auto& tx : block.vtx | std::views::drop(1)) {
+            for (const auto& input : tx->vin) {
+                m_inputs.emplace_back(input.prevout);
+            }
+        }
+        while (ProcessInput()) {}
+        return CreateResetGuard();
+    }
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -20,12 +20,14 @@
 #include <util/check.h>
 #include <util/overflow.h>
 #include <util/hasher.h>
+#include <util/threadpool.h>
 
 #include <cassert>
 #include <cstdint>
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <unordered_map>
@@ -594,7 +596,7 @@ private:
     std::vector<InputToFetch> m_inputs{};
 
     /**
-     * Claim and fetch the next input in the queue.
+     * Claim and fetch the next input in the queue. Safe to call from any thread.
      *
      * @return true if there are more inputs in the queue to fetch
      * @return false if there are no more inputs in the queue to fetch
@@ -640,9 +642,12 @@ private:
             return std::move(input.coin);
         }
 
-        // We will only get here for BIP30 checks.
+        // We will only get here for BIP30 checks or when parallel fetching is disabled.
         return base->PeekCoin(outpoint);
     }
+
+    //! Non-null. May have zero workers when input fetching is disabled.
+    std::shared_ptr<ThreadPool> m_thread_pool;
 
 protected:
     void Reset() noexcept override
@@ -652,9 +657,11 @@ protected:
     }
 
 public:
-    explicit CoinsViewOverlay(CCoinsView* in_base, bool deterministic = false) noexcept
-        : CCoinsViewCache{in_base, deterministic}
+    explicit CoinsViewOverlay(CCoinsView* in_base, std::shared_ptr<ThreadPool> thread_pool,
+                              bool deterministic = false) noexcept
+        : CCoinsViewCache{in_base, deterministic}, m_thread_pool{std::move(thread_pool)}
     {
+        Assert(m_thread_pool);
         // Reserve to maximum theoretical number so emplace_back in StartFetching never reallocates m_inputs.
         m_inputs.reserve(MAX_INPUTS_PER_BLOCK);
     }

--- a/src/coins.h
+++ b/src/coins.h
@@ -8,6 +8,7 @@
 
 #include <attributes.h>
 #include <compressor.h>
+#include <consensus/consensus.h>
 #include <core_memusage.h>
 #include <memusage.h>
 #include <primitives/block.h>
@@ -579,11 +580,15 @@ private:
 
     //! The inputs of the block which is being fetched.
     struct InputToFetch {
+        //! Workers set this after setting the coin. The main thread tests this before reading the coin.
+        mutable std::atomic_flag ready{};
         //! The outpoint of the input to fetch.
         const COutPoint& outpoint;
         //! The coin that workers will fetch and main thread will insert into cache.
         mutable std::optional<Coin> coin{std::nullopt};
 
+        //! The move constructor will never be used, since m_inputs will never need to reallocate.
+        InputToFetch(InputToFetch&& other) noexcept : outpoint{other.outpoint} { Assert(false); }
         explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
     };
     std::vector<InputToFetch> m_inputs{};
@@ -601,6 +606,9 @@ private:
 
         auto& input{m_inputs[i]};
         input.coin = base->PeekCoin(input.outpoint);
+        // Use release so writing coin above happens before the main thread acquires.
+        input.ready.test_and_set(std::memory_order_release);
+        input.ready.notify_one();
         return true;
     }
 
@@ -619,6 +627,15 @@ private:
         if (m_input_tail < m_inputs.size() && m_inputs[m_input_tail].outpoint == outpoint) {
             // We advance the tail since the input is cached and not accessed through this method again.
             auto& input{m_inputs[m_input_tail++]};
+            // Check if the coin is ready to be read. We need acquire so we match the worker thread's release.
+            while (!input.ready.test(std::memory_order_acquire)) {
+                // Work instead of waiting if the coin is not ready
+                if (!ProcessInput()) {
+                    // No more work, just wait
+                    input.ready.wait(/*old=*/false, std::memory_order_acquire);
+                    break;
+                }
+            }
             // We can move the coin since we won't access this input again.
             return std::move(input.coin);
         }
@@ -635,7 +652,12 @@ protected:
     }
 
 public:
-    using CCoinsViewCache::CCoinsViewCache;
+    explicit CoinsViewOverlay(CCoinsView* in_base, bool deterministic = false) noexcept
+        : CCoinsViewCache{in_base, deterministic}
+    {
+        // Reserve to maximum theoretical number so emplace_back in StartFetching never reallocates m_inputs.
+        m_inputs.reserve(MAX_INPUTS_PER_BLOCK);
+    }
 
     //! Start fetching inputs from block.
     [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -20,6 +20,12 @@ static const int COINBASE_MATURITY = 100;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 
+/** The minimum serialized size of a CTxIn even with an empty scriptSig
+ * (32 byte txid + 4 byte vout + 1 byte scriptSig length + 4 byte sequence) */
+static constexpr uint32_t MIN_TXIN_SERIALIZED_SIZE{41};
+/** The maximum number of possible inputs included in a block */
+static constexpr uint32_t MAX_INPUTS_PER_BLOCK{(MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR) / MIN_TXIN_SERIALIZED_SIZE};
+
 static const size_t MIN_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 60; // 60 is the lower bound for the size of a valid serialized CTransaction
 static const size_t MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 10; // 10 is the lower bound for the size of a serialized CTransaction
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -517,6 +517,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
         MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-inputfetchthreads=<n>", strprintf("Set the number of input fetch threads (0 disables, up to %d, default: %d). Negative values are rejected.", MAX_INPUTFETCH_THREADS, DEFAULT_INPUTFETCH_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempoolv1",
                    strprintf("Whether a mempool.dat file created by -persistmempool or the savemempool RPC will be written in the legacy format "

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(bitcoinkernel
   ../uint256.cpp
   ../util/chaintype.cpp
   ../util/check.cpp
+  ../util/exception.cpp
   ../util/expected.cpp
   ../util/feefrac.cpp
   ../util/fs.cpp
@@ -70,6 +71,7 @@ add_library(bitcoinkernel
   ../util/rbf.cpp
   ../util/signalinterrupt.cpp
   ../util/syserror.cpp
+  ../util/thread.cpp
   ../util/threadnames.cpp
   ../util/time.cpp
   ../util/tokenpipe.cpp

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -22,6 +22,7 @@ class CChainParams;
 class ValidationSignals;
 
 static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
+static constexpr int32_t DEFAULT_INPUTFETCH_THREADS{4};
 
 namespace kernel {
 
@@ -46,6 +47,8 @@ struct ChainstateManagerOpts {
     ValidationSignals* signals{nullptr};
     //! Number of script check worker threads. Zero means no parallel verification.
     int worker_threads_num{0};
+    //! Number of input fetch worker threads. Zero means no parallel fetching.
+    int32_t inputfetch_threads_num{DEFAULT_INPUTFETCH_THREADS};
     size_t script_execution_cache_bytes{DEFAULT_SCRIPT_EXECUTION_CACHE_BYTES};
     size_t signature_cache_bytes{DEFAULT_SIGNATURE_CACHE_BYTES};
 };

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -60,6 +60,13 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
     // Subtract 1 because the main thread counts towards the par threads.
     opts.worker_threads_num = script_threads - 1;
 
+    if (auto value{args.GetIntArg("-inputfetchthreads")}) {
+        if (*value < 0) {
+            return util::Error{Untranslated(strprintf("-inputfetchthreads must be non-negative (got %d). Use 0 to disable input fetching.", *value))};
+        }
+        opts.inputfetch_threads_num = static_cast<int32_t>(std::min<int64_t>(*value, MAX_INPUTFETCH_THREADS));
+    }
+
     if (auto max_size = args.GetIntArg("-maxsigcachesize")) {
         // 1. When supplied with a max_size of 0, both the signature cache and
         //    script execution cache create the minimum possible cache (2

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <memory>
 #include <ranges>
+#include <unordered_set>
 
 BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
 
@@ -32,10 +33,13 @@ CBlock CreateBlock() noexcept
     coinbase.vin.emplace_back();
     block.vtx.push_back(MakeTransactionRef(coinbase));
 
+    Txid prevhash{Txid::FromUint256(uint256{1})};
+
     for (const auto i : std::views::iota(1, NUM_TXS)) {
         CMutableTransaction tx;
-        Txid txid{Txid::FromUint256(uint256(i))};
+        const Txid txid{i % 2 == 0 ? Txid::FromUint256(uint256(i)) : prevhash};
         tx.vin.emplace_back(txid, 0);
+        prevhash = tx.GetHash();
         block.vtx.push_back(MakeTransactionRef(tx));
     }
 
@@ -47,12 +51,16 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
     CCoinsViewCache cache{&view};
     cache.SetBestBlock(uint256::ONE);
 
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
     for (const auto& tx : block.vtx | std::views::drop(1)) {
         for (const auto& in : tx->vin) {
+            if (txids.contains(in.prevout.hash)) continue;
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
             cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
         }
+        txids.emplace(tx->GetHash());
     }
 
     cache.Flush();
@@ -72,6 +80,8 @@ std::shared_ptr<ThreadPool> StartedThreadPool()
 void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 {
     uint32_t counter{0};
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
 
     for (const auto& tx : block.vtx) {
         if (tx->IsCoinBase()) {
@@ -82,9 +92,12 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
                 const auto& first{cache.AccessCoin(outpoint)};
                 const auto& second{cache.AccessCoin(outpoint)};
                 BOOST_CHECK_EQUAL(&first, &second);
-                ++counter;
-                BOOST_CHECK(cache.HaveCoinInCache(outpoint));
+                const auto should_have{!txids.contains(outpoint.hash)};
+                if (should_have) ++counter;
+                const auto have{cache.HaveCoinInCache(outpoint)};
+                BOOST_CHECK_EQUAL(should_have, have);
             }
+            txids.emplace(tx->GetHash());
         }
     }
     BOOST_CHECK_EQUAL(cache.GetCacheSize(), counter);
@@ -99,6 +112,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
@@ -126,6 +140,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     CheckCache(block, view);
 
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
@@ -146,6 +161,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     // Add all inputs as spent already in cache
     PopulateView(block, main_cache, /*spent=*/true);
     CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -164,6 +180,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -173,6 +190,66 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
         }
     }
     BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+}
+
+// Access coins that are not block inputs
+BOOST_AUTO_TEST_CASE(access_non_input_coins)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    Coin coin{};
+    coin.out.nValue = 1;
+    const COutPoint outpoint{Txid::FromUint256(uint256::ZERO), 0};
+    main_cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, std::move(coin));
+    const COutPoint missing_outpoint{Txid::FromUint256(uint256::ONE), 0};
+
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
+
+    // Non-input fallback hit.
+    const auto& accessed_coin{view.AccessCoin(outpoint)};
+    BOOST_CHECK(!accessed_coin.IsSpent());
+
+    // Non-input fallback miss.
+    const auto& missing_coin{view.AccessCoin(missing_outpoint)};
+    BOOST_CHECK(missing_coin.IsSpent());
+    BOOST_CHECK(!view.HaveCoinInCache(missing_outpoint));
+}
+
+// Test that disabled input fetching falls back to normal cache lookups via base->PeekCoin.
+BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+    auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
+    CoinsViewOverlay view{&main_cache, thread_pool};
+    const auto reset_guard{view.StartFetching(block)};
+    CheckCache(block, view);
+}
+
+BOOST_AUTO_TEST_CASE(reservation_holds_for_max_inputs)
+{
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    CMutableTransaction tx;
+    tx.vin.reserve(MAX_INPUTS_PER_BLOCK);
+    const Txid prev{Txid::FromUint256(uint256::ONE)};
+    for (const auto i : std::views::iota(0u, MAX_INPUTS_PER_BLOCK)) {
+        tx.vin.emplace_back(prev, i);
+    }
+    block.vtx.push_back(MakeTransactionRef(tx));
+
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
+    // If the reservation were too small, this would abort
+    const auto reset_guard{view.StartFetching(block)};
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
@@ -10,11 +11,13 @@
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/hasher.h>
+#include <util/threadpool.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <ranges>
 
 BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
@@ -55,6 +58,17 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
     cache.Flush();
 }
 
+//! Returns a started thread pool shared across tests, mirroring how production reuses pools.
+std::shared_ptr<ThreadPool> StartedThreadPool()
+{
+    static const auto thread_pool{[] {
+        auto pool{std::make_shared<ThreadPool>("fetch_test")};
+        pool->Start(DEFAULT_INPUTFETCH_THREADS);
+        return pool;
+    }()};
+    return thread_pool;
+}
+
 void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 {
     uint32_t counter{0};
@@ -84,7 +98,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
@@ -111,7 +125,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
     CheckCache(block, view);
 
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
@@ -131,7 +145,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     CCoinsViewCache main_cache{&db};
     // Add all inputs as spent already in cache
     PopulateView(block, main_cache, /*spent=*/true);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -149,7 +163,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, StartedThreadPool()};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -437,3 +437,23 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_R
     const auto reset_guard{coins_view_cache.StartFetching(block)};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }
+
+FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    StartPoolIfNeeded();
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    auto db_params = DBParams{
+        .path = "",
+        .cache_bytes = 1_MiB,
+        .memory_only = true,
+    };
+    CCoinsViewDB backend_base_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewCache backend_cache{&backend_base_coins_view, /*deterministic=*/true};
+    TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
+    CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
+    CBlock block{BuildRandomBlock(fuzzed_data_provider)};
+    const auto reset_guard{coins_view_cache.StartFetching(block)};
+    TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
+    TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
+}

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -373,6 +373,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 // called.
 FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
     CoinsViewOverlay coins_view_cache{&backend_cache, /*deterministic=*/true};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <policy/policy.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -94,6 +95,31 @@ void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
     LOCK(g_thread_pool_mutex);
     if (g_thread_pool->WorkersCount() == DEFAULT_INPUTFETCH_THREADS) return;
     g_thread_pool->Start(DEFAULT_INPUTFETCH_THREADS);
+}
+
+//! Build a random block for async cache testing
+CBlock BuildRandomBlock(FuzzedDataProvider& fuzzed_data_provider)
+{
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    Txid prevhash{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
+    {
+        CMutableTransaction tx;
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
+        {
+            const Txid txid{fuzzed_data_provider.ConsumeBool()
+                                ? Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))
+                                : prevhash};
+            tx.vin.emplace_back(COutPoint{txid, fuzzed_data_provider.ConsumeIntegral<uint32_t>()});
+        }
+        prevhash = tx.GetHash();
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+    return block;
 }
 
 } // namespace
@@ -335,19 +361,35 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
     }
 
     {
-        const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
-        const bool exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
-        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
-        const bool exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
-        if (auto coin{coins_view_cache.GetCoin(random_out_point)}) {
-            assert(*coin == coin_using_access_coin);
-            assert(exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin);
-        } else {
-            assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
+        bool exists_using_access_coin;
+        bool is_spent_using_access_coin;
+        bool exists_using_have_coin;
+        bool exists_using_have_coin_in_cache;
+        // Scope coin_using_access_coin so the reference cannot outlive the cache state it points to.
+        // CreateResetGuard() below clears cache and prefetched coins, which would invalidate it.
+        {
+            const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
+            exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
+            is_spent_using_access_coin = coin_using_access_coin.IsSpent();
+            exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
+            exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
+            if (auto coin{coins_view_cache.GetCoin(random_out_point)}) {
+                assert(*coin == coin_using_access_coin);
+                assert(exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin);
+            } else {
+                assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
+            }
         }
+
+        // Stop async workers before accessing backend_coins_view to avoid data race
+        // (HaveCoin/GetCoin on CCoinsViewCache mutate cacheCoins via FetchCoin)
+        if (auto* async_cache{dynamic_cast<CoinsViewOverlay*>(&coins_view_cache)}) {
+            const auto reset_guard{async_cache->CreateResetGuard()};
+        }
+
         // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
         const bool exists_using_have_coin_in_backend = backend_coins_view->HaveCoin(random_out_point);
-        if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
+        if (!is_spent_using_access_coin && exists_using_have_coin_in_backend) {
             assert(exists_using_have_coin);
         }
         if (auto coin{backend_coins_view->GetCoin(random_out_point)}) {
@@ -391,5 +433,7 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_R
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
     CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
+    CBlock block{BuildRandomBlock(fuzzed_data_provider)};
+    const auto reset_guard{coins_view_cache.StartFetching(block)};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -7,6 +7,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -16,6 +17,7 @@
 #include <test/util/setup_common.h>
 #include <txdb.h>
 #include <util/hasher.h>
+#include <util/threadpool.h>
 
 #include <cassert>
 #include <algorithm>
@@ -83,6 +85,17 @@ public:
 
     using CCoinsViewCache::CCoinsViewCache;
 };
+
+std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("view_fuzz")};
+Mutex g_thread_pool_mutex;
+
+void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    LOCK(g_thread_pool_mutex);
+    if (g_thread_pool->WorkersCount() == DEFAULT_INPUTFETCH_THREADS) return;
+    g_thread_pool->Start(DEFAULT_INPUTFETCH_THREADS);
+}
+
 } // namespace
 
 void initialize_coins_view()
@@ -371,11 +384,12 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 // This allows us to exercise all methods on a CoinsViewOverlay, while also
 // ensuring that nothing can mutate the underlying cache until Flush or Sync is
 // called.
-FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
+    StartPoolIfNeeded();
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
-    CoinsViewOverlay coins_view_cache{&backend_cache, /*deterministic=*/true};
+    CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -5,6 +5,7 @@
 #include <coins.h>
 #include <crypto/sha256.h>
 #include <kernel/chainstatemanager_opts.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -37,12 +38,20 @@ struct PrecomputedData
     //! Randomly generated Coin values.
     Coin coins[NUM_COINS];
 
+    //! Block with a tx containing as inputs the above outpoints.
+    CBlock block;
+
     PrecomputedData()
     {
         static const uint8_t PREFIX_O[1] = {'o'}; /** Hash prefix for outpoint hashes. */
         static const uint8_t PREFIX_S[1] = {'s'}; /** Hash prefix for coins scriptPubKeys. */
         static const uint8_t PREFIX_M[1] = {'m'}; /** Hash prefix for coins nValue/fCoinBase. */
 
+        CMutableTransaction coinbase;
+        coinbase.vin.emplace_back();
+        block.vtx.push_back(MakeTransactionRef(coinbase));
+
+        CMutableTransaction tx;
         for (uint32_t i = 0; i < NUM_OUTPOINTS; ++i) {
             uint32_t idx = (i * 1200U) >> 12; /* Map 3 or 4 entries to same txid. */
             const uint8_t ser[4] = {uint8_t(idx), uint8_t(idx >> 8), uint8_t(idx >> 16), uint8_t(idx >> 24)};
@@ -50,7 +59,9 @@ struct PrecomputedData
             CSHA256().Write(PREFIX_O, 1).Write(ser, sizeof(ser)).Finalize(txid.begin());
             outpoints[i].hash = Txid::FromUint256(txid);
             outpoints[i].n = i;
+            tx.vin.emplace_back(outpoints[i]);
         }
+        block.vtx.push_back(MakeTransactionRef(tx));
 
         for (uint32_t i = 0; i < NUM_COINS; ++i) {
             const uint8_t ser[4] = {uint8_t(i), uint8_t(i >> 8), uint8_t(i >> 16), uint8_t(i >> 24)};
@@ -185,6 +196,14 @@ public:
     }
 };
 
+// Hold a non-movable ResetGuard on the heap so StartFetching can remain active
+// for the lifetime of a CoinsViewOverlay cache level.
+struct OverlayFetchScope
+{
+    CCoinsViewCache::ResetGuard guard;
+    OverlayFetchScope(CoinsViewOverlay& view, const CBlock& block) : guard(view.StartFetching(block)) {}
+};
+
 std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
 Mutex g_thread_pool_mutex;
 
@@ -199,6 +218,7 @@ void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 
 FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     StartPoolIfNeeded();
     /** Precomputed COutPoint and CCoins values. */
     static const PrecomputedData data;
@@ -207,6 +227,8 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
     CoinsViewBottom bottom;
     /** Real CCoinsViewCache objects. */
     std::vector<std::unique_ptr<CCoinsViewCache>> caches;
+    /** Long-lived StartFetching guard (nullptr unless corresponding level is a CoinsViewOverlay). */
+    std::unique_ptr<OverlayFetchScope> overlay_fetch_scope;
     /** Simulated cache data (sim_caches[0] matches bottom, sim_caches[i+1] matches caches[i]). */
     CacheLevel sim_caches[MAX_CACHES + 1];
     /** Current height in the simulation. */
@@ -382,11 +404,17 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
 
             [&]() { // Add a cache level (if not already at the max).
                 if (caches.size() != MAX_CACHES) {
+                    if (overlay_fetch_scope) {
+                        overlay_fetch_scope.reset();
+                        sim_caches[caches.size()].Wipe();
+                    }
                     // Apply to real caches.
                     if (provider.ConsumeBool()) {
                         caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
                     } else {
                         caches.emplace_back(new CoinsViewOverlay(&*caches.back(), g_thread_pool, /*deterministic=*/true));
+                        auto& overlay{static_cast<CoinsViewOverlay&>(*caches.back())};
+                        overlay_fetch_scope = std::make_unique<OverlayFetchScope>(overlay, data.block);
                     }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();
@@ -396,6 +424,7 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
             [&]() { // Remove a cache level.
                 // Apply to real caches (this reduces caches.size(), implicitly doing the same on the simulation data).
                 caches.back()->SanityCheck();
+                overlay_fetch_scope.reset();
                 caches.pop_back();
             },
 
@@ -415,9 +444,13 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
 
             [&]() { // Reset.
                 sim_caches[caches.size()].Wipe();
-                // Apply to real caches.
-                {
-                    const auto reset_guard{caches.back()->CreateResetGuard()};
+                // Apply to real caches. Optionally start fetching again.
+                if (overlay_fetch_scope && provider.ConsumeBool()) {
+                    overlay_fetch_scope.reset();
+                    auto& overlay{static_cast<CoinsViewOverlay&>(*caches.back())};
+                    overlay_fetch_scope = std::make_unique<OverlayFetchScope>(overlay, data.block);
+                } else {
+                    (void)caches.back()->CreateResetGuard();
                 }
             },
 
@@ -441,22 +474,21 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
     }
 
     // Full comparison between caches and simulation data, from bottom to top,
-    // as AccessCoin on a higher cache may affect caches below it.
     for (unsigned sim_idx = 1; sim_idx <= caches.size(); ++sim_idx) {
         auto& cache = *caches[sim_idx - 1];
         size_t cache_size = 0;
 
         for (uint32_t outpointidx = 0; outpointidx < NUM_OUTPOINTS; ++outpointidx) {
             cache_size += cache.HaveCoinInCache(data.outpoints[outpointidx]);
-            const auto& real = cache.AccessCoin(data.outpoints[outpointidx]);
+            const auto real{cache.PeekCoin(data.outpoints[outpointidx])};
             auto sim = lookup(outpointidx, sim_idx);
             if (!sim.has_value()) {
-                assert(real.IsSpent());
+                assert(!real);
             } else {
-                assert(!real.IsSpent());
-                assert(real.out == data.coins[sim->first].out);
-                assert(real.fCoinBase == data.coins[sim->first].fCoinBase);
-                assert(real.nHeight == sim->second);
+                assert(!real->IsSpent());
+                assert(real->out == data.coins[sim->first].out);
+                assert(real->fCoinBase == data.coins[sim->first].fCoinBase);
+                assert(real->nHeight == sim->second);
             }
         }
 

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -4,10 +4,13 @@
 
 #include <coins.h>
 #include <crypto/sha256.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <util/threadpool.h>
 
 #include <cassert>
 #include <cstdint>
@@ -182,10 +185,21 @@ public:
     }
 };
 
+std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
+Mutex g_thread_pool_mutex;
+
+void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    LOCK(g_thread_pool_mutex);
+    if (g_thread_pool->WorkersCount() == DEFAULT_INPUTFETCH_THREADS) return;
+    g_thread_pool->Start(DEFAULT_INPUTFETCH_THREADS);
+}
+
 } // namespace
 
-FUZZ_TARGET(coinscache_sim)
+FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
+    StartPoolIfNeeded();
     /** Precomputed COutPoint and CCoins values. */
     static const PrecomputedData data;
 
@@ -372,7 +386,7 @@ FUZZ_TARGET(coinscache_sim)
                     if (provider.ConsumeBool()) {
                         caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
                     } else {
-                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), /*deterministic=*/true));
+                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), g_thread_pool, /*deterministic=*/true));
                     }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3028,8 +3028,8 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CCoinsViewCache& view{*m_coins_views->m_connect_block_view};
-        const auto reset_guard{view.CreateResetGuard()};
+        CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
+        const auto reset_guard{view.StartFetching(*block_to_connect)};
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1850,11 +1850,15 @@ CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
     : m_dbview{std::move(db_params), std::move(options)},
       m_catcherview(&m_dbview) {}
 
-void CoinsViews::InitCache()
+void CoinsViews::InitCache(int32_t inputfetch_threads)
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
-    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview);
+    auto thread_pool{std::make_shared<ThreadPool>("inputfetch")};
+    if (inputfetch_threads > 0) {
+        thread_pool->Start(inputfetch_threads);
+    }
+    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview, std::move(thread_pool));
 }
 
 Chainstate::Chainstate(
@@ -1930,7 +1934,7 @@ void Chainstate::InitCoinsCache(size_t cache_size_bytes)
     AssertLockHeld(::cs_main);
     assert(m_coins_views != nullptr);
     m_coinstip_cache_size_bytes = cache_size_bytes;
-    m_coins_views->InitCache();
+    m_coins_views->InitCache(m_chainman.m_options.inputfetch_threads_num);
 }
 
 // Lock-free: depends on `m_cached_is_ibd`, which is latched by `UpdateIBDStatus()`.

--- a/src/validation.h
+++ b/src/validation.h
@@ -89,6 +89,9 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES{550_MiB};
 /** Maximum number of dedicated script-checking threads allowed */
 static constexpr int MAX_SCRIPTCHECK_THREADS{15};
 
+/** Maximum number of dedicated input-fetch threads allowed */
+static constexpr int32_t MAX_INPUTFETCH_THREADS{16};
+
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,

--- a/src/validation.h
+++ b/src/validation.h
@@ -506,7 +506,7 @@ public:
     CoinsViews(DBParams db_params, CoinsViewOptions options);
 
     //! Initialize the CCoinsViewCache member.
-    void InitCache() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void InitCache(int32_t inputfetch_threads) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 
 enum class CoinsCacheSizeState

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -135,6 +135,7 @@ class ProxyTest(BitcoinTestFramework):
         if self.have_unix_sockets:
             args[5] = ['-listen', f'-proxy=unix:{socket_path}']
             args[6] = ['-listen', f'-onion=unix:{socket_path}']
+        args = [a + ['-inputfetchthreads=0'] for a in args]
         self.add_nodes(self.num_nodes, extra_args=args)
         self.start_nodes()
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -594,6 +594,7 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
         #  nMaxConnections = available_fds - min_required_fds = 256 - 161 = 94;
         f.write("maxconnections=94\n")
         f.write("par=" + str(min(2, os.cpu_count())) + "\n")
+        f.write("inputfetchthreads=1\n")
         f.write(extra_config)
 
 


### PR DESCRIPTION
**Note: This PR was closed but the change is continuing review in https://github.com/bitcoin/bitcoin/pull/35295.**

_Parts of this PR are isolated in independent smaller PRs to ease review:_

* [x] _https://github.com/bitcoin/bitcoin/pull/34164_
* [x] _https://github.com/bitcoin/bitcoin/pull/34165_
* [x] _https://github.com/bitcoin/bitcoin/pull/34576_

---

This PR parallelizes fetching all input prevouts of a block during block connection, achieving over 3x faster IBD performance in some scenarios[^1][^2][^3][^4][^5].

### Problem

Currently, when fetching inputs in `ConnectBlock`, each input is fetched from the cache sequentially. A cache miss requires a round trip to the disk database to fetch the outpoint and insert it into the cache. Since the database is read-only during `ConnectBlock`, we can fetch all inputs of a block in parallel on multiple threads while connecting.

### Solution

We add a ThreadPool to CoinsViewOverlay to fetch block inputs in parallel. The block is passed to the `CoinsViewOverlay` view before entering `ConnectBlock`, which kicks off the worker threads to begin fetching the inputs. The cache returns fetched coins as they become available via the overridden `FetchCoinFromBase` method. If not available yet, the main thread also fetches coins as it waits.

### Implementation Details

The `CoinsViewOverlay` implements a lock-free MPSC (Multiple Producer, Single Consumer) queue design:

- **Work Distribution**: Collects all input prevouts into a queue, then submits N tasks to the `ThreadPool`. Workers race on the queue index (`m_input_head.fetch_add(...)`) to claim entries.
- **Synchronization**: Worker threads use an atomic counter to claim which inputs to fetch, and each input has an atomic flag to signal completion to the main thread
- **Main Thread Processing**: The main thread waits for inputs in order and moves their `Coin` into the `cacheCoins` map as they become available.
- **Work Stealing**: If the main thread catches up to the workers, it assists with fetching to maximize parallelism
- **Completion**: All thread futures are waited on in StopFetching, which is called from any mutating method (Flush/Sync/SetBackend/Reset). The ResetGuard going out of scope ensure this happens before the block is destroyed.

### Safety and Correctness

- The `CoinsViewOverlay` works on a block that has not been fully validated, but it does not interfere or modify any of the validation during `ConnectBlock`
- It simply fetches inputs in parallel, which must be fetched before a transaction is validated anyways
- **Invalid blocks**: If an invalid block is mined, the temporary cache is reset without being flushed, so existing inputs are not inserted into the main `CoinsTip()` cache when pulled through for an invalid block. This behavior was introduced in #34165 and is preserved here.

### Performance

Benchmarks show over 3x faster IBD performance in a cloud environment with network connected storage[^1], 3x faster IBD for an M4 Mac and up to 46% faster with directly connected storage[^2][^3][^4][^5]. The parallelization of expensive disk lookups provides significant speedup.

[Flamegraphs show how the execution is changed](https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3617315125).

### Credits

Inspired by [this comment](https://github.com/bitcoin/bitcoin/pull/18941#issuecomment-638553680).

Resolves https://github.com/bitcoin/bitcoin/issues/34121.

[^1]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3678847806
[^2]: https://github.com/bitcoin/bitcoin/pull/31132#pullrequestreview-3515011880
[^3]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3463894000
[^4]: https://github.com/bitcoin/bitcoin/pull/31132#pullrequestreview-3347436866
[^5]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3488760623