### PR TITLE
build: Fix coverage builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,8 +436,16 @@ configure_file(contrib/filter-lcov.py filter-lcov.py USE_SOURCE_PERMISSIONS COPY
 # Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK)
 
-try_append_cxx_flags("-ffile-prefix-map=A=B" TARGET core_interface SKIP_LINK
-  IF_CHECK_PASSED "-ffile-prefix-map=${PROJECT_SOURCE_DIR}/src=."
+# Avoiding the `-ffile-prefix-map` compiler option because it implies
+# `-fcoverage-prefix-map` on Clang or `-fprofile-prefix-map` on GCC,
+# which can cause issues with coverage builds, particularly when using
+# Clang in the OSS-Fuzz environment due to its use of other options
+# and a third party script, or with GCC.
+try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
+  IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}/src=."
+)
+try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
+  IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )
 
 # Currently all versions of gcc are subject to a class of bugs, see the


### PR DESCRIPTION
This PR follows up on https://github.com/bitcoin/bitcoin/pull/30811, which inadvertently broke coverage builds:
1. For GCC. See https://github.com/bitcoin/bitcoin/pull/31337#issuecomment-2490598011.
2. For [Clang's source-based code coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) in the OSS-Fuzz environment due to its use of other options and a third party script. See https://issues.oss-fuzz.com/issues/379122777.

The root cause of this regression is that the `-ffile-prefix-map` option implicitly applies:
-  [`-fprofile-prefix-map`](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fprofile-prefix-map) when using GCC.
- [`-fcoverage-prefix-map`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fcoverage-prefix-map) when using Clang. ~This behaviour is not explicitly documented~ See https://github.com/llvm/llvm-project/commit/994c544c18c86cbdb6536aae5d27ef7e2f592486.

With this PR, only the `-fdebug-prefix-map` and `-fmacro-prefix-map` options are applied.

**Note for reviewers:** Please ensure that https://github.com/bitcoin/bitcoin/issues/30799 is not reintroduced.