### PR TITLE
depends: Fix compiling `libevent` package on NetBSD

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://github.com/libevent/libevent/releases/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 $(package)_patches=cmake_fixups.patch
+$(package)_patches += netbsd_fixup.patch
 $(package)_build_subdir=build
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
@@ -23,7 +24,8 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch
+  patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch && \
+  patch -p1 < $($(package)_patch_dir)/netbsd_fixup.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/netbsd_fixup.patch
+++ b/depends/patches/libevent/netbsd_fixup.patch
@@ -1,0 +1,23 @@
+Improve portability on NetBSD
+
+According to GCC documentation, "the various `-std` options disable
+certain keywords".
+This change adheres to GCC's recommendation by replacing the `typeof`
+keyword with its alternative, `__typeof__`.
+
+See https://github.com/libevent/libevent/commit/1759485e9a59147a47a674f5132fcfe764e7748c.
+
+
+--- a/kqueue.c
++++ b/kqueue.c
+@@ -52,8 +52,8 @@
+  * intptr_t, whereas others define it as void*.  There doesn't seem to be an
+  * easy way to tell them apart via autoconf, so we need to use OS macros. */
+ #if defined(__NetBSD__)
+-#define PTR_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(x))
+-#define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
++#define PTR_TO_UDATA(x) ((__typeof__(((struct kevent *)0)->udata))(x))
++#define INT_TO_UDATA(x) ((__typeof__(((struct kevent *)0)->udata))(intptr_t)(x))
+ #elif defined(EVENT__HAVE_INTTYPES_H) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__darwin__) && !defined(__APPLE__) && !defined(__CloudABI__)
+ #define PTR_TO_UDATA(x)	((intptr_t)(x))
+ #define INT_TO_UDATA(x) ((intptr_t)(x))


### PR DESCRIPTION
Libevent [introduced](https://github.com/libevent/libevent/pull/909) the [`typeof`](https://gcc.gnu.org/onlinedocs/gcc/Typeof.html) C language extension in the NetBSD-specific code, which was pulled into our depends in https://github.com/bitcoin/bitcoin/pull/21991.

However, GCC [states](https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html):
> the various `-std` options disable certain keywords.

Due to our use of https://github.com/bitcoin/bitcoin/blob/b042c4f0538c6f9cdf8efbcef552796851e38a85/depends/hosts/netbsd.mk#L1

the `typeof` keyword is disabled, resulting in a compilation error:
```
$ gmake -C depends libevent CC=/usr/pkg/gcc14/bin/gcc CXX=/usr/pkg/gcc14/bin/g++
<snip>
[ 37%] Building C object CMakeFiles/event_core_static.dir/kqueue.c.o
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c: In function 'kq_setup_kevent':
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:56:27: error: implicit declaration of function 'typeof' [-Wimplicit-function-declaration]
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                           ^~~~~~
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:190:30: note: in expansion of macro 'INT_TO_UDATA'
  190 |                 out->udata = INT_TO_UDATA(ADD_UDATA);
      |                              ^~~~~~~~~~~~
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:56:64: error: expected expression before 'intptr_t'
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                                                                ^~~~~~~~
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:190:30: note: in expansion of macro 'INT_TO_UDATA'
  190 |                 out->udata = INT_TO_UDATA(ADD_UDATA);
      |                              ^~~~~~~~~~~~
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:56:27: error: called object is not a function or function pointer
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                          ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/libevent/2.1.12-stable-ca6b96ec97c/kqueue.c:190:30: note: in expansion of macro 'INT_TO_UDATA'
  190 |                 out->udata = INT_TO_UDATA(ADD_UDATA);
      |                              ^~~~~~~~~~~~
gmake[3]: *** [CMakeFiles/event_core_static.dir/build.make:328: CMakeFiles/event_core_static.dir/kqueue.c.o] Error 1
<snip>
```

This PR resolves this issue by following GCC's [recommendation](https://gcc.gnu.org/onlinedocs/gcc/Typeof.html):
> write `__typeof__` instead of `typeof`.