### PR TITLE
doc: Fix dead links to mailing list archives

### DIFF
--- a/doc/policy/mempool-limits.md
+++ b/doc/policy/mempool-limits.md
@@ -39,7 +39,7 @@ of the following conditions are met:
 
 *Rationale*: this rule was introduced to prevent pinning by domination of a transaction's descendant
 limits in two-party contract protocols such as LN.  Also see the [mailing list
-post](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html).
+post](https://gnusha.org/pi/bitcoindev/c3f68b73-84c6-7428-4bf6-b47802141392@mattcorallo.com/).
 
 This rule was introduced in [PR #15681](https://github.com/bitcoin/bitcoin/pull/15681).
 

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -85,7 +85,7 @@ public:
  * is intended to represent a set of elements.
  *
  * See also https://cseweb.ucsd.edu/~mihir/papers/inchash.pdf and
- * https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014337.html.
+ * https://gnusha.org/pi/bitcoindev/CAPg+sBgruEiXya6oFy6VpmR1KPDebjeGDtZZU+facZx5=L_a5w@mail.gmail.com/.
  */
 class MuHash3072
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1012,7 +1012,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // being able to broadcast descendants of an unconfirmed transaction
         // to be secure by simply only having two immediately-spendable
         // outputs - one for each counterparty. For more info on the uses for
-        // this, see https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html
+        // this, see https://gnusha.org/pi/bitcoindev/c3f68b73-84c6-7428-4bf6-b47802141392@mattcorallo.com/
         CTxMemPool::Limits cpfp_carve_out_limits{
             .ancestor_count = 2,
             .ancestor_size_vbytes = maybe_rbf_limits.ancestor_size_vbytes,
@@ -4115,7 +4115,7 @@ bool IsBlockMutated(const CBlock& block, bool check_witness_root)
     if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
         // Consider the block mutated if any transaction is 64 bytes in size (see 3.1
         // in "Weaknesses in Bitcoin’s Merkle Root Construction":
-        // https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20190225/a27d8837/attachment-0001.pdf).
+        // https://gnusha.org/pi/bitcoindev/CAFp6fsGtEm9p-ZQF_XqfqyQGzZK7BS2SNp2z680QBsJiFDraEA@mail.gmail.com/2-BitcoinMerkle.pdf.
         //
         // Note: This is not a consensus change as this only applies to blocks that
         // don't have a coinbase transaction and would therefore already be invalid.
@@ -4556,7 +4556,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         // Skipping AcceptBlock() for CheckBlock() failures means that we will never mark a block as invalid if
         // CheckBlock() fails.  This is protective against consensus failure if there are any unknown forms of block
         // malleability that cause CheckBlock() to fail; see e.g. CVE-2012-2459 and
-        // https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-February/016697.html.  Because CheckBlock() is
+        // https://gnusha.org/pi/bitcoindev/CAFp6fsGtEm9p-ZQF_XqfqyQGzZK7BS2SNp2z680QBsJiFDraEA@mail.gmail.com/.  Because CheckBlock() is
         // not very expensive, the anti-DoS benefits of caching failure (of a definitely-invalid block) are not substantial.
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {

--- a/test/functional/test_framework/crypto/muhash.py
+++ b/test/functional/test_framework/crypto/muhash.py
@@ -18,7 +18,7 @@ def data_to_num3072(data):
 class MuHash3072:
     """Class representing the MuHash3072 computation of a set.
 
-    See https://cseweb.ucsd.edu/~mihir/papers/inchash.pdf and https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014337.html
+    See https://cseweb.ucsd.edu/~mihir/papers/inchash.pdf and https://gnusha.org/pi/bitcoindev/CAPg+sBgruEiXya6oFy6VpmR1KPDebjeGDtZZU+facZx5=L_a5w@mail.gmail.com/
     """
 
     MODULUS = 2**3072 - 1103717


### PR DESCRIPTION
Unfortunately, lists.linuxfoundation.org is no longer hosting any mailing list archives, not just for bitcoin-dev but all the other mailing lists too.

I'm opening this to discuss how to best approach the fix.

kanzure suggested in https://github.com/bitcoin/bitcoin/pull/29782#issuecomment-2460974096: 

> Wait and see if they put it back up.
> 
> Update those locations in the source code to the proposed new urls like https://gnusha.org/pi/bitcoindev/c3f68b73-84c6-7428-4bf6-b47802141392@mattcorallo.com/ with the Message-ID in the url.
> 
> Use https://gnusha.org/url/https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-February/016697.html style urls to help others fight web/bit rot for similar links on the web.

The current PR takes approach 2, update old `lists.linuxfoundation.org` links with `gnusha.org` ones. I'll implement approach 3 if that's the consensus of the community.