### PR TITLE
Fix spelling and formatting issues

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,7 +71,7 @@ It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin
 
 `sqlite` is required to support for descriptor wallets.
 
-macOS ships with a useable `sqlite` package, meaning you don't need to
+macOS ships with a usable `sqlite` package, meaning you don't need to
 install anything.
 
 ###### Legacy Wallet Support

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -151,7 +151,7 @@ class Class
 public:
     bool Function(const std::string& s, int n)
     {
-        // Comment summarising what this section of code does
+        // Comment summarizing what this section of code does
         for (int i = 0; i < n; ++i) {
             int total_sum{0};
             // When something fails, return early

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -114,13 +114,13 @@ Setup:
 - All three now run `addmultisigaddress 2 ["Kalice","Kbob","Kcarol"]` to teach
   their wallet about the multisig script. Call the address produced by this
   command *Amulti*. They may be required to explicitly specify the same
-  addresstype option each, to avoid constructing different versions due to
+  address type option each, to avoid constructing different versions due to
   differences in configuration.
 - They also run `importaddress "Amulti" "" false` to make their wallets treat
   payments to *Amulti* as contributing to the watch-only balance.
 - Others can verify the produced address by running
   `createmultisig 2 ["Kalice","Kbob","Kcarol"]`, and expecting *Amulti* as
-  output. Again, it may be necessary to explicitly specify the addresstype
+  output. Again, it may be necessary to explicitly specify the address type
   in order to get a result that matches. This command won't enable them to
   initiate transactions later, however.
 - They can now give out *Amulti* as address others can pay to.


### PR DESCRIPTION
### Description:
This pull request addresses the following changes:

1. Corrected the spelling of "useable" to "usable".
2. Changed "summarising" to the American English spelling "summarizing".
3. Updated "addresstype" to "address type" for clarity and consistency.

### Changes:
- `useable` → `usable`
- `summarising` → `summarizing`
- `addresstype` → `address type`