### PR TITLE
build: increase minimum supported Windows to 10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,8 +479,7 @@ if(ENABLE_HARDENING)
     try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
 
     if(MINGW)
-      # stack-clash-protection doesn't compile with GCC 10 and earlier.
-      # In any case, it is a no-op for Windows.
+      # stack-clash-protection is a no-op for Windows.
       # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
     else()
       try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,8 +253,8 @@ if(WIN32)
   ]=]
 
   target_compile_definitions(core_interface INTERFACE
-    _WIN32_WINNT=0x0601
-    _WIN32_IE=0x0501
+    _WIN32_WINNT=0x0A00
+    _WIN32_IE=0x0A00
     WIN32_LEAN_AND_MEAN
     NOMINMAX
   )
@@ -292,9 +292,11 @@ if(WIN32)
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412.
     try_append_cxx_flags("-Wa,-muse-unaligned-vector-move" TARGET core_interface SKIP_LINK)
     try_append_linker_flag("-static" TARGET core_interface)
-    # We require Windows 7 (NT 6.1) or later.
+    # We support Windows 10+, however it's not possible to set these values accordingly,
+    # due to a bug in mingw-w64. See https://sourceforge.net/p/mingw-w64/bugs/968/.
+    # As a best effort, target Windows 8.
     try_append_linker_flag("-Wl,--major-subsystem-version,6" TARGET core_interface)
-    try_append_linker_flag("-Wl,--minor-subsystem-version,1" TARGET core_interface)
+    try_append_linker_flag("-Wl,--minor-subsystem-version,2" TARGET core_interface)
   endif()
 endif()
 

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -260,7 +260,7 @@ def check_PE_libraries(binary) -> bool:
 def check_PE_subsystem_version(binary) -> bool:
     major: int = binary.optional_header.major_subsystem_version
     minor: int = binary.optional_header.minor_subsystem_version
-    if major == 6 and minor == 1:
+    if major == 6 and minor == 2:
         return True
     return False
 

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -135,7 +135,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lpdh', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lpdh', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,2']),
             (1, 'pdh.dll is not in ALLOWED_LIBRARIES!\n' +
                  executable + ': failed DYNAMIC_LIBRARIES'))
 
@@ -166,7 +166,7 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lole32', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
+        self.assertEqual(call_symbol_check(cxx, source, executable, ['-lole32', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,2']),
                 (0, ''))
 
 

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -23,5 +23,5 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 mingw32_cmake_system_name=Windows
-# Windows 7 (NT 6.1).
-mingw32_cmake_system_version=6.1
+# Windows 10
+mingw32_cmake_system_version=10.0

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -8,14 +8,14 @@ $(package)_patches+=fix_mingw_link.patch
 $(package)_build_subdir=build
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
-# version as we do in configure. Due to quirks in libevents build system, this
+# version as we do in releases. Due to quirks in libevents build system, this
 # is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
   $(package)_config_opts=-DEVENT__DISABLE_BENCHMARK=ON -DEVENT__DISABLE_OPENSSL=ON
   $(package)_config_opts+=-DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON
   $(package)_config_opts+=-DEVENT__DISABLE_TESTS=ON -DEVENT__LIBRARY_TYPE=STATIC
   $(package)_cppflags += -D_GNU_SOURCE
-  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
+  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0A00
 
   ifeq ($(NO_HARDEN),)
   $(package)_cppflags+=-D_FORTIFY_SOURCE=3

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -18,7 +18,7 @@ define $(package)_set_vars
   $(package)_config_opts += -DBUILD_SHARED=OFF -DBUILD_TESTS=OFF -DZMQ_BUILD_TESTS=OFF
   $(package)_config_opts += -DENABLE_DRAFTS=OFF -DZMQ_BUILD_TESTS=OFF
   $(package)_cxxflags += -ffile-prefix-map=$($(package)_extract_dir)=/usr
-  $(package)_config_opts_mingw32 += -DZMQ_WIN32_WINNT=0x0601 -DZMQ_HAVE_IPC=OFF
+  $(package)_config_opts_mingw32 += -DZMQ_WIN32_WINNT=0x0A00 -DZMQ_HAVE_IPC=OFF
 endef
 
 define $(package)_preprocess_cmds

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -42,8 +42,8 @@ codesign -s - bitcoin-cli bitcoin-qt bitcoin-tx bitcoin-util bitcoin-wallet bitc
 Compatibility
 ==============
 
-Bitcoin Core is supported and extensively tested on operating systems
-using the Linux Kernel 3.17+, macOS 13.0+, and Windows 7 and newer. Bitcoin
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13.0+, and Windows 10 and newer. Bitcoin
 Core should also work on most other Unix-like systems but is not as
 frequently tested on them. It is not recommended to use Bitcoin Core on
 unsupported systems.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -51,23 +51,23 @@ except UnicodeDecodeError:
     CROSS = "x "
     CIRCLE = "o "
 
-if platform.system() != 'Windows' or sys.getwindowsversion() >= (10, 0, 14393): #type:ignore
-    if platform.system() == 'Windows':
-        import ctypes
-        kernel32 = ctypes.windll.kernel32  # type: ignore
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
-        STD_OUTPUT_HANDLE = -11
-        STD_ERROR_HANDLE = -12
-        # Enable ascii color control to stdout
-        stdout = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
-        stdout_mode = ctypes.c_int32()
-        kernel32.GetConsoleMode(stdout, ctypes.byref(stdout_mode))
-        kernel32.SetConsoleMode(stdout, stdout_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-        # Enable ascii color control to stderr
-        stderr = kernel32.GetStdHandle(STD_ERROR_HANDLE)
-        stderr_mode = ctypes.c_int32()
-        kernel32.GetConsoleMode(stderr, ctypes.byref(stderr_mode))
-        kernel32.SetConsoleMode(stderr, stderr_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+if platform.system() == 'Windows':
+    import ctypes
+    kernel32 = ctypes.windll.kernel32  # type: ignore
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+    STD_OUTPUT_HANDLE = -11
+    STD_ERROR_HANDLE = -12
+    # Enable ascii color control to stdout
+    stdout = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+    stdout_mode = ctypes.c_int32()
+    kernel32.GetConsoleMode(stdout, ctypes.byref(stdout_mode))
+    kernel32.SetConsoleMode(stdout, stdout_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+    # Enable ascii color control to stderr
+    stderr = kernel32.GetStdHandle(STD_ERROR_HANDLE)
+    stderr_mode = ctypes.c_int32()
+    kernel32.GetConsoleMode(stderr, ctypes.byref(stderr_mode))
+    kernel32.SetConsoleMode(stderr, stderr_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+else:
     # primitive formatting on supported
     # terminal via ANSI escape sequences:
     DEFAULT = ('\033[0m', '\033[0m')


### PR DESCRIPTION
Follows up to https://github.com/bitcoin/bitcoin/pull/31048#discussion_r1803165670.

We definitely cannot claim that Bitcoin Core is "supported and extensively tested on" on Windows 7.

Note that #30997 is also increasing the minimum required Windows version (for the GUI) to 10.