### PR TITLE
doc: emphasize that `Assume` always evaluates

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -93,6 +93,7 @@ constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] con
  * - For fatal errors, use Assert().
  * - For non-fatal errors in interactive sessions (e.g. RPC or command line
  *   interfaces), CHECK_NONFATAL() might be more appropriate.
+ *   Note that the assumption is always fully evaluated - even in non-debug builds.
  */
 #define Assume(val) inline_assertion_check<false>(val, __FILE__, __LINE__, __func__, #val)
 


### PR DESCRIPTION
We've been surprised multiple times by `Assume` doing heavy computations in `release`:
* https://github.com/bitcoin/bitcoin/issues/31178#issuecomment-2448867990
* https://github.com/bitcoin/bitcoin/pull/31490#discussion_r1887765453

Since `Assume` is a macro, it could have been written differently to avoid parameter evaluation (similarly to `LogDebug`, which doesn't evaluate the parameters).
