### PR TITLE
depends: Fix `CXXFLAGS` on NetBSD

### DIFF
--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -7,8 +7,6 @@ netbsd_NM = $(host_toolchain)gcc-nm
 netbsd_RANLIB = $(host_toolchain)gcc-ranlib
 endif
 
-netbsd_CXXFLAGS=$(netbsd_CFLAGS)
-
 netbsd_release_CFLAGS=-O2
 netbsd_release_CXXFLAGS=$(netbsd_release_CFLAGS)
 


### PR DESCRIPTION
This PR corrects an issue where `CXXFLAGS` were mistakenly overridden by `CFLAGS`. This behaviour was introduced in 7e7b3e42fa98b584ae60513a6774037bf677b8ce (from https://github.com/bitcoin/bitcoin/pull/22380).

On the master branch:
```
$ gmake --no-print-directory -C depends print-x86_64_netbsd_CXXFLAGS
x86_64_netbsd_CXXFLAGS=-pipe -std=c11
```

With this PR:
```
$ gmake --no-print-directory -C depends print-x86_64_netbsd_CXXFLAGS
x86_64_netbsd_CXXFLAGS=-pipe -std=c++20
```