### PR TITLE
Improve lockunspent validation for vout

### DIFF
--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -318,7 +318,12 @@ RPCHelpMan lockunspent()
             });
 
         const Txid txid = Txid::FromUint256(ParseHashO(o, "txid"));
-        const int nOutput = o.find_value("vout").getInt<int>();
+        const UniValue& vout_value = o.find_value("vout");
+        const std::string& vout_str = vout_value.getValStr();
+        if (vout_str.find('.') != std::string::npos) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be an integer");
+        }
+        const int nOutput = vout_value.getInt<int>();
         if (nOutput < 0) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout cannot be negative");
         }

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -185,6 +185,9 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, vout index out of bounds",
                                 self.nodes[2].lockunspent, False,
                                 [{"txid": unspent_0["txid"], "vout": 999}])
+        assert_raises_rpc_error(-8, "Invalid parameter, vout must be an integer",
+                                self.nodes[2].lockunspent, False,
+                                [{"txid": unspent_0["txid"], "vout": 1.0}])
 
         # The lock on a manually selected output is ignored
         unspent_0 = self.nodes[1].listunspent()[0]


### PR DESCRIPTION
This PR adds a check for the vout value passed during the `lockunspent` RPC call. The code verifies if a floating-point number is provided and returns a descriptive error message.

The primary goal of this change is to enhance the user experience by providing clear feedback on invalid parameters. Currently, when a floating-point value is passed for the `vout`, it results in a vague "JSON integer out of range" error. This message is not descriptive and can lead to user confusion. By implementing this check, users will immediately understand that `vout` must be strictly an integer.