### PR TITLE
Update init.md

### DIFF
--- a/doc/init.md
+++ b/doc/init.md
@@ -22,7 +22,7 @@ Configuration
 
 Running bitcoind as a daemon does not require any manual configuration. You may
 set the `rpcauth` setting in the `bitcoin.conf` configuration file to override
-the default behaviour of using a special cookie for authentication.
+the default behavior of using a special cookie for authentication.
 
 This password does not have to be remembered or typed as it is mostly used
 as a fixed token that bitcoind and client programs read from the configuration


### PR DESCRIPTION
###Motivation for the patch:

The change corrects a spelling error in the documentation, where "behaviour" was mistakenly used instead of the correct American English spelling "behavior." Since Bitcoin Core's official documentation follows American English conventions, this fix ensures consistency and accuracy, making the documentation clearer and more professional for users and developers.