### PR TITLE
build: Temporarily disable compiling `fuzz/utxo_snapshot.cpp` with MSVC

### DIFF
--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -123,7 +123,10 @@ add_executable(fuzz
   tx_pool.cpp
   txorphan.cpp
   txrequest.cpp
-  utxo_snapshot.cpp
+  # Visual Studio 2022 version 17.12 introduced a bug
+  # that causes an internal compiler error.
+  # See: https://github.com/bitcoin/bitcoin/issues/31303
+  $<$<VERSION_LESS:${MSVC_VERSION},1942>:utxo_snapshot.cpp>
   utxo_total_supply.cpp
   validation_load_mempool.cpp
   vecdeque.cpp


### PR DESCRIPTION
This PR suggests a temporary workaround for a compiler bug [introduced](https://github.com/bitcoin/bitcoin/issues/31303) in Visual Studio 2022 version 17.12.

This workaround is required to fix the CI until the upstream compiler bug is resolved.