### PR TITLE
refactor: Use immediate lambda to work around GCC bug 117966

### DIFF
--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -192,7 +192,10 @@ int ecdsa_signature_parse_der_lax(secp256k1_ecdsa_signature* sig, const unsigned
  *  For an example script for calculating H, refer to the unit tests in
  *  ./test/functional/test_framework/crypto/secp256k1.py
  */
-constexpr XOnlyPubKey XOnlyPubKey::NUMS_H{"50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"_hex_u8};
+constexpr XOnlyPubKey XOnlyPubKey::NUMS_H{
+    // Use immediate lambda to work around GCC-14 bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117966
+    []() consteval { return XOnlyPubKey{"50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"_hex_u8}; }(),
+};
 
 std::vector<CKeyID> XOnlyPubKey::GetKeyIDs() const
 {


### PR DESCRIPTION
Currently the libstdc++ debug mode can only be used with version 11, or 15 (and later), due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117966

This seems restrictive.

Add a temporary workaround for now, which makes the global (temporary) `std::span` local to a lambda.