### PR TITLE
depends: Update minimum required CMake version

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -4,12 +4,17 @@ $(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 $(package)_build_subdir=build
+$(package)_patches += cmake_minimum.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DBUILD_SHARED_LIBS=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_PNG=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_BZip2=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec=TRUE
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/freetype/cmake_minimum.patch
+++ b/depends/patches/freetype/cmake_minimum.patch
@@ -1,0 +1,25 @@
+Set a more sane minimum required CMake version.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,19 +94,7 @@
+ #   (this is compatible with the same CMake variables in zlib's CMake
+ #   support).
+ 
+-# FreeType explicitly marks the API to be exported and relies on the compiler
+-# to hide all other symbols. CMake supports a C_VISBILITY_PRESET property
+-# starting with 2.8.12.
+-cmake_minimum_required(VERSION 2.8.12)
+-
+-if (NOT CMAKE_VERSION VERSION_LESS 3.3)
+-  # Allow symbol visibility settings also on static libraries. CMake < 3.3
+-  # only sets the property on a shared library build.
+-  cmake_policy(SET CMP0063 NEW)
+-
+-  # Support new IN_LIST if() operator.
+-  cmake_policy(SET CMP0057 NEW)
+-endif ()
++cmake_minimum_required(VERSION 3.16)
+ 
+ include(CheckIncludeFile)
+ 

--- a/depends/patches/libevent/cmake_fixups.patch
+++ b/depends/patches/libevent/cmake_fixups.patch
@@ -1,4 +1,11 @@
-cmake: set minimum version to 3.5
+cmake: Update minimum required version
+
+Compatibility with versions of CMake older than 3.10 is now deprecated
+and will be removed from a future version.
+
+
+See: https://github.com/libevent/libevent/pull/1752.
+
 
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
@@ -7,7 +14,7 @@ cmake: set minimum version to 3.5
  #
  
 -cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
  
  if (POLICY CMP0054)
      cmake_policy(SET CMP0054 NEW)

--- a/depends/patches/qrencode/cmake_fixups.patch
+++ b/depends/patches/qrencode/cmake_fixups.patch
@@ -1,4 +1,4 @@
-cmake: set minimum version to 3.5
+cmake: set minimum version to 3.10
 
 Correct some dev warning output.
 
@@ -8,7 +8,7 @@ index 773e037..a558145 100644
 +++ b/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.1.0)
-+cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
  
  project(QRencode VERSION 4.1.1 LANGUAGES C)
  


### PR DESCRIPTION
From the CMake 3.31 [Release Notes](https://cmake.org/cmake/help/v3.31/release/3.31.html):

> Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version.

This PR updates the `cmake_minimum_required` command across all packages in depends to ensure the minimum version is not set below 3.10.

Without this change, CMake 3.31 emits a warning:
```
$ make -C depends freetype
make: Entering directory '/home/hebasto/git/bitcoin/depends'
Extracting freetype...
/home/hebasto/git/bitcoin/depends/sources/freetype-2.11.0.tar.xz: OK
Preprocessing freetype...
Configuring freetype...
CMake Deprecation Warning at CMakeLists.txt:100 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is GNU 13.2.0
< snip >
```