### PR TITLE
cmake: De-duplicate libraries on link lines opportunistically

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -14,6 +14,12 @@ generate_header_from_json(data/tx_invalid.json)
 generate_header_from_json(data/tx_valid.json)
 generate_header_from_raw(data/asmap.raw test::data)
 
+if(POLICY CMP0156)
+  # De-duplicate libraries on link lines based on linker capabilities.
+  # See: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+  cmake_policy(SET CMP0156 NEW)
+endif()
+
 # Do not use generator expressions in test sources because the
 # SOURCES property is processed to gather test suite macros.
 add_executable(test_bitcoin

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -4,6 +4,12 @@
 
 add_subdirectory(util)
 
+if(POLICY CMP0156)
+  # De-duplicate libraries on link lines based on linker capabilities.
+  # See: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+  cmake_policy(SET CMP0156 NEW)
+endif()
+
 add_executable(fuzz
   addition_overflow.cpp
   addrman.cpp


### PR DESCRIPTION
This PR resolves "ignoring duplicate libraries" linker warnings on [macOS](https://github.com/bitcoin/bitcoin/actions/runs/12324827707/job/34403065736):
```
[892/895] Linking CXX executable src/test/test_bitcoin
ld: warning: ignoring duplicate libraries: 'src/secp256k1/lib/libsecp256k1.a'
<snip>
[894/895] Linking CXX executable src/test/fuzz/fuzz
ld: warning: ignoring duplicate libraries: 'libleveldb.a', 'libminisketch.a', 'src/libbitcoin_common.a', 'src/secp256k1/lib/libsecp256k1.a', 'src/univalue/libunivalue.a', 'src/util/libbitcoin_util.a'
```