### PR TITLE
cmake: Remove unused `BUILD_TESTING` variable from "dev-mode" preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,7 +71,6 @@
         "BUILD_GUI_TESTS": "ON",
         "BUILD_KERNEL_LIB": "ON",
         "BUILD_SHARED_LIBS": "ON",
-        "BUILD_TESTING": "ON",
         "BUILD_TESTS": "ON",
         "BUILD_TX": "ON",
         "BUILD_UTIL": "ON",


### PR DESCRIPTION
On the master branch @ bb57017b2945d5e0bbd95c7f1a9369a8ab7c6fcd:
```
$ cmake -B build --preset dev-mode -DWITH_MULTIPROCESS=OFF
<snip>
-- Configuring done (12.0s)
-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING


-- Build files have been written to: /home/hebasto/git/bitcoin/build
```

This PR resolves the issue.

The removed `BUILD_TESTING` variable is a part of the [`CTest`](https://cmake.org/cmake/help/latest/module/CTest.html) module, which we do not include in the project.
