### PR TITLE
doc: correct typos

### DIFF
--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -671,7 +671,7 @@ public:
         m_sorted_to_original(depgraph.TxCount()),
         m_original_to_sorted(depgraph.PositionRange())
     {
-        // Determine reordering mapping, by sorting by decreasing feerate. Unusued positions are
+        // Determine reordering mapping, by sorting by decreasing feerate. Unused positions are
         // not included, as they will never be looked up anyway.
         ClusterIndex sorted_pos{0};
         for (auto i : depgraph.Positions()) {

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -54,7 +54,7 @@ public:
     //! The optional `ready_fn` callback will be called after the event loop is
     //! created but before it is started. This can be useful in tests to trigger
     //! client connections from another thread as soon as the event loop is
-    //! available, but should not be neccessary in normal code which starts
+    //! available, but should not be necessary in normal code which starts
     //! clients and servers independently.
     virtual void serve(int fd, const char* exe_name, interfaces::Init& init, const std::function<void()>& ready_fn = {}) = 0;
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -136,7 +136,7 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
 }
 
 // Bypasses the actual proof of work check during fuzz testing with a simplified validation checking whether
-// the most signficant bit of the last byte of the hash is set.
+// the most significant bit of the last byte of the hash is set.
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
     if constexpr (G_FUZZING) return (hash.data()[31] & 0x80) == 0;

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -61,7 +61,7 @@ namespace miniscript {
  *   - Is always "OP_SWAP [B]" or "OP_TOALTSTACK [B] OP_FROMALTSTACK".
  *   - For example sc:pk_k(key) = OP_SWAP <key> OP_CHECKSIG
  *
- * There a type properties that help reasoning about correctness:
+ * There are type properties that help reasoning about correctness:
  * - "z" Zero-arg:
  *   - Is known to always consume exactly 0 stack elements.
  *   - For example after(n) = <n> OP_CHECKLOCKTIMEVERIFY
@@ -84,7 +84,7 @@ namespace miniscript {
  * - "e" Expression:
  *   - This implies property 'd', but the dissatisfaction is nonmalleable.
  *   - This generally requires 'e' for all subexpressions which are invoked for that
- *     dissatifsaction, and property 'f' for the unexecuted subexpressions in that case.
+ *     dissatisfaction, and property 'f' for the unexecuted subexpressions in that case.
  *   - Conflicts with type 'V'.
  * - "f" Forced:
  *   - Dissatisfactions (if any) for this expression always involve at least one signature.

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -82,7 +82,7 @@ static bool CheckOrphanBehavior(node::TxDownloadManagerImpl& txdownload_impl, co
     }
 
     if (expect_orphan != txdownload_impl.m_orphanage.HaveTx(tx->GetWitnessHash())) {
-        err_msg = strprintf("unexpectedly %s tx in orpanage", expect_orphan ? "did not find" : "found");
+        err_msg = strprintf("unexpectedly %s tx in orphanage", expect_orphan ? "did not find" : "found");
         return false;
     }
     if (expect_keep != ret.m_should_add_extra_compact_tx) {

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -114,7 +114,7 @@ class Socks5Connection():
         self.conn = conn
 
     def handle(self):
-        """Handle socks5 request according to RFC192."""
+        """Handle socks5 request according to RFC1928."""
         try:
             # Verify socks version
             ver = recvall(self.conn, 1)[0]


### PR DESCRIPTION
Includes #31253.
Includes https://github.com/bitcoin/bitcoin/pull/31239#pullrequestreview-2425008603.
Fixes remaining lint output.