### PR TITLE
cluster mempool: introduce TxGraph

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,6 +301,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   signet.cpp
   torcontrol.cpp
   txdb.cpp
+  txgraph.cpp
   txmempool.cpp
   txorphanage.cpp
   txrequest.cpp

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -19,8 +19,8 @@
 
 namespace cluster_linearize {
 
-/** Data type to represent transaction indices in clusters. */
-using ClusterIndex = uint32_t;
+/** Data type to represent transaction indices in DepGraphs and the clusters they represent. */
+using DepGraphIndex = uint32_t;
 
 /** Data structure that holds a transaction graph's preprocessed data (fee, size, ancestors,
  *  descendants). */
@@ -86,11 +86,11 @@ public:
      *
      * Complexity: O(N^2) where N=depgraph.TxCount().
      */
-    DepGraph(const DepGraph<SetType>& depgraph, std::span<const ClusterIndex> mapping, ClusterIndex pos_range) noexcept : entries(pos_range)
+    DepGraph(const DepGraph<SetType>& depgraph, std::span<const DepGraphIndex> mapping, DepGraphIndex pos_range) noexcept : entries(pos_range)
     {
         Assume(mapping.size() == depgraph.PositionRange());
         Assume((pos_range == 0) == (depgraph.TxCount() == 0));
-        for (ClusterIndex i : depgraph.Positions()) {
+        for (DepGraphIndex i : depgraph.Positions()) {
             auto new_idx = mapping[i];
             Assume(new_idx < pos_range);
             // Add transaction.
@@ -100,7 +100,7 @@ public:
             // Fill in fee and size.
             entries[new_idx].feerate = depgraph.entries[i].feerate;
         }
-        for (ClusterIndex i : depgraph.Positions()) {
+        for (DepGraphIndex i : depgraph.Positions()) {
             // Fill in dependencies by mapping direct parents.
             SetType parents;
             for (auto j : depgraph.GetReducedParents(i)) parents.Set(mapping[j]);
@@ -113,29 +113,29 @@ public:
     /** Get the set of transactions positions in use. Complexity: O(1). */
     const SetType& Positions() const noexcept { return m_used; }
     /** Get the range of positions in this DepGraph. All entries in Positions() are in [0, PositionRange() - 1]. */
-    ClusterIndex PositionRange() const noexcept { return entries.size(); }
+    DepGraphIndex PositionRange() const noexcept { return entries.size(); }
     /** Get the number of transactions in the graph. Complexity: O(1). */
     auto TxCount() const noexcept { return m_used.Count(); }
     /** Get the feerate of a given transaction i. Complexity: O(1). */
-    const FeeFrac& FeeRate(ClusterIndex i) const noexcept { return entries[i].feerate; }
+    const FeeFrac& FeeRate(DepGraphIndex i) const noexcept { return entries[i].feerate; }
     /** Get the mutable feerate of a given transaction i. Complexity: O(1). */
-    FeeFrac& FeeRate(ClusterIndex i) noexcept { return entries[i].feerate; }
+    FeeFrac& FeeRate(DepGraphIndex i) noexcept { return entries[i].feerate; }
     /** Get the ancestors of a given transaction i. Complexity: O(1). */
-    const SetType& Ancestors(ClusterIndex i) const noexcept { return entries[i].ancestors; }
+    const SetType& Ancestors(DepGraphIndex i) const noexcept { return entries[i].ancestors; }
     /** Get the descendants of a given transaction i. Complexity: O(1). */
-    const SetType& Descendants(ClusterIndex i) const noexcept { return entries[i].descendants; }
+    const SetType& Descendants(DepGraphIndex i) const noexcept { return entries[i].descendants; }
 
     /** Add a new unconnected transaction to this transaction graph (in the first available
-     *  position), and return its ClusterIndex.
+     *  position), and return its DepGraphIndex.
      *
      * Complexity: O(1) (amortized, due to resizing of backing vector).
      */
-    ClusterIndex AddTransaction(const FeeFrac& feefrac) noexcept
+    DepGraphIndex AddTransaction(const FeeFrac& feefrac) noexcept
     {
         static constexpr auto ALL_POSITIONS = SetType::Fill(SetType::Size());
         auto available = ALL_POSITIONS - m_used;
         Assume(available.Any());
-        ClusterIndex new_idx = available.First();
+        DepGraphIndex new_idx = available.First();
         if (new_idx == entries.size()) {
             entries.emplace_back(feefrac, SetType::Singleton(new_idx), SetType::Singleton(new_idx));
         } else {
@@ -174,7 +174,7 @@ public:
      *
      * Complexity: O(N) where N=TxCount().
      */
-    void AddDependencies(const SetType& parents, ClusterIndex child) noexcept
+    void AddDependencies(const SetType& parents, DepGraphIndex child) noexcept
     {
         Assume(m_used[child]);
         Assume(parents.IsSubsetOf(m_used));
@@ -205,7 +205,7 @@ public:
      *
      * Complexity: O(N) where N=Ancestors(i).Count() (which is bounded by TxCount()).
      */
-    SetType GetReducedParents(ClusterIndex i) const noexcept
+    SetType GetReducedParents(DepGraphIndex i) const noexcept
     {
         SetType parents = Ancestors(i);
         parents.Reset(i);
@@ -226,7 +226,7 @@ public:
      *
      * Complexity: O(N) where N=Descendants(i).Count() (which is bounded by TxCount()).
      */
-    SetType GetReducedChildren(ClusterIndex i) const noexcept
+    SetType GetReducedChildren(DepGraphIndex i) const noexcept
     {
         SetType children = Descendants(i);
         children.Reset(i);
@@ -298,11 +298,11 @@ public:
      *
      * Complexity: O(select.Count() * log(select.Count())).
      */
-    void AppendTopo(std::vector<ClusterIndex>& list, const SetType& select) const noexcept
+    void AppendTopo(std::vector<DepGraphIndex>& list, const SetType& select) const noexcept
     {
-        ClusterIndex old_len = list.size();
+        DepGraphIndex old_len = list.size();
         for (auto i : select) list.push_back(i);
-        std::sort(list.begin() + old_len, list.end(), [&](ClusterIndex a, ClusterIndex b) noexcept {
+        std::sort(list.begin() + old_len, list.end(), [&](DepGraphIndex a, DepGraphIndex b) noexcept {
             const auto a_anc_count = entries[a].ancestors.Count();
             const auto b_anc_count = entries[b].ancestors.Count();
             if (a_anc_count != b_anc_count) return a_anc_count < b_anc_count;
@@ -338,7 +338,7 @@ struct SetInfo
     SetInfo(const SetType& txn, const FeeFrac& fr) noexcept : transactions(txn), feerate(fr) {}
 
     /** Construct a SetInfo for a given transaction in a depgraph. */
-    explicit SetInfo(const DepGraph<SetType>& depgraph, ClusterIndex pos) noexcept :
+    explicit SetInfo(const DepGraph<SetType>& depgraph, DepGraphIndex pos) noexcept :
         transactions(SetType::Singleton(pos)), feerate(depgraph.FeeRate(pos)) {}
 
     /** Construct a SetInfo for a set of transactions in a depgraph. */
@@ -346,7 +346,7 @@ struct SetInfo
         transactions(txn), feerate(depgraph.FeeRate(txn)) {}
 
     /** Add a transaction to this SetInfo (which must not yet be in it). */
-    void Set(const DepGraph<SetType>& depgraph, ClusterIndex pos) noexcept
+    void Set(const DepGraph<SetType>& depgraph, DepGraphIndex pos) noexcept
     {
         Assume(!transactions[pos]);
         transactions.Set(pos);
@@ -382,10 +382,10 @@ struct SetInfo
 
 /** Compute the feerates of the chunks of linearization. */
 template<typename SetType>
-std::vector<FeeFrac> ChunkLinearization(const DepGraph<SetType>& depgraph, std::span<const ClusterIndex> linearization) noexcept
+std::vector<FeeFrac> ChunkLinearization(const DepGraph<SetType>& depgraph, std::span<const DepGraphIndex> linearization) noexcept
 {
     std::vector<FeeFrac> ret;
-    for (ClusterIndex i : linearization) {
+    for (DepGraphIndex i : linearization) {
         /** The new chunk to be added, initially a singleton. */
         auto new_chunk = depgraph.FeeRate(i);
         // As long as the new chunk has a higher feerate than the last chunk so far, absorb it.
@@ -407,13 +407,13 @@ class LinearizationChunking
     const DepGraph<SetType>& m_depgraph;
 
     /** The linearization we started from, possibly with removed prefix stripped. */
-    std::span<const ClusterIndex> m_linearization;
+    std::span<const DepGraphIndex> m_linearization;
 
     /** Chunk sets and their feerates, of what remains of the linearization. */
     std::vector<SetInfo<SetType>> m_chunks;
 
     /** How large a prefix of m_chunks corresponds to removed transactions. */
-    ClusterIndex m_chunks_skip{0};
+    DepGraphIndex m_chunks_skip{0};
 
     /** Which transactions remain in the linearization. */
     SetType m_todo;
@@ -448,7 +448,7 @@ class LinearizationChunking
 
 public:
     /** Initialize a LinearizationSubset object for a given length of linearization. */
-    explicit LinearizationChunking(const DepGraph<SetType>& depgraph LIFETIMEBOUND, std::span<const ClusterIndex> lin LIFETIMEBOUND) noexcept :
+    explicit LinearizationChunking(const DepGraph<SetType>& depgraph LIFETIMEBOUND, std::span<const DepGraphIndex> lin LIFETIMEBOUND) noexcept :
         m_depgraph(depgraph), m_linearization(lin)
     {
         // Mark everything in lin as todo still.
@@ -459,10 +459,10 @@ public:
     }
 
     /** Determine how many chunks remain in the linearization. */
-    ClusterIndex NumChunksLeft() const noexcept { return m_chunks.size() - m_chunks_skip; }
+    DepGraphIndex NumChunksLeft() const noexcept { return m_chunks.size() - m_chunks_skip; }
 
     /** Access a chunk. Chunk 0 is the highest-feerate prefix of what remains. */
-    const SetInfo<SetType>& GetChunk(ClusterIndex n) const noexcept
+    const SetInfo<SetType>& GetChunk(DepGraphIndex n) const noexcept
     {
         Assume(n + m_chunks_skip < m_chunks.size());
         return m_chunks[n + m_chunks_skip];
@@ -505,7 +505,7 @@ public:
         Assume(subset.transactions.IsSubsetOf(m_todo));
         SetInfo<SetType> accumulator;
         // Iterate over all chunks of the remaining linearization.
-        for (ClusterIndex i = 0; i < NumChunksLeft(); ++i) {
+        for (DepGraphIndex i = 0; i < NumChunksLeft(); ++i) {
             // Find what (if any) intersection the chunk has with subset.
             const SetType to_add = GetChunk(i).transactions & subset.transactions;
             if (to_add.Any()) {
@@ -557,13 +557,13 @@ public:
         m_ancestor_set_feerates(depgraph.PositionRange())
     {
         // Precompute ancestor-set feerates.
-        for (ClusterIndex i : m_depgraph.Positions()) {
+        for (DepGraphIndex i : m_depgraph.Positions()) {
             /** The remaining ancestors for transaction i. */
             SetType anc_to_add = m_depgraph.Ancestors(i);
             FeeFrac anc_feerate;
             // Reuse accumulated feerate from first ancestor, if usable.
             Assume(anc_to_add.Any());
-            ClusterIndex first = anc_to_add.First();
+            DepGraphIndex first = anc_to_add.First();
             if (first < i) {
                 anc_feerate = m_ancestor_set_feerates[first];
                 Assume(!anc_feerate.IsEmpty());
@@ -603,7 +603,7 @@ public:
     }
 
     /** Count the number of remaining unlinearized transactions. */
-    ClusterIndex NumRemaining() const noexcept
+    DepGraphIndex NumRemaining() const noexcept
     {
         return m_todo.Count();
     }
@@ -616,7 +616,7 @@ public:
     SetInfo<SetType> FindCandidateSet() const noexcept
     {
         Assume(!AllDone());
-        std::optional<ClusterIndex> best;
+        std::optional<DepGraphIndex> best;
         for (auto i : m_todo) {
             if (best.has_value()) {
                 Assume(!m_ancestor_set_feerates[i].IsEmpty());
@@ -644,9 +644,9 @@ class SearchCandidateFinder
     /** Internal RNG. */
     InsecureRandomContext m_rng;
     /** m_sorted_to_original[i] is the original position that sorted transaction position i had. */
-    std::vector<ClusterIndex> m_sorted_to_original;
+    std::vector<DepGraphIndex> m_sorted_to_original;
     /** m_original_to_sorted[i] is the sorted position original transaction position i has. */
-    std::vector<ClusterIndex> m_original_to_sorted;
+    std::vector<DepGraphIndex> m_original_to_sorted;
     /** Internal dependency graph for the cluster (with transactions in decreasing individual
      *  feerate order). */
     DepGraph<SetType> m_sorted_depgraph;
@@ -684,7 +684,7 @@ public:
     {
         // Determine reordering mapping, by sorting by decreasing feerate. Unused positions are
         // not included, as they will never be looked up anyway.
-        ClusterIndex sorted_pos{0};
+        DepGraphIndex sorted_pos{0};
         for (auto i : depgraph.Positions()) {
             m_sorted_to_original[sorted_pos++] = i;
         }
@@ -694,7 +694,7 @@ public:
             return feerate_cmp > 0;
         });
         // Compute reverse mapping.
-        for (ClusterIndex i = 0; i < m_sorted_to_original.size(); ++i) {
+        for (DepGraphIndex i = 0; i < m_sorted_to_original.size(); ++i) {
             m_original_to_sorted[m_sorted_to_original[i]] = i;
         }
         // Compute reordered dependency graph.
@@ -793,7 +793,7 @@ public:
         /** The set of transactions in m_todo which have feerate > best's. */
         SetType imp = m_todo;
         while (imp.Any()) {
-            ClusterIndex check = imp.Last();
+            DepGraphIndex check = imp.Last();
             if (m_sorted_depgraph.FeeRate(check) >> best.feerate) break;
             imp.Reset(check);
         }
@@ -850,7 +850,7 @@ public:
                     best = inc;
                     // See if we can remove any entries from imp now.
                     while (imp.Any()) {
-                        ClusterIndex check = imp.Last();
+                        DepGraphIndex check = imp.Last();
                         if (m_sorted_depgraph.FeeRate(check) >> best.feerate) break;
                         imp.Reset(check);
                     }
@@ -891,7 +891,7 @@ public:
             // If pot is empty, then so is inc.
             Assume(elem.inc.feerate.IsEmpty() == elem.pot_feerate.IsEmpty());
 
-            const ClusterIndex first = elem.und.First();
+            const DepGraphIndex first = elem.und.First();
             if (!elem.inc.feerate.IsEmpty()) {
                 // If no undecided transactions remain with feerate higher than best, this entry
                 // cannot be improved beyond best.
@@ -917,17 +917,17 @@ public:
             // most. Let I(t) be the size of the undecided set after including t, and E(t) the size
             // of the undecided set after excluding t. Then choose the split transaction t such
             // that 2^I(t) + 2^E(t) is minimal, tie-breaking by highest individual feerate for t.
-            ClusterIndex split = 0;
+            DepGraphIndex split = 0;
             const auto select = elem.und & m_sorted_depgraph.Ancestors(first);
             Assume(select.Any());
-            std::optional<std::pair<ClusterIndex, ClusterIndex>> split_counts;
+            std::optional<std::pair<DepGraphIndex, DepGraphIndex>> split_counts;
             for (auto t : select) {
                 // Call max = max(I(t), E(t)) and min = min(I(t), E(t)). Let counts = {max,min}.
                 // Sorting by the tuple counts is equivalent to sorting by 2^I(t) + 2^E(t). This
                 // expression is equal to 2^max + 2^min = 2^max * (1 + 1/2^(max - min)). The second
                 // factor (1 + 1/2^(max - min)) there is in (1,2]. Thus increasing max will always
                 // increase it, even when min decreases. Because of this, we can first sort by max.
-                std::pair<ClusterIndex, ClusterIndex> counts{
+                std::pair<DepGraphIndex, DepGraphIndex> counts{
                     (elem.und - m_sorted_depgraph.Ancestors(t)).Count(),
                     (elem.und - m_sorted_depgraph.Descendants(t)).Count()};
                 if (counts.first < counts.second) std::swap(counts.first, counts.second);
@@ -1027,13 +1027,13 @@ public:
  * Complexity: possibly O(N * min(max_iterations + N, sqrt(2^N))) where N=depgraph.TxCount().
  */
 template<typename SetType>
-std::pair<std::vector<ClusterIndex>, bool> Linearize(const DepGraph<SetType>& depgraph, uint64_t max_iterations, uint64_t rng_seed, std::span<const ClusterIndex> old_linearization = {}) noexcept
+std::pair<std::vector<DepGraphIndex>, bool> Linearize(const DepGraph<SetType>& depgraph, uint64_t max_iterations, uint64_t rng_seed, std::span<const DepGraphIndex> old_linearization = {}) noexcept
 {
     Assume(old_linearization.empty() || old_linearization.size() == depgraph.TxCount());
     if (depgraph.TxCount() == 0) return {{}, true};
 
     uint64_t iterations_left = max_iterations;
-    std::vector<ClusterIndex> linearization;
+    std::vector<DepGraphIndex> linearization;
 
     AncestorCandidateFinder anc_finder(depgraph);
     std::optional<SearchCandidateFinder<SetType>> src_finder;
@@ -1121,7 +1121,7 @@ std::pair<std::vector<ClusterIndex>, bool> Linearize(const DepGraph<SetType>& de
  *   postlinearize" process.
  */
 template<typename SetType>
-void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> linearization)
+void PostLinearize(const DepGraph<SetType>& depgraph, std::span<DepGraphIndex> linearization)
 {
     // This algorithm performs a number of passes (currently 2); the even ones operate from back to
     // front, the odd ones from front to back. Each results in an equal-or-better linearization
@@ -1159,9 +1159,9 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
     // entries[0].
 
     /** Index of the sentinel in the entries array below. */
-    static constexpr ClusterIndex SENTINEL{0};
+    static constexpr DepGraphIndex SENTINEL{0};
     /** Indicator that a group has no previous transaction. */
-    static constexpr ClusterIndex NO_PREV_TX{0};
+    static constexpr DepGraphIndex NO_PREV_TX{0};
 
 
     /** Data structure per transaction entry. */
@@ -1169,16 +1169,16 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
     {
         /** The index of the previous transaction in this group; NO_PREV_TX if this is the first
          *  entry of a group. */
-        ClusterIndex prev_tx;
+        DepGraphIndex prev_tx;
 
         // The fields below are only used for transactions that are the last one in a group
         // (referred to as tail transactions below).
 
         /** Index of the first transaction in this group, possibly itself. */
-        ClusterIndex first_tx;
+        DepGraphIndex first_tx;
         /** Index of the last transaction in the previous group. The first group (the sentinel)
          *  points back to the last group here, making it a singly-linked circular list. */
-        ClusterIndex prev_group;
+        DepGraphIndex prev_group;
         /** All transactions in the group. Empty for the sentinel. */
         SetType group;
         /** All dependencies of the group (descendants in even passes; ancestors in odd ones). */
@@ -1221,12 +1221,12 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
         Assume(entries[SENTINEL].feerate.IsEmpty());
 
         // Iterate over all elements in the existing linearization.
-        for (ClusterIndex i = 0; i < linearization.size(); ++i) {
+        for (DepGraphIndex i = 0; i < linearization.size(); ++i) {
             // Even passes are from back to front; odd passes from front to back.
-            ClusterIndex idx = linearization[rev ? linearization.size() - 1 - i : i];
+            DepGraphIndex idx = linearization[rev ? linearization.size() - 1 - i : i];
             // Construct a new group containing just idx. In even passes, the meaning of
             // parent/child and high/low feerate are swapped.
-            ClusterIndex cur_group = idx + 1;
+            DepGraphIndex cur_group = idx + 1;
             entries[cur_group].group = SetType::Singleton(idx);
             entries[cur_group].deps = rev ? depgraph.Descendants(idx): depgraph.Ancestors(idx);
             entries[cur_group].feerate = depgraph.FeeRate(idx);
@@ -1238,8 +1238,8 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
             entries[SENTINEL].prev_group = cur_group;
 
             // Start merge/swap cycle.
-            ClusterIndex next_group = SENTINEL; // We inserted at the end, so next group is sentinel.
-            ClusterIndex prev_group = entries[cur_group].prev_group;
+            DepGraphIndex next_group = SENTINEL; // We inserted at the end, so next group is sentinel.
+            DepGraphIndex prev_group = entries[cur_group].prev_group;
             // Continue as long as the current group has higher feerate than the previous one.
             while (entries[cur_group].feerate >> entries[prev_group].feerate) {
                 // prev_group/cur_group/next_group refer to (the last transactions of) 3
@@ -1267,7 +1267,7 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
                     entries[cur_group].prev_group = prev_group;
                 } else {
                     // There is no dependency between cur_group and prev_group; swap them.
-                    ClusterIndex preprev_group = entries[prev_group].prev_group;
+                    DepGraphIndex preprev_group = entries[prev_group].prev_group;
                     // If PP, P, C, N were the old preprev, prev, cur, next groups, then the new
                     // layout becomes [PP, C, P, N]. Update prev_groups to reflect that order.
                     entries[next_group].prev_group = prev_group;
@@ -1282,10 +1282,10 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
         }
 
         // Convert the entries back to linearization (overwriting the existing one).
-        ClusterIndex cur_group = entries[0].prev_group;
-        ClusterIndex done = 0;
+        DepGraphIndex cur_group = entries[0].prev_group;
+        DepGraphIndex done = 0;
         while (cur_group != SENTINEL) {
-            ClusterIndex cur_tx = cur_group;
+            DepGraphIndex cur_tx = cur_group;
             // Traverse the transactions of cur_group (from back to front), and write them in the
             // same order during odd passes, and reversed (front to back) in even passes.
             if (rev) {
@@ -1310,7 +1310,7 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> li
  * Complexity: O(N^2) where N=depgraph.TxCount(); O(N) if both inputs are identical.
  */
 template<typename SetType>
-std::vector<ClusterIndex> MergeLinearizations(const DepGraph<SetType>& depgraph, std::span<const ClusterIndex> lin1, std::span<const ClusterIndex> lin2)
+std::vector<DepGraphIndex> MergeLinearizations(const DepGraph<SetType>& depgraph, std::span<const DepGraphIndex> lin1, std::span<const DepGraphIndex> lin2)
 {
     Assume(lin1.size() == depgraph.TxCount());
     Assume(lin2.size() == depgraph.TxCount());
@@ -1318,7 +1318,7 @@ std::vector<ClusterIndex> MergeLinearizations(const DepGraph<SetType>& depgraph,
     /** Chunkings of what remains of both input linearizations. */
     LinearizationChunking chunking1(depgraph, lin1), chunking2(depgraph, lin2);
     /** Output linearization. */
-    std::vector<ClusterIndex> ret;
+    std::vector<DepGraphIndex> ret;
     if (depgraph.TxCount() == 0) return ret;
     ret.reserve(depgraph.TxCount());
 
@@ -1349,18 +1349,18 @@ std::vector<ClusterIndex> MergeLinearizations(const DepGraph<SetType>& depgraph,
 
 /** Make linearization topological, retaining its ordering where possible. */
 template<typename SetType>
-void FixLinearization(const DepGraph<SetType>& depgraph, std::span<ClusterIndex> linearization) noexcept
+void FixLinearization(const DepGraph<SetType>& depgraph, std::span<DepGraphIndex> linearization) noexcept
 {
     // This algorithm can be summarized as moving every element in the linearization backwards
     // until it is placed after all its ancestors.
     SetType done;
     const auto len = linearization.size();
     // Iterate over the elements of linearization from back to front (i is distance from back).
-    for (ClusterIndex i = 0; i < len; ++i) {
+    for (DepGraphIndex i = 0; i < len; ++i) {
         /** The element at that position. */
-        ClusterIndex elem = linearization[len - 1 - i];
+        DepGraphIndex elem = linearization[len - 1 - i];
         /** j represents how far from the back of the linearization elem should be placed. */
-        ClusterIndex j = i;
+        DepGraphIndex j = i;
         // Figure out which elements need to be moved before elem.
         SetType place_before = done & depgraph.Ancestors(elem);
         // Find which position to place elem in (updating j), continuously moving the elements

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -309,6 +309,17 @@ public:
             return a < b;
         });
     }
+
+    /** Check if this graph is acyclic. */
+    bool IsAcyclic() const noexcept
+    {
+        for (auto i : Positions()) {
+            if ((Ancestors(i) & Descendants(i)) != SetType::Singleton(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
 };
 
 /** A set of transactions together with their aggregate feerate. */

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -28,11 +28,11 @@ void TestDepGraphSerialization(const std::vector<std::pair<FeeFrac, SetType>>& c
     // Construct DepGraph from cluster argument.
     DepGraph<SetType> depgraph;
     SetType holes;
-    for (ClusterIndex i = 0; i < cluster.size(); ++i) {
+    for (DepGraphIndex i = 0; i < cluster.size(); ++i) {
         depgraph.AddTransaction(cluster[i].first);
         if (cluster[i] == HOLE) holes.Set(i);
     }
-    for (ClusterIndex i = 0; i < cluster.size(); ++i) {
+    for (DepGraphIndex i = 0; i < cluster.size(); ++i) {
         depgraph.AddDependencies(cluster[i].second, i);
     }
     depgraph.RemoveTransactions(holes);

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(fuzz
   tx_in.cpp
   tx_out.cpp
   tx_pool.cpp
+  txgraph.cpp
   txorphan.cpp
   txrequest.cpp
   # Visual Studio 2022 version 17.12 introduced a bug

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -526,6 +526,10 @@ FUZZ_TARGET(txgraph)
                 // these here without making more calls to real, which could affect its internal
                 // state. A full comparison is done at the end.
                 break;
+            } else if (command-- == 0) {
+                // DoWork.
+                real->DoWork();
+                break;
             }
         }
     }

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <set>
 #include <stdint.h>
 #include <utility>
 
@@ -21,7 +22,8 @@ using namespace cluster_linearize;
 namespace {
 
 /** Data type representing a naive simulated TxGraph, keeping all transactions (even from
- *  disconnected components) in a single DepGraph. */
+ *  disconnected components) in a single DepGraph. Unlike the real TxGraph, this only models
+ *  a single graph, and multiple instances are used to simulate main/staging. */
 struct SimTxGraph
 {
     /** Maximum number of transactions to support simultaneously. Set this higher than txgraph's
@@ -38,19 +40,27 @@ struct SimTxGraph
     /** The dependency graph (for all transactions in the simulation, regardless of
      *  connectivity/clustering). */
     DepGraph<SetType> graph;
-    /** For each position in graph, which TxGraph::Ref it corresponds with (if any). */
-    std::array<std::unique_ptr<TxGraph::Ref>, MAX_TRANSACTIONS> simmap;
+    /** For each position in graph, which TxGraph::Ref it corresponds with (if any). Use shared_ptr
+     *  so that a SimTxGraph can be copied to create a staging one, while sharing Refs with
+     *  the main graph. */
+    std::array<std::shared_ptr<TxGraph::Ref>, MAX_TRANSACTIONS> simmap;
     /** For each TxGraph::Ref in graph, the position it corresponds with. */
     std::map<const TxGraph::Ref*, Pos> simrevmap;
     /** The set of TxGraph::Ref entries that have been removed, but not yet destroyed. */
-    std::vector<std::unique_ptr<TxGraph::Ref>> removed;
+    std::vector<std::shared_ptr<TxGraph::Ref>> removed;
     /** Whether the graph is oversized (true = yes, false = no, std::nullopt = unknown). */
     std::optional<bool> oversized;
     /** The configured maximum number of transactions per cluster. */
     DepGraphIndex max_cluster_count;
 
-    /** Construct a new SimData with the specified maximum cluster count. */
+    /** Construct a new SimTxGraph with the specified maximum cluster count. */
     explicit SimTxGraph(DepGraphIndex max_cluster) : max_cluster_count(max_cluster) {}
+
+    // Permit copying and moving.
+    SimTxGraph(const SimTxGraph&) noexcept = default;
+    SimTxGraph& operator=(const SimTxGraph&) noexcept = default;
+    SimTxGraph(SimTxGraph&&) noexcept = default;
+    SimTxGraph& operator=(SimTxGraph&&) noexcept = default;
 
     /** Check whether this graph is oversized (contains a connected component whose number of
      *  transactions exceeds max_cluster_count. */
@@ -95,7 +105,7 @@ struct SimTxGraph
         assert(graph.TxCount() < MAX_TRANSACTIONS);
         auto simpos = graph.AddTransaction(feerate);
         assert(graph.Positions()[simpos]);
-        simmap[simpos] = std::make_unique<TxGraph::Ref>();
+        simmap[simpos] = std::make_shared<TxGraph::Ref>();
         auto ptr = simmap[simpos].get();
         simrevmap[ptr] = simpos;
         return ptr;
@@ -202,32 +212,43 @@ FUZZ_TARGET(txgraph)
     // Decide the maximum number of transactions per cluster we will use in this simulation.
     auto max_count = provider.ConsumeIntegralInRange<DepGraphIndex>(1, MAX_CLUSTER_COUNT_LIMIT);
 
-    // Construct a real and a simulated graph.
+    // Construct a real graph, and a vector of simulated graphs (main, and possibly staging).
     auto real = MakeTxGraph(max_count);
-    SimTxGraph sim(max_count);
+    std::vector<SimTxGraph> sims;
+    sims.reserve(2);
+    sims.emplace_back(max_count);
 
-    /** Function to pick any Ref (from sim.simmap or sim.removed, or the empty Ref). */
+    /** Function to pick any Ref (for either sim in sims: from sim.simmap or sim.removed, or the
+     *  empty Ref). */
     auto pick_fn = [&]() noexcept -> TxGraph::Ref* {
-        auto tx_count = sim.GetTransactionCount();
+        size_t tx_count[2] = {sims[0].GetTransactionCount(), 0};
         /** The number of possible choices. */
-        size_t choices = tx_count + sim.removed.size() + 1;
+        size_t choices = tx_count[0] + sims[0].removed.size() + 1;
+        if (sims.size() == 2) {
+            tx_count[1] = sims[1].GetTransactionCount();
+            choices += tx_count[1] + sims[1].removed.size();
+        }
         /** Pick one of them. */
         auto choice = provider.ConsumeIntegralInRange<size_t>(0, choices - 1);
-        if (choice < tx_count) {
-            // Return from real.
-            for (auto i : sim.graph.Positions()) {
-                if (choice == 0) return sim.GetRef(i);
-                --choice;
+        // Consider both main and (if it exists) staging.
+        for (size_t level = 0; level < sims.size(); ++level) {
+            auto& sim = sims[level];
+            if (choice < tx_count[level]) {
+                // Return from graph.
+                for (auto i : sim.graph.Positions()) {
+                    if (choice == 0) return sim.GetRef(i);
+                    --choice;
+                }
+                assert(false);
+            } else {
+                choice -= tx_count[level];
             }
-            assert(false);
-        } else {
-            choice -= tx_count;
-        }
-        if (choice < sim.removed.size()) {
-            // Return from removed.
-            return sim.removed[choice].get();
-        } else {
-            choice -= sim.removed.size();
+            if (choice < sim.removed.size()) {
+                // Return from removed.
+                return sim.removed[choice].get();
+            } else {
+                choice -= sim.removed.size();
+            }
         }
         // Return empty.
         assert(choice == 0);
@@ -237,15 +258,24 @@ FUZZ_TARGET(txgraph)
     LIMITED_WHILE(provider.remaining_bytes() > 0, 200) {
         // Read a one-byte command.
         int command = provider.ConsumeIntegral<uint8_t>();
-        // Treat it lowest bit as a flag (which selects a variant of some of the operations), and
-        // leave the rest of the bits in command.
+        // Treat the lowest bit of a command as a flag (which selects a variant of some of the
+        // operations), and the second-lowest bit as a way of selecting main vs. staging, and leave
+        // the rest of the bits in command.
         bool alt = command & 1;
-        command >>= 1;
+        bool use_main = command & 2;
+        command >>= 2;
+
+        // Provide convenient aliases for the top simulated graph (main, or staging if it exists),
+        // one for the simulated graph selected based on use_main (for operations that can operate
+        // on both graphs), and one that always refers to the main graph.
+        auto& top_sim = sims.back();
+        auto& sel_sim = use_main ? sims[0] : top_sim;
+        auto& main_sim = sims[0];
 
         // Keep decrementing command for each applicable operation, until one is hit. Multiple
         // iterations may be necessary.
         while (true) {
-            if (sim.GetTransactionCount() < SimTxGraph::MAX_TRANSACTIONS && command-- == 0) {
+            if (top_sim.GetTransactionCount() < SimTxGraph::MAX_TRANSACTIONS && command-- == 0) {
                 // AddTransaction.
                 int64_t fee;
                 int32_t size;
@@ -262,51 +292,54 @@ FUZZ_TARGET(txgraph)
                 FeePerWeight feerate{fee, size};
                 // Create a real TxGraph::Ref.
                 auto ref = real->AddTransaction(feerate);
-                // Create a unique_ptr place in the simulation to put the Ref in.
-                auto ref_loc = sim.AddTransaction(feerate);
+                // Create a shared_ptr place in the simulation to put the Ref in.
+                auto ref_loc = top_sim.AddTransaction(feerate);
                 // Move it in place.
                 *ref_loc = std::move(ref);
                 break;
-            } else if (sim.GetTransactionCount() + sim.removed.size() > 1 && command-- == 0) {
+            } else if (top_sim.GetTransactionCount() + top_sim.removed.size() > 1 && command-- == 0) {
                 // AddDependency.
                 auto par = pick_fn();
                 auto chl = pick_fn();
-                auto pos_par = sim.Find(par);
-                auto pos_chl = sim.Find(chl);
+                auto pos_par = top_sim.Find(par);
+                auto pos_chl = top_sim.Find(chl);
                 if (pos_par != SimTxGraph::MISSING && pos_chl != SimTxGraph::MISSING) {
                     // Determine if adding this would introduce a cycle (not allowed by TxGraph),
                     // and if so, skip.
-                    if (sim.graph.Ancestors(pos_par)[pos_chl]) break;
+                    if (top_sim.graph.Ancestors(pos_par)[pos_chl]) break;
                 }
-                sim.AddDependency(par, chl);
+                top_sim.AddDependency(par, chl);
                 real->AddDependency(*par, *chl);
                 break;
-            } else if (sim.removed.size() < 100 && command-- == 0) {
+            } else if (top_sim.removed.size() < 100 && command-- == 0) {
                 // RemoveTransaction. Either all its ancestors or all its descendants are also
                 // removed (if any), to make sure TxGraph's reordering of removals and dependencies
                 // has no effect.
                 std::vector<TxGraph::Ref*> to_remove;
                 to_remove.push_back(pick_fn());
-                sim.IncludeAncDesc(to_remove, alt);
+                top_sim.IncludeAncDesc(to_remove, alt);
                 // The order in which these ancestors/descendants are removed should not matter;
                 // randomly shuffle them.
                 std::shuffle(to_remove.begin(), to_remove.end(), rng);
                 for (TxGraph::Ref* ptr : to_remove) {
                     real->RemoveTransaction(*ptr);
-                    sim.RemoveTransaction(ptr);
+                    top_sim.RemoveTransaction(ptr);
                 }
                 break;
-            } else if (sim.removed.size() > 0 && command-- == 0) {
+            } else if (sel_sim.removed.size() > 0 && command-- == 0) {
                 // ~Ref. Destroying a TxGraph::Ref has an observable effect on the TxGraph it
                 // refers to, so this simulation permits doing so separately from other actions on
                 // TxGraph.
 
-                // Pick a Ref of sim.removed to destroy.
-                auto removed_pos = provider.ConsumeIntegralInRange<size_t>(0, sim.removed.size() - 1);
-                if (removed_pos != sim.removed.size() - 1) {
-                    std::swap(sim.removed[removed_pos], sim.removed.back());
+                // Pick a Ref of sel_sim.removed to destroy. Note that the same Ref may still occur
+                // in the other graph, and thus not actually trigger ~Ref yet (which is exactly
+                // what we want, as destroying Refs is only allowed when it does not refer to an
+                // existing transaction in either graph).
+                auto removed_pos = provider.ConsumeIntegralInRange<size_t>(0, sel_sim.removed.size() - 1);
+                if (removed_pos != sel_sim.removed.size() - 1) {
+                    std::swap(sel_sim.removed[removed_pos], sel_sim.removed.back());
                 }
-                sim.removed.pop_back();
+                sel_sim.removed.pop_back();
                 break;
             } else if (command-- == 0) {
                 // SetTransactionFee.
@@ -318,77 +351,83 @@ FUZZ_TARGET(txgraph)
                 }
                 auto ref = pick_fn();
                 real->SetTransactionFee(*ref, fee);
-                sim.SetTransactionFee(ref, fee);
+                for (auto& sim : sims) {
+                    sim.SetTransactionFee(ref, fee);
+                }
                 break;
             } else if (command-- == 0) {
                 // GetTransactionCount.
-                assert(real->GetTransactionCount() == sim.GetTransactionCount());
+                assert(real->GetTransactionCount(use_main) == sel_sim.GetTransactionCount());
                 break;
             } else if (command-- == 0) {
                 // Exists.
                 auto ref = pick_fn();
-                bool exists = real->Exists(*ref);
-                bool should_exist = sim.Find(ref) != SimTxGraph::MISSING;
+                bool exists = real->Exists(*ref, use_main);
+                bool should_exist = sel_sim.Find(ref) != SimTxGraph::MISSING;
                 assert(exists == should_exist);
                 break;
             } else if (command-- == 0) {
                 // IsOversized.
-                assert(sim.IsOversized() == real->IsOversized());
+                assert(sel_sim.IsOversized() == real->IsOversized(use_main));
                 break;
             } else if (command-- == 0) {
                 // GetIndividualFeerate.
                 auto ref = pick_fn();
                 auto feerate = real->GetIndividualFeerate(*ref);
-                auto simpos = sim.Find(ref);
-                if (simpos == SimTxGraph::MISSING) {
-                    assert(feerate.IsEmpty());
-                } else {
-                    assert(feerate == sim.graph.FeeRate(simpos));
+                bool found{false};
+                for (auto& sim : sims) {
+                    auto simpos = sim.Find(ref);
+                    if (simpos != SimTxGraph::MISSING) {
+                        found = true;
+                        assert(feerate == sim.graph.FeeRate(simpos));
+                    }
                 }
+                if (!found) assert(feerate.IsEmpty());
                 break;
-            } else if (!sim.IsOversized() && command-- == 0) {
-                // GetChunkFeerate.
+            } else if (!main_sim.IsOversized() && command-- == 0) {
+                // GetMainChunkFeerate.
                 auto ref = pick_fn();
-                auto feerate = real->GetChunkFeerate(*ref);
-                auto simpos = sim.Find(ref);
+                auto feerate = real->GetMainChunkFeerate(*ref);
+                auto simpos = main_sim.Find(ref);
                 if (simpos == SimTxGraph::MISSING) {
                     assert(feerate.IsEmpty());
                 } else {
                     // Just do some quick checks that the reported value is in range. A full
                     // recomputation of expected chunk feerates is done at the end.
-                    assert(feerate.size >= sim.graph.FeeRate(simpos).size);
+                    assert(feerate.size >= main_sim.graph.FeeRate(simpos).size);
                 }
                 break;
-            } else if (!sim.IsOversized() && command-- == 0) {
+            } else if (!sel_sim.IsOversized() && command-- == 0) {
                 // GetAncestors/GetDescendants.
                 auto ref = pick_fn();
-                auto result = alt ? real->GetDescendants(*ref) : real->GetAncestors(*ref);
+                auto result = alt ? real->GetDescendants(*ref, use_main)
+                                  : real->GetAncestors(*ref, use_main);
                 assert(result.size() <= max_count);
-                auto result_set = sim.MakeSet(result);
+                auto result_set = sel_sim.MakeSet(result);
                 assert(result.size() == result_set.Count());
-                auto expect_set = sim.GetAncDesc(ref, alt);
+                auto expect_set = sel_sim.GetAncDesc(ref, alt);
                 assert(result_set == expect_set);
                 break;
-            } else if (!sim.IsOversized() && command-- == 0) {
+            } else if (!sel_sim.IsOversized() && command-- == 0) {
                 // GetCluster.
                 auto ref = pick_fn();
-                auto result = real->GetCluster(*ref);
+                auto result = real->GetCluster(*ref, use_main);
                 // Check cluster count limit.
                 assert(result.size() <= max_count);
                 // Require the result to be topologically valid and not contain duplicates.
-                auto left = sim.graph.Positions();
+                auto left = sel_sim.graph.Positions();
                 for (auto refptr : result) {
-                    auto simpos = sim.Find(refptr);
+                    auto simpos = sel_sim.Find(refptr);
                     assert(simpos != SimTxGraph::MISSING);
                     assert(left[simpos]);
                     left.Reset(simpos);
-                    assert(!sim.graph.Ancestors(simpos).Overlaps(left));
+                    assert(!sel_sim.graph.Ancestors(simpos).Overlaps(left));
                 }
                 // Require the set to be connected.
-                auto result_set = sim.MakeSet(result);
-                assert(sim.graph.IsConnected(result_set));
+                auto result_set = sel_sim.MakeSet(result);
+                assert(sel_sim.graph.IsConnected(result_set));
                 // If ref exists, the result must contain it. If not, it must be empty.
-                auto simpos = sim.Find(ref);
+                auto simpos = sel_sim.Find(ref);
                 if (simpos != SimTxGraph::MISSING) {
                     assert(result_set[simpos]);
                 } else {
@@ -396,9 +435,28 @@ FUZZ_TARGET(txgraph)
                 }
                 // Require the set not to have ancestors or descendants outside of it.
                 for (auto i : result_set) {
-                    assert(sim.graph.Ancestors(i).IsSubsetOf(result_set));
-                    assert(sim.graph.Descendants(i).IsSubsetOf(result_set));
+                    assert(sel_sim.graph.Ancestors(i).IsSubsetOf(result_set));
+                    assert(sel_sim.graph.Descendants(i).IsSubsetOf(result_set));
                 }
+                break;
+            } else if (command-- == 0) {
+                // HaveStaging.
+                assert((sims.size() == 2) == real->HaveStaging());
+                break;
+            } else if (sims.size() < 2 && command-- == 0) {
+                // StartStaging.
+                sims.emplace_back(sims.back());
+                real->StartStaging();
+                break;
+            } else if (sims.size() > 1 && command-- == 0) {
+                // CommitStaging.
+                real->CommitStaging();
+                sims.erase(sims.begin());
+                break;
+            } else if (sims.size() > 1 && command-- == 0) {
+                // AbortStaging.
+                real->AbortStaging();
+                sims.pop_back();
                 break;
             }
         }
@@ -407,63 +465,70 @@ FUZZ_TARGET(txgraph)
     // After running all modifications, perform an internal sanity check (before invoking
     // inspectors that may modify the internal state).
     real->SanityCheck();
+    assert(real->HaveStaging() == (sims.size() > 1));
 
-    // Compare simple properties of the graph with the simulation.
-    assert(real->IsOversized() == sim.IsOversized());
-    assert(real->GetTransactionCount() == sim.GetTransactionCount());
-
-    // If the graph (and the simulation) are not oversized, perform a full comparison.
-    if (!sim.IsOversized()) {
-        auto todo = sim.graph.Positions();
-        // Iterate over all connected components of the resulting (simulated) graph, each of which
-        // should correspond to a cluster in the real one.
-        while (todo.Any()) {
-            auto component = sim.graph.FindConnectedComponent(todo);
-            todo -= component;
-            // Iterate over the transactions in that component.
-            for (auto i : component) {
-                // Check its individual feerate against simulation.
-                assert(sim.graph.FeeRate(i) == real->GetIndividualFeerate(*sim.GetRef(i)));
-                // Check its ancestors against simulation.
-                auto expect_anc = sim.graph.Ancestors(i);
-                auto anc = sim.MakeSet(real->GetAncestors(*sim.GetRef(i)));
-                assert(anc.Count() <= max_count);
-                assert(anc == expect_anc);
-                // Check its descendants against simulation.
-                auto expect_desc = sim.graph.Descendants(i);
-                auto desc = sim.MakeSet(real->GetDescendants(*sim.GetRef(i)));
-                assert(desc.Count() <= max_count);
-                assert(desc == expect_desc);
-                // Check the cluster the transaction is part of.
-                auto cluster = real->GetCluster(*sim.GetRef(i));
-                assert(cluster.size() <= max_count);
-                assert(sim.MakeSet(cluster) == component);
-                // Check that the cluster is reported in a valid topological order (its
-                // linearization).
-                std::vector<DepGraphIndex> simlin;
-                SimTxGraph::SetType done;
-                for (TxGraph::Ref* ptr : cluster) {
-                    auto simpos = sim.Find(ptr);
-                    assert(sim.graph.Descendants(simpos).IsSubsetOf(component - done));
-                    done.Set(simpos);
-                    assert(sim.graph.Ancestors(simpos).IsSubsetOf(done));
-                    simlin.push_back(simpos);
-                }
-                // Construct a chunking object for the simulated graph, using the reported cluster
-                // linearization as ordering, and compare it against the reported chunk feerates.
-                cluster_linearize::LinearizationChunking simlinchunk(sim.graph, simlin);
-                DepGraphIndex idx{0};
-                for (unsigned chunknum = 0; chunknum < simlinchunk.NumChunksLeft(); ++chunknum) {
-                    auto chunk = simlinchunk.GetChunk(chunknum);
-                    // Require that the chunks of cluster linearizations are connected (this must
-                    // be the case as all linearizations inside are PostLinearized).
-                    assert(sim.graph.IsConnected(chunk.transactions));
-                    // Check the chunk feerates of all transactions in the cluster.
-                    while (chunk.transactions.Any()) {
-                        assert(chunk.transactions[simlin[idx]]);
-                        chunk.transactions.Reset(simlin[idx]);
-                        assert(chunk.feerate == real->GetChunkFeerate(*cluster[idx]));
-                        ++idx;
+    // Try to run a full comparison, for both main_only=false and main_only=true in TxGraph
+    // inspector functions that support both.
+    for (int main_only = 0; main_only < 2; ++main_only) {
+        auto& sim = main_only ? sims[0] : sims.back();
+        // Compare simple properties of the graph with the simulation.
+        assert(real->IsOversized(main_only) == sim.IsOversized());
+        assert(real->GetTransactionCount(main_only) == sim.GetTransactionCount());
+        // If the graph (and the simulation) are not oversized, perform a full comparison.
+        if (!sim.IsOversized()) {
+            auto todo = sim.graph.Positions();
+            // Iterate over all connected components of the resulting (simulated) graph, each of which
+            // should correspond to a cluster in the real one.
+            while (todo.Any()) {
+                auto component = sim.graph.FindConnectedComponent(todo);
+                todo -= component;
+                // Iterate over the transactions in that component.
+                for (auto i : component) {
+                    // Check its individual feerate against simulation.
+                    assert(sim.graph.FeeRate(i) == real->GetIndividualFeerate(*sim.GetRef(i)));
+                    // Check its ancestors against simulation.
+                    auto expect_anc = sim.graph.Ancestors(i);
+                    auto anc = sim.MakeSet(real->GetAncestors(*sim.GetRef(i), main_only));
+                    assert(anc.Count() <= max_count);
+                    assert(anc == expect_anc);
+                    // Check its descendants against simulation.
+                    auto expect_desc = sim.graph.Descendants(i);
+                    auto desc = sim.MakeSet(real->GetDescendants(*sim.GetRef(i), main_only));
+                    assert(desc.Count() <= max_count);
+                    assert(desc == expect_desc);
+                    // Check the cluster the transaction is part of.
+                    auto cluster = real->GetCluster(*sim.GetRef(i), main_only);
+                    assert(cluster.size() <= max_count);
+                    assert(sim.MakeSet(cluster) == component);
+                    // Check that the cluster is reported in a valid topological order (its
+                    // linearization).
+                    std::vector<DepGraphIndex> simlin;
+                    SimTxGraph::SetType done;
+                    for (TxGraph::Ref* ptr : cluster) {
+                        auto simpos = sim.Find(ptr);
+                        assert(sim.graph.Descendants(simpos).IsSubsetOf(component - done));
+                        done.Set(simpos);
+                        assert(sim.graph.Ancestors(simpos).IsSubsetOf(done));
+                        simlin.push_back(simpos);
+                    }
+                    // Construct a chunking object for the simulated graph, using the reported cluster
+                    // linearization as ordering, and compare it against the reported chunk feerates.
+                    if (sims.size() == 1 || main_only) {
+                        cluster_linearize::LinearizationChunking simlinchunk(sim.graph, simlin);
+                        DepGraphIndex idx{0};
+                        for (unsigned chunknum = 0; chunknum < simlinchunk.NumChunksLeft(); ++chunknum) {
+                            auto chunk = simlinchunk.GetChunk(chunknum);
+                            // Require that the chunks of cluster linearizations are connected (this must
+                            // be the case as all linearizations inside are PostLinearized).
+                            assert(sim.graph.IsConnected(chunk.transactions));
+                            // Check the chunk feerates of all transactions in the cluster.
+                            while (chunk.transactions.Any()) {
+                                assert(chunk.transactions[simlin[idx]]);
+                                chunk.transactions.Reset(simlin[idx]);
+                                assert(chunk.feerate == real->GetMainChunkFeerate(*cluster[idx]));
+                                ++idx;
+                            }
+                        }
                     }
                 }
             }
@@ -475,8 +540,10 @@ FUZZ_TARGET(txgraph)
 
     // Remove all remaining transactions, because Refs cannot be destroyed otherwise (this will be
     // addressed in a follow-up commit).
-    for (auto i : sim.graph.Positions()) {
-        auto ref = sim.GetRef(i);
-        real->RemoveTransaction(*ref);
+    for (auto& sim : sims) {
+        for (auto i : sim.graph.Positions()) {
+            auto ref = sim.GetRef(i);
+            real->RemoveTransaction(*ref);
+        }
     }
 }

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -363,6 +363,11 @@ FUZZ_TARGET(txgraph)
             }
         }
     }
+
+    // After running all modifications, perform an internal sanity check (before invoking
+    // inspectors that may modify the internal state).
+    real->SanityCheck();
+
     // Compare simple properties of the graph with the simulation.
     assert(real->GetTransactionCount() == sim.GetTransactionCount());
 
@@ -410,6 +415,9 @@ FUZZ_TARGET(txgraph)
             }
         }
     }
+
+    // Sanity check again (because invoking inspectors may modify internal unobservable state).
+    real->SanityCheck();
 
     // Remove all remaining transactions, because Refs cannot be destroyed otherwise (this will be
     // addressed in a follow-up commit).

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -1,0 +1,420 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <txgraph.h>
+#include <cluster_linearize.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/util/random.h>
+#include <util/bitset.h>
+#include <util/feefrac.h>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <stdint.h>
+#include <utility>
+
+using namespace cluster_linearize;
+
+namespace {
+
+/** Data type representing a naive simulated TxGraph, keeping all transactions (even from
+ *  disconnected components) in a single DepGraph. */
+struct SimTxGraph
+{
+    /** Maximum number of transactions to support simultaneously. Set this higher than txgraph's
+     *  cluster count, so we can exercise situations with more transactions than fit in one
+     *  cluster. */
+    static constexpr unsigned MAX_TRANSACTIONS = CLUSTER_COUNT_LIMIT * 2;
+    /** Set type to use in the simulation. */
+    using SetType = BitSet<MAX_TRANSACTIONS>;
+    /** Data type for representing positions within SimTxGraph::graph. */
+    using Pos = DepGraphIndex;
+    /** Constant to mean "missing in this graph". */
+    static constexpr auto MISSING = Pos(-1);
+
+    /** The dependency graph (for all transactions in the simulation, regardless of
+     *  connectivity/clustering). */
+    DepGraph<SetType> graph;
+    /** For each position in graph, which TxGraph::Ref it corresponds with (if any). */
+    std::array<std::unique_ptr<TxGraph::Ref>, MAX_TRANSACTIONS> simmap;
+    /** For each TxGraph::Ref in graph, the position it corresponds with. */
+    std::map<const TxGraph::Ref*, Pos> simrevmap;
+    /** The set of TxGraph::Ref entries that have been removed, but not yet destroyed. */
+    std::vector<std::unique_ptr<TxGraph::Ref>> removed;
+
+    /** Determine the number of (non-removed) transactions in the graph. */
+    DepGraphIndex GetTransactionCount() const { return graph.TxCount(); }
+
+    /** Get the position where ref occurs in this simulated graph, or -1 if it does not. */
+    Pos Find(const TxGraph::Ref* ref) const
+    {
+        auto it = simrevmap.find(ref);
+        if (it != simrevmap.end()) return it->second;
+        return MISSING;
+    }
+
+    /** Given a position in this simulated graph, get the corresponding TxGraph::Ref. */
+    TxGraph::Ref* GetRef(Pos pos)
+    {
+        assert(graph.Positions()[pos]);
+        assert(simmap[pos]);
+        return simmap[pos].get();
+    }
+
+    /** Add a new transaction to the simulation. */
+    TxGraph::Ref* AddTransaction(const FeePerWeight& feerate)
+    {
+        assert(graph.TxCount() < MAX_TRANSACTIONS);
+        auto simpos = graph.AddTransaction(feerate);
+        assert(graph.Positions()[simpos]);
+        simmap[simpos] = std::make_unique<TxGraph::Ref>();
+        auto ptr = simmap[simpos].get();
+        simrevmap[ptr] = simpos;
+        return ptr;
+    }
+
+    /** Add a dependency between two positions in this graph. */
+    void AddDependency(TxGraph::Ref* parent, TxGraph::Ref* child)
+    {
+        auto par_pos = Find(parent);
+        if (par_pos == MISSING) return;
+        auto chl_pos = Find(child);
+        if (chl_pos == MISSING) return;
+        graph.AddDependencies(SetType::Singleton(par_pos), chl_pos);
+    }
+
+    /** Modify the transaction fee of a ref, if it exists. */
+    void SetTransactionFee(TxGraph::Ref* ref, int64_t fee)
+    {
+        auto pos = Find(ref);
+        if (pos == MISSING) return;
+        graph.FeeRate(pos).fee = fee;
+    }
+
+    /** Remove the transaction in the specified position from the graph. */
+    void RemoveTransaction(TxGraph::Ref* ref)
+    {
+        auto pos = Find(ref);
+        if (pos == MISSING) return;
+        graph.RemoveTransactions(SetType::Singleton(pos));
+        simrevmap.erase(simmap[pos].get());
+        // Retain the TxGraph::Ref corresponding to this position, so the Ref destruction isn't
+        // invoked until the simulation explicitly decided to do so.
+        removed.push_back(std::move(simmap[pos]));
+        simmap[pos].reset();
+    }
+
+    /** Construct the set with all positions in this graph corresponding to the specified
+     *  TxGraph::Refs. All of them must occur in this graph and not be removed. */
+    SetType MakeSet(std::span<TxGraph::Ref* const> arg)
+    {
+        SetType ret;
+        for (TxGraph::Ref* ptr : arg) {
+            auto pos = Find(ptr);
+            assert(pos != Pos(-1));
+            ret.Set(pos);
+        }
+        return ret;
+    }
+
+    /** Get the set of ancestors (desc=false) or descendants (desc=true) in this graph. */
+    SetType GetAncDesc(TxGraph::Ref* arg, bool desc)
+    {
+        auto pos = Find(arg);
+        if (pos == MISSING) return {};
+        return desc ? graph.Descendants(pos) : graph.Ancestors(pos);
+    }
+
+    /** Given a set of Refs (given as a vector of pointers), expand the set to include all its
+     *  ancestors (desc=false) or all its descendants (desc=true) in this graph. */
+    void IncludeAncDesc(std::vector<TxGraph::Ref*>& arg, bool desc)
+    {
+        std::vector<TxGraph::Ref*> ret;
+        for (auto ptr : arg) {
+            auto simpos = Find(ptr);
+            if (simpos != MISSING) {
+                for (auto i : desc ? graph.Descendants(simpos) : graph.Ancestors(simpos)) {
+                    ret.push_back(simmap[i].get());
+                }
+            } else {
+                ret.push_back(ptr);
+            }
+        }
+        // Deduplicate.
+        std::sort(ret.begin(), ret.end());
+        ret.erase(std::unique(ret.begin(), ret.end()), ret.end());
+        // Replace input.
+        arg = std::move(ret);
+    }
+};
+
+} // namespace
+
+FUZZ_TARGET(txgraph)
+{
+    // This is a big simulation test for TxGraph, which performs a fuzz-derived sequence of valid
+    // operations on a TxGraph instance, as well as on a simpler (mostly) reimplementation (see
+    // SimTxGraph above), comparing the outcome of functions that return a result, and finally
+    // performing a full comparison between the two.
+
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider provider(buffer.data(), buffer.size());
+
+    /** Internal test RNG, used only for decisions which would require significant amount of data
+     *  to be read from the provider, without realistically impacting test sensitivity. */
+    InsecureRandomContext rng(0xdecade2009added + buffer.size());
+
+    /** Variable used whenever an empty TxGraph::Ref is needed. */
+    TxGraph::Ref empty_ref;
+
+    // Construct a real and a simulated graph.
+    auto real = MakeTxGraph();
+    SimTxGraph sim;
+
+    /** Function to pick any Ref (from sim.simmap or sim.removed, or the empty Ref). */
+    auto pick_fn = [&]() noexcept -> TxGraph::Ref* {
+        auto tx_count = sim.GetTransactionCount();
+        /** The number of possible choices. */
+        size_t choices = tx_count + sim.removed.size() + 1;
+        /** Pick one of them. */
+        auto choice = provider.ConsumeIntegralInRange<size_t>(0, choices - 1);
+        if (choice < tx_count) {
+            // Return from real.
+            for (auto i : sim.graph.Positions()) {
+                if (choice == 0) return sim.GetRef(i);
+                --choice;
+            }
+            assert(false);
+        } else {
+            choice -= tx_count;
+        }
+        if (choice < sim.removed.size()) {
+            // Return from removed.
+            return sim.removed[choice].get();
+        } else {
+            choice -= sim.removed.size();
+        }
+        // Return empty.
+        assert(choice == 0);
+        return &empty_ref;
+    };
+
+    LIMITED_WHILE(provider.remaining_bytes() > 0, 200) {
+        // Read a one-byte command.
+        int command = provider.ConsumeIntegral<uint8_t>();
+        // Treat it lowest bit as a flag (which selects a variant of some of the operations), and
+        // leave the rest of the bits in command.
+        bool alt = command & 1;
+        command >>= 1;
+
+        // Keep decrementing command for each applicable operation, until one is hit. Multiple
+        // iterations may be necessary.
+        while (true) {
+            if (sim.GetTransactionCount() < SimTxGraph::MAX_TRANSACTIONS && command-- == 0) {
+                // AddTransaction.
+                int64_t fee;
+                int32_t size;
+                if (alt) {
+                    // If alt is true, pick fee and size from the entire range.
+                    fee = provider.ConsumeIntegralInRange<int64_t>(-0x8000000000000, 0x7ffffffffffff);
+                    size = provider.ConsumeIntegralInRange<int32_t>(1, 0x3fffff);
+                } else {
+                    // Otherwise, use smaller range which consume fewer fuzz input bytes, as just
+                    // these are likely sufficient to trigger all interesting code paths already.
+                    fee = provider.ConsumeIntegral<uint8_t>();
+                    size = provider.ConsumeIntegral<uint8_t>() + 1;
+                }
+                FeePerWeight feerate{fee, size};
+                // Create a real TxGraph::Ref.
+                auto ref = real->AddTransaction(feerate);
+                // Create a unique_ptr place in the simulation to put the Ref in.
+                auto ref_loc = sim.AddTransaction(feerate);
+                // Move it in place.
+                *ref_loc = std::move(ref);
+                break;
+            } else if (sim.GetTransactionCount() + sim.removed.size() > 1 && command-- == 0) {
+                // AddDependency.
+                auto par = pick_fn();
+                auto chl = pick_fn();
+                auto pos_par = sim.Find(par);
+                auto pos_chl = sim.Find(chl);
+                if (pos_par != SimTxGraph::MISSING && pos_chl != SimTxGraph::MISSING) {
+                    // Determine if adding this would introduce a cycle (not allowed by TxGraph),
+                    // and if so, skip.
+                    if (sim.graph.Ancestors(pos_par)[pos_chl]) break;
+                    // Determine if adding this would violate CLUSTER_COUNT_LIMIT, and if so, skip.
+                    auto temp_depgraph = sim.graph;
+                    temp_depgraph.AddDependencies(SimTxGraph::SetType::Singleton(pos_par), pos_chl);
+                    auto todo = temp_depgraph.Positions();
+                    bool oversize{false};
+                    while (todo.Any()) {
+                        auto component = temp_depgraph.FindConnectedComponent(todo);
+                        if (component.Count() > CLUSTER_COUNT_LIMIT) oversize = true;
+                        todo -= component;
+                    }
+                    if (oversize) break;
+                }
+                sim.AddDependency(par, chl);
+                real->AddDependency(*par, *chl);
+                break;
+            } else if (sim.removed.size() < 100 && command-- == 0) {
+                // RemoveTransaction. Either all its ancestors or all its descendants are also
+                // removed (if any), to make sure TxGraph's reordering of removals and dependencies
+                // has no effect.
+                std::vector<TxGraph::Ref*> to_remove;
+                to_remove.push_back(pick_fn());
+                sim.IncludeAncDesc(to_remove, alt);
+                // The order in which these ancestors/descendants are removed should not matter;
+                // randomly shuffle them.
+                std::shuffle(to_remove.begin(), to_remove.end(), rng);
+                for (TxGraph::Ref* ptr : to_remove) {
+                    real->RemoveTransaction(*ptr);
+                    sim.RemoveTransaction(ptr);
+                }
+                break;
+            } else if (sim.removed.size() > 0 && command-- == 0) {
+                // ~Ref. Destroying a TxGraph::Ref has an observable effect on the TxGraph it
+                // refers to, so this simulation permits doing so separately from other actions on
+                // TxGraph.
+
+                // Pick a Ref of sim.removed to destroy.
+                auto removed_pos = provider.ConsumeIntegralInRange<size_t>(0, sim.removed.size() - 1);
+                if (removed_pos != sim.removed.size() - 1) {
+                    std::swap(sim.removed[removed_pos], sim.removed.back());
+                }
+                sim.removed.pop_back();
+                break;
+            } else if (command-- == 0) {
+                // SetTransactionFee.
+                int64_t fee;
+                if (alt) {
+                    fee = provider.ConsumeIntegralInRange<int64_t>(-0x8000000000000, 0x7ffffffffffff);
+                } else {
+                    fee = provider.ConsumeIntegral<uint8_t>();
+                }
+                auto ref = pick_fn();
+                real->SetTransactionFee(*ref, fee);
+                sim.SetTransactionFee(ref, fee);
+                break;
+            } else if (command-- == 0) {
+                // GetTransactionCount.
+                assert(real->GetTransactionCount() == sim.GetTransactionCount());
+                break;
+            } else if (command-- == 0) {
+                // Exists.
+                auto ref = pick_fn();
+                bool exists = real->Exists(*ref);
+                bool should_exist = sim.Find(ref) != SimTxGraph::MISSING;
+                assert(exists == should_exist);
+                break;
+            } else if (command-- == 0) {
+                // GetIndividualFeerate.
+                auto ref = pick_fn();
+                auto feerate = real->GetIndividualFeerate(*ref);
+                auto simpos = sim.Find(ref);
+                if (simpos == SimTxGraph::MISSING) {
+                    assert(feerate.IsEmpty());
+                } else {
+                    assert(feerate == sim.graph.FeeRate(simpos));
+                }
+                break;
+            } else if (command-- == 0) {
+                // GetAncestors/GetDescendants.
+                auto ref = pick_fn();
+                auto result_set = sim.MakeSet(alt ? real->GetDescendants(*ref) :
+                                                    real->GetAncestors(*ref));
+                auto expect_set = sim.GetAncDesc(ref, alt);
+                assert(result_set == expect_set);
+                break;
+            } else if (command-- == 0) {
+                // GetCluster.
+                auto ref = pick_fn();
+                auto result = real->GetCluster(*ref);
+                // Check cluster count limit.
+                assert(result.size() <= CLUSTER_COUNT_LIMIT);
+                // Require the result to be topologically valid and not contain duplicates.
+                auto left = sim.graph.Positions();
+                for (auto refptr : result) {
+                    auto simpos = sim.Find(refptr);
+                    assert(simpos != SimTxGraph::MISSING);
+                    assert(left[simpos]);
+                    left.Reset(simpos);
+                    assert(!sim.graph.Ancestors(simpos).Overlaps(left));
+                }
+                // Require the set to be connected.
+                auto result_set = sim.MakeSet(result);
+                assert(sim.graph.IsConnected(result_set));
+                // If ref exists, the result must contain it. If not, it must be empty.
+                auto simpos = sim.Find(ref);
+                if (simpos != SimTxGraph::MISSING) {
+                    assert(result_set[simpos]);
+                } else {
+                    assert(result_set.None());
+                }
+                // Require the set not to have ancestors or descendants outside of it.
+                for (auto i : result_set) {
+                    assert(sim.graph.Ancestors(i).IsSubsetOf(result_set));
+                    assert(sim.graph.Descendants(i).IsSubsetOf(result_set));
+                }
+                break;
+            }
+        }
+    }
+    // Compare simple properties of the graph with the simulation.
+    assert(real->GetTransactionCount() == sim.GetTransactionCount());
+
+    // Perform a full comparison.
+    auto todo = sim.graph.Positions();
+    // Iterate over all connected components of the resulting (simulated) graph, each of which
+    // should correspond to a cluster in the real one.
+    while (todo.Any()) {
+        auto component = sim.graph.FindConnectedComponent(todo);
+        todo -= component;
+        // Iterate over the transactions in that component.
+        for (auto i : component) {
+            // Check its individual feerate against simulation.
+            assert(sim.graph.FeeRate(i) == real->GetIndividualFeerate(*sim.GetRef(i)));
+            // Check its ancestors against simulation.
+            auto expect_anc = sim.graph.Ancestors(i);
+            auto anc = sim.MakeSet(real->GetAncestors(*sim.GetRef(i)));
+            assert(anc == expect_anc);
+            // Check its descendants against simulation.
+            auto expect_desc = sim.graph.Descendants(i);
+            auto desc = sim.MakeSet(real->GetDescendants(*sim.GetRef(i)));
+            assert(desc == expect_desc);
+            // Check the cluster the transaction is part of.
+            auto cluster = real->GetCluster(*sim.GetRef(i));
+            assert(sim.MakeSet(cluster) == component);
+            // Check that the cluster is reported in a valid topological order (its
+            // linearization).
+            std::vector<DepGraphIndex> simlin;
+            SimTxGraph::SetType done;
+            for (TxGraph::Ref* ptr : cluster) {
+                auto simpos = sim.Find(ptr);
+                assert(sim.graph.Descendants(simpos).IsSubsetOf(component - done));
+                done.Set(simpos);
+                assert(sim.graph.Ancestors(simpos).IsSubsetOf(done));
+                simlin.push_back(simpos);
+            }
+            // Construct a chunking object for the simulated graph, using the reported cluster
+            // linearization as ordering.
+            cluster_linearize::LinearizationChunking simlinchunk(sim.graph, simlin);
+            for (unsigned chunknum = 0; chunknum < simlinchunk.NumChunksLeft(); ++chunknum) {
+                auto chunk = simlinchunk.GetChunk(chunknum);
+                // Require that the chunks of cluster linearizations are connected (this must
+                // be the case as all linearizations inside are PostLinearized).
+                assert(sim.graph.IsConnected(chunk.transactions));
+            }
+        }
+    }
+
+    // Remove all remaining transactions, because Refs cannot be destroyed otherwise (this will be
+    // addressed in a follow-up commit).
+    for (auto i : sim.graph.Positions()) {
+        auto ref = sim.GetRef(i);
+        real->RemoveTransaction(*ref);
+    }
+}

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -587,4 +587,10 @@ FUZZ_TARGET(txgraph)
 
     // Sanity check again (because invoking inspectors may modify internal unobservable state).
     real->SanityCheck();
+
+    // Kill the TxGraph object.
+    real.reset();
+    // Kill the simulated graphs, with all remaining Refs in it. If any, this verifies that Refs
+    // can outlive the TxGraph that created them.
+    sims.clear();
 }

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -122,10 +122,10 @@ struct DepGraphFormatter
     static void Ser(Stream& s, const DepGraph<SetType>& depgraph)
     {
         /** Construct a topological order to serialize the transactions in. */
-        std::vector<ClusterIndex> topo_order;
+        std::vector<DepGraphIndex> topo_order;
         topo_order.reserve(depgraph.TxCount());
         for (auto i : depgraph.Positions()) topo_order.push_back(i);
-        std::sort(topo_order.begin(), topo_order.end(), [&](ClusterIndex a, ClusterIndex b) {
+        std::sort(topo_order.begin(), topo_order.end(), [&](DepGraphIndex a, DepGraphIndex b) {
             auto anc_a = depgraph.Ancestors(a).Count(), anc_b = depgraph.Ancestors(b).Count();
             if (anc_a != anc_b) return anc_a < anc_b;
             return a < b;
@@ -136,9 +136,9 @@ struct DepGraphFormatter
         SetType done;
 
         // Loop over the transactions in topological order.
-        for (ClusterIndex topo_idx = 0; topo_idx < topo_order.size(); ++topo_idx) {
+        for (DepGraphIndex topo_idx = 0; topo_idx < topo_order.size(); ++topo_idx) {
             /** Which depgraph index we are currently writing. */
-            ClusterIndex idx = topo_order[topo_idx];
+            DepGraphIndex idx = topo_order[topo_idx];
             // Write size, which must be larger than 0.
             s << VARINT_MODE(depgraph.FeeRate(idx).size, VarIntMode::NONNEGATIVE_SIGNED);
             // Write fee, encoded as an unsigned varint (odd=negative, even=non-negative).
@@ -146,9 +146,9 @@ struct DepGraphFormatter
             // Write dependency information.
             SetType written_parents;
             uint64_t diff = 0; //!< How many potential parent/child relations we have skipped over.
-            for (ClusterIndex dep_dist = 0; dep_dist < topo_idx; ++dep_dist) {
+            for (DepGraphIndex dep_dist = 0; dep_dist < topo_idx; ++dep_dist) {
                 /** Which depgraph index we are currently considering as parent of idx. */
-                ClusterIndex dep_idx = topo_order[topo_idx - 1 - dep_dist];
+                DepGraphIndex dep_idx = topo_order[topo_idx - 1 - dep_dist];
                 // Ignore transactions which are already known to be ancestors.
                 if (depgraph.Descendants(dep_idx).Overlaps(written_parents)) continue;
                 if (depgraph.Ancestors(idx)[dep_idx]) {
@@ -191,9 +191,9 @@ struct DepGraphFormatter
         DepGraph<SetType> topo_depgraph;
         /** Mapping from serialization order to cluster order, used later to reconstruct the
          *  cluster order. */
-        std::vector<ClusterIndex> reordering;
+        std::vector<DepGraphIndex> reordering;
         /** How big the entries vector in the reconstructed depgraph will be (including holes). */
-        ClusterIndex total_size{0};
+        DepGraphIndex total_size{0};
 
         // Read transactions in topological order.
         while (true) {
@@ -217,9 +217,9 @@ struct DepGraphFormatter
                 // Read dependency information.
                 auto topo_idx = reordering.size();
                 s >> VARINT(diff);
-                for (ClusterIndex dep_dist = 0; dep_dist < topo_idx; ++dep_dist) {
+                for (DepGraphIndex dep_dist = 0; dep_dist < topo_idx; ++dep_dist) {
                     /** Which topo_depgraph index we are currently considering as parent of topo_idx. */
-                    ClusterIndex dep_topo_idx = topo_idx - 1 - dep_dist;
+                    DepGraphIndex dep_topo_idx = topo_idx - 1 - dep_dist;
                     // Ignore transactions which are already known ancestors of topo_idx.
                     if (new_ancestors[dep_topo_idx]) continue;
                     if (diff == 0) {
@@ -286,9 +286,9 @@ template<typename SetType>
 void SanityCheck(const DepGraph<SetType>& depgraph)
 {
     // Verify Positions and PositionRange consistency.
-    ClusterIndex num_positions{0};
-    ClusterIndex position_range{0};
-    for (ClusterIndex i : depgraph.Positions()) {
+    DepGraphIndex num_positions{0};
+    DepGraphIndex position_range{0};
+    for (DepGraphIndex i : depgraph.Positions()) {
         ++num_positions;
         position_range = i + 1;
     }
@@ -297,7 +297,7 @@ void SanityCheck(const DepGraph<SetType>& depgraph)
     assert(position_range >= num_positions);
     assert(position_range <= SetType::Size());
     // Consistency check between ancestors internally.
-    for (ClusterIndex i : depgraph.Positions()) {
+    for (DepGraphIndex i : depgraph.Positions()) {
         // Transactions include themselves as ancestors.
         assert(depgraph.Ancestors(i)[i]);
         // If a is an ancestor of b, then b's ancestors must include all of a's ancestors.
@@ -306,8 +306,8 @@ void SanityCheck(const DepGraph<SetType>& depgraph)
         }
     }
     // Consistency check between ancestors and descendants.
-    for (ClusterIndex i : depgraph.Positions()) {
-        for (ClusterIndex j : depgraph.Positions()) {
+    for (DepGraphIndex i : depgraph.Positions()) {
+        for (DepGraphIndex j : depgraph.Positions()) {
             assert(depgraph.Ancestors(i)[j] == depgraph.Descendants(j)[i]);
         }
         // No transaction is a parent or child of itself.
@@ -348,7 +348,7 @@ void SanityCheck(const DepGraph<SetType>& depgraph)
         // In acyclic graphs, the union of parents with parents of parents etc. yields the
         // full ancestor set (and similar for children and descendants).
         std::vector<SetType> parents(depgraph.PositionRange()), children(depgraph.PositionRange());
-        for (ClusterIndex i : depgraph.Positions()) {
+        for (DepGraphIndex i : depgraph.Positions()) {
             parents[i] = depgraph.GetReducedParents(i);
             children[i] = depgraph.GetReducedChildren(i);
         }
@@ -380,7 +380,7 @@ void SanityCheck(const DepGraph<SetType>& depgraph)
 
 /** Perform a sanity check on a linearization. */
 template<typename SetType>
-void SanityCheck(const DepGraph<SetType>& depgraph, std::span<const ClusterIndex> linearization)
+void SanityCheck(const DepGraph<SetType>& depgraph, std::span<const DepGraphIndex> linearization)
 {
     // Check completeness.
     assert(linearization.size() == depgraph.TxCount());

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -23,18 +23,6 @@ using namespace cluster_linearize;
 
 using TestBitSet = BitSet<32>;
 
-/** Check if a graph is acyclic. */
-template<typename SetType>
-bool IsAcyclic(const DepGraph<SetType>& depgraph) noexcept
-{
-    for (ClusterIndex i : depgraph.Positions()) {
-        if ((depgraph.Ancestors(i) & depgraph.Descendants(i)) != SetType::Singleton(i)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 /** A formatter for a bespoke serialization for acyclic DepGraph objects.
  *
  * The serialization format outputs information about transactions in a topological order (parents
@@ -337,7 +325,7 @@ void SanityCheck(const DepGraph<SetType>& depgraph)
             assert((depgraph.Descendants(child) & children).IsSubsetOf(SetType::Singleton(child)));
         }
     }
-    if (IsAcyclic(depgraph)) {
+    if (depgraph.IsAcyclic()) {
         // If DepGraph is acyclic, serialize + deserialize must roundtrip.
         std::vector<unsigned char> ser;
         VectorWriter writer(ser, 0);

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -1,0 +1,1138 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <txgraph.h>
+
+#include <cluster_linearize.h>
+#include <random.h>
+#include <util/bitset.h>
+#include <util/check.h>
+#include <util/feefrac.h>
+
+#include <compare>
+#include <memory>
+#include <span>
+#include <utility>
+
+namespace {
+
+using namespace cluster_linearize;
+
+// Forward declare the TxGraph implementation class.
+class TxGraphImpl;
+
+/** Position of a DepGraphIndex within a Cluster::m_linearization. */
+using LinearizationIndex = uint32_t;
+/** Position of a Cluster within Graph::m_clusters. */
+using ClusterSetIndex = uint32_t;
+
+/** Quality levels for cached cluster linearizations. */
+enum class QualityLevel
+{
+    /** This cluster may have multiple disconnected components, which are all NEEDS_RELINEARIZE. */
+    NEEDS_SPLIT,
+    /** This cluster has undergone changes that warrant re-linearization. */
+    NEEDS_RELINEARIZE,
+    /** The minimal level of linearization has been performed, but it is not known to be optimal. */
+    ACCEPTABLE,
+    /** The linearization is known to be optimal. */
+    OPTIMAL,
+    /** This cluster is not registered in any m_clusters.
+     *  This must be the last entry in QualityLevel as m_clusters is sized using it. */
+    NONE,
+};
+
+/** A grouping of connected transactions inside a TxGraphImpl. */
+class Cluster
+{
+    friend class TxGraphImpl;
+    using GraphIndex = TxGraph::GraphIndex;
+    using SetType = BitSet<CLUSTER_COUNT_LIMIT>;
+    /** The DepGraph for this cluster, holding all feerates, and ancestors/descendants. */
+    DepGraph<SetType> m_depgraph;
+    /** m_mapping[i] gives the GraphIndex for the position i transaction in m_depgraph. Values for
+     *  positions i that do not exist in m_depgraph shouldn't ever be accessed and thus don't
+     *  matter. m_mapping.size() equals m_depgraph.PositionRange(). */
+    std::vector<GraphIndex> m_mapping;
+    /** The current linearization of the cluster. m_linearization.size() equals
+     *  m_depgraph.TxCount(). This is always kept topological. */
+    std::vector<DepGraphIndex> m_linearization;
+    /** The quality level of m_linearization. */
+    QualityLevel m_quality{QualityLevel::NONE};
+    /** Which position this Cluster has in Graph::m_clusters[m_quality]. */
+    ClusterSetIndex m_setindex{ClusterSetIndex(-1)};
+
+public:
+    /** Construct an empty Cluster. */
+    Cluster() noexcept = default;
+    /** Construct a singleton Cluster. */
+    explicit Cluster(TxGraphImpl& graph, const FeePerWeight& feerate, GraphIndex graph_index) noexcept;
+
+    // Cannot move or copy (would invalidate Cluster* in Locator and TxGraphImpl). */
+    Cluster(const Cluster&) = delete;
+    Cluster& operator=(const Cluster&) = delete;
+    Cluster(Cluster&&) = delete;
+    Cluster& operator=(Cluster&&) = delete;
+
+    // Generic helper functions.
+
+    /** Whether the linearization of this Cluster can be exposed. */
+    bool IsAcceptable() const noexcept
+    {
+        return m_quality == QualityLevel::ACCEPTABLE || m_quality == QualityLevel::OPTIMAL;
+    }
+    /** Whether the linearization of this Cluster is optimal. */
+    bool IsOptimal() const noexcept
+    {
+        return m_quality == QualityLevel::OPTIMAL;
+    }
+    /** Whether this cluster requires splitting. */
+    bool NeedsSplitting() const noexcept
+    {
+        return m_quality == QualityLevel::NEEDS_SPLIT;
+    }
+    /** Get the number of transactions in this Cluster. */
+    LinearizationIndex GetTxCount() const noexcept { return m_linearization.size(); }
+    /** Only called by Graph::SwapIndexes. */
+    void UpdateMapping(DepGraphIndex cluster_idx, GraphIndex graph_idx) noexcept { m_mapping[cluster_idx] = graph_idx; }
+    /** Push changes to Cluster and its linearization to the TxGraphImpl Entry objects. */
+    void Updated(TxGraphImpl& graph) noexcept;
+
+    // Functions that implement the Cluster-specific side of internal TxGraphImpl mutations.
+
+    /** Apply all removals from the front of to_remove that apply to this Cluster, popping them
+     *  off. These must be at least one such entry. */
+    void ApplyRemovals(TxGraphImpl& graph, std::span<GraphIndex>& to_remove) noexcept;
+    /** Split this cluster (must have a NEEDS_SPLIT* quality). Returns whether to delete this
+     *  Cluster afterwards. */
+    [[nodiscard]] bool Split(TxGraphImpl& graph) noexcept;
+    /** Move all transactions from cluster to *this (as separate components). */
+    void Merge(TxGraphImpl& graph, Cluster& cluster) noexcept;
+    /** Given a span of (parent, child) pairs that all belong to this Cluster, apply them. */
+    void ApplyDependencies(TxGraphImpl& graph, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept;
+    /** Improve the linearization of this Cluster. */
+    void Relinearize(TxGraphImpl& graph, uint64_t max_iters) noexcept;
+
+    // Functions that implement the Cluster-specific side of public TxGraph functions.
+
+    /** Get a vector of Refs for the ancestors of a given Cluster element. */
+    std::vector<TxGraph::Ref*> GetAncestorRefs(const TxGraphImpl& graph, DepGraphIndex idx) noexcept;
+    /** Get a vector of Refs for the descendants of a given Cluster element. */
+    std::vector<TxGraph::Ref*> GetDescendantRefs(const TxGraphImpl& graph, DepGraphIndex idx) noexcept;
+    /** Get a vector of Refs for all elements of this Cluster, in linearization order. */
+    std::vector<TxGraph::Ref*> GetClusterRefs(const TxGraphImpl& graph) noexcept;
+    /** Get the individual transaction feerate of a Cluster element. */
+    FeePerWeight GetIndividualFeerate(DepGraphIndex idx) noexcept;
+    /** Modify the fee of a Cluster element. */
+    void SetFee(TxGraphImpl& graph, DepGraphIndex idx, int64_t fee) noexcept;
+};
+
+/** The transaction graph.
+ *
+ * The overall design of the data structure consists of 3 interlinked representations:
+ * - The transactions (held as a vector of TxGraphImpl::Entry inside TxGraphImpl).
+ * - The clusters (Cluster objects in per-quality vectors inside TxGraphImpl).
+ * - The Refs (TxGraph::Ref objects, held externally by users of the TxGraph class)
+ *
+ * Clusters and Refs contain the index of the Entry objects they refer to, and the Entry objects
+ * refer back to the Clusters and Refs the corresponding transaction is contained in.
+ *
+ * While redundant, this permits moving all of them independently, without invalidating things
+ * or costly iteration to fix up everything:
+ * - Entry objects can be moved to fill holes left by removed transactions in the Entry vector
+ *   (see TxGraphImpl::Compact).
+ * - Clusters can be rewritten continuously (removals can cause them to split, new dependencies
+ *   can cause them to be merged).
+ * - Ref objects can be held outside the class, while permitting them to be moved around, and
+ *   inherited from.
+ */
+class TxGraphImpl final : public TxGraph
+{
+    friend class Cluster;
+private:
+    /** Internal RNG. */
+    FastRandomContext m_rng;
+
+    /** Information about one group of Clusters to be merged. */
+    struct GroupEntry
+    {
+        /** Which clusters are to be merged. */
+        std::vector<Cluster*> m_clusters;
+        /** Which dependencies are to be applied to those merged clusters, as (parent, child)
+         *  pairs. */
+        std::vector<std::pair<GraphIndex, GraphIndex>> m_deps;
+    };
+
+    /** The vectors of clusters, one vector per quality level. ClusterSetIndex indexes into each. */
+    std::array<std::vector<std::unique_ptr<Cluster>>, int(QualityLevel::NONE)> m_clusters;
+    /** Which removals have yet to be applied. */
+    std::vector<GraphIndex> m_to_remove;
+    /** Which dependencies are to be added ((parent,child) pairs). GroupData::m_deps_offset indexes
+     *  into this. */
+    std::vector<std::pair<GraphIndex, GraphIndex>> m_deps_to_add;
+    /** Information about the merges to be performed, if known. */
+    std::optional<std::vector<GroupEntry>> m_group_data = std::vector<GroupEntry>{};
+    /** Total number of transactions in this graph (sum of all transaction counts in all Clusters).
+     *  */
+    GraphIndex m_txcount{0};
+
+    /** A Locator that describes whether, where, and in which Cluster an Entry appears. */
+    struct Locator
+    {
+        /** Which Cluster the Entry appears in (nullptr = missing). */
+        Cluster* cluster{nullptr};
+        /** Where in the Cluster it appears (only if cluster != nullptr). */
+        DepGraphIndex index{0};
+
+        /** Mark this Locator as missing. */
+        void SetMissing() noexcept { cluster = nullptr; index = 0; }
+        /** Mark this Locator as present, in the specified Cluster. */
+        void SetPresent(Cluster* c, DepGraphIndex i) noexcept { cluster = c; index = i; }
+        /** Check if this Locator is present (in some Cluster). */
+        bool IsPresent() const noexcept { return cluster != nullptr; }
+    };
+
+    /** Internal information about each transaction in a TxGraphImpl. */
+    struct Entry
+    {
+        /** Pointer to the corresponding Ref object if any, or nullptr if unlinked. */
+        Ref* m_ref{nullptr};
+        /** Which Cluster and position therein this Entry appears in. */
+        Locator m_locator;
+    };
+
+    /** The set of all transactions. GraphIndex values index into this. */
+    std::vector<Entry> m_entries;
+
+    /** Set of Entries which have no linked Ref anymore. */
+    std::vector<GraphIndex> m_unlinked;
+
+public:
+    /** Construct a new TxGraphImpl. */
+    explicit TxGraphImpl() noexcept {}
+
+    // Cannot move or copy (would invalidate TxGraphImpl* in Ref, MiningOrder, EvictionOrder).
+    TxGraphImpl(const TxGraphImpl&) = delete;
+    TxGraphImpl& operator=(const TxGraphImpl&) = delete;
+    TxGraphImpl(TxGraphImpl&&) = delete;
+    TxGraphImpl& operator=(TxGraphImpl&&) = delete;
+
+    // Simple helper functions.
+
+    /** Swap the Entrys referred to by a and b. */
+    void SwapIndexes(GraphIndex a, GraphIndex b) noexcept;
+    /** Extract a Cluster. */
+    std::unique_ptr<Cluster> ExtractCluster(QualityLevel quality, ClusterSetIndex setindex) noexcept;
+    /** Delete a Cluster. */
+    void DeleteCluster(Cluster& cluster) noexcept;
+    /** Insert a Cluster. */
+    ClusterSetIndex InsertCluster(std::unique_ptr<Cluster>&& cluster, QualityLevel quality) noexcept;
+    /** Change the QualityLevel of a Cluster (identified by old_quality and old_index). */
+    void SetClusterQuality(QualityLevel old_quality, ClusterSetIndex old_index, QualityLevel new_quality) noexcept;
+
+    // Functions for handling Refs.
+
+    /** Only called by Ref's move constructor/assignment to update Ref locations. */
+    void UpdateRef(GraphIndex idx, Ref& new_location) noexcept final
+    {
+        auto& entry = m_entries[idx];
+        Assume(entry.m_ref != nullptr);
+        entry.m_ref = &new_location;
+    }
+
+    /** Only called by Ref::~Ref to unlink Refs, and Ref's move assignment. */
+    void UnlinkRef(GraphIndex idx) noexcept final
+    {
+        auto& entry = m_entries[idx];
+        Assume(entry.m_ref != nullptr);
+        entry.m_ref = nullptr;
+        m_unlinked.push_back(idx);
+        Compact();
+    }
+
+    // Functions related to various normalization/application steps.
+    /** Get rid of unlinked Entry objects in m_entries, if possible (this changes the GraphIndex
+     *  values for remaining Entrys, so this only does something when no to-be-applied operations
+     *  referring to GraphIndexes remain). */
+    void Compact() noexcept;
+    /** Apply all removals queued up in m_to_remove to the relevant Clusters (which get a
+     *  NEEDS_SPLIT* QualityLevel). */
+    void ApplyRemovals() noexcept;
+    /** Split an individual cluster. */
+    void Split(Cluster& cluster) noexcept;
+    /** Split all clusters that need splitting. */
+    void SplitAll() noexcept;
+    /** Populate m_group_data based on m_deps_to_add. */
+    void GroupClusters() noexcept;
+    /** Merge the specified clusters. */
+    void Merge(std::span<Cluster*> to_merge) noexcept;
+    /** Apply all m_deps_to_add to the relevant Clusters. */
+    void ApplyDependencies() noexcept;
+    /** Make a specified Cluster have quality ACCEPTABLE or OPTIMAL. */
+    void MakeAcceptable(Cluster& cluster) noexcept;
+
+    // Implementations for the public TxGraph interface.
+
+    Ref AddTransaction(const FeePerWeight& feerate) noexcept final;
+    void RemoveTransaction(const Ref& arg) noexcept final;
+    void AddDependency(const Ref& parent, const Ref& child) noexcept final;
+    void SetTransactionFee(const Ref&, int64_t fee) noexcept final;
+
+    bool Exists(const Ref& arg) noexcept final;
+    FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept final;
+    std::vector<Ref*> GetCluster(const Ref& arg) noexcept final;
+    std::vector<Ref*> GetAncestors(const Ref& arg) noexcept final;
+    std::vector<Ref*> GetDescendants(const Ref& arg) noexcept final;
+    GraphIndex GetTransactionCount() noexcept final;
+};
+
+void Cluster::Updated(TxGraphImpl& graph) noexcept
+{
+    // Update all the Locators for this Cluster's Entrys.
+    for (DepGraphIndex idx : m_linearization) {
+        auto& entry = graph.m_entries[m_mapping[idx]];
+        entry.m_locator.SetPresent(this, idx);
+    }
+}
+
+void Cluster::ApplyRemovals(TxGraphImpl& graph, std::span<GraphIndex>& to_remove) noexcept
+{
+    // Iterate over the prefix of to_remove that applies to this cluster.
+    Assume(!to_remove.empty());
+    SetType todo;
+    do {
+        GraphIndex idx = to_remove.front();
+        Assume(idx < graph.m_entries.size());
+        auto& entry = graph.m_entries[idx];
+        auto& locator = entry.m_locator;
+        // Stop once we hit an entry that applies to another Cluster.
+        if (locator.cluster != this) break;
+        // - Remember it in a set of to-remove DepGraphIndexes.
+        todo.Set(locator.index);
+        // - Remove from m_mapping. This isn't strictly necessary as unused positions in m_mapping
+        //   are just never accessed, but set it to -1 here to increase the ability to detect a bug
+        //   that causes it to be accessed regardless.
+        m_mapping[locator.index] = GraphIndex(-1);
+        // - Mark it as removed in the Entry's locator.
+        locator.SetMissing();
+        to_remove = to_remove.subspan(1);
+        --graph.m_txcount;
+    } while(!to_remove.empty());
+
+    Assume(todo.Any());
+    // Wipe from the Cluster's DepGraph (this is O(n) regardless of the number of entries
+    // removed, so we benefit from batching all the removals).
+    m_depgraph.RemoveTransactions(todo);
+    m_mapping.resize(m_depgraph.PositionRange());
+
+    // Filter removals out of m_linearization.
+    m_linearization.erase(std::remove_if(
+        m_linearization.begin(),
+        m_linearization.end(),
+        [&](auto pos) { return todo[pos]; }), m_linearization.end());
+
+    graph.SetClusterQuality(m_quality, m_setindex, QualityLevel::NEEDS_SPLIT);
+    Updated(graph);
+}
+
+bool Cluster::Split(TxGraphImpl& graph) noexcept
+{
+    // This function can only be called when the Cluster needs splitting.
+    Assume(NeedsSplitting());
+    /** Which positions are still left in this Cluster. */
+    auto todo = m_depgraph.Positions();
+    /** Mapping from transaction positions in this Cluster to the Cluster where it ends up, and
+     *  its position therein. */
+    std::vector<std::pair<Cluster*, DepGraphIndex>> remap(m_depgraph.PositionRange());
+    std::vector<Cluster*> new_clusters;
+    bool first{true};
+    // Iterate over the connected components of this Cluster's m_depgraph.
+    while (todo.Any()) {
+        auto component = m_depgraph.FindConnectedComponent(todo);
+        if (first && component == todo) {
+            // The existing Cluster is an entire component. Leave it be, but update its quality.
+            Assume(todo == m_depgraph.Positions());
+            graph.SetClusterQuality(m_quality, m_setindex, QualityLevel::NEEDS_RELINEARIZE);
+            // We need to recompute and cache its chunking.
+            Updated(graph);
+            return false;
+        }
+        first = false;
+        // Construct a new Cluster to hold the found component.
+        auto new_cluster = std::make_unique<Cluster>();
+        new_clusters.push_back(new_cluster.get());
+        // Remember that all the component's transactions go to this new Cluster. The positions
+        // will be determined below, so use -1 for now.
+        for (auto i : component) {
+            remap[i] = {new_cluster.get(), DepGraphIndex(-1)};
+        }
+        graph.InsertCluster(std::move(new_cluster), QualityLevel::NEEDS_RELINEARIZE);
+        todo -= component;
+    }
+    // Redistribute the transactions.
+    for (auto i : m_linearization) {
+        /** The cluster which transaction originally in position i is moved to. */
+        Cluster* new_cluster = remap[i].first;
+        // Copy the transaction to the new cluster's depgraph, and remember the position.
+        remap[i].second = new_cluster->m_depgraph.AddTransaction(m_depgraph.FeeRate(i));
+        // Create new mapping entry.
+        new_cluster->m_mapping.push_back(m_mapping[i]);
+        // Create a new linearization entry. As we're only appending transactions, they equal the
+        // DepGraphIndex.
+        new_cluster->m_linearization.push_back(remap[i].second);
+    }
+    // Redistribute the dependencies.
+    for (auto i : m_linearization) {
+        /** The cluster transaction in position i is moved to. */
+        Cluster* new_cluster = remap[i].first;
+        // Copy its parents, translating positions.
+        SetType new_parents;
+        for (auto par : m_depgraph.GetReducedParents(i)) new_parents.Set(remap[par].second);
+        new_cluster->m_depgraph.AddDependencies(new_parents, remap[i].second);
+    }
+    // Update all the Locators of moved transactions.
+    for (Cluster* new_cluster : new_clusters) {
+        new_cluster->Updated(graph);
+    }
+    // Wipe this Cluster, and return that it needs to be deleted.
+    m_depgraph = DepGraph<SetType>{};
+    m_mapping.clear();
+    m_linearization.clear();
+    return true;
+}
+
+void Cluster::Merge(TxGraphImpl& graph, Cluster& other) noexcept
+{
+    /** Vector to store the positions in this Cluster for each position in other. */
+    std::vector<DepGraphIndex> remap(other.m_depgraph.PositionRange());
+    // Iterate over all transactions in the other Cluster (the one being absorbed).
+    for (auto pos : other.m_linearization) {
+        auto idx = other.m_mapping[pos];
+        // Copy the transaction into this Cluster, and remember its position.
+        auto new_pos = m_depgraph.AddTransaction(other.m_depgraph.FeeRate(pos));
+        remap[pos] = new_pos;
+        if (new_pos == m_mapping.size()) {
+            m_mapping.push_back(idx);
+        } else {
+            m_mapping[new_pos] = idx;
+        }
+        m_linearization.push_back(new_pos);
+        // Copy the transaction's dependencies, translating them using remap. Note that since
+        // pos iterates over other.m_linearization, which is in topological order, all parents
+        // of pos should already be in remap.
+        SetType parents;
+        for (auto par : other.m_depgraph.GetReducedParents(pos)) {
+            parents.Set(remap[par]);
+        }
+        m_depgraph.AddDependencies(parents, remap[pos]);
+        // Update the transaction's Locator. There is no need to call Updated() to update chunk
+        // feerates, as Updated() will be invoked by Cluster::ApplyDependencies on the resulting
+        // merged Cluster later anyway).
+        graph.m_entries[idx].m_locator.SetPresent(this, new_pos);
+    }
+    // Purge the other Cluster, now that everything has been moved.
+    other.m_depgraph = DepGraph<SetType>{};
+    other.m_linearization.clear();
+    other.m_mapping.clear();
+}
+
+void Cluster::ApplyDependencies(TxGraphImpl& graph, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept
+{
+    // This function is invoked by TxGraphImpl::ApplyDependencies after merging groups of Clusters
+    // between which dependencies are added, which simply concatenates their linearizations. Invoke
+    // PostLinearize, which has the effect that the linearization becomes a merge-sort of the
+    // constituent linearizations. Do this here rather than in Cluster::Merge, because this
+    // function is only invoked once per merged Cluster, rather than once per constituent one.
+    // This concatenation + post-linearization could be replaced with an explicit merge-sort.
+    PostLinearize(m_depgraph, m_linearization);
+
+    // Sort the list of dependencies to apply by child, so those can be applied in batch.
+    std::sort(to_apply.begin(), to_apply.end(), [](auto& a, auto& b) { return a.second < b.second; });
+    // Iterate over groups of to-be-added dependencies with the same child.
+    auto it = to_apply.begin();
+    while (it != to_apply.end()) {
+        auto& first_child = graph.m_entries[it->second].m_locator;
+        const auto child_idx = first_child.index;
+        // Iterate over all to-be-added dependencies within that same child, gather the relevant
+        // parents.
+        SetType parents;
+        while (it != to_apply.end()) {
+            auto& child = graph.m_entries[it->second].m_locator;
+            auto& parent = graph.m_entries[it->first].m_locator;
+            Assume(child.cluster == this && parent.cluster == this);
+            if (child.index != child_idx) break;
+            parents.Set(parent.index);
+            ++it;
+        }
+        // Push all dependencies to the underlying DepGraph. Note that this is O(N) in the size of
+        // the cluster, regardless of the number of parents being added, so batching them together
+        // has a performance benefit.
+        m_depgraph.AddDependencies(parents, child_idx);
+    }
+
+    // Finally fix the linearization, as the new dependencies may have invalidated the
+    // linearization, and post-linearize it to fix up the worst problems with it.
+    FixLinearization(m_depgraph, m_linearization);
+    PostLinearize(m_depgraph, m_linearization);
+
+    // Finally push the changes to graph.m_entries.
+    Updated(graph);
+}
+
+std::unique_ptr<Cluster> TxGraphImpl::ExtractCluster(QualityLevel quality, ClusterSetIndex setindex) noexcept
+{
+    Assume(quality != QualityLevel::NONE);
+
+    auto& quality_clusters = m_clusters[int(quality)];
+    Assume(setindex < quality_clusters.size());
+
+    // Extract the Cluster-owning unique_ptr.
+    std::unique_ptr<Cluster> ret = std::move(quality_clusters[setindex]);
+    ret->m_quality = QualityLevel::NONE;
+    ret->m_setindex = ClusterSetIndex(-1);
+
+    // Clean up space in quality_cluster.
+    auto max_setindex = quality_clusters.size() - 1;
+    if (setindex != max_setindex) {
+        // If the cluster was not the last element of quality_clusters, move that to take its place.
+        quality_clusters.back()->m_setindex = setindex;
+        quality_clusters[setindex] = std::move(quality_clusters.back());
+    }
+    // The last element of quality_clusters is now unused; drop it.
+    quality_clusters.pop_back();
+
+    return ret;
+}
+
+ClusterSetIndex TxGraphImpl::InsertCluster(std::unique_ptr<Cluster>&& cluster, QualityLevel quality) noexcept
+{
+    // Cannot insert with quality level NONE (as that would mean not inserted).
+    Assume(quality != QualityLevel::NONE);
+    // The passed-in Cluster must not currently be in the TxGraphImpl.
+    Assume(cluster->m_quality == QualityLevel::NONE);
+
+    // Append it at the end of the relevant TxGraphImpl::m_cluster.
+    auto& quality_clusters = m_clusters[int(quality)];
+    ClusterSetIndex ret = quality_clusters.size();
+    cluster->m_quality = quality;
+    cluster->m_setindex = ret;
+    quality_clusters.push_back(std::move(cluster));
+    return ret;
+}
+
+void TxGraphImpl::SetClusterQuality(QualityLevel old_quality, ClusterSetIndex old_index, QualityLevel new_quality) noexcept
+{
+    Assume(new_quality != QualityLevel::NONE);
+
+    // Don't do anything if the quality did not change.
+    if (old_quality == new_quality) return;
+    // Extract the cluster from where it currently resides.
+    auto cluster_ptr = ExtractCluster(old_quality, old_index);
+    // And re-insert it where it belongs.
+    InsertCluster(std::move(cluster_ptr), new_quality);
+}
+
+void TxGraphImpl::DeleteCluster(Cluster& cluster) noexcept
+{
+    // Extract the cluster from where it currently resides.
+    auto cluster_ptr = ExtractCluster(cluster.m_quality, cluster.m_setindex);
+    // And throw it away.
+    cluster_ptr.reset();
+}
+
+void TxGraphImpl::ApplyRemovals() noexcept
+{
+    auto& to_remove = m_to_remove;
+    // Skip if there is nothing to remove.
+    if (to_remove.empty()) return;
+    // Group the set of to-be-removed entries by Cluster*.
+    std::sort(m_to_remove.begin(), m_to_remove.end(), [&](GraphIndex a, GraphIndex b) noexcept {
+        return std::less{}(m_entries[a].m_locator.cluster, m_entries[b].m_locator.cluster);
+    });
+    // Process per Cluster.
+    std::span to_remove_span{m_to_remove};
+    while (!to_remove_span.empty()) {
+        Cluster* cluster = m_entries[to_remove_span.front()].m_locator.cluster;
+        if (cluster != nullptr) {
+            // If the first to_remove_span entry's Cluster exists, hand to_remove_span to it, so it
+            // can pop off whatever applies to it.
+            cluster->ApplyRemovals(*this, to_remove_span);
+        } else {
+            // Otherwise, skip this already-removed entry. This may happen when RemoveTransaction
+            // was called twice on the same Ref.
+            to_remove_span = to_remove_span.subspan(1);
+        }
+    }
+    m_to_remove.clear();
+    Compact();
+}
+
+void TxGraphImpl::SwapIndexes(GraphIndex a, GraphIndex b) noexcept
+{
+    Assume(a < m_entries.size());
+    Assume(b < m_entries.size());
+    // Swap the Entry objects.
+    std::swap(m_entries[a], m_entries[b]);
+    // Iterate over both objects.
+    for (int i = 0; i < 2; ++i) {
+        GraphIndex idx = i ? b : a;
+        Entry& entry = m_entries[idx];
+        // Update linked Ref.
+        if (entry.m_ref) GetRefIndex(*entry.m_ref) = idx;
+        // Update the locator. The rest of the Entry information will not change, so no need to
+        // invoke Cluster::Updated().
+        Locator& locator = entry.m_locator;
+        if (locator.IsPresent()) {
+            locator.cluster->UpdateMapping(locator.index, idx);
+        }
+    }
+}
+
+void TxGraphImpl::Compact() noexcept
+{
+    // We cannot compact while any to-be-applied operations remain, as we'd need to rewrite them.
+    // It is easier to delay the compaction until they have been applied.
+    if (!m_deps_to_add.empty()) return;
+    if (!m_to_remove.empty()) return;
+
+    // Sort the GraphIndexes that need to be cleaned up. They are sorted in reverse, so the last
+    // ones get processed first. This means earlier-processed GraphIndexes will not cause moving of
+    // later-processed ones during the "swap with end of m_entries" step below (which might
+    // invalidate them).
+    std::sort(m_unlinked.begin(), m_unlinked.end(), std::greater{});
+
+    auto last = GraphIndex(-1);
+    for (GraphIndex idx : m_unlinked) {
+        // m_unlinked should never contain the same GraphIndex twice (the code below would fail
+        // if so, because GraphIndexes get invalidated by removing them).
+        Assume(idx != last);
+        last = idx;
+
+        // Make sure the entry is unlinked.
+        Entry& entry = m_entries[idx];
+        Assume(entry.m_ref == nullptr);
+        // Make sure the entry does not occur in the graph.
+        Assume(!entry.m_locator.IsPresent());
+
+        // Move the entry to the end.
+        if (idx != m_entries.size() - 1) SwapIndexes(idx, m_entries.size() - 1);
+        // Drop the entry for idx, now that it is at the end.
+        m_entries.pop_back();
+    }
+    m_unlinked.clear();
+}
+
+void TxGraphImpl::Split(Cluster& cluster) noexcept
+{
+    // To split a Cluster, first make sure all removals are applied (as we might need to split
+    // again afterwards otherwise).
+    ApplyRemovals();
+    bool del = cluster.Split(*this);
+    if (del) {
+        // Cluster::Split reports whether the Cluster is to be deleted.
+        DeleteCluster(cluster);
+    }
+}
+
+void TxGraphImpl::SplitAll() noexcept
+{
+    // Before splitting all Cluster, first make sure all removals are applied.
+    ApplyRemovals();
+    auto& queue = m_clusters[int(QualityLevel::NEEDS_SPLIT)];
+    while (!queue.empty()) {
+        Split(*queue.back().get());
+    }
+}
+
+void TxGraphImpl::GroupClusters() noexcept
+{
+    // If the groupings have been computed already, nothing is left to be done.
+    if (m_group_data.has_value()) return;
+
+    // Before computing which Clusters need to be merged together, first apply all removals and
+    // split the Clusters into connected components. If we would group first, we might end up
+    // with inefficient Clusters which just end up being split again anyway.
+    SplitAll();
+
+    /** Annotated clusters: an entry for each Cluster, together with the representative for the
+     *  partition it is in if known, or with nullptr if not yet known. */
+    std::vector<std::pair<Cluster*, Cluster*>> an_clusters;
+    /** Annotated dependencies: an entry for each m_deps_to_add entry (excluding ones that apply
+     *  to removed transactions), together with the representative root of the partition of
+     *  Clusters it applies to. */
+    std::vector<std::pair<std::pair<GraphIndex, GraphIndex>, Cluster*>> an_deps;
+
+    // Construct a an_clusters entry for every parent and child in the to-be-applied dependencies.
+    for (const auto& [par, chl] : m_deps_to_add) {
+        auto par_cluster = m_entries[par].m_locator.cluster;
+        auto chl_cluster = m_entries[chl].m_locator.cluster;
+        // Skip dependencies for which the parent or child transaction is removed.
+        if (par_cluster == nullptr || chl_cluster == nullptr) continue;
+        an_clusters.emplace_back(par_cluster, nullptr);
+        // Do not include a duplicate when parent and child are identical, as it'll be removed
+        // below anyway.
+        if (chl_cluster != par_cluster) an_clusters.emplace_back(chl_cluster, nullptr);
+    }
+    // Sort and deduplicate an_clusters, so we end up with a sorted list of all involved Clusters
+    // to which dependencies apply.
+    std::sort(an_clusters.begin(), an_clusters.end());
+    an_clusters.erase(std::unique(an_clusters.begin(), an_clusters.end()), an_clusters.end());
+
+    // Run the union-find algorithm to to find partitions of the input Clusters which need to be
+    // grouped together. See https://en.wikipedia.org/wiki/Disjoint-set_data_structure.
+    {
+        /** Each PartitionData entry contains information about a single input Cluster. */
+        struct PartitionData
+        {
+            /** The cluster this holds information for. */
+            Cluster* cluster;
+            /** All PartitionData entries belonging to the same partition are organized in a tree.
+             *  Each element points to its parent, or to itself if it is the root. The root is then
+             *  a representative for the entire tree, and can be found by walking upwards from any
+             *  element. */
+            PartitionData* parent;
+            /** (only if this is a root, so when parent == this) An upper bound on the height of
+             *  tree for this partition. */
+            unsigned rank;
+        };
+        /** Information about each input Cluster. Sorted by Cluster* pointer. */
+        std::vector<PartitionData> partition_data;
+
+        /** Given a Cluster, find its corresponding PartitionData. */
+        auto locate_fn = [&](Cluster* arg) noexcept -> PartitionData* {
+            auto it = std::lower_bound(partition_data.begin(), partition_data.end(), arg,
+                                       [](auto& a, Cluster* ptr) noexcept { return a.cluster < ptr; });
+            Assume(it != partition_data.end());
+            Assume(it->cluster == arg);
+            return &*it;
+        };
+
+        /** Given a PartitionData, find the root of the tree it is in (its representative). */
+        static constexpr auto find_root_fn = [](PartitionData* data) noexcept -> PartitionData* {
+            while (data->parent != data) {
+                // Replace pointers to parents with pointers to grandparents.
+                // See https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Finding_set_representatives.
+                auto par = data->parent;
+                data->parent = par->parent;
+                data = par;
+            }
+            return data;
+        };
+
+        /** Given two PartitionDatas, union the partitions they are in. */
+        static constexpr auto union_fn = [](PartitionData* arg1, PartitionData* arg2) noexcept {
+            // Find the roots of the trees, and bail out if they are already equal (which would
+            // mean they are in the same partition already).
+            auto rep1 = find_root_fn(arg1);
+            auto rep2 = find_root_fn(arg2);
+            if (rep1 == rep2) return;
+            // Pick the lower-rank root to become a child of the higher-rank one.
+            // See https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Union_by_rank.
+            if (rep1->rank < rep2->rank) std::swap(rep1, rep2);
+            rep2->parent = rep1;
+            rep1->rank += (rep1->rank == rep2->rank);
+        };
+
+        // Start by initializing every Cluster as its own singleton partition.
+        partition_data.resize(an_clusters.size());
+        for (size_t i = 0; i < an_clusters.size(); ++i) {
+            partition_data[i].cluster = an_clusters[i].first;
+            partition_data[i].parent = &partition_data[i];
+            partition_data[i].rank = 0;
+        }
+
+        // Run through all parent/child pairs in m_deps_to_add, and union the
+        // the partitions their Clusters are in.
+        for (const auto& [par, chl] : m_deps_to_add) {
+            auto par_cluster = m_entries[par].m_locator.cluster;
+            auto chl_cluster = m_entries[chl].m_locator.cluster;
+            // Nothing to do if parent and child are in the same Cluster.
+            if (par_cluster == chl_cluster) continue;
+            // Nothing to do if either parent or child transaction is removed already.
+            if (par_cluster == nullptr || chl_cluster == nullptr) continue;
+            Assume(par != chl);
+            union_fn(locate_fn(par_cluster), locate_fn(chl_cluster));
+        }
+
+        // Populate the an_clusters and an_deps data structures with the list of input Clusters,
+        // and the input dependencies, annotated with the representative of the Cluster partition
+        // it applies to.
+        for (size_t i = 0; i < partition_data.size(); ++i) {
+            auto& data = partition_data[i];
+            // Find the representative of the partition Cluster i is in, and store it with the
+            // Cluster.
+            auto rep = find_root_fn(&data)->cluster;
+            Assume(an_clusters[i].second == nullptr);
+            an_clusters[i].second = rep;
+        }
+        an_deps.reserve(m_deps_to_add.size());
+        for (auto [par, chl] : m_deps_to_add) {
+            auto chl_cluster = m_entries[chl].m_locator.cluster;
+            auto par_cluster = m_entries[par].m_locator.cluster;
+            // Nothing to do if either parent or child transaction is removed already.
+            if (par_cluster == nullptr || chl_cluster == nullptr) continue;
+            // Find the representative of the partition which this dependency's child is in (which
+            // should be the same as the one for the parent).
+            auto rep = find_root_fn(locate_fn(chl_cluster))->cluster;
+            // Create an_deps entry.
+            an_deps.emplace_back(std::pair{par, chl}, rep);
+        }
+    }
+
+    // Sort both an_clusters and an_deps by representative of the partition they are in, grouping
+    // all those applying to the same partition together.
+    std::sort(an_deps.begin(), an_deps.end(), [](auto& a, auto& b) noexcept { return a.second < b.second; });
+    std::sort(an_clusters.begin(), an_clusters.end(), [](auto& a, auto& b) noexcept { return a.second < b.second; });
+
+    // Translate the resulting cluster groups to the m_group_data structure.
+    m_group_data = std::vector<GroupEntry>{};
+    auto an_deps_it = an_deps.begin();
+    auto an_clusters_it = an_clusters.begin();
+    while (an_clusters_it != an_clusters.end()) {
+        // Process all clusters/dependencies belonging to the partition with representative rep.
+        auto rep = an_clusters_it->second;
+        // Create and initialize a new GroupData entry for the partition.
+        auto& new_entry = m_group_data->emplace_back();
+        // Add all its clusters to it (copying those from an_clusters to m_clusters).
+        while (an_clusters_it != an_clusters.end() && an_clusters_it->second == rep) {
+            new_entry.m_clusters.push_back(an_clusters_it->first);
+            ++an_clusters_it;
+        }
+        // Add all its dependencies to it (copying those back from an_deps to m_deps).
+        while (an_deps_it != an_deps.end() && an_deps_it->second == rep) {
+            new_entry.m_deps.push_back(an_deps_it->first);
+            ++an_deps_it;
+        }
+    }
+    Assume(an_deps_it == an_deps.end());
+    Assume(an_clusters_it == an_clusters.end());
+    Compact();
+}
+
+void TxGraphImpl::Merge(std::span<Cluster*> to_merge) noexcept
+{
+    Assume(!to_merge.empty());
+    // Nothing to do if a group consists of just a single Cluster.
+    if (to_merge.size() == 1) return;
+
+    // Move the largest Cluster to the front of to_merge. As all transactions in other to-be-merged
+    // Clusters will be moved to that one, putting the largest one first minimizes the number of
+    // moves.
+    size_t max_size_pos{0};
+    DepGraphIndex max_size = to_merge[max_size_pos]->GetTxCount();
+    for (size_t i = 1; i < to_merge.size(); ++i) {
+        DepGraphIndex size = to_merge[i]->GetTxCount();
+        if (size > max_size) {
+            max_size_pos = i;
+            max_size = size;
+        }
+    }
+    if (max_size_pos != 0) std::swap(to_merge[0], to_merge[max_size_pos]);
+
+    // Merge all further Clusters in the group into the first one, and delete them.
+    for (size_t i = 1; i < to_merge.size(); ++i) {
+        to_merge[0]->Merge(*this, *to_merge[i]);
+        DeleteCluster(*to_merge[i]);
+    }
+}
+
+void TxGraphImpl::ApplyDependencies() noexcept
+{
+    // Compute the groups of to-be-merged Clusters (which also applies all removals, and splits).
+    GroupClusters();
+    Assume(m_group_data.has_value());
+    // Nothing to do if there are no dependencies to be added.
+    if (m_deps_to_add.empty()) return;
+
+    // For each group of to-be-merged Clusters.
+    for (auto& group_data : *m_group_data) {
+        // Invoke Merge() to merge them into a single Cluster.
+        Merge(group_data.m_clusters);
+        // Actually apply all to-be-added dependencies (all parents and children from this grouping
+        // belong to the same Cluster at this point because of the merging above).
+        const auto& loc = m_entries[group_data.m_deps[0].second].m_locator;
+        Assume(loc.IsPresent());
+        loc.cluster->ApplyDependencies(*this, group_data.m_deps);
+    }
+
+    // Wipe the list of to-be-added dependencies now that they are applied.
+    m_deps_to_add.clear();
+    Compact();
+    // Also no further Cluster mergings are needed (note that we clear, but don't set to
+    // std::nullopt, as that would imply the groupings are unknown).
+    m_group_data = std::vector<GroupEntry>{};
+}
+
+void Cluster::Relinearize(TxGraphImpl& graph, uint64_t max_iters) noexcept
+{
+    // We can only relinearize Clusters that do not need splitting.
+    Assume(!NeedsSplitting());
+    // No work is required for Clusters which are already optimally linearized.
+    if (IsOptimal()) return;
+    // Invoke the actual linearization algorithm (passing in the existing one).
+    uint64_t rng_seed = graph.m_rng.rand64();
+    auto [linearization, optimal] = Linearize(m_depgraph, max_iters, rng_seed, m_linearization);
+    // Postlinearize if the result isn't optimal already. This guarantees (among other things)
+    // that the chunks of the resulting linearization are all connected.
+    if (!optimal) PostLinearize(m_depgraph, linearization);
+    // Update the linearization.
+    m_linearization = std::move(linearization);
+    // Update the Cluster's quality.
+    auto new_quality = optimal ? QualityLevel::OPTIMAL : QualityLevel::ACCEPTABLE;
+    graph.SetClusterQuality(m_quality, m_setindex, new_quality);
+    // Update the Entry objects.
+    Updated(graph);
+}
+
+void TxGraphImpl::MakeAcceptable(Cluster& cluster) noexcept
+{
+    // Relinearize the Cluster if needed.
+    if (!cluster.NeedsSplitting() && !cluster.IsAcceptable()) {
+        cluster.Relinearize(*this, 10000);
+    }
+}
+
+Cluster::Cluster(TxGraphImpl& graph, const FeePerWeight& feerate, GraphIndex graph_index) noexcept
+{
+    // Create a new transaction in the DepGraph, and remember its position in m_mapping.
+    auto cluster_idx = m_depgraph.AddTransaction(feerate);
+    m_mapping.push_back(graph_index);
+    m_linearization.push_back(cluster_idx);
+}
+
+TxGraph::Ref TxGraphImpl::AddTransaction(const FeePerWeight& feerate) noexcept
+{
+    // Construct a new Ref.
+    Ref ret;
+    // Construct a new Entry, and link it with the Ref.
+    auto idx = m_entries.size();
+    m_entries.emplace_back();
+    auto& entry = m_entries.back();
+    entry.m_ref = &ret;
+    GetRefGraph(ret) = this;
+    GetRefIndex(ret) = idx;
+    // Construct a new singleton Cluster (which is necessarily optimally linearized).
+    auto cluster = std::make_unique<Cluster>(*this, feerate, idx);
+    auto cluster_ptr = cluster.get();
+    InsertCluster(std::move(cluster), QualityLevel::OPTIMAL);
+    cluster_ptr->Updated(*this);
+    ++m_txcount;
+    // Return the Ref.
+    return ret;
+}
+
+void TxGraphImpl::RemoveTransaction(const Ref& arg) noexcept
+{
+    // Don't do anything if the Ref is empty (which may be indicative of the transaction already
+    // having been removed).
+    if (GetRefGraph(arg) == nullptr) return;
+    Assume(GetRefGraph(arg) == this);
+    // Find the Cluster the transaction is in, and stop if it isn't in any.
+    auto cluster = m_entries[GetRefIndex(arg)].m_locator.cluster;
+    if (cluster == nullptr) return;
+    // Remember that the transaction is to be removed.
+    m_to_remove.push_back(GetRefIndex(arg));
+    // Wipe m_group_data (as it will need to be recomputed).
+    m_group_data.reset();
+}
+
+void TxGraphImpl::AddDependency(const Ref& parent, const Ref& child) noexcept
+{
+    // Don't do anything if either Ref is empty (which may be indicative of it having already been
+    // removed).
+    if (GetRefGraph(parent) == nullptr || GetRefGraph(child) == nullptr) return;
+    Assume(GetRefGraph(parent) == this && GetRefGraph(child) == this);
+    // Don't do anything if this is a dependency on self.
+    if (GetRefIndex(parent) == GetRefIndex(child)) return;
+    // Find the Cluster the parent and child transaction are in, and stop if either appears to be
+    // already removed.
+    auto par_cluster = m_entries[GetRefIndex(parent)].m_locator.cluster;
+    if (par_cluster == nullptr) return;
+    auto chl_cluster = m_entries[GetRefIndex(child)].m_locator.cluster;
+    if (chl_cluster == nullptr) return;
+    // Remember that this dependency is to be applied.
+    m_deps_to_add.emplace_back(GetRefIndex(parent), GetRefIndex(child));
+    // Wipe m_group_data (as it will need to be recomputed).
+    m_group_data.reset();
+}
+
+bool TxGraphImpl::Exists(const Ref& arg) noexcept
+{
+    if (GetRefGraph(arg) == nullptr) return false;
+    Assume(GetRefGraph(arg) == this);
+    // Make sure the transaction isn't scheduled for removal.
+    ApplyRemovals();
+    return m_entries[GetRefIndex(arg)].m_locator.IsPresent();
+}
+
+std::vector<TxGraph::Ref*> Cluster::GetAncestorRefs(const TxGraphImpl& graph, DepGraphIndex idx) noexcept
+{
+    std::vector<TxGraph::Ref*> ret;
+    ret.reserve(m_depgraph.Ancestors(idx).Count());
+    // Translate all ancestors (in arbitrary order) to Refs (if they have any), and return them.
+    for (auto idx : m_depgraph.Ancestors(idx)) {
+        const auto& entry = graph.m_entries[m_mapping[idx]];
+        ret.push_back(entry.m_ref);
+    }
+    return ret;
+}
+
+std::vector<TxGraph::Ref*> Cluster::GetDescendantRefs(const TxGraphImpl& graph, DepGraphIndex idx) noexcept
+{
+    std::vector<TxGraph::Ref*> ret;
+    ret.reserve(m_depgraph.Descendants(idx).Count());
+    // Translate all descendants (in arbitrary order) to Refs (if they have any), and return them.
+    for (auto idx : m_depgraph.Descendants(idx)) {
+        const auto& entry = graph.m_entries[m_mapping[idx]];
+        ret.push_back(entry.m_ref);
+    }
+    return ret;
+}
+
+std::vector<TxGraph::Ref*> Cluster::GetClusterRefs(const TxGraphImpl& graph) noexcept
+{
+    std::vector<TxGraph::Ref*> ret;
+    ret.reserve(m_linearization.size());
+    // Translate all transactions in the Cluster (in linearization order) to Refs.
+    for (auto idx : m_linearization) {
+        const auto& entry = graph.m_entries[m_mapping[idx]];
+        ret.push_back(entry.m_ref);
+    }
+    return ret;
+}
+
+FeePerWeight Cluster::GetIndividualFeerate(DepGraphIndex idx) noexcept
+{
+    return FeePerWeight::FromFeeFrac(m_depgraph.FeeRate(idx));
+}
+
+std::vector<TxGraph::Ref*> TxGraphImpl::GetAncestors(const Ref& arg) noexcept
+{
+    // Return the empty vector if the Ref is empty.
+    if (GetRefGraph(arg) == nullptr) return {};
+    Assume(GetRefGraph(arg) == this);
+    // Apply all removals and dependencies, as the result might be incorrect otherwise.
+    ApplyDependencies();
+    // Find the Cluster the argument is in, and return the empty vector if it isn't in any.
+    auto cluster = m_entries[GetRefIndex(arg)].m_locator.cluster;
+    if (cluster == nullptr) return {};
+    // Dispatch to the Cluster.
+    return cluster->GetAncestorRefs(*this, m_entries[GetRefIndex(arg)].m_locator.index);
+}
+
+std::vector<TxGraph::Ref*> TxGraphImpl::GetDescendants(const Ref& arg) noexcept
+{
+    // Return the empty vector if the Ref is empty.
+    if (GetRefGraph(arg) == nullptr) return {};
+    Assume(GetRefGraph(arg) == this);
+    // Apply all removals and dependencies, as the result might be incorrect otherwise.
+    ApplyDependencies();
+    // Find the Cluster the argument is in, and return the empty vector if it isn't in any.
+    auto cluster = m_entries[GetRefIndex(arg)].m_locator.cluster;
+    if (cluster == nullptr) return {};
+    // Dispatch to the Cluster.
+    return cluster->GetDescendantRefs(*this, m_entries[GetRefIndex(arg)].m_locator.index);
+}
+
+std::vector<TxGraph::Ref*> TxGraphImpl::GetCluster(const Ref& arg) noexcept
+{
+    // Return the empty vector if the Ref is empty.
+    if (GetRefGraph(arg) == nullptr) return {};
+    Assume(GetRefGraph(arg) == this);
+    // Apply all removals and dependencies, as the result might be incorrect otherwise.
+    ApplyDependencies();
+    // Find the Cluster the argument is in, and return the empty vector if it isn't in any.
+    auto cluster = m_entries[GetRefIndex(arg)].m_locator.cluster;
+    if (cluster == nullptr) return {};
+    // Make sure the Cluster has an acceptable quality level, and then dispatch to it.
+    MakeAcceptable(*cluster);
+    return cluster->GetClusterRefs(*this);
+}
+
+TxGraph::GraphIndex TxGraphImpl::GetTransactionCount() noexcept
+{
+    ApplyRemovals();
+    return m_txcount;
+}
+
+FeePerWeight TxGraphImpl::GetIndividualFeerate(const Ref& arg) noexcept
+{
+    // Return the empty FeePerWeight if the passed Ref is empty.
+    if (GetRefGraph(arg) == nullptr) return {};
+    Assume(GetRefGraph(arg) == this);
+    // Apply removals, so that we can correctly report FeePerWeight{} for non-existing transaction.
+    ApplyRemovals();
+    // Find the cluster the argument is in, and return the empty FeePerWeight if it isn't in any.
+    auto cluster = m_entries[GetRefIndex(arg)].m_locator.cluster;
+    if (cluster == nullptr) return {};
+    // Dispatch to the Cluster.
+    return cluster->GetIndividualFeerate(m_entries[GetRefIndex(arg)].m_locator.index);
+}
+
+void Cluster::SetFee(TxGraphImpl& graph, DepGraphIndex idx, int64_t fee) noexcept
+{
+    // Make sure the specified DepGraphIndex exists in this Cluster.
+    Assume(m_depgraph.Positions()[idx]);
+    // Bail out if the fee isn't actually being changed.
+    if (m_depgraph.FeeRate(idx).fee == fee) return;
+    // Update the fee, remember that relinearization will be necessary, and update the Entries
+    // in the same Cluster.
+    m_depgraph.FeeRate(idx).fee = fee;
+    if (!NeedsSplitting()) {
+        graph.SetClusterQuality(m_quality, m_setindex, QualityLevel::NEEDS_RELINEARIZE);
+    }
+    Updated(graph);
+}
+
+void TxGraphImpl::SetTransactionFee(const Ref& ref, int64_t fee) noexcept
+{
+    // Don't do anything if the passed Ref is empty.
+    if (GetRefGraph(ref) == nullptr) return;
+    Assume(GetRefGraph(ref) == this);
+    // Find the entry, its locator, and inform its Cluster about the new feerate, if any.
+    auto& entry = m_entries[GetRefIndex(ref)];
+    auto& locator = entry.m_locator;
+    if (locator.IsPresent()) {
+        locator.cluster->SetFee(*this, locator.index, fee);
+    }
+}
+
+} // namespace
+
+TxGraph::Ref::~Ref()
+{
+    if (m_graph) {
+        // Inform the TxGraph about the Ref being destroyed.
+        m_graph->UnlinkRef(m_index);
+        m_graph = nullptr;
+    }
+}
+
+TxGraph::Ref& TxGraph::Ref::operator=(Ref&& other) noexcept
+{
+    // Unlink the current graph, if any.
+    if (m_graph) m_graph->UnlinkRef(m_index);
+    // Inform the other's graph about the move, if any.
+    if (other.m_graph) other.m_graph->UpdateRef(other.m_index, *this);
+    // Actually update the contents.
+    m_graph = other.m_graph;
+    m_index = other.m_index;
+    other.m_graph = nullptr;
+    other.m_index = GraphIndex(-1);
+    return *this;
+}
+
+TxGraph::Ref::Ref(Ref&& other) noexcept
+{
+    // Inform the TxGraph of other that its Ref is being moved.
+    if (other.m_graph) other.m_graph->UpdateRef(other.m_index, *this);
+    // Actually move the contents.
+    std::swap(m_graph, other.m_graph);
+    std::swap(m_index, other.m_index);
+}
+
+std::unique_ptr<TxGraph> MakeTxGraph() noexcept
+{
+    return std::make_unique<TxGraphImpl>();
+}

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -29,6 +29,12 @@ static constexpr unsigned CLUSTER_COUNT_LIMIT{64};
  *
  * For more explanation, see https://delvingbitcoin.org/t/introduction-to-cluster-linearization/1032
  *
+ * This linearization is partitioned into chunks: groups of transactions that according to this
+ * order would be mined together. Each chunk consists of the highest-feerate prefix of what remains
+ * of the linearization after removing previous chunks. TxGraph guarantees that the maintained
+ * linearization always results in chunks consisting of transactions that are connected. A chunk's
+ * transactions always belong to the same cluster.
+ *
  * The interface is designed to accommodate an implementation that only stores the transitive
  * closure of dependencies, so if B spends C, it does not distinguish between "A spending B" and
  * "A spending both B and C".
@@ -82,6 +88,9 @@ public:
     /** Get the individual transaction feerate of transaction arg. Returns the empty FeePerWeight
      *  if arg does not exist. */
     virtual FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept = 0;
+    /** Get the feerate of the chunk which transaction arg is in. Returns the empty FeePerWeight if
+     *  arg does not exist. */
+    virtual FeePerWeight GetChunkFeerate(const Ref& arg) noexcept = 0;
     /** Get pointers to all transactions in the cluster which arg is in. The transactions will be
      *  returned in graph order. Returns {} if arg does not exist in the graph. */
     virtual std::vector<Ref*> GetCluster(const Ref& arg) noexcept = 0;

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -141,6 +141,9 @@ public:
      *  graph exists, it is queried; otherwise the main graph is queried. This is available even
      *  for oversized graphs. */
     virtual GraphIndex GetTransactionCount(bool main_only = false) noexcept = 0;
+    /** Compare two transactions according to their order in the main graph. Both transactions must
+     *  be in the main graph. The main graph must not be oversized. */
+    virtual std::strong_ordering CompareMainOrder(const Ref& a, const Ref& b) noexcept = 0;
 
     /** Perform an internal consistency check on this object. */
     virtual void SanityCheck() const = 0;

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -142,6 +142,14 @@ public:
      *  queried; otherwise the main graph is queried. The queried graph must not be oversized.
      *  Returns {} if arg does not exist in the graph. */
     virtual std::vector<Ref*> GetDescendants(const Ref& arg, bool main_only = false) noexcept = 0;
+    /** Like GetAncestors, but return the Refs for all transactions in the union of the provided
+     *  arguments' ancestors (each transaction is only reported once). Refs that do not exist in
+     *  the queried graph are ignored. */
+    virtual std::vector<Ref*> GetAncestorsUnion(std::span<const Ref* const> args, bool main_only = false) noexcept = 0;
+    /** Like GetDescendants, but return the Refs for all transactions in the union of the provided
+     *  arguments' descendants (each transaction is only reported once). Refs that do not exist in
+     *  the queried graph are ignored. */
+    virtual std::vector<Ref*> GetDescendantsUnion(std::span<const Ref* const> args, bool main_only = false) noexcept = 0;
     /** Get the total number of transactions in the graph. If main_only is false and a staging
      *  graph exists, it is queried; otherwise the main graph is queried. This is available even
      *  for oversized graphs. */

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -12,8 +12,7 @@
 #ifndef BITCOIN_TXGRAPH_H
 #define BITCOIN_TXGRAPH_H
 
-/** No connected component within TxGraph is allowed to exceed this number of transactions. */
-static constexpr unsigned CLUSTER_COUNT_LIMIT{64};
+static constexpr unsigned MAX_CLUSTER_COUNT_LIMIT{64};
 
 /** Data structure to encapsulate fees, sizes, and dependencies for a set of transactions.
  *
@@ -83,24 +82,33 @@ public:
      *  removed), this has no effect. */
     virtual void SetTransactionFee(const Ref& arg, int64_t fee) noexcept = 0;
 
-    /** Determine whether arg exists in this graph (i.e., was not removed). */
+    /** Determine whether the graph is oversized (contains a connected component of more than the
+     *  configured maximum cluster count). Some of the functions below are not available
+     *  for oversized graphs. The mutators above are always available. */
+    virtual bool IsOversized() noexcept = 0;
+    /** Determine whether arg exists in this graph (i.e., was not removed). This is available even
+     *  for oversized graphs. */
     virtual bool Exists(const Ref& arg) noexcept = 0;
     /** Get the individual transaction feerate of transaction arg. Returns the empty FeePerWeight
-     *  if arg does not exist. */
+     *  if arg does not exist. This is available even for oversized graphs. */
     virtual FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept = 0;
     /** Get the feerate of the chunk which transaction arg is in. Returns the empty FeePerWeight if
-     *  arg does not exist. */
+     *  arg does not exist. The graph must not be oversized. */
     virtual FeePerWeight GetChunkFeerate(const Ref& arg) noexcept = 0;
     /** Get pointers to all transactions in the cluster which arg is in. The transactions will be
-     *  returned in graph order. Returns {} if arg does not exist in the graph. */
+     *  returned in graph order. The graph must not be oversized. Returns {} if arg does not exist
+     *  in the graph. */
     virtual std::vector<Ref*> GetCluster(const Ref& arg) noexcept = 0;
     /** Get pointers to all ancestors of the specified transaction (including the transaction
-     *  itself), in unspecified order. Returns {} if arg does not exist in the graph. */
+     *  itself), in unspecified order. The graph must not be oversized. Returns {} if arg does not
+     *  exist in the graph. */
     virtual std::vector<Ref*> GetAncestors(const Ref& arg) noexcept = 0;
     /** Get pointers to all descendants of the specified transaction (including the transaction
-     *  itself), in unspecified order. Returns {} if arg does not exist in the graph. */
+     *  itself), in unspecified order. The graph must not be oversized. Returns {} if arg does not
+     *  exist in the graph. */
     virtual std::vector<Ref*> GetDescendants(const Ref& arg) noexcept = 0;
-    /** Get the total number of transactions in the graph. */
+    /** Get the total number of transactions in the graph. This is available even for oversized
+     *  graphs. */
     virtual GraphIndex GetTransactionCount() noexcept = 0;
 
     /** Perform an internal consistency check on this object. */
@@ -145,7 +153,8 @@ public:
     };
 };
 
-/** Construct a new TxGraph. */
-std::unique_ptr<TxGraph> MakeTxGraph() noexcept;
+/** Construct a new TxGraph with the specified limit on transactions within a cluster. That
+ *  number cannot exceed MAX_CLUSTER_COUNT_LIMIT. */
+std::unique_ptr<TxGraph> MakeTxGraph(unsigned max_cluster_count) noexcept;
 
 #endif // BITCOIN_TXGRAPH_H

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -16,15 +16,18 @@ static constexpr unsigned MAX_CLUSTER_COUNT_LIMIT{64};
 
 /** Data structure to encapsulate fees, sizes, and dependencies for a set of transactions.
  *
- * The connected components within the transaction graph are called clusters: whenever one
+ * Each TxGraph represents one or two such graphs ("main", and optionally "staging"), to allow for
+ * working with batches of changes that may still be discarded.
+ *
+ * The connected components within each transaction graph are called clusters: whenever one
  * transaction is reachable from another, through any sequence of is-parent-of or is-child-of
  * relations, they belong to the same cluster (so clusters include parents, children, but also
  * grandparents, siblings, cousins twice removed, ...).
  *
- * TxGraph implicitly defines an associated total ordering on its transactions (its linearization)
- * that respects topology (parents go before their children), aiming for it to be close to the
- * optimal order those transactions should be mined in if the goal is fee maximization, though this
- * is a best effort only, not a strong guarantee.
+ * For each graph, TxGraph implicitly defines an associated total ordering on its transactions
+ * (its linearization) that respects topology (parents go before their children), aiming for it to
+ * be close to the optimal order those transactions should be mined in if the goal is fee
+ * maximization, though this is a best effort only, not a strong guarantee.
  *
  * For more explanation, see https://delvingbitcoin.org/t/introduction-to-cluster-linearization/1032
  *
@@ -56,11 +59,13 @@ public:
 
     /** Virtual destructor, so inheriting is safe. */
     virtual ~TxGraph() = default;
-    /** Construct a new transaction with the specified feerate, and return a Ref to it. In all
+    /** Construct a new transaction with the specified feerate, and return a Ref to it.
+     *  If a staging graph exists, the new transaction is only created there. In all
      *  further calls, only Refs created by AddTransaction() are allowed to be passed to this
      *  TxGraph object (or empty Ref objects). */
     [[nodiscard]] virtual Ref AddTransaction(const FeePerWeight& feerate) noexcept = 0;
-    /** Remove the specified transaction. This is a no-op if the transaction was already removed.
+    /** Remove the specified transaction. If a staging graph exists, the removal only happens
+     *  there. This is a no-op if the transaction was already removed.
      *
      * TxGraph may internally reorder transaction removals with dependency additions for
      * performance reasons. If together with any transaction removal all its descendants, or all
@@ -74,42 +79,64 @@ public:
      * original order case and the reordered case.
      */
     virtual void RemoveTransaction(const Ref& arg) noexcept = 0;
-    /** Add a dependency between two specified transactions. Parent may not be a descendant of
-     *  child already (but may be an ancestor of it already, in which case this is a no-op). If
-     *  either transaction is already removed, this is a no-op. */
+    /** Add a dependency between two specified transactions. If a staging graph exists, the
+     *  dependency is only added there. Parent may not be a descendant of child already (but may
+     *  be an ancestor of it already, in which case this is a no-op). If either transaction is
+     *  already removed, this is a no-op. */
     virtual void AddDependency(const Ref& parent, const Ref& child) noexcept = 0;
-    /** Modify the fee of the specified transaction. If the transaction does not exist (or was
-     *  removed), this has no effect. */
+    /** Modify the fee of the specified transaction, in both the main graph and the staging
+     *  graph if it exists. Wherever the transaction does not exist (or was removed), this has no
+     *  effect. */
     virtual void SetTransactionFee(const Ref& arg, int64_t fee) noexcept = 0;
 
+    /** Create a staging graph (which cannot exist already). This acts as if a full copy of
+     *  the transaction graph is made, upon which further modifications are made. This copy can
+     *  be inspected, and then either discarded, or the main graph can be replaced by it by
+     *  commiting it. */
+    virtual void StartStaging() noexcept = 0;
+    /** Discard the existing active staging graph (which must exist). */
+    virtual void AbortStaging() noexcept = 0;
+    /** Replace the main graph with the staging graph (which must exist). */
+    virtual void CommitStaging() noexcept = 0;
+    /** Check whether a staging graph exists. */
+    virtual bool HaveStaging() const noexcept = 0;
+
     /** Determine whether the graph is oversized (contains a connected component of more than the
-     *  configured maximum cluster count). Some of the functions below are not available
+     *  configured maximum cluster count). If main_only is false and a staging graph exists, it is
+     *  queried; otherwise the main graph is queried. Some of the functions below are not available
      *  for oversized graphs. The mutators above are always available. */
-    virtual bool IsOversized() noexcept = 0;
-    /** Determine whether arg exists in this graph (i.e., was not removed). This is available even
-     *  for oversized graphs. */
-    virtual bool Exists(const Ref& arg) noexcept = 0;
+    virtual bool IsOversized(bool main_only = false) noexcept = 0;
+    /** Determine whether arg exists in the graph (i.e., was not removed). If main_only is false
+     *  and a staging graph exists, it is queried; otherwise the main graph is queried. This is
+     *  available even for oversized graphs. */
+    virtual bool Exists(const Ref& arg, bool main_only = false) noexcept = 0;
     /** Get the individual transaction feerate of transaction arg. Returns the empty FeePerWeight
-     *  if arg does not exist. This is available even for oversized graphs. */
-    virtual FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept = 0;
-    /** Get the feerate of the chunk which transaction arg is in. Returns the empty FeePerWeight if
-     *  arg does not exist. The graph must not be oversized. */
-    virtual FeePerWeight GetChunkFeerate(const Ref& arg) noexcept = 0;
-    /** Get pointers to all transactions in the cluster which arg is in. The transactions will be
-     *  returned in graph order. The graph must not be oversized. Returns {} if arg does not exist
-     *  in the graph. */
-    virtual std::vector<Ref*> GetCluster(const Ref& arg) noexcept = 0;
-    /** Get pointers to all ancestors of the specified transaction (including the transaction
-     *  itself), in unspecified order. The graph must not be oversized. Returns {} if arg does not
-     *  exist in the graph. */
-    virtual std::vector<Ref*> GetAncestors(const Ref& arg) noexcept = 0;
-    /** Get pointers to all descendants of the specified transaction (including the transaction
-     *  itself), in unspecified order. The graph must not be oversized. Returns {} if arg does not
-     *  exist in the graph. */
-    virtual std::vector<Ref*> GetDescendants(const Ref& arg) noexcept = 0;
-    /** Get the total number of transactions in the graph. This is available even for oversized
+     *  if arg does not exist in either main or staging. This is available even for oversized
      *  graphs. */
-    virtual GraphIndex GetTransactionCount() noexcept = 0;
+    virtual FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept = 0;
+    /** Get the feerate of the chunk which transaction arg is in, in the main graph. Returns the
+     *  empty FeePerWeight if arg does not exist in the main graph. The main graph must not be
+     *  oversized. */
+    virtual FeePerWeight GetMainChunkFeerate(const Ref& arg) noexcept = 0;
+    /** Get pointers to all transactions in the cluster which arg is in. The transactions are
+     *  returned in graph order. If main_only is false and a staging graph exists, it is queried;
+     *  otherwise the main graph is queried. The queried graph must not be oversized. Returns {} if
+     *  arg does not exist in the queried graph. */
+    virtual std::vector<Ref*> GetCluster(const Ref& arg, bool main_only = false) noexcept = 0;
+    /** Get pointers to all ancestors of the specified transaction (including the transaction
+     *  itself), in unspecified order. If main_only is false and a staging graph exists, it is
+     *  queried; otherwise the main graph is queried. The queried graph must not be oversized.
+     *  Returns {} if arg does not exist in the graph. */
+    virtual std::vector<Ref*> GetAncestors(const Ref& arg, bool main_only = false) noexcept = 0;
+    /** Get pointers to all descendants of the specified transaction (including the transaction
+     *  itself), in unspecified order. If main_only is false and a staging graph exists, it is
+     *  queried; otherwise the main graph is queried. The queried graph must not be oversized.
+     *  Returns {} if arg does not exist in the graph. */
+    virtual std::vector<Ref*> GetDescendants(const Ref& arg, bool main_only = false) noexcept = 0;
+    /** Get the total number of transactions in the graph. If main_only is false and a staging
+     *  graph exists, it is queried; otherwise the main graph is queried. This is available even
+     *  for oversized graphs. */
+    virtual GraphIndex GetTransactionCount(bool main_only = false) noexcept = 0;
 
     /** Perform an internal consistency check on this object. */
     virtual void SanityCheck() const = 0;
@@ -141,7 +168,7 @@ public:
          *  TxGraph::AddTransaction. */
         Ref() noexcept = default;
         /** Destroy this Ref. This is only allowed when it is empty, or the transaction it refers
-         *  to has been removed from the graph. */
+         *  to does not exist in the graph (in main nor staging). */
         virtual ~Ref();
         // Support moving a Ref.
         Ref& operator=(Ref&& other) noexcept;

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -91,6 +91,11 @@ public:
      *  effect. */
     virtual void SetTransactionFee(const Ref& arg, int64_t fee) noexcept = 0;
 
+    /** TxGraph is internally lazy, and will not compute many things until they are needed.
+     *  Calling DoWork will compute everything now, so that future operations are fast. This can be
+     *  invoked while oversized. */
+    virtual void DoWork() noexcept = 0;
+
     /** Create a staging graph (which cannot exist already). This acts as if a full copy of
      *  the transaction graph is made, upon which further modifications are made. This copy can
      *  be inspected, and then either discarded, or the main graph can be replaced by it by

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -94,6 +94,9 @@ public:
     /** Get the total number of transactions in the graph. */
     virtual GraphIndex GetTransactionCount() noexcept = 0;
 
+    /** Perform an internal consistency check on this object. */
+    virtual void SanityCheck() const = 0;
+
 protected:
     // Allow TxGraph::Ref to call UpdateRef and UnlinkRef.
     friend class TxGraph::Ref;

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -1,0 +1,139 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <compare>
+#include <stdint.h>
+#include <memory>
+#include <vector>
+
+#include <util/feefrac.h>
+
+#ifndef BITCOIN_TXGRAPH_H
+#define BITCOIN_TXGRAPH_H
+
+/** No connected component within TxGraph is allowed to exceed this number of transactions. */
+static constexpr unsigned CLUSTER_COUNT_LIMIT{64};
+
+/** Data structure to encapsulate fees, sizes, and dependencies for a set of transactions.
+ *
+ * The connected components within the transaction graph are called clusters: whenever one
+ * transaction is reachable from another, through any sequence of is-parent-of or is-child-of
+ * relations, they belong to the same cluster (so clusters include parents, children, but also
+ * grandparents, siblings, cousins twice removed, ...).
+ *
+ * TxGraph implicitly defines an associated total ordering on its transactions (its linearization)
+ * that respects topology (parents go before their children), aiming for it to be close to the
+ * optimal order those transactions should be mined in if the goal is fee maximization, though this
+ * is a best effort only, not a strong guarantee.
+ *
+ * For more explanation, see https://delvingbitcoin.org/t/introduction-to-cluster-linearization/1032
+ *
+ * The interface is designed to accommodate an implementation that only stores the transitive
+ * closure of dependencies, so if B spends C, it does not distinguish between "A spending B" and
+ * "A spending both B and C".
+ */
+class TxGraph
+{
+public:
+    /** Internal identifier for a transaction within a TxGraph. */
+    using GraphIndex = uint32_t;
+
+    /** Data type used to reference transactions within a TxGraph.
+     *
+     * Every transaction within a TxGraph has exactly one corresponding TxGraph::Ref, held by users
+     * of the class. Refs can only be destroyed after the transaction is removed from the graph.
+     *
+     * Users of the class can inherit from TxGraph::Ref. If all Refs are inherited this way, the
+     * Ref* pointers returned by TxGraph functions can be cast to, and used as, this inherited type.
+     */
+    class Ref;
+
+    /** Virtual destructor, so inheriting is safe. */
+    virtual ~TxGraph() = default;
+    /** Construct a new transaction with the specified feerate, and return a Ref to it. In all
+     *  further calls, only Refs created by AddTransaction() are allowed to be passed to this
+     *  TxGraph object (or empty Ref objects). */
+    [[nodiscard]] virtual Ref AddTransaction(const FeePerWeight& feerate) noexcept = 0;
+    /** Remove the specified transaction. This is a no-op if the transaction was already removed.
+     *
+     * TxGraph may internally reorder transaction removals with dependency additions for
+     * performance reasons. If together with any transaction removal all its descendants, or all
+     * its ancestors, are removed as well (which is what always happens in realistic scenarios),
+     * this reordering will not affect the behavior of TxGraph.
+     *
+     * As an example, imagine 3 transactions A,B,C where B depends on A. If a dependency of C on B
+     * is added, and then B is deleted, C will still depend on A. If the deletion of B is reordered
+     * before the C->B dependency is added, the dependency adding has no effect. If, together with
+     * the deletion of B also either A or C is deleted, there is no distinction between the
+     * original order case and the reordered case.
+     */
+    virtual void RemoveTransaction(const Ref& arg) noexcept = 0;
+    /** Add a dependency between two specified transactions. Parent may not be a descendant of
+     *  child already (but may be an ancestor of it already, in which case this is a no-op). If
+     *  either transaction is already removed, this is a no-op. */
+    virtual void AddDependency(const Ref& parent, const Ref& child) noexcept = 0;
+    /** Modify the fee of the specified transaction. If the transaction does not exist (or was
+     *  removed), this has no effect. */
+    virtual void SetTransactionFee(const Ref& arg, int64_t fee) noexcept = 0;
+
+    /** Determine whether arg exists in this graph (i.e., was not removed). */
+    virtual bool Exists(const Ref& arg) noexcept = 0;
+    /** Get the individual transaction feerate of transaction arg. Returns the empty FeePerWeight
+     *  if arg does not exist. */
+    virtual FeePerWeight GetIndividualFeerate(const Ref& arg) noexcept = 0;
+    /** Get pointers to all transactions in the cluster which arg is in. The transactions will be
+     *  returned in graph order. Returns {} if arg does not exist in the graph. */
+    virtual std::vector<Ref*> GetCluster(const Ref& arg) noexcept = 0;
+    /** Get pointers to all ancestors of the specified transaction (including the transaction
+     *  itself), in unspecified order. Returns {} if arg does not exist in the graph. */
+    virtual std::vector<Ref*> GetAncestors(const Ref& arg) noexcept = 0;
+    /** Get pointers to all descendants of the specified transaction (including the transaction
+     *  itself), in unspecified order. Returns {} if arg does not exist in the graph. */
+    virtual std::vector<Ref*> GetDescendants(const Ref& arg) noexcept = 0;
+    /** Get the total number of transactions in the graph. */
+    virtual GraphIndex GetTransactionCount() noexcept = 0;
+
+protected:
+    // Allow TxGraph::Ref to call UpdateRef and UnlinkRef.
+    friend class TxGraph::Ref;
+    /** Inform the TxGraph implementation that a TxGraph::Ref has moved. */
+    virtual void UpdateRef(GraphIndex index, Ref& new_location) noexcept = 0;
+    /** Inform the TxGraph implementation that a TxGraph::Ref was destroyed. */
+    virtual void UnlinkRef(GraphIndex index) noexcept = 0;
+    // Allow TxGraph implementations (inheriting from it) to access Ref internals.
+    static TxGraph*& GetRefGraph(Ref& arg) noexcept { return arg.m_graph; }
+    static TxGraph* GetRefGraph(const Ref& arg) noexcept { return arg.m_graph; }
+    static GraphIndex& GetRefIndex(Ref& arg) noexcept { return arg.m_index; }
+    static GraphIndex GetRefIndex(const Ref& arg) noexcept { return arg.m_index; }
+
+public:
+    class Ref
+    {
+        // Allow TxGraph's GetRefGraph and GetRefIndex to access internals.
+        friend class TxGraph;
+        /** Which Graph the Entry lives in. nullptr if this Ref is empty. */
+        TxGraph* m_graph = nullptr;
+        /** Index into the Graph's m_entries. Only used if m_graph != nullptr. */
+        GraphIndex m_index = GraphIndex(-1);
+    public:
+        /** Construct an empty Ref. Non-empty Refs can only be created using
+         *  TxGraph::AddTransaction. */
+        Ref() noexcept = default;
+        /** Destroy this Ref. This is only allowed when it is empty, or the transaction it refers
+         *  to has been removed from the graph. */
+        virtual ~Ref();
+        // Support moving a Ref.
+        Ref& operator=(Ref&& other) noexcept;
+        Ref(Ref&& other) noexcept;
+        // Do not permit copy constructing or copy assignment. A TxGraph entry can have at most one
+        // Ref pointing to it.
+        Ref& operator=(const Ref&) = delete;
+        Ref(const Ref&) = delete;
+    };
+};
+
+/** Construct a new TxGraph. */
+std::unique_ptr<TxGraph> MakeTxGraph() noexcept;
+
+#endif // BITCOIN_TXGRAPH_H

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -63,7 +63,8 @@ public:
     /** Construct a new transaction with the specified feerate, and return a Ref to it.
      *  If a staging graph exists, the new transaction is only created there. In all
      *  further calls, only Refs created by AddTransaction() are allowed to be passed to this
-     *  TxGraph object (or empty Ref objects). */
+     *  TxGraph object (or empty Ref objects). Ref objects may outlive the TxGraph they were
+     *  created for. */
     [[nodiscard]] virtual Ref AddTransaction(const FeePerWeight& feerate) noexcept = 0;
     /** Remove the specified transaction. If a staging graph exists, the removal only happens
      *  there. This is a no-op if the transaction was already removed.

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -149,6 +149,11 @@ public:
     /** Compare two transactions according to their order in the main graph. Both transactions must
      *  be in the main graph. The main graph must not be oversized. */
     virtual std::strong_ordering CompareMainOrder(const Ref& a, const Ref& b) noexcept = 0;
+    /** Count the number of distinct clusters that the specified transactions belong to. If
+     *  main_only is false and a staging graph exists, staging clusters are counted. Otherwise,
+     *  main clusters are counted. Refs that do not exist in the queried graph are ignored. The
+     *  queried graph must not be oversized. */
+    virtual GraphIndex CountDistinctClusters(std::span<const Ref* const>, bool main_only = false) noexcept = 0;
 
     /** Perform an internal consistency check on this object. */
     virtual void SanityCheck() const = 0;

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -156,4 +156,26 @@ struct FeeFrac
  */
 std::partial_ordering CompareChunks(std::span<const FeeFrac> chunks0, std::span<const FeeFrac> chunks1);
 
+/** Tagged wrapper around FeeFrac to avoid unit confusion. */
+template<typename Tag>
+struct FeePerUnit : public FeeFrac
+{
+    // Inherit FeeFrac constructors.
+    using FeeFrac::FeeFrac;
+
+    /** Convert a FeeFrac to a FeePerUnit. */
+    static FeePerUnit FromFeeFrac(const FeeFrac& feefrac) noexcept
+    {
+        return {feefrac.fee, feefrac.size};
+    }
+};
+
+// FeePerUnit instance for satoshi / vbyte.
+struct VSizeTag {};
+using FeePerVSize = FeePerUnit<VSizeTag>;
+
+// FeePerUnit instance for satoshi / WU.
+struct WeightTag {};
+using FeePerWeight = FeePerUnit<WeightTag>;
+
 #endif // BITCOIN_UTIL_FEEFRAC_H


### PR DESCRIPTION
Part of cluster mempool: #30289.

### 1. Overview

This introduces the `TxGraph` class, which encapsulates knowledge about the (effective) fees, sizes, and dependencies between all mempool transactions, but nothing else. In particular, it lacks knowledge about `CTransaction`, inputs, outputs, txids, wtxids, prioritization, validatity, policy rules, and a lot more. Being restricted to just those aspects of the mempool makes the behavior very easy to fully specify (ignoring the actual linearizations produced), and write simulation-based tests for (which are included in this PR).

### 2. Interface

The interface can be largely categorized into:
* Mutation functions:
  * `AddTransaction` (add a new transaction with specified feerate, and get a `Ref` object back to identify it).
  * `RemoveTransaction` (given a `Ref` object, remove the transaction).
  * `AddDependency` (given two `Ref` objects, add a dependency between them).
  * `SetTransactionFee` (modify the fee associated with a Ref object).
* Inspector functions:
  * `GetAncestors` (get the ancestor set in the form of `Ref*` pointers)
  * `GetAncestorsUnion` (like above, but for the union of ancestors of multiple `Ref*` pointers)
  * `GetDescendants` (get the descendant set in the form of `Ref*` pointers)
  * `GetDescendantsUnion` (like above, but for the union of ancestors of multiple `Ref*` pointers)
  * `GetCluster` (get the connected component set in the form of `Ref*` pointers, in the order they would be mined).
  * `GetIndividualFeerate` (get the feerate of a transaction)
  * `GetChunkFeerate` (get the mining score of a transaction)
  * `CountDistinctClusters` (count the number of distinct clusters a list of `Ref`s belong to)
* Staging functions:
  * `StartStaging` (make all future mutations operate on a proposed transaction graph)
  * `CommitStaging` (apply all the changes that are staged)
  * `AbortStaging` (discard all the changes that are staged)
* Miscellaneous functions:
  * `DoWork` (do queued-up computations now, so that future operations are fast)

This `TxGraph::Ref` type used as a "handle" on transactions in the graph can be inherited from, and the idea is that in the full cluster mempool implementation (#28676, after it is rebased on this), `CTxMempoolEntry` will inherit from it, and all actually used Ref objects will be `CTxMempoolEntry`s. With that, the mempool code can just cast any `Ref*` returned by txgraph to `CTxMempoolEntry*`.

### 3. Implementation

Internally the graph data is kept in clustered form (partitioned into connected components), for which linearizations are maintained and updated as needed using the `cluster_linearize.h` algorithms under the hood, but this is hidden from the users of this class. Implementation-wise, mutations are generally applied lazily, appending to queues of to-be-removed transactions and to-be-added dependencies, so they can be batched for higher performance. Inspectors will generally only evaluate as much as is needed to answer queries, with roughly 5 levels of processing to go to fully instantiated and acceptable cluster linearizations, in order:
1. `ApplyRemovals` (take batches of to-be-removed transactions and translate them to "holes" in the corresponding Clusters/DepGraphs).
2. `SplitAll` (creating holes in Clusters may cause them to break apart into smaller connected components, so make turn them into separate Clusters/linearizations).
3. `GroupClusters` (figure out which Clusters will need to be combined in order to add requested to-be-added dependencies, as these may span clusters).
4. `ApplyDependencies` (actually merge Clusters as precomputed by `GroupClusters`, and add the dependencies between them).
5. `MakeAcceptable` (perform the LIMO linearization algorithm on Clusters to make sure their linearizations are acceptable).

### 4. Future work

This is only an initial version of TxGraph, and some functionality is missing before #28676 can be rebased on top of it:
* The ability to get comparative feerate diagrams before/after for the set of staged changes (to evaluate RBF incentive-compatibility).
* Mining interface (ability to iterate transactions quickly in mining score order) (see #31444).
* Eviction interface (reverse of mining order, plus memory usage accounting) (see #31444).
* Ability to fix oversizedness of clusters (before or after committing) - this is needed for reorgs where aborting/rejecting the change just is not an option (see #31553).
* Interface for controlling how much effort is spent on LIMO. In this PR it is hardcoded.

Then there are further improvements possible which would not block other work:
* Making Cluster a virtual class with different implementations based on transaction count (which could dramatically reduce memory usage, as most Clusters are just a single transaction, for which the current implementation is overkill).
* The ability to have background thread(s) for improving cluster linearizations.