### PR TITLE
test: raise explicit error if any of the needed release binaries is missing

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -526,6 +526,15 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             binary = [get_bin_from_version(v, 'bitcoind', self.options.bitcoind) for v in versions]
         if binary_cli is None:
             binary_cli = [get_bin_from_version(v, 'bitcoin-cli', self.options.bitcoincli) for v in versions]
+        # Fail test if any of the needed release binaries is missing
+        bins_missing = False
+        for bin_path in binary + binary_cli:
+            if shutil.which(bin_path) is None:
+                self.log.error(f"Binary not found: {bin_path}")
+                bins_missing = True
+        if bins_missing:
+            raise AssertionError("At least one release binary is missing. "
+                                 "Previous releases binaries can be downloaded via `test/get_previous_releases.py -b`.")
         assert_equal(len(extra_confs), num_nodes)
         assert_equal(len(extra_args), num_nodes)
         assert_equal(len(versions), num_nodes)


### PR DESCRIPTION
If the `releases` directory exists, but still only a subset of the necessary previous release binaries are available, the test fails by throwing an exception (sometimes leading to follow-up exceptions like `AssertionError: [node 0] Error: no RPC connection`) and printing out a stack trace, which can be confusing and at a first glance suggests that the node crashed or some alike.
Improve this by checking and printing out *all* of the missing release binaries and failing with an explicit error in this case. Also add an info on how to download previous releases binaries. Noticed while testing #30328.

Can be tested by e.g.

```
$ rm -rf ./releases
$ ./test/get_previous_releases.py -b
$ rm -rf ./releases/v28.0/
$ ./build/test/functional/wallet_migration.py
```


master:
<details>
<summary>Long test fail output</summary>

```
...
2024-12-10T18:48:54.067000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 590, in start_nodes
    node.start(extra_args[i], *args, **kwargs)
  File "/home/thestack/bitcoin/test/functional/test_framework/test_node.py", line 257, in start
    self.process = subprocess.Popen(self.args + extra_args, env=subp_env, stdout=stdout, stderr=stderr, cwd=cwd, **kwargs)
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/thestack/bitcoin/releases/v28.0/bin/bitcoind'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 131, in main
    self.setup()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 315, in setup
    self.setup_network()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 409, in setup_network
    self.setup_nodes()
  File "/home/thestack/bitcoin/./build/test/functional/wallet_migration.py", line 54, in setup_nodes
    self.start_nodes()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 595, in start_nodes
    self.stop_nodes()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 610, in stop_nodes
    node.stop_node(wait=wait, wait_until_stopped=False)
  File "/home/thestack/bitcoin/test/functional/test_framework/test_node.py", line 396, in stop_node
    self.stop(wait=wait)
  File "/home/thestack/bitcoin/test/functional/test_framework/test_node.py", line 215, in __getattr__
    assert self.rpc_connected and self.rpc is not None, self._node_msg("Error: no RPC connection")
AssertionError: [node 0] Error: no RPC connection
2024-12-10T18:48:54.118000Z TestFramework (INFO): Stopping nodes
Traceback (most recent call last):
  File "/home/thestack/bitcoin/./build/test/functional/wallet_migration.py", line 1097, in <module>
    WalletMigrationTest(__file__).main()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 159, in main
    exit_code = self.shutdown()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 331, in shutdown
    self.stop_nodes()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 610, in stop_nodes
    node.stop_node(wait=wait, wait_until_stopped=False)
  File "/home/thestack/bitcoin/test/functional/test_framework/test_node.py", line 396, in stop_node
    self.stop(wait=wait)
  File "/home/thestack/bitcoin/test/functional/test_framework/test_node.py", line 215, in __getattr__
    assert self.rpc_connected and self.rpc is not None, self._node_msg("Error: no RPC connection")
AssertionError: [node 0] Error: no RPC connection
[node 0] Cleaning up leftover process
...
```
</details>

PR:
```
...
2025-01-01T20:26:27.999000Z TestFramework (INFO): PRNG seed is: 4570383538468804512
2025-01-01T20:26:28.000000Z TestFramework (INFO): Initializing test directory /tmp/bitcoin_func_test_lz66_zcu
2025-01-01T20:26:28.003000Z TestFramework (ERROR): Binary not found: /home/thestack/bitcoin/releases/v28.0/bin/bitcoind
2025-01-01T20:26:28.003000Z TestFramework (ERROR): Binary not found: /home/thestack/bitcoin/releases/v28.0/bin/bitcoin-cli
2025-01-01T20:26:28.003000Z TestFramework (INFO): Previous releases binaries can be downloaded via `test/get_previous_releases.py -b`.
2025-01-01T20:26:28.003000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 131, in main
    self.setup()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 315, in setup
    self.setup_network()
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 409, in setup_network
    self.setup_nodes()
  File "/home/thestack/bitcoin/./build/test/functional/wallet_migration.py", line 50, in setup_nodes
    self.add_nodes(self.num_nodes, versions=[
  File "/home/thestack/bitcoin/test/functional/test_framework/test_framework.py", line 537, in add_nodes
    raise AssertionError("At least one release binary is missing")
AssertionError: At least one release binary is missing
2025-01-01T20:26:28.061000Z TestFramework (INFO): Stopping nodes
...
```
