### PR TITLE
build: enable libc++ hardening in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,6 +554,12 @@ else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     try_append_linker_flag("-Wl,-fixup_chains" TARGET core_interface)
   endif()
+
+  if(HAVE_LIBCPP)
+    # https://libcxx.llvm.org/Hardening.html
+    target_compile_definitions(core_interface INTERFACE
+      $<IF:$<CONFIG:Debug>,_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG,>)
+  endif()
 endif()
 
 if(REDUCE_EXPORTS)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -6,6 +6,8 @@ include(CheckCXXSourceCompiles)
 include(CheckCXXSymbolExists)
 include(CheckIncludeFileCXX)
 
+check_cxx_symbol_exists(_LIBCPP_VERSION "version" HAVE_LIBCPP)
+
 check_cxx_symbol_exists(O_CLOEXEC "fcntl.h" HAVE_O_CLOEXEC)
 check_cxx_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
 check_cxx_symbol_exists(fork "unistd.h" HAVE_DECL_FORK)


### PR DESCRIPTION
When compiling with libc++ in debug mode, then enable full libc++ hardening.

Inspired by https://github.com/bitcoin/bitcoin/issues/31272#issuecomment-2518700939

---

Note that `libstdc++`'s `_GLIBCXX_ASSERTIONS` (aka light debug mode) is [enabled by default](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html) when compiling without optimizations), that is in our debug builds. But see https://github.com/bitcoin/bitcoin/pull/31424#issuecomment-2732100998.

---

Further considerations:

* Consider enabling `libstdc++`s `_GLIBCXX_ASSERTIONS` (aka light debug mode) also in non-debug builds. Should assess [performance impact](https://github.com/bitcoin/bitcoin/pull/31424#discussion_r1910658664).

* Consider enabling `libc++`s `_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST` in non-debug builds. Should assess peformance impact as well.