### PR TITLE
guix: Do not set `C{PLUS}_INCLUDE_PATH` variables for Darwin builds

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -69,8 +69,14 @@ unset CPLUS_INCLUDE_PATH
 unset OBJC_INCLUDE_PATH
 unset OBJCPLUS_INCLUDE_PATH
 
-export C_INCLUDE_PATH="${NATIVE_GCC}/include"
-export CPLUS_INCLUDE_PATH="${NATIVE_GCC}/include/c++:${NATIVE_GCC}/include"
+case "$HOST" in
+    *darwin*)
+        ;;
+    *)
+        export C_INCLUDE_PATH="${NATIVE_GCC}/include"
+        export CPLUS_INCLUDE_PATH="${NATIVE_GCC}/include/c++:${NATIVE_GCC}/include"
+        ;;
+esac
 
 case "$HOST" in
     *darwin*) export LIBRARY_PATH="${NATIVE_GCC}/lib" ;; # Required for qt/qmake
@@ -176,13 +182,13 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    x86_64_linux_AR=x86_64-linux-gnu-gcc-ar \
                                    x86_64_linux_RANLIB=x86_64-linux-gnu-gcc-ranlib \
                                    x86_64_linux_NM=x86_64-linux-gnu-gcc-nm \
-                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip
+                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip \
+                                   build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include" \
+                                   build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
 
 case "$HOST" in
     *darwin*)
         # Unset now that Qt is built
-        unset C_INCLUDE_PATH
-        unset CPLUS_INCLUDE_PATH
         unset LIBRARY_PATH
         ;;
 esac


### PR DESCRIPTION
When cross-building for macOS, the `C{PLUS}_INCLUDE_PATH` environment variables modify the default include directories for both native GCC and cross Clang compilers, which is overkill and undesirable for the latter.

This change avoids setting the `C{PLUS}_INCLUDE_PATH` environment variables and instead sets the required `-isystem` flags for the native compiler explicitly.

Additionally, this PR helps avoid non-trivial [patching](https://github.com/bitcoin/bitcoin/blob/add3067e766db6f6732836f2c3191a627583c18a/depends/patches/qt/guard_headers_properly.patch) of Qt 6.