### PR TITLE
doc: Install `net/py-pyzmq` port on FreeBSD for `interface_zmq.py`

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -96,7 +96,7 @@ There is an included test suite that is useful for testing code changes when dev
 To run the test suite (recommended), you will need to have Python 3 installed:
 
 ```bash
-pkg install python3 databases/py-sqlite3
+pkg install python3 databases/py-sqlite3 net/py-pyzmq
 ```
 ---
 


### PR DESCRIPTION
On FreeBSD, Python's `zmq` module is provided as a separate port.

This PR updates the FreeBSD Build Guide to include this port, enabling the `interface_zmq.py` functional test.