### PR TITLE
test: Remove non-portable IPv6 test

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -194,13 +194,6 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_CHECK(!addr.IsBindAny());
     BOOST_CHECK_EQUAL(addr.ToStringAddr(), scoped_addr);
 
-    // Test that the delimiter "%" and default zone id of 0 can be omitted for the default scope.
-    addr = LookupHost(link_local + "%0", false).value();
-    BOOST_REQUIRE(addr.IsValid());
-    BOOST_REQUIRE(addr.IsIPv6());
-    BOOST_CHECK(!addr.IsBindAny());
-    BOOST_CHECK_EQUAL(addr.ToStringAddr(), link_local);
-
     // TORv2, no longer supported
     BOOST_CHECK(!addr.SetSpecial("6hzph5hv6337r6p2.onion"));
 


### PR DESCRIPTION
On Illumos-based systems, such as OpenIndiana and OmniOS, the assumption that "the default zone ID of 0 can be omitted for the default scope" is incorrect. As a result, `getaddrinfo("fe80::1%0", ...)` returns the `EAI_NONAME` error instead of resolving to "fe80::1".

See: https://www.illumos.org/man/3SOCKET/getaddrinfo.

This PR removes the problematic code introduced in https://github.com/bitcoin/bitcoin/pull/19951.