### PR TITLE
doc: Add missing 'blank=true' option in offline-signing-tutorial.md

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -60,7 +60,8 @@ The `watch_only_wallet` wallet will be used to track and validate incoming trans
 ```sh
 [online]$ ./build/src/bitcoin-cli -signet -named createwallet \
               wallet_name="watch_only_wallet" \
-              disable_private_keys=true
+              disable_private_keys=true \
+              blank=true
 
 {
   "name": "watch_only_wallet"


### PR DESCRIPTION
Issue:

The text mentions that the `createwallet` command should use the options `disable_private_keys=true, blank=true`, but the provided command only includes `disable_private_keys=true`, missing the `blank=true` option.

Correction:

Added `blank=true` to the command to match the options described in the text.

Explanation:

The `blank=true` option is necessary to create a blank wallet. Including this option ensures the command matches the options specified in the text.