### PR TITLE
ci: Update Clang in "tidy" job

### DIFF
--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -8,7 +8,8 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_tidy
-export TIDY_LLVM_V="18"
+export TIDY_LLVM_V="19"
+export APT_LLVM_V="${TIDY_LLVM_V}"
 export PACKAGES="clang-${TIDY_LLVM_V} libclang-${TIDY_LLVM_V}-dev llvm-${TIDY_LLVM_V}-dev libomp-${TIDY_LLVM_V}-dev clang-tidy-${TIDY_LLVM_V} jq libevent-dev libboost-dev libzmq3-dev systemtap-sdt-dev qtbase5-dev qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,4 +1,3 @@
-# Fixups / upstreamed changes
+# Nothing for now.
 [
-  { include: [ "<bits/chrono.h>", private, "<chrono>", public ] },
 ]

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -39,7 +39,7 @@ public:
             }
             mapOpNames[strName] = static_cast<opcodetype>(op);
             // Convenience: OP_ADD and just ADD are both recognized:
-            if (strName.compare(0, 3, "OP_") == 0) { // strName starts with "OP_"
+            if (strName.starts_with("OP_")) {
                 mapOpNames[strName.substr(3)] = static_cast<opcodetype>(op);
             }
         }

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -63,7 +63,8 @@ void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args
 {
     ExpectResult(result, true, str);
     BOOST_CHECK_EQUAL(result.has_value(), true);
-    BOOST_CHECK_EQUAL(result.value(), T{std::forward<Args>(args)...});
+    T expected{std::forward<Args>(args)...};
+    BOOST_CHECK_EQUAL(result.value(), expected);
     BOOST_CHECK_EQUAL(&result.value(), &*result);
 }
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -356,7 +356,7 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
     std::string socks_location;
     if (reply.code == 250) {
         for (const auto& line : reply.lines) {
-            if (0 == line.compare(0, 20, "net/listeners/socks=")) {
+            if (line.starts_with("net/listeners/socks=")) {
                 const std::string port_list_str = line.substr(20);
                 std::vector<std::string> port_list = SplitString(port_list_str, ' ');
 
@@ -367,7 +367,7 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
                         if (portstr.empty()) continue;
                     }
                     socks_location = portstr;
-                    if (0 == portstr.compare(0, 10, "127.0.0.1:")) {
+                    if (portstr.starts_with("127.0.0.1:")) {
                         // Prefer localhost - ignore other ports
                         break;
                     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1013,7 +1013,7 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
             // "1" or "p" for present (which was written prior to
             // f5ba424cd44619d9b9be88b8593d69a7ba96db26).
             pwallet->LoadAddressPreviouslySpent(dest);
-        } else if (strKey.compare(0, 2, "rr") == 0) {
+        } else if (strKey.starts_with("rr")) {
             // Load "rr##" keys where ## is a decimal number, and strValue
             // is a serialized RecentRequestEntry object.
             pwallet->LoadAddressReceiveRequest(dest, strKey.substr(2), strValue);


### PR DESCRIPTION
This PR switches to the latest [IWYU 0.23](https://github.com/include-what-you-use/include-what-you-use/releases/tag/0.23), which is compatible with Clang 19.

New "bugprone-use-after-move" and "modernize-use-starts-ends-with" warnings that emerged have been addressed.