### PR TITLE
addrman: cap the `max_pct` to not exceed the maximum number of addresses

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -812,9 +812,11 @@ nid_type AddrManImpl::GetEntry(bool use_tried, size_t bucket, size_t position) c
 std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
 {
     AssertLockHeld(cs);
+    Assume(max_pct <= 100);
 
     size_t nNodes = vRandom.size();
     if (max_pct != 0) {
+        max_pct = std::min(max_pct, size_t{100});
         nNodes = max_pct * nNodes / 100;
     }
     if (max_addresses != 0) {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -166,7 +166,7 @@ public:
      * Return all or many randomly selected addresses, optionally by network.
      *
      * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
-     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all). Value must be from 0 to 100.
      * @param[in] network        Select only addresses of this network (nullopt = all).
      * @param[in] filtered       Select only addresses that are considered good quality (false = all).
      *

--- a/src/net.h
+++ b/src/net.h
@@ -1152,7 +1152,7 @@ public:
      * Return all or many randomly selected addresses, optionally by network.
      *
      * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
-     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all). Value must be from 0 to 100.
      * @param[in] network        Select only addresses of this network (nullopt = all).
      * @param[in] filtered       Select only addresses that are considered high quality (false = all).
      */

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -173,7 +173,7 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
         network = fuzzed_data_provider.PickValueInArray(ALL_NETWORKS);
     }
     auto max_addresses = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096);
-    auto max_pct = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096);
+    auto max_pct = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 100);
     auto filtered = fuzzed_data_provider.ConsumeBool();
     (void)const_addr_man.GetAddr(max_addresses, max_pct, network, filtered);
 

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -110,13 +110,13 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             },
             [&] {
                 auto max_addresses = fuzzed_data_provider.ConsumeIntegral<size_t>();
-                auto max_pct = fuzzed_data_provider.ConsumeIntegral<size_t>();
+                auto max_pct = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 100);
                 auto filtered = fuzzed_data_provider.ConsumeBool();
                 (void)connman.GetAddresses(max_addresses, max_pct, /*network=*/std::nullopt, filtered);
             },
             [&] {
                 auto max_addresses = fuzzed_data_provider.ConsumeIntegral<size_t>();
-                auto max_pct = fuzzed_data_provider.ConsumeIntegral<size_t>();
+                auto max_pct = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 100);
                 (void)connman.GetAddresses(/*requestor=*/random_node, max_addresses, max_pct);
             },
             [&] {


### PR DESCRIPTION
Fixes #31234

This PR fixes a bad alloc issue in `GetAddresses` by capping the value `max_pct`. In practice, values greater than 100 should be treated as 100 since it's the percentage of addresses to return. Also, it limites the value `max_pct` in connman target to exercise values between 0 and 100.  