### PR TITLE
fuzz: Expand script verification flag testing to segwit v0 and tapscript

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -265,6 +265,18 @@ public:
          return false;
     }
 
+    virtual bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                        const std::vector<unsigned char>& program,
+                                        const uint256& tapleaf_hash) const
+    {
+         return false;
+    }
+    virtual bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                        const CScript& exec_script) const
+    {
+         return false;
+    }
+
     virtual ~BaseSignatureChecker() = default;
 };
 
@@ -301,6 +313,11 @@ public:
     bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
     bool CheckSequence(const CScriptNum& nSequence) const override;
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override;
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override;
 };
 
 using TransactionSignatureChecker = GenericTransactionSignatureChecker<CTransaction>;
@@ -331,6 +348,18 @@ public:
     bool CheckSequence(const CScriptNum& nSequence) const override
     {
         return m_checker.CheckSequence(nSequence);
+    }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return m_checker.CheckTaprootCommitment(control, program, tapleaf_hash);
+    }
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return m_checker.CheckWitnessScriptHash(program, exec_script);
     }
 };
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -704,6 +704,19 @@ public:
     bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror) const override { return sig.size() != 0; }
     bool CheckLockTime(const CScriptNum& nLockTime) const override { return true; }
     bool CheckSequence(const CScriptNum& nSequence) const override { return true; }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return true;
+    }
+
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return true;
+    }
 };
 }
 

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -299,6 +299,18 @@ const struct CheckerContext: BaseSignatureChecker {
     }
     bool CheckLockTime(const CScriptNum& nLockTime) const override { return nLockTime.GetInt64() & 1; }
     bool CheckSequence(const CScriptNum& nSequence) const override { return nSequence.GetInt64() & 1; }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return true;
+    }
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return true;
+    }
 } CHECKER_CTX;
 
 //! Context to check for duplicates when instancing a Node.

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
+#include <crypto/siphash.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <serialize.h>
@@ -15,7 +16,75 @@
 #include <utility>
 #include <vector>
 
-FUZZ_TARGET(script_flags)
+namespace {
+
+inline uint64_t HashSig(Span<const unsigned char> sig)
+{
+    CSipHasher hasher{0xdead, 0xbeef};
+    hasher.Write(sig);
+    return hasher.Finalize();
+}
+// Reduce a CScriptNum to one bit
+inline bool HashScriptNum(const CScriptNum& num)
+{
+    CSipHasher hasher{0xdead, 0xbeef};
+    hasher.Write(num.getvch());
+    return hasher.Finalize() & 1;
+}
+
+class FuzzedSignatureChecker : public BaseSignatureChecker
+{
+public:
+    FuzzedSignatureChecker(const CTransaction* tx, unsigned int in,
+                           const CAmount& amount, const PrecomputedTransactionData& tx_data,
+                           MissingDataBehavior mdb) {}
+
+    bool CheckECDSASignature(const std::vector<unsigned char>& sig, const std::vector<unsigned char>& pub_key,
+                             const CScript& script_code, SigVersion sig_version) const override
+    {
+        return !sig.empty() && (HashSig(sig) & 1);
+    }
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pub_key,
+                               SigVersion sig_version, ScriptExecutionData& exec_data,
+                               ScriptError* script_error = nullptr) const override
+    {
+        uint64_t fuzz_hash{HashSig(sig)};
+        bool sig_ok = fuzz_hash & 1;
+        if (!sig_ok && script_error) {
+            constexpr std::array<ScriptError, 3> schnorr_errs = {
+                SCRIPT_ERR_SCHNORR_SIG,
+                SCRIPT_ERR_SCHNORR_SIG_SIZE,
+                SCRIPT_ERR_SCHNORR_SIG_HASHTYPE};
+            *script_error = schnorr_errs[(fuzz_hash >> 1) % schnorr_errs.size()];
+        }
+
+        return sig_ok;
+    }
+    bool CheckLockTime(const CScriptNum& lock_time) const override
+    {
+        return HashScriptNum(lock_time);
+    }
+    bool CheckSequence(const CScriptNum& sequence) const override
+    {
+        return HashScriptNum(sequence);
+    }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return !program.empty() && (program[0] & 1);
+    }
+
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return !program.empty() && (program[0] & 1);
+    }
+};
+
+template <typename SigChecker>
+void CheckScriptFlags(FuzzBufferType buffer)
 {
     if (buffer.size() > 100'000) return;
     DataStream ds{buffer};
@@ -45,7 +114,7 @@ FUZZ_TARGET(script_flags)
 
         for (unsigned i = 0; i < tx.vin.size(); ++i) {
             const CTxOut& prevout = txdata.m_spent_outputs.at(i);
-            const TransactionSignatureChecker checker{&tx, i, prevout.nValue, txdata, MissingDataBehavior::ASSERT_FAIL};
+            const SigChecker checker{&tx, i, prevout.nValue, txdata, MissingDataBehavior::ASSERT_FAIL};
 
             ScriptError serror;
             const bool ret = VerifyScript(tx.vin.at(i).scriptSig, prevout.scriptPubKey, &tx.vin.at(i).scriptWitness, verify_flags, checker, &serror);
@@ -68,4 +137,22 @@ FUZZ_TARGET(script_flags)
     } catch (const std::ios_base::failure&) {
         return;
     }
+}
+} // namespace
+
+
+/**
+ * Both of the following harnesses test that all script verification flags only
+ * tighten the interpreter rules (i.e. they represent soft-forks).
+ */
+
+FUZZ_TARGET(script_flags)
+{
+    CheckScriptFlags<TransactionSignatureChecker>(buffer);
+}
+
+// Signature validation is mocked out through FuzzedSignatureChecker
+FUZZ_TARGET(script_flags_mocked)
+{
+    CheckScriptFlags<FuzzedSignatureChecker>(buffer);
 }

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -44,6 +44,18 @@ public:
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
     virtual ~FuzzedSignatureChecker() = default;
 };
 } // namespace

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -289,6 +289,19 @@ public:
         // Delegate to Satisfier.
         return ctx.CheckOlder(sequence.GetInt64());
     }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return true;
+    }
+
+    bool CheckWitnessScriptHash(Span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return true;
+    }
 };
 
 using Fragment = miniscript::Fragment;


### PR DESCRIPTION
The `script_flags` harness aims to test that our script verification flags are soft-forks (i.e. applying flags can only tighten the verification rules and not widen them). `SigVersion::WITNESS_V0` and `SigVersion::TAPSCRIPT` scripts are currently not covered by this test, as fuzzers are blocked from e.g. creating a valid taproot script path spend commitment.

This PR:

*  Moves the taproot commitment and witness script hash checks to `BaseSignatureChecker` (real impl in `GenericTransactionSignatureChecker`)
* Introduces a second script flags harness `script_flags_mocked` which uses a `BaseSignatureChecker` mock, unblocking fuzzers from reaching segwit v{0,1} interpreter code (as well as paths relating to valid signatures)