### PR TITLE
util: detect and warn when using exFAT on MacOS

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -18,6 +18,8 @@
 
 - [Installed Files](#installed-files)
 
+- [Filesystem recommendations](#filesystem-recommendations)
+
 ## Data directory location
 
 The data directory is the default location where the Bitcoin Core files are stored.
@@ -160,3 +162,8 @@ This table describes the files installed by Bitcoin Core across different platfo
 - *Italicized* files are only installed in source builds if relevant CMake options are enabled. They are not included in binary releases.
 - README and bitcoin.conf files are included in binary releases but not installed in source builds.
 - On Windows, binaries have a `.exe` suffix (e.g., `bitcoin-cli.exe`).
+
+## Filesystem recommendations
+
+When choosing a filesystem for the data directory (`datadir`) or blocks directory (`blocksdir`) on **macOS**,the `exFAT` filesystem should be avoided.
+There have been multiple reports of database corruption and data loss when using this filesystem with Bitcoin Core, see [Issue #31454](https://github.com/bitcoin/bitcoin/issues/31454) for more details.

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -14,6 +14,23 @@
 #include <limits>
 #include <optional>
 
+#ifdef __APPLE__
+enum class FSType {
+    EXFAT,
+    OTHER,
+    ERROR
+};
+
+/**
+ * Detect filesystem type for a given path.
+ * Currently identifies exFAT filesystems which cause issues on macOS.
+ *
+ * @param[in] path The directory path to check
+ * @return FSType enum indicating the filesystem type
+ */
+FSType GetFilesystemType(const fs::path& path);
+#endif
+
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific
  * feature analogous to fsync().


### PR DESCRIPTION
exFAT is known to cause intermittent corruption on MacOS. 

Therefore we should warn when using this fs format for either the blocks or data directories.

See #28552 for more context.