### PR TITLE
guix: disable gcov in base-linux-gcc

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -420,6 +420,7 @@ inspecting signatures in Mach-O binaries.")
             ;; https://gcc.gnu.org/install/configure.html
             (list "--enable-threads=posix",
                   "--enable-default-ssp=yes",
+                  "--disable-gcov",
                   building-on)))))))
 
 (define-public linux-base-gcc
@@ -435,6 +436,7 @@ inspecting signatures in Mach-O binaries.")
                   "--enable-default-pie=yes",
                   "--enable-standard-branch-protection=yes",
                   "--enable-cet=yes",
+                  "--disable-gcov",
                   building-on)))
         ((#:phases phases)
           `(modify-phases ,phases


### PR DESCRIPTION
In a `x86_64-linux-gnu` build, this drops:
```bash
x86_64-linux-gnu/bin/x86_64-linux-gnu-gcov
x86_64-linux-gnu/bin/x86_64-linux-gnu-gcov-dump
x86_64-linux-gnu/bin/x86_64-linux-gnu-gcov-tool
x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/12.4.0: libgcov.a
```

For mingw-w64-gcc, `--disable-gcov` is currently passed for this target in Guix, due to issues with mingw-w64, see
https://github.com/fanquake/guix/blob/8bed031e58c9cf895d243790e7c80808b0075de7/gnu/packages/gcc.scm#L99-L102. However we'll add it in any case, in case it's re-enabled in future, when the underlying issues are fixed.