### PR TITLE
lint: bump MLC to v0.19.0

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -59,7 +59,7 @@ curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
-MLC_VERSION=v0.18.0
+MLC_VERSION=v0.19.0
 MLC_BIN=mlc-x86_64-linux
 curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -530,7 +530,7 @@ fn lint_markdown() -> LintResult {
                 r#"
 One or more markdown links are broken.
 
-Relative links are preferred (but not required) as jumping to file works natively within Emacs.
+Note: relative links are preferred as jump-to-file works natively within Emacs, but they are not required.
 
 Markdown link errors found:
 {}

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -516,6 +516,7 @@ fn lint_markdown() -> LintResult {
         "--ignore-path",
         md_ignore_path_str.as_str(),
         "--gitignore",
+        "--gituntracked",
         "--root-dir",
         ".",
     ])


### PR DESCRIPTION
Fixes: #31044

This MLC update includes a change which will ignore files being ignored by git, and help avoid false-positives when linting in this repo.