### PR TITLE
ci: Switch to latest macOS and Windows images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: ${{ matrix.job-name }}
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
-    runs-on: macos-14
+    runs-on: macos-15
 
     # When a contributor maintains a fork of the repo, any pull request they make
     # to their own fork, or to the main repository, will trigger two CI runs:
@@ -96,10 +96,10 @@ jobs:
         include:
           - job-type: standard
             file-env: './ci/test/00_setup_env_mac_native.sh'
-            job-name: 'macOS 14 native, arm64, no depends, sqlite only, gui'
+            job-name: 'macOS 15 native, arm64, no depends, sqlite only, gui'
           - job-type: fuzz
             file-env: './ci/test/00_setup_env_mac_native_fuzz.sh'
-            job-name: 'macOS 14 native, arm64, fuzz'
+            job-name: 'macOS 15 native, arm64, fuzz'
 
     env:
       DANGER_RUN_CI_ON_HOST: 1
@@ -111,7 +111,7 @@ jobs:
 
       - name: Clang version
         run: |
-          sudo xcode-select --switch /Applications/Xcode_15.0.app
+          sudo xcode-select --switch /Applications/Xcode_15.4.0.app
           clang --version
 
       - name: Install Homebrew packages
@@ -150,7 +150,7 @@ jobs:
     name: ${{ matrix.job-name }}
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 


### PR DESCRIPTION
This PR updates the macOS and Windows images to their latest versions, in line with our usual practice.

Additionally, the Xcode version has been updated to 16.2.

For more details regarding these images, please refer to:
- https://github.com/actions/runner-images/issues/10686
- https://github.com/actions/runner-images/issues/11228