### PR TITLE
refactor: Drop deprecated space in operator""_mst

### DIFF
--- a/src/script/miniscript.cpp
+++ b/src/script/miniscript.cpp
@@ -1,14 +1,17 @@
-// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Copyright (c) 2019-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <string>
+#include <limits>
 #include <vector>
-#include <script/script.h>
-#include <script/miniscript.h>
-#include <serialize.h>
 
-#include <assert.h>
+#include <primitives/transaction.h>
+#include <script/miniscript.h>
+#include <script/script.h>
+#include <script/solver.h>
+#include <span.h>
+#include <util/check.h>
+#include <util/vector.h>
 
 namespace miniscript {
 namespace internal {

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Copyright (c) 2019-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,20 +6,24 @@
 #define BITCOIN_SCRIPT_MINISCRIPT_H
 
 #include <algorithm>
-#include <functional>
-#include <numeric>
+#include <compare>
+#include <cstdint>
+#include <cstdlib>
+#include <iterator>
 #include <memory>
 #include <optional>
-#include <string>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
 #include <vector>
 
-#include <assert.h>
-#include <cstdlib>
-
+#include <consensus/consensus.h>
 #include <policy/policy.h>
-#include <primitives/transaction.h>
+#include <script/interpreter.h>
 #include <script/parsing.h>
 #include <script/script.h>
+#include <serialize.h>
 #include <span.h>
 #include <util/check.h>
 #include <util/strencodings.h>
@@ -150,7 +154,8 @@ public:
 };
 
 //! Literal operator to construct Type objects.
-inline consteval Type operator"" _mst(const char* c, size_t l) {
+inline consteval Type operator""_mst(const char* c, size_t l)
+{
     Type typ{Type::Make(0)};
 
     for (const char *p = c; p < c + l; p++) {

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -22,7 +22,7 @@ using NodeRef = miniscript::NodeRef<CPubKey>;
 using Node = miniscript::Node<CPubKey>;
 using Type = miniscript::Type;
 using MsCtx = miniscript::MiniscriptContext;
-using miniscript::operator"" _mst;
+using miniscript::operator""_mst;
 
 //! Some pre-computed data for more efficient string roundtrips and to simulate challenges.
 struct TestData {

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -293,7 +293,7 @@ public:
 
 using Fragment = miniscript::Fragment;
 using NodeRef = miniscript::NodeRef<CPubKey>;
-using miniscript::operator"" _mst;
+using miniscript::operator""_mst;
 using Node = miniscript::Node<CPubKey>;
 
 /** Compute all challenges (pubkeys, hashes, timelocks) that occur in a given Miniscript. */


### PR DESCRIPTION
The space is deprecated according to https://en.cppreference.com/w/cpp/language/user_literal#Literal_operators and compilers will start to warn about this. For example, GCC-15 should warn when compiling under C++23, according to https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-literal-operator and Clang-20 will do so by default, according to https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-literal-operator.

Fix it by removing the unused and deprecated space.

Also, fix the iwyu include list, while touching the module.