### PR TITLE
Typo Update bitcoin-conf.md

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -25,7 +25,7 @@ Blank lines are allowed and ignored by the parser.
 A comment starts with a number sign (`#`) and extends to the end of the line. All comments are ignored by the parser.
 
 Comments may appear in two ways:
-- on their own on an otherwise empty line (_preferable_);
+- on their own on an otherwise empty line (_preferred_);
 - after an `option=value` entry.
 
 ### Network specific options


### PR DESCRIPTION
This pull request corrects a minor but important typographical error in the documentation. In the section discussing the placement of comments in the `bitcoin.conf` configuration file, the word **"preferable"** was used incorrectly. The correct word in this context is **"preferred"**.

- **Before:** "Comments may appear in two ways: on their own on an otherwise empty line (_preferable_);"
- **After:** "Comments may appear in two ways: on their own on an otherwise empty line (_preferred_);"

This change ensures that the language is precise and clear. "Preferred" is the more appropriate word to describe something that is favored or recommended, which aligns with the intended meaning. The fix enhances readability and professionalism in the documentation.