### PR TITLE
ci: Bump centos stream 10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,7 +140,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
 task:
-  name: 'CentOS, dash, gui'
+  name: 'CentOS, depends, gui'
   << : *GLOBAL_TASK_TEMPLATE
   persistent_worker:
     labels:

--- a/ci/test/00_setup_env_native_centos.sh
+++ b/ci/test/00_setup_env_native_centos.sh
@@ -7,9 +7,8 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_centos
-export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream9"
-export STREAM_GCC_V="12"
-export CI_BASE_PACKAGES="gcc-toolset-${STREAM_GCC_V}-gcc-c++ glibc-devel gcc-toolset-${STREAM_GCC_V}-libstdc++-devel ccache make git python3 python3-pip which patch xz procps-ng dash rsync coreutils bison e2fsprogs cmake"
+export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
+export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake"
 export PIP_PACKAGES="pyzmq"
 export GOAL="install"
 export BITCOIN_CONFIG="-DWITH_ZMQ=ON -DBUILD_GUI=ON -DREDUCE_EXPORTS=ON"

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -92,9 +92,7 @@ fi
 
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
-    SHELL_OPTS="CONFIG_SHELL=/bin/dash"
-    # shellcheck disable=SC1090
-    source "/opt/rh/gcc-toolset-${STREAM_GCC_V}/enable"
+    SHELL_OPTS="CONFIG_SHELL=/bin/ksh"  # Temporarily use ksh instead of dash, until https://bugzilla.redhat.com/show_bug.cgi?id=2335416 is fixed.
   else
     SHELL_OPTS="CONFIG_SHELL="
   fi


### PR DESCRIPTION
This is a follow-up to fa47baa03bcfcf44fb2ed05f009a32d32f860c45, which bumped the gcc version to avoid a warning bloat in the CI log. However, it is also required to bump python3, see https://github.com/bitcoin/bitcoin/issues/31476#issue-2735206340

> This will uncover an issue in the centos task that the correct python version is missing. I guess this should be fixed by installing and activating an acceptable python version.

Instead of bumping the packages individually in centos stream 9, just bump to stream 10.