### PR TITLE
test: run functional tests from ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ option(BUILD_FOR_FUZZING "Build for fuzzing. Enabling this will disable all othe
 
 option(INSTALL_MAN "Install man pages." ON)
 
+option(ENABLE_FUNCTIONAL_TESTS "Include functional tests on ctest" OFF)
+
 set(APPEND_CPPFLAGS "" CACHE STRING "Preprocessor flags that are appended to the command line after all other flags added by the build system. This variable is intended for debugging and special builds.")
 set(APPEND_CFLAGS "" CACHE STRING "C compiler flags that are appended to the command line after all other flags added by the build system. This variable is intended for debugging and special builds.")
 set(APPEND_CXXFLAGS "" CACHE STRING "(Objective) C++ compiler flags that are appended to the command line after all other flags added by the build system. This variable is intended for debugging and special builds.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,3 +46,9 @@ foreach(script ${functional_tests} fuzz/test_runner.py util/rpcauth-test.py util
   file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/${script} ${CMAKE_CURRENT_BINARY_DIR}/${script} COPY_ON_ERROR ${symlink})
 endforeach()
 unset(functional_tests)
+
+if (ENABLE_FUNCTIONAL_TESTS AND PYTHON_COMMAND)
+  add_test(NAME functional_test_runner
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_BINARY_DIR}/test/functional/test_runner.py
+  )
+endif()


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/18816

This PR enables functional tests to be included in the ctest suite when the ENABLE_FUNCTIONAL_TESTS flag is set to ON during the CMake configuration.

i.e
```
cmake -B build -DENABLE_FUNCTIONAL_TESTS=ON
cmake --build build
ctest --test-dir build
```