### PR TITLE
depends: add `-g` to *BSD_debug flags

### DIFF
--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -4,7 +4,7 @@ freebsd_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
 freebsd_release_CFLAGS=-O2
 freebsd_release_CXXFLAGS=$(freebsd_release_CFLAGS)
 
-freebsd_debug_CFLAGS=-O1
+freebsd_debug_CFLAGS=-O1 -g
 freebsd_debug_CXXFLAGS=$(freebsd_debug_CFLAGS)
 
 ifeq (86,$(findstring 86,$(build_arch)))

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -12,7 +12,7 @@ netbsd_CXXFLAGS=$(netbsd_CFLAGS)
 netbsd_release_CFLAGS=-O2
 netbsd_release_CXXFLAGS=$(netbsd_release_CFLAGS)
 
-netbsd_debug_CFLAGS=-O1
+netbsd_debug_CFLAGS=-O1 -g
 netbsd_debug_CXXFLAGS=$(netbsd_debug_CFLAGS)
 
 ifeq (86,$(findstring 86,$(build_arch)))

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -4,7 +4,7 @@ openbsd_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
 openbsd_release_CFLAGS=-O2
 openbsd_release_CXXFLAGS=$(openbsd_release_CFLAGS)
 
-openbsd_debug_CFLAGS=-O1
+openbsd_debug_CFLAGS=-O1 -g
 openbsd_debug_CXXFLAGS=$(openbsd_debug_CFLAGS)
 
 ifeq (86,$(findstring 86,$(build_arch)))


### PR DESCRIPTION
To match the other HOST_debug_flags. Pulled out of #29796.