### PR TITLE
test: avoid internet traffic

### DIFF
--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -6,6 +6,7 @@
 
 import itertools
 
+from test_framework.netutil import UNREACHABLE_PROXY_ARG
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -14,7 +15,7 @@ class P2PDNSSeeds(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-dnsseed=1"]]
+        self.extra_args = [["-dnsseed=1", UNREACHABLE_PROXY_ARG]]
 
     def run_test(self):
         self.init_arg_tests()
@@ -29,11 +30,11 @@ class P2PDNSSeeds(BitcoinTestFramework):
         self.log.info("Check that setting -connect disables -dnsseed by default")
         self.nodes[0].stop_node()
         with self.nodes[0].assert_debug_log(expected_msgs=["DNS seeding disabled"]):
-            self.start_node(0, [f"-connect={fakeaddr}"])
+            self.start_node(0, extra_args=[f"-connect={fakeaddr}", UNREACHABLE_PROXY_ARG])
 
         self.log.info("Check that running -connect and -dnsseed means DNS logic runs.")
         with self.nodes[0].assert_debug_log(expected_msgs=["Loading addresses from DNS seed"], timeout=12):
-            self.restart_node(0, [f"-connect={fakeaddr}", "-dnsseed=1"])
+            self.restart_node(0, extra_args=[f"-connect={fakeaddr}", "-dnsseed=1", UNREACHABLE_PROXY_ARG])
 
         self.log.info("Check that running -forcednsseed and -dnsseed=0 throws an error.")
         self.nodes[0].stop_node()
@@ -88,7 +89,7 @@ class P2PDNSSeeds(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(expected_msgs=["Loading addresses from DNS seed"], timeout=12):
             # -dnsseed defaults to 1 in bitcoind, but 0 in the test framework,
             # so pass it explicitly here
-            self.restart_node(0, ["-forcednsseed", "-dnsseed=1"])
+            self.restart_node(0, ["-forcednsseed", "-dnsseed=1", UNREACHABLE_PROXY_ARG])
 
         # Restore default for subsequent tests
         self.restart_node(0)

--- a/test/functional/p2p_seednode.py
+++ b/test/functional/p2p_seednode.py
@@ -9,6 +9,7 @@ Test seednode interaction with the AddrMan
 import random
 import time
 
+from test_framework.netutil import UNREACHABLE_PROXY_ARG
 from test_framework.test_framework import BitcoinTestFramework
 
 ADD_NEXT_SEEDNODE = 10
@@ -17,22 +18,24 @@ ADD_NEXT_SEEDNODE = 10
 class P2PSeedNodes(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        # Specify a non-working proxy to make sure no actual connections to random IPs are attempted.
+        self.extra_args = [[UNREACHABLE_PROXY_ARG]]
         self.disable_autoconnect = False
 
     def test_no_seednode(self):
         self.log.info("Check that if no seednode is provided, the node proceeds as usual (without waiting)")
         with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=["Empty addrman, adding seednode", f"Couldn't connect to peers from addrman after {ADD_NEXT_SEEDNODE} seconds. Adding seednode"], timeout=ADD_NEXT_SEEDNODE):
-            self.restart_node(0)
+            self.restart_node(0, extra_args=self.nodes[0].extra_args)
 
     def test_seednode_empty_addrman(self):
-        seed_node = "0.0.0.1"
+        seed_node = "25.0.0.1"
         self.log.info("Check that the seednode is immediately added on bootstrap on an empty addrman")
         with self.nodes[0].assert_debug_log(expected_msgs=[f"Empty addrman, adding seednode ({seed_node}) to addrfetch"], timeout=ADD_NEXT_SEEDNODE):
-            self.restart_node(0, extra_args=[f'-seednode={seed_node}'])
+            self.restart_node(0, extra_args=self.nodes[0].extra_args + [f'-seednode={seed_node}'])
 
     def test_seednode_non_empty_addrman(self):
         self.log.info("Check that if addrman is non-empty, seednodes are queried with a delay")
-        seed_node = "0.0.0.2"
+        seed_node = "25.0.0.2"
         node = self.nodes[0]
         # Fill the addrman with unreachable nodes
         for i in range(10):
@@ -40,9 +43,9 @@ class P2PSeedNodes(BitcoinTestFramework):
             port = 8333 + i
             node.addpeeraddress(ip, port)
 
-        # Restart the node so seednode is processed again. Specify a non-working proxy to make sure no actual connections to random IPs are attempted.
+        # Restart the node so seednode is processed again.
         with node.assert_debug_log(expected_msgs=["trying v1 connection"], timeout=ADD_NEXT_SEEDNODE):
-            self.restart_node(0, extra_args=[f'-seednode={seed_node}', '-proxy=127.0.0.1:1'])
+            self.restart_node(0, extra_args=self.nodes[0].extra_args + [f'-seednode={seed_node}'])
 
         with node.assert_debug_log(expected_msgs=[f"Couldn't connect to peers from addrman after {ADD_NEXT_SEEDNODE} seconds. Adding seednode ({seed_node}) to addrfetch"], unexpected_msgs=["Empty addrman, adding seednode"], timeout=ADD_NEXT_SEEDNODE * 1.5):
             node.setmocktime(int(time.time()) + ADD_NEXT_SEEDNODE + 1)

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -13,6 +13,10 @@ import struct
 import array
 import os
 
+# Easily unreachable address. Attempts to connect to it will stay within the machine.
+# Used to avoid non-loopback traffic or DNS queries.
+UNREACHABLE_PROXY_ARG = '-proxy=127.0.0.1:1'
+
 # STATE_ESTABLISHED = '01'
 # STATE_SYN_SENT  = '02'
 # STATE_SYN_RECV = '03'


### PR DESCRIPTION
Avoid generating outbound traffic on a non-loopback interface during tests. Fix all tests, including ones that generate DNS traffic.

---

This is a subset of https://github.com/bitcoin/bitcoin/pull/31349 containing only the changes to the tests, without the CI changes to detect future regressions.