### PR TITLE
depends: Fix spacing issue

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -141,7 +141,7 @@ include packages/packages.mk
 #     2. Before including packages/*.mk (excluding packages/packages.mk), since
 #        they rely on the build_id variables
 #
-build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' AR='$(build_AR) 'NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' AR='$(build_AR)' NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 $(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(host_CXX)' CXX_STANDARD='$(CXX_STANDARD)' AR='$(host_AR)' NM='$(host_NM)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
 boost_packages_$(NO_BOOST) = $(boost_packages)


### PR DESCRIPTION
This PR resolves an issue where a missing space caused the value of the `build_AR` variable to be concatenated with the "NM=" string. This resulted in subsequent calls to `${AR}` and `${NM}` failing.

Here is a diff for the `make -C depends print-build_id DEBUG=1` output:
```diff
@@ -110,50 +110,18 @@
 CXX_STANDARD=c++20
 END CXX
 BEGIN AR
-ar: invalid option -- '='
-Usage: ar [emulation options] [-]{dmpqrstx}[abcDfilMNoOPsSTuvV] [--plugin <name>] [member-name] [count] archive-file file...
-       ar -M [<mri-script]
- commands:
-  d            - delete file(s) from the archive
-  m[ab]        - move file(s) in the archive
-  p            - print file(s) found in the archive
-  q[f]         - quick append file(s) to the archive
-  r[ab][f][u]  - replace existing or insert new file(s) into the archive
-  s            - act as ranlib
-  t[O][v]      - display contents of the archive
-  x[o]         - extract file(s) from the archive
- command specific modifiers:
-  [a]          - put file(s) after [member-name]
-  [b]          - put file(s) before [member-name] (same as [i])
-  [D]          - use zero for timestamps and uids/gids (default)
-  [U]          - use actual timestamps and uids/gids
-  [N]          - use instance [count] of name
-  [f]          - truncate inserted file names
-  [P]          - use full path names when matching
-  [o]          - preserve original dates
-  [O]          - display offsets of files in the archive
-  [u]          - only replace files that are newer than current archive contents
- generic modifiers:
-  [c]          - do not warn if the library had to be created
-  [s]          - create an archive index (cf. ranlib)
-  [l <text> ]  - specify the dependencies of this library
-  [S]          - do not build a symbol table
-  [T]          - deprecated, use --thin instead
-  [v]          - be verbose
-  [V]          - display the version number
-  @<file>      - read options from <file>
-  --target=BFDNAME - specify the target object format as BFDNAME
-  --output=DIRNAME - specify the output directory for extraction operations
-  --record-libdeps=<text> - specify the dependencies of this library
-  --thin       - make a thin archive
- optional:
-  --plugin <p> - load the specified plugin
- emulation options: 
-  No emulation specific options
-ar: supported targets: elf64-x86-64 elf32-i386 elf32-iamcu elf32-x86-64 pei-i386 pe-x86-64 pei-x86-64 elf64-little elf64-big elf32-little elf32-big elf64-littleaarch64 elf64-bigaarch64 elf32-littleaarch64 elf32-bigaarch64 elf32-littlearm elf32-bigarm pei-aarch64-little pe-aarch64-little elf64-alpha ecoff-littlealpha elf32-littlearm-fdpic elf32-bigarm-fdpic elf32-hppa-linux elf32-hppa elf64-ia64-little elf64-ia64-big pei-ia64 elf64-loongarch elf32-loongarch pei-loongarch64 elf32-m32r-linux elf32-m32rle-linux elf32-m68k elf32-tradbigmips elf32-tradlittlemips ecoff-bigmips ecoff-littlemips elf32-ntradbigmips elf64-tradbigmips elf32-ntradlittlemips elf64-tradlittlemips elf32-powerpc aixcoff-rs6000 elf32-powerpcle ppcboot elf64-powerpc elf64-powerpcle aixcoff64-rs6000 aix5coff64-rs6000 elf64-littleriscv elf32-littleriscv elf32-bigriscv elf64-bigriscv pei-riscv64-little elf32-s390 elf64-s390 elf32-sh-linux elf32-shbig-linux elf32-sh-fdpic elf32-shbig-fdpic elf32-sparc elf64-sparc pe-bigobj-x86-64 pe-i386 pdb srec symbolsrec verilog tekhex binary ihex plugin
+GNU ar (GNU Binutils for Ubuntu) 2.42
+Copyright (C) 2024 Free Software Foundation, Inc.
+This program is free software; you may redistribute it under the terms of
+the GNU General Public License version 3 or (at your option) any later version.
+This program has absolutely no warranty.
 END AR
 BEGIN NM
-bash: line 1: --version: command not found
+GNU nm (GNU Binutils for Ubuntu) 2.42
+Copyright (C) 2024 Free Software Foundation, Inc.
+This program is free software; you may redistribute it under the terms of
+the GNU General Public License version 3 or (at your option) any later version.
+This program has absolutely no warranty.
 END NM
 BEGIN RANLIB
 GNU ranlib (GNU Binutils for Ubuntu) 2.42
@@ -321,5 +289,5 @@
 NO_HARDEN=
 END NO_HARDEN
 END ALL
-build_id=b7effe2aa166e73f6d2587fb4805ea1cca4d3f1e5c3aae2cfd59c592816b05e3
+build_id=4173a5f75182c792550652e621f6b4a68cc27c8909385580d4efc7bc7a769f51
 make: Leaving directory '/home/hebasto/git/bitcoin/depends'
```

It was accidentally introduced in https://github.com/bitcoin/bitcoin/pull/29249.