### PR TITLE
test: avoid internet traffic in rpc_net.py

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -63,6 +63,9 @@ class NetTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [["-minrelaytxfee=0.00001000"], ["-minrelaytxfee=0.00000500"]]
+        # Specify a non-working proxy to make sure no actual connections to public IPs are attempted
+        for args in self.extra_args:
+            args.append("-proxy=127.0.0.1:1")
         self.supports_cli = False
 
     def run_test(self):


### PR DESCRIPTION
In order to avoid connecting to the internet in the functional test `rpc_net.py`, specify a non-working proxy (parameter `-proxy=127.0.0.1:1`, same approach as in #31142) for the nodes.  There is at least one known instance where this is currently happening on master where a connection attempt to a public IP is made (see also the discussion in #31339):

https://github.com/bitcoin/bitcoin/blob/17834bd1976df7a2ff6c2f5f05a59ae3fd3f6875/test/functional/rpc_net.py#L253

Can be tested by running
```
$ sudo tcpdump -i eth0 host 11.22.33.44
```
both on master and the PR branch and verifying that no packets appear in the tcpdump in the latter anymore.