### PR TITLE
test: report detailed msg during utf8 response decoding error

### DIFF
--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -188,7 +188,12 @@ class AuthServiceProxy():
                 {'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)},
                 http_response.status)
 
-        responsedata = http_response.read().decode('utf8')
+        data = http_response.read()
+        try:
+            responsedata = data.decode('utf8')
+        except UnicodeDecodeError as e:
+            raise JSONRPCException({
+                'code': -342, 'message': f'Cannot decode response in utf8 format, content: {data}, exception: {e}'})
         response = json.loads(responsedata, parse_float=decimal.Decimal)
         elapsed = time.time() - req_start_time
         if "error" in response and response["error"] is None:


### PR DESCRIPTION
Useful for debugging issues such https://github.com/bitcoin/bitcoin/pull/31241#issuecomment-2462816933.

Prints the entire response content instead of printing only the position of the byte it can't be decoded.

The diff between the error messages can be seen by running the `wallet_migration.py` functional test with the following patch applied:
```
diff --git a/src/wallet/rpc/wallet.cpp b/src/wallet/rpc/wallet.cpp
--- a/src/wallet/rpc/wallet.cpp	(revision d65918c5da52c7d5035b4151dee9ffb2e94d4761)
+++ b/src/wallet/rpc/wallet.cpp	(date 1731005254673)
@@ -801,7 +801,7 @@
             }
 
             UniValue r{UniValue::VOBJ};
-            r.pushKV("wallet_name", res->wallet_name);
+            r.pushKV("wallet_name", "\xc3\x28");
             if (res->watchonly_wallet) {
                 r.pushKV("watchonly_name", res->watchonly_wallet->GetName());
             }
```