### PR TITLE
test: expect that files may disappear from /proc/PID/fd/

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -37,9 +37,12 @@ def get_socket_inodes(pid):
     base = '/proc/%i/fd' % pid
     inodes = []
     for item in os.listdir(base):
-        target = os.readlink(os.path.join(base, item))
-        if target.startswith('socket:'):
-            inodes.append(int(target[8:-1]))
+        try:
+            target = os.readlink(os.path.join(base, item))
+            if target.startswith('socket:'):
+                inodes.append(int(target[8:-1]))
+        except FileNotFoundError:
+            pass
     return inodes
 
 def _remove_empty(array):


### PR DESCRIPTION
`get_socket_inodes()` calls `os.listdir()` and then iterates on the results using `os.readlink()`. However a file may disappear from the directory after `os.listdir()` and before `os.readlink()` resulting in a `FileNotFoundError` exception.

It is expected that this may happen for `bitcoind` which is running and could open or close files or sockets at any time. Thus ignore the `FileNotFoundError` exception.