### PR TITLE
test: Avoid logging error when logging error

### DIFF
--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2010 ArtForz -- public domain half-a-node
 # Copyright (c) 2012 Jeff Garzik
-# Copyright (c) 2010-2022 The Bitcoin Core developers
+# Copyright (c) 2010-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test objects for interacting with a bitcoind node over the p2p protocol.
@@ -369,7 +369,7 @@ class P2PConnection(asyncio.Protocol):
                 self.on_message(t)
         except Exception as e:
             if not self.reconnect:
-                logger.exception('Error reading message:', repr(e))
+                logger.exception(f"Error reading message: {repr(e)}")
             raise
 
     def on_message(self, message):
@@ -659,7 +659,7 @@ class P2PInterface(P2PConnection):
         def test_function():
             last_getheaders = self.last_message.pop("getheaders", None)
             if block_hash is None:
-                 return last_getheaders
+                return last_getheaders
             if last_getheaders is None:
                 return False
             return block_hash == last_getheaders.locator.vHave[0]

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -236,6 +236,7 @@ fn lint_py_lint() -> LintResult {
             "F822", // undefined name name in __all__
             "F823", // local variable name … referenced before assignment
             "F841", // local variable 'foo' is assigned to but never used
+            "PLE", // Pylint errors
             "W191", // indentation contains tabs
             "W291", // trailing whitespace
             "W292", // no newline at end of file


### PR DESCRIPTION
Currently a logging error in the form of `--- Logging error ---` happens when an error is logged in the `_on_data` helper.

Fix it by properly logging the error.

Also, treat pylint errors as errors, to avoid this problem in the future.

Can be tested by running `p2p_addrv2_relay.py` with the following example diff:

```diff
diff --git a/test/functional/test_framework/p2p.py b/test/functional/test_framework/p2p.py
index 523e1bd068..0f1eb29d13 100755
--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -137,7 +137,7 @@ MESSAGEMAP = {
     b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
-    b"sendaddrv2": msg_sendaddrv2,
+    #b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
     b"sendtxrcncl": msg_sendtxrcncl,