### PR TITLE
macOS: swap docs & CI from pkg-config to pkgconf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           # A workaround for "The `brew link` step did not complete successfully" error.
           brew install --quiet python@3 || brew link --overwrite python@3
-          brew install --quiet coreutils ninja pkg-config gnu-getopt ccache boost libevent zeromq qt@5 qrencode
+          # Update to install pkgconf, once the GHA image has been updated.
+          brew install --quiet coreutils ninja gnu-getopt ccache boost libevent zeromq qt@5 qrencode
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -48,7 +48,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 To install, run the following from your terminal:
 
 ``` bash
-brew install cmake boost pkg-config libevent
+brew install cmake boost pkgconf libevent
 ```
 
 ### 4. Clone Bitcoin repository


### PR DESCRIPTION
Migrate the macOS build docs and CI from `pkg-config` to `pkgconf`. As the former now just redirects to the later.

Upstream is currently mass-migrating its formula. i.e https://github.com/Homebrew/homebrew-core/pull/198317.

Fixes #31334.