### PR TITLE
contrib: fix `test_deterministic_coverage.sh` script for out-of-tree builds

### DIFF
--- a/contrib/devtools/test_deterministic_coverage.sh
+++ b/contrib/devtools/test_deterministic_coverage.sh
@@ -34,7 +34,9 @@ NON_DETERMINISTIC_TESTS=(
     "wallet_tests/wallet_disableprivkeys"                     # validation.cpp: if (signals.CallbacksPending() > 10)
 )
 
-TEST_BITCOIN_BINARY="src/test/test_bitcoin"
+TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
+BUILDDIR=${BUILDDIR:-$TOPDIR/build}
+TEST_BITCOIN_BINARY="$BUILDDIR/src/test/test_bitcoin"
 
 print_usage() {
     echo "Usage: $0 [custom test filter (default: all but known non-deterministic tests)] [number of test runs (default: 2)]"
@@ -86,7 +88,7 @@ if [[ ! -e ${TEST_BITCOIN_BINARY} ]]; then
 fi
 
 get_file_suffix_count() {
-    find src/ -type f -name "*.$1" | wc -l
+    find "$BUILDDIR/src/" -type f -name "*.$1" | wc -l
 }
 
 if [[ $(get_file_suffix_count gcno) == 0 ]]; then
@@ -102,7 +104,7 @@ TEST_RUN_ID=0
 while [[ ${TEST_RUN_ID} -lt ${N_TEST_RUNS} ]]; do
     TEST_RUN_ID=$((TEST_RUN_ID + 1))
     echo "[$(date +"%Y-%m-%d %H:%M:%S")] Measuring coverage, run #${TEST_RUN_ID} of ${N_TEST_RUNS}"
-    find src/ -type f -name "*.gcda" -exec rm {} \;
+    find "$BUILDDIR/src/" -type f -name "*.gcda" -exec rm {} \;
     if [[ $(get_file_suffix_count gcda) != 0 ]]; then
         echo "Error: Stale *.gcda files found. Exiting."
         exit 1
@@ -119,7 +121,7 @@ while [[ ${TEST_RUN_ID} -lt ${N_TEST_RUNS} ]]; do
         exit 1
     fi
     GCOVR_TEMPFILE=$(mktemp)
-    if ! gcovr --gcov-executable "${GCOV_EXECUTABLE}" -r src/ > "${GCOVR_TEMPFILE}"; then
+    if ! gcovr --gcov-executable "${GCOV_EXECUTABLE}" -r "$TOPDIR/src/" "$BUILDDIR/src/" > "${GCOVR_TEMPFILE}"; then
         echo "Error: gcovr failed. Output written to ${GCOVR_TEMPFILE}. Exiting."
         exit 1
     fi

--- a/contrib/devtools/test_deterministic_coverage.sh
+++ b/contrib/devtools/test_deterministic_coverage.sh
@@ -109,7 +109,7 @@ while [[ ${TEST_RUN_ID} -lt ${N_TEST_RUNS} ]]; do
         echo "Error: Stale *.gcda files found. Exiting."
         exit 1
     fi
-    TEST_OUTPUT_TEMPFILE=$(mktemp)
+    TEST_OUTPUT_TEMPFILE="$BUILDDIR/deterministic_coverage_test_output.tmp"
     if ! BOOST_TEST_RUN_FILTERS="${BOOST_TEST_RUN_FILTERS}" ${TEST_BITCOIN_BINARY} > "${TEST_OUTPUT_TEMPFILE}" 2>&1; then
         cat "${TEST_OUTPUT_TEMPFILE}"
         rm "${TEST_OUTPUT_TEMPFILE}"
@@ -120,7 +120,7 @@ while [[ ${TEST_RUN_ID} -lt ${N_TEST_RUNS} ]]; do
         echo "Error: Running the test suite did not create any *.gcda files. The gcda files are generated when the instrumented test programs are executed. Run \"cmake -B build -DCMAKE_BUILD_TYPE=Coverage\" and re-compile."
         exit 1
     fi
-    GCOVR_TEMPFILE=$(mktemp)
+    GCOVR_TEMPFILE="$BUILDDIR/deterministic_coverage_gcovr_output.tmp"
     if ! gcovr --gcov-executable "${GCOV_EXECUTABLE}" -r "$TOPDIR/src/" "$BUILDDIR/src/" > "${GCOVR_TEMPFILE}"; then
         echo "Error: gcovr failed. Output written to ${GCOVR_TEMPFILE}. Exiting."
         exit 1


### PR DESCRIPTION
The determinstic line coverage checking script `test_deterministic_coverage.sh` was seemingly forgotten to be adapted in the course of switching from autotools to CMake (only the error messages containing build instructions were updated in a9964c04447745435747d9cc557165c43902783b / #30875). Since `gcovr` needs to access both the source and build files, the path to the latter has to be passed explicitly as they are not in the same anymore (see e.g. https://github.com/gcovr/gcovr/issues/340).

Can be tested by:
```
$ cmake -B build -DCMAKE_BUILD_TYPE=Coverage
$ cmake --build build
$ ./contrib/devtools/test_deterministic_coverage.sh
```

Alternatively, if the script is not needed anymore (apparently no-one else tried to execute it for the last three months?), it could also be deleted.