### PR TITLE
test: cover edge case for lockunspent rpc

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -185,6 +185,9 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, vout index out of bounds",
                                 self.nodes[2].lockunspent, False,
                                 [{"txid": unspent_0["txid"], "vout": 999}])
+        assert_raises_rpc_error(-8, "Invalid parameter, vout cannot be negative",
+                                self.nodes[2].lockunspent, False,
+                                [{"txid": unspent_0["txid"], "vout": -1}])
 
         # The lock on a manually selected output is ignored
         unspent_0 = self.nodes[1].listunspent()[0]


### PR DESCRIPTION
This PR tests the scenario where a negative number is passed as the vout value during the `lockunspent` RPC call. The rationale behind this test is to validate the input parameters for the `lockunspent` function and ensure that the system behaves correctly when given invalid data. By confirming that the error message "Invalid parameter: vout cannot be negative" is returned, we can prevent unexpected behavior or vulnerabilities in the application. 
