### PR TITLE
key: clear out secret data in `DecodeExtKey`

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -274,6 +274,9 @@ CExtKey DecodeExtKey(const std::string& str)
             key.Decode(data.data() + prefix.size());
         }
     }
+    if (!data.empty()) {
+        memory_cleanse(data.data(), data.size());
+    }
     return key;
 }
 


### PR DESCRIPTION
Same as in `DecodeSecret`, we should also clear out the secret data from the vector resulting from the Base58Check parsing for xprv keys. Note that the if condition is needed in order to avoid UB, see #14242 (commit d855e4cac8303ad4e34ac31cfa7634286589ce99).