### PR TITLE
[POC] cmake: Introduce LLVM's Source-based Code Coverage reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,18 @@ if(BUILD_FOR_COVERAGE)
     add_custom_target(test_bitcoin_coverage
       DEPENDS ${PROJECT_BINARY_DIR}/test_bitcoin.coverage/index.html
     )
+
+    add_custom_command(
+      OUTPUT ${PROJECT_BINARY_DIR}/total.coverage/index.html
+      COMMAND Python3::Interpreter ${PROJECT_BINARY_DIR}/test/functional/test_runner.py
+      COMMAND llvm-profdata merge --instr ${PROFILE_DATA_DIR}/*.profraw --output ${PROFILE_DATA_DIR}/total.profdata
+      COMMAND llvm-cov show -instr-profile=${PROFILE_DATA_DIR}/total.profdata -object=$<TARGET_FILE:bitcoind> -object=$<TARGET_FILE:bitcoin-cli> -object=$<TARGET_FILE:bitcoin-wallet> -object=$<TARGET_FILE:test_bitcoin> -object=$<TARGET_FILE:bitcoin-util> -object=$<TARGET_FILE:bitcoin-tx> -output-dir=${PROJECT_BINARY_DIR}/total.coverage -format=html ${coverage_ignore_paths}
+      DEPENDS bitcoind bitcoin-cli bitcoin-wallet
+    )
+    add_custom_target(total_coverage
+      DEPENDS ${PROJECT_BINARY_DIR}/total.coverage/index.html
+    )
+    add_dependencies(total_coverage test_bitcoin_coverage)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,20 @@ if(BUILD_FOR_COVERAGE)
       DEPENDS ${PROJECT_BINARY_DIR}/total.coverage/index.html
     )
     add_dependencies(total_coverage test_bitcoin_coverage)
+  else()
+    if(NOT FUZZ_CORPORA_DIR)
+      set(FUZZ_CORPORA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/qa-assets/fuzz_corpora)
+    endif()
+    add_custom_command(
+      OUTPUT ${PROJECT_BINARY_DIR}/fuzz.coverage/index.html
+      COMMAND Python3::Interpreter test/fuzz/test_runner.py ${FUZZ_CORPORA_DIR} --loglevel DEBUG
+      COMMAND llvm-profdata merge --instr ${PROFILE_DATA_DIR}/*.profraw --output ${PROFILE_DATA_DIR}/fuzz.profdata
+      COMMAND llvm-cov show -instr-profile=${PROFILE_DATA_DIR}/fuzz.profdata -object=$<TARGET_FILE:fuzz> -output-dir=${PROJECT_BINARY_DIR}/fuzz.coverage -format=html ${coverage_ignore_paths}
+      DEPENDS fuzz
+    )
+    add_custom_target(fuzz_coverage
+      DEPENDS ${PROJECT_BINARY_DIR}/fuzz.coverage/index.html
+    )
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ option(BUILD_BENCH "Build bench_bitcoin executable." OFF)
 option(BUILD_FUZZ_BINARY "Build fuzz binary." OFF)
 option(BUILD_FOR_FUZZING "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF)
 
+option(BUILD_FOR_COVERAGE "Build with Code Coverage instrumentation" OFF)
+
 option(INSTALL_MAN "Install man pages." ON)
 
 set(APPEND_CPPFLAGS "" CACHE STRING "Preprocessor flags that are appended to the command line after all other flags added by the build system. This variable is intended for debugging and special builds.")
@@ -369,6 +371,29 @@ if(BUILD_FUZZ_BINARY)
       extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return 0; }
       // No main() function.
     " FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION
+  )
+endif()
+
+# The coverage_interface library is intended to be used
+# only for code whose coverage report is of interest.
+add_library(coverage_interface INTERFACE)
+if(BUILD_FOR_COVERAGE)
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "BUILD_FOR_COVERAGE can only be specified when compiling with Clang.")
+  endif()
+  if(NOT PROFILE_FILE_PATTERN)
+    if(NOT PROFILE_DATA_DIR)
+      file(TO_NATIVE_PATH "${PROJECT_BINARY_DIR}/profiles" PROFILE_DATA_DIR)
+    endif()
+    file(TO_NATIVE_PATH "${PROFILE_DATA_DIR}/%m.profraw" PROFILE_FILE_PATTERN)
+  endif()
+  target_compile_options(coverage_interface INTERFACE
+    -fprofile-instr-generate=${PROFILE_FILE_PATTERN}
+    -fcoverage-mapping
+  )
+  target_link_options(coverage_interface INTERFACE
+    -fprofile-instr-generate=${PROFILE_FILE_PATTERN}
+    -fcoverage-mapping
   )
 endif()
 
@@ -624,6 +649,7 @@ message("  test_bitcoin ........................ ${BUILD_TESTS}")
 message("  test_bitcoin-qt ..................... ${BUILD_GUI_TESTS}")
 message("  bench_bitcoin ....................... ${BUILD_BENCH}")
 message("  fuzz binary ......................... ${BUILD_FUZZ_BINARY}")
+message("  Code Coverage instrumentation ....... ${BUILD_FOR_COVERAGE}")
 message("")
 if(CMAKE_CROSSCOMPILING)
   set(cross_status "TRUE, for ${CMAKE_SYSTEM_NAME}, ${CMAKE_SYSTEM_PROCESSOR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,28 @@ if(BUILD_FOR_COVERAGE)
     -fprofile-instr-generate=${PROFILE_FILE_PATTERN}
     -fcoverage-mapping
   )
+
+  set(coverage_ignore_paths
+    src/leveldb/
+    src/crc32c/
+    src/crypto/ctaes/
+    src/minisketch/
+    src/secp256k1/
+  )
+  list(TRANSFORM coverage_ignore_paths PREPEND "-ignore-filename-regex=")
+
+  if(NOT BUILD_FOR_FUZZING)
+    add_custom_command(
+      OUTPUT ${PROJECT_BINARY_DIR}/test_bitcoin.coverage/index.html
+      COMMAND ${CMAKE_CTEST_COMMAND} --test-dir ${PROJECT_BINARY_DIR} --exclude-regex secp256k1_
+      COMMAND llvm-profdata merge --instr ${PROFILE_DATA_DIR}/*.profraw --output ${PROFILE_DATA_DIR}/test_bitcoin.profdata
+      COMMAND llvm-cov show -instr-profile=${PROFILE_DATA_DIR}/test_bitcoin.profdata -object=$<TARGET_FILE:test_bitcoin> -object=$<TARGET_FILE:bitcoin-util> -object=$<TARGET_FILE:bitcoin-tx> -output-dir=${PROJECT_BINARY_DIR}/test_bitcoin.coverage -format=html ${coverage_ignore_paths}
+      DEPENDS test_bitcoin bitcoin-util bitcoin-tx unitester object
+    )
+    add_custom_target(test_bitcoin_coverage
+      DEPENDS ${PROJECT_BINARY_DIR}/test_bitcoin.coverage/index.html
+    )
+  endif()
 endif()
 
 include(AddBoostIfNeeded)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(bitcoin_clientversion OBJECT EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_clientversion
   PRIVATE
     core_interface
+    coverage_interface
 )
 add_dependencies(bitcoin_clientversion generate_build_info)
 
@@ -92,6 +93,7 @@ add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_consensus
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_crypto
     secp256k1
 )
@@ -156,6 +158,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_common
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_consensus
     bitcoin_util
     univalue
@@ -179,6 +182,7 @@ if(ENABLE_WALLET)
     add_windows_resources(bitcoin-wallet bitcoin-wallet-res.rc)
     target_link_libraries(bitcoin-wallet
       core_interface
+      coverage_interface
       bitcoin_wallet
       bitcoin_common
       bitcoin_util
@@ -289,6 +293,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_node
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_common
     bitcoin_util
     $<TARGET_NAME_IF_EXISTS:bitcoin_zmq>
@@ -312,6 +317,7 @@ if(BUILD_DAEMON)
   add_windows_resources(bitcoind bitcoind-res.rc)
   target_link_libraries(bitcoind
     core_interface
+    coverage_interface
     bitcoin_node
     $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
@@ -324,6 +330,7 @@ if(WITH_MULTIPROCESS)
   )
   target_link_libraries(bitcoin-node
     core_interface
+    coverage_interface
     bitcoin_node
     bitcoin_ipc
     $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
@@ -355,6 +362,7 @@ add_library(bitcoin_cli STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_cli
   PUBLIC
     core_interface
+    coverage_interface
     univalue
 )
 
@@ -365,6 +373,7 @@ if(BUILD_CLI)
   add_windows_resources(bitcoin-cli bitcoin-cli-res.rc)
   target_link_libraries(bitcoin-cli
     core_interface
+    coverage_interface
     bitcoin_cli
     bitcoin_common
     bitcoin_util
@@ -380,6 +389,7 @@ if(BUILD_TX)
   add_windows_resources(bitcoin-tx bitcoin-tx-res.rc)
   target_link_libraries(bitcoin-tx
     core_interface
+    coverage_interface
     bitcoin_common
     bitcoin_util
     univalue
@@ -393,6 +403,7 @@ if(BUILD_UTIL)
   add_windows_resources(bitcoin-util bitcoin-util-res.rc)
   target_link_libraries(bitcoin-util
     core_interface
+    coverage_interface
     bitcoin_common
     bitcoin_util
   )
@@ -425,6 +436,7 @@ if(BUILD_UTIL_CHAINSTATE)
   target_link_libraries(bitcoin-chainstate
     PRIVATE
       core_interface
+      coverage_interface
       bitcoinkernel
   )
 endif()

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_crypto
   PRIVATE
     core_interface
+    coverage_interface
 )
 
 if(HAVE_SSE41)
@@ -33,7 +34,7 @@ if(HAVE_SSE41)
   )
   target_compile_definitions(bitcoin_crypto_sse41 PUBLIC ENABLE_SSE41)
   target_compile_options(bitcoin_crypto_sse41 PRIVATE ${SSE41_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_sse41 PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto_sse41 PRIVATE core_interface coverage_interface)
   target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_sse41)
 endif()
 
@@ -43,7 +44,7 @@ if(HAVE_AVX2)
   )
   target_compile_definitions(bitcoin_crypto_avx2 PUBLIC ENABLE_AVX2)
   target_compile_options(bitcoin_crypto_avx2 PRIVATE ${AVX2_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_avx2 PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto_avx2 PRIVATE core_interface coverage_interface)
   target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_avx2)
 endif()
 
@@ -53,7 +54,7 @@ if(HAVE_SSE41 AND HAVE_X86_SHANI)
   )
   target_compile_definitions(bitcoin_crypto_x86_shani PUBLIC ENABLE_SSE41 ENABLE_X86_SHANI)
   target_compile_options(bitcoin_crypto_x86_shani PRIVATE ${X86_SHANI_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_x86_shani PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto_x86_shani PRIVATE core_interface coverage_interface)
   target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_x86_shani)
 endif()
 
@@ -63,6 +64,6 @@ if(HAVE_ARM_SHANI)
   )
   target_compile_definitions(bitcoin_crypto_arm_shani PUBLIC ENABLE_ARM_SHANI)
   target_compile_options(bitcoin_crypto_arm_shani PRIVATE ${ARM_SHANI_CXXFLAGS})
-  target_link_libraries(bitcoin_crypto_arm_shani PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto_arm_shani PRIVATE core_interface coverage_interface)
   target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_arm_shani)
 endif()

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -19,5 +19,6 @@ target_capnp_sources(bitcoin_ipc ${PROJECT_SOURCE_DIR}
 target_link_libraries(bitcoin_ipc
   PRIVATE
     core_interface
+    coverage_interface
     univalue
 )

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(bitcoinkernel
 target_link_libraries(bitcoinkernel
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_clientversion
     bitcoin_crypto
     leveldb

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -148,6 +148,7 @@ add_executable(test_bitcoin
 
 target_link_libraries(test_bitcoin
   core_interface
+  coverage_interface
   test_util
   bitcoin_cli
   bitcoin_node
@@ -165,6 +166,7 @@ if(WITH_MULTIPROCESS)
   target_link_libraries(bitcoin_ipc_test
     PRIVATE
       core_interface
+      coverage_interface
       univalue
   )
 

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(fuzz
 )
 target_link_libraries(fuzz
   core_interface
+  coverage_interface
   test_fuzz
   bitcoin_cli
   bitcoin_common

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
 target_link_libraries(test_fuzz
   PRIVATE
     core_interface
+    coverage_interface
     test_util
     bitcoin_node
     Boost::headers

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
 target_link_libraries(test_util
   PRIVATE
     core_interface
+    coverage_interface
     Boost::headers
   PUBLIC
     univalue

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -12,7 +12,11 @@ target_include_directories(univalue
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_link_libraries(univalue PRIVATE core_interface)
+target_link_libraries(univalue
+  PRIVATE
+    core_interface
+    coverage_interface
+)
 
 if(BUILD_TESTS)
   add_executable(unitester test/unitester.cpp)
@@ -23,6 +27,7 @@ if(BUILD_TESTS)
   target_link_libraries(unitester
     PRIVATE
       core_interface
+      coverage_interface
       univalue
   )
   add_test(NAME univalue_test
@@ -33,6 +38,7 @@ if(BUILD_TESTS)
   target_link_libraries(object
     PRIVATE
       core_interface
+      coverage_interface
       univalue
   )
   add_test(NAME univalue_object_test

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_util
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_clientversion
     bitcoin_crypto
     $<$<PLATFORM_ID:Windows>:ws2_32>

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
 target_link_libraries(bitcoin_wallet
   PRIVATE
     core_interface
+    coverage_interface
     bitcoin_common
     univalue
     Boost::headers

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -16,6 +16,7 @@ target_compile_definitions(bitcoin_zmq
 target_link_libraries(bitcoin_zmq
   PRIVATE
     core_interface
+    coverage_interface
     univalue
     zeromq
 )


### PR DESCRIPTION
The `gcov`-based code coverage does not work with Clang (please refer to https://github.com/bitcoin/bitcoin/issues/31047 for more details).

This PR employs the LLVM's [Source-based Code Coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html).

Here are some examples of usage:
```
cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_FOR_COVERAGE=ON
cmake --build build --target total_coverage
firefox build/test_bitcoin.coverage/index.html
```
or
```
cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_FOR_COVERAGE=ON
cmake --build build --target total_coverage
firefox build/total.coverage/index.html
```
or
```
cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_FOR_COVERAGE=ON -DBUILD_FOR_FUZZING=ON
cmake --build build --target fuzz_coverage
firefox build/fuzz.coverage/index.html
```

---

As a proof of concept, the new targets still lack the ability to customize `llvm-cov` options.

I haven't yet assessed the quality of the resulting coverage reports. However, messages like this:
```
warning: 502 functions have mismatched data
```
are quite concerning.

---

Also see a discussion in https://github.com/hebasto/bitcoin/pull/233.