### PR TITLE
test: Revert to random path element

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -75,6 +75,8 @@ using node::VerifyLoadedChainstate;
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 constexpr inline auto TEST_DIR_PATH_ELEMENT{"test_common bitcoin"}; // Includes a space to catch possible path escape issues.
+/** Random context to get unique temp data dirs. Separate from m_rng, which can be seeded from a const env var */
+static FastRandomContext g_rng_temp_path;
 
 struct NetworkSetup
 {
@@ -138,8 +140,12 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
 
     const std::string test_name{G_TEST_GET_FULL_NAME ? G_TEST_GET_FULL_NAME() : ""};
     if (!m_node.args->IsArgSet("-testdatadir")) {
-        const auto now{TicksSinceEpoch<std::chrono::nanoseconds>(SystemClock::now())};
-        m_path_root = fs::temp_directory_path() / TEST_DIR_PATH_ELEMENT / test_name / util::ToString(now);
+        // To avoid colliding with a leftover prior datadir, and to allow
+        // tests, such as the fuzz tests to run in several processes at the
+        // same time, add a random element to the path. Keep it small enough to
+        // avoid a MAX_PATH violation on Windows.
+        const auto rand{HexStr(g_rng_temp_path.randbytes(10))};
+        m_path_root = fs::temp_directory_path() / TEST_DIR_PATH_ELEMENT / test_name / rand;
         TryCreateDirectories(m_path_root);
     } else {
         // Custom data directory

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -77,6 +77,11 @@ const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 constexpr inline auto TEST_DIR_PATH_ELEMENT{"test_common bitcoin"}; // Includes a space to catch possible path escape issues.
 /** Random context to get unique temp data dirs. Separate from m_rng, which can be seeded from a const env var */
 static FastRandomContext g_rng_temp_path;
+static const bool g_rng_temp_path_init{[] {
+    // Must be initialized before any SeedRandomForTest
+    (void)g_rng_temp_path.rand64();
+    return true;
+}()};
 
 struct NetworkSetup
 {
@@ -134,8 +139,6 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
         }
     }
 
-    // Use randomly chosen seed for deterministic PRNG, so that (by default) test
-    // data directories use a random name that doesn't overlap with other tests.
     SeedRandomForTest(SeedRand::FIXED_SEED);
 
     const std::string test_name{G_TEST_GET_FULL_NAME ? G_TEST_GET_FULL_NAME() : ""};


### PR DESCRIPTION
The randomness in the path element is required to allow a single fuzz test to run in parallel. Previous releases used a uint256 random value, but 10 random bytes should be sufficient as well, while avoiding a `MAX_PATH` violation on Windows.

The issue was introduced by myself, by suggesting to use the current time in https://github.com/bitcoin/bitcoin/pull/31000#discussion_r1835351305.