### PR TITLE
refactor: modernize recent `ByteType` usages and read/write functions

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -59,7 +59,7 @@ void ChaCha20Aligned::Seek(Nonce96 nonce, uint32_t block_counter) noexcept
 
 inline void ChaCha20Aligned::Keystream(Span<std::byte> output) noexcept
 {
-    unsigned char* c = UCharCast(output.data());
+    std::byte* c = output.data();
     size_t blocks = output.size() / BLOCKLEN;
     assert(blocks * BLOCKLEN == output.size());
 
@@ -161,8 +161,8 @@ inline void ChaCha20Aligned::Keystream(Span<std::byte> output) noexcept
 inline void ChaCha20Aligned::Crypt(Span<const std::byte> in_bytes, Span<std::byte> out_bytes) noexcept
 {
     assert(in_bytes.size() == out_bytes.size());
-    const unsigned char* m = UCharCast(in_bytes.data());
-    unsigned char* c = UCharCast(out_bytes.data());
+    const std::byte* m = in_bytes.data();
+    std::byte* c = out_bytes.data();
     size_t blocks = out_bytes.size() / BLOCKLEN;
     assert(blocks * BLOCKLEN == out_bytes.size());
 

--- a/src/crypto/chacha20poly1305.cpp
+++ b/src/crypto/chacha20poly1305.cpp
@@ -56,8 +56,8 @@ void ComputeTag(ChaCha20& chacha20, Span<const std::byte> aad, Span<const std::b
     poly1305.Update(cipher).Update(Span{PADDING}.first(cipher_padding_length));
     // - Process the AAD and plaintext length with Poly1305.
     std::byte length_desc[Poly1305::TAGLEN];
-    WriteLE64(UCharCast(length_desc), aad.size());
-    WriteLE64(UCharCast(length_desc + 8), cipher.size());
+    WriteLE64(length_desc, aad.size());
+    WriteLE64(length_desc + 8, cipher.size());
     poly1305.Update(length_desc);
 
     // Output tag.

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -13,93 +13,81 @@
 #include <cstring>
 
 template <typename B>
-concept ByteType = std::same_as<B, unsigned char> || std::same_as<B, std::byte>;
+concept ByteType = std::same_as<B, uint8_t> || std::same_as<B, std::byte>;
 
-template <ByteType B>
-inline uint16_t ReadLE16(const B* ptr)
+uint16_t ReadLE16(const ByteType auto* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
     return le16toh_internal(x);
 }
 
-template <ByteType B>
-inline uint32_t ReadLE32(const B* ptr)
+uint32_t ReadLE32(const ByteType auto* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
     return le32toh_internal(x);
 }
 
-template <ByteType B>
-inline uint64_t ReadLE64(const B* ptr)
+uint64_t ReadLE64(const ByteType auto* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
     return le64toh_internal(x);
 }
 
-template <ByteType B>
-inline void WriteLE16(B* ptr, uint16_t x)
+void WriteLE16(ByteType auto* ptr, uint16_t x)
 {
     uint16_t v = htole16_internal(x);
     memcpy(ptr, &v, 2);
 }
 
-template <ByteType B>
-inline void WriteLE32(B* ptr, uint32_t x)
+void WriteLE32(ByteType auto* ptr, uint32_t x)
 {
     uint32_t v = htole32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
-template <ByteType B>
-inline void WriteLE64(B* ptr, uint64_t x)
+void WriteLE64(ByteType auto* ptr, uint64_t x)
 {
     uint64_t v = htole64_internal(x);
     memcpy(ptr, &v, 8);
 }
 
-template <ByteType B>
-inline uint16_t ReadBE16(const B* ptr)
+uint16_t ReadBE16(const ByteType auto* ptr)
 {
     uint16_t x;
     memcpy(&x, ptr, 2);
     return be16toh_internal(x);
 }
 
-template <ByteType B>
-inline uint32_t ReadBE32(const B* ptr)
+uint32_t ReadBE32(const ByteType auto* ptr)
 {
     uint32_t x;
     memcpy(&x, ptr, 4);
     return be32toh_internal(x);
 }
 
-template <ByteType B>
-inline uint64_t ReadBE64(const B* ptr)
+uint64_t ReadBE64(const ByteType auto* ptr)
 {
     uint64_t x;
     memcpy(&x, ptr, 8);
     return be64toh_internal(x);
 }
 
-template <ByteType B>
-inline void WriteBE16(B* ptr, uint16_t x)
+void WriteBE16(ByteType auto* ptr, uint16_t x)
 {
     uint16_t v = htobe16_internal(x);
     memcpy(ptr, &v, 2);
 }
 
-template <ByteType B>
-inline void WriteBE32(B* ptr, uint32_t x)
+void WriteBE32(ByteType auto* ptr, uint32_t x)
 {
     uint32_t v = htobe32_internal(x);
     memcpy(ptr, &v, 4);
 }
 
-template <ByteType B>
-inline void WriteBE64(B* ptr, uint64_t x)
+void WriteBE64(ByteType auto* ptr, uint64_t x)
 {
     uint64_t v = htobe64_internal(x);
     memcpy(ptr, &v, 8);

--- a/src/random.h
+++ b/src/random.h
@@ -268,12 +268,12 @@ public:
     {
         while (span.size() >= 8) {
             uint64_t gen = Impl().rand64();
-            WriteLE64(UCharCast(span.data()), gen);
+            WriteLE64(span.data(), gen);
             span = span.subspan(8);
         }
         if (span.size() >= 4) {
             uint32_t gen = Impl().rand32();
-            WriteLE32(UCharCast(span.data()), gen);
+            WriteLE32(span.data(), gen);
             span = span.subspan(4);
         }
         while (span.size()) {
@@ -397,7 +397,7 @@ public:
         if (requires_seed) RandomSeed();
         std::array<std::byte, 8> buf;
         rng.Keystream(buf);
-        return ReadLE64(UCharCast(buf.data()));
+        return ReadLE64(buf.data());
     }
 
     /** Fill a byte Span with random bytes. This overrides the RandomMixin version. */

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -603,7 +603,7 @@ void BerkeleyRODatabase::Open()
 
     // Read subdatabase page number
     // It is written as a big endian 32 bit number
-    uint32_t main_db_page = ReadBE32(UCharCast(std::get<DataRecord>(page.records.at(1)).data.data()));
+    uint32_t main_db_page = ReadBE32(std::get<DataRecord>(page.records.at(1)).data.data());
 
     // The main database is in a page that doesn't exist
     if (main_db_page > outer_meta.last_page) {


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/31524, applying a few of the review suggestions to the affected code, while enabling more trivial reads/writes to use the new `std::byte` interface.