### PR TITLE
test: descriptor: fix test for `MaxSatisfactionWeight`

### DIFF
--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -161,7 +161,8 @@ void DoCheck(std::string prv, std::string pub, const std::string& norm_pub, int 
     // We must be able to estimate the max satisfaction size for any solvable descriptor top descriptor (but combo).
     const bool is_nontop_or_nonsolvable{!parse_priv->IsSolvable() || !parse_priv->GetOutputType()};
     const auto max_sat_maxsig{parse_priv->MaxSatisfactionWeight(true)};
-    const auto max_sat_nonmaxsig{parse_priv->MaxSatisfactionWeight(true)};
+    const auto max_sat_nonmaxsig{parse_priv->MaxSatisfactionWeight(false)};
+    BOOST_CHECK(max_sat_nonmaxsig <= max_sat_maxsig);
     const auto max_elems{parse_priv->MaxSatisfactionElems()};
     const bool is_input_size_info_set{max_sat_maxsig && max_sat_nonmaxsig && max_elems};
     BOOST_CHECK_MESSAGE(is_input_size_info_set || is_nontop_or_nonsolvable, prv);


### PR DESCRIPTION
To get the maximum size of a satisfaction for a descriptor with no max sig, the parameter `use_max_sig` should be false.