### PR TITLE
ci, macos: Install `pkgconf` Homebrew's package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,7 @@ jobs:
         run: |
           # A workaround for "The `brew link` step did not complete successfully" error.
           brew install --quiet python@3 || brew link --overwrite python@3
-          # Update to install pkgconf, once the GHA image has been updated.
-          brew install --quiet coreutils ninja gnu-getopt ccache boost libevent zeromq qt@5 qrencode
+          brew install --quiet coreutils ninja pkgconf gnu-getopt ccache boost libevent zeromq qt@5 qrencode
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
The updated GHA image [`20241125.556`](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20241125.556) is now fully [deployed](https://github.com/actions/runner-images/blob/main/README.md#available-images), enabling the installation of `pkgconf` as documented in [`doc/build-osx.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md#3-install-required-dependencies).