### PR TITLE
test, univalue: Specify path to tests instead of hardcoding

### DIFF
--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -16,10 +16,6 @@ target_link_libraries(univalue PRIVATE core_interface)
 
 if(BUILD_TESTS)
   add_executable(unitester test/unitester.cpp)
-  target_compile_definitions(unitester
-    PRIVATE
-      JSON_TEST_SRC=\"${CMAKE_CURRENT_SOURCE_DIR}/test\"
-  )
   target_link_libraries(unitester
     PRIVATE
       core_interface
@@ -27,6 +23,9 @@ if(BUILD_TESTS)
   )
   add_test(NAME univalue_test
     COMMAND unitester
+  )
+  set_property(TEST univalue_test PROPERTY
+    ENVIRONMENT_MODIFICATION UNIVALUE_JSON_TEST_SRC=set:${CMAKE_CURRENT_SOURCE_DIR}/test
   )
 
   add_executable(object test/object.cpp)

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -6,13 +6,15 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 
-#ifndef JSON_TEST_SRC
-#error JSON_TEST_SRC must point to test source directory
-#endif
-
-std::string srcdir(JSON_TEST_SRC);
+std::string srcdir = []() {
+    if (const char* env_srcdir = std::getenv("UNIVALUE_JSON_TEST_SRC")) {
+        return env_srcdir;
+    }
+    return ".";
+}();
 
 static std::string rtrim(std::string s)
 {


### PR DESCRIPTION
This change is required to pass cross builds on to a different machine after the build.

For tests managed by CTest, the new `UNIVALUE_JSON_TEST_SRC` environment variable is set automatically. For other cases, it must be set manually. If not set, it defaults to the current working directory.

See for example https://github.com/bitcoin/bitcoin/pull/31176, but this PR will also allow someone to implement it outside this repo.

Also see: https://github.com/bitcoin/bitcoin/pull/31176#discussion_r1871722532.