### PR TITLE
CI: Add Riscv bare metal job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_msan.sh'
 
+          - name: 'riscv32 bare metal, static libbitcoin_consensus'
+            warp-runner: 'warp-ubuntu-latest-x64-16x'
+            fallback-runner: 'ubuntu-latest'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_riscv_bare_cross.sh'
+
     steps:
       - *ANNOTATION_PR_NUMBER
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,22 +204,28 @@ endif()
 # Check and set PIC/PIE
 #=============================
 set(configure_warnings)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
 include(CheckLinkerSupportsPIE)
 # Set CMAKE_POSITION_INDEPENDENT_CODE early so it applies to all
 # subsequent checks, including dependency packages and tool flags.
 check_linker_supports_pie(configure_warnings)
+endif()
 
 #=============================
 # Find dependencies
 #=============================
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(core_interface INTERFACE
   Threads::Threads
 )
+endif()
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
 include(AddBoostIfNeeded)
 add_boost_if_needed()
+endif()
 
 if(ENABLE_WALLET)
   if(VCPKG_TARGET_TRIPLET)

--- a/ci/test/00_setup_env_riscv_bare_cross.sh
+++ b/ci/test/00_setup_env_riscv_bare_cross.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_native_riscv_bare
+
+export GOAL="bitcoin_consensus bitcoin_crypto secp256k1"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
+export HOST="riscv32-unknown-elf-gcc"
+export PACKAGES="autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev"
+export BITCOIN_CONFIG="-DCMAKE_C_COMPILER=/opt/riscv-ilp32/bin/riscv32-unknown-elf-gcc \
+ -DCMAKE_CXX_COMPILER=/opt/riscv-ilp32/bin/riscv32-unknown-elf-g++ \
+ -DBUILD_KERNEL_LIB=OFF \
+ -DBUILD_UTIL_CHAINSTATE=OFF \
+ -DBUILD_TESTS=OFF \
+ -DBUILD_BENCH=OFF \
+ -DBUILD_FUZZ_BINARY=OFF \
+ -DBUILD_DAEMON=OFF \
+ -DBUILD_TX=OFF \
+ -DBUILD_UTIL=OFF \
+ -DBUILD_CLI=OFF \
+ -DBUILD_BITCOIN_BIN=OFF \
+ -DENABLE_WALLET=OFF \
+ -DENABLE_EXTERNAL_SIGNER=OFF \
+ -DENABLE_IPC=OFF \
+ -DCMAKE_SYSTEM_NAME=Generic \
+ -DIFADDR_LINKS_WITHOUT_LIBSOCKET=ON \
+ "
+
+export BARE_METAL_RISCV="true"
+export RUN_UNIT_TESTS="false"
+export RUN_FUNCTIONAL_TESTS="false"
+export NO_DEPENDS="true"

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -87,6 +87,14 @@ if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
   rm -rf /llvm-project
 fi
 
+if [[ ${BARE_METAL_RISCV} == "true" ]]; then
+    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/riscv-collab/riscv-gnu-toolchain -b 2026.06.06 /riscv/gcc
+    ( cd /riscv/gcc;
+      ./configure --prefix=/opt/riscv-ilp32 --with-arch=rv32gc --with-abi=ilp32 --disable-gdb;
+      make "$MAKEJOBS"; )
+    rm -rf /riscv/gcc
+fi
+
 if [[ "${RUN_IWYU}" == true ]]; then
   ${CI_RETRY_EXE} git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_"${IWYU_LLVM_V}" /include-what-you-use
   pushd /include-what-you-use

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -167,6 +167,11 @@ if [ -n "${CI_LIMIT_STACK_SIZE}" ]; then
   ulimit -s 512
 fi
 
+if [[ ${BARE_METAL_RISCV} == "true" ]]; then
+    export BASE_BUILD_DIR
+    "${BASE_ROOT_DIR}/ci/test/link-riscv.sh"
+fi
+
 if [ -n "$USE_VALGRIND" ]; then
   "${BASE_ROOT_DIR}/ci/test/wrap-valgrind.py"
 fi

--- a/ci/test/link-riscv.sh
+++ b/ci/test/link-riscv.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+set -o errexit -o xtrace -o pipefail
+
+GCC=/opt/riscv-ilp32/bin/riscv32-unknown-elf-gcc
+GXX=/opt/riscv-ilp32/bin/riscv32-unknown-elf-g++
+CRTBEGIN=$("${GCC}" -print-file-name=crtbegin.o)
+LIBGCC=$("${GCC}" -print-libgcc-file-name)
+LIBSTDCXX=$("${GXX}" -print-file-name=libstdc++.a)
+LIBC=$("${GCC}" -print-file-name=libc.a)
+LIBM=$("${GCC}" -print-file-name=libm.a)
+
+echo -e "#include <script/script_error.h>\n int main() { return ScriptErrorString(ScriptError_t::SCRIPT_ERR_UNKNOWN_ERROR).size() > 0; }" > test.cpp
+
+"${GXX}" -I "${BASE_ROOT_DIR}"/src -g -std=c++20 -c test.cpp -o test.o
+
+# Make the binary executable on linux for testing purposes
+echo -e ".section .text
+      .global _start
+      .type _start, @function
+
+      _start:
+          .option push
+          .option norelax
+          la gp, __global_pointer$
+          .option pop
+
+          call main
+
+          # Put Exit2 system call number into the a7 register
+          li a7, 93
+          ecall" > start.s
+
+"${GCC}" -c start.s -o start.o
+
+echo -e "#include <sys/stat.h>
+      void _exit(int code) { while(1); }
+      int _sbrk(int incr) { return 0; }
+      int _write(int file, char *ptr, int len) { return 0; }
+      int _close(int file) { return -1; }
+      int _fstat(int file, struct stat *st) { st->st_mode = S_IFCHR; return 0; }
+      int _isatty(int file) { return 1; }
+      int _lseek(int file, int ptr, int dir) { return 0; }
+      int _read(int file, char *ptr, int len) { return 0; }
+      int _kill(int pid, int sig) { return -1; }
+      int _getpid(void) { return -1; }" > syscalls.c
+
+"${GCC}" -g -c syscalls.c -o syscalls.o
+
+"${GXX}" -g -std=c++20 \
+    -nostdlib \
+    "${CRTBEGIN}" \
+    test.o \
+    start.o \
+    syscalls.o \
+    -Wl,--whole-archive \
+    "${BASE_BUILD_DIR}"/lib/libbitcoin_consensus.a \
+    "${BASE_BUILD_DIR}"/lib/libbitcoin_crypto.a \
+    "${BASE_BUILD_DIR}"/src/secp256k1/lib/libsecp256k1.a \
+    -Wl,--no-whole-archive \
+    "${LIBSTDCXX}" \
+    "${LIBC}" \
+    "${LIBM}" \
+    "${LIBGCC}" \
+    -o test.elf
+
+file test.elf
+

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -17,7 +17,9 @@ if(NOT WIN32)
 endif()
 
 include(TestAppendRequiredLibraries)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
 test_append_atomic_library(core_interface)
+endif()
 
 # Even though ::system is part of the standard library, we still check
 # for it, to support building targets that don't have it, such as iOS.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,7 +289,7 @@ target_link_libraries(bitcoin_node
     leveldb
     minisketch
     univalue
-    Boost::headers
+    $<TARGET_NAME_IF_EXISTS:Boost::headers>
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
 if(WITH_EMBEDDED_ASMAP)

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
-  aes.cpp
+  $<$<NOT:$<STREQUAL:${CMAKE_SYSTEM_NAME},Generic>>:aes.cpp>
   chacha20.cpp
   chacha20poly1305.cpp
   hex_base.cpp
@@ -20,7 +20,7 @@ add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
   sha512.cpp
   siphash.cpp
   ../support/cleanse.cpp
-  ../support/lockedpool.cpp
+  $<$<NOT:$<STREQUAL:${CMAKE_SYSTEM_NAME},Generic>>:../support/lockedpool.cpp>
 )
 
 target_link_libraries(bitcoin_crypto

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
 target_link_libraries(test_util
   PRIVATE
     core_interface
-    Boost::headers
+    $<TARGET_NAME_IF_EXISTS:Boost::headers>
     $<$<BOOL:${ENABLE_WALLET}>:SQLite3::SQLite3>
   PUBLIC
     univalue


### PR DESCRIPTION
This adds a CI job for building the static consensus library and linking it to an executable. It uses newlib-cygwin as a C library for the final linking step. This ensure compatibility with this target going forward and can serve as a starting point for enabling bare metal builds for the entire kernel library. This would have also caught the error fixed in #31365.