### PR TITLE
cmake, qt: Use absolute paths for includes in MOC-generated files

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -35,6 +35,7 @@ endfunction()
 #  - https://doc.qt.io/qt-5/cmake-manual.html
 
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOMOC_MOC_OPTIONS "-p${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS forms)

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+set(CMAKE_AUTOMOC_MOC_OPTIONS "-p${CMAKE_CURRENT_SOURCE_DIR}")
+
 add_executable(test_bitcoin-qt
   apptests.cpp
   optiontests.cpp


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/31145.

From the `moc --help` output:
```
  -p <path>                         Path prefix for included file.
```