### PR TITLE
cmake: Link `bitcoin_consensus` as a library

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,7 +18,6 @@ generate_header_from_raw(data/asmap.raw test::data)
 # SOURCES property is processed to gather test suite macros.
 add_executable(test_bitcoin
   main.cpp
-  $<TARGET_OBJECTS:bitcoin_consensus>
   ${CMAKE_CURRENT_BINARY_DIR}/data/asmap.raw.h
   ${CMAKE_CURRENT_BINARY_DIR}/data/base58_encode_decode.json.h
   ${CMAKE_CURRENT_BINARY_DIR}/data/bip341_wallet_vectors.json.h
@@ -151,6 +150,7 @@ target_link_libraries(test_bitcoin
   test_util
   bitcoin_cli
   bitcoin_node
+  bitcoin_consensus
   minisketch
   secp256k1
   Boost::headers


### PR DESCRIPTION
The [`TARGET_OBJECTS`](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_OBJECTS) generator expression was introduced in the staging branch when we aimed to build the libbitcoinconsensus shared library. However, `bitcoin_consensus` is a `STATIC` library, not an `OBJECT` library.

This change updates the build system to link `bitcoin_consensus` normally to `test_bitcoin`, resolving [linking issues](https://github.com/bitcoin/bitcoin/issues/31456#issuecomment-2538798107) when building with clang-cl.