### PR TITLE
ci: Skip broken Wine64 tests by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,7 +131,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_arm.sh"
 
 task:
-  name: 'Win64, unit tests, no gui tests, no functional tests'
+  name: 'Win64-cross'
   << : *GLOBAL_TASK_TEMPLATE
   persistent_worker:
     labels:

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -11,6 +11,9 @@ export CI_IMAGE_NAME_TAG="docker.io/amd64/debian:bookworm"  # Check that https:/
 export HOST=x86_64-w64-mingw32
 export DPKG_ADD_ARCH="i386"
 export PACKAGES="nsis g++-mingw-w64-x86-64-posix wine-binfmt wine64 wine32 file"
+# Install wine, but do not run unit tests, as they surface frequent
+# false-positives.
+export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-false}
 export RUN_FUNCTIONAL_TESTS=false
 export GOAL="deploy"
 # Prior to 11.0.0, the mingw-w64 headers were missing noreturn attributes, causing warnings when


### PR DESCRIPTION
I don't think the unit tests run in Wine after the Windows cross-compilation have ever shown a true positive since the MSVC task was added. However, they are a source of frequent false-positives.

Thus, disable them by default for now. Anyone can still enable them by setting `RUN_UNIT_TESTS=true`.

A follow-up could run them on real Windows, see https://github.com/bitcoin/bitcoin/pull/31176.

Conceptually there are many other nightly tasks, which rarely find issues and are not run by default, like the valgrind or s390x tasks. So putting the Wine unit tests in the same bucket should be fine.