### PR TITLE
doc: Clarify GUI Compilation Instructions for Qt Libraries in build-n…

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -67,7 +67,7 @@ pkgin install db4
 ###### Qt5
 
 Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
-the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
+the necessary Qt libraries and `qrencode`, and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
 ```bash
 pkgin install qt5-qtbase qt5-qttools


### PR DESCRIPTION
This PR updates build-netbsd.md to improve clarity regarding the installation of Qt libraries for GUI compilation.

This small change enhances clarity for developers by ensuring that instructions for Qt installation and the GUI build option are more explicit, especially for those less familiar with the process on NetBSD.