### PR TITLE
depends: Avoid using helper variables in toolchain file

### DIFF
--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -115,37 +115,35 @@ endif()
 
 
 # Set configuration options for the main build system.
-set(qt_packages @qt_packages@)
-if("${qt_packages}" STREQUAL "")
+# The depends/Makefile can generate values with "not-set"
+# semantics as empty strings or strings containing only spaces.
+# Therefore, MATCHES must be used rather than STREQUAL.
+if("@qt_packages@" MATCHES "^[ ]*$")
   set(BUILD_GUI OFF CACHE BOOL "")
 else()
   set(BUILD_GUI ON CACHE BOOL "")
   set(Qt6_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")
 endif()
 
-set(qrencode_packages @qrencode_packages@)
-if("${qrencode_packages}" STREQUAL "")
+if("@qrencode_packages@" MATCHES "^[ ]*$")
   set(WITH_QRENCODE OFF CACHE BOOL "")
 else()
   set(WITH_QRENCODE ON CACHE BOOL "")
 endif()
 
-set(zmq_packages @zmq_packages@)
-if("${zmq_packages}" STREQUAL "")
+if("@zmq_packages@" MATCHES "^[ ]*$")
   set(WITH_ZMQ OFF CACHE BOOL "")
 else()
   set(WITH_ZMQ ON CACHE BOOL "")
 endif()
 
-set(wallet_packages @wallet_packages@)
-if("${wallet_packages}" STREQUAL "")
+if("@wallet_packages@" MATCHES "^[ ]*$")
   set(ENABLE_WALLET OFF CACHE BOOL "")
 else()
   set(ENABLE_WALLET ON CACHE BOOL "")
 endif()
 
-set(usdt_packages @usdt_packages@)
-if("${usdt_packages}" STREQUAL "")
+if("@usdt_packages@" MATCHES "^[ ]*$")
   set(WITH_USDT OFF CACHE BOOL "")
 else()
   set(WITH_USDT ON CACHE BOOL "")


### PR DESCRIPTION
Using helper variables has two issues:
1. They contaminate the global namespace of the main build script.
2. They can be used as `set(var)`, effectively [exposing](https://cmake.org/cmake/help/latest/command/set.html) a cache variable `var`, which makes the toolchain file susceptible to the build environment.

The [`depends/Makefile`](https://github.com/bitcoin/bitcoin/blob/master/depends/Makefile) can generate values with "not-set" semantics as empty strings or strings containing only spaces. For example:https://github.com/bitcoin/bitcoin/blob/2638fdb4f934be96b7c798dbac38ea5ab8a6374a/depends/Makefile#L157
Therefore, [`MATCHES`](https://cmake.org/cmake/help/latest/command/if.html#matches) must be used rather than [`STREQUAL`](https://cmake.org/cmake/help/latest/command/if.html#strequal).