### PR TITLE
doc: Update NetBSD Build Guide

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,6 +1,6 @@
 # NetBSD Build Guide
 
-**Updated for NetBSD [10.0](https://netbsd.org/releases/formal-10/NetBSD-10.0.html)**
+**Updated for NetBSD [10.1](https://netbsd.org/releases/formal-10/NetBSD-10.1.html)**
 
 This guide describes how to build bitcoind, command-line utilities, and GUI on NetBSD.
 
@@ -83,6 +83,13 @@ pkgin install qrencode
 
 Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
 
+#### Notifications
+###### ZeroMQ
+
+Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+```bash
+pkgin zeromq
+```
 
 #### Test Suite Dependencies
 
@@ -90,10 +97,10 @@ There is an included test suite that is useful for testing code changes when dev
 To run the test suite (recommended), you will need to have Python 3 installed:
 
 ```bash
-pkgin install python39
+pkgin install python310 py310-zmq
 ```
 
-### Building Bitcoin Core
+## Building Bitcoin Core
 
 ### 1. Configuration
 


### PR DESCRIPTION
This PR:

1. Updates the documented NetBSD version.

2. Adds the optional ZeroMQ package to align the guide with other *BSD systems.

3. Updates the Python version to meet the minimum requirement specified in https://github.com/bitcoin/bitcoin/pull/30527.

4. Suggests to Install [`net/py-zmq`](https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/net/py-zmq/index.html) package to enable the `interface_zmq.py` functional test.

5. Fix a formatting issue.

See also the recent NetBSD nightly build at https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12554769828/job/35003929261.