### PR TITLE
refactor: convert ContainsNoNUL to ContainsNUL

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -14,7 +14,7 @@
 
 #include <limits>
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -128,7 +128,7 @@ std::string EncodeBase58(Span<const unsigned char> input)
 
 bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
 {
-    if (!ContainsNoNUL(str)) {
+    if (ContainsNUL(str)) {
         return false;
     }
     return DecodeBase58(str.c_str(), vchRet, max_ret_len);
@@ -162,7 +162,7 @@ std::string EncodeBase58Check(Span<const unsigned char> input)
 
 bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret)
 {
-    if (!ContainsNoNUL(str)) {
+    if (ContainsNUL(str)) {
         return false;
     }
     return DecodeBase58Check(str.c_str(), vchRet, max_ret);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <tuple>
 
-using util::ContainsNoNUL;
 using util::HasPrefix;
 
 CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
@@ -210,7 +209,7 @@ static void Checksum(Span<const uint8_t> addr_pubkey, uint8_t (&checksum)[CHECKS
 
 bool CNetAddr::SetSpecial(const std::string& addr)
 {
-    if (!ContainsNoNUL(addr)) {
+    if (util::ContainsNUL(addr)) {
         return false;
     }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -27,7 +27,7 @@
 #include <sys/un.h>
 #endif
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 
 // Settings
 static GlobalMutex g_proxyinfo_mutex;
@@ -147,7 +147,7 @@ std::vector<std::string> GetNetworkNames(bool append_unroutable)
 
 static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) return {};
+    if (ContainsNUL(name)) return {};
     {
         CNetAddr addr;
         // From our perspective, onion addresses are not hostnames but rather
@@ -176,7 +176,7 @@ static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int 
 
 std::vector<CNetAddr> LookupHost(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) return {};
+    if (ContainsNUL(name)) return {};
     std::string strHost = name;
     if (strHost.empty()) return {};
     if (strHost.front() == '[' && strHost.back() == ']') {
@@ -194,7 +194,7 @@ std::optional<CNetAddr> LookupHost(const std::string& name, bool fAllowLookup, D
 
 std::vector<CService> Lookup(const std::string& name, uint16_t portDefault, bool fAllowLookup, unsigned int nMaxSolutions, DNSLookupFn dns_lookup_function)
 {
-    if (name.empty() || !ContainsNoNUL(name)) {
+    if (name.empty() || ContainsNUL(name)) {
         return {};
     }
     uint16_t port{portDefault};
@@ -219,7 +219,7 @@ std::optional<CService> Lookup(const std::string& name, uint16_t portDefault, bo
 
 CService LookupNumeric(const std::string& name, uint16_t portDefault, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) {
+    if (ContainsNUL(name)) {
         return {};
     }
     // "1.2:345" will fail to resolve the ip, but will still set the port.
@@ -757,7 +757,7 @@ CSubNet LookupSubNet(const std::string& subnet_str)
 {
     CSubNet subnet;
     assert(!subnet.IsValid());
-    if (!ContainsNoNUL(subnet_str)) {
+    if (ContainsNUL(subnet_str)) {
         return subnet;
     }
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -40,7 +40,7 @@ using common::AmountErrMsg;
 using common::AmountHighWarn;
 using common::FeeModeFromString;
 using common::ResolveErrMsg;
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 using util::Join;
 using util::RemovePrefix;
 using util::SplitString;
@@ -100,7 +100,7 @@ FUZZ_TARGET(string)
     (void)TrimString(random_string_1);
     (void)TrimString(random_string_1, random_string_2);
     (void)UrlDecode(random_string_1);
-    (void)ContainsNoNUL(random_string_1);
+    (void)ContainsNUL(random_string_1);
     try {
         throw scriptnum_error{random_string_1};
     } catch (const std::runtime_error&) {

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <optional>
 
-using util::ContainsNoNUL;
 using util::TrimString;
 
 std::string FormatMoney(const CAmount n)
@@ -44,7 +43,7 @@ std::string FormatMoney(const CAmount n)
 
 std::optional<CAmount> ParseMoney(const std::string& money_string)
 {
-    if (!ContainsNoNUL(money_string)) {
+    if (util::ContainsNUL(money_string)) {
         return std::nullopt;
     }
     const std::string str = TrimString(money_string);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -212,14 +212,12 @@ inline std::string MakeUnorderedList(const std::vector<std::string>& items)
 }
 
 /**
- * Check if a string does not contain any embedded NUL (\0) characters
+ * Check if a string contains any embedded NUL (\0) characters
  */
-[[nodiscard]] inline bool ContainsNoNUL(std::string_view str) noexcept
+[[nodiscard]] inline bool ContainsNUL(std::string_view str) noexcept
 {
-    for (auto c : str) {
-        if (c == 0) return false;
-    }
-    return true;
+    // Consider using str.contains('\0') once C++23 is mandatory
+    return str.find('\0') != std::string_view::npos;
 }
 
 /**


### PR DESCRIPTION
This allows us to convert all the double negative calls such as `!ContainsNoNUL()` -> `ContainsNUL()`.

There are no usages which aren't double negatives. This makes the code more understandable

Also, use str.find instead of manually looping