### PR TITLE
refactor: Allow std::byte in (Read/Write)(LE/BE)

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,14 +25,14 @@
 void ChaCha20Aligned::SetKey(Span<const std::byte> key) noexcept
 {
     assert(key.size() == KEYLEN);
-    input[0] = ReadLE32(UCharCast(key.data() + 0));
-    input[1] = ReadLE32(UCharCast(key.data() + 4));
-    input[2] = ReadLE32(UCharCast(key.data() + 8));
-    input[3] = ReadLE32(UCharCast(key.data() + 12));
-    input[4] = ReadLE32(UCharCast(key.data() + 16));
-    input[5] = ReadLE32(UCharCast(key.data() + 20));
-    input[6] = ReadLE32(UCharCast(key.data() + 24));
-    input[7] = ReadLE32(UCharCast(key.data() + 28));
+    input[0] = ReadLE32(key.data() + 0);
+    input[1] = ReadLE32(key.data() + 4);
+    input[2] = ReadLE32(key.data() + 8);
+    input[3] = ReadLE32(key.data() + 12);
+    input[4] = ReadLE32(key.data() + 16);
+    input[5] = ReadLE32(key.data() + 20);
+    input[6] = ReadLE32(key.data() + 24);
+    input[7] = ReadLE32(key.data() + 28);
     input[8] = 0;
     input[9] = 0;
     input[10] = 0;

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,82 +7,99 @@
 
 #include <compat/endian.h>
 
+#include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 
-uint16_t static inline ReadLE16(const unsigned char* ptr)
+template <typename B>
+concept ByteType = std::same_as<B, unsigned char> || std::same_as<B, std::byte>;
+
+template <ByteType B>
+inline uint16_t ReadLE16(const B* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
     return le16toh_internal(x);
 }
 
-uint32_t static inline ReadLE32(const unsigned char* ptr)
+template <ByteType B>
+inline uint32_t ReadLE32(const B* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
     return le32toh_internal(x);
 }
 
-uint64_t static inline ReadLE64(const unsigned char* ptr)
+template <ByteType B>
+inline uint64_t ReadLE64(const B* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
     return le64toh_internal(x);
 }
 
-void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+template <ByteType B>
+inline void WriteLE16(B* ptr, uint16_t x)
 {
     uint16_t v = htole16_internal(x);
     memcpy(ptr, &v, 2);
 }
 
-void static inline WriteLE32(unsigned char* ptr, uint32_t x)
+template <ByteType B>
+inline void WriteLE32(B* ptr, uint32_t x)
 {
     uint32_t v = htole32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
-void static inline WriteLE64(unsigned char* ptr, uint64_t x)
+template <ByteType B>
+inline void WriteLE64(B* ptr, uint64_t x)
 {
     uint64_t v = htole64_internal(x);
     memcpy(ptr, &v, 8);
 }
 
-uint16_t static inline ReadBE16(const unsigned char* ptr)
+template <ByteType B>
+inline uint16_t ReadBE16(const B* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
     return be16toh_internal(x);
 }
 
-uint32_t static inline ReadBE32(const unsigned char* ptr)
+template <ByteType B>
+inline uint32_t ReadBE32(const B* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
     return be32toh_internal(x);
 }
 
-uint64_t static inline ReadBE64(const unsigned char* ptr)
+template <ByteType B>
+inline uint64_t ReadBE64(const B* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
     return be64toh_internal(x);
 }
 
-void static inline WriteBE16(unsigned char* ptr, uint16_t x)
+template <ByteType B>
+inline void WriteBE16(B* ptr, uint16_t x)
 {
     uint16_t v = htobe16_internal(x);
     memcpy(ptr, &v, 2);
 }
 
-void static inline WriteBE32(unsigned char* ptr, uint32_t x)
+template <ByteType B>
+inline void WriteBE32(B* ptr, uint32_t x)
 {
     uint32_t v = htobe32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
-void static inline WriteBE64(unsigned char* ptr, uint64_t x)
+template <ByteType B>
+inline void WriteBE64(B* ptr, uint64_t x)
 {
     uint64_t v = htobe64_internal(x);
     memcpy(ptr, &v, 8);


### PR DESCRIPTION
Starting with C++17, `std::byte` is often (not always) a better choice over `uint8_t` for new code.

However, the existing codebase discourages the use of `std::byte`, when helpers such as `ReadLE32` are used. This is because calling code will be cluttered with byte-casts.

Fix it by allowing `std::byte` pointers in `ReadLE32` (and friends).