### PR TITLE
fuzz: Faster leak check when generating corpus

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -278,6 +278,7 @@ def generate_corpus(*, fuzz_pool, src_dir, fuzz_bin, corpus_dir, targets):
         use_value_profile = int(random.random() < .3)
         command = [
             fuzz_bin,
+            "-detect_leaks=0",  # Disable leak detection on every iteration, it is still run on shutdown.
             "-rss_limit_mb=8000",
             "-max_total_time=6000",
             "-reload=0",


### PR DESCRIPTION
Currently, when running the fuzz targets under asan, leak detection may be expensive when global memory is involved on every iteration. For example when `SeedRandomStateForTest(SeedRand::ZEROS)` is called on every iteration.

Fix it by disabling leak check on every iteration, but still do it at the end.