### PR TITLE
descriptors: inference process, do not return unparsable multisig descriptors

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -153,7 +153,9 @@ void ScriptToUniv(const CScript& script, UniValue& out, bool include_hex, bool i
 
     out.pushKV("asm", ScriptToAsmStr(script));
     if (include_address) {
-        out.pushKV("desc", InferDescriptor(script, provider ? *provider : DUMMY_SIGNING_PROVIDER)->ToString());
+        auto desc = InferDescriptor(script, provider ? *provider : DUMMY_SIGNING_PROVIDER);
+        // future: make 'InferDescriptor' return the error cause
+        if (desc) out.pushKV("desc", desc->ToString());
     }
     if (include_hex) {
         out.pushKV("hex", HexStr(script));

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -87,7 +87,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
         unsigned char m = vSolutions.front()[0];
         unsigned char n = vSolutions.back()[0];
         // Support up to x-of-3 multisig txns as standard
-        if (n < 1 || n > 3)
+        if (n < 1 || n > MAX_BARE_MULTISIG_PUBKEYS_NUM)
             return false;
         if (m < 1 || m > n)
             return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,8 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
+/** The maximum number of pubkeys in a bare multisig output script */
+static constexpr unsigned int MAX_BARE_MULTISIG_PUBKEYS_NUM{3};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */

--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -146,6 +146,7 @@ static RPCHelpMan createmultisig()
 
             // Make the descriptor
             std::unique_ptr<Descriptor> descriptor = InferDescriptor(GetScriptForDestination(dest), keystore);
+            if (!descriptor) throw JSONRPCError(RPC_INTERNAL_ERROR, "Invalid descriptor generated");
 
             UniValue result(UniValue::VOBJ);
             result.pushKV("address", EncodeDestination(dest));

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1852,8 +1852,8 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
             return {};
         }
         if (ctx == ParseScriptContext::TOP) {
-            if (providers.size() > 3) {
-                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most 3 pubkeys", providers.size());
+            if (providers.size() > MAX_BARE_MULTISIG_PUBKEYS_NUM) {
+                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most %d pubkeys", providers.size(), MAX_BARE_MULTISIG_PUBKEYS_NUM);
                 return {};
             }
         }

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1853,7 +1853,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         }
         if (ctx == ParseScriptContext::TOP) {
             if (providers.size() > MAX_BARE_MULTISIG_PUBKEYS_NUM) {
-                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most %d pubkeys", providers.size(), MAX_BARE_MULTISIG_PUBKEYS_NUM);
+                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most %u pubkeys", providers.size(), MAX_BARE_MULTISIG_PUBKEYS_NUM);
                 return {};
             }
         }
@@ -2239,6 +2239,17 @@ std::unique_ptr<DescriptorImpl> InferScript(const CScript& script, ParseScriptCo
                 break;
             }
         }
+
+        // Check bare multisig pubkeys number limit
+        if (ctx == ParseScriptContext::TOP && providers.size() > MAX_BARE_MULTISIG_PUBKEYS_NUM) {
+            return nullptr;
+        }
+
+        // Verify we don't exceed consensus limits
+        if (ctx == ParseScriptContext::P2SH && script.size() > MAX_SCRIPT_ELEMENT_SIZE) {
+            return nullptr;
+        }
+
         if (ok) return std::make_unique<MultisigDescriptor>((int)data[0][0], std::move(providers));
     }
     if (txntype == TxoutType::SCRIPTHASH && ctx == ParseScriptContext::TOP) {

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -96,6 +96,16 @@ class DecodeScriptTest(BitcoinTestFramework):
         assert_equal('witness_v0_scripthash', rpc_result['segwit']['type'])
         assert_equal('0 ' + multisig_script_hash, rpc_result['segwit']['asm'])
 
+        # Check decoding a multisig redeem script doesn't return an invalid descriptor
+        self.log.info("- multisig invalid")
+        # Decode a +520 bytes consensus-invalid p2sh multisig - provided script translates to multi(20, keys)
+        large_multisig_script = '0114' + push_public_key * 20 + '0114' + 'ae'
+        rpc_result = self.nodes[0].decodescript(large_multisig_script)
+        # Verify it is valid only under segwit rules, not for bare multisig nor p2sh.
+        assert 'desc' not in rpc_result
+        assert 'p2sh' not in rpc_result
+        assert 'segwit' in rpc_result
+
         self.log.info ("- P2SH")
         # OP_HASH160 <Hash160(redeemScript)> OP_EQUAL.
         # push_public_key_hash here should actually be the hash of a redeem script.


### PR DESCRIPTION
The internal script-to-descriptor inference procedure shouldn't return invalid
descriptors or ones that fail the string-to-descriptor parsing process. These
two procedures should always support seamless roundtrips.

This inlines `InferScript`/`InferDescriptor` to the actual descriptors
`ParseScript` logic for the multisig path, ensuring only valid descriptors are
produced.

Examples where this presents an issue:
1) Because the legacy wallet allowed the import of invalid scripts, the process
    could end up inferring and storing an unparsable descriptor, which crashes
    the software during any subsequent wallet load.

    Note:
    This issue will no longer exist after [#31378](https://github.com/bitcoin/bitcoin/pull/31378), because we will discard multisig
    scripts that are consensus-invalid or descriptors-incompatible prior to calling
    the descriptors inference procedure but fixing this also at the descriptors level
    prevents future misuses.

2) The `decodescript()` RPC command currently return unusable multisig descriptors.
     For example, providing a P2SH multisig redeem script with more than 520 bytes results
     in a descriptor when it shouldn't due to its large size.