### PR TITLE
rpc, cli: return "verificationprogress" of 1 when up to date

### DIFF
--- a/doc/release-notes-31135.md
+++ b/doc/release-notes-31135.md
@@ -1,0 +1,10 @@
+Low-level changes
+=================
+
+RPC
+---
+
+- When the node is synced, RPCs getblockchaininfo and getchainstates now return
+  a "verificationprogress" of 1 and CLI -getinfo returns 100.0000%. The previous
+  behavior at the tip was to return a value like 0.9999991055242994, or 99.9999%
+  for -getinfo. (#31135)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1329,15 +1329,16 @@ RPCHelpMan getblockchaininfo()
 
     const CBlockIndex& tip{*CHECK_NONFATAL(active_chainstate.m_chain.Tip())};
     const int height{tip.nHeight};
+    const int headers{chainman.m_best_header ? chainman.m_best_header->nHeight : -1};
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
     obj.pushKV("blocks", height);
-    obj.pushKV("headers", chainman.m_best_header ? chainman.m_best_header->nHeight : -1);
+    obj.pushKV("headers", headers);
     obj.pushKV("bestblockhash", tip.GetBlockHash().GetHex());
     obj.pushKV("difficulty", GetDifficulty(tip));
     obj.pushKV("time", tip.GetBlockTime());
     obj.pushKV("mediantime", tip.GetMedianTimePast());
-    obj.pushKV("verificationprogress", GuessVerificationProgress(chainman.GetParams().TxData(), &tip));
+    obj.pushKV("verificationprogress", height == headers ? 1 : GuessVerificationProgress(chainman.GetParams().TxData(), &tip));
     obj.pushKV("initialblockdownload", chainman.IsInitialBlockDownload());
     obj.pushKV("chainwork", tip.nChainWork.GetHex());
     obj.pushKV("size_on_disk", chainman.m_blockman.CalculateCurrentUsage());


### PR DESCRIPTION
in getblockchaininfo/-getinfo and getchainstates, as requested in issues https://github.com/bitcoin/bitcoin/issues/31127 and https://github.com/bitcoin/bitcoin/issues/26433. Verification progress estimates in the debug logging remain unchanged.