### PR TITLE
doc: Add missing 'blank=true' option in offline-signing-tutorial.md

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -61,6 +61,7 @@ The `watch_only_wallet` wallet will be used to track and validate incoming trans
 [online]$ ./build/src/bitcoin-cli -signet -named createwallet \
               wallet_name="watch_only_wallet" \
               disable_private_keys=true
+              blank=true
 
 {
   "name": "watch_only_wallet"


### PR DESCRIPTION
### **Issue:**

The text mentions that the `createwallet` command should use the options `disable_private_keys=true, blank=true`, but the provided command only includes `disable_private_keys=true`, missing the `blank=true` option.

---

### **Details:**

**Original Text:**

> This is achieved by using the `createwallet` options: `disable_private_keys=true, blank=true`.

**Original Command:**

```sh
[online]$ ./build/src/bitcoin-cli -signet -named createwallet \
              wallet_name="watch_only_wallet" \
              disable_private_keys=true
```

---

### **Correction:**

Added `blank=true` to the command to match the options described in the text.

**Revised Command:**

```sh
[online]$ ./build/src/bitcoin-cli -signet -named createwallet \
              wallet_name="watch_only_wallet" \
              disable_private_keys=true \
              blank=true
```

---

### **Explanation:**

The `blank=true` option is necessary to create a blank wallet. Including this option ensures the command matches the options specified in the text.