### PR TITLE
cmake: Add `CheckLinkerSupportsPIE` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,16 +186,8 @@ string(APPEND CMAKE_CXX_LINK_EXECUTABLE " ${APPEND_LDFLAGS}")
 
 set(configure_warnings)
 
-include(CheckPIESupported)
-check_pie_supported(OUTPUT_VARIABLE check_pie_output LANGUAGES CXX)
-if(CMAKE_CXX_LINK_PIE_SUPPORTED)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-elseif(NOT WIN32)
-  # The warning is superfluous for Windows.
-  message(WARNING "PIE is not supported at link time: ${check_pie_output}")
-  list(APPEND configure_warnings "Position independent code disabled.")
-endif()
-unset(check_pie_output)
+include(CheckLinkerSupportsPIE)
+check_linker_supports_pie(configure_warnings)
 
 # The core_interface library aims to encapsulate common build flags.
 # It is a usage requirement for all targets except for secp256k1, which

--- a/cmake/module/CheckLinkerSupportsPIE.cmake
+++ b/cmake/module/CheckLinkerSupportsPIE.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+include_guard(GLOBAL)
+
+function(check_linker_supports_pie warnings)
+  # Workaround for a bug in the check_pie_supported() function.
+  # See:
+  # - https://gitlab.kitware.com/cmake/cmake/-/issues/26463
+  # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10034
+  if(CMAKE_VERSION VERSION_LESS 3.32)
+    # CMAKE_CXX_COMPILE_OPTIONS_PIE is a list, whereas CMAKE_REQUIRED_FLAGS
+    # must be a string. Therefore, a proper conversion is required.
+    list(JOIN CMAKE_CXX_COMPILE_OPTIONS_PIE " " CMAKE_REQUIRED_FLAGS)
+  endif()
+
+  include(CheckPIESupported)
+  check_pie_supported(OUTPUT_VARIABLE output LANGUAGES CXX)
+  if(CMAKE_CXX_LINK_PIE_SUPPORTED)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON PARENT_SCOPE)
+  elseif(NOT WIN32)
+    # The warning is superfluous for Windows.
+    message(WARNING "PIE is not supported at link time: ${output}")
+    set(${warnings} ${${warnings}} "Position independent code disabled." PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/module/CheckLinkerSupportsPIE.cmake
+++ b/cmake/module/CheckLinkerSupportsPIE.cmake
@@ -21,7 +21,7 @@ function(check_linker_supports_pie warnings)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON PARENT_SCOPE)
   elseif(NOT WIN32)
     # The warning is superfluous for Windows.
-    message(WARNING "PIE is not supported at link time: ${output}")
+    message(WARNING "PIE is not supported at link time. See the configure log for details.")
     set(${warnings} ${${warnings}} "Position independent code disabled." PARENT_SCOPE)
   endif()
 endfunction()


### PR DESCRIPTION
This new module is a wrapper around CMake's `CheckPIESupported` module that fixes an upstream bug.

See: https://gitlab.kitware.com/cmake/cmake/-/issues/26463.

Fixes https://github.com/bitcoin/bitcoin/issues/30771.