### PR TITLE
test: added test to assert TX decode rpc error on submitpackage rpc

### DIFF
--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -369,6 +369,14 @@ class RPCPackagesTest(BitcoinTestFramework):
     def test_submitpackage(self):
         node = self.nodes[0]
 
+        self.log.info("Submitpackage only allows valid hex inputs")
+        valid_tx_list = self.wallet.create_self_transfer_chain(chain_length=2)
+        hex_list = [valid_tx_list[0]["hex"][:-1] + 'X', valid_tx_list[1]["hex"]]
+        txid_list = [valid_tx_list[0]["txid"], valid_tx_list[1]["txid"]]
+        assert_raises_rpc_error(-22, "TX decode failed:", node.submitpackage, hex_list)
+        assert txid_list[0] not in node.getrawmempool()
+        assert txid_list[1] not in node.getrawmempool()
+
         self.log.info("Submitpackage valid packages with 1 child and some number of parents")
         for num_parents in [1, 2, 24]:
             self.test_submit_child_with_parents(num_parents, False)


### PR DESCRIPTION
This PR adds coverage for this line https://github.com/bitcoin/bitcoin/blob/master/src/rpc/mempool.cpp#L996

If you run the following you will get no results for `submitpackage`
`grep -nri "TX decode failed" ./test/functional`