### PR TITLE
ci: allow passing extra args to docker build with CI_IMAGE_BUILD_EXTRA_ARGS

### DIFF
--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -33,6 +33,7 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
       $MAYBE_CPUSET \
       --label="${CI_IMAGE_LABEL}" \
       --tag="${CONTAINER_NAME}" \
+      $CI_IMAGE_BUILD_EXTRA_ARGS \
       "${BASE_READ_ONLY_DIR}"
 
   docker volume create "${CONTAINER_NAME}_ccache" || true


### PR DESCRIPTION
By setting `CI_IMAGE_BUILD_EXTRA_ARGS`, a CI runner can influence the docker build of the CI container image. This allows to, for example, pass `--cache-to` and `--cache-from` to the build, which is useful for ephemeral, self-hosted CI runners.
