### PR TITLE
build: use `-mbig-obj` for Windows debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,15 @@ if(WIN32)
     try_append_linker_flag("-Wl,--major-subsystem-version,6" TARGET core_interface)
     try_append_linker_flag("-Wl,--minor-subsystem-version,2" TARGET core_interface)
   endif()
+
+  # Workaround producing large object files, which cannot be handled by the assembler.
+  # More likely to happen with no, or lower levels of optimisation.
+  # See discussion in https://github.com/bitcoin/bitcoin/issues/28109.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    try_append_cxx_flags("/bigobj" TARGET core_interface_debug SKIP_LINK)
+  else()
+    try_append_cxx_flags("-Wa,-mbig-obj" TARGET core_interface_debug SKIP_LINK)
+  endif()
 endif()
 
 # Use 64-bit off_t on 32-bit Linux.


### PR DESCRIPTION
Windows cross builds using `-O0` (`-DCMAKE_BUILD_TYPE=Debug`) currently fail to compile, as some objects have too many sections. As a convenience, add `-mbig-obj` to our compile flags when using the `Debug` build type, so that if someone tries to build this way, it will work.

This would also be needed if we switched the depends flags to -O0. (maybe in #29796).

`-mbig-obj`

> On PE/COFF target this option forces the use of big object
> file format, which allows more than 32768 sections.

Closes #28109. Seems unlikely that we are going to break up the relevant object files, and the main issue is still the inclusion of Boost.