### PR TITLE
fuzz: Fix misplaced SeedRand::ZEROS

### DIFF
--- a/src/test/fuzz/util/check_globals.cpp
+++ b/src/test/fuzz/util/check_globals.cpp
@@ -24,12 +24,12 @@ struct CheckGlobalsImpl {
                          "The current fuzz target used the global random state.\n\n"
 
                          "This is acceptable, but requires the fuzz target to call \n"
-                         "SeedRandomStateForTest(SeedRand::ZEROS) at the beginning \n"
-                         "of processing the fuzz input.\n\n"
+                         "SeedRandomStateForTest(SeedRand::ZEROS) in the first line \n"
+                         "of the FUZZ_TARGET function.\n\n"
 
                          "An alternative solution would be to avoid any use of globals.\n\n"
 
-                         "Without a solution, fuzz stability and determinism can lead \n"
+                         "Without a solution, fuzz instability and non-determinism can lead \n"
                          "to non-reproducible bugs or inefficient fuzzing.\n\n"
                       << std::endl;
             std::abort(); // Abort, because AFL may try to recover from a std::exit

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -21,6 +21,7 @@ using node::BlockAssembler;
 
 FUZZ_TARGET(utxo_total_supply)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     /** The testing setup that creates a chainman only (no chainstate) */
     ChainTestingSetup test_setup{
         ChainType::REGTEST,
@@ -28,7 +29,6 @@ FUZZ_TARGET(utxo_total_supply)
             .extra_args = {"-testactivationheight=bip34@2"},
         },
     };
-    SeedRandomStateForTest(SeedRand::ZEROS); // Can not be done before test_setup
     // Create chainstate
     test_setup.LoadVerifyActivateChainstate();
     auto& node{test_setup.m_node};


### PR DESCRIPTION
After commit fae63bf13033adec80c7e6d73144a21ea3cfbc6d this must be placed even before test_setup. This is nice, because it makes the usage consistently appear in the first line.

The change is moving a `SeedRandomForTest(SeedRand::ZEROS)` to happen earlier. This is fine, because it will either have no effect, or make the code more deterministic, because after commit fae63bf, no other re-seeding other than `ZEROS` can happen in fuzz tests.
