### PR TITLE
ci: Enable DEBUG=1 for one GCC-12+ build to catch 117966 regressions

### DIFF
--- a/ci/test/00_setup_env_native_centos.sh
+++ b/ci/test/00_setup_env_native_centos.sh
@@ -10,5 +10,6 @@ export CONTAINER_NAME=ci_native_centos
 export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
 export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake"
 export PIP_PACKAGES="pyzmq"
+export DEP_OPTS="DEBUG=1"  # Temporarily enable a DEBUG=1 build to check for GCC-bug-117966 regressions. This can be removed once the minimum GCC version is bumped to 12 in the previous releases task, see https://github.com/bitcoin/bitcoin/issues/31436#issuecomment-2530717875
 export GOAL="install"
-export BITCOIN_CONFIG="-DWITH_ZMQ=ON -DBUILD_GUI=ON -DREDUCE_EXPORTS=ON"
+export BITCOIN_CONFIG="-DWITH_ZMQ=ON -DBUILD_GUI=ON -DREDUCE_EXPORTS=ON -DCMAKE_BUILD_TYPE=Debug"

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <optional>
 
 FUZZ_TARGET(float)
 {
@@ -18,7 +19,7 @@ FUZZ_TARGET(float)
 
     {
         const double d{[&] {
-            double tmp;
+            std::optional<double> tmp;
             CallOneOf(
                 fuzzed_data_provider,
                 // an actual number
@@ -42,7 +43,7 @@ FUZZ_TARGET(float)
                       }); },
                 // Anything from raw memory (also checks that DecodeDouble doesn't crash on any input)
                 [&] { tmp = DecodeDouble(fuzzed_data_provider.ConsumeIntegral<uint64_t>()); });
-            return tmp;
+            return *tmp;
         }()};
         (void)memusage::DynamicUsage(d);
 


### PR DESCRIPTION
It is possible that someone accidentally removes the workaround in fa9e0489f57968945d54ef56b275f51540f3e5e4, or more likely that someone accidentally adds new code without the workaround.

Avoid this by adding a temporary CI check.

This can be tested by reverting the workaround and observing a failure.