### PR TITLE
test: add unit tests for SigningResultString function

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1746,6 +1746,15 @@ BOOST_AUTO_TEST_CASE(message_hash)
     BOOST_CHECK_NE(message_hash1, signature_hash);
 }
 
+BOOST_AUTO_TEST_CASE(signing_result_string)
+{
+    BOOST_CHECK_EQUAL(SigningResultString(SigningResult::OK), "No error");
+
+    BOOST_CHECK_EQUAL(SigningResultString(SigningResult::PRIVATE_KEY_NOT_AVAILABLE), "Private key not available");
+
+    BOOST_CHECK_EQUAL(SigningResultString(SigningResult::SIGNING_FAILED), "Sign failed");
+}
+
 BOOST_AUTO_TEST_CASE(remove_prefix)
 {
     BOOST_CHECK_EQUAL(RemovePrefix("./common/system.h", "./"), "common/system.h");


### PR DESCRIPTION
This PR introduces new unit tests for the `SigningResultString` function located in the file [src/common/signmessage.cpp](https://github.com/bitcoin/bitcoin/blob/master/src/common/signmessage.cpp).

#### **Motivation**:
Prior to this PR, the `SigningResultString` function had no test coverage. This update adds the necessary test cases to ensure that the function behaves as expected.

#### **Changes**:
- Added unit tests to cover all the cases in the switch statement within the `SigningResultString` function.
- Ensured that each valid `SigningResult` enum value is tested for the expected output string:
  - `SigningResult::OK`
  - `SigningResult::PRIVATE_KEY_NOT_AVAILABLE`
  - `SigningResult::SIGNING_FAILED`
- Placed the new tests in the file location that matches the context of other related tests, ensuring consistency in test organization.

#### **Suggested Follow-Up**:
The current implementation of the function includes an `assert(false)` for invalid enum values, as there is no `default` case in the switch statement. Since modifying the original function is not within the scope of this PR, perhaps someone with more C++ experience could explore writing a test to verify the behavior of the `assert` and the compiler warnings referenced in the comment:

> // no default case, so the compiler can warn about missing cases