### PR TITLE
fuzz: Limit wallet_notifications iterations

### DIFF
--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -84,7 +84,7 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
         auto& [coins, block]{chain.back()};
         coins.emplace(total_amount, COutPoint{Txid::FromUint256(uint256::ONE), 1});
     }
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 200)
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 20)
     {
         CallOneOf(
             fuzzed_data_provider,


### PR DESCRIPTION
I don't think the fuzz target has ever found a real issue. The closest being https://github.com/bitcoin/bitcoin/pull/25869

It is also, by far, the slowest fuzz target. For example, looking at https://cirrus-ci.com/task/5533338067271680?logs=ci#L3974, it takes more than one hour:

```
Run wallet_notifications with args ['/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/src/test/fuzz/fuzz', '-runs=1', PosixPath('/ci_container_base/ci/scratch/qa-assets/fuzz_corpora/wallet_notifications')]INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1096115652
INFO: Loaded 1 modules   (625824 inline 8-bit counters): 625824 [0x5628396d9138, 0x562839771dd8), 
INFO: Loaded 1 PC tables (625824 PCs): 625824 [0x562839771dd8,0x56283a0fe7d8), 
INFO:     1287 files found in /ci_container_base/ci/scratch/qa-assets/fuzz_corpora/wallet_notifications
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1047827 bytes
INFO: seed corpus: files: 1287 min: 1b max: 1047827b total: 11616898b rss: 172Mb
#16	pulse  cov: 14328 ft: 25341 corp: 14/239b exec/s: 5 rss: 204Mb
#64	pulse  cov: 19179 ft: 58412 corp: 61/3587b exec/s: 5 rss: 320Mb
#128	pulse  cov: 19692 ft: 85738 corp: 125/16Kb exec/s: 3 rss: 544Mb
#256	pulse  cov: 19923 ft: 107490 corp: 253/72Kb exec/s: 2 rss: 556Mb
#512	pulse  cov: 20107 ft: 124704 corp: 509/330Kb exec/s: 2 rss: 590Mb
Slowest unit: 10 s:
artifact_prefix='./'; Test unit written to ./slow-unit-9fa5f7d7e4afa1626622ef1b3c70a7563eecf11d
#1024	pulse  cov: 20360 ft: 136324 corp: 1009/2488Kb exec/s: 0 rss: 726Mb
Slowest unit: 23 s:
artifact_prefix='./'; Test unit written to ./slow-unit-5d99a20de2c2b6bedb0cbaf0ba3743ae3ba13c7c
Slowest unit: 26 s:
artifact_prefix='./'; Test unit written to ./slow-unit-8889ecb61bdc0650355e0d0d27c012f3239d07a4
Slowest unit: 42 s:
artifact_prefix='./'; Test unit written to ./slow-unit-d16c084282ac1a85fcdc43c48e49836b08446686
#1289	INITED cov: 20409 ft: 138281 corp: 1245/10323Kb exec/s: 0 rss: 880Mb
#1289	DONE   cov: 20409 ft: 138281 corp: 1245/10323Kb lim: 1047827 exec/s: 0 rss: 880Mb
Done 1289 runs in 3813 second(s)
```

Looking at the flame graphs, it looks like the slow runs spend most of their time in the Knapsack solver. This seems reasonable, because it may run 1000 inner Knapsack iterations 200 times. So reduce the fuzz iterations from 200 to 20 to avoid fuzz timeouts and wasted resources.