### PR TITLE
qa: Ensure consistent use of decimals instead of floats

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -9,6 +9,7 @@ to a hash that has been compiled into bitcoind.
 The assumeutxo value generated and used here is committed to in
 `CRegTestParams::m_assumeutxo_data` in `src/kernel/chainparams.cpp`.
 """
+from decimal import Decimal
 from shutil import rmtree
 
 from dataclasses import dataclass
@@ -560,7 +561,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         prev_tx = n0.getblock(spend_coin_blockhash, 3)['tx'][0]
         prevout = {"txid": prev_tx['txid'], "vout": 0, "scriptPubKey": prev_tx['vout'][0]['scriptPubKey']['hex']}
         privkey = n0.get_deterministic_priv_key().key
-        raw_tx = n1.createrawtransaction([prevout], {getnewdestination()[2]: 24.99})
+        raw_tx = n1.createrawtransaction([prevout], {getnewdestination()[2]: Decimal("24.99")})
         signed_tx = n1.signrawtransactionwithkey(raw_tx, [privkey], [prevout])['hex']
         signed_txid = tx_from_hex(signed_tx).rehash()
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -104,13 +104,13 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Amount out of range", lambda: self.check_mempool_result(
             result_expected=None,
             rawtxs=[raw_tx_in_block],
-            maxfeerate=-0.01,
+            maxfeerate=Decimal("-0.01"),
         ))
         # ... 0.99 passes
         self.check_mempool_result(
             result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject-reason': 'txn-already-known'}],
             rawtxs=[raw_tx_in_block],
-            maxfeerate=0.99,
+            maxfeerate=Decimal("0.99"),
         )
 
         self.log.info('A transaction not in the mempool')

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -343,7 +343,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Test sendrawtransaction with missing input")
         inputs = [{'txid': TXID, 'vout': 1}]  # won't exist
         address = getnewdestination()[2]
-        outputs = {address: 4.998}
+        outputs = {address: Decimal("4.998")}
         rawtx = self.nodes[2].createrawtransaction(inputs, outputs)
         assert_raises_rpc_error(-25, "bad-txns-inputs-missingorspent", self.nodes[2].sendrawtransaction, rawtx)
 
@@ -382,7 +382,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         tx_val = 0.001
         tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_RETURN] + [OP_FALSE] * 30))]
         tx_hex = tx.serialize().hex()
-        assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex, 0, 0.0009)
+        assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex, 0, Decimal("0.0009"))
 
         # Test a transaction where our burn falls short of maxburnamount
         tx = self.wallet.create_self_transfer()['tx']
@@ -406,11 +406,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Fee rate is 0.00100000 BTC/kvB
         tx = self.wallet.create_self_transfer(fee_rate=Decimal('0.00100000'))
         # Thus, testmempoolaccept should reject
-        testres = self.nodes[2].testmempoolaccept([tx['hex']], 0.00001000)[0]
+        testres = self.nodes[2].testmempoolaccept([tx['hex']], Decimal("0.00001000"))[0]
         assert_equal(testres['allowed'], False)
         assert_equal(testres['reject-reason'], 'max-fee-exceeded')
         # and sendrawtransaction should throw
-        assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'], 0.00001000)
+        assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'], Decimal("0.00001000"))
         # and the following calls should both succeed
         testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']])[0]
         assert_equal(testres['allowed'], True)
@@ -535,7 +535,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey'], addr3Obj['pubkey']])['address']
 
-        txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
+        txId = self.nodes[0].sendtoaddress(mSigObj, Decimal("2.2"))
         decTx = self.nodes[0].gettransaction(txId)
         rawTx = self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
@@ -551,7 +551,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         bal = self.nodes[0].getbalance()
         inputs = [{"txid": txId, "vout": vout['n'], "scriptPubKey": vout['scriptPubKey']['hex'], "amount": vout['value']}]
-        outputs = {self.nodes[0].getnewaddress(): 2.19}
+        outputs = {self.nodes[0].getnewaddress(): Decimal("2.19")}
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxPartialSigned = self.nodes[1].signrawtransactionwithwallet(rawTx, inputs)
         assert_equal(rawTxPartialSigned['complete'], False)  # node1 only has one key, can't comp. sign the tx
@@ -576,7 +576,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey']])['address']
         mSigObjValid = self.nodes[2].getaddressinfo(mSigObj)
 
-        txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
+        txId = self.nodes[0].sendtoaddress(mSigObj, Decimal("2.2"))
         decTx = self.nodes[0].gettransaction(txId)
         rawTx2 = self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
@@ -590,7 +590,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         bal = self.nodes[0].getbalance()
         inputs = [{"txid": txId, "vout": vout['n'], "scriptPubKey": vout['scriptPubKey']['hex'], "redeemScript": mSigObjValid['hex'], "amount": vout['value']}]
-        outputs = {self.nodes[0].getnewaddress(): 2.19}
+        outputs = {self.nodes[0].getnewaddress(): Decimal("2.19")}
         rawTx2 = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxPartialSigned1 = self.nodes[1].signrawtransactionwithwallet(rawTx2, inputs)
         self.log.debug(rawTxPartialSigned1)

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -42,7 +42,7 @@ INPUTS = [
     {'txid': '83a4f6a6b73660e13ee6cb3c6063fa3759c50c9b7521d0536022961898f4fb02', 'vout': 0,
      'scriptPubKey': '76a914669b857c03a5ed269d5d85a1ffac9ed5d663072788ac'},
 ]
-OUTPUTS = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
+OUTPUTS = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': Decimal("0.1")}
 
 class SignRawTransactionWithKeyTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -26,6 +26,7 @@ total. This ensures we are not relying on specific values for the UTXOs,
 but still know when to expect mixing due to the wallet being close to empty.
 
 """
+from decimal import Decimal
 
 import random
 from test_framework.test_framework import BitcoinTestFramework
@@ -172,7 +173,7 @@ class AddressInputTypeGrouping(BitcoinTestFramework):
             self.generate(A, 1)
             assert is_same_type(B, tx)
 
-        tx = self.make_payment(A, B, 30.99, random.choice(ADDRESS_TYPES))
+        tx = self.make_payment(A, B, Decimal("30.99"), random.choice(ADDRESS_TYPES))
         assert not is_same_type(B, tx)
 
 

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -244,7 +244,7 @@ class WalletTest(BitcoinTestFramework):
         before = self.nodes[1].getbalances()['mine']['untrusted_pending']
         dst = self.nodes[1].getnewaddress()
         self.nodes[1].unloadwallet(self.default_wallet_name)
-        self.nodes[0].sendtoaddress(dst, 0.1)
+        self.nodes[0].sendtoaddress(dst, Decimal('0.1'))
         self.sync_all()
         self.nodes[1].loadwallet(self.default_wallet_name)
         after = self.nodes[1].getbalances()['mine']['untrusted_pending']
@@ -296,7 +296,7 @@ class WalletTest(BitcoinTestFramework):
             self.log.info('Check if mempool is taken into account after import*')
             address = self.nodes[0].getnewaddress()
             privkey = self.nodes[0].dumpprivkey(address)
-            self.nodes[0].sendtoaddress(address, 0.1)
+            self.nodes[0].sendtoaddress(address, Decimal("0.1"))
             self.nodes[0].unloadwallet('')
             # check importaddress on fresh wallet
             self.nodes[0].createwallet('w1', False, True)
@@ -333,7 +333,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(walletinfo['lastprocessedblock']['hash'], prev_hash)
 
         self.log.info("Test gettransaction returns expected lastprocessedblock json object")
-        txid = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+        txid = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), Decimal("0.01"))
         tx_info = self.nodes[1].gettransaction(txid)
         assert_equal(tx_info['lastprocessedblock']['height'], prev_height)
         assert_equal(tx_info['lastprocessedblock']['hash'], prev_hash)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -355,7 +355,7 @@ class WalletTest(BitcoinTestFramework):
         # 4. check if recipient (node0) can list the zero value tx
         usp = self.nodes[1].listunspent(query_options={'minimumAmount': '49.998'})[0]
         inputs = [{"txid": usp['txid'], "vout": usp['vout']}]
-        outputs = {self.nodes[1].getnewaddress(): 49.998, self.nodes[0].getnewaddress(): 11.11}
+        outputs = {self.nodes[1].getnewaddress(): Decimal("49.998"), self.nodes[0].getnewaddress(): Decimal("11.11")}
 
         raw_tx = self.nodes[1].createrawtransaction(inputs, outputs).replace("c0833842", "00000000")  # replace 11.11 with 0.0 (int32)
         signed_raw_tx = self.nodes[1].signrawtransactionwithwallet(raw_tx)

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test wallet change address selection"""
 
+from decimal import Decimal
 import re
 
 from test_framework.blocktools import COINBASE_MATURITY
@@ -66,7 +67,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         for i in range(20):
             for n in [1, 2]:
                 self.log.debug(f"Send transaction from node {n}: expected change index {i}")
-                txid = self.nodes[n].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
+                txid = self.nodes[n].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("0.2"))
                 tx = self.nodes[n].getrawtransaction(txid, True)
                 # find the change output and ensure that expected change index was used
                 self.assert_change_index(self.nodes[n], tx, i)
@@ -78,10 +79,10 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         w2 = self.nodes[2].get_wallet_rpc("w2")
         addr1 = w1.getnewaddress()
         addr2 = w2.getnewaddress()
-        self.nodes[0].sendtoaddress(addr1, 3.0)
-        self.nodes[0].sendtoaddress(addr1, 0.1)
-        self.nodes[0].sendtoaddress(addr2, 3.0)
-        self.nodes[0].sendtoaddress(addr2, 0.1)
+        self.nodes[0].sendtoaddress(addr1, Decimal("3.0"))
+        self.nodes[0].sendtoaddress(addr1, Decimal("0.1"))
+        self.nodes[0].sendtoaddress(addr2, Decimal("3.0"))
+        self.nodes[0].sendtoaddress(addr2, Decimal("0.1"))
         self.generate(self.nodes[0], 1)
 
         sendTo1 = self.nodes[0].getnewaddress()

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -80,7 +80,7 @@ class TxConflicts(BitcoinTestFramework):
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
 
         # Now that 'AB_parent_tx' was broadcast, build 'Child_Tx'
-        output_c = self.get_utxo_of_value(from_tx_id=txid_AB_parent, search_value=19.99998)
+        output_c = self.get_utxo_of_value(from_tx_id=txid_AB_parent, search_value=Decimal("19.99998"))
         inputs_tx_C_child = [({"txid": txid_AB_parent, "vout": output_c})]
 
         tx_C_child = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs_tx_C_child, {self.nodes[0].getnewaddress() : Decimal("19.99996")}))
@@ -152,15 +152,15 @@ class TxConflicts(BitcoinTestFramework):
         assert all([tx["amount"] == 25 for tx in unspents])
 
         # tx1 spends unspent[0] and unspent[1]
-        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{bob.getnewaddress() : 49.9999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{bob.getnewaddress() : Decimal("49.9999")}])
         tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         # tx2 spends unspent[1] and unspent[2], conflicts with tx1
-        raw_tx = alice.createrawtransaction(inputs=[unspents[1], unspents[2]], outputs=[{bob.getnewaddress() : 49.99}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1], unspents[2]], outputs=[{bob.getnewaddress() : Decimal("49.99")}])
         tx2 = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         # tx3 spends unspent[2], conflicts with tx2
-        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{bob.getnewaddress() : 24.9899}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{bob.getnewaddress() : Decimal("24.9899")}])
         tx3 = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         # broadcast tx1
@@ -222,21 +222,21 @@ class TxConflicts(BitcoinTestFramework):
         self.disconnect_nodes(0, 1)
 
         # Sends funds to bob
-        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : 24.99999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : Decimal("24.99999")}])
         raw_tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
         tx1_txid = bob.sendrawtransaction(raw_tx1) # broadcast original tx spending unspents[0] only to bob
 
         # create a conflict to previous tx (also spends unspents[0]), but don't broadcast, sends funds back to alice
-        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[2]], outputs=[{alice.getnewaddress() : 49.999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[2]], outputs=[{alice.getnewaddress() : Decimal("49.999")}])
         tx1_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         # Sends funds to bob
-        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{bob.getnewaddress() : 24.9999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{bob.getnewaddress() : Decimal("24.9999")}])
         raw_tx2 = alice.signrawtransactionwithwallet(raw_tx)['hex']
         tx2_txid = bob.sendrawtransaction(raw_tx2) # broadcast another original tx spending unspents[1] only to bob
 
         # create a conflict to previous tx (also spends unspents[1]), but don't broadcast, sends funds to alice
-        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{alice.getnewaddress() : 24.9999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{alice.getnewaddress() : Decimal("24.9999")}])
         tx2_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         bob_unspents = [{"txid" : element, "vout" : 0} for element in [tx1_txid, tx2_txid]]
@@ -245,7 +245,7 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("49.99989000"))
 
         # spend both of bob's unspents, child tx of tx1 and tx2
-        raw_tx = bob.createrawtransaction(inputs=[bob_unspents[0], bob_unspents[1]], outputs=[{bob.getnewaddress() : 49.999}])
+        raw_tx = bob.createrawtransaction(inputs=[bob_unspents[0], bob_unspents[1]], outputs=[{bob.getnewaddress() : Decimal("49.999")}])
         raw_tx3 = bob.signrawtransactionwithwallet(raw_tx)['hex']
         tx3_txid = bob.sendrawtransaction(raw_tx3) # broadcast tx only to bob
 
@@ -301,7 +301,7 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("24.99990000"))
 
         # create a conflict to previous tx (also spends unspents[2]), but don't broadcast, sends funds back to alice
-        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{alice.getnewaddress() : 24.99}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{alice.getnewaddress() : Decimal("24.99")}])
         tx1_conflict_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
 
         bob.sendrawtransaction(tx1_conflict_conflict) # kick tx1_conflict out of the mempool
@@ -344,7 +344,7 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(alice.getrawmempool(), [])
 
         # Alice spends first utxo to bob in tx1
-        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : 24.9999}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : Decimal("24.9999")}])
         tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
         tx1_txid = alice.sendrawtransaction(tx1)
 
@@ -355,7 +355,7 @@ class TxConflicts(BitcoinTestFramework):
 
         assert_equal(bob.gettransaction(tx1_txid)["mempoolconflicts"],  [])
 
-        raw_tx = bob.createrawtransaction(inputs=[bob.listunspent(minconf=0)[0]], outputs=[{carol.getnewaddress() : 24.999}])
+        raw_tx = bob.createrawtransaction(inputs=[bob.listunspent(minconf=0)[0]], outputs=[{carol.getnewaddress() : Decimal("24.999")}])
         # Bob creates a child to tx1
         tx1_child = bob.signrawtransactionwithwallet(raw_tx)['hex']
         tx1_child_txid = bob.sendrawtransaction(tx1_child)
@@ -373,7 +373,7 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(carol.getbalances()["mine"]["untrusted_pending"], Decimal("24.99900000"))
 
         # Alice spends first unspent again, conflicting with tx1
-        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{carol.getnewaddress() : 49.99}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{carol.getnewaddress() : Decimal("49.99")}])
         tx1_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
         tx1_conflict_txid = alice.sendrawtransaction(tx1_conflict)
 
@@ -392,7 +392,7 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(bob.gettransaction(tx1_child_txid)["mempoolconflicts"],  [tx1_conflict_txid])
 
         # Now create a conflict to tx1_conflict, so that it gets kicked out of the mempool
-        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{carol.getnewaddress() : 24.9895}])
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{carol.getnewaddress() : Decimal("24.9895")}])
         tx1_conflict_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
         tx1_conflict_conflict_txid = alice.sendrawtransaction(tx1_conflict_conflict)
 

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -3,6 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+from decimal import Decimal
+
 from test_framework.messages import (
     tx_from_hex,
 )
@@ -53,7 +55,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate
-        outputs = {self.nodes[0].getnewaddress(address_type='bech32'): 0.000025 for _ in range(400)}
+        outputs = {self.nodes[0].getnewaddress(address_type='bech32'): Decimal("0.000025") for _ in range(400)}
         raw_tx = self.nodes[0].createrawtransaction(inputs=[], outputs=outputs)
 
         for fee_setting in ['-minrelaytxfee=0.01', '-mintxfee=0.01', '-paytxfee=0.01']:
@@ -106,7 +108,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
         # Sending one more chained transaction will fail
         options = {"minconf": 0, "include_unsafe": True, 'add_inputs': True}
         assert_raises_rpc_error(-4, "Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool",
-                                test_wallet.send, outputs=[{test_wallet.getnewaddress(): 0.3}], options=options)
+                                test_wallet.send, outputs=[{test_wallet.getnewaddress(): Decimal("0.3")}], options=options)
 
         test_wallet.unloadwallet()
 

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -199,9 +199,9 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.nodes[0].sendtoaddress(self.nodes[3].get_wallet_rpc(self.default_wallet_name).getnewaddress(), self.watchonly_amount / 10)
 
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal("1.5"))
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal("1.0"))
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal("5.0"))
 
         self.generate(self.nodes[0], 1)
 
@@ -210,7 +210,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_simple(self):
         self.log.info("Test fundrawtxn")
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("1.0") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
@@ -219,7 +219,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_simple_two_coins(self):
         self.log.info("Test fundrawtxn with 2 coins")
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.2 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("2.2") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
@@ -230,7 +230,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Test fundrawtxn with 2 outputs")
 
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.6, self.nodes[1].getnewaddress() : 2.5 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("2.6"), self.nodes[1].getnewaddress() : Decimal("2.5") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
@@ -244,7 +244,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
-        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("1.0") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -341,7 +341,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx = get_unspent(self.nodes[2].listunspent(), 1)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
-        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("1.0") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
 
         # 4-byte version + 1-byte vin count + 36-byte prevout then script_len
@@ -376,7 +376,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : 6.0 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("6.0") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -407,7 +407,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : 6.0, self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("6.0"), self.nodes[0].getnewaddress() : Decimal("1.0") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -430,7 +430,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         txid = "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1"
         vout = 0
         inputs  = [ {'txid' : txid, 'vout' : vout} ] #invalid vin!
-        outputs = { self.nodes[0].getnewaddress() : 1.0}
+        outputs = { self.nodes[0].getnewaddress() : Decimal("1.0")}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         assert_raises_rpc_error(-4, "Unable to find UTXO for external input", self.nodes[2].fundrawtransaction, rawtx)
 
@@ -439,12 +439,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Test fundrawtxn p2pkh fee")
         self.lock_outputs_type(self.nodes[0], "p2pkh")
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1}
+        outputs = {self.nodes[1].getnewaddress():Decimal("1.1")}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
         # Create same transaction over sendtoaddress.
-        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
+        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), Decimal("1.1"))
         signedFee = self.nodes[0].getmempoolentry(txId)['fees']['base']
 
         # Compare fee.
@@ -459,12 +459,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.lock_outputs_type(self.nodes[0], "p2pkh")
         inputs = []
         outputs = {
-            self.nodes[1].getnewaddress():1.1,
-            self.nodes[1].getnewaddress():1.2,
-            self.nodes[1].getnewaddress():0.1,
-            self.nodes[1].getnewaddress():1.3,
-            self.nodes[1].getnewaddress():0.2,
-            self.nodes[1].getnewaddress():0.3,
+            self.nodes[1].getnewaddress():Decimal("1.1"),
+            self.nodes[1].getnewaddress():Decimal("1.2"),
+            self.nodes[1].getnewaddress():Decimal("0.1"),
+            self.nodes[1].getnewaddress():Decimal("1.3"),
+            self.nodes[1].getnewaddress():Decimal("0.2"),
+            self.nodes[1].getnewaddress():Decimal("0.3"),
         }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
@@ -492,12 +492,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         mSigObj = self.nodes[3].createmultisig(2, [addr1Obj['pubkey'], addr2Obj['pubkey']])['address']
 
         inputs = []
-        outputs = {mSigObj:1.1}
+        outputs = {mSigObj:Decimal("1.1")}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
         # Create same transaction over sendtoaddress.
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
+        txId = self.nodes[0].sendtoaddress(mSigObj, Decimal("1.1"))
         signedFee = self.nodes[0].getmempoolentry(txId)['fees']['base']
 
         # Compare fee.
@@ -536,12 +536,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         )['address']
 
         inputs = []
-        outputs = {mSigObj:1.1}
+        outputs = {mSigObj:Decimal("1.1")}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
         # Create same transaction over sendtoaddress.
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
+        txId = self.nodes[0].sendtoaddress(mSigObj, Decimal("1.1"))
         signedFee = self.nodes[0].getmempoolentry(txId)['fees']['base']
 
         # Compare fee.
@@ -575,12 +575,12 @@ class RawTransactionsTest(BitcoinTestFramework):
             wmulti.importaddress(mSigObj)
 
         # Send 1.2 BTC to msig addr.
-        self.nodes[0].sendtoaddress(mSigObj, 1.2)
+        self.nodes[0].sendtoaddress(mSigObj, Decimal("1.2"))
         self.generate(self.nodes[0], 1)
 
         oldBalance = self.nodes[1].getbalance()
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1}
+        outputs = {self.nodes[1].getnewaddress():Decimal("1.1")}
         funded_psbt = wmulti.walletcreatefundedpsbt(inputs=inputs, outputs=outputs, changeAddress=w2.getrawchangeaddress())['psbt']
 
         signed_psbt = w2.walletprocesspsbt(funded_psbt)
@@ -649,12 +649,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         with WalletUnlock(wallet, "test"):
             wallet.keypoolrefill(8) #need to refill the keypool to get an internal change address
 
-        assert_raises_rpc_error(-13, "walletpassphrase", wallet.sendtoaddress, self.nodes[0].getnewaddress(), 1.2)
+        assert_raises_rpc_error(-13, "walletpassphrase", wallet.sendtoaddress, self.nodes[0].getnewaddress(), Decimal("1.2"))
 
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():1.1}
+        outputs = {self.nodes[0].getnewaddress():Decimal("1.1")}
         rawtx = wallet.createrawtransaction(inputs, outputs)
         fundedTx = wallet.fundrawtransaction(rawtx)
         assert fundedTx["changepos"] != -1
@@ -682,12 +682,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.generate(self.nodes[1], 1)
 
         for _ in range(20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), Decimal("0.01"))
         self.generate(self.nodes[0], 1)
 
         # Fund a tx with ~20 small inputs.
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():Decimal("0.15"),self.nodes[0].getnewaddress():Decimal("0.04")}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
 
@@ -708,14 +708,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.generate(self.nodes[1], 1)
 
         for _ in range(20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), Decimal("0.01"))
         self.generate(self.nodes[0], 1)
 
         # Fund a tx with ~20 small inputs.
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():Decimal("0.15"),self.nodes[0].getnewaddress():Decimal("0.04")}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
@@ -860,20 +860,20 @@ class RawTransactionsTest(BitcoinTestFramework):
             assert_raises_rpc_error(-3, "Amount is not a number or string",
                 node.fundrawtransaction, rawtx, add_inputs=True, **{param: {"foo": "bar"}})
             # Test fee rate values that don't pass fixed-point parsing checks.
-            for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
+            for invalid_value in [""] + list(map(Decimal, "0.000000001 1e-09 1.111111111 1111111111111111 31.999999999999999999999".split())):
                 assert_raises_rpc_error(-3, "Invalid amount", node.fundrawtransaction, rawtx, add_inputs=True, **{param: invalid_value})
         # Test fee_rate values that cannot be represented in sat/vB.
-        for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999]:
+        for invalid_value in list(map(Decimal, "0.0001 0.00000001 0.00099999 31.99999999".split())):
             assert_raises_rpc_error(-3, "Invalid amount",
                 node.fundrawtransaction, rawtx, fee_rate=invalid_value, add_inputs=True)
 
         self.log.info("Test min fee rate checks are bypassed with fundrawtxn, e.g. a fee_rate under 1 sat/vB is allowed")
-        node.fundrawtransaction(rawtx, fee_rate=0.999, add_inputs=True)
-        node.fundrawtransaction(rawtx, feeRate=0.00000999, add_inputs=True)
+        node.fundrawtransaction(rawtx, fee_rate=Decimal("0.999"), add_inputs=True)
+        node.fundrawtransaction(rawtx, feeRate=Decimal("0.00000999"), add_inputs=True)
 
         self.log.info("- raises RPC error if both feeRate and fee_rate are passed")
         assert_raises_rpc_error(-8, "Cannot specify both fee_rate (sat/vB) and feeRate (BTC/kvB)",
-            node.fundrawtransaction, rawtx, fee_rate=0.1, feeRate=0.1, add_inputs=True)
+            node.fundrawtransaction, rawtx, fee_rate=Decimal("0.1"), feeRate=Decimal("0.1"), add_inputs=True)
 
         self.log.info("- raises RPC error if both feeRate and estimate_mode passed")
         assert_raises_rpc_error(-8, "Cannot specify both estimate_mode and feeRate",
@@ -955,7 +955,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(change[3] + result[3]['fee'], change[4])
 
         inputs = []
-        outputs = {self.nodes[2].getnewaddress(): value for value in (1.0, 1.1, 1.2, 1.3)}
+        outputs = {self.nodes[2].getnewaddress(): value for value in list(map(Decimal, "1.0 1.1 1.2 1.3".split()))}
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
 
         result = [self.nodes[3].fundrawtransaction(rawtx),
@@ -1011,7 +1011,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
         recipient = self.nodes[0].get_wallet_rpc("large")
         outputs = {}
-        rawtx = recipient.createrawtransaction([], {wallet.getnewaddress(): 147.99899260})
+        rawtx = recipient.createrawtransaction([], {wallet.getnewaddress(): Decimal("147.99899260")})
 
         # Make 1500 0.1 BTC outputs. The amount that we target for funding is in
         # the BnB range when these outputs are used.  However if these outputs
@@ -1021,7 +1021,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # First, force the wallet to bulk-generate the addresses we'll need.
         recipient.keypoolrefill(1500)
         for _ in range(1500):
-            outputs[recipient.getnewaddress()] = 0.1
+            outputs[recipient.getnewaddress()] = Decimal("0.1")
         wallet.sendmany("", outputs)
         self.generate(self.nodes[0], 10)
         assert_raises_rpc_error(-4, "The inputs size exceeds the maximum weight. "
@@ -1321,12 +1321,12 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         outputs = []
         for _ in range(1472):
-            outputs.append({wallet.getnewaddress(address_type="legacy"): 0.1})
+            outputs.append({wallet.getnewaddress(address_type="legacy"): Decimal("0.1")})
         txid = self.nodes[0].send(outputs=outputs, change_position=0)["txid"]
         self.generate(self.nodes[0], 1)
 
         # 272 WU per input (273 when high-s); picking 1471 inputs will exceed the max standard tx weight.
-        rawtx = wallet.createrawtransaction([], [{wallet.getnewaddress(): 0.1 * 1471}])
+        rawtx = wallet.createrawtransaction([], [{wallet.getnewaddress(): Decimal("0.1") * 1471}])
 
         # 1) Try to fund transaction only using the preset inputs (pick all 1472 inputs to cover the fee)
         input_weights = []
@@ -1360,7 +1360,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_mempools()
 
         # Unsafe inputs are ignored by default.
-        rawtx = wallet.createrawtransaction([], [{self.nodes[2].getnewaddress(): 7.5}])
+        rawtx = wallet.createrawtransaction([], [{self.nodes[2].getnewaddress(): Decimal("7.5")}])
         assert_raises_rpc_error(-4, "Insufficient funds", wallet.fundrawtransaction, rawtx)
 
         # But we can opt-in to use them for funding.
@@ -1405,8 +1405,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
 
         # Create transactions in order to calculate fees for the target bounds that can trigger this bug
-        change_tx = tester.fundrawtransaction(tester.createrawtransaction([], [{funds.getnewaddress(): 1.5}]))
-        tx = tester.createrawtransaction([], [{funds.getnewaddress(): 2}])
+        change_tx = tester.fundrawtransaction(tester.createrawtransaction([], [{funds.getnewaddress(): Decimal("1.5")}]))
+        tx = tester.createrawtransaction([], [{funds.getnewaddress(): Decimal("2")}])
         no_change_tx = tester.fundrawtransaction(tx, subtractFeeFromOutputs=[0])
 
         overhead_fees = feerate * len(tx) / 2 / 1000
@@ -1458,8 +1458,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         # In the former case, the calculated needed fee is higher than the actual fee being paid, so an assertion is reached
         # To test this does not happen, we subtract 202 sats from the input value. If working correctly, this should
         # fail with insufficient funds rather than bitcoind asserting.
-        rawtx = w.createrawtransaction(inputs=[], outputs=[{self.nodes[0].getnewaddress(address_type="bech32"): 1 - 0.00000202}])
-        assert_raises_rpc_error(-4, "Insufficient funds", w.fundrawtransaction, rawtx, fee_rate=1.85)
+        rawtx = w.createrawtransaction(inputs=[], outputs=[{self.nodes[0].getnewaddress(address_type="bech32"): Decimal("1") - Decimal("0.00000202")}])
+        assert_raises_rpc_error(-4, "Insufficient funds", w.fundrawtransaction, rawtx, fee_rate=Decimal("1.85"))
 
     def test_input_confs_control(self):
         self.nodes[0].createwallet("minconf")
@@ -1470,12 +1470,12 @@ class RawTransactionsTest(BitcoinTestFramework):
             self.nodes[2].sendmany("", {wallet.getnewaddress():1, wallet.getnewaddress():1})
             self.generate(self.nodes[2], 1)
 
-        unconfirmed_txid = wallet.sendtoaddress(wallet.getnewaddress(), 0.5)
+        unconfirmed_txid = wallet.sendtoaddress(wallet.getnewaddress(), Decimal("0.5"))
 
         self.log.info("Crafting TX using an unconfirmed input")
         target_address = self.nodes[2].getnewaddress()
-        raw_tx1 = wallet.createrawtransaction([], {target_address: 0.1}, 0, True)
-        funded_tx1 = wallet.fundrawtransaction(raw_tx1, {'fee_rate': 1, 'maxconf': 0})['hex']
+        raw_tx1 = wallet.createrawtransaction([], {target_address: Decimal("0.1")}, 0, True)
+        funded_tx1 = wallet.fundrawtransaction(raw_tx1, {'fee_rate': Decimal("1"), 'maxconf': 0})['hex']
 
         # Make sure we only had the one input
         tx1_inputs = self.nodes[0].decoderawtransaction(funded_tx1)['vin']

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -31,7 +31,10 @@ from test_framework.util import (
 )
 
 import collections
-from decimal import Decimal
+from decimal import (
+    Decimal,
+    ROUND_HALF_UP,
+)
 import enum
 import itertools
 import random
@@ -149,7 +152,7 @@ def get_rand_amount(min_amount=AMOUNT_DUST):
     assert min_amount <= 1
     r = random.uniform(min_amount, 1)
     # note: min_amount can get rounded down here
-    return Decimal(str(round(r, 8)))
+    return Decimal(r).quantize(Decimal("1E-8"), rounding=ROUND_HALF_UP)
 
 
 class ImportRescanTest(BitcoinTestFramework):

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -15,6 +15,7 @@ variants.
 - `test_address()` is called to call getaddressinfo for an address on node1
   and test the values returned."""
 
+from decimal import Decimal
 import concurrent.futures
 import time
 
@@ -410,9 +411,9 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                      address,
                      solvable=True,
                      ismine=True)
-        txid = w0.sendtoaddress(address, 49.99995540)
+        txid = w0.sendtoaddress(address, Decimal("49.99995540"))
         self.generatetoaddress(self.nodes[0], 6, w0.getnewaddress())
-        tx = wpriv.createrawtransaction([{"txid": txid, "vout": 0}], {w0.getnewaddress(): 49.999})
+        tx = wpriv.createrawtransaction([{"txid": txid, "vout": 0}], {w0.getnewaddress(): Decimal("49.999")})
         signed_tx = wpriv.signrawtransactionwithwallet(tx)
         w1.sendrawtransaction(signed_tx['hex'])
 
@@ -551,7 +552,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(res[1]['success'], True)
         assert_equal(res[1]['warnings'][0], 'Not all private keys provided. Some wallet functionality may return unexpected errors')
 
-        rawtx = self.nodes[1].createrawtransaction([utxo], {w0.getnewaddress(): 9.999})
+        rawtx = self.nodes[1].createrawtransaction([utxo], {w0.getnewaddress(): Decimal("9.999")})
         tx_signed_1 = wmulti_priv1.signrawtransactionwithwallet(rawtx)
         assert_equal(tx_signed_1['complete'], False)
         tx_signed_2 = wmulti_priv2.signrawtransactionwithwallet(tx_signed_1['hex'])
@@ -586,7 +587,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         w0.sendtoaddress(addr, 10)
         self.generate(self.nodes[0], 1)
         # It is standard and would relay.
-        txid = wmulti_priv_big.sendtoaddress(w0.getnewaddress(), 9.999)
+        txid = wmulti_priv_big.sendtoaddress(w0.getnewaddress(), Decimal("9.999"))
         decoded = wmulti_priv_big.gettransaction(txid=txid, verbose=True)['decoded']
         # 20 sigs + dummy + witness script
         assert_equal(len(decoded['vin'][0]['txinwitness']), 22)
@@ -645,7 +646,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
             }])
         assert_equal(res[0]['success'], True)
 
-        rawtx = self.nodes[1].createrawtransaction([utxo2], {w0.getnewaddress(): 9.999})
+        rawtx = self.nodes[1].createrawtransaction([utxo2], {w0.getnewaddress(): Decimal("9.999")})
         tx = wmulti_priv3.signrawtransactionwithwallet(rawtx)
         assert_equal(tx['complete'], True)
         self.nodes[1].sendrawtransaction(tx['hex'])

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -66,17 +66,17 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['ismine'], False)
 
         # Send funds to self
-        txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
+        txnid1 = self.nodes[0].sendtoaddress(address1, Decimal("0.1"))
         self.generate(self.nodes[0], 1)
         rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
         proof1 = self.nodes[0].gettxoutproof([txnid1])
 
-        txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
+        txnid2 = self.nodes[0].sendtoaddress(address2, Decimal("0.05"))
         self.generate(self.nodes[0], 1)
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
         proof2 = self.nodes[0].gettxoutproof([txnid2])
 
-        txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
+        txnid3 = self.nodes[0].sendtoaddress(address3, Decimal("0.025"))
         self.generate(self.nodes[0], 1)
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
         proof3 = self.nodes[0].gettxoutproof([txnid3])

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -192,30 +192,30 @@ class KeyPoolTest(BitcoinTestFramework):
 
         # Using a fee rate (10 sat / byte) well above the minimum relay rate
         # creating a 5,000 sat transaction with change should not be possible
-        assert_raises_rpc_error(-4, "Transaction needs a change address, but we can't generate it.", w2.walletcreatefundedpsbt, inputs=[], outputs=[{addr.pop(): 0.00005000}], subtractFeeFromOutputs=[0], feeRate=0.00010)
+        assert_raises_rpc_error(-4, "Transaction needs a change address, but we can't generate it.", w2.walletcreatefundedpsbt, inputs=[], outputs=[{addr.pop(): Decimal("0.00005000")}], subtractFeeFromOutputs=[0], feeRate=Decimal("0.00010"))
 
         # creating a 10,000 sat transaction without change, with a manual input, should still be possible
-        res = w2.walletcreatefundedpsbt(inputs=w2.listunspent(), outputs=[{destination: 0.00010000}], subtractFeeFromOutputs=[0], feeRate=0.00010)
+        res = w2.walletcreatefundedpsbt(inputs=w2.listunspent(), outputs=[{destination: Decimal("0.00010000")}], subtractFeeFromOutputs=[0], feeRate=Decimal("0.00010"))
         assert_equal("psbt" in res, True)
 
         # creating a 10,000 sat transaction without change should still be possible
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], subtractFeeFromOutputs=[0], feeRate=0.00010)
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: Decimal("0.00010000")}], subtractFeeFromOutputs=[0], feeRate=Decimal("0.00010"))
         assert_equal("psbt" in res, True)
         # should work without subtractFeeFromOutputs if the exact fee is subtracted from the amount
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008900}], feeRate=0.00010)
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: Decimal("0.00008900")}], feeRate=Decimal("0.00010"))
         assert_equal("psbt" in res, True)
 
         # dust change should be removed
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008800}], feeRate=0.00010)
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: Decimal("0.00008800")}], feeRate=Decimal("0.00010"))
         assert_equal("psbt" in res, True)
 
         # create a transaction without change at the maximum fee rate, such that the output is still spendable:
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], subtractFeeFromOutputs=[0], feeRate=0.0008823)
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: Decimal("0.00010000")}], subtractFeeFromOutputs=[0], feeRate=Decimal("0.0008823"))
         assert_equal("psbt" in res, True)
         assert_equal(res["fee"], Decimal("0.00009706"))
 
         # creating a 10,000 sat transaction with a manual change address should be possible
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], subtractFeeFromOutputs=[0], feeRate=0.00010, changeAddress=addr.pop())
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: Decimal("0.00010000")}], subtractFeeFromOutputs=[0], feeRate=Decimal("0.00010"), changeAddress=addr.pop())
         assert_equal("psbt" in res, True)
 
         if not self.options.descriptors:

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -36,7 +36,7 @@ class ReceivedByTest(BitcoinTestFramework):
 
         # Send from node 0 to 1
         addr = self.nodes[1].getnewaddress()
-        txid = self.nodes[0].sendtoaddress(addr, 0.1)
+        txid = self.nodes[0].sendtoaddress(addr, Decimal("0.1"))
         self.sync_all()
 
         # Check not listed in listreceivedbyaddress because has 0 confirmations
@@ -83,7 +83,7 @@ class ReceivedByTest(BitcoinTestFramework):
         res = self.nodes[1].listreceivedbyaddress(0, True, True)
         assert_equal(len(res), 2 + num_cb_reward_addresses)  # Right now 2 entries
         other_addr = self.nodes[1].getnewaddress()
-        txid2 = self.nodes[0].sendtoaddress(other_addr, 0.1)
+        txid2 = self.nodes[0].sendtoaddress(other_addr, Decimal("0.1"))
         self.generate(self.nodes[0], 1)
         # Same test as above should still pass
         expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 11, "txids": [txid, ]}
@@ -108,7 +108,7 @@ class ReceivedByTest(BitcoinTestFramework):
 
         # Send from node 0 to 1
         addr = self.nodes[1].getnewaddress()
-        txid = self.nodes[0].sendtoaddress(addr, 0.1)
+        txid = self.nodes[0].sendtoaddress(addr, Decimal("0.1"))
         self.sync_all()
 
         # Check balance is 0 because of 0 confirmations
@@ -136,7 +136,7 @@ class ReceivedByTest(BitcoinTestFramework):
         received_by_label_json = [r for r in self.nodes[1].listreceivedbylabel() if r["label"] == label][0]
         balance_by_label = self.nodes[1].getreceivedbylabel(label)
 
-        txid = self.nodes[0].sendtoaddress(addr, 0.1)
+        txid = self.nodes[0].sendtoaddress(addr, Decimal("0.1"))
         self.sync_all()
 
         # getreceivedbylabel returns an error if the wallet doesn't own the label

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -35,7 +35,7 @@ class ListTransactionsTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Test simple send from node0 to node1")
-        txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+        txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), Decimal("0.1"))
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
@@ -54,7 +54,7 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"category": "receive", "amount": Decimal("0.1"), "confirmations": 1, "blockhash": blockhash, "blockheight": blockheight})
 
         self.log.info("Test send-to-self on node0")
-        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("0.2"))
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid, "category": "send"},
                             {"amount": Decimal("-0.2")})
@@ -63,10 +63,10 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"amount": Decimal("0.2")})
 
         self.log.info("Test sendmany from node1: twice to self, twice to node0")
-        send_to = {self.nodes[0].getnewaddress(): 0.11,
-                   self.nodes[1].getnewaddress(): 0.22,
-                   self.nodes[0].getnewaddress(): 0.33,
-                   self.nodes[1].getnewaddress(): 0.44}
+        send_to = {self.nodes[0].getnewaddress(): Decimal("0.11"),
+                   self.nodes[1].getnewaddress(): Decimal("0.22"),
+                   self.nodes[0].getnewaddress(): Decimal("0.33"),
+                   self.nodes[1].getnewaddress(): Decimal("0.44")}
         txid = self.nodes[1].sendmany("", send_to)
         self.sync_all()
         assert_array_result(self.nodes[1].listtransactions(),
@@ -100,7 +100,7 @@ class ListTransactionsTest(BitcoinTestFramework):
             pubkey = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())['pubkey']
             multisig = self.nodes[1].createmultisig(1, [pubkey])
             self.nodes[0].importaddress(multisig["redeemScript"], "watchonly", False, True)
-            txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
+            txid = self.nodes[1].sendtoaddress(multisig["address"], Decimal("0.1"))
             self.generate(self.nodes[1], 1)
             assert_equal(len(self.nodes[0].listtransactions(label="watchonly", include_watchonly=True)), 1)
             assert_equal(len(self.nodes[0].listtransactions(dummy="watchonly", include_watchonly=True)), 1)
@@ -284,8 +284,8 @@ class ListTransactionsTest(BitcoinTestFramework):
 
     def run_coinjoin_test(self):
         self.log.info('Check "coin-join" transaction')
-        input_0 = next(i for i in self.nodes[0].listunspent(query_options={"minimumAmount": 0.2}, include_unsafe=False))
-        input_1 = next(i for i in self.nodes[1].listunspent(query_options={"minimumAmount": 0.2}, include_unsafe=False))
+        input_0 = next(i for i in self.nodes[0].listunspent(query_options={"minimumAmount": Decimal("0.2")}, include_unsafe=False))
+        input_1 = next(i for i in self.nodes[1].listunspent(query_options={"minimumAmount": Decimal("0.2")}, include_unsafe=False))
         raw_hex = self.nodes[0].createrawtransaction(
             inputs=[
                 {

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -4,6 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Miniscript descriptors integration in the wallet."""
 
+from decimal import Decimal
+
 from test_framework.descriptors import descsum_create
 from test_framework.psbt import PSBT, PSBT_IN_SHA256
 from test_framework.test_framework import BitcoinTestFramework
@@ -289,7 +291,7 @@ class WalletMiniscriptTest(BitcoinTestFramework):
                     "sequence": seq,
                 }
             ],
-            [{dest_addr: 0.009}],
+            [{dest_addr: Decimal("0.009")}],
             lt,
         )
 

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -7,6 +7,8 @@
 This is meant to be documentation as much as functional tests, so it is kept as simple and readable as possible.
 """
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
@@ -104,7 +106,7 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
         coordinator_wallet = participants["signers"][0]
         self.generatetoaddress(self.nodes[0], 101, coordinator_wallet.getnewaddress())
 
-        deposit_amount = 6.15
+        deposit_amount = Decimal("6.15")
         multisig_receiving_address = participants["multisigs"][0].getnewaddress()
         self.log.info("Send funds to the resulting multisig receiving address...")
         coordinator_wallet.sendtoaddress(multisig_receiving_address, deposit_amount)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -337,7 +337,7 @@ class WalletSendTest(BitcoinTestFramework):
         fee = self.nodes[1].decodepsbt(res["psbt"])["fee"]
         assert_fee_amount(fee, count_bytes(res["hex"]), Decimal("0.00002"))
 
-        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=4.531, add_to_wallet=False)
+        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=Decimal("4.531"), add_to_wallet=False)
         fee = self.nodes[1].decodepsbt(res["psbt"])["fee"]
         assert_fee_amount(fee, count_bytes(res["hex"]), Decimal("0.00004531"))
 
@@ -590,23 +590,23 @@ class WalletSendTest(BitcoinTestFramework):
         # Picking 1471 inputs will exceed the max standard tx weight.
         outputs = []
         for _ in range(1472):
-            outputs.append({wallet.getnewaddress(address_type="legacy"): 0.1})
+            outputs.append({wallet.getnewaddress(address_type="legacy"): Decimal("0.1")})
         self.nodes[0].send(outputs=outputs)
         self.generate(self.nodes[0], 1)
 
         # 1) Try to fund transaction only using the preset inputs
         inputs = wallet.listunspent()
         assert_raises_rpc_error(-4, "Transaction too large",
-                                wallet.send, outputs=[{wallet.getnewaddress(): 0.1 * 1471}], options={"inputs": inputs, "add_inputs": False})
+                                wallet.send, outputs=[{wallet.getnewaddress(): Decimal("0.1") * 1471}], options={"inputs": inputs, "add_inputs": False})
 
         # 2) Let the wallet fund the transaction
         assert_raises_rpc_error(-4, "The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs",
-                                wallet.send, outputs=[{wallet.getnewaddress(): 0.1 * 1471}])
+                                wallet.send, outputs=[{wallet.getnewaddress(): Decimal("0.1") * 1471}])
 
         # 3) Pre-select some inputs and let the wallet fill-up the remaining amount
         inputs = inputs[0:1000]
         assert_raises_rpc_error(-4, "The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet's UTXOs",
-                                wallet.send, outputs=[{wallet.getnewaddress(): 0.1 * 1471}], options={"inputs": inputs, "add_inputs": True})
+                                wallet.send, outputs=[{wallet.getnewaddress(): Decimal("0.1") * 1471}], options={"inputs": inputs, "add_inputs": True})
 
         self.nodes[1].unloadwallet("test_weight_limits")
 

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -173,8 +173,8 @@ class SendallTest(BitcoinTestFramework):
         self.nodes[0].createwallet("dustwallet")
         dust_wallet = self.nodes[0].get_wallet_rpc("dustwallet")
 
-        self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), 0.00000400)
-        self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), 0.00000300)
+        self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), Decimal("0.00000400"))
+        self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), Decimal("0.00000300"))
         self.generate(self.nodes[0], 1)
         assert_greater_than(dust_wallet.getbalances()["mine"]["trusted"], 0)
 
@@ -187,7 +187,7 @@ class SendallTest(BitcoinTestFramework):
     @cleanup
     def sendall_with_send_max(self):
         self.log.info("Check that `send_max` option causes negative value UTXOs to be left behind")
-        self.add_utxos([0.00000400, 0.00000300, 1])
+        self.add_utxos([Decimal("0.00000400"), Decimal("0.00000300"), 1])
 
         # sendall with send_max
         sendall_tx_receipt = self.wallet.sendall(recipients=[self.remainder_target], fee_rate=300, send_max=True)
@@ -445,7 +445,7 @@ class SendallTest(BitcoinTestFramework):
         self.wallet.keypoolrefill(1600)
 
         # create many inputs
-        outputs = {self.wallet.getnewaddress(): 0.000025 for _ in range(1600)}
+        outputs = {self.wallet.getnewaddress(): Decimal("0.000025") for _ in range(1600)}
         self.def_wallet.sendmany(amounts=outputs)
         self.generate(self.nodes[0], 1)
 

--- a/test/functional/wallet_signrawtransactionwithwallet.py
+++ b/test/functional/wallet_signrawtransactionwithwallet.py
@@ -87,7 +87,7 @@ class SignRawTransactionWithWalletTest(BitcoinTestFramework):
              'scriptPubKey': 'badbadbadbad'}
         ]
 
-        outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
+        outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': Decimal("0.1")}
 
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
 

--- a/test/functional/wallet_simulaterawtx.py
+++ b/test/functional/wallet_simulaterawtx.py
@@ -87,9 +87,9 @@ class SimulateTxTest(BitcoinTestFramework):
         tx1hex = tx1ob["txid"]
         tx1vout = 1 - tx1changepos
         # tx3 spends new w1 UTXO paying to w0
-        tx3 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w0.getnewaddress(): 4.9999})
+        tx3 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w0.getnewaddress(): Decimal("4.9999")})
         # tx4 spends new w1 UTXO paying to w1
-        tx4 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w1.getnewaddress(): 4.9999})
+        tx4 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w1.getnewaddress(): Decimal("4.9999")})
 
         # on their own, both should fail due to missing input(s)
         assert_raises_rpc_error(-8, "One or more transaction inputs are missing or have been spent already", w0.simulaterawtransaction, [tx3])

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -148,15 +148,15 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.def_wallet.sendtoaddress(address=wallet.getnewaddress(), amount=2)
         self.generate(self.nodes[0], 1) # confirm funding tx
 
-        parent_one_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1.5, fee_rate=2)
+        parent_one_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=Decimal("1.5"), fee_rate=2)
         p_one_tx = wallet.gettransaction(txid=parent_one_txid, verbose=True)
         self.assert_undershoots_target(p_one_tx)
 
-        parent_two_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1.5, fee_rate=1)
+        parent_two_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=Decimal("1.5"), fee_rate=1)
         p_two_tx = wallet.gettransaction(txid=parent_two_txid, verbose=True)
         self.assert_undershoots_target(p_two_tx)
 
-        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=2.8, fee_rate=self.target_fee_rate)
+        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("2.8"), fee_rate=self.target_fee_rate)
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
         self.assert_spends_only_parents(ancestor_aware_tx, [parent_one_txid, parent_two_txid])
 
@@ -176,17 +176,17 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.def_wallet.sendtoaddress(address=wallet.getnewaddress(), amount=2)
         self.generate(self.nodes[0], 1) # confirm funding tx
 
-        high_parent_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1.5, fee_rate=self.target_fee_rate*2)
+        high_parent_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=Decimal("1.5"), fee_rate=self.target_fee_rate*2)
         p_high_tx = wallet.gettransaction(txid=high_parent_txid, verbose=True)
         # This time the parent is greater than the child
         self.assert_beats_target(p_high_tx)
 
-        parent_low_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1.5, fee_rate=1)
+        parent_low_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=Decimal("1.5"), fee_rate=1)
         p_low_tx = wallet.gettransaction(txid=parent_low_txid, verbose=True)
         # Other parent needs bump
         self.assert_undershoots_target(p_low_tx)
 
-        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=2.8, fee_rate=self.target_fee_rate)
+        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("2.8"), fee_rate=self.target_fee_rate)
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
         self.assert_spends_only_parents(ancestor_aware_tx, [parent_low_txid, high_parent_txid])
 
@@ -370,12 +370,12 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.assert_undershoots_target(parent_tx)
 
         # create sibling tx
-        sibling_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=0.9, fee_rate=1)
+        sibling_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("0.9"), fee_rate=1)
         sibling_tx = wallet.gettransaction(txid=sibling_txid, verbose=True)
         self.assert_undershoots_target(sibling_tx)
 
         # spend both outputs from parent transaction
-        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=0.5, fee_rate=self.target_fee_rate)
+        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("0.5"), fee_rate=self.target_fee_rate)
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
 
         self.assert_spends_only_parents(ancestor_aware_tx, [parent_txid])
@@ -397,12 +397,12 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.assert_undershoots_target(parent_tx)
 
         # create sibling tx
-        sibling_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=0.9, fee_rate=3*self.target_fee_rate)
+        sibling_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("0.9"), fee_rate=3*self.target_fee_rate)
         sibling_tx = wallet.gettransaction(txid=sibling_txid, verbose=True)
         self.assert_beats_target(sibling_tx)
 
         # spend both outputs from parent transaction
-        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=0.5, fee_rate=self.target_fee_rate)
+        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("0.5"), fee_rate=self.target_fee_rate)
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
 
         self.assert_spends_only_parents(ancestor_aware_tx, [parent_txid])
@@ -426,10 +426,10 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         wallet = self.setup_and_fund_wallet("confirmed_and_unconfirmed_wallet")
         confirmed_parent_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1, fee_rate=self.target_fee_rate)
         self.generate(self.nodes[0], 1) # Wallet has two confirmed UTXOs of ~1BTC each
-        unconfirmed_parent_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=0.5, fee_rate=0.5*self.target_fee_rate)
+        unconfirmed_parent_txid = wallet.sendtoaddress(address=wallet.getnewaddress(), amount=Decimal("0.5"), fee_rate=0.5*self.target_fee_rate)
 
         # wallet has one confirmed UTXO of 1BTC and two unconfirmed UTXOs of ~0.5BTC each
-        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=1.4, fee_rate=self.target_fee_rate)
+        ancestor_aware_txid = wallet.sendtoaddress(address=self.def_wallet.getnewaddress(), amount=Decimal("1.4"), fee_rate=self.target_fee_rate)
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
         self.assert_spends_only_parents(ancestor_aware_tx, [confirmed_parent_txid, unconfirmed_parent_txid])
         resulting_fee_rate = self.calc_fee_rate(ancestor_aware_tx)

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -5,6 +5,8 @@
 """Test createwallet watchonly arguments.
 """
 
+from decimal import Decimal
+
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -55,8 +57,8 @@ class CreateWalletWatchonlyTest(BitcoinTestFramework):
 
         self.log.info('Test sending from a watch-only wallet raises RPC error')
         msg = "Error: Private keys are disabled for this wallet"
-        assert_raises_rpc_error(-4, msg, wo_wallet.sendtoaddress, a1, 0.1)
-        assert_raises_rpc_error(-4, msg, wo_wallet.sendmany, amounts={a1: 0.1})
+        assert_raises_rpc_error(-4, msg, wo_wallet.sendtoaddress, a1, Decimal("0.1"))
+        assert_raises_rpc_error(-4, msg, wo_wallet.sendmany, amounts={a1: Decimal("0.1")})
 
         self.log.info('Testing listreceivedbyaddress watch-only defaults')
         result = wo_wallet.listreceivedbyaddress()


### PR DESCRIPTION
On NetBSD, with newer Python versions 3.12.8 and 3.13.1, many functional tests fail due to `float` numbers internal representation.

A typical error looks as follows:
```
$ python3.12 ./build/test/functional/feature_assumeutxo.py
...
2025-01-02T20:43:01.865000Z TestFramework (INFO): Submit a spending transaction for a snapshot chainstate coin to the mempool
2025-01-02T20:43:01.889000Z TestFramework (ERROR): JSONRPC error
Traceback (most recent call last):
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/test_framework.py", line 135, in main
    self.run_test()
  File "/home/hebasto/dev/bitcoin/./build/test/functional/feature_assumeutxo.py", line 563, in run_test
    raw_tx = n1.createrawtransaction([prevout], {getnewdestination()[2]: 24.99})
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/coverage.py", line 50, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/authproxy.py", line 146, in __call__
    raise JSONRPCException(response['error'], status)
test_framework.authproxy.JSONRPCException: Invalid amount (-3)
2025-01-02T20:43:01.954000Z TestFramework (INFO): Stopping nodes
...
```

Running the same test with `--tracerpc`:
```
$ python3.12 ./build/test/functional/feature_assumeutxo.py --tracerpc
...
-2269-> createrawtransaction [[{"txid": "7935c5e149f7206122dfc8de0db6e5b2484923650b94ed56b8612609b896e021", "vout": 0, "scriptPubKey": "76a9142b4569203694fc997e13f2c0a1383b9e16c77a0d88ac"}], {"bcrt1pehl52uxx4ndz844j2xkasc3kqesyfmjhfukx42wdte2u5elzxhgqf9nnkt": 24.989999999999998}]
<-- [0.013652] {"jsonrpc":"2.0","error":{"code":-3,"message":"Invalid amount"},"id":2269}

2025-01-03T08:17:42.532000Z TestFramework (ERROR): JSONRPC error
Traceback (most recent call last):
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/test_framework.py", line 135, in main
    self.run_test()
  File "/home/hebasto/dev/bitcoin/./build/test/functional/feature_assumeutxo.py", line 563, in run_test
    raw_tx = n1.createrawtransaction([prevout], {getnewdestination()[2]: 24.99})
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/coverage.py", line 50, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hebasto/dev/bitcoin/test/functional/test_framework/authproxy.py", line 146, in __call__
    raise JSONRPCException(response['error'], status)
test_framework.authproxy.JSONRPCException: Invalid amount (-3)
2025-01-03T08:17:42.588000Z TestFramework (INFO): Stopping nodes
...
```

This PR fixes this issue by consistent use of `Decimal` numbers.