### PR TITLE
rpc, logging: return "verificationprogress" of 1 when up to date

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -324,7 +324,8 @@ public:
     }
     double getVerificationProgress() override
     {
-        return chainman().GuessVerificationProgress(WITH_LOCK(chainman().GetMutex(), return chainman().ActiveChain().Tip()));
+        LOCK(chainman().GetMutex());
+        return chainman().GuessVerificationProgress(chainman().ActiveChain().Tip());
     }
     bool isInitialBlockDownload() override
     {
@@ -408,7 +409,7 @@ public:
     {
         return MakeSignalHandler(::uiInterface.NotifyBlockTip_connect([fn, this](SynchronizationState sync_state, const CBlockIndex* block) {
             fn(sync_state, BlockTip{block->nHeight, block->GetBlockTime(), block->GetBlockHash()},
-               chainman().GuessVerificationProgress(block));
+                WITH_LOCK(chainman().GetMutex(), return chainman().GuessVerificationProgress(block)));
         }));
     }
     std::unique_ptr<Handler> handleNotifyHeaderTip(NotifyHeaderTipFn fn) override

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5625,10 +5625,9 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
         return 0.0;
     }
 
-    int64_t end_of_chain_timestamp = pindex->GetBlockTime();
-
+    int64_t end_of_chain_timestamp = TicksSinceEpoch<std::chrono::seconds>(NodeClock::time_point{std::chrono::seconds{pindex->GetBlockTime()}});
     if (m_best_header && m_best_header->nChainWork > pindex->nChainWork) {
-        int64_t header_age = time(nullptr) - m_best_header->GetBlockTime();
+        int64_t header_age = TicksSinceEpoch<std::chrono::seconds>(Now<NodeSeconds>()) - m_best_header->GetBlockTime();
         if (header_age < 24 * 60 * 60) {
             end_of_chain_timestamp = std::max(end_of_chain_timestamp, m_best_header->GetBlockTime());
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5613,12 +5613,8 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     return ret;
 }
 
-//! Guess how far we are in the verification process at the given block index and the best headers chain
-//! require cs_main if pindex has not been validated yet (because m_chain_tx_count might be unset)
 double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) const
 {
-    const ChainTxData& data{GetParams().TxData()};
-    LOCK(::cs_main);
     if (pindex == nullptr) {
         return 0.0;
     }
@@ -5639,7 +5635,7 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
     }
 
     double fTxTotal;
-
+    const ChainTxData& data{GetParams().TxData()};
     if (pindex->m_chain_tx_count <= data.tx_count) {
         fTxTotal = data.tx_count + (end_of_chain_timestamp - data.nTime) * data.dTxRate;
     } else {

--- a/src/validation.h
+++ b/src/validation.h
@@ -1149,7 +1149,7 @@ public:
     bool IsInitialBlockDownload() const;
 
     /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
-    double GuessVerificationProgress(const CBlockIndex* pindex) const;
+    double GuessVerificationProgress(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Import blocks from an external file


### PR DESCRIPTION
```getblockchaininfo``` never reaches 1.0 as reported in issue https://github.com/bitcoin/bitcoin/issues/31127.
This PR is based on the reviews given on https://github.com/bitcoin/bitcoin/pull/31135.