### PR TITLE
refactor: Remove redundant edge case in fee rate rounding logic

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -28,10 +28,7 @@ CAmount CFeeRate::GetFee(uint32_t num_bytes) const
     // We've previously had issues with the silent double->int64_t conversion.
     CAmount nFee{static_cast<CAmount>(std::ceil(nSatoshisPerK * nSize / 1000.0))};
 
-    if (nFee == 0 && nSize != 0) {
-        if (nSatoshisPerK > 0) nFee = CAmount(1);
-        if (nSatoshisPerK < 0) nFee = CAmount(-1);
-    }
+    if (nFee == 0 && nSize != 0 && nSatoshisPerK < 0) if (nSatoshisPerK < 0) nFee = CAmount(-1);
 
     return nFee;
 }

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -28,7 +28,7 @@ CAmount CFeeRate::GetFee(uint32_t num_bytes) const
     // We've previously had issues with the silent double->int64_t conversion.
     CAmount nFee{static_cast<CAmount>(std::ceil(nSatoshisPerK * nSize / 1000.0))};
 
-    if (nFee == 0 && nSize != 0 && nSatoshisPerK < 0) if (nSatoshisPerK < 0) nFee = CAmount(-1);
+    if (nFee == 0 && nSize != 0 && nSatoshisPerK < 0) nFee = CAmount(-1);
 
     return nFee;
 }


### PR DESCRIPTION
Positive fractional fee rates are already rounded away from zero, so the first half of this if-statement is unnecessary:

```
if (nFee == 0 && nSize != 0) {
    if (nSatoshisPerK > 0) nFee = CAmount(1);
    if (nSatoshisPerK < 0) nFee = CAmount(-1);
}
```

Addresses #31558. This fix improves code readability.