### PR TITLE
build, test: Build `db_tests.cpp` regardless of `USE_BDB`

### DIFF
--- a/src/wallet/test/CMakeLists.txt
+++ b/src/wallet/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(test_bitcoin
   PRIVATE
     init_test_fixture.cpp
     wallet_test_fixture.cpp
+    db_tests.cpp
     coinselector_tests.cpp
     feebumper_tests.cpp
     group_outputs_tests.cpp
@@ -22,10 +23,4 @@ target_sources(test_bitcoin
     walletdb_tests.cpp
     walletload_tests.cpp
 )
-if(USE_BDB)
-  target_sources(test_bitcoin
-    PRIVATE
-      db_tests.cpp
-  )
-endif()
 target_link_libraries(test_bitcoin bitcoin_wallet)

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -62,6 +62,7 @@ static void CheckPrefix(DatabaseBatch& batch, Span<const std::byte> prefix, Mock
 
 BOOST_FIXTURE_TEST_SUITE(db_tests, BasicTestingSetup)
 
+#ifdef USE_BDB
 static std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& path, fs::path& database_filename)
 {
     fs::path data_file = BDBDataFile(path);
@@ -124,6 +125,7 @@ BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_free_instance)
     BOOST_CHECK(env_1_a != env_1_b);
     BOOST_CHECK(env_2_a == env_2_b);
 }
+#endif
 
 static std::vector<std::unique_ptr<WalletDatabase>> TestDatabases(const fs::path& path_root)
 {


### PR DESCRIPTION
When the building of `db_tests.cpp` was made conditional on `USE_BDB` in commit a58b719cf75e2d97205ec260bcff0d4780fe4fb8, all `db_tests` were indeed specific to BDB wallets.

However, the tests have since been [extended](https://github.com/bitcoin/bitcoin/commit/ba616b932cb9e9adb7eb9f1826caa62ce422a22d) to include SQLite wallets as well.

On the master branch @ 433412fd8478923dfdb20044f74c5d1e19fa8dd8, tests specific to SQLite wallets are not built and run if configured with `WITH_BDB=OFF` (the default option).

This PR resolves this issue by guarding BDB-specific code in `db_tests.cpp` and ensuring this source file is compiled regardless of the `WITH_BDB` option.