### PR TITLE
Cleanups to port mapping module post UPnP drop

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -121,7 +121,7 @@ public:
     virtual void resetSettings() = 0;
 
     //! Map port.
-    virtual void mapPort(bool use_pcp) = 0;
+    virtual void mapPort(bool enable) = 0;
 
     //! Get proxy.
     virtual bool getProxy(Network net, Proxy& proxy_info) = 0;

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -161,14 +161,9 @@ static void DispatchMapPort()
     }
 }
 
-static void MapPortProtoSetEnabled(bool enabled)
-{
-    g_mapport_enabled = enabled;
-}
-
 void StartMapPort(bool enable)
 {
-    MapPortProtoSetEnabled(enable);
+    g_mapport_enabled = enable;
     DispatchMapPort();
 }
 

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -166,9 +166,9 @@ static void MapPortProtoSetEnabled(bool enabled)
     g_mapport_enabled = enabled;
 }
 
-void StartMapPort(bool use_pcp)
+void StartMapPort(bool enable)
 {
-    MapPortProtoSetEnabled(use_pcp);
+    MapPortProtoSetEnabled(enable);
     DispatchMapPort();
 }
 

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -26,7 +26,6 @@
 static CThreadInterrupt g_mapport_interrupt;
 static std::thread g_mapport_thread;
 static std::atomic_bool g_mapport_enabled{false};
-static std::atomic_bool g_mapport_current{false};
 
 using namespace std::chrono_literals;
 static constexpr auto PORT_MAPPING_REANNOUNCE_PERIOD{20min};
@@ -130,12 +129,10 @@ static void ThreadMapPort()
         ok = false;
 
         if (g_mapport_enabled) {
-            g_mapport_current = true;
             ok = ProcessPCP();
             if (ok) continue;
         }
 
-        g_mapport_current = false;
         if (!g_mapport_enabled) {
             return;
         }
@@ -154,9 +151,9 @@ void StartThreadMapPort()
 void StartMapPort(bool enable)
 {
     g_mapport_enabled = enable;
-    if (!g_mapport_current && g_mapport_enabled) {
+    if (g_mapport_enabled) {
         StartThreadMapPort();
-    } else if (g_mapport_current && !g_mapport_enabled) {
+    } else {
         InterruptMapPort();
         StopMapPort();
     }

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;
 static constexpr auto PORT_MAPPING_REANNOUNCE_PERIOD{20min};
 static constexpr auto PORT_MAPPING_RETRY_PERIOD{5min};
 
-static bool ProcessPCP()
+static void ProcessPCP()
 {
     // The same nonce is used for all mappings, this is allowed by the spec, and simplifies keeping track of them.
     PCPMappingNonce pcp_nonce;
@@ -106,7 +106,7 @@ static bool ProcessPCP()
         // Sanity-check returned lifetime.
         if (actual_lifetime < 30) {
             LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "portmap: Got impossibly short mapping lifetime of %d seconds\n", actual_lifetime);
-            return false;
+            return;
         }
         // RFC6887 11.2.1 recommends that clients send their first renewal packet at a time chosen with uniform random
         // distribution in the range 1/2 to 5/8 of expiration time.
@@ -117,8 +117,6 @@ static bool ProcessPCP()
 
     // We don't delete the mappings when the thread is interrupted because this would add additional complexity, so
     // we rather just choose a fairly short expiry time.
-
-    return ret;
 }
 
 static void ThreadMapPort()

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -151,20 +151,15 @@ void StartThreadMapPort()
     }
 }
 
-static void DispatchMapPort()
+void StartMapPort(bool enable)
 {
+    g_mapport_enabled = enable;
     if (!g_mapport_current && g_mapport_enabled) {
         StartThreadMapPort();
     } else if (g_mapport_current && !g_mapport_enabled) {
         InterruptMapPort();
         StopMapPort();
     }
-}
-
-void StartMapPort(bool enable)
-{
-    g_mapport_enabled = enable;
-    DispatchMapPort();
 }
 
 void InterruptMapPort()

--- a/src/mapport.h
+++ b/src/mapport.h
@@ -7,12 +7,6 @@
 
 static constexpr bool DEFAULT_NATPMP = false;
 
-enum MapPortProtoFlag : unsigned int {
-    NONE = 0x00,
-    // 0x01 was for UPnP, for which we dropped support.
-    PCP = 0x02,   // PCP with NAT-PMP fallback.
-};
-
 void StartMapPort(bool use_pcp);
 void InterruptMapPort();
 void StopMapPort();

--- a/src/mapport.h
+++ b/src/mapport.h
@@ -7,7 +7,7 @@
 
 static constexpr bool DEFAULT_NATPMP = false;
 
-void StartMapPort(bool use_pcp);
+void StartMapPort(bool enable);
 void InterruptMapPort();
 void StopMapPort();
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -187,7 +187,7 @@ public:
         });
         args().WriteSettingsFile();
     }
-    void mapPort(bool use_pcp) override { StartMapPort(use_pcp); }
+    void mapPort(bool enable) override { StartMapPort(enable); }
     bool getProxy(Network net, Proxy& proxy_info) override { return GetProxy(net, proxy_info); }
     size_t getNodeCount(ConnectionDirection flags) override
     {


### PR DESCRIPTION
Followup to #31130, this does a couple cleanups to `src/mapport.*` to clarify the logic now that there is a single protocol option for port mapping.