### PR TITLE
doc: Fix invalid txid in `gettransaction` RPC example

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -743,10 +743,10 @@ RPCHelpMan gettransaction()
                     })
                 },
                 RPCExamples{
-                    HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
-            + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" true")
-            + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" false true")
-            + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+                    HelpExampleCli("gettransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\"")
+            + HelpExampleCli("gettransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\" true")
+            + HelpExampleCli("gettransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\" false true")
+            + HelpExampleRpc("gettransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\"")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -818,8 +818,8 @@ RPCHelpMan abandontransaction()
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
-                    HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
-            + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+                    HelpExampleCli("abandontransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\"")
+            + HelpExampleRpc("abandontransaction", "\"d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781\"")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
The RPC examples previously used an invalid 63-character txid, causing errors such as:
```
build/src/bitcoin-cli gettransaction "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d" true
error code: -8
error message:
txid must be of length 64 (not 63, for '1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d')
```

This commit replaces the invalid txid with a valid one from https://github.com/bitcoin/bitcoin/blob/df5c643f92d4a6b1ef4dfe4b9c54f902990bb54b/src/validation.cpp#L2582

----

You can verify the fix by checking the following:

The original txid does not exist:
* https://mempool.space/tx/1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d.

The new txid is valid:
* https://mempool.space/tx/d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781.

Or use the commands below to validate locally:
```bash
# Build the Bitcoin Core binaries
cmake -B build && cmake --build build -j$(nproc)

# Start bitcoind with an up-to-date datadir and txindex enabled
build/src/bitcoind -datadir="~/your-up-to-date-bitcoin-datadir" -daemon -txindex=1 

# Wait a few seconds, then test the txids
build/src/bitcoin-cli getrawtransaction "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d" # invalid
build/src/bitcoin-cli getrawtransaction "d4f7fbbf92f4a3014a230b2dc70b8058d02eb36ac06b4a0736d9d60eaa9e8781" # valid

# Stop bitcoind to clean up
build/src/bitcoin-cli stop
 ```

