### PR TITLE
doc: Use more precise anchor link to codesigning docs

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -68,7 +68,7 @@ following from the top of a clean repository:
 
 The `guix-codesign` command attaches codesignatures (produced by codesigners) to
 existing non-codesigned outputs. Please see the [release process
-documentation](/doc/release-process.md) for more context.
+documentation](/doc/release-process.md#codesigning) for more context.
 
 It respects many of the same environment variable flags as `guix-build`, with 2
 crucial differences:


### PR DESCRIPTION
The "Codesigning" section is what users presumably are looking for when they follow this link.