### PR TITLE
depends: Use base system's `sha256sum` utility on FreeBSD

### DIFF
--- a/depends/builders/freebsd.mk
+++ b/depends/builders/freebsd.mk
@@ -1,5 +1,5 @@
 build_freebsd_CC=clang
 build_freebsd_CXX=clang++
 
-build_freebsd_SHA256SUM = shasum -a 256
+build_freebsd_SHA256SUM = sha256sum
 build_freebsd_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o


### PR DESCRIPTION
On FreeBSD, the `shasum` utility is provided by the [`perl5`](https://ports.freebsd.org/cgi/ports.cgi?query=%5Eperl5&stype=all&sektion=all) port, which is not part of the base system and must be [installed](https://github.com/hebasto/bitcoin-core-nightly/blob/0e3518579a02e6c79bafc67817136220579a0d5c/.github/workflows/freebsd.yml#L104) separately. Note that this requirement is currently not documented in [`depends/README.md`](https://github.com/bitcoin/bitcoin/blob/master/depends/README.md).

This PR switches to using the [`sha256sum`](https://man.freebsd.org/cgi/man.cgi?query=sha256sum&apropos=0&sektion=0&manpath=FreeBSD+14.2-RELEASE+and+Ports&arch=default&format=html) utility, which is included in the base system.