### PR TITLE
Add `contrib/justfile` containing useful development workflow commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ test/lint/test_runner/target/
 /guix-build-*
 
 /ci/scratch/
+
+# ignore so users can symlink `contrib/justfile` into root
+/justfile

--- a/contrib/justfile
+++ b/contrib/justfile
@@ -1,0 +1,28 @@
+# dependencies:
+#   just: https://github.com/casey/just
+#   watchexec: https://github.com/watchexec/watchexec
+
+set positional-arguments
+
+n := num_cpus()
+
+build: configure
+  cmake --build build -j {{ n }}
+
+configure:
+  @[[ -d build ]] || cmake -B build
+
+clean:
+  rm -rf build
+
+d *args:
+  ./build/src/bitcoind -regtest "$@"
+
+cli *args:
+  ./build/src/bitcoin-cli -regtest "$@"
+
+test: build
+  ctest --test-dir build -j {{ n }}
+
+watch:
+  watchexec 'just build'


### PR DESCRIPTION
Add `contrib/justfile` containing useful development workflow commands.

Just recipes can be run by symlinking `contrib/justfile` into the repository root:

    ln -s contrib/justfile justfile

And running:

    just RECIPE

From any subdirectory.

Also add `/justfile` to `.gitignore`, to ignore the symlink into the repository root.

`just` is command runner with make-like syntax. It is not a build system, and only serves as convenient way of saving and running commands. It is available here:

    https://github.com/casey/just/

Added in `contrib/justfile`, since `just` is a large, unreviewed dependency. Developers considering using `just` should make sure to take this into consideration.

I feel a bit uncomfortable opening a PR which adds a `justfile`, since I wrote and maintain `just`, but whenever I work on Bitcoin Core, I always wind up adding a `justfile` to make running and remembering commands easy, and I think others might find it useful as well.

I thought that adding it to `contrib/justfile` would be best. I try to maintain `just` to high standards, but those standards are those of an open source developer tool project, not a highly security sensitive project like Bitcoin Core, so putting it in `contrib` signals that users should take that into consideration before using `just`.

`just` supports a number of features that `make` doesn't, and in general is less error prone:

- Recipes can take arguments
- No `.PHONY` needed
- Good error messages, both for runtime and syntax errors
- Uses `{{…}}` for interpolation instead of `$`, so no need to `$$`
- List recipes with `just --list`
- Completion scripts for most shells

A `justfile` serves as a convenient way to save and run commands, and as a form of documentation of what commands developers are likely to need when working on the project.

I included `configure`, `build`, `clean`, `test`, and `watch` commands, along with `d` and `cli` commands which run the built `bitcoind` and `bitcoin-cli` in regtest mode, forwarding any additional arguments.