### PR TITLE
util: Treat Assume as Assert when evaluating at compile-time

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -42,9 +42,9 @@ void assertion_fail(std::string_view file, int line, std::string_view func, std:
 template <bool IS_ASSERT, typename T>
 constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
-    if constexpr (IS_ASSERT
+    if (IS_ASSERT || std::is_constant_evaluated()
 #ifdef ABORT_ON_FAILED_ASSUME
-                  || true
+        || true
 #endif
     ) {
         if (!val) {


### PR DESCRIPTION
There is no downside or cost of treating an `Assume` at compile-time as an `Assert` and it may even help to find bugs while compiling without `ABORT_ON_FAILED_ASSUME`.

This is also required for https://github.com/bitcoin/bitcoin/pull/31093