### PR TITLE
Comment coypright date update

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Copyright (c) 2012-2025 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
doc: updated comments in line 1 from: 

// Copyright (c) 2012-2022 The Bitcoin Core developers 
to 
// Copyright (c) 2012-2025 The Bitcoin Core developers


PR was for comment update only so no testing was performed.