### PR TITLE
util: use explicit cast in MultiIntBitSet::Fill()

### DIFF
--- a/src/util/bitset.h
+++ b/src/util/bitset.h
@@ -366,7 +366,7 @@ public:
         if (count) {
             unsigned i = 0;
             while (count > LIMB_BITS) {
-                ret.m_val[i++] = ~I{0};
+                ret.m_val[i++] = I(~I{0});
                 count -= LIMB_BITS;
             }
             ret.m_val[i] = I(~I{0}) >> (LIMB_BITS - count);


### PR DESCRIPTION
The current code does not have a bug, but is implicitly casting -1 to 65535 and the sanitizer has no way to know whether we intend that or not.

```
FUZZ=bitset src/test/fuzz/fuzz /tmp/fuz

error: implicit conversion from type 'int' of value -1 (32-bit, signed)
to type 'value_type' (aka 'unsigned short') changed the value to 65535
(16-bit, unsigned)

Base64: Qv7bX/8=
```

https://api.cirrus-ci.com/v1/task/5685829642747904/logs/ci.log
