### PR TITLE
depends: Update capnproto to 1.1.0

### DIFF
--- a/depends/packages/native_capnp.mk
+++ b/depends/packages/native_capnp.mk
@@ -1,9 +1,9 @@
 package=native_capnp
-$(package)_version=1.0.2
+$(package)_version=1.1.0
 $(package)_download_path=https://capnproto.org/
 $(package)_download_file=capnproto-c++-$($(package)_version).tar.gz
 $(package)_file_name=capnproto-cxx-$($(package)_version).tar.gz
-$(package)_sha256_hash=9057dbc0223366b74bbeca33a05de164a229b0377927f1b7ef3828cdd8cb1d7e
+$(package)_sha256_hash=07167580e563f5e821e3b2af1c238c16ec7181612650c5901330fa9a0da50939
 
 define $(package)_set_vars
   $(package)_config_opts := -DBUILD_TESTING=OFF


### PR DESCRIPTION
This change fixes compilation on NetBSD with GCC 14:

```
$ gmake -C depends capnp MULTIPROCESS=1 CC=/usr/pkg/gcc14/bin/gcc CXX=/usr/pkg/gcc14/bin/g++
gmake: Entering directory '/home/hebasto/dev/bitcoin/depends'
<snip>
In file included from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/memory.h:24,
                 from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/exception.h:24,
                 from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async-prelude.h:27,
                 from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async.h:24,
                 from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async-io.h:24,
                 from /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async-io-unix.c++:35:
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async-io-unix.c++: In lambda function:
/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/src/kj/async-io-unix.c++:1243:24: error: 'AI_V4MAPPED' was not declared in this scope
 1243 |       hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
      |                        ^~~~~~~~~~~
gmake[3]: *** [src/kj/CMakeFiles/kj-async.dir/build.make:146: src/kj/CMakeFiles/kj-async.dir/async-io-unix.c++.o] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:203: src/kj/CMakeFiles/kj-async.dir/all] Error 2
gmake[1]: *** [Makefile:136: all] Error 2
gmake[1]: Leaving directory '/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5'
gmake: *** [funcs.mk:302: /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/capnp/1.0.2-ffdefffd9f5/./.stamp_built] Error 2
gmake: Leaving directory '/home/hebasto/dev/bitcoin/depends'
```

See: https://github.com/capnproto/capnproto/commit/ccaa1f87c1c8cc289a088e9c508323c51bd638cf.

However, the other changes between [`v1.0.2`](https://github.com/capnproto/capnproto/releases/tag/v1.0.2) and [`v1.1.0`](https://github.com/capnproto/capnproto/releases/tag/v1.1.0) require a sanity check.