### PR TITLE
validation: ensure assumevalid is always used during reindex

### DIFF
--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -353,6 +353,7 @@ public:
     static constexpr auto PRUNE_TARGET_MANUAL{std::numeric_limits<uint64_t>::max()};
 
     [[nodiscard]] bool LoadingBlocks() const { return m_importing || !m_blockfiles_indexed; }
+    [[nodiscard]] bool IsReindexing() const { return m_importing && !m_blockfiles_indexed; }
 
     /** Calculate the amount of disk space the block & undo files currently use */
     uint64_t CalculateCurrentUsage();

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -11,12 +11,36 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.messages import MAGIC_BYTES
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    create_block,
+    create_coinbase,
+)
+from test_framework.messages import (
+    MAGIC_BYTES,
+    CBlockHeader,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    msg_block,
+    msg_headers,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
 from test_framework.util import (
     assert_equal,
     util_xor,
 )
 
+class BaseNode(P2PInterface):
+    def send_header_for_blocks(self, new_blocks):
+        headers_message = msg_headers()
+        headers_message.headers = [CBlockHeader(b) for b in new_blocks]
+        self.send_without_ping(headers_message)
 
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -97,6 +121,90 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
+    # Check that reindex uses -assumevalid
+    def assume_valid(self):
+        self.log.info("Testing reindex with -assumevalid")
+        self.start_node(0)
+        node = self.nodes[0]
+        self.generate(node, 1)
+        coinbase_to_spend = node.getblock(node.getbestblockhash())['tx'][0]
+        # Generate COINBASE_MATURITY blocks to make the coinbase spendable
+        self.generate(node, COINBASE_MATURITY)
+        best_blockhash = node.getbestblockhash()
+        tip = int(best_blockhash, 16)
+        block_info = node.getblock(best_blockhash)
+        block_time = block_info['time'] + 1
+        height = block_info['height'] + 1
+        blocks = []
+
+        # Create a block with an invalid signature
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(int(coinbase_to_spend, 16), 0), scriptSig=b""))
+        tx.vout.append(CTxOut(49 * 10000, CScript([OP_TRUE])))
+
+        invalid_block = create_block(tip, create_coinbase(height), block_time, txlist=[tx])
+        invalid_block.solve()
+        tip = invalid_block.hash_int
+        blocks.append(invalid_block)
+
+        # Bury that block with roughly two weeks' worth of blocks (2100 blocks) and an extra 100 blocks
+        for _ in range(2200):
+            block_time += 1
+            height += 1
+            block = create_block(tip, create_coinbase(height), block_time)
+            block.solve()
+            blocks.append(block)
+            tip = block.hash_int
+
+        # Start node0 with -assumevalid pointing to the last block
+        node.stop_node()
+        self.start_node(0, extra_args=["-assumevalid=" + blocks[-1].hash_hex])
+
+        # Send blocks to node0
+        p2p0 = node.add_p2p_connection(BaseNode())
+        p2p0.send_header_for_blocks(blocks[0:2000])
+        p2p0.send_header_for_blocks(blocks[2000:])
+        # Only send the first 2100 blocks so the assumevalid block is not saved to disk before we reindex
+        # This allows us to test that assumevalid is used in reindex even if the assumevalid block was not loaded during reindex
+        for block in blocks[:2101]:
+            p2p0.send_without_ping(msg_block(block))
+        p2p0.sync_with_ping(timeout=960)
+
+        expected_height = height - 100
+        # node0 should sync to tip of the chain, ignoring the invalid signature
+        assert_equal(node.getblock(node.getbestblockhash())['height'], expected_height)
+
+        self.log.info("Testing reindex with assumevalid block in block index and minchainwork > best_header chainwork")
+        # Restart node0 but raise minimumchainwork to be 100 blocks greater than the chainwork of the best header
+        best_header_target = int(node.getblock(node.getbestblockhash())['target'], 16)
+        chainwork = (100 + expected_height) * (2**256) // (best_header_target + 1)
+        chainwork = format(chainwork, '064x')
+        node.stop_node()
+        self.start_node(0, extra_args=["-reindex", "-assumevalid=" + blocks[2100].hash_hex, "-minimumchainwork=" + chainwork])
+
+        # node0 should sync to tip of the chain, ignoring the invalid signature
+        best_blockhash = node.getbestblockhash()
+        assert_equal(node.getblock(best_blockhash)['height'], expected_height)
+        assert_equal(int(best_blockhash, 16), blocks[2100].hash_int)
+
+        self.log.info("Testing reindex with assumevalid block not in block index")
+        node.stop_node()
+        self.start_node(0, extra_args=["-reindex", "-assumevalid=" + blocks[-1].hash_hex])
+
+        # node0 should still sync to tip of the chain, ignoring the invalid signature
+        best_blockhash = node.getbestblockhash()
+        assert_equal(node.getblock(best_blockhash)['height'], expected_height)
+        assert_equal(int(best_blockhash, 16), blocks[2100].hash_int)
+
+        self.log.info("Test reindex without -assumevalid does not skip script validation")
+        node.stop_node()
+        self.start_node(0, extra_args=["-reindex"])
+        best_blockhash = node.getbestblockhash()
+        assert_equal(node.getblock(best_blockhash)['height'], block_info['height'])
+        assert_equal(best_blockhash, block_info['hash'])
+
+        self.log.info("Success")
+
     def run_test(self):
         self.reindex(False)
         self.reindex(True)
@@ -105,6 +213,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
+        self.assume_valid()
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -104,6 +104,7 @@ BASE_SCRIPTS = [
     'p2p_segwit.py',
     'feature_maxuploadtarget.py',
     'feature_assumeutxo.py',
+    'feature_reindex.py',
     'mempool_updatefromblock.py',
     'mempool_persist.py',
     # vv Tests less than 60s vv
@@ -153,7 +154,6 @@ BASE_SCRIPTS = [
     'wallet_listreceivedby.py',
     'wallet_abandonconflict.py',
     'wallet_anchor.py',
-    'feature_reindex.py',
     'feature_reindex_readonly.py',
     'wallet_labels.py',
     'p2p_compactblocks.py',


### PR DESCRIPTION
assumevalid may be ignored during reindex for the following reasons:
- the assumevalid block is not in the block index:  this happens when the assumevalid block could not be downloaded before the previous IBD run was interrupted
-  the chainwork of the best header is less than the minimumchainwork: happens if the previous IBD was interrupted before it could connect blocks up to minimumchainwork. See Issue https://github.com/bitcoin/bitcoin/issues/31494

This PR fixes this by skipping script verification during reindex if assumevalid is enabled. 

EDIT: While the minimumchainwork is typically set to match the assumevalid block height, users typically adjust the assumevalid block without also adjusting the minimumchainwork; Scenario 2 from the list can occur if the assumevalid block is set to an older block without also reducing the minimumchainwork.