### PR TITLE
docs: Improve wording in benchmarking Update benchmarking.md

### DIFF
--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -10,7 +10,7 @@ Running
 
 For benchmarking, you only need to compile `bench_bitcoin`.  The bench runner
 warns if you configure with `-DCMAKE_BUILD_TYPE=Debug`, but consider if building without
-it will impact the benchmark(s) you are interested in by unlatching log printers
+it will impact the benchmark(s) you are interested in by disabling log printers
 and lock analysis.
 
     cmake -B build -DBUILD_BENCH=ON


### PR DESCRIPTION
The term "unlatching" used in the benchmarking documentation is not appropriate in the given context. It has been replaced with "**disabling**," which better reflects the intended meaning of turning off log printers and lock analysis.

The updated sentence now reads:  
> "...by disabling log printers and lock analysis."
