### PR TITLE
depends, NetBSD: Fix `bdb` package compilation with GCC-14

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -10,6 +10,7 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security -Wno-error=implicit-int
+$(package)_cflags_netbsd+=-Wno-error=int-conversion
 $(package)_cppflags_freebsd=-D_XOPEN_SOURCE=600 -D__BSD_VISIBLE=1
 $(package)_cppflags_netbsd=-D_XOPEN_SOURCE=600
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE


### PR DESCRIPTION
On NetBSD 10, compilation of the `bdb` package with GCC-14 fails with the following error:
```
$ gmake -C depends bdb CC=/usr/pkg/gcc14/bin/gcc
<snip>
./libtool --mode=compile /usr/pkg/gcc14/bin/gcc -c -I. -I../dist/./..   -I/home/hebasto/dev/bitcoin/depends/x86_64-unknown-netbsd10.0/include -D_XOPEN_SOURCE=600  -pipe -std=c11 -O2 -Wno-error=implicit-function-declaration -Wno-error=format-security -Wno-error=implicit-int  ../dist/./../env/env_config.c
libtool: compile:  /usr/pkg/gcc14/bin/gcc -c -I. -I../dist/./.. -I/home/hebasto/dev/bitcoin/depends/x86_64-unknown-netbsd10.0/include -D_XOPEN_SOURCE=600 -pipe -std=c11 -O2 -Wno-error=implicit-function-declaration -Wno-error=format-security -Wno-error=implicit-int ../dist/./../env/env_config.c  -fPIC -DPIC -o env_config.o
../dist/./../env/env_config.c: In function '__config_parse':
../dist/./../env/env_config.c:98:13: warning: implicit declaration of function 'strcasecmp'; did you mean 'strncmp'? [-Wimplicit-function-declaration]
   98 |         if (strcasecmp(s, argv[0]) == 0) {                              \
      |             ^~~~~~~~~~
../dist/./../env/env_config.c:135:9: note: in expansion of macro 'CONFIG_UINT32'
  135 |         CONFIG_UINT32("mutex_set_align", __mutex_set_align);
      |         ^~~~~~~~~~~~~
../dist/./../env/env_config.c: In function '__config_split':
../dist/./../env/env_config.c:537:43: warning: implicit declaration of function 'strsep'; did you mean 'strdup'? [-Wimplicit-function-declaration]
  537 |         for (count = 0, ap = argv; (*ap = strsep(&input, " \t\n")) != NULL;)
      |                                           ^~~~~~
      |                                           strdup
../dist/./../env/env_config.c:537:41: error: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  537 |         for (count = 0, ap = argv; (*ap = strsep(&input, " \t\n")) != NULL;)
      |                                         ^
gmake[1]: *** [Makefile:1664: env_config.o] Error 1
gmake[1]: Leaving directory '/home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/bdb/4.8.30-cac45822ba8/build_unix'
gmake: *** [funcs.mk:302: /home/hebasto/dev/bitcoin/depends/work/build/x86_64-unknown-netbsd10.0/bdb/4.8.30-cac45822ba8/build_unix/.stamp_built] Error 2
gmake: Leaving directory '/home/hebasto/dev/bitcoin/depends'
```

This PR resolves the compilation issue.