### PR TITLE
fuzz: Implement G_TEST_GET_FULL_NAME

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -35,8 +35,6 @@ __AFL_FUZZ_INIT();
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
-const std::function<std::string()> G_TEST_GET_FULL_NAME{};
-
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.
@@ -80,6 +78,9 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 static std::string_view g_fuzz_target;
 static const TypeTestOneInput* g_test_one_input{nullptr};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{[]{
+    return std::string{g_fuzz_target};
+}};
 
 #if defined(__clang__) && defined(__linux__)
 extern "C" void __llvm_profile_reset_counters(void) __attribute__((weak));


### PR DESCRIPTION
Catching up to bench & unit tests. Makes for more orderly paths for fuzz tests using `BasicTestingSetup`.

### Before
```
/tmp/test_common bitcoin/0748ae43ef8fa80703bc/regtest/blocks/xor.dat
```
### After
```
/tmp/test_common bitcoin/tx_pool_standard/f18b3744625e0600eb0c/regtest/blocks/xor.dat
```