### PR TITLE
Fix Broken Link in bitcoinconsensus.h Documentation

### DIFF
--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -230,7 +230,7 @@ bindings such as [python-bitcoinlib](https://pypi.python.org/pypi/python-bitcoin
 alternative node implementations.
 
 This library is called `libbitcoinconsensus.so` (or, `.dll` for Windows).
-Its interface is defined in the C header [bitcoinconsensus.h](https://github.com/bitcoin/bitcoin/blob/0.10/src/script/bitcoinconsensus.h).
+Its interface is defined in the C header [bitcoinconsensus.h](https://github.com/bitcoin/bitcoin/blob/v0.10.0/src/script/bitcoinconsensus.h).
 
 In its initial version the API includes two functions:
 


### PR DESCRIPTION
### Motivation

The `bitcoinconsensus.h` file contained a broken link to the Bitcoin Core GitHub repository. This outdated link (`https://github.com/bitcoin/bitcoin/blob/0.10/src/script/bitcoinconsensus.h`) led to a non-functional page. To improve the documentation's accuracy and usability, the link was updated to a valid URL (`https://github.com/bitcoin/bitcoin/blob/v0.10.0/src/script/bitcoinconsensus.h`).

### How This Improves Bitcoin Core

This change improves the developer experience by ensuring that the documentation provides accurate and functional links, preventing confusion or misdirection when navigating the repository.

### Testing

This change was verified manually:
- The new URL was tested to confirm it resolves correctly to the intended file.
- No further code changes were made, and the documentation update does not impact runtime or functionality.

### Additional Notes

- This is a minor documentation fix, so no new unit tests or functional tests are required.
- The change does not introduce new dependencies or alter existing functionality.
