### PR TITLE
cmake, qt, test: Remove problematic code

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -32,14 +32,6 @@ if(ENABLE_WALLET)
   )
 endif()
 
-if(NOT QT_IS_STATIC)
-  add_custom_command(
-    TARGET test_bitcoin-qt POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_PROPERTY:Qt5::QMinimalIntegrationPlugin,LOCATION_$<UPPER_CASE:$<CONFIG>>> $<TARGET_FILE_DIR:test_bitcoin-qt>/plugins/platforms
-    VERBATIM
-  )
-endif()
-
 add_test(NAME test_bitcoin-qt
   COMMAND test_bitcoin-qt
 )


### PR DESCRIPTION
Split from https://github.com/bitcoin/bitcoin/pull/30997.

The removed code aimed to make Qt's minimal integration plugin DLL available for `test_bitcoin-qt.exe` on Windows.

However, there are two issues:
1. The code is broken because the destination directory must end with a trailing slash (`/`).
2. It is unnecessary because Qt's minimal integration plugin is not used on Windows. For more details, please refer to the following code:https://github.com/bitcoin/bitcoin/blob/fb46d57d4e7263495c007f4a499a349bff2b21e0/src/qt/test/CMakeLists.txt#L38-L44

As a side effect, this PR fixes https://github.com/bitcoin-core/gui/issues/842.