### PR TITLE
depends, doc: List packages required to build `qt` package separately

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -41,11 +41,17 @@ The paths are automatically configured and no other options are needed.
 
 #### Common
 
-    apt install bison cmake curl make patch pkg-config python3 xz-utils
+    apt install cmake curl make patch
+
+#### GUI
+
+Skip the following packages if you don't intend to use the GUI and will build with [`NO_QT=1`](#dependency-options):
+
+    apt install bison g++ pkg-config python3 xz-utils
 
 #### For macOS cross compilation
 
-    apt install clang lld llvm g++ zip
+    apt install clang lld llvm zip
 
 Clang 18 or later is required. You must also obtain the macOS SDK before
 proceeding with a cross-compile. Under the depends directory, create a


### PR DESCRIPTION
Suggested in https://github.com/bitcoin/bitcoin/pull/30997#discussion_r1791789613:
> There's probably enough GUI-only stuff here, i.e `bison`, `ninja-build`, `python3`, `xz-utils`, that this could be moved to it's own `#### Gui` section.