### PR TITLE
tracing: Rename the `MIN` macro to `_TRACEPOINT_TEST_MIN` in log_raw_p2p_msgs

### DIFF
--- a/contrib/tracing/log_raw_p2p_msgs.py
+++ b/contrib/tracing/log_raw_p2p_msgs.py
@@ -41,7 +41,8 @@ from bcc import BPF, USDT
 program = """
 #include <uapi/linux/ptrace.h>
 
-#define MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+// A min() macro. Prefixed with _TRACEPOINT_TEST to avoid collision with other MIN macros.
+#define _TRACEPOINT_TEST_MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
 
 // Maximum possible allocation size
 // from include/linux/percpu.h in the Linux kernel
@@ -88,7 +89,7 @@ int trace_inbound_message(struct pt_regs *ctx) {
     bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
     bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
     bpf_usdt_readarg(5, ctx, &msg->msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg->msg, MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg_p(6, ctx, &msg->msg, _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
 
     inbound_messages.perf_submit(ctx, msg, sizeof(*msg));
     return 0;
@@ -108,7 +109,7 @@ int trace_outbound_message(struct pt_regs *ctx) {
     bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
     bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
     bpf_usdt_readarg(5, ctx, &msg->msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg->msg,  MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg_p(6, ctx, &msg->msg,  _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
 
     outbound_messages.perf_submit(ctx, msg, sizeof(*msg));
     return 0;


### PR DESCRIPTION
Inspired by: 00c1dbd26ddb816e5541c5724397015a92a3d06b (#31419)

Unless there's a reason we *don't* want the same change here...?