### PR TITLE
ci: Temporary workaround for old CCACHE_DIR cirrus env

### DIFF
--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -59,11 +59,16 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   fi
 
   if [ "$DANGER_CI_ON_HOST_CCACHE_FOLDER" ]; then
+   # Temporary exclusion for https://github.com/bitcoin/bitcoin/issues/31108
+   # to allow CI configs and envs generated in the past to work for a bit longer.
+   # Can be removed in March 2025.
+   if [ "${CCACHE_DIR}" != "/tmp/ccache_dir" ]; then
     if [ ! -d "${CCACHE_DIR}" ]; then
       echo "Error: Directory '${CCACHE_DIR}' must be created in advance."
       exit 1
     fi
     CI_CCACHE_MOUNT="type=bind,src=${CCACHE_DIR},dst=${CCACHE_DIR}"
+   fi # End temporary exclusion
   fi
 
   docker network create --ipv6 --subnet 1111:1111::/112 ci-ip6net || true


### PR DESCRIPTION
On a CI re-run, the historic env vars and CI config is used from Cirrus. However, the most recent CI config and CI scripts from this repo are used. This may lead to issues.

For example, `CCACHE_DIR` in the old location may be missing on new CI workers and lead to errors.

Fix it, by falling back to the old logic when the old `CCACHE_DIR` was detected.

