### PR TITLE
doc: warn that CheckBlock() underestimates sigops

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4094,6 +4094,8 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), tx_state.GetDebugMessage()));
         }
     }
+    // This underestimates the number of sigops, because unlike ConnectBlock it
+    // does not count witness and p2sh sigops.
     unsigned int nSigOps = 0;
     for (const auto& tx : block.vtx)
     {


### PR DESCRIPTION
Counting sigops in the witness requires context that `CheckBlock()`  does not have, so it only counts sigops for non-segwit transactions.

It's useful to document, but it should not be a problem.

The commit message contains some historical context.