### PR TITLE
Set notifications m_tip_block in LoadChainTip()

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -75,8 +75,8 @@ public:
     virtual std::optional<BlockRef> getTip() = 0;
 
     /**
-     * Waits for the connected tip to change. If the tip was not connected on
-     * startup, this will wait.
+     * Waits for the connected tip to change. During node initialization, this will
+     * wait until the tip is connected.
      *
      * @param[in] current_tip block hash of the current chain tip. Function waits
      *                        for the chain tip to differ from this.

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -430,6 +430,7 @@ public:
     void CleanupBlockRevFiles() const;
 };
 
+// Calls ActivateBestChain() even if no blocks are imported.
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
 } // namespace node
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -56,9 +56,9 @@ public:
 
     Mutex m_tip_block_mutex;
     std::condition_variable m_tip_block_cv GUARDED_BY(m_tip_block_mutex);
-    //! The block for which the last blockTip notification was received for.
-    //! The initial ZERO means that no block has been connected yet, which may
-    //! be true even long after startup, until shutdown.
+    //! The block for which the last blockTip notification was received.
+    //! It's first set when the tip is connected during node initialization.
+    //! Might be unset during an early shutdown.
     uint256 m_tip_block GUARDED_BY(m_tip_block_mutex){uint256::ZERO};
 
 private:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4721,6 +4721,13 @@ bool Chainstate::LoadChainTip()
               m_chain.Height(),
               FormatISO8601DateTime(tip->GetBlockTime()),
               GuessVerificationProgress(m_chainman.GetParams().TxData(), tip));
+
+    // Ensure KernelNotifications m_tip_block is set even if no new block arrives.
+    if (this->GetRole() != ChainstateRole::BACKGROUND) {
+        // Ignoring return value for now.
+        (void)m_chainman.GetNotifications().blockTip(GetSynchronizationState(/*init=*/true, m_chainman.m_blockman.m_blockfiles_indexed), *pindex);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Ensure KernelNotifications `m_tip_block` is set even if no new block arrives.

Suggested in https://github.com/bitcoin/bitcoin/pull/31297#issuecomment-2486457573
