### PR TITLE
refactor: spanify DecodeBits, use constexpr std::array instead of vector

### DIFF
--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -21,7 +21,7 @@ namespace {
 
 constexpr uint32_t INVALID = 0xFFFFFFFF;
 
-uint32_t DecodeBits(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos, uint8_t minval, const std::vector<uint8_t> &bit_sizes)
+uint32_t DecodeBits(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos, uint8_t minval, std::span<const uint8_t> bit_sizes)
 {
     uint32_t val = minval;
     bool bit;
@@ -57,27 +57,27 @@ enum class Instruction : uint32_t
     DEFAULT = 3,
 };
 
-const std::vector<uint8_t> TYPE_BIT_SIZES{0, 0, 1};
+constexpr std::array<uint8_t, 3> TYPE_BIT_SIZES{0, 0, 1};
 Instruction DecodeType(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return Instruction(DecodeBits(bitpos, endpos, 0, TYPE_BIT_SIZES));
 }
 
-const std::vector<uint8_t> ASN_BIT_SIZES{15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+constexpr std::array<uint8_t, 10> ASN_BIT_SIZES{15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
 uint32_t DecodeASN(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return DecodeBits(bitpos, endpos, 1, ASN_BIT_SIZES);
 }
 
 
-const std::vector<uint8_t> MATCH_BIT_SIZES{1, 2, 3, 4, 5, 6, 7, 8};
+constexpr std::array<uint8_t, 8> MATCH_BIT_SIZES{1, 2, 3, 4, 5, 6, 7, 8};
 uint32_t DecodeMatch(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return DecodeBits(bitpos, endpos, 2, MATCH_BIT_SIZES);
 }
 
 
-const std::vector<uint8_t> JUMP_BIT_SIZES{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
+constexpr std::array<uint8_t, 26> JUMP_BIT_SIZES{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
 uint32_t DecodeJump(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return DecodeBits(bitpos, endpos, 17, JUMP_BIT_SIZES);


### PR DESCRIPTION
Should generally prefer using std::span over const std::vector&, and generally should use constexpr std::array instead of the const std::vector as used here. This allows the interface to be more flexible (thought the value is low here) and allows it to be more constexpr.

Brief investigation was made into spanifing other interfaces in this file; however, the usage of the specialization std::vector<bool> made that incompatible with trivial spanification