### PR TITLE
init,log: Unify block index log line

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1245,7 +1245,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
             "", CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…").translated);
-    const auto load_block_index_start_time{SteadyClock::now()};
     auto catch_exceptions = [](auto&& f) {
         try {
             return f();
@@ -1263,7 +1262,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
         }
         std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
-            LogPrintf(" block index %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - load_block_index_start_time));
+            LogInfo("Block index and chainstate loaded");
         }
     }
     return {status, error};


### PR DESCRIPTION
The line has been present since the beginning.

Removed redundant duration as well since it can be recovered from the timestamps.

Example logs before the change:
```
2025-01-07T11:58:33Z Verification progress: 99%
2025-01-07T11:58:33Z Verification: No coin database inconsistencies in last 6 blocks (18905 transactions)
2025-01-07T11:58:33Z  block index           31892ms
2025-01-07T11:58:33Z Setting NODE_NETWORK on non-prune mode
```