### PR TITLE
cmake: add optional source files to bitcoin_crypto and crc32c directly

### DIFF
--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -78,8 +78,11 @@ check_cxx_source_compiles_with_flags("${ARM64_CRC_CXXFLAGS}" "
   " HAVE_ARM64_CRC32C
 )
 
-add_library(crc32c_common INTERFACE)
-target_compile_definitions(crc32c_common INTERFACE
+add_library(crc32c STATIC EXCLUDE_FROM_ALL
+  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
+  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_portable.cc
+)
+target_compile_definitions(crc32c PRIVATE
   HAVE_BUILTIN_PREFETCH=$<BOOL:${HAVE_BUILTIN_PREFETCH}>
   HAVE_MM_PREFETCH=$<BOOL:${HAVE_MM_PREFETCH}>
   HAVE_STRONG_GETAUXVAL=$<BOOL:${HAVE_STRONG_GETAUXVAL}>
@@ -87,37 +90,23 @@ target_compile_definitions(crc32c_common INTERFACE
   HAVE_SSE42=$<BOOL:${HAVE_SSE42}>
   HAVE_ARM64_CRC32C=$<BOOL:${HAVE_ARM64_CRC32C}>
 )
-target_link_libraries(crc32c_common INTERFACE
-  core_interface
-)
-
-add_library(crc32c STATIC EXCLUDE_FROM_ALL
-  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
-  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_portable.cc
-)
 target_include_directories(crc32c
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/crc32c/include>
 )
-target_link_libraries(crc32c PRIVATE crc32c_common)
+target_link_libraries(crc32c PRIVATE core_interface)
 set_target_properties(crc32c PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 
 if(HAVE_SSE42)
-  add_library(crc32c_sse42 STATIC EXCLUDE_FROM_ALL
-    ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_sse42.cc
-  )
-  target_compile_options(crc32c_sse42 PRIVATE ${SSE42_CXXFLAGS})
-  target_link_libraries(crc32c_sse42 PRIVATE crc32c_common)
-  set_target_properties(crc32c_sse42 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
-  target_link_libraries(crc32c PRIVATE crc32c_sse42)
+  set(_crc32_src ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_sse42.cc)
+  target_sources(crc32c PRIVATE ${_crc32_src})
+  set_property(SOURCE ${_crc32_src} PROPERTY COMPILE_OPTIONS ${SSE42_CXXFLAGS})
 endif()
 
 if(HAVE_ARM64_CRC32C)
-  add_library(crc32c_arm64 STATIC EXCLUDE_FROM_ALL
-    ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_arm64.cc
-  )
-  target_compile_options(crc32c_arm64 PRIVATE ${ARM64_CRC_CXXFLAGS})
-  target_link_libraries(crc32c_arm64 PRIVATE crc32c_common)
-  set_target_properties(crc32c_arm64 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
-  target_link_libraries(crc32c PRIVATE crc32c_arm64)
+  set(_crc32_src ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_arm64.cc)
+  target_sources(crc32c PRIVATE ${_crc32_src})
+  set_property(SOURCE ${_crc32_src} PROPERTY COMPILE_OPTIONS ${ARM64_CRC_CXXFLAGS})
 endif()
+
+unset(_crc32_src)

--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -8,7 +8,7 @@ declare -A LIBS
 LIBS[cli]="libbitcoin_cli.a"
 LIBS[common]="libbitcoin_common.a"
 LIBS[consensus]="libbitcoin_consensus.a"
-LIBS[crypto]="crypto/libbitcoin_crypto.a crypto/libbitcoin_crypto_x86_shani.a crypto/libbitcoin_crypto_sse41.a crypto/libbitcoin_crypto_avx2.a"
+LIBS[crypto]="crypto/libbitcoin_crypto.a"
 LIBS[node]="libbitcoin_node.a"
 LIBS[util]="util/libbitcoin_util.a"
 LIBS[wallet]="wallet/libbitcoin_wallet.a"

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -28,41 +28,33 @@ target_link_libraries(bitcoin_crypto
 )
 
 if(HAVE_SSE41)
-  add_library(bitcoin_crypto_sse41 STATIC EXCLUDE_FROM_ALL
-    sha256_sse41.cpp
+  target_compile_definitions(bitcoin_crypto PRIVATE ENABLE_SSE41)
+  target_sources(bitcoin_crypto PRIVATE sha256_sse41.cpp)
+  set_property(SOURCE sha256_sse41.cpp PROPERTY
+    COMPILE_OPTIONS ${SSE41_CXXFLAGS}
   )
-  target_compile_definitions(bitcoin_crypto_sse41 PUBLIC ENABLE_SSE41)
-  target_compile_options(bitcoin_crypto_sse41 PRIVATE ${SSE41_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_sse41 PRIVATE core_interface)
-  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_sse41)
 endif()
 
 if(HAVE_AVX2)
-  add_library(bitcoin_crypto_avx2 STATIC EXCLUDE_FROM_ALL
-    sha256_avx2.cpp
+  target_compile_definitions(bitcoin_crypto PRIVATE ENABLE_AVX2)
+  target_sources(bitcoin_crypto PRIVATE sha256_avx2.cpp)
+  set_property(SOURCE sha256_avx2.cpp PROPERTY
+    COMPILE_OPTIONS ${AVX2_CXXFLAGS}
   )
-  target_compile_definitions(bitcoin_crypto_avx2 PUBLIC ENABLE_AVX2)
-  target_compile_options(bitcoin_crypto_avx2 PRIVATE ${AVX2_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_avx2 PRIVATE core_interface)
-  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_avx2)
 endif()
 
 if(HAVE_SSE41 AND HAVE_X86_SHANI)
-  add_library(bitcoin_crypto_x86_shani STATIC EXCLUDE_FROM_ALL
-    sha256_x86_shani.cpp
+  target_compile_definitions(bitcoin_crypto PRIVATE ENABLE_SSE41 ENABLE_X86_SHANI)
+  target_sources(bitcoin_crypto PRIVATE sha256_x86_shani.cpp)
+  set_property(SOURCE sha256_x86_shani.cpp PROPERTY
+    COMPILE_OPTIONS ${X86_SHANI_CXXFLAGS}
   )
-  target_compile_definitions(bitcoin_crypto_x86_shani PUBLIC ENABLE_SSE41 ENABLE_X86_SHANI)
-  target_compile_options(bitcoin_crypto_x86_shani PRIVATE ${X86_SHANI_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_x86_shani PRIVATE core_interface)
-  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_x86_shani)
 endif()
 
 if(HAVE_ARM_SHANI)
-  add_library(bitcoin_crypto_arm_shani STATIC EXCLUDE_FROM_ALL
-    sha256_arm_shani.cpp
+  target_compile_definitions(bitcoin_crypto PRIVATE ENABLE_ARM_SHANI)
+  target_sources(bitcoin_crypto PRIVATE sha256_arm_shani.cpp)
+  set_property(SOURCE sha256_arm_shani.cpp PROPERTY
+    COMPILE_OPTIONS ${ARM_SHANI_CXXFLAGS}
   )
-  target_compile_definitions(bitcoin_crypto_arm_shani PUBLIC ENABLE_ARM_SHANI)
-  target_compile_options(bitcoin_crypto_arm_shani PRIVATE ${ARM_SHANI_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_arm_shani PRIVATE core_interface)
-  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_arm_shani)
 endif()


### PR DESCRIPTION
Avoid having many static libraries by adding the optional sources to the target `bitcoin_crypto` directly.
Set the necessary compile options at the source file level, rather than the target level.

fixes: #31697