### PR TITLE
Add and use `satToBtc` and `btcToSat` util functions

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -13,13 +13,13 @@ from test_framework.blocktools import (
     script_to_p2wsh_script,
 )
 from test_framework.messages import (
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
     CTxInWitness,
     CTxOut,
     tx_from_hex,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -91,7 +91,7 @@ class BIP68Test(BitcoinTestFramework):
         utxo = self.wallet.send_self_transfer(from_node=self.nodes[0])["new_utxo"]
 
         tx1 = CTransaction()
-        value = int((utxo["value"] - self.relayfee) * COIN)
+        value = btcToSat(utxo["value"] - self.relayfee)
 
         # Check that the disable flag disables relative locktime.
         # If sequence locks were used, this would require 1 block for the
@@ -112,7 +112,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2.vin = [CTxIn(COutPoint(tx1_id, 0), nSequence=sequence_value)]
         tx2.wit.vtxinwit = [CTxInWitness()]
         tx2.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
-        tx2.vout = [CTxOut(int(value - self.relayfee * COIN), SCRIPT_W0_SH_OP_TRUE)]
+        tx2.vout = [CTxOut(int(value - btcToSat(self.relayfee)), SCRIPT_W0_SH_OP_TRUE)]
         tx2.rehash()
 
         assert_raises_rpc_error(-26, NOT_FINAL_ERROR, self.wallet.sendrawtransaction, from_node=self.nodes[0], tx_hex=tx2.serialize().hex())
@@ -197,10 +197,10 @@ class BIP68Test(BitcoinTestFramework):
                             sequence_value = ((cur_time - orig_time) >> SEQUENCE_LOCKTIME_GRANULARITY)+1
                         sequence_value |= SEQUENCE_LOCKTIME_TYPE_FLAG
                 tx.vin.append(CTxIn(COutPoint(int(utxos[j]["txid"], 16), utxos[j]["vout"]), nSequence=sequence_value))
-                value += utxos[j]["value"]*COIN
+                value += btcToSat(utxos[j]["value"])
             # Overestimate the size of the tx - signatures should be less than 120 bytes, and leave 50 for the output
             tx_size = len(tx.serialize().hex())//2 + 120*num_inputs + 50
-            tx.vout.append(CTxOut(int(value - self.relayfee * tx_size * COIN / 1000), SCRIPT_W0_SH_OP_TRUE))
+            tx.vout.append(CTxOut(int(value - btcToSat(self.relayfee * tx_size) / 1000), SCRIPT_W0_SH_OP_TRUE))
             self.wallet.sign_tx(tx=tx)
 
             if (using_sequence_locks and not should_pass):
@@ -230,7 +230,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.version = 2
         tx2.vin = [CTxIn(COutPoint(tx1.sha256, 0), nSequence=0)]
-        tx2.vout = [CTxOut(int(tx1.vout[0].nValue - self.relayfee * COIN), SCRIPT_W0_SH_OP_TRUE)]
+        tx2.vout = [CTxOut(int(tx1.vout[0].nValue - btcToSat(self.relayfee)), SCRIPT_W0_SH_OP_TRUE)]
         self.wallet.sign_tx(tx=tx2)
         tx2_raw = tx2.serialize().hex()
         tx2.rehash()
@@ -250,7 +250,7 @@ class BIP68Test(BitcoinTestFramework):
             tx.vin = [CTxIn(COutPoint(orig_tx.sha256, 0), nSequence=sequence_value)]
             tx.wit.vtxinwit = [CTxInWitness()]
             tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
-            tx.vout = [CTxOut(int(orig_tx.vout[0].nValue - relayfee * COIN), SCRIPT_W0_SH_OP_TRUE)]
+            tx.vout = [CTxOut(int(orig_tx.vout[0].nValue - btcToSat(relayfee)), SCRIPT_W0_SH_OP_TRUE)]
             tx.rehash()
 
             if (orig_tx.hash in node.getrawmempool()):
@@ -267,7 +267,7 @@ class BIP68Test(BitcoinTestFramework):
 
         # Now mine some blocks, but make sure tx2 doesn't get mined.
         # Use prioritisetransaction to lower the effective feerate to 0
-        self.nodes[0].prioritisetransaction(txid=tx2.hash, fee_delta=int(-self.relayfee*COIN))
+        self.nodes[0].prioritisetransaction(txid=tx2.hash, fee_delta=btcToSat(-self.relayfee))
         cur_time = int(time.time())
         for _ in range(10):
             self.nodes[0].setmocktime(cur_time + 600)
@@ -280,7 +280,7 @@ class BIP68Test(BitcoinTestFramework):
         test_nonzero_locks(tx2, self.nodes[0], self.relayfee, use_height_lock=False)
 
         # Mine tx2, and then try again
-        self.nodes[0].prioritisetransaction(txid=tx2.hash, fee_delta=int(self.relayfee*COIN))
+        self.nodes[0].prioritisetransaction(txid=tx2.hash, fee_delta=btcToSat(self.relayfee))
 
         # Advance the time on the node so that we can test timelocks
         self.nodes[0].setmocktime(cur_time+600)
@@ -307,7 +307,7 @@ class BIP68Test(BitcoinTestFramework):
 
         utxo = self.wallet.get_utxo()
         tx5.vin.append(CTxIn(COutPoint(int(utxo["txid"], 16), utxo["vout"]), nSequence=1))
-        tx5.vout[0].nValue += int(utxo["value"]*COIN)
+        tx5.vout[0].nValue += btcToSat(utxo["value"])
         self.wallet.sign_tx(tx=tx5)
 
         assert_raises_rpc_error(-26, NOT_FINAL_ERROR, self.wallet.sendrawtransaction, from_node=self.nodes[0], tx_hex=tx5.serialize().hex())
@@ -362,7 +362,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.version = 1
         tx2.vin = [CTxIn(COutPoint(tx1.sha256, 0), nSequence=0)]
-        tx2.vout = [CTxOut(int(tx1.vout[0].nValue - self.relayfee * COIN), SCRIPT_W0_SH_OP_TRUE)]
+        tx2.vout = [CTxOut(int(tx1.vout[0].nValue - btcToSat(self.relayfee)), SCRIPT_W0_SH_OP_TRUE)]
 
         # sign tx2
         self.wallet.sign_tx(tx=tx2)
@@ -380,7 +380,7 @@ class BIP68Test(BitcoinTestFramework):
         tx3.vin = [CTxIn(COutPoint(tx2.sha256, 0), nSequence=sequence_value)]
         tx3.wit.vtxinwit = [CTxInWitness()]
         tx3.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
-        tx3.vout = [CTxOut(int(tx2.vout[0].nValue - self.relayfee * COIN), SCRIPT_W0_SH_OP_TRUE)]
+        tx3.vout = [CTxOut(int(tx2.vout[0].nValue - btcToSat(self.relayfee)), SCRIPT_W0_SH_OP_TRUE)]
         tx3.rehash()
 
         assert_raises_rpc_error(-26, NOT_FINAL_ERROR, self.wallet.sendrawtransaction, from_node=self.nodes[0], tx_hex=tx3.serialize().hex())

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -15,7 +15,6 @@ from test_framework.blocktools import (
 )
 from test_framework.messages import (
     CBlock,
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
@@ -24,6 +23,7 @@ from test_framework.messages import (
     SEQUENCE_FINAL,
     uint256_from_compact,
     uint256_from_str,
+    btcToSat,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (
@@ -809,7 +809,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.log.info("Reject a block with a transaction with outputs > inputs")
         self.move_tip(57)
         self.next_block(59)
-        tx = self.create_and_sign_transaction(out[17], 51 * COIN)
+        tx = self.create_and_sign_transaction(out[17], btcToSat(51))
         b59 = self.update_block(59, [tx])
         self.send_blocks([b59], success=False, reject_reason='bad-txns-in-belowout', reconnect=True)
 
@@ -1159,18 +1159,18 @@ class FullBlockTest(BitcoinTestFramework):
         self.log.info("Test transaction resurrection during a re-org")
         self.move_tip(76)
         self.next_block(77)
-        tx77 = self.create_and_sign_transaction(out[24], 10 * COIN)
+        tx77 = self.create_and_sign_transaction(out[24], btcToSat(10))
         b77 = self.update_block(77, [tx77])
         self.send_blocks([b77], True)
         self.save_spendable_output()
 
         self.next_block(78)
-        tx78 = self.create_tx(tx77, 0, 9 * COIN)
+        tx78 = self.create_tx(tx77, 0, btcToSat(9))
         b78 = self.update_block(78, [tx78])
         self.send_blocks([b78], True)
 
         self.next_block(79)
-        tx79 = self.create_tx(tx78, 0, 8 * COIN)
+        tx79 = self.create_tx(tx78, 0, btcToSat(8))
         b79 = self.update_block(79, [tx79])
         self.send_blocks([b79], True)
 

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -17,8 +17,8 @@ from test_framework.blocktools import (
     create_coinbase,
 )
 from test_framework.messages import (
-    COIN,
     CTxOut,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -152,7 +152,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         tx1 = self.wallet.send_to(
             from_node=node,
             scriptPubKey=self.wallet.get_scriptPubKey(),
-            amount=21 * COIN,
+            amount=btcToSat(21),
         )
 
         # Find the right position of the 21 BTC output
@@ -161,7 +161,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         # Generate and send another tx with an OP_RETURN output (which is unspendable)
         tx2 = self.wallet.create_self_transfer(utxo_to_spend=tx1_out_21)['tx']
         tx2_val = '20.99'
-        tx2.vout = [CTxOut(int(Decimal(tx2_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
+        tx2.vout = [CTxOut(btcToSat(Decimal(tx2_val)), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx2_hex = tx2.serialize().hex()
         self.nodes[0].sendrawtransaction(tx2_hex, 0, tx2_val)
 
@@ -189,7 +189,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         # Create a coinbase that does not claim full subsidy and also
         # has two outputs
         cb = create_coinbase(109, nValue=35)
-        cb.vout.append(CTxOut(5 * COIN, CScript([OP_FALSE])))
+        cb.vout.append(CTxOut(btcToSat(5), CScript([OP_FALSE])))
         cb.rehash()
 
         # Generate a block that includes previous coinbase

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -32,7 +32,7 @@ import time
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.messages import (
-    COIN,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -189,7 +189,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         random.shuffle(utxo_list)
         while len(utxo_list) >= 2 and num_transactions < count:
             utxos_to_spend = [utxo_list.pop() for _ in range(2)]
-            input_amount = int(sum([utxo['value'] for utxo in utxos_to_spend]) * COIN)
+            input_amount = btcToSat(sum([utxo['value'] for utxo in utxos_to_spend]))
             if input_amount < FEE:
                 # Sanity check -- if we chose inputs that are too small, skip
                 continue

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -11,6 +11,8 @@ import time
 
 from test_framework.messages import (
     COIN,
+    satToBtc,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -57,9 +59,9 @@ def small_txpuzzle_randfee(
         utxos_to_spend=utxos_to_spend,
         fee_per_output=0,
     )["tx"]
-    tx.vout[0].nValue = int((total_in - amount - fee) * COIN)
+    tx.vout[0].nValue = btcToSat((total_in - amount - fee))
     tx.vout.append(deepcopy(tx.vout[0]))
-    tx.vout[1].nValue = int(amount * COIN)
+    tx.vout[1].nValue = btcToSat(amount)
     tx.rehash()
     txid = tx.hash
     tx_hex = tx.serialize().hex()
@@ -125,7 +127,7 @@ def make_tx(wallet, utxo, feerate):
     """Create a 1in-1out transaction with a specific input and feerate (sat/vb)."""
     return wallet.create_self_transfer(
         utxo_to_spend=utxo,
-        fee_rate=Decimal(feerate * 1000) / COIN,
+        fee_rate=satToBtc(feerate * 1000),
     )
 
 def check_fee_estimates_btw_modes(node, expected_conservative, expected_economical):
@@ -298,7 +300,7 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         # Only 10% of the transactions were really confirmed with a low feerate,
         # the rest needed to be RBF'd. We must return the 90% conf rate feerate.
-        high_feerate_kvb = Decimal(high_feerate) / COIN * 10 ** 3
+        high_feerate_kvb = satToBtc(high_feerate) * 10 ** 3
         est_feerate = node.estimatesmartfee(2)["feerate"]
         assert_equal(est_feerate, high_feerate_kvb)
 

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -19,12 +19,12 @@ from test_framework.blocktools import (
 )
 from test_framework.descriptors import descsum_create
 from test_framework.messages import (
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
     CTxOut,
     tx_from_hex,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -276,7 +276,7 @@ class SegWitTest(BitcoinTestFramework):
         # Now create tx2, which will spend from txid1.
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(int(txid1, 16), 0), b''))
-        tx.vout.append(CTxOut(int(49.99 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
+        tx.vout.append(CTxOut(btcToSat(49.99), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
         tx2_hex = self.nodes[0].signrawtransactionwithwallet(tx.serialize().hex())['hex']
         txid2 = self.nodes[0].sendrawtransaction(tx2_hex)
         tx = tx_from_hex(tx2_hex)
@@ -292,7 +292,7 @@ class SegWitTest(BitcoinTestFramework):
         # Now create tx3, which will spend from txid2
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(int(txid2, 16), 0), b""))
-        tx.vout.append(CTxOut(int(49.95 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))  # Huge fee
+        tx.vout.append(CTxOut(btcToSat(49.95), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))  # Huge fee
         tx.calc_sha256()
         txid3 = self.nodes[0].sendrawtransaction(hexstring=tx.serialize().hex(), maxfeerate=0)
         assert tx.wit.is_null()

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -14,7 +14,7 @@ import urllib.parse
 
 from test_framework.messages import (
     BLOCK_HEADER_SIZE,
-    COIN,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -96,7 +96,7 @@ class RESTTest (BitcoinTestFramework):
         self.wallet = MiniWallet(self.nodes[0])
 
         self.log.info("Broadcast test transaction and sync nodes")
-        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=int(0.1 * COIN))["txid"]
+        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=btcToSat(0.1))["txid"]
         self.sync_all()
 
         self.log.info("Test the /tx URI")
@@ -173,7 +173,7 @@ class RESTTest (BitcoinTestFramework):
         # found with or without /checkmempool.
 
         # do a tx and don't sync
-        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=int(0.1 * COIN))["txid"]
+        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=btcToSat(0.1))["txid"]
         json_obj = self.test_rest_request(f"/tx/{txid}")
         # get the spent output to later check for utxo (should be spent by then)
         spent = (json_obj['vin'][0]['txid'], json_obj['vin'][0]['vout'])

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -17,7 +17,7 @@ except ImportError:
     pass
 
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.messages import COIN, DEFAULT_MEMPOOL_EXPIRY_HOURS
+from test_framework.messages import DEFAULT_MEMPOOL_EXPIRY_HOURS, satToBtc
 from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -169,7 +169,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Sending transaction...")
         fee = Decimal(31200)
-        tx = self.wallet.send_self_transfer(from_node=node, fee=fee / COIN)
+        tx = self.wallet.send_self_transfer(from_node=node, fee=satToBtc(fee))
 
         self.log.info("Polling buffer...")
         bpf.perf_buffer_poll(timeout=200)
@@ -206,7 +206,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Sending transaction...")
         fee = Decimal(31200)
-        tx = self.wallet.send_self_transfer(from_node=node, fee=fee / COIN)
+        tx = self.wallet.send_self_transfer(from_node=node, fee=satToBtc(fee))
         txid = tx["txid"]
 
         self.log.info("Fast-forwarding time to mempool expiry...")
@@ -255,14 +255,14 @@ class MempoolTracepointTest(BitcoinTestFramework):
         utxo = self.wallet.get_utxo(mark_as_spent=True)
         original_fee = Decimal(40000)
         original_tx = self.wallet.send_self_transfer(
-            from_node=node, utxo_to_spend=utxo, fee=original_fee / COIN
+            from_node=node, utxo_to_spend=utxo, fee=satToBtc(original_fee)
         )
         entry_time = node.getmempoolentry(original_tx["txid"])["time"]
 
         self.log.info("Sending replacement transaction...")
         replacement_fee = Decimal(45000)
         replacement_tx = self.wallet.send_self_transfer(
-            from_node=node, utxo_to_spend=utxo, fee=replacement_fee / COIN
+            from_node=node, utxo_to_spend=utxo, fee=satToBtc(replacement_fee)
         )
 
         self.log.info("Polling buffer...")

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -13,7 +13,7 @@ try:
     from bcc import BPF, USDT # type: ignore[import]
 except ImportError:
     pass
-from test_framework.messages import COIN
+from test_framework.messages import btcToSat
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.wallet import MiniWallet
@@ -192,7 +192,7 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
                 assert_equal(block_1_coinbase_txid, bytes(event.txid[::-1]).hex())
                 assert_equal(0, event.index)  # prevout index
                 assert_equal(EARLY_BLOCK_HEIGHT, event.height)
-                assert_equal(50 * COIN, event.value)
+                assert_equal(btcToSat(50), event.value)
                 assert_equal(True, event.is_coinbase)
             except AssertionError:
                 self.log.exception("Assertion failed")
@@ -298,7 +298,7 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
                         "txid": vin["txid"],
                         "index": vin["vout"],
                         "height": prevout_tx_block["height"],
-                        "value": int(prevout_tx["vout"][vin["vout"]]["value"] * COIN),
+                        "value": btcToSat(prevout_tx["vout"][vin["vout"]]["value"]),
                         "is_coinbase": spends_coinbase,
                     })
             for (i, vout) in enumerate(tx["vout"]):
@@ -307,7 +307,7 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
                         "txid": tx["txid"],
                         "index": i,
                         "height": block["height"],
-                        "value": int(vout["value"] * COIN),
+                        "value": btcToSat(vout["value"]),
                         "is_coinbase": block_index == 0,
                     })
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -22,6 +22,7 @@ from test_framework.messages import (
     MAX_MONEY,
     SEQUENCE_FINAL,
     tx_from_hex,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -88,8 +89,8 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.log.info('A transaction already in the blockchain')
         tx = self.wallet.create_self_transfer()['tx']  # Pick a random coin(base) to spend
         tx.vout.append(deepcopy(tx.vout[0]))
-        tx.vout[0].nValue = int(0.3 * COIN)
-        tx.vout[1].nValue = int(49 * COIN)
+        tx.vout[0].nValue = btcToSat(0.3)
+        tx.vout[1].nValue = btcToSat(49)
         raw_tx_in_block = tx.serialize().hex()
         txid_in_block = self.wallet.sendrawtransaction(from_node=node, tx_hex=raw_tx_in_block)
         self.generate(node, 1)
@@ -117,7 +118,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         fee = Decimal('0.000007')
         utxo_to_spend = self.wallet.get_utxo(txid=txid_in_block)  # use 0.3 BTC UTXO
         tx = self.wallet.create_self_transfer(utxo_to_spend=utxo_to_spend, sequence=MAX_BIP125_RBF_SEQUENCE)['tx']
-        tx.vout[0].nValue = int((Decimal('0.3') - fee) * COIN)
+        tx.vout[0].nValue = btcToSat((Decimal('0.3') - fee))
         raw_tx_0 = tx.serialize().hex()
         txid_0 = tx.rehash()
         self.check_mempool_result(
@@ -131,7 +132,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             sequence=SEQUENCE_FINAL,
             locktime=node.getblockcount() + 2000,  # Can be anything
         )['tx']
-        tx.vout[0].nValue = int(output_amount * COIN)
+        tx.vout[0].nValue = btcToSat(output_amount)
         raw_tx_final = tx.serialize().hex()
         tx = tx_from_hex(raw_tx_final)
         fee_expected = Decimal('50.0') - output_amount
@@ -153,7 +154,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         self.log.info('A transaction that replaces a mempool transaction')
         tx = tx_from_hex(raw_tx_0)
-        tx.vout[0].nValue -= int(fee * COIN)  # Double the fee
+        tx.vout[0].nValue -= btcToSat(fee)  # Double the fee
         raw_tx_0 = tx.serialize().hex()
         txid_0 = tx.rehash()
         self.check_mempool_result(
@@ -181,7 +182,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx.wit.vtxinwit.append(deepcopy(tx.wit.vtxinwit[0]))
         tx.vin[0].prevout = COutPoint(hash=int(txid_0, 16), n=0)
         tx.vin[1].prevout = COutPoint(hash=int(txid_1, 16), n=0)
-        tx.vout[0].nValue = int(0.1 * COIN)
+        tx.vout[0].nValue = btcToSat(0.1)
         raw_tx_spend_both = tx.serialize().hex()
         txid_spend_both = self.wallet.sendrawtransaction(from_node=node, tx_hex=raw_tx_spend_both)
         self.generate(node, 1)
@@ -199,7 +200,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.log.info('Create a "reference" tx for later use')
         utxo_to_spend = self.wallet.get_utxo(txid=txid_spend_both)
         tx = self.wallet.create_self_transfer(utxo_to_spend=utxo_to_spend, sequence=SEQUENCE_FINAL)['tx']
-        tx.vout[0].nValue = int(0.05 * COIN)
+        tx.vout[0].nValue = btcToSat(0.05)
         raw_tx_reference = tx.serialize().hex()
         # Reference tx should be valid on itself
         self.check_mempool_result(
@@ -386,7 +387,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         # First spend has non-empty witness, will be rejected to prevent third party wtxid malleability
         anchor_nonempty_wit_spend = CTransaction()
         anchor_nonempty_wit_spend.vin.append(CTxIn(COutPoint(int(create_anchor_tx["txid"], 16), create_anchor_tx["sent_vout"]), b""))
-        anchor_nonempty_wit_spend.vout.append(CTxOut(anchor_value - int(fee*COIN), script_to_p2wsh_script(CScript([OP_TRUE]))))
+        anchor_nonempty_wit_spend.vout.append(CTxOut(anchor_value - btcToSat(fee), script_to_p2wsh_script(CScript([OP_TRUE]))))
         anchor_nonempty_wit_spend.wit.vtxinwit.append(CTxInWitness())
         anchor_nonempty_wit_spend.wit.vtxinwit[0].scriptWitness.stack.append(b"f")
         anchor_nonempty_wit_spend.rehash()
@@ -406,7 +407,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         anchor_spend = CTransaction()
         anchor_spend.vin.append(CTxIn(COutPoint(int(create_anchor_tx["txid"], 16), create_anchor_tx["sent_vout"]), b""))
-        anchor_spend.vout.append(CTxOut(anchor_value - int(fee*COIN), script_to_p2wsh_script(CScript([OP_TRUE]))))
+        anchor_spend.vout.append(CTxOut(anchor_value - btcToSat(fee), script_to_p2wsh_script(CScript([OP_TRUE]))))
         anchor_spend.wit.vtxinwit.append(CTxInWitness())
         # It's "segwit" but txid == wtxid since there is no witness data
         assert_equal(anchor_spend.rehash(), anchor_spend.getwtxid())
@@ -426,7 +427,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         nested_anchor_spend = CTransaction()
         nested_anchor_spend.vin.append(CTxIn(COutPoint(nested_anchor_tx.sha256, 0), b""))
         nested_anchor_spend.vin[0].scriptSig = CScript([bytes(PAY_TO_ANCHOR)])
-        nested_anchor_spend.vout.append(CTxOut(nested_anchor_tx.vout[0].nValue - int(fee*COIN), script_to_p2wsh_script(CScript([OP_TRUE]))))
+        nested_anchor_spend.vout.append(CTxOut(nested_anchor_tx.vout[0].nValue - btcToSat(fee), script_to_p2wsh_script(CScript([OP_TRUE]))))
         nested_anchor_spend.rehash()
 
         self.check_mempool_result(
@@ -446,7 +447,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.generateblock(node, address, [tx.serialize().hex()])
         tx_spend = CTransaction()
         tx_spend.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx_spend.vout.append(CTxOut(tx.vout[0].nValue - int(fee*COIN), script_to_p2wsh_script(CScript([OP_TRUE]))))
+        tx_spend.vout.append(CTxOut(tx.vout[0].nValue - btcToSat(fee), script_to_p2wsh_script(CScript([OP_TRUE]))))
         tx_spend.rehash()
         sign_input_legacy(tx_spend, 0, tx.vout[0].scriptPubKey, privkey, sighash_type=SIGHASH_ALL)
         tx_spend.vin[0].scriptSig = bytes(CScript([OP_0])) + tx_spend.vin[0].scriptSig

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -9,13 +9,13 @@ with identical non-witness data but different witness.
 
 from copy import deepcopy
 from test_framework.messages import (
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
     CTxInWitness,
     CTxOut,
     sha256,
+    btcToSat,
 )
 from test_framework.p2p import P2PTxInvStore
 from test_framework.script import (
@@ -56,7 +56,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
 
         parent = CTransaction()
         parent.vin.append(CTxIn(COutPoint(int(txid, 16), 0), b""))
-        parent.vout.append(CTxOut(int(9.99998 * COIN), script_pubkey))
+        parent.vout.append(CTxOut(btcToSat(9.99998), script_pubkey))
         parent.rehash()
 
         privkeys = [node.get_deterministic_priv_key().key]
@@ -73,7 +73,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
 
         child_one = CTransaction()
         child_one.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b""))
-        child_one.vout.append(CTxOut(int(9.99996 * COIN), child_script_pubkey))
+        child_one.vout.append(CTxOut(btcToSat(9.99996), child_script_pubkey))
         child_one.wit.vtxinwit.append(CTxInWitness())
         child_one.wit.vtxinwit[0].scriptWitness.stack = [b'Preimage', b'\x01', witness_script]
         child_one_wtxid = child_one.getwtxid()

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from test_framework.messages import (
     COIN,
     CTxOut,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -50,7 +51,7 @@ class DustRelayFeeTest(BitcoinTestFramework):
         else:
             tx_size = len(CTxOut(nValue=0, scriptPubKey=output_script).serialize())
             tx_size += 67 if output_script.IsWitnessProgram() else 148
-            dust_threshold = int(get_fee(tx_size, dust_relay_fee) * COIN)
+            dust_threshold = btcToSat(get_fee(tx_size, dust_relay_fee))
         self.log.info(f"-> Test {type_desc} output (size {len(output_script)}, limit {dust_threshold})")
 
         # amount right on the dust threshold should pass

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 from test_framework.messages import (
     COIN,
     CTxOut,
+    satToBtc,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mempool_util import assert_mempool_contents
@@ -36,7 +38,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         result["tx"].vout.append(CTxOut(output_value, result["tx"].vout[0].scriptPubKey))
         # Take value from first output
         result["tx"].vout[0].nValue -= output_value
-        result["new_utxos"][0]["value"] = Decimal(result["tx"].vout[0].nValue) / COIN
+        result["new_utxos"][0]["value"] = satToBtc(result["tx"].vout[0].nValue)
         new_txid = result["tx"].rehash()
         result["txid"]  = new_txid
         result["wtxid"] = result["tx"].getwtxid()
@@ -45,7 +47,7 @@ class EphemeralDustTest(BitcoinTestFramework):
             new_utxo["txid"] = new_txid
             new_utxo["wtxid"] = result["tx"].getwtxid()
 
-        result["new_utxos"].append({"txid": new_txid, "vout": len(result["tx"].vout) - 1, "value": Decimal(output_value) / COIN, "height": 0, "coinbase": False, "confirmations": 0})
+        result["new_utxos"].append({"txid": new_txid, "vout": len(result["tx"].vout) - 1, "value": satToBtc(output_value), "height": 0, "coinbase": False, "confirmations": 0})
 
     def run_test(self):
 
@@ -134,7 +136,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         sats_fee = 1
         dusty_tx = self.wallet.create_self_transfer_multi(fee_per_output=sats_fee, version=3)
         self.add_output_to_create_multi_result(dusty_tx)
-        assert_equal(int(COIN * dusty_tx["fee"]), sats_fee) # has fees
+        assert_equal(btcToSat(dusty_tx["fee"]), sats_fee) # has fees
         assert_greater_than(dusty_tx["tx"].vout[0].nValue, 330) # main output is not dust
         assert_equal(dusty_tx["tx"].vout[1].nValue, 0) # added one is dust
 

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -18,9 +18,9 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
-    COIN,
     DEFAULT_FEE,
     MiniWallet,
+    btcToSat,
 )
 
 
@@ -251,7 +251,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # - When there is mid-package eviction, high enough feerate to meet the new mempoolminfee
         # - When there is no mid-package eviction, low enough feerate to be evicted immediately after submission.
         magic_satoshis = 1200
-        cpfp_satoshis = int(cpfp_fee * COIN) + magic_satoshis
+        cpfp_satoshis = btcToSat(cpfp_fee) + magic_satoshis
 
         child = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=cpfp_satoshis)
         package_hex.append(child["hex"])
@@ -320,7 +320,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # Create a child spending everything, CPFPing the low-feerate parent.
         approx_child_vsize = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos)["tx"].get_vsize()
         cpfp_fee = (2 * mempoolmin_feerate / 1000) * (cpfp_parent["tx"].get_vsize() + approx_child_vsize) - cpfp_parent["fee"]
-        child = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=int(cpfp_fee * COIN))
+        child = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=btcToSat(cpfp_fee))
         # It's very important that the cpfp_parent is before replacement_tx so that its input (from
         # replaced_tx) is first looked up *before* replacement_tx is submitted.
         package_hex = [cpfp_parent["hex"], replacement_tx["hex"], child["hex"]]
@@ -369,7 +369,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # another is below the mempool minimum feerate but bumped by the child.
         tx_poor = miniwallet.create_self_transfer(fee_rate=relayfee)
         tx_rich = miniwallet.create_self_transfer(fee=0, fee_rate=0)
-        node.prioritisetransaction(tx_rich["txid"], 0, int(DEFAULT_FEE * COIN))
+        node.prioritisetransaction(tx_rich["txid"], 0, btcToSat(DEFAULT_FEE))
         package_txns = [tx_rich, tx_poor]
         coins = [tx["new_utxo"] for tx in package_txns]
         tx_child = miniwallet.create_self_transfer_multi(utxos_to_spend=coins, fee_per_output=10000) #DEFAULT_FEE

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -6,8 +6,9 @@
 from decimal import Decimal
 
 from test_framework.messages import (
-    COIN,
     MAX_BIP125_RBF_SEQUENCE,
+    satToBtc,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mempool_util import fill_mempool
@@ -62,7 +63,7 @@ class PackageRBFTest(BitcoinTestFramework):
         child_result = self.wallet.create_self_transfer_multi(
             utxos_to_spend=[parent_result["new_utxo"]],
             num_outputs=num_child_outputs,
-            fee_per_output=int(child_fee * COIN // num_child_outputs),
+            fee_per_output=btcToSat(child_fee) // num_child_outputs,
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
         package_hex = [parent_result["hex"], child_result["hex"]]
@@ -163,7 +164,7 @@ class PackageRBFTest(BitcoinTestFramework):
         self.log.info("Check replacement pays for incremental bandwidth")
         _, placeholder_txns3 = self.create_simple_package(coin)
         package_3_size = sum([tx.get_vsize() for tx in placeholder_txns3])
-        incremental_sats_required = Decimal(package_3_size) / COIN
+        incremental_sats_required = satToBtc(package_3_size)
         incremental_sats_short = incremental_sats_required - Decimal("0.00000001")
         # Recreate the package with slightly higher fee once we know the size of the new package, but still short of required fee
         failure_package_hex3, failure_package_txns3 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_CHILD_FEE + incremental_sats_short)
@@ -278,7 +279,7 @@ class PackageRBFTest(BitcoinTestFramework):
         # to in-mempool ancestry
         self.ctr += 1
         child_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_CHILD_FEE),
             utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
@@ -311,14 +312,14 @@ class PackageRBFTest(BitcoinTestFramework):
 
         self.ctr += 1
         child_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[parent_result["new_utxo"], coin2],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
 
         self.ctr += 1
         grandchild_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[child_result["new_utxos"][0], coin3],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
@@ -364,14 +365,14 @@ class PackageRBFTest(BitcoinTestFramework):
 
         self.ctr += 1
         parent2_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[coin2],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
 
         self.ctr += 1
         child_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[parent1_result["new_utxo"], parent2_result["new_utxos"][0], coin3],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
@@ -409,7 +410,7 @@ class PackageRBFTest(BitcoinTestFramework):
 
         self.ctr += 1
         parent_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             num_outputs=2,
             utxos_to_spend=[coin1],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
@@ -417,14 +418,14 @@ class PackageRBFTest(BitcoinTestFramework):
 
         self.ctr += 1
         child1_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[parent_result["new_utxos"][0], coin2],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
 
         self.ctr += 1
         child2_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE),
             utxos_to_spend=[parent_result["new_utxos"][1], coin3],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
@@ -488,7 +489,7 @@ class PackageRBFTest(BitcoinTestFramework):
         # to pkg size
         self.ctr += 1
         child_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_CHILD_FEE),
             utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )
@@ -576,7 +577,7 @@ class PackageRBFTest(BitcoinTestFramework):
         # which is not inside the current package
         self.ctr += 1
         child_result = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
+            fee_per_output=btcToSat(DEFAULT_CHILD_FEE),
             utxos_to_spend=[parent_result["new_utxo"], coin],
             sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
         )

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -46,7 +46,8 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet import MiniWallet, COIN
+from test_framework.wallet import MiniWallet
+from test_framework.messages import COIN, btcToSat
 
 
 class MempoolPersistTest(BitcoinTestFramework):
@@ -230,8 +231,8 @@ class MempoolPersistTest(BitcoinTestFramework):
         tx_node01 = self.mini_wallet.create_self_transfer()
         tx_node01_secret = self.mini_wallet.create_self_transfer()
         self.nodes[0].prioritisetransaction(tx_node01["txid"], 0, COIN)
-        self.nodes[0].prioritisetransaction(tx_node01_secret["txid"], 0, 2 * COIN)
-        self.nodes[1].prioritisetransaction(tx_node01_secret["txid"], 0, 3 * COIN)
+        self.nodes[0].prioritisetransaction(tx_node01_secret["txid"], 0, btcToSat(2))
+        self.nodes[1].prioritisetransaction(tx_node01_secret["txid"], 0, btcToSat(3))
         self.nodes[0].sendrawtransaction(tx_node01["hex"])
         self.nodes[1].sendrawtransaction(tx_node01["hex"])
         assert tx_node0["txid"] in self.nodes[0].getrawmempool()

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -12,9 +12,9 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
-    COIN,
     DEFAULT_FEE,
     MiniWallet,
+    btcToSat,
 )
 
 MAX_REPLACEMENT_CANDIDATES = 100
@@ -548,7 +548,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_unrelated_replacee = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=utxo_unrelated_conflict)
         assert tx_unrelated_replacee["txid"] in node.getrawmempool()
 
-        fee_to_beat = max(int(tx_v3_child_2["fee"] * COIN), int(tx_unrelated_replacee["fee"]*COIN))
+        fee_to_beat = max(btcToSat(tx_v3_child_2["fee"]), btcToSat(tx_unrelated_replacee["fee"]))
 
         tx_v3_child_3 = self.wallet.create_self_transfer_multi(
             utxos_to_spend=[tx_v3_parent["new_utxos"][0], utxo_unrelated_conflict], fee_per_output=fee_to_beat*2, version=3

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -10,6 +10,8 @@ import time
 from test_framework.messages import (
     COIN,
     MAX_BLOCK_WEIGHT,
+    satToBtc,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -45,7 +47,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes[0].prioritisetransaction(tx_replacee["txid"], 0, 100)
         assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : 100, "in_mempool" : False}})
         self.nodes[0].sendrawtransaction(tx_replacee["hex"])
-        assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : 100, "in_mempool" : True, "modified_fee": int(tx_replacee["fee"] * COIN + 100)}})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : 100, "in_mempool" : True, "modified_fee": btcToSat(tx_replacee["fee"]) + 100}})
         self.nodes[0].sendrawtransaction(tx_replacement["hex"])
         assert tx_replacee["txid"] not in self.nodes[0].getrawmempool()
         assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : 100, "in_mempool" : False}})
@@ -53,7 +55,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # PrioritiseTransaction is additive
         self.nodes[0].prioritisetransaction(tx_replacee["txid"], 0, COIN)
         self.nodes[0].sendrawtransaction(tx_replacee["hex"])
-        assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : COIN + 100, "in_mempool" : True, "modified_fee": int(tx_replacee["fee"] * COIN + COIN + 100)}})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), { tx_replacee["txid"] : { "fee_delta" : COIN + 100, "in_mempool" : True, "modified_fee": btcToSat(tx_replacee["fee"]) + COIN + 100}})
         self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].getprioritisedtransactions(), {})
 
@@ -94,12 +96,12 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
 
         self.log.info("Test priority while txs are in mempool")
         raw_before = self.nodes[0].getrawmempool(verbose=True)
-        fee_delta_b = Decimal(9999) / COIN
-        fee_delta_c_1 = Decimal(-1234) / COIN
-        fee_delta_c_2 = Decimal(8888) / COIN
-        self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=int(fee_delta_b * COIN))
-        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_1 * COIN))
-        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_2 * COIN))
+        fee_delta_b = satToBtc(Decimal(9999))
+        fee_delta_c_1 = satToBtc(Decimal(-1234))
+        fee_delta_c_2 = satToBtc(Decimal(8888))
+        self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=btcToSat(fee_delta_b))
+        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=btcToSat(fee_delta_c_1))
+        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=btcToSat(fee_delta_c_2))
         raw_before[txid_a]["fees"]["descendant"] += fee_delta_b + fee_delta_c_1 + fee_delta_c_2
         raw_before[txid_b]["fees"]["modified"] += fee_delta_b
         raw_before[txid_b]["fees"]["ancestor"] += fee_delta_b
@@ -111,7 +113,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         raw_after = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(raw_before[txid_a], raw_after[txid_a])
         assert_equal(raw_before, raw_after)
-        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True, "modified_fee": int(fee_delta_b*COIN + COIN * tx_o_b["fee"])}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True, "modified_fee": int((fee_delta_c_1 + fee_delta_c_2 ) * COIN + COIN * tx_o_c["fee"])}})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : btcToSat(fee_delta_b), "in_mempool" : True, "modified_fee": btcToSat(fee_delta_b) + btcToSat(tx_o_b["fee"])}, txid_c: {"fee_delta" : btcToSat((fee_delta_c_1 + fee_delta_c_2)), "in_mempool" : True, "modified_fee": btcToSat((fee_delta_c_1 + fee_delta_c_2 )) + btcToSat(tx_o_c["fee"])}})
         # Clear prioritisation, otherwise the transactions' fee deltas are persisted to mempool.dat and loaded again when the node
         # is restarted at the end of this subtest. Deltas are removed when a transaction is mined, but only at that time. We do
         # not check whether mapDeltas transactions were mined when loading from mempool.dat.
@@ -121,16 +123,16 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.restart_node(0, extra_args=["-nopersistmempool"])
         self.nodes[0].setmocktime(mock_time)
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
-        self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=int(fee_delta_b * COIN))
-        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_1 * COIN))
-        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_2 * COIN))
-        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : False}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : False}})
+        self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=btcToSat(fee_delta_b))
+        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=btcToSat(fee_delta_c_1))
+        self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=btcToSat(fee_delta_c_2))
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : btcToSat(fee_delta_b), "in_mempool" : False}, txid_c: {"fee_delta" : btcToSat(fee_delta_c_1 + fee_delta_c_2), "in_mempool" : False}})
         for t in [tx_o_a["hex"], tx_o_b["hex"], tx_o_c["hex"], tx_o_d["hex"]]:
             self.nodes[0].sendrawtransaction(t)
         raw_after = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(raw_before[txid_a], raw_after[txid_a])
         assert_equal(raw_before, raw_after)
-        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True, "modified_fee": int(fee_delta_b*COIN + COIN * tx_o_b["fee"])}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True, "modified_fee": int((fee_delta_c_1 + fee_delta_c_2 ) * COIN + COIN * tx_o_c["fee"])}})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : btcToSat(fee_delta_b), "in_mempool" : True, "modified_fee": btcToSat(fee_delta_b) + btcToSat(tx_o_b["fee"])}, txid_c: {"fee_delta" : btcToSat(fee_delta_c_1 + fee_delta_c_2), "in_mempool" : True, "modified_fee": btcToSat(fee_delta_c_1 + fee_delta_c_2 ) + btcToSat(tx_o_c["fee"])}})
 
         # Clear mempool
         self.generate(self.nodes[0], 1)
@@ -210,14 +212,14 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getprioritisedtransactions(), {})
         # add a fee delta to something in the cheapest bucket and make sure it gets mined
         # also check that a different entry in the cheapest bucket is NOT mined
-        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=int(3*base_fee*COIN))
-        assert_equal(self.nodes[0].getprioritisedtransactions(), {txids[0][0] : { "fee_delta" : 3*base_fee*COIN, "in_mempool" : True, "modified_fee": int(3*base_fee*COIN + COIN * 1 * base_fee)}})
+        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=btcToSat(3*base_fee))
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txids[0][0] : { "fee_delta" : btcToSat(3*base_fee), "in_mempool" : True, "modified_fee": btcToSat(3*base_fee) + btcToSat(1 * base_fee)}})
 
         # Priority disappears when prioritisetransaction is called with an inverse value...
-        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=int(-3*base_fee*COIN))
+        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=btcToSat(-3*base_fee))
         assert txids[0][0] not in self.nodes[0].getprioritisedtransactions()
         # ... and reappears when prioritisetransaction is called again.
-        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=int(3*base_fee*COIN))
+        self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=btcToSat(3*base_fee))
         assert txids[0][0] in self.nodes[0].getprioritisedtransactions()
 
         self.generate(self.nodes[0], 1)
@@ -237,8 +239,8 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
 
         # Add a prioritisation before a tx is in the mempool (de-prioritising a
         # high-fee transaction so that it's now low fee).
-        self.nodes[0].prioritisetransaction(txid=high_fee_tx, fee_delta=-int(2*base_fee*COIN))
-        assert_equal(self.nodes[0].getprioritisedtransactions()[high_fee_tx], { "fee_delta" : -2*base_fee*COIN, "in_mempool" : False})
+        self.nodes[0].prioritisetransaction(txid=high_fee_tx, fee_delta=-btcToSat(2*base_fee))
+        assert_equal(self.nodes[0].getprioritisedtransactions()[high_fee_tx], { "fee_delta" : btcToSat(-2*base_fee), "in_mempool" : False})
 
         # Add everything back to mempool
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
@@ -258,7 +260,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         mempool = self.nodes[0].getrawmempool()
         self.log.info("Assert that de-prioritised transaction is still in mempool")
         assert high_fee_tx in mempool
-        assert_equal(self.nodes[0].getprioritisedtransactions()[high_fee_tx], { "fee_delta" : -2*base_fee*COIN, "in_mempool" : True, "modified_fee": int(-2*base_fee*COIN + COIN * 3 * base_fee)})
+        assert_equal(self.nodes[0].getprioritisedtransactions()[high_fee_tx], { "fee_delta" : btcToSat(-2*base_fee), "in_mempool" : True, "modified_fee": btcToSat(-2*base_fee) + btcToSat(3 * base_fee)})
         for x in txids[2]:
             if (x != high_fee_tx):
                 assert x not in mempool
@@ -281,20 +283,20 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # This is a less than 1000-byte transaction, so just set the fee
         # to be the minimum for a 1000-byte transaction and check that it is
         # accepted.
-        self.nodes[0].prioritisetransaction(txid=tx_id, fee_delta=int(self.relayfee*COIN))
-        assert_equal(self.nodes[0].getprioritisedtransactions()[tx_id], { "fee_delta" : self.relayfee*COIN, "in_mempool" : False})
+        self.nodes[0].prioritisetransaction(txid=tx_id, fee_delta=btcToSat(self.relayfee))
+        assert_equal(self.nodes[0].getprioritisedtransactions()[tx_id], { "fee_delta" : btcToSat(self.relayfee), "in_mempool" : False})
 
         self.log.info("Assert that prioritised free transaction is accepted to mempool")
         assert_equal(self.nodes[0].sendrawtransaction(tx_hex), tx_id)
         assert tx_id in self.nodes[0].getrawmempool()
-        assert_equal(self.nodes[0].getprioritisedtransactions()[tx_id], { "fee_delta" : self.relayfee*COIN, "in_mempool" : True, "modified_fee": int(self.relayfee*COIN + COIN * tx_res["fee"])})
+        assert_equal(self.nodes[0].getprioritisedtransactions()[tx_id], { "fee_delta" : btcToSat(self.relayfee), "in_mempool" : True, "modified_fee": btcToSat(self.relayfee)+ btcToSat(tx_res["fee"])})
 
         # Test that calling prioritisetransaction is sufficient to trigger
         # getblocktemplate to (eventually) return a new block.
         mock_time = int(time.time())
         self.nodes[0].setmocktime(mock_time)
         template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
-        self.nodes[0].prioritisetransaction(txid=tx_id, fee_delta=-int(self.relayfee*COIN))
+        self.nodes[0].prioritisetransaction(txid=tx_id, fee_delta=-btcToSat(self.relayfee))
 
         # Calling prioritisetransaction with the inverse amount should delete its prioritisation entry
         assert tx_id not in self.nodes[0].getprioritisedtransactions()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -8,7 +8,6 @@ Test BIP 37
 
 from test_framework.messages import (
     CInv,
-    COIN,
     MAX_BLOOM_FILTER_SIZE,
     MAX_BLOOM_HASH_FUNCS,
     MSG_WTX,
@@ -20,6 +19,7 @@ from test_framework.messages import (
     msg_getdata,
     msg_mempool,
     msg_version,
+    btcToSat,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -138,8 +138,8 @@ class FilterTest(BitcoinTestFramework):
         filter_peer = P2PBloomFilter()
 
         self.log.info("Create two tx before connecting, one relevant to the node another that is not")
-        rel_txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=1 * COIN)["txid"]
-        irr_result = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=2 * COIN)
+        rel_txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=btcToSat(1))["txid"]
+        irr_result = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=btcToSat(2))
         irr_txid = irr_result["txid"]
         irr_wtxid = irr_result["wtxid"]
 
@@ -157,7 +157,7 @@ class FilterTest(BitcoinTestFramework):
     def test_frelay_false(self, filter_peer):
         self.log.info("Check that a node with fRelay set to false does not receive invs until the filter is set")
         filter_peer.tx_received = False
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
+        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=btcToSat(9))
         # Sync to make sure the reason filter_peer doesn't receive the tx is not p2p delays
         filter_peer.sync_with_ping()
         assert not filter_peer.tx_received
@@ -186,21 +186,21 @@ class FilterTest(BitcoinTestFramework):
         self.log.info('Check that we not receive a tx if the filter does not match a mempool tx')
         filter_peer.merkleblock_received = False
         filter_peer.tx_received = False
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=7 * COIN)
+        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=btcToSat(7))
         filter_peer.sync_with_ping()
         assert not filter_peer.merkleblock_received
         assert not filter_peer.tx_received
 
         self.log.info('Check that we receive a tx if the filter matches a mempool tx')
         filter_peer.merkleblock_received = False
-        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)["txid"]
+        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=btcToSat(9))["txid"]
         filter_peer.wait_for_tx(txid)
         assert not filter_peer.merkleblock_received
 
         self.log.info('Check that after deleting filter all txs get relayed again')
         filter_peer.send_and_ping(msg_filterclear())
         for _ in range(5):
-            txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=7 * COIN)["txid"]
+            txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=btcToSat(7))["txid"]
             filter_peer.wait_for_tx(txid)
 
         self.log.info('Check that request for filtered blocks is ignored if no filter is set')

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -8,17 +8,16 @@
 - Ignore all transaction messages
 """
 
-from decimal import Decimal
 import time
 
 from test_framework.messages import (
         CInv,
-        COIN,
         CTransaction,
         from_hex,
         msg_inv,
         msg_tx,
         MSG_WTX,
+        satToBtc,
 )
 from test_framework.p2p import (
         NONPREF_PEER_TX_DELAY,
@@ -28,8 +27,8 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 
-MAX_FEE_FILTER = Decimal(9170997) / COIN
-NORMAL_FEE_FILTER = Decimal(100) / COIN
+MAX_FEE_FILTER = satToBtc(9170997)
+NORMAL_FEE_FILTER = satToBtc(100)
 
 
 class P2PIBDTxRelayTest(BitcoinTestFramework):

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -21,7 +21,7 @@ from test_framework.blocktools import (
     create_coinbase,
     create_tx_with_script,
 )
-from test_framework.messages import COIN
+from test_framework.messages import btcToSat
 from test_framework.p2p import P2PDataStore
 from test_framework.script import OP_TRUE
 from test_framework.test_framework import BitcoinTestFramework
@@ -69,8 +69,8 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         # For more information on merkle-root malleability see src/consensus/merkle.cpp.
         self.log.info("Test merkle root malleability.")
 
-        tx1 = create_tx_with_script(block1.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
-        tx2 = create_tx_with_script(tx1, 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
+        tx1 = create_tx_with_script(block1.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=btcToSat(50))
+        tx2 = create_tx_with_script(tx1, 0, script_sig=bytes([OP_TRUE]), amount=btcToSat(50))
         block2 = create_block(tip, create_coinbase(height), block_time, txlist=[tx1, tx2])
         block_time += 1
         block2.solve()
@@ -117,7 +117,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         # Complete testing of CVE-2018-17144, by checking for the inflation bug.
         # Create a block that spends the output of a tx in a previous block.
-        tx3 = create_tx_with_script(tx2, 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
+        tx3 = create_tx_with_script(tx2, 0, script_sig=bytes([OP_TRUE]), amount=btcToSat(50))
         tx3.vin.append(tx3.vin[0])  # Duplicates input
         tx3.rehash()
         block4 = create_block(tip, create_coinbase(height), block_time, txlist=[tx3])

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -7,11 +7,11 @@
 In this test we connect to one node over p2p, and test tx requests."""
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import (
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
     CTxOut,
+    btcToSat,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
@@ -92,30 +92,30 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         SCRIPT_PUB_KEY_OP_TRUE = b'\x51\x75' * 15 + b'\x51'
         tx_withhold = CTransaction()
         tx_withhold.vin.append(CTxIn(outpoint=COutPoint(block1.vtx[0].sha256, 0)))
-        tx_withhold.vout = [CTxOut(nValue=25 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
+        tx_withhold.vout = [CTxOut(nValue=btcToSat(25) - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
         tx_withhold.calc_sha256()
 
         # Our first orphan tx with some outputs to create further orphan txs
         tx_orphan_1 = CTransaction()
         tx_orphan_1.vin.append(CTxIn(outpoint=COutPoint(tx_withhold.sha256, 0)))
-        tx_orphan_1.vout = [CTxOut(nValue=8 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 3
+        tx_orphan_1.vout = [CTxOut(nValue=btcToSat(8), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 3
         tx_orphan_1.calc_sha256()
 
         # A valid transaction with low fee
         tx_orphan_2_no_fee = CTransaction()
         tx_orphan_2_no_fee.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 0)))
-        tx_orphan_2_no_fee.vout.append(CTxOut(nValue=8 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_no_fee.vout.append(CTxOut(nValue=btcToSat(8), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
 
         # A valid transaction with sufficient fee
         tx_orphan_2_valid = CTransaction()
         tx_orphan_2_valid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 1)))
-        tx_orphan_2_valid.vout.append(CTxOut(nValue=8 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_valid.vout.append(CTxOut(nValue=btcToSat(8) - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_2_valid.calc_sha256()
 
         # An invalid transaction with negative fee
         tx_orphan_2_invalid = CTransaction()
         tx_orphan_2_invalid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 2)))
-        tx_orphan_2_invalid.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_invalid.vout.append(CTxOut(nValue=btcToSat(11), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_2_invalid.calc_sha256()
 
         self.log.info('Send the orphans ... ')
@@ -151,7 +151,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         orphan_tx_pool = [CTransaction() for _ in range(101)]
         for i in range(len(orphan_tx_pool)):
             orphan_tx_pool[i].vin.append(CTxIn(outpoint=COutPoint(i, 333)))
-            orphan_tx_pool[i].vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+            orphan_tx_pool[i].vout.append(CTxOut(nValue=btcToSat(11), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
 
         with node.assert_debug_log(['orphanage overflow, removed 1 tx']):
             node.p2ps[0].send_txs_and_test(orphan_tx_pool, node, success=False)
@@ -159,7 +159,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info('Test orphan with rejected parents')
         rejected_parent = CTransaction()
         rejected_parent.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_2_invalid.sha256, 0)))
-        rejected_parent.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        rejected_parent.vout.append(CTxOut(nValue=btcToSat(11), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         rejected_parent.rehash()
         with node.assert_debug_log(['not keeping orphan with rejected parents {}'.format(rejected_parent.hash)]):
             node.p2ps[0].send_txs_and_test([rejected_parent], node, success=False)
@@ -171,12 +171,12 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info('Test that a transaction in the orphan pool is included in a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_A = CTransaction()
         tx_withhold_until_block_A.vin.append(CTxIn(outpoint=COutPoint(tx_withhold.sha256, 1)))
-        tx_withhold_until_block_A.vout = [CTxOut(nValue=12 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
+        tx_withhold_until_block_A.vout = [CTxOut(nValue=btcToSat(12), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
         tx_withhold_until_block_A.calc_sha256()
 
         tx_orphan_include_by_block_A = CTransaction()
         tx_orphan_include_by_block_A.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_A.sha256, 0)))
-        tx_orphan_include_by_block_A.vout.append(CTxOut(nValue=12 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_include_by_block_A.vout.append(CTxOut(nValue=btcToSat(12) - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_include_by_block_A.calc_sha256()
 
         self.log.info('Send the orphan ... ')
@@ -196,17 +196,17 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info('Test that a transaction in the orphan pool conflicts with a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_B = CTransaction()
         tx_withhold_until_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_A.sha256, 1)))
-        tx_withhold_until_block_B.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_withhold_until_block_B.vout.append(CTxOut(nValue=btcToSat(11), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_withhold_until_block_B.calc_sha256()
 
         tx_orphan_include_by_block_B = CTransaction()
         tx_orphan_include_by_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_B.sha256, 0)))
-        tx_orphan_include_by_block_B.vout.append(CTxOut(nValue=10 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_include_by_block_B.vout.append(CTxOut(nValue=btcToSat(10), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_include_by_block_B.calc_sha256()
 
         tx_orphan_conflict_by_block_B = CTransaction()
         tx_orphan_conflict_by_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_B.sha256, 0)))
-        tx_orphan_conflict_by_block_B.vout.append(CTxOut(nValue=9 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_conflict_by_block_B.vout.append(CTxOut(nValue=btcToSat(9), scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_conflict_by_block_B.calc_sha256()
         self.log.info('Send the orphan ... ')
         node.p2ps[0].send_txs_and_test([tx_orphan_conflict_by_block_B], node, success=False)

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -36,9 +36,9 @@ from test_framework.blocktools import (
 )
 from test_framework.messages import (
     CBlockHeader,
-    COIN,
     from_hex,
     msg_block,
+    btcToSat,
 )
 from test_framework.p2p import P2PInterface
 from test_framework.script import hash256, OP_TRUE
@@ -676,7 +676,7 @@ class BlockchainTest(BitcoinTestFramework):
 
         self.log.info("Test getblock when block data is available but undo data isn't")
         # Submits a block building on the header-only block, so it can't be connected and has no undo data
-        tx = create_tx_with_script(block.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
+        tx = create_tx_with_script(block.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=btcToSat(50))
         block_noundo = create_block(block.sha256, create_coinbase(current_height + 2, nValue=100), block_time + 1, txlist=[tx])
         block_noundo.solve()
         node.submitblock(block_noundo.serialize().hex())

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -11,7 +11,7 @@ import os
 from test_framework.address import address_to_scriptpubkey
 from test_framework.descriptors import descsum_create, drop_origins
 from test_framework.key import ECPubKey
-from test_framework.messages import COIN
+from test_framework.messages import btcToSat
 from test_framework.script_util import keys_to_multisig_script
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -156,7 +156,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         spk = address_to_scriptpubkey(madd)
         value = decimal.Decimal("0.00004000")
-        tx = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=spk, amount=int(value * COIN))
+        tx = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=spk, amount=btcToSat(value))
         prevtxs = [{"txid": tx["txid"], "vout": tx["sent_vout"], "scriptPubKey": spk.hex(), "redeemScript": mredeem, "amount": value}]
 
         self.generate(node0, 1)

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -23,9 +23,9 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
-    COIN,
     DEFAULT_FEE,
     MiniWallet,
+    btcToSat,
 )
 
 
@@ -245,7 +245,7 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         # Add a child that spends both at high feerate to submit via submitpackage
         tx_child = self.wallet.create_self_transfer_multi(
-            fee_per_output=int(DEFAULT_FEE * 5 * COIN),
+            fee_per_output=btcToSat(DEFAULT_FEE * 5),
             utxos_to_spend=[tx1["new_utxo"], tx2["new_utxo"]],
         )
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -18,10 +18,10 @@ from itertools import product
 
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
-    COIN,
     CTransaction,
     CTxOut,
     tx_from_hex,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -359,42 +359,42 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Test that datacarrier transaction with default maxburnamount (0) does not get sent
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.001
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx_hex = tx.serialize().hex()
         assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex)
 
         # Test that oversized script gets rejected by sendrawtransaction
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.001
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_FALSE] * 10001))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_FALSE] * 10001))]
         tx_hex = tx.serialize().hex()
         assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex)
 
         # Test that script containing invalid opcode gets rejected by sendrawtransaction
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.01
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_INVALIDOPCODE]))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_INVALIDOPCODE]))]
         tx_hex = tx.serialize().hex()
         assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex)
 
         # Test a transaction where our burn exceeds maxburnamount
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.001
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx_hex = tx.serialize().hex()
         assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex, 0, 0.0009)
 
         # Test a transaction where our burn falls short of maxburnamount
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.001
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx_hex = tx.serialize().hex()
         self.nodes[2].sendrawtransaction(hexstring=tx_hex, maxfeerate='0', maxburnamount='0.0011')
 
         # Test a transaction where our burn equals maxburnamount
         tx = self.wallet.create_self_transfer()['tx']
         tx_val = 0.001
-        tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
+        tx.vout = [CTxOut(btcToSat(Decimal(tx_val)), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx_hex = tx.serialize().hex()
         self.nodes[2].sendrawtransaction(hexstring=tx_hex, maxfeerate='0', maxburnamount='0.001')
 

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -8,7 +8,7 @@ from test_framework.blockfilter import (
     bip158_basic_element_hash,
     bip158_relevant_scriptpubkeys,
 )
-from test_framework.messages import COIN
+from test_framework.messages import btcToSat
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -31,14 +31,14 @@ class ScanblocksTest(BitcoinTestFramework):
 
         # send 1.0, mempool only
         _, spk_1, addr_1 = getnewdestination()
-        wallet.send_to(from_node=node, scriptPubKey=spk_1, amount=1 * COIN)
+        wallet.send_to(from_node=node, scriptPubKey=spk_1, amount=btcToSat(1))
 
         parent_key = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B"
         # send 1.0, mempool only
         # childkey 5 of `parent_key`
         wallet.send_to(from_node=node,
                        scriptPubKey=address_to_scriptpubkey("mkS4HXoTYWRTescLGaUTGbtTTYX5EjJyEE"),
-                       amount=1 * COIN)
+                       amount=btcToSat(1))
 
         # mine a block and assure that the mined blockhash is in the filterresult
         blockhash = self.generate(node, 1)[0]

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -5,7 +5,7 @@
 """Test transaction signing using the signrawtransactionwithkey RPC."""
 
 from test_framework.messages import (
-    COIN,
+    btcToSat,
 )
 from test_framework.address import (
     address_to_scriptpubkey,
@@ -50,7 +50,7 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
 
     def send_to_address(self, addr, amount):
         script_pub_key = address_to_scriptpubkey(addr)
-        tx = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=script_pub_key, amount=int(amount * COIN))
+        tx = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=script_pub_key, amount=btcToSat(amount))
         return tx["txid"], tx["sent_vout"]
 
     def assert_signing_completed_successfully(self, signed_tx):

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -17,7 +17,6 @@ from .address import (
 )
 from .messages import (
     CBlock,
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
@@ -29,6 +28,7 @@ from .messages import (
     tx_from_hex,
     uint256_from_str,
     WITNESS_SCALE_FACTOR,
+    btcToSat,
 )
 from .script import (
     CScript,
@@ -134,7 +134,7 @@ def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_scr
     coinbase = CTransaction()
     coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), SEQUENCE_FINAL))
     coinbaseoutput = CTxOut()
-    coinbaseoutput.nValue = nValue * COIN
+    coinbaseoutput.nValue = btcToSat(nValue)
     if nValue == 50:
         halvings = int(height / 150)  # regtest
         coinbaseoutput.nValue >>= halvings

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -30,6 +30,7 @@ import unittest
 
 from test_framework.crypto.siphash import siphash256
 from test_framework.util import assert_equal
+from decimal import Decimal
 
 MAX_LOCATOR_SZ = 101
 MAX_BLOCK_WEIGHT = 4000000
@@ -232,6 +233,14 @@ def from_binary(cls, stream):
     if was_bytes:
         assert len(stream.read()) == 0
     return obj
+
+
+def satToBtc(sat_value: int) -> Decimal:
+    return Decimal(sat_value) / COIN
+
+
+def btcToSat(btc_value: Decimal) -> int:
+    return int(btc_value * COIN)
 
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized
@@ -662,7 +671,7 @@ class CTransaction:
     def is_valid(self):
         self.calc_sha256()
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+            if tout.nValue < 0 or tout.nValue > btcToSat(21000000):
                 return False
         return True
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -26,7 +26,6 @@ from test_framework.key import (
     compute_xonly_pubkey,
 )
 from test_framework.messages import (
-    COIN,
     COutPoint,
     CTransaction,
     CTxIn,
@@ -34,6 +33,8 @@ from test_framework.messages import (
     CTxOut,
     hash256,
     ser_compact_size,
+    satToBtc,
+    btcToSat,
 )
 from test_framework.script import (
     CScript,
@@ -318,12 +319,12 @@ class MiniWallet:
         assert_equal(len(utxos_to_spend), len(sequence))
 
         # calculate output amount
-        inputs_value_total = sum([int(COIN * utxo['value']) for utxo in utxos_to_spend])
+        inputs_value_total = sum([btcToSat(utxo['value']) for utxo in utxos_to_spend])
         outputs_value_total = inputs_value_total - fee_per_output * num_outputs
         amount_per_output = amount_per_output or (outputs_value_total // num_outputs)
         assert amount_per_output > 0
         outputs_value_total = amount_per_output * num_outputs
-        fee = Decimal(inputs_value_total - outputs_value_total) / COIN
+        fee = satToBtc(inputs_value_total - outputs_value_total)
 
         # create tx
         tx = CTransaction()
@@ -342,7 +343,7 @@ class MiniWallet:
             "new_utxos": [self._create_utxo(
                 txid=txid,
                 vout=i,
-                value=Decimal(tx.vout[i].nValue) / COIN,
+                value=satToBtc(tx.vout[i].nValue),
                 height=0,
                 coinbase=False,
                 confirmations=0,
@@ -382,7 +383,7 @@ class MiniWallet:
         # create tx
         tx = self.create_self_transfer_multi(
             utxos_to_spend=[utxo_to_spend],
-            amount_per_output=int(COIN * send_value),
+            amount_per_output=btcToSat(send_value),
             target_vsize=target_vsize,
             **kwargs,
         )

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -13,7 +13,7 @@ See feature_assumeutxo.py for background.
 """
 from test_framework.address import address_to_scriptpubkey
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.messages import COIN
+from test_framework.messages import btcToSat
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
@@ -119,8 +119,8 @@ class AssumeutxoTest(BitcoinTestFramework):
         w2_skp = address_to_scriptpubkey(w2_address)
         for i in range(100):
             if i % 3 == 0:
-                self.mini_wallet.send_to(from_node=n0, scriptPubKey=w_skp, amount=1 * COIN)
-                self.mini_wallet.send_to(from_node=n0, scriptPubKey=w2_skp, amount=10 * COIN)
+                self.mini_wallet.send_to(from_node=n0, scriptPubKey=w_skp, amount=btcToSat(1))
+                self.mini_wallet.send_to(from_node=n0, scriptPubKey=w2_skp, amount=btcToSat(10))
             self.generate(n0, nblocks=1, sync_fun=self.no_op)
 
         assert_equal(n0.getblockcount(), FINAL_HEIGHT)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -9,8 +9,8 @@ from itertools import product
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
 from test_framework.messages import (
-    COIN,
     DEFAULT_ANCESTOR_LIMIT,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -814,7 +814,7 @@ class WalletTest(BitcoinTestFramework):
             this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info["txid"] == t["txid"])
             assert_equal(this_unspent['ancestorcount'], i + 1)
             assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
-            assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
+            assert_equal(this_unspent['ancestorfees'], btcToSat(ancestor_fees))
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -12,9 +12,9 @@ from test_framework.address import address_to_scriptpubkey
 
 from test_framework.descriptors import descsum_create
 from test_framework.messages import (
-    COIN,
     CTransaction,
     CTxOut,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -164,7 +164,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         address = self.nodes[0].getnewaddress("bech32")
         tx = CTransaction()
         tx.vin = []
-        tx.vout = [CTxOut(1 * COIN, bytearray(address_to_scriptpubkey(address)))] * 2
+        tx.vout = [CTxOut(btcToSat(1), bytearray(address_to_scriptpubkey(address)))] * 2
         tx.nLockTime = 0
         tx_hex = tx.serialize().hex()
         res = w.fundrawtransaction(tx_hex, add_inputs=True)
@@ -1301,7 +1301,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # with 71-byte signatures we should expect following tx size
         # tx overhead (10) + 2 inputs (41 each) + 2 p2wpkh (31 each) + (segwit marker and flag (2) + 2 p2wpkh 71 byte sig witnesses (107 each)) / witness scaling factor (4)
         tx_size = ceil(10 + 41*2 + 31*2 + (2 + 107*2)/4)
-        assert_equal(fundedtx['fee'] * COIN, tx_size * 10)
+        assert_equal(btcToSat(fundedtx['fee']), tx_size * 10)
 
         # Using the other output should have 72 byte sigs
         rawtx = wallet.createrawtransaction([ext_utxo], [{self.nodes[0].getnewaddress(): 13}])
@@ -1309,7 +1309,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedtx = wallet.fundrawtransaction(rawtx, fee_rate=10, change_type="bech32", solving_data={"descriptors": [ext_desc]})
         # tx overhead (10) + 3 inputs (41 each) + 2 p2wpkh(31 each) + (segwit marker and flag (2) + 2 p2wpkh 71 bytes sig witnesses (107 each) + p2wpkh 72 byte sig witness (108)) / witness scaling factor (4)
         tx_size = ceil(10 + 41*3 + 31*2 + (2 + 107*2 + 108)/4)
-        assert_equal(fundedtx['fee'] * COIN, tx_size * 10)
+        assert_equal(btcToSat(fundedtx['fee']), tx_size * 10)
 
         self.nodes[2].unloadwallet("test_weight_calculation")
 

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -9,8 +9,8 @@ import os
 import shutil
 
 from test_framework.messages import (
-    COIN,
     tx_from_hex,
+    btcToSat,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -195,7 +195,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.log.info("Test tx with unknown RBF state (bip125-replaceable=unknown)")
         # Replace tx3, and check that tx4 becomes unknown
         tx3_b = tx3_modified
-        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN)  # bump the fee
+        tx3_b.vout[0].nValue -= btcToSat(Decimal("0.004"))  # bump the fee
         tx3_b = tx3_b.serialize().hex()
         tx3_b_signed = self.nodes[0].signrawtransactionwithwallet(tx3_b)['hex']
         txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, 0)


### PR DESCRIPTION
Introduce utility functions `satToBtc` and `btcToSat` to simplify and standardize conversions between satoshis and bitcoins in functional tests

#closes #31345

This PR implements the solution proposed in the issue. The goal is to simplify conversions between satoshis and bitcoins in the functional tests by using utility functions. For example, code like `fee_rate=Decimal(feerate * 1000) / COIN` could become `fee_rate=satToBtc(feerate * 1000)` in the proposed solution.

An additional benefit of satToBtc() is that it ensures the use of Decimal.

This issue was briefly mentioned in [this discussion](https://github.com/bitcoin/bitcoin/pull/30079#discussion_r1602965411), where the conversion `Decimal(value) / COIN` was noted to be repetitive.

While some may prefer to continue using the `/ COIN` and `* COIN` conversions, I don’t have a strong preference either way. I’d like to hear your opinions and, if needed, implement the approach that works best.