### PR TITLE
txmempool: fix typos in comments

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -442,7 +442,7 @@ void CTxMemPool::Apply(ChangeSet* changeset)
         std::optional<CTxMemPool::setEntries> ancestors;
         if (i == 0) {
             // Note: ChangeSet::CalculateMemPoolAncestors() will return a
-            // cached value if mempool ancestors for this tranaction were
+            // cached value if mempool ancestors for this transaction were
             // previously calculated.
             // We can only use a cached ancestor calculation for the first
             // transaction in a package, because in-package parents won't be

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -810,7 +810,7 @@ public:
      * mempool.
      *
      * CalculateMemPoolAncestors() calculates the in-mempool (not including
-     * what is in the change set itself) ancestors of a given transacion.
+     * what is in the change set itself) ancestors of a given transaction.
      *
      * Apply() will apply the removals and additions that are staged into the
      * mempool.


### PR DESCRIPTION
Fixed typos identified by codespell lint in CI.