### PR TITLE
doc, test: more ephemeral dust follow-ups

### DIFF
--- a/src/policy/ephemeral_policy.h
+++ b/src/policy/ephemeral_policy.h
@@ -30,7 +30,7 @@ class TxValidationState;
  * TxC, spends TxA's dust
  *
  * All the dust is spent if TxA+TxB+TxC is accepted, but the mining template may just pick
- * up TxA+TxB rather than the three "legal configurations:
+ * up TxA+TxB rather than the three "legal configurations":
  * 1) None
  * 2) TxA+TxB+TxC
  * 3) TxA+TxC


### PR DESCRIPTION
This small PR contains ephemeral dust follow-ups mentioned in #30329 that were not tackled in the first follow-up PR #31279:

https://github.com/bitcoin/bitcoin/pull/30239#discussion_r1828577696
https://github.com/bitcoin/bitcoin/pull/30239#discussion_r1825279952

Happy to add more if I missed some or anyone has concrete commits to add.