### PR TITLE
Execute Discover() when bind=0.0.0.0 or :: is set

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -146,8 +146,10 @@ uint16_t GetListenPort()
     // If -bind= is provided with ":port" part, use that (first one if multiple are provided).
     for (const std::string& bind_arg : gArgs.GetArgs("-bind")) {
         constexpr uint16_t dummy_port = 0;
+        // maybe bind_arg has "=onion"
+        const std::string truncated_bind_arg = bind_arg.substr(0, bind_arg.rfind('='));
 
-        const std::optional<CService> bind_addr{Lookup(bind_arg, dummy_port, /*fAllowLookup=*/false)};
+        const std::optional<CService> bind_addr{Lookup(truncated_bind_arg, dummy_port, /*fAllowLookup=*/false)};
         if (bind_addr.has_value() && bind_addr->GetPort() != dummy_port) return bind_addr->GetPort();
     }
 
@@ -3273,7 +3275,7 @@ bool CConnman::InitBinds(const Options& options)
             return false;
         }
     }
-    if (options.bind_on_any) {
+    if (options.bind_on_any && options.vBinds.empty() && options.onion_binds.empty()) {
         // Don't consider errors to bind on IPv6 "::" fatal because the host OS
         // may not have IPv6 support and the user did not explicitly ask us to
         // bind on that.
@@ -3284,6 +3286,14 @@ bool CConnman::InitBinds(const Options& options)
         inaddr_any.s_addr = htonl(INADDR_ANY);
         const CService ipv4_any{inaddr_any, GetListenPort()}; // 0.0.0.0
         if (!Bind(ipv4_any, BF_REPORT_ERROR, NetPermissionFlags::None)) {
+            return false;
+        }
+
+        struct in_addr onion_service_target;
+        onion_service_target.s_addr = htonl(INADDR_LOOPBACK);
+        const uint16_t onion_port = GetListenPort() + 1;
+        const CService onion_addr = {onion_service_target, onion_port}; // 127.0.0.1
+        if (!Bind(onion_addr, BF_REPORT_ERROR | BF_DONT_ADVERTISE, NetPermissionFlags::None)) {
             return false;
         }
     }

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -27,13 +27,35 @@ BIND_PORT = 31001
 class BindPortDiscoverTest(BitcoinTestFramework):
     def set_test_params(self):
         # Avoid any -bind= on the command line. Force the framework to avoid adding -bind=127.0.0.1.
-        self.setup_clean_chain = True
         self.bind_to_localhost_only = False
         self.extra_args = [
             ['-discover', f'-port={BIND_PORT}'], # bind on any
             ['-discover', f'-bind={ADDR1}:{BIND_PORT}'],
+            ['-discover', f'-bind=0.0.0.0:{BIND_PORT+1}'],
+            ['-discover', f'-bind=[::]:{BIND_PORT+2}'],
+            ['-discover', '-bind=::', f'-port={BIND_PORT+3}'],
+            ['-discover', f'-bind=0.0.0.0:{BIND_PORT+4}=onion'],
         ]
         self.num_nodes = len(self.extra_args)
+
+    def setup_network(self):
+        """
+        BitcoinTestFramework.setup_network() without connecting node0 to node1,
+        we don't need that and avoiding it makes the test faster.
+        """
+        self.setup_nodes()
+
+    def setup_nodes(self):
+        """
+        BitcoinTestFramework.setup_nodes() with overridden has_explicit_bind=True
+        for each node and without the chain setup.
+        """
+        self.add_nodes(self.num_nodes, self.extra_args)
+        # TestNode.start() will add -bind= to extra_args if has_explicit_bind is
+        # False. We do not want any -bind= thus set has_explicit_bind to True.
+        for node in self.nodes:
+            node.has_explicit_bind = True
+        self.start_nodes()
 
     def add_options(self, parser):
         parser.add_argument(
@@ -47,32 +69,50 @@ class BindPortDiscoverTest(BitcoinTestFramework):
                 f"To run this test make sure that {ADDR1} and {ADDR2} (routable addresses) are "
                 "assigned to the interfaces on this machine and rerun with --ihave1111and2222")
 
+    def verify_addrs(self, found_addrs, expected_addr1, expected_addr2, port):
+        print(found_addrs, port)
+        found_addr1 = False
+        found_addr2 = False
+        for local in found_addrs:
+            if local['address'] == ADDR1:
+                found_addr1 = True
+                assert_equal(local['port'], port)
+            if local['address'] == ADDR2:
+                found_addr2 = True
+                assert_equal(local['port'], port)
+        assert found_addr1 == expected_addr1
+        assert found_addr2 == expected_addr2
+
     def run_test(self):
         self.log.info(
                 "Test that if -bind= is not passed then all addresses are "
                 "added to localaddresses")
-        found_addr1 = False
-        found_addr2 = False
-        for local in self.nodes[0].getnetworkinfo()['localaddresses']:
-            if local['address'] == ADDR1:
-                found_addr1 = True
-                assert_equal(local['port'], BIND_PORT)
-            if local['address'] == ADDR2:
-                found_addr2 = True
-                assert_equal(local['port'], BIND_PORT)
-        assert found_addr1
-        assert found_addr2
+        self.verify_addrs(self.nodes[0].getnetworkinfo()['localaddresses'], True, True, BIND_PORT)
 
         self.log.info(
                 "Test that if -bind= is passed then only that address is "
                 "added to localaddresses")
-        found_addr1 = False
-        for local in self.nodes[1].getnetworkinfo()['localaddresses']:
-            if local['address'] == ADDR1:
-                found_addr1 = True
-                assert_equal(local['port'], BIND_PORT)
-            assert local['address'] != ADDR2
-        assert found_addr1
+        self.verify_addrs(self.nodes[1].getnetworkinfo()['localaddresses'], True, False, BIND_PORT)
+
+        self.log.info(
+                "Test that if -bind=0.0.0.0:port is passed then all addresses are "
+                "added to localaddresses")
+        self.verify_addrs(self.nodes[2].getnetworkinfo()['localaddresses'], True, True, BIND_PORT+1)
+
+        self.log.info(
+                "Test that if -bind=[::]:port is passed then all addresses are "
+                "added to localaddresses")
+        self.verify_addrs(self.nodes[3].getnetworkinfo()['localaddresses'], True, True, BIND_PORT+2)
+
+        self.log.info(
+                "Test that if -bind=:: is passed then all addresses are "
+                "added to localaddresses")
+        self.verify_addrs(self.nodes[4].getnetworkinfo()['localaddresses'], True, True, BIND_PORT+3)
+
+        self.log.info(
+                "Test that if -bind=0.0.0.0:port=onion is passed then all addresses are "
+                "added to localaddresses")
+        self.verify_addrs(self.nodes[5].getnetworkinfo()['localaddresses'], True, True, BIND_PORT+4)
 
 if __name__ == '__main__':
     BindPortDiscoverTest(__file__).main()


### PR DESCRIPTION
If `-bind=0.0.0.0` or `-bind=::` is specified, it indicates that we can bind to any available address. In this case, the `Discover()` function should be executed to retrieve the local addresses. This behavior should also work for "=onion" addresses.

I updated the `GetListenPort()` function to also consider ports from onion address. Without this change, when `-bind=0.0.0.0:port=onion` is used, the bound port would not match the specified port.

### How to test
Prepare the addresses to be found by `Discover()`
```bash
ip link add name lo_dummy type dummy
ip addr add 127.0.1.2/8 dev lo_dummy
ip link set lo_dummy up
ifconfig lo_dummy:0 1.1.1.1/32 up && ifconfig lo_dummy:1 2.2.2.2/32 up
```
Execute the test
```bash
./build/test/functional/test_runner.py --ihave1111and2222 feature_bind_port_discover
```
Undo the changes after the test execution
```bash
ifconfig lo_dummy:0 down && ifconfig lo_dummy:1
ip link set lo_dummy down
ip link delete lo_dummy
```

Fixes #31293
This PR also fixes the test `feature_bind_port_discover.py` that was falling.
Fixes #31336