### PR TITLE
depends: Ignore prefix directory on OpenBSD

### DIFF
--- a/depends/.gitignore
+++ b/depends/.gitignore
@@ -3,6 +3,7 @@ work/
 built/
 sources/
 x86_64*
+amd64*
 i686*
 mips*
 arm*


### PR DESCRIPTION
On OpenBSD, the prefix directory is named as follows:
```
$ gmake --no-print-directory -C depends print-x86_64_openbsd_prefix
x86_64_openbsd_prefix=/home/hebasto/dev/bitcoin/depends/amd64-unknown-openbsd7.6
```

This name does not match any pattern in `depends/.gitignore`.

This PR resolves this issue.