### PR TITLE
doc: Use more precise anchor links to Xcode SDK extraction

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -31,7 +31,7 @@ section](#choosing-your-security-model) before proceeding to perform a build.
 
 In order to perform a build for macOS (which is included in the default set of
 platform triples to build), you'll need to extract the macOS SDK tarball using
-tools found in the [`macdeploy` directory](../macdeploy/README.md).
+tools found in the [`macdeploy` directory](../macdeploy/README.md#sdk-extraction).
 
 You can then either point to the SDK using the `SDK_PATH` environment variable:
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -134,7 +134,7 @@ git -C ./guix.sigs pull
 ### Create the macOS SDK tarball (first time, or when SDK version changes)
 
 Create the macOS SDK tarball, see the [macdeploy
-instructions](/contrib/macdeploy/README.md#deterministic-macos-app-notes) for
+instructions](/contrib/macdeploy/README.md#sdk-extraction) for
 details.
 
 ### Build and attest to build outputs


### PR DESCRIPTION
The "SDK Extraction" section is what users presumably are looking for when they follow these links.