### PR TITLE
Fix memory issue during chainstate initialization on 2GB box

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -6,9 +6,10 @@ There are a few parameters that can be dialed down to reduce the memory usage of
 
 The size of some in-memory caches can be reduced. As caches trade off memory usage for performance, reducing these will usually have a negative effect on performance.
 
-- `-dbcache=<n>` - the UTXO database cache size, this defaults to `450`. The unit is MiB (1024).
+- `-dbcache=<n>` - the UTXO database cache size, this defaults to `100`. The unit is MiB (1024).
   - The minimum value for `-dbcache` is 4.
   - A lower `-dbcache` makes initial sync time much longer. After the initial sync, the effect is less pronounced for most use-cases, unless fast validation of blocks is important, such as for mining.
+  - On systems with less than 4GB of RAM, the `-dbcache` value is automatically adjusted to 100 MiB if it exceeds this value.
 
 ## Memory pool
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -22,7 +22,7 @@ class COutPoint;
 class uint256;
 
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 450;
+static const int64_t nDefaultDbCache = 100;
 //! -dbbatchsize default (bytes)
 static const int64_t nDefaultDbBatchSize = 16 << 20;
 //! min. -dbcache (MiB)

--- a/src/validation.h
+++ b/src/validation.h
@@ -1352,4 +1352,19 @@ bool IsBIP30Repeat(const CBlockIndex& block_index);
 /** Identifies blocks which coinbase output was subsequently overwritten in the UTXO set (see BIP30) */
 bool IsBIP30Unspendable(const CBlockIndex& block_index);
 
+/**
+ * Check if the system has less than 4GB of RAM and adjust dbcache if necessary.
+ */
+void AdjustDbCacheForLowMemory(int64_t& nDefaultDbCache)
+{
+    // Check if the system has less than 4GB of RAM
+    uint64_t totalMemory = GetTotalSystemMemory();
+    if (totalMemory < 4ULL * 1024 * 1024 * 1024) {
+        // Adjust dbcache to 100 MiB if the system has less than 4GB of RAM
+        if (nDefaultDbCache > 100) {
+            nDefaultDbCache = 100;
+        }
+    }
+}
+
 #endif // BITCOIN_VALIDATION_H


### PR DESCRIPTION
Fixes #31573

Reduce memory usage during chainstate initialization on low-memory systems.

* **src/txdb.h**
  - Reduce the default `dbcache` value to 100 MiB.
* **src/validation.h**
  - Add a function to adjust `dbcache` to 100 MiB if the system has less than 4GB of RAM.
* **doc/reduce-memory.md**
  - Update the documentation to reflect the new default `dbcache` value.
  - Add information about the memory check for systems with less than 4GB of RAM.

