### PR TITLE
leveldb: show non-default options during init

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -28,11 +28,12 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdarg>
-#include <cstdint>
-#include <cstdio>
+#include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
 
@@ -214,6 +215,46 @@ struct LevelDBContext {
     leveldb::DB* pdb;
 };
 
+static std::string GetChangedOptions(const LevelDBContext& context)
+{
+    std::map<std::string, std::string> current, defaults;
+    auto process_options{[&]<typename OPTION>(const OPTION& options, const OPTION& default_options, const std::string& prefix) {
+        auto add_options_to_map{[&](const OPTION& op, std::map<std::string, std::string>& map) {
+            auto ToString{[](const bool value) { return value ? "true" : "false"; }};
+            if constexpr (std::is_same_v<OPTION, leveldb::Options>) {
+                map[prefix + "create_if_missing"] = ToString(op.create_if_missing);
+                map[prefix + "error_if_exists"] = ToString(op.error_if_exists);
+                map[prefix + "paranoid_checks"] = ToString(op.paranoid_checks);
+                map[prefix + "write_buffer_size"] = util::ToString(op.write_buffer_size);
+                map[prefix + "max_open_files"] = util::ToString(op.max_open_files);
+                map[prefix + "block_size"] = util::ToString(op.block_size);
+                map[prefix + "max_file_size"] = util::ToString(op.max_file_size);
+                map[prefix + "compression"] = op.compression == leveldb::kNoCompression ? "NoCompression" : "SnappyCompression";
+            } else if constexpr (std::is_same_v<OPTION, leveldb::ReadOptions>) {
+                map[prefix + "verify_checksums"] = ToString(op.verify_checksums);
+                map[prefix + "fill_cache"] = ToString(op.fill_cache);
+            } else if constexpr (std::is_same_v<OPTION, leveldb::WriteOptions>) {
+                map[prefix + "sync"] = ToString(op.sync);
+            }
+        }};
+        add_options_to_map(options, current);
+        add_options_to_map(default_options, defaults);
+    }};
+
+    process_options(context.options, leveldb::Options(), "options.");
+    for (const auto& op : {&context.readoptions, &context.iteroptions}) process_options(*op, leveldb::ReadOptions(), "readoptions.");
+    for (const auto& op : {&context.writeoptions, &context.syncoptions}) process_options(*op, leveldb::WriteOptions(), "writeoptions.");
+
+    std::string result;
+    for (const auto& [key, current_value] : current) {
+        if (current_value != defaults[key]) {
+            if (result.size()) result += ", ";
+            result += key + "=" + current_value;
+        }
+    }
+    return result;
+}
+
 CDBWrapper::CDBWrapper(const DBParams& params)
     : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
 {
@@ -243,6 +284,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
     HandleError(status);
     LogInfo("Opened LevelDB successfully");
+    LogDebug(BCLog::LEVELDB, "startup options: %s", GetChangedOptions(DBContext()));
 
     if (params.options.force_compact) {
         LogInfo("Starting database compaction of %s", fs::PathToString(params.path));


### PR DESCRIPTION
To help with to debugging and traceability (in alignment with displaying other non-default args such as `Command-line arg: dbcache="10000"`) we can extend the LevelDB opening log with an additional debug message for the used non-default settings.

To avoid showing booleans as e.g. `create_if_missing=1`, I've added a local `ToString` lambda for `bool`.
I wanted to use `util::Join` at the end, but couldn't find any way that I liked.

Example output after the change:
```bash
2025-10-15T02:39:45Z Opened LevelDB successfully
2025-10-15T02:39:45Z [leveldb] startup options: options.compression=NoCompression, options.create_if_missing=true, options.max_file_size=33554432, options.paranoid_checks=true, options.write_buffer_size=524288, readoptions.fill_cache=false, readoptions.verify_checksums=true, writeoptions.sync=true
```