### PR TITLE
kernel: Flush in ChainstateManager destructor

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -396,9 +396,9 @@ void Shutdown(NodeContext& node)
     if (node.validation_signals) {
         node.validation_signals->UnregisterAllValidationInterfaces();
     }
+    node.chainman.reset();
     node.mempool.reset();
     node.fee_estimator.reset();
-    node.chainman.reset();
     node.validation_signals.reset();
     node.scheduler.reset();
     node.ecc_context.reset();
@@ -1277,8 +1277,8 @@ static ChainstateLoadResult InitAndLoadChainstate(
 {
     // This function may be called twice, so any dirty state must be reset.
     node.notifications.reset(); // Drop state, such as a cached tip block
-    node.mempool.reset();
     node.chainman.reset(); // Drop state, such as an initialized m_block_tree_db
+    node.mempool.reset();
 
     const CChainParams& chainparams = Params();
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1007,15 +1007,6 @@ const btck_BlockTreeEntry* btck_chainstate_manager_get_block_tree_entry_by_hash(
 
 void btck_chainstate_manager_destroy(btck_ChainstateManager* chainman)
 {
-    {
-        LOCK(btck_ChainstateManager::get(chainman).m_chainman->GetMutex());
-        for (const auto& chainstate : btck_ChainstateManager::get(chainman).m_chainman->m_chainstates) {
-            if (chainstate->CanFlushToDisk()) {
-                chainstate->ForceFlushStateToDisk();
-            }
-        }
-    }
-
     delete chainman;
 }
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1012,7 +1012,6 @@ void btck_chainstate_manager_destroy(btck_ChainstateManager* chainman)
         for (const auto& chainstate : btck_ChainstateManager::get(chainman).m_chainman->m_chainstates) {
             if (chainstate->CanFlushToDisk()) {
                 chainstate->ForceFlushStateToDisk();
-                chainstate->ResetCoinsViews();
             }
         }
     }

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -340,6 +340,8 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
 
     node.validation_signals->UnregisterSharedValidationInterface(outpoints_updater);
 
+    chainstate.SetMempool(g_setup->m_node.mempool.get());
+
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
 }
 
@@ -534,6 +536,8 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
     }
 
     node.validation_signals->UnregisterSharedValidationInterface(outpoints_updater);
+
+    chainstate.SetMempool(g_setup->m_node.mempool.get());
 
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
 }

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -90,7 +90,7 @@ void SetMempoolConstraints(ArgsManager& args, FuzzedDataProvider& fuzzed_data_pr
                      ToString(fuzzed_data_provider.ConsumeIntegralInRange<unsigned>(0, 999)));
 }
 
-void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Chainstate& chainstate)
+void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, DummyChainState& chainstate)
 {
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
     {
@@ -136,6 +136,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
     }
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
     g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    chainstate.SetMempool(g_setup->m_node.mempool.get());
 }
 
 void MockTime(FuzzedDataProvider& fuzzed_data_provider, const Chainstate& chainstate)

--- a/src/test/fuzz/util/mempool.h
+++ b/src/test/fuzz/util/mempool.h
@@ -6,20 +6,9 @@
 #define BITCOIN_TEST_FUZZ_UTIL_MEMPOOL_H
 
 #include <kernel/mempool_entry.h>
-#include <validation.h>
 
 class CTransaction;
-class CTxMemPool;
 class FuzzedDataProvider;
-
-class DummyChainState final : public Chainstate
-{
-public:
-    void SetMempool(CTxMemPool* mempool)
-    {
-        m_mempool = mempool;
-    }
-};
 
 [[nodiscard]] CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, const CTransaction& tx, uint32_t max_height=std::numeric_limits<uint32_t>::max()) noexcept;
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -51,19 +51,7 @@ struct MinerTestingSetup : public TestingSetup {
     }
     CTxMemPool& MakeMempool()
     {
-        // Delete the previous mempool to ensure with valgrind that the old
-        // pointer is not accessed, when the new one should be accessed
-        // instead.
-        m_node.mempool.reset();
-        bilingual_str error;
-        auto opts = MemPoolOptionsForTest(m_node);
-        // The "block size > limit" test creates a cluster of 1192590 vbytes,
-        // so set the cluster vbytes limit big enough so that the txgraph
-        // doesn't become oversized.
-        opts.limits.cluster_size_vbytes = 1'200'000;
-        m_node.mempool = std::make_unique<CTxMemPool>(opts, error);
-        Assert(error.empty());
-        return *m_node.mempool;
+        return ReplaceMempool();
     }
     std::unique_ptr<Mining> MakeMining()
     {

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -77,6 +77,7 @@ CreateAndActivateUTXOSnapshot(
             CBlockIndex *orig_tip = node.chainman->ActiveChainstate().m_chain.Tip();
             uint256 gen_hash = node.chainman->ActiveChainstate().m_chain[0]->GetBlockHash();
             node.chainman->ResetChainstates();
+            Assert(node.chainman->m_chainstates.size() == 0);
             node.chainman->InitializeChainstate(node.mempool.get());
             Chainstate& chain = node.chainman->ActiveChainstate();
             Assert(chain.LoadGenesisBlock());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -299,9 +299,9 @@ ChainTestingSetup::~ChainTestingSetup()
     m_node.addrman.reset();
     m_node.netgroupman.reset();
     m_node.args = nullptr;
+    m_node.chainman.reset();
     m_node.mempool.reset();
     Assert(!m_node.fee_estimator); // Each test must create a local object, if they wish to use the fee_estimator
-    m_node.chainman.reset();
     m_node.validation_signals.reset();
     m_node.scheduler.reset();
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -114,6 +114,8 @@ struct ChainTestingSetup : public BasicTestingSetup {
 
     // Supplies a chainstate, if one is needed
     void LoadVerifyActivateChainstate();
+
+    CTxMemPool& ReplaceMempool();
 };
 
 /** Testing setup that configures a complete environment.

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -8,6 +8,7 @@
 #include <policy/packages.h>
 #include <txmempool.h>
 #include <util/time.h>
+#include <validation.h>
 
 namespace node {
 struct NodeContext;
@@ -15,6 +16,15 @@ struct NodeContext;
 struct PackageMempoolAcceptResult;
 
 CTxMemPool::Options MemPoolOptionsForTest(const node::NodeContext& node);
+
+class DummyChainState final : public Chainstate
+{
+public:
+    void SetMempool(CTxMemPool* mempool)
+    {
+        m_mempool = mempool;
+    }
+};
 
 struct TestMemPoolEntryHelper {
     // Default values

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -365,25 +365,12 @@ struct SnapshotTestSetup : TestChain100Setup {
     // @returns a reference to the "restarted" ChainstateManager
     ChainstateManager& SimulateNodeRestart()
     {
-        ChainstateManager& chainman = *Assert(m_node.chainman);
-
         BOOST_TEST_MESSAGE("Simulating node restart");
         {
-            LOCK(chainman.GetMutex());
-            for (const auto& cs : chainman.m_chainstates) {
-                if (cs->CanFlushToDisk()) cs->ForceFlushStateToDisk();
-            }
-        }
-        {
-            // Process all callbacks referring to the old manager before wiping it.
-            m_node.validation_signals->SyncWithValidationInterfaceQueue();
-            LOCK(::cs_main);
-            chainman.ResetChainstates();
-            BOOST_CHECK_EQUAL(chainman.m_chainstates.size(), 0);
             m_node.notifications = std::make_unique<KernelNotifications>(Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings));
             const ChainstateManager::Options chainman_opts{
                 .chainparams = ::Params(),
-                .datadir = chainman.m_options.datadir,
+                .datadir = Assert(m_node.chainman)->m_options.datadir,
                 .notifications = *m_node.notifications,
                 .signals = m_node.validation_signals.get(),
             };
@@ -392,7 +379,7 @@ struct SnapshotTestSetup : TestChain100Setup {
                 .blocks_dir = m_args.GetBlocksDirPath(),
                 .notifications = chainman_opts.notifications,
                 .block_tree_db_params = DBParams{
-                    .path = chainman.m_options.datadir / "blocks" / "index",
+                    .path = Assert(m_node.chainman)->m_options.datadir / "blocks" / "index",
                     .cache_bytes = m_kernel_cache_sizes.block_tree_db,
                     .memory_only = m_block_tree_db_in_memory,
                 },
@@ -400,7 +387,11 @@ struct SnapshotTestSetup : TestChain100Setup {
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.
             m_node.chainman.reset();
+            // Process all callbacks referring to the old manager before creating a
+            // new one.
+            m_node.validation_signals->SyncWithValidationInterfaceQueue();
             m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            BOOST_CHECK_EQUAL(WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->m_chainstates.size()), 0);
         }
         return *Assert(m_node.chainman);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6215,7 +6215,6 @@ ChainstateManager::~ChainstateManager()
     for (const auto& chainstate : m_chainstates) {
         if (chainstate->CanFlushToDisk()) {
             chainstate->ForceFlushStateToDisk();
-            chainstate->ResetCoinsViews();
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6212,6 +6212,12 @@ ChainstateManager::ChainstateManager(const util::SignalInterrupt& interrupt, Opt
 ChainstateManager::~ChainstateManager()
 {
     LOCK(::cs_main);
+    for (const auto& chainstate : m_chainstates) {
+        if (chainstate->CanFlushToDisk()) {
+            chainstate->ForceFlushStateToDisk();
+            chainstate->ResetCoinsViews();
+        }
+    }
 
     m_versionbitscache.Clear();
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -705,9 +705,6 @@ public:
         return Assert(m_coins_views)->m_catcherview;
     }
 
-    //! Destructs all objects related to accessing the UTXO set.
-    void ResetCoinsViews() { m_coins_views.reset(); }
-
     //! The cache size of the on-disk coins view.
     size_t m_coinsdb_cache_size_bytes{0};
 

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -73,6 +73,8 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
         .dust_relay_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, 1'000'000)}
     };
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, error);
+    auto& dummy_chainstate{static_cast<DummyChainState&>(node.chainman->ActiveChainstate())};
+    dummy_chainstate.SetMempool(node.mempool.get());
     std::unique_ptr<CBlockPolicyEstimator> fee_estimator = std::make_unique<FuzzedBlockPolicyEstimator>(fuzzed_data_provider);
     g_setup->SetFeeEstimator(std::move(fee_estimator));
     auto target_feerate{CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/1'000'000)}};


### PR DESCRIPTION
This simplifies the shutdown code a bit and reduces the amount of extra logic required in kernel/bitcoinkernel.cpp to tear down the chainman.

Moving the second flush out of the Shutdown function into the ChainstateManager destructor, should be safe since there should be no new events created after the first flush. Tweak the chainman tests to actually exercise this new tear down behaviour.

---

This PR is part of the [libbitcoinkernel project](https://github.com/bitcoin/bitcoin/issues/27587)