### PR TITLE
qa: Fix `wallet_multiwallet.py`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,9 +400,8 @@ jobs:
 
       - name: Run functional tests
         env:
-          # TODO: Fix the excluded test and re-enable it.
           # feature_unsupported_utxo_db.py fails on windows because of emojis in the test data directory
-          EXCLUDE: '--exclude wallet_multiwallet.py,feature_unsupported_utxo_db.py'
+          EXCLUDE: '--exclude feature_unsupported_utxo_db.py'
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
         run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="$RUNNER_TEMP" --combinedlogslen=99999999 --timeout-factor=$TEST_RUNNER_TIMEOUT_FACTOR $EXCLUDE $TEST_RUNNER_EXTRA
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/31409.

The first commit prevents possible false positives by ensuring that each condition potentially causing the "Error scanning" log message is tested separately.

The second commit disables a problematic check on Windows.