### PR TITLE
cmake: Add `FindQRencode` module and enable `libqrencode` package for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,7 @@ cmake_dependent_option(ENABLE_EXTERNAL_SIGNER "Enable external signer support." 
 
 cmake_dependent_option(WITH_QRENCODE "Enable QR code support." ON "BUILD_GUI" OFF)
 if(WITH_QRENCODE)
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(libqrencode REQUIRED IMPORTED_TARGET libqrencode)
+  find_package(QRencode MODULE REQUIRED)
   set(USE_QRCODE TRUE)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,8 +15,7 @@
       "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows",
-        "BUILD_GUI": "ON",
-        "WITH_QRENCODE": "OFF"
+        "BUILD_GUI": "ON"
       }
     },
     {
@@ -32,8 +31,7 @@
       "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-        "BUILD_GUI": "ON",
-        "WITH_QRENCODE": "OFF"
+        "BUILD_GUI": "ON"
       }
     },
     {

--- a/cmake/module/FindQRencode.cmake
+++ b/cmake/module/FindQRencode.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+#[=======================================================================[
+FindQRencode
+------------
+
+Finds the QRencode header and library.
+
+This is a wrapper around find_package()/pkg_check_modules() commands that:
+ - facilitates searching in various build environments
+ - prints a standard log message
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_QRencode QUIET libqrencode)
+endif()
+
+find_path(QRencode_INCLUDE_DIR
+  NAMES qrencode.h
+  PATHS ${PC_QRencode_INCLUDE_DIRS}
+)
+
+find_library(QRencode_LIBRARY_RELEASE
+  NAMES qrencode
+  PATHS ${PC_QRencode_LIBRARY_DIRS}
+)
+find_library(QRencode_LIBRARY_DEBUG
+  NAMES qrencoded qrencode
+  PATHS ${PC_QRencode_LIBRARY_DIRS}
+)
+include(SelectLibraryConfigurations)
+select_library_configurations(QRencode)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QRencode
+  REQUIRED_VARS QRencode_LIBRARY QRencode_INCLUDE_DIR
+  VERSION_VAR PC_QRencode_VERSION
+)
+
+if(QRencode_FOUND)
+  if(NOT TARGET QRencode::QRencode)
+    add_library(QRencode::QRencode UNKNOWN IMPORTED)
+  endif()
+  if(QRencode_LIBRARY_RELEASE)
+    set_property(TARGET QRencode::QRencode APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
+    )
+    set_target_properties(QRencode::QRencode PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${QRencode_LIBRARY_RELEASE}"
+    )
+  endif()
+  if(QRencode_LIBRARY_DEBUG)
+    set_property(TARGET QRencode::QRencode APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS DEBUG
+    )
+    set_target_properties(QRencode::QRencode PROPERTIES
+      IMPORTED_LOCATION_DEBUG "${QRencode_LIBRARY_DEBUG}"
+    )
+  endif()
+  set_target_properties(QRencode::QRencode PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${QRencode_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  QRencode_INCLUDE_DIR
+)

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -42,9 +42,7 @@ Available presets can be listed as follows:
 cmake --list-presets
 ```
 
-By default, all presets:
-- Set `BUILD_GUI` to `ON`.
-- Set `WITH_QRENCODE` to `OFF`, due to known build issues when using vcpkg's `libqrencode` package.
+By default, all presets set `BUILD_GUI` to `ON`.
 
 ## Building
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -133,7 +133,7 @@ target_link_libraries(bitcoinqt
     bitcoin_cli
     leveldb
     Boost::headers
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::libqrencode>
+    $<TARGET_NAME_IF_EXISTS:QRencode::QRencode>
     $<$<PLATFORM_ID:Darwin>:-framework\ AppKit>
     $<$<CXX_COMPILER_ID:MSVC>:shlwapi>
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -25,7 +25,8 @@
       "description": "Build GUI, Qt 5",
       "dependencies": [
         "qt5-base",
-        "qt5-tools"
+        "qt5-tools",
+        "libqrencode"
       ]
     },
     "sqlite": {


### PR DESCRIPTION
This PR introduces the `FindQRencode` CMake module, following the official CMake [guidelines](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#find-modules) for managing [upstream libraries](https://github.com/fukuchi/libqrencode) that lack a config file package. This module enhances flexibility in locating the `libqrencode` library by making the use of `pkg-config` optional.

With this update, `libqrencode` can be detected on systems where either `pkg-config` or the `libqrencode.pc` file is unavailable, such as Windows environments using the vcpkg package manager. However, if `libqrencode.pc` is available, it remains beneficial as the only direct source of the library's version information.

Additionally, the `libqrencode` vcpkg package is enabled for MSVC builds.

Here is a diff for configuration output on Ubuntu 24.10:
```diff
 -- Detecting CXX compile features - done
 -- Found SQLite3: /usr/include (found suitable version "3.46.1", minimum required is "3.7.17")
 -- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
--- Checking for module 'libqrencode'
---   Found libqrencode, version 4.1.1
+-- Found QRencode: /usr/lib/x86_64-linux-gnu/libqrencode.so (found version "4.1.1")
 -- Found Qt: /usr/lib/x86_64-linux-gnu/cmake/Qt5 (found suitable version "5.15.15", minimum required is "5.11.3")
 -- Performing Test CXX_SUPPORTS__WERROR
 -- Performing Test CXX_SUPPORTS__WERROR - Success
```