### PR TITLE
doc: Clarify min macOS and Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   macos-native-arm64:
     name: ${{ matrix.job-name }}
-    # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
+    # Use any image to support the xcode-select below, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
     runs-on: macos-14
 
@@ -111,6 +111,10 @@ jobs:
 
       - name: Clang version
         run: |
+          # Use the earliest Xcode supported by the version of macOS denoted in
+          # doc/release-notes-empty-template.md and providing at least the
+          # minimum clang version denoted in doc/dependencies.md.
+          # See: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes
           sudo xcode-select --switch /Applications/Xcode_15.0.app
           clang --version
 

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -43,7 +43,7 @@ Compatibility
 ==============
 
 Bitcoin Core is supported and tested on operating systems using the
-Linux Kernel 3.17+, macOS 13.0+, and Windows 10 and newer. Bitcoin
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
 Core should also work on most other Unix-like systems but is not as
 frequently tested on them. It is not recommended to use Bitcoin Core on
 unsupported systems.


### PR DESCRIPTION
Two minor doc fixups:

* Clarify that `macOS 13.0+` means `macOS 13+`, indicating that on any major version, only the latest security release is supported.
* Clarify that the Xcode version was selected based on the minimum required macOS version and the minimum required clang version.