### PR TITLE
cmake: Always provide `RPATH` on NetBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,8 +580,13 @@ endif()
 # Relevant discussions:
 # - https://github.com/hebasto/bitcoin/pull/236#issuecomment-2183120953
 # - https://github.com/bitcoin/bitcoin/pull/30312#issuecomment-2191235833
-set(CMAKE_SKIP_BUILD_RPATH TRUE)
-set(CMAKE_SKIP_INSTALL_RPATH TRUE)
+# NetBSD always requires runtime paths to be set for executables.
+if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+else()
+  set(CMAKE_SKIP_BUILD_RPATH TRUE)
+  set(CMAKE_SKIP_INSTALL_RPATH TRUE)
+endif()
 add_subdirectory(test)
 add_subdirectory(doc)
 


### PR DESCRIPTION
Apparently, runtime paths cannot be skipped on NetBSD, even for system-wide packages.

On NetBSD 10.0:
- on the master branch @ bb57017b2945d5e0bbd95c7f1a9369a8ab7c6fcd:
```
$ cmake -B build -DCMAKE_C_COMPILER="/usr/pkg/gcc14/bin/gcc" -DCMAKE_CXX_COMPILER="/usr/pkg/gcc14/bin/g++"
$ cmake --build build
$ ./build/src/bitcoin-wallet -version
./build/src/bitcoin-wallet: Shared object "libsqlite3.so.0" not found
$ cmake --install build --prefix /home/hebasto/INSTALL
$ /home/hebasto/INSTALL/bin/bitcoin-wallet -version 
/home/hebasto/INSTALL/bin/bitcoin-wallet: Shared object "libsqlite3.so.0" not found
```
- with this PR:
```
$ cmake -B build -DCMAKE_C_COMPILER="/usr/pkg/gcc14/bin/gcc" -DCMAKE_CXX_COMPILER="/usr/pkg/gcc14/bin/g++"
$ cmake --build build
$ ./build/src/bitcoin-wallet -version | head -1
Bitcoin Core bitcoin-wallet utility version v28.99.0-11115e9aa845
$ cmake --install build --prefix /home/hebasto/INSTALL
$ /home/hebasto/INSTALL/bin/bitcoin-wallet -version | head -1
Bitcoin Core bitcoin-wallet utility version v28.99.0-11115e9aa845
```