### PR TITLE
msvc: Update vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,10 +57,6 @@
     {
       "name": "libevent",
       "version": "2.1.12#7"
-    },
-    {
-      "name": "liblzma",
-      "version": "5.4.1#1"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -55,6 +55,7 @@
   },
   "overrides": [
     {
+      "$comment": "Newer unreleased libevent versions cause https://github.com/bitcoin/bitcoin/issues/30096",
       "name": "libevent",
       "version": "2.1.12#7"
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
-  "overrides":[
-    {"name": "libevent", "version": "2.1.12#7"},
-    {"name": "liblzma", "version": "5.4.1#1"}
-  ],
   "dependencies": [
     "boost-date-time",
     "boost-multi-index",
@@ -12,35 +8,59 @@
     "libevent"
   ],
   "default-features": [
-    "wallet",
-    "zeromq",
+    "qt5",
     "tests",
-    "qt5"
+    "wallet",
+    "zeromq"
   ],
   "features": {
-    "wallet": {
-      "description": "Enable wallet",
-      "dependencies": [ "berkeleydb", "sqlite3" ]
-    },
-    "sqlite": {
-      "description": "Enable SQLite wallet support",
-      "dependencies": [ "sqlite3" ]
-    },
     "berkeleydb": {
       "description": "Enable Berkeley DB wallet support",
-      "dependencies": [ "berkeleydb" ]
-    },
-    "zeromq": {
-      "description": "Enable ZMQ notifications",
-      "dependencies": [ "zeromq" ]
-    },
-    "tests": {
-      "description": "Build test_bitcoin.exe executable",
-      "dependencies": [ "boost-test" ]
+      "dependencies": [
+        "berkeleydb"
+      ]
     },
     "qt5": {
       "description": "Build GUI, Qt 5",
-      "dependencies": [ "qt5-base", "qt5-tools" ]
+      "dependencies": [
+        "qt5-base",
+        "qt5-tools"
+      ]
+    },
+    "sqlite": {
+      "description": "Enable SQLite wallet support",
+      "dependencies": [
+        "sqlite3"
+      ]
+    },
+    "tests": {
+      "description": "Build test_bitcoin.exe executable",
+      "dependencies": [
+        "boost-test"
+      ]
+    },
+    "wallet": {
+      "description": "Enable wallet",
+      "dependencies": [
+        "berkeleydb",
+        "sqlite3"
+      ]
+    },
+    "zeromq": {
+      "description": "Enable ZMQ notifications",
+      "dependencies": [
+        "zeromq"
+      ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "libevent",
+      "version": "2.1.12#7"
+    },
+    {
+      "name": "liblzma",
+      "version": "5.4.1#1"
+    }
+  ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
+  "$comment": "The builtin-baseline corresponds to 2024.09.30 Release",
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
+  "builtin-baseline": "c82f74667287d3dc386bce81e44964370c91a289",
   "dependencies": [
     "boost-date-time",
     "boost-multi-index",


### PR DESCRIPTION
This PR updates the vcpkg manifest baseline from the [2023.08.09 Release ](https://github.com/microsoft/vcpkg/releases/tag/2023.08.09) to the [2024.09.30 Release](https://github.com/microsoft/vcpkg/releases/tag/2024.09.30), with the following package changes:
- `boost`: 1.82.0#2 --> 1.85.0#1,2
- `qt5`: 5.15.10#5 -> 5.15.15
- `sqlite3`: 3.42.0#1 --> 3.46.1
- `zeromq`: 2023-06-20#1 --> 4.3.5#2

The previous update was made in https://github.com/bitcoin/bitcoin/pull/28938.

For additional minor improvements, please refer to the commit messages.
