### PR TITLE
lint: Disable signature output in git log

### DIFF
--- a/test/lint/lint-git-commit-check.py
+++ b/test/lint/lint-git-commit-check.py
@@ -36,10 +36,10 @@ def main():
     assert os.getenv("COMMIT_RANGE")  # E.g. COMMIT_RANGE='HEAD~n..HEAD'
     commit_range = os.getenv("COMMIT_RANGE")
 
-    commit_hashes = check_output(["git", "log", commit_range, "--format=%H"], text=True, encoding="utf8").splitlines()
+    commit_hashes = check_output(["git", "-c", "log.showSignature=false", "log", commit_range, "--format=%H"], text=True, encoding="utf8").splitlines()
 
     for hash in commit_hashes:
-        commit_info = check_output(["git", "log", "--format=%B", "-n", "1", hash], text=True, encoding="utf8").splitlines()
+        commit_info = check_output(["git", "-c", "log.showSignature=false", "log", "--format=%B", "-n", "1", hash], text=True, encoding="utf8").splitlines()
         if len(commit_info) >= 2:
             if commit_info[1]:
                 print(f"The subject line of commit hash {hash} is followed by a non-empty line. Subject lines should always be followed by a blank line.")


### PR DESCRIPTION
Necessary for users that have signature output enabled by default, since the script would stumble on them and error out.

---

### Testing setup

Set local repo config to show signatures in log by default, simulating a user having that setting turned on globally.
```
₿ git config set log.showSignature true
```
### Command under test

```
₿ ( cd ./test/lint/test_runner/ && COMMIT_RANGE='HEAD^..HEAD' cargo run )
```
#### Before
```
...
fatal: invalid object name 'gpg'.
Traceback (most recent call last):
  File "/home/hodlinator/bitcoin/test/lint/lint-git-commit-check.py", line 52, in <module>
    main()
  File "/home/hodlinator/bitcoin/test/lint/lint-git-commit-check.py", line 42, in main
    commit_info = check_output(["git", "log", "--format=%B", "-n", "1", hash], text=True, encoding="utf8").splitlines()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/wfbjq35kxs6x83c3ncpfxdyl5gbhdx4h-python3-3.12.6/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/wfbjq35kxs6x83c3ncpfxdyl5gbhdx4h-python3-3.12.6/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'log', '--format=%B', '-n', '1', 'gpg: Signature made ons 11 dec 2024 10:46:34 CET']' returned non-zero exit status 128.
^---- ⚠️ Failure generated from lint-git-commit-check.py
...
```
#### After

(No failure generated by *lint-git-commit-check.py*).