### PR TITLE
cmake: Check `-Wno-*` compiler options for `leveldb` target

### DIFF
--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -88,9 +88,11 @@ if(MSVC)
     _CRT_NONSTDC_NO_WARNINGS
   )
 else()
-  target_compile_options(nowarn_leveldb_interface INTERFACE
-    -Wno-conditional-uninitialized
-    -Wno-suggest-override
+  try_append_cxx_flags("-Wconditional-uninitialized" TARGET nowarn_leveldb_interface SKIP_LINK
+    IF_CHECK_PASSED "-Wno-conditional-uninitialized"
+  )
+  try_append_cxx_flags("-Wsuggest-override" TARGET nowarn_leveldb_interface SKIP_LINK
+    IF_CHECK_PASSED "-Wno-suggest-override"
   )
 endif()
 


### PR DESCRIPTION
Otherwise, https://cirrus-ci.com/task/4830737755537408:
```
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-conditional-uninitialized’ may have been intended to silence earlier diagnostics
```