### PR TITLE
guix: remove `util-linux`

### DIFF
--- a/ci/test/00_setup_env_i686_centos.sh
+++ b/ci/test/00_setup_env_i686_centos.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=i686-pc-linux-gnu
 export CONTAINER_NAME=ci_i686_centos
 export CI_IMAGE_NAME_TAG="quay.io/centos/amd64:stream9"
-export CI_BASE_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache make git python3 python3-pip which patch lbzip2 xz procps-ng dash rsync coreutils bison util-linux e2fsprogs cmake"
+export CI_BASE_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache make git python3 python3-pip which patch lbzip2 xz procps-ng dash rsync coreutils bison e2fsprogs cmake"
 export PIP_PACKAGES="pyzmq"
 export GOAL="install"
 export NO_WERROR=1  # Suppress error: #warning _FORTIFY_SOURCE > 2 is treated like 2 on this platform [-Werror=cpp]

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -10,7 +10,7 @@
              (gnu packages gawk)
              (gnu packages gcc)
              ((gnu packages installers) #:select (nsis-x86_64))
-             ((gnu packages linux) #:select (linux-libre-headers-6.1 util-linux))
+             ((gnu packages linux) #:select (linux-libre-headers-6.1))
              (gnu packages llvm)
              (gnu packages mingw)
              (gnu packages moreutils)
@@ -493,7 +493,6 @@ inspecting signatures in Mach-O binaries.")
         bash-minimal
         which
         coreutils-minimal
-        util-linux
         ;; File(system) inspection
         file
         grep


### PR DESCRIPTION
`hexdump` was used for the tests, until CMake. This package is no-longer needed to complete a Guix build (or needed in the CI). `util-linux` has been in the manifest since Guix was first introduced (3e80ec3ea9691c7c89173de922a113e643fe976b).

Guix build:
```bash
b681575760a0d19445a17d0d54f50a65d705923caee3a7cd7502e6611950dc11  guix-build-4d668549825c/output/aarch64-linux-gnu/SHA256SUMS.part
7af1420fedd8b4d10df650e92840287106dd74c289b6ef6fd2fd039387824647  guix-build-4d668549825c/output/aarch64-linux-gnu/bitcoin-4d668549825c-aarch64-linux-gnu-debug.tar.gz
bd6520732b5c7805002a3227fe2d16f56a77453d913f5204e5be869aaf4a9534  guix-build-4d668549825c/output/aarch64-linux-gnu/bitcoin-4d668549825c-aarch64-linux-gnu.tar.gz
83230468eb9289d294f7bdbb9b410cb7473a2e4dd1463097559dc0752f53cbc0  guix-build-4d668549825c/output/arm-linux-gnueabihf/SHA256SUMS.part
b4d79380642763428b7ca79a66c5920797864b163759081be5369631b4c33c73  guix-build-4d668549825c/output/arm-linux-gnueabihf/bitcoin-4d668549825c-arm-linux-gnueabihf-debug.tar.gz
65d0c3888ca98dc9c7a1d6c25c9d6bc66ca6435c1fb42178ef8794dfa3b40255  guix-build-4d668549825c/output/arm-linux-gnueabihf/bitcoin-4d668549825c-arm-linux-gnueabihf.tar.gz
17d6297ddd9a94913987c596715e66cff0d91d726d06cca2eeb8f3c94056e8db  guix-build-4d668549825c/output/arm64-apple-darwin/SHA256SUMS.part
02faa61796d88b3cff69feeddc50bc579195da3676e5daace2ffc2332f3cbc1a  guix-build-4d668549825c/output/arm64-apple-darwin/bitcoin-4d668549825c-arm64-apple-darwin-unsigned.tar.gz
0e02ef1418f56f67c472dc785041c1988637e509e77337d2a6eeb69b0c4cd844  guix-build-4d668549825c/output/arm64-apple-darwin/bitcoin-4d668549825c-arm64-apple-darwin-unsigned.zip
d4320588db28f4f98b5de4c2e725e02b2f5f1379e376e534f1e4509928d187d4  guix-build-4d668549825c/output/arm64-apple-darwin/bitcoin-4d668549825c-arm64-apple-darwin.tar.gz
7aa217a438fb97f0438ed1d8478cbeb52fd974fac94cbe7cf6c780231e17d8d6  guix-build-4d668549825c/output/dist-archive/bitcoin-4d668549825c.tar.gz
157f1b597eee99ee64722ec28a2770d6fea84bbd711f83ad22ab2bb6b44f15fc  guix-build-4d668549825c/output/powerpc64-linux-gnu/SHA256SUMS.part
60569cdafcf802648c44d2c55758fc5cd2c00d4c37c0f31d9da95e8472438c57  guix-build-4d668549825c/output/powerpc64-linux-gnu/bitcoin-4d668549825c-powerpc64-linux-gnu-debug.tar.gz
5e1581caf3404ffcb1b061d518465f584faf543e3da69b1b116f8a70368455d8  guix-build-4d668549825c/output/powerpc64-linux-gnu/bitcoin-4d668549825c-powerpc64-linux-gnu.tar.gz
db62e80ca99b163d62fc4d473f87de56d97da52dd37ec5043aaaaf4cf96bde25  guix-build-4d668549825c/output/riscv64-linux-gnu/SHA256SUMS.part
47905dd06466f5c197689f9e02d417f959904762321f6dc70e3bf2cc9a2fc04d  guix-build-4d668549825c/output/riscv64-linux-gnu/bitcoin-4d668549825c-riscv64-linux-gnu-debug.tar.gz
558b9ff6aff7b1a49f7bbba81d57025192aca532e7ee6b90b61a36bba0bfd342  guix-build-4d668549825c/output/riscv64-linux-gnu/bitcoin-4d668549825c-riscv64-linux-gnu.tar.gz
a946b5d730fa12f6e388db31e2e4b5de2c48653f16613146fb848ce9cdee8b81  guix-build-4d668549825c/output/x86_64-apple-darwin/SHA256SUMS.part
6d0bfd4443507fe46422b099a2e92e28024c800a37d43539382ac0d8cb00f45d  guix-build-4d668549825c/output/x86_64-apple-darwin/bitcoin-4d668549825c-x86_64-apple-darwin-unsigned.tar.gz
06ef2f4df72377b9f2bb872d624fdcbf391470e4694b85295eb529d90e37ff62  guix-build-4d668549825c/output/x86_64-apple-darwin/bitcoin-4d668549825c-x86_64-apple-darwin-unsigned.zip
bc9fe0032d6f5e9d9576ddb9ea5333bb1d0741731dfa4da4ef1b3daf7dd9241d  guix-build-4d668549825c/output/x86_64-apple-darwin/bitcoin-4d668549825c-x86_64-apple-darwin.tar.gz
4668e50be850961409a4ade5bb7522cc2366e9ab31542247243fa8473d100cb1  guix-build-4d668549825c/output/x86_64-linux-gnu/SHA256SUMS.part
63662bbd98f8d71346ab24b956cb27a1aa03a48825e7c965ced0338024cc97e8  guix-build-4d668549825c/output/x86_64-linux-gnu/bitcoin-4d668549825c-x86_64-linux-gnu-debug.tar.gz
514a726a2bae3944de8e1dbb606bade4f129f01477d5c607fb5e489b22792462  guix-build-4d668549825c/output/x86_64-linux-gnu/bitcoin-4d668549825c-x86_64-linux-gnu.tar.gz
365a33f3046c680a399d9dabeaca589dd7918642c79f0c33205a724084ff5c1c  guix-build-4d668549825c/output/x86_64-w64-mingw32/SHA256SUMS.part
306c6425c1cebaf9dae65853bc3035d478e7670c333616270d63c4ffd08ec724  guix-build-4d668549825c/output/x86_64-w64-mingw32/bitcoin-4d668549825c-win64-debug.zip
817fff3665f49a9eda4e7929e95c645172f6f0432410f4a0319638ce80a50771  guix-build-4d668549825c/output/x86_64-w64-mingw32/bitcoin-4d668549825c-win64-setup-unsigned.exe
f06e3a88a19b29dbad03e1667183eb295a2e6a6e6f69bcdd6f53c7ee4d777a7d  guix-build-4d668549825c/output/x86_64-w64-mingw32/bitcoin-4d668549825c-win64-unsigned.tar.gz
ec1c6fc83198e7e9e1871f1ac25ac49c519a2dab11bb09e1a7153161cb284b79  guix-build-4d668549825c/output/x86_64-w64-mingw32/bitcoin-4d668549825c-win64.zip
```