### PR TITLE
wallet: fix crash during migration due to invalid multisig descriptors

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -87,7 +87,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
         unsigned char m = vSolutions.front()[0];
         unsigned char n = vSolutions.back()[0];
         // Support up to x-of-3 multisig txns as standard
-        if (n < 1 || n > 3)
+        if (n < 1 || n > MAX_BARE_MULTISIG_PUBKEYS_NUM)
             return false;
         if (m < 1 || m > n)
             return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,8 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
+/** The maximum number of pubkeys in a bare multisig output script */
+static constexpr unsigned int MAX_BARE_MULTISIG_PUBKEYS_NUM{3};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1852,8 +1852,8 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
             return {};
         }
         if (ctx == ParseScriptContext::TOP) {
-            if (providers.size() > 3) {
-                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most 3 pubkeys", providers.size());
+            if (providers.size() > MAX_BARE_MULTISIG_PUBKEYS_NUM) {
+                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most %d pubkeys", providers.size(), MAX_BARE_MULTISIG_PUBKEYS_NUM);
                 return {};
             }
         }


### PR DESCRIPTION
Ensure legacy wallet migration skips the never standard bare multisig with +3 keys
and consensus-invalid multisig scripts. Treating them as valid causes migration to
crash because we are enforcing this rules within the descriptors parsing logic.

Testing Notes:
This can be verified by cherry-picking and running the test commit on master.
It will crash there but pass on this branch.