### PR TITLE
refactor: Fix "modernize-use-starts-ends-with" clang-tidy warning

### DIFF
--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -72,7 +72,7 @@ static bool ParseAddress(std::string& address,
                   struct sockaddr_un& addr,
                   std::string& error)
 {
-    if (address.compare(0, 4, "unix") == 0 && (address.size() == 4 || address[4] == ':')) {
+    if (address == "unix" || address.starts_with("unix:")) {
         fs::path path;
         if (address.size() <= 5) {
             path = data_dir / fs::PathFromString(strprintf("%s.sock", RemovePrefixView(dest_exe_name, "bitcoin-")));


### PR DESCRIPTION
This PR is a follow-up to #31306 and fixes the "modernize-use-starts-ends-with" warning in the multiprocess code (see https://github.com/bitcoin/bitcoin/pull/30975#issuecomment-2527008761).

Fixes https://github.com/chaincodelabs/libmultiprocess/issues/124.