### PR TITLE
fuzz: Fix test_runner error reporting

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -371,10 +371,6 @@ def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, using_libfuzzer
     for future in as_completed(jobs):
         output, result, target = future.result()
         logging.debug(output)
-        if using_libfuzzer:
-            done_stat = [l for l in output.splitlines() if "DONE" in l]
-            assert len(done_stat) == 1
-            stats.append((target, done_stat[0]))
         try:
             result.check_returncode()
         except subprocess.CalledProcessError as e:
@@ -382,8 +378,12 @@ def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, using_libfuzzer
                 logging.info(e.stdout)
             if e.stderr:
                 logging.info(e.stderr)
-            logging.info(f"Target {result.args} failed with exit code {e.returncode}")
+            logging.info(f"⚠️ Failure generated from target with exit code {e.returncode}: {result.args}")
             sys.exit(1)
+        if using_libfuzzer:
+            done_stat = [l for l in output.splitlines() if "DONE" in l]
+            assert len(done_stat) == 1
+            stats.append((target, done_stat[0]))
 
     if using_libfuzzer:
         print("Summary:")


### PR DESCRIPTION
The error reporting is confusing, because right now it prints:

https://cirrus-ci.com/task/4846031060336640?logs=ci#L4931

```
...
Traceback (most recent call last):
  File "/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/test/fuzz/test_runner.py", line 411, in <module>
    main()
  File "/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/test/fuzz/test_runner.py", line 199, in main
    run_once(
  File "/ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/test/fuzz/test_runner.py", line 376, in run_once
    assert len(done_stat) == 1
           ^^^^^^^^^^^^^^^^^^^
AssertionError
```

This is harmless, but confusing.

Fix it by collecting statistics only when the program has not aborted. (Can be reviewed with `--color-moved=dimmed-zebra`)

Also, reword the error message to align it with error messages in other test_runners in this repo.