### PR TITLE
build, ci: Fix linking `bitcoin-chainstate.exe` to `bitcoinkernel.dll` on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.job-type }}-ccache-${{ github.run_id }}
 
   win64-native:
-    name: ${{ matrix.job-name }}
+    name: 'Windows, VS 2022, ${{ matrix.job-name }}'
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
     runs-on: windows-2022
@@ -165,14 +165,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job-type: [standard, fuzz]
+        job-type: [gui, kernel-shared, kernel-static, fuzz]
         include:
-          - job-type: standard
+          - job-type: gui
             generate-options: '-DBUILD_GUI=ON -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
-            job-name: 'Win64 native, VS 2022'
+            job-name: 'gui, no functional tests'
+          - job-type: kernel-shared
+            generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests;zeromq" -DBUILD_GUI=OFF -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=ON -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
+            job-name: 'shared libbitcoinkernel, no functional tests'
+          - job-type: kernel-static
+            generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests;zeromq" -DBUILD_GUI=OFF -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=OFF -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
+            job-name: 'static libbitcoinkernel'
+            run-functional-test: true
           - job-type: fuzz
             generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="sqlite" -DBUILD_GUI=OFF -DBUILD_FOR_FUZZING=ON -DWERROR=ON'
-            job-name: 'Win64 native fuzz, VS 2022'
+            job-name: 'fuzz'
 
     steps:
       - name: Checkout
@@ -218,7 +225,7 @@ jobs:
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4
-        if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
+        if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'gui'
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
@@ -229,13 +236,13 @@ jobs:
           cmake --build . -j $env:NUMBER_OF_PROCESSORS --config Release
 
       - name: Run test suite
-        if: matrix.job-type == 'standard'
+        if: matrix.job-type != 'fuzz'
         working-directory: build
         run: |
           ctest --output-on-failure --stop-on-failure -j $env:NUMBER_OF_PROCESSORS -C Release
 
       - name: Run functional tests
-        if: matrix.job-type == 'standard'
+        if: matrix.run-functional-test == 'true'
         working-directory: build
         env:
           BITCOIND: '${{ github.workspace }}\build\src\Release\bitcoind.exe'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
           key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
 
       - name: Generate build system
+        env:
+          # Treat linker warnings as errors.
+          LDFLAGS: '/WX'
         run: |
           cmake -B build --preset vs2022-static -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" ${{ matrix.generate-options }}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,6 +158,10 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   script/signingprovider.cpp
   script/solver.cpp
 )
+target_compile_definitions(bitcoin_common
+  PUBLIC
+    BITCOIN_BUILD_INTERNAL
+)
 target_link_libraries(bitcoin_common
   PRIVATE
     core_interface

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -90,14 +90,22 @@ target_link_libraries(bitcoinkernel
     Boost::headers
 )
 
-# libbitcoinkernel requires default symbol visibility, explicitly
-# specify that here so that things still work even when user
-# configures with -DREDUCE_EXPORTS=ON
-#
-# Note this is a quick hack that will be removed as we
-# incrementally define what to export from the library.
+target_compile_definitions(bitcoinkernel
+  PUBLIC
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:BITCOINKERNEL_STATIC>
+)
+
 set_target_properties(bitcoinkernel PROPERTIES
+  # libbitcoinkernel requires default symbol visibility, explicitly
+  # specify that here so that things still work even when user
+  # configures with -DREDUCE_EXPORTS=ON
+  #
+  # Note this is a quick hack that will be removed as we
+  # incrementally define what to export from the library.
   CXX_VISIBILITY_PRESET default
+  # Temporarily enable WINDOWS_EXPORT_ALL_SYMBOLS until a dedicated
+  # header with __declspec(dllexport) directives is available.
+  WINDOWS_EXPORT_ALL_SYMBOLS TRUE
 )
 
 # When building the static library, install all static libraries the

--- a/src/kernel/cs_main.h
+++ b/src/kernel/cs_main.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_KERNEL_CS_MAIN_H
 #define BITCOIN_KERNEL_CS_MAIN_H
 
+#include <kernel/symbol_visibility.h>
 #include <sync.h>
 
 /**
@@ -17,6 +18,6 @@
  * The transaction pool has a separate lock to allow reading from it and the
  * chainstate at the same time.
  */
-extern RecursiveMutex cs_main;
+BITCOINKERNEL_EXPORT extern RecursiveMutex cs_main;
 
 #endif // BITCOIN_KERNEL_CS_MAIN_H

--- a/src/kernel/symbol_visibility.h
+++ b/src/kernel/symbol_visibility.h
@@ -1,0 +1,18 @@
+#ifndef BITCOIN_KERNEL_SYMBOL_VISIBILITY_H
+#define BITCOIN_KERNEL_SYMBOL_VISIBILITY_H
+
+#if defined(bitcoinkernel_EXPORTS)
+  #if defined(_WIN32)
+    #define BITCOINKERNEL_EXPORT __declspec(dllexport)
+  #else
+    #define BITCOINKERNEL_EXPORT __attribute__ ((visibility ("default")))
+  #endif
+#elif defined(_WIN32) && !defined(BITCOIN_BUILD_INTERNAL) && !defined(BITCOINKERNEL_STATIC)
+  #define BITCOINKERNEL_EXPORT __declspec(dllimport)
+#endif
+
+#ifndef BITCOINKERNEL_EXPORT
+  #define BITCOINKERNEL_EXPORT
+#endif
+
+#endif // BITCOIN_KERNEL_SYMBOL_VISIBILITY_H

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -19,7 +19,10 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
   validation.cpp
   $<$<BOOL:${ENABLE_WALLET}>:${PROJECT_SOURCE_DIR}/src/wallet/test/util.cpp>
 )
-
+target_compile_definitions(test_util
+  PUBLIC
+    BITCOIN_BUILD_INTERNAL
+)
 target_link_libraries(test_util
   PRIVATE
     core_interface


### PR DESCRIPTION
On the master branch @ 9a7206a34e3179d7280de98a818a13374178ee7b, linking `bitcoin-chainstate.exe` to `bitcoinkernel.dll` fails:
```
> cmake -B build --preset vs2022-static -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=ON
> cmake --build build --config Release -t bitcoin-chainstate
...
LINK : fatal error LNK1181: cannot open input file 'kernel\Release\bitcoinkernel.lib' [C:\Users\hebasto\source\repos\bitcoin\build-static\src\bitcoin-chainstate.vcxproj]
```

This PR fixes this issue and enables the same scenario in the "Win64 native" CI job.