### PR TITLE
mining: add early return to waitTipChanged()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1795,7 +1795,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (WITH_LOCK(chainman.GetMutex(), return chainman.ActiveTip() == nullptr)) {
         WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
         kernel_notifications.m_tip_block_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-            return !kernel_notifications.m_tip_block.IsNull() || ShutdownRequested(node);
+            return kernel_notifications.m_tip_block.has_value() || ShutdownRequested(node);
         });
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -973,7 +973,7 @@ public:
         {
             WAIT_LOCK(notifications().m_tip_block_mutex, lock);
             notifications().m_tip_block_cv.wait_for(lock, timeout, [&]() EXCLUSIVE_LOCKS_REQUIRED(notifications().m_tip_block_mutex) {
-                return (notifications().m_tip_block != current_tip && notifications().m_tip_block != uint256::ZERO) || chainman().m_interrupt;
+                return (notifications().m_tip_block && notifications().m_tip_block.value() != current_tip) || chainman().m_interrupt;
             });
         }
         // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -57,9 +57,9 @@ public:
     Mutex m_tip_block_mutex;
     std::condition_variable m_tip_block_cv GUARDED_BY(m_tip_block_mutex);
     //! The block for which the last blockTip notification was received for.
-    //! The initial ZERO means that no block has been connected yet, which may
-    //! be true even long after startup, until shutdown.
-    uint256 m_tip_block GUARDED_BY(m_tip_block_mutex){uint256::ZERO};
+    //! It's unset until a block is connected, which may be the case even
+    //! long after startup, until shutdown.
+    std::optional<uint256> m_tip_block GUARDED_BY(m_tip_block_mutex){};
 
 private:
     const std::function<bool()>& m_shutdown_request;

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -72,7 +72,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     ChainstateManager& chainman = *Assert(m_node.chainman);
     const auto get_notify_tip{[&]() {
         LOCK(m_node.notifications->m_tip_block_mutex);
-        return m_node.notifications->m_tip_block;
+        BOOST_REQUIRE(m_node.notifications->m_tip_block);
+        return m_node.notifications->m_tip_block.value();
     }};
     uint256 curr_tip = get_notify_tip();
 


### PR DESCRIPTION
It's useful to be able to wait for an active chaintip to appear, by calling ` waitTipChanged(uint256::ZERO);`.

Unfortunately this doesn't work out of the box, because `notifications().m_tip_block` is `ZERO` until a new block arrives.

Additionally we need an early return before calling `wait_for`.