### PR TITLE
fix: typos in documentation files

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -105,7 +105,7 @@ RPC interface will be abused.
   includes being able to record any passphrases you enter for unlocking
   your encrypted wallets or changing settings so that your Bitcoin Core
   program tells you that certain transactions have multiple
-  confirmations even when they aren't part of the best block chain.  For
+  confirmations even when they aren't part of the best blockchain.  For
   this reason, you should not use Bitcoin Core for security sensitive
   operations on systems you do not exclusively control, such as shared
   computers or virtual private servers.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -82,7 +82,7 @@ Responds with 404 if block not found.
 #### Chaininfos
 `GET /rest/chaininfo.json`
 
-Returns various state info regarding block chain processing.
+Returns various state info regarding blockchain processing.
 Only supports JSON as output format.
 Refer to the `getblockchaininfo` RPC help for details.
 

--- a/src/crc32c/CMakeLists.txt
+++ b/src/crc32c/CMakeLists.txt
@@ -112,7 +112,7 @@ int main() {
 "  HAVE_MM_PREFETCH)
 
 # Check for SSE4.2 support in the compiler.
-set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} /arch:AVX")
 else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -134,10 +134,10 @@ int main() {
   return 0;
 }
 "  HAVE_SSE42)
-set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 
 # Check for ARMv8 w/ CRC and CRYPTO extensions support in the compiler.
-set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # TODO(pwnall): Insert correct flag when VS gets ARM CRC32C support.
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} /arch:NOTYET")
@@ -154,7 +154,7 @@ int main() {
   return 0;
 }
 " HAVE_ARM64_CRC32C)
-set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 
 # Check for strong getauxval() support in the system headers.
 check_cxx_source_compiles("


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `block chain` to `blockchain` x2
Corrected `OLD_CMAKE_REQURED_FLAGS` to `OLD_CMAKE_REQUIRED_FLAGS` x4

Please review the changes and let me know if any additional changes are needed.

