### PR TITLE
wallet: Migrate non-HD keys to combo() descriptor

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1799,7 +1799,7 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
                 keyid_it++;
                 continue;
             }
-            if (m_hd_chain.seed_id == meta.hd_seed_id || m_inactive_hd_chains.count(meta.hd_seed_id) > 0) {
+            if (!meta.hd_seed_id.IsNull() && (m_hd_chain.seed_id == meta.hd_seed_id || m_inactive_hd_chains.count(meta.hd_seed_id) > 0)) {
                 keyid_it = keyids.erase(keyid_it);
                 continue;
             }

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -1032,15 +1032,11 @@ class WalletMigrationTest(BitcoinTestFramework):
         # There should be descriptors containing the imported key for: pk(), pkh(), sh(wpkh()), wpkh()
         key_origin = hash160(pubkey)[:4].hex()
         pubkey_hex = pubkey.hex()
-        pk_desc = descsum_create(f'pk([{key_origin}]{pubkey_hex})')
-        pkh_desc = descsum_create(f'pkh([{key_origin}]{pubkey_hex})')
-        sh_wpkh_desc = descsum_create(f'sh(wpkh([{key_origin}]{pubkey_hex}))')
-        wpkh_desc = descsum_create(f'wpkh([{key_origin}]{pubkey_hex})')
-        expected_descs = [pk_desc, pkh_desc, sh_wpkh_desc, wpkh_desc]
+        combo_desc = descsum_create(f"combo([{key_origin}]{pubkey_hex})")
 
         # Verify all expected descriptors were migrated
         migrated_desc = [item['desc'] for item in wallet.listdescriptors()['descriptors'] if pubkey.hex() in item['desc']]
-        assert_equal(expected_descs, migrated_desc)
+        assert_equal([combo_desc], migrated_desc)
         wallet.unloadwallet()
 
         ######################################################


### PR DESCRIPTION
Non-HD keys do not have an HD seed ID associated with them, so if this value is the null value (all 0s), then we should not perform any seed ID comparison that would result in excluding the keys from combo() migration.

This changes the migration of non-HD wallets (or blank wallets with imported private keys) to make a single combo() descriptors for the non-HD/imported keys, rather than pk(), pkh(), sh(wpkh()), and wpkh() descriptors for the keys.

Implements https://github.com/bitcoin/bitcoin/pull/31374#discussion_r1876650074