### PR TITLE
Correct spelling and grammar improvements

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,7 +71,7 @@ It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin
 
 `sqlite` is required to support for descriptor wallets.
 
-macOS ships with a useable `sqlite` package, meaning you don't need to
+macOS ships with a usable `sqlite` package, meaning you don't need to
 install anything.
 
 ###### Legacy Wallet Support

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -309,7 +309,7 @@ serialization of data structures is probably fine, a `sleep(10s)` not.
 TRACEPOINT_SEMAPHORE(example, gated_expensive_argument);
 …
 if (TRACEPOINT_ACTIVE(example, gated_expensive_argument)) {
-    expensive_argument = expensive_calulation();
+    expensive_argument = expensive_calculation();
     TRACEPOINT(example, gated_expensive_argument, expensive_argument);
 }
 ```

--- a/doc/translation_strings_policy.md
+++ b/doc/translation_strings_policy.md
@@ -49,7 +49,7 @@ Avoid dividing up a message into fragments. Translators see every string separat
 ### Avoid HTML in translation strings
 
 There have been difficulties with the use of HTML in translation strings; translators should not be able to accidentally affect the formatting of messages.
-This may sometimes be at conflict with the recommendation in the previous section.
+This may sometimes be in conflict with the recommendation in the previous section.
 
 ### Plurals
 


### PR DESCRIPTION
1. **Spelling Corrections**:

  - `useable` → `usable` (Correct spelling of the word)
   - `expensive_calulation` → `expensive_calculation` (The word "calulation" is incorrectly spelled, and the correct spelling is "calculation" from the verb "to calculate")

2. **Grammar Improvement**:

- `be at conflict` → `be in conflict` (The preposition "at" is replaced with "in" because the correct expression is "to be in conflict with," which always uses the preposition "in")
