### PR TITLE
build: Make G_FUZZING constexpr, require -DBUILD_FOR_FUZZING=ON to fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,20 +212,6 @@ jobs:
         shell: cmd
         run: py -3 test\functional\test_runner.py --jobs %NUMBER_OF_PROCESSORS% --ci --quiet --tmpdirprefix=%RUNNER_TEMP% --combinedlogslen=99999999 --timeout-factor=%TEST_RUNNER_TIMEOUT_FACTOR% %TEST_RUNNER_EXTRA%
 
-      - name: Clone fuzz corpus
-        run: |
-          git clone --depth=1 https://github.com/bitcoin-core/qa-assets "$env:RUNNER_TEMP\qa-assets"
-          Set-Location "$env:RUNNER_TEMP\qa-assets"
-          Write-Host "Using qa-assets repo from commit ..."
-          git log -1
-
-      - name: Run fuzz binaries
-        working-directory: build
-        env:
-          BITCOINFUZZ: '${{ github.workspace }}\build\src\test\fuzz\Release\fuzz.exe'
-        shell: cmd
-        run: py -3 test\fuzz\test_runner.py --par %NUMBER_OF_PROCESSORS% --loglevel DEBUG %RUNNER_TEMP%\qa-assets\fuzz_corpora
-
   asan-lsan-ubsan-integer-no-depends-usdt:
     name: 'ASan + LSan + UBSan + integer, no depends, USDT'
     runs-on: ubuntu-24.04 # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,10 @@ if(BUILD_FOR_FUZZING)
   set(BUILD_GUI_TESTS OFF)
   set(BUILD_BENCH OFF)
   set(BUILD_FUZZ_BINARY ON)
+
+  target_compile_definitions(core_interface INTERFACE
+    FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  )
 endif()
 
 include(ProcessConfigurations)

--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -15,4 +15,3 @@ export BITCOIN_CONFIG="-DBUILD_GUI=ON -DWITH_ZMQ=ON -DREDUCE_EXPORTS=ON"
 export CI_OS_NAME="macos"
 export NO_DEPENDS=1
 export OSX_SDK=""
-export RUN_FUZZ_TESTS=true

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -139,7 +139,7 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
 // the most signficant bit of the last byte of the hash is set.
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
-    if (g_fuzzing) return (hash.data()[31] & 0x80) == 0;
+    if constexpr (G_FUZZING) return (hash.data()[31] & 0x80) == 0;
     return CheckProofOfWorkImpl(hash, nBits, params);
 }
 

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -102,8 +102,6 @@ void ResetCoverageCounters() {}
 
 void initialize()
 {
-    g_fuzzing = true;
-
     // By default, make the RNG deterministic with a fixed seed. This will affect all
     // randomness during the fuzz test, except:
     // - GetStrongRandBytes(), which is used for the creation of private key material.
@@ -154,6 +152,10 @@ void initialize()
     const auto it = FuzzTargets().find(g_fuzz_target);
     if (it == FuzzTargets().end()) {
         std::cerr << "No fuzz target compiled for " << g_fuzz_target << "." << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    if constexpr (!G_FUZZING) {
+        std::cerr << "Must compile with -DBUILD_FOR_FUZZING=ON to execute a fuzz target." << std::endl;
         std::exit(EXIT_FAILURE);
     }
     Assert(!g_test_one_input);

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -14,8 +14,6 @@
 #include <string>
 #include <string_view>
 
-bool g_fuzzing = false;
-
 std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func)
 {
     return strprintf("Internal bug detected: %s\n%s:%d (%s)\n"

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -13,7 +13,13 @@
 #include <string_view>
 #include <utility>
 
-extern bool g_fuzzing;
+constexpr bool G_FUZZING{
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    true
+#else
+    false
+#endif
+};
 
 std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func);
 
@@ -44,7 +50,7 @@ void assertion_fail(std::string_view file, int line, std::string_view func, std:
 template <bool IS_ASSERT, typename T>
 constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
-    if (IS_ASSERT || std::is_constant_evaluated() || g_fuzzing
+    if (IS_ASSERT || std::is_constant_evaluated() || G_FUZZING
 #ifdef ABORT_ON_FAILED_ASSUME
         || true
 #endif


### PR DESCRIPTION
`g_fuzzing` is used inside `Assume` at runtime, causing significant overhead in hot paths. See https://github.com/bitcoin/bitcoin/issues/31178

One could simply remove the `g_fuzzing` check from the `Assume`, but this would make fuzzing a bit less useful. Also, it would be unclear if `g_fuzzing` adds a runtime overhead in other code paths today or in the future.

Fix all issues by making `G_FUZZING` equal to the build option `BUILD_FOR_FUZZING`, and for consistency in fuzzing, require it to be set when executing any fuzz target.

Fixes https://github.com/bitcoin/bitcoin/issues/31178

Temporarily this drops fuzzing from two CI tasks, but they can be re-added in a follow-up with something like https://github.com/bitcoin/bitcoin/pull/31073