### PR TITLE
doc: Make list of targets in depends README consistent

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -22,15 +22,15 @@ created. To use it during configuring Bitcoin Core:
 
 Common `host-platform-triplet`s for cross compilation are:
 
-- `i686-pc-linux-gnu` for Linux 32 bit
-- `x86_64-pc-linux-gnu` for x86 Linux
+- `i686-pc-linux-gnu` for Linux x86 32 bit
+- `x86_64-pc-linux-gnu` for Linux x86 64 bit
 - `x86_64-w64-mingw32` for Win64
 - `x86_64-apple-darwin` for macOS
 - `arm64-apple-darwin` for ARM macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit
-- `powerpc64-linux-gnu` for Linux POWER 64-bit (big endian)
-- `powerpc64le-linux-gnu` for Linux POWER 64-bit (little endian)
+- `powerpc64-linux-gnu` for Linux POWER 64 bit (big endian)
+- `powerpc64le-linux-gnu` for Linux POWER 64 bit (little endian)
 - `riscv32-linux-gnu` for Linux RISC-V 32 bit
 - `riscv64-linux-gnu` for Linux RISC-V 64 bit
 - `s390x-linux-gnu` for Linux S390X


### PR DESCRIPTION
The description of `i686-pc-linux-gnu` and `x86_64-pc-linux-gnu` is incomplete and inconsistent with the others. Fix this. Also use "64 bit" consistently instead of "64-bit".