### PR TITLE
test: add missing segwitv1 test cases to `script_standard_tests`

### DIFF
--- a/src/addresstype.h
+++ b/src/addresstype.h
@@ -117,10 +117,13 @@ public:
     }
 };
 
+/** Witness program for Pay-to-Anchor output script type */
+static const std::vector<unsigned char> ANCHOR_BYTES{0x4e, 0x73};
+
 struct PayToAnchor : public WitnessUnknown
 {
-    PayToAnchor() : WitnessUnknown(1, {0x4e, 0x73}) {
-        Assume(CScript::IsPayToAnchor(1, {0x4e, 0x73}));
+    PayToAnchor() : WitnessUnknown(1, ANCHOR_BYTES) {
+        Assume(CScript::IsPayToAnchor(1, ANCHOR_BYTES));
     };
 };
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <test/data/bip341_wallet_vectors.json.h>
 
+#include <addresstype.h>
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
@@ -130,9 +131,8 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK(solutions[1] == ToByteVector(uint256::ONE));
 
     // TxoutType::ANCHOR
-    std::vector<unsigned char> anchor_bytes{0x4e, 0x73};
     s.clear();
-    s << OP_1 << anchor_bytes;
+    s << OP_1 << ANCHOR_BYTES;
     BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::ANCHOR);
     BOOST_CHECK(solutions.empty());
 
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
 
     // TxoutType::ANCHOR but wrong witness version
     s.clear();
-    s << OP_2 << std::vector<unsigned char>{0x4e, 0x73};
+    s << OP_2 << ANCHOR_BYTES;
     BOOST_CHECK(!s.IsPayToAnchor());
     BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::WITNESS_UNKNOWN);
 
@@ -284,9 +284,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     BOOST_CHECK(std::get<WitnessV1Taproot>(address) == WitnessV1Taproot(xpk));
 
     // TxoutType::ANCHOR
-    std::vector<unsigned char> anchor_bytes{0x4e, 0x73};
     s.clear();
-    s << OP_1 << anchor_bytes;
+    s << OP_1 << ANCHOR_BYTES;
     BOOST_CHECK(ExtractDestination(s, address));
     BOOST_CHECK(std::get<PayToAnchor>(address) == PayToAnchor());
 
@@ -379,9 +378,8 @@ BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)
     BOOST_CHECK(result == expected);
 
     // PayToAnchor
-    std::vector<unsigned char> anchor_bytes{0x4e, 0x73};
     expected.clear();
-    expected << OP_1 << anchor_bytes;
+    expected << OP_1 << ANCHOR_BYTES;
     result = GetScriptForDestination(PayToAnchor());
     BOOST_CHECK(result == expected);
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1040,7 +1040,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     }
 
     // Check anchor outputs
-    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>{0x4e, 0x73};
+    t.vout[0].scriptPubKey = CScript() << OP_1 << ANCHOR_BYTES;
     BOOST_CHECK(t.vout[0].scriptPubKey.IsPayToAnchor());
     t.vout[0].nValue = 240;
     CheckIsStandard(t);


### PR DESCRIPTION
Currently we have two segwitv1 output script types that are considered standard:
- `TxoutType::WITNESS_V1_TAPROOT` (P2TR): witness program has size 32 (introduced with taproot soft-fork)
- `TxoutType::ANCHOR` (P2A): witness program is {0x4e, 0x7e} (introduced with #30352)

This PR adds them to the script standardness unit tests where missing, i.e. for using them with the `ExtractDestination` and `GetScriptForDestination` functions.