### PR TITLE
contrib: fix BUILDDIR in gen-bitcoin-conf script

### DIFF
--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -5,7 +5,7 @@
 
 export LC_ALL=C
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
-BUILDDIR=${BUILDDIR:-$TOPDIR}
+BUILDDIR=${BUILDDIR:-$TOPDIR/build}
 BINDIR=${BINDIR:-$BUILDDIR/src}
 BITCOIND=${BITCOIND:-$BINDIR/bitcoind}
 SHARE_EXAMPLES_DIR=${SHARE_EXAMPLES_DIR:-$TOPDIR/share/examples}


### PR DESCRIPTION
On master the gen-bitcoin-conf script doesn't work as it cannot find bitcoind.
This is because of the build dir that is now being used since cmake.

This PR fixes it.

**master**
```
./gen-bitcoin-conf.sh 
/home/marnix/projects/bitcoin/src/bitcoind not found or not executable.
```

**PR**
```
./gen-bitcoin-conf.sh 
Generating example bitcoin.conf file in share/examples/
```