### PR TITLE
Fix typos and improve consistency in documentation

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -105,7 +105,7 @@ RPC interface will be abused.
   includes being able to record any passphrases you enter for unlocking
   your encrypted wallets or changing settings so that your Bitcoin Core
   program tells you that certain transactions have multiple
-  confirmations even when they aren't part of the best block chain.  For
+  confirmations even when they aren't part of the best blockchain.  For
   this reason, you should not use Bitcoin Core for security sensitive
   operations on systems you do not exclusively control, such as shared
   computers or virtual private servers.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -82,7 +82,7 @@ Responds with 404 if block not found.
 #### Chaininfos
 `GET /rest/chaininfo.json`
 
-Returns various state info regarding block chain processing.
+Returns various state info regarding blockchain processing.
 Only supports JSON as output format.
 Refer to the `getblockchaininfo` RPC help for details.
 

--- a/doc/release-notes/release-notes-0.12.1.md
+++ b/doc/release-notes/release-notes-0.12.1.md
@@ -95,7 +95,7 @@ in any transaction in that block.
 
 Miners get to choose what time they use for their header time, with the
 consensus rule being that no node will accept a block whose time is more
-than two hours in the future.  This creates a incentive for miners to
+than two hours in the future.  This creates an incentive for miners to
 set their header times to future values in order to include locktimed
 transactions which weren't supposed to be included for up to two more
 hours.

--- a/doc/release-notes/release-notes-0.13.2.md
+++ b/doc/release-notes/release-notes-0.13.2.md
@@ -19,7 +19,7 @@ Compatibility
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
 an OS initially released in 2001. This means that not even critical security
 updates will be released anymore. Without security updates, using a bitcoin
-wallet on a XP machine is irresponsible at least.
+wallet on an XP machine is irresponsible at least.
 
 In addition to that, with 0.12.x there have been varied reports of Bitcoin Core
 randomly crashing on Windows XP. It is [not clear](https://github.com/bitcoin/bitcoin/issues/7681#issuecomment-217439891)

--- a/doc/release-notes/release-notes-0.6.3.md
+++ b/doc/release-notes/release-notes-0.6.3.md
@@ -17,7 +17,7 @@ speed up processing of new block messages and make propagating
 blocks across the network faster.
 
 Fixed an obscure bug that could cause the bitcoin process to get
-stuck on an invalid block-chain, if the invalid chain was
+stuck on an invalid blockchain, if the invalid chain was
 hundreds of blocks long.
 
 Bitcoin-Qt no longer automatically selects the first address

--- a/doc/release-notes/release-notes-0.8.0.md
+++ b/doc/release-notes/release-notes-0.8.0.md
@@ -25,7 +25,7 @@ Incompatible Changes
 This release no longer maintains a full index of historical transaction ids
 by default, so looking up an arbitrary transaction using the getrawtransaction
 RPC call will not work. If you need that functionality, you must run once
-with -txindex=1 -reindex=1 to rebuild block-chain indices (see below for more
+with -txindex=1 -reindex=1 to rebuild blockchain indices (see below for more
 details).
 
 Improvements

--- a/doc/release-notes/release-notes-0.9.2.md
+++ b/doc/release-notes/release-notes-0.9.2.md
@@ -78,7 +78,7 @@ Command-line options:
 - Fix `-printblocktree` output
 - Show error message if ReadConfigFile fails
 
-Block-chain handling and storage:
+Blockchain handling and storage:
 
 - Fix for GetBlockValue() after block 13,440,000 (BIP42)
 - Upgrade leveldb to 1.17


### PR DESCRIPTION
This pull request addresses several typographical errors and ensures consistency in terminology across the Bitcoin Core documentation.

#### Changes include:
- Replacing "block chain" with the correct term "blockchain" in multiple documentation files.
- Correcting the article usage from "a" to "an" where necessary, specifically before "XP".
- Minor grammatical improvements, such as adding "an" instead of "a" in contexts where the following word starts with a vowel sound.

#### Affected files:
- `doc/JSON-RPC-interface.md`
- `doc/REST-interface.md`
- `doc/release-notes/release-notes-0.13.2.md`
- `doc/release-notes/release-notes-0.12.1.md`
- `doc/release-notes/release-notes-0.6.3.md`
- `doc/release-notes/release-notes-0.8.0.md`
- `doc/release-notes/release-notes-0.9.2.md`

These changes help maintain the clarity and professionalism of the Bitcoin Core documentation, ensuring more accurate and consistent terminology throughout.
