### PR TITLE
test: fix TestShell initialization for cmake build directory

### DIFF
--- a/test/functional/test-shell.md
+++ b/test/functional/test-shell.md
@@ -24,13 +24,17 @@ user inputs. Such environments include the Python3 command line interpreter or
 
 ## 2. Importing `TestShell` from the Bitcoin Core repository
 
-We can import the `TestShell` by adding the path of the Bitcoin Core
+We can import the `TestShell` by adding the path of the configured Bitcoin Core
 `test_framework` module to the beginning of the PATH variable, and then
-importing the `TestShell` class from the `test_shell` sub-package.
+importing the `TestShell` class from the `test_shell` sub-package. Since
+the build system creates a copy of the `test_framework` module into a new `build/`
+directory along with the required configuration file, the path to the build copy
+must be used.
+
 
 ```
 >>> import sys
->>> sys.path.insert(0, "/path/to/bitcoin/test/functional")
+>>> sys.path.insert(0, "/path/to/bitcoin/build/test/functional")
 >>> from test_framework.test_shell import TestShell
 ```
 

--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -74,7 +74,11 @@ class TestShell:
             # cache. Since TestShell is meant for interactive use, there is no concrete
             # test; passing a dummy name is fine though, as only the containing directory
             # is relevant for successful initialization.
-            tests_directory = pathlib.Path(__file__).resolve().parent.parent
+            # The cmake build system writes the required config.ini file to the build/
+            # directory, but the build/.../test–framework/ directory there symlinks back to the
+            # working directory in the repository, where there is no config.ini file.
+            # For that reason, we do NOT follow symlinks from the dummy file.
+            tests_directory = pathlib.Path(__file__).parent.parent
             TestShell.instance = TestShell.__TestShell(tests_directory / "testshell_dummy.py")
             TestShell.instance.running = False
         return TestShell.instance


### PR DESCRIPTION
The cmake build system creates a `build/` directory and writes `config.ini` there, along with a tree of symlinks to `test_framework` and all the individual test files. This symlink breaks the fix in https://github.com/bitcoin/bitcoin/pull/30714 which resolved those symlinks, causing the `TestShell` to initialize in the original test directory, where `config.ini` does not exist.

The fix in this patch is simply not to resolve the symlinks, so `TestShell` uses:

- `/path/to/bitcoin/build/test/config.ini`
- `/path/to/bitcoin/build/test/cache`

Note that any arguments like `configfile` and `cachedir` that are passed to `setup()` will be **too late to work around the issue** since the constructor `TestShell()` is invoked with a file path first and that path determines config file and cache location.

Test script:

```python
#!/usr/bin/env python3

# USAGE: shell.py /path/to/bitcoin/repo

from pathlib import Path
import sys
REPO = Path(sys.argv.pop())
sys.path.insert(0, f"{REPO / 'build' / 'test' / 'functional'}")
from test_framework.test_shell import TestShell

TestShell().setup(num_nodes=1, setup_clean_chain=True)
TestShell().shutdown()
```

Fails on master:

```
FileNotFoundError: [Errno 2] No such file or directory: '/Users/matthewzipkin/Desktop/work/bitcoin/test/config.ini'
```
