### PR TITLE
Fees:  add Fee rate Forecaster Manager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,6 +240,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   policy/ephemeral_policy.cpp
   policy/fees/block_policy_estimator.cpp
   policy/fees/block_policy_estimator_args.cpp
+  policy/fees/forecaster_man.cpp
   policy/packages.cpp
   policy/rbf.cpp
   policy/settings.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   policy/fees/block_policy_estimator.cpp
   policy/fees/block_policy_estimator_args.cpp
   policy/fees/forecaster_man.cpp
+  policy/fees/mempool_forecaster.cpp
   policy/packages.cpp
   policy/rbf.cpp
   policy/settings.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   netbase.cpp
   outputtype.cpp
   policy/feerate.cpp
+  policy/fees/forecaster_util.cpp
   policy/policy.cpp
   pow.cpp
   protocol.cpp

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -15,7 +15,7 @@
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
 #include <node/warnings.h>
-#include <policy/fees/block_policy_estimator.h>
+#include <policy/fees/forecaster_man.h>
 #include <scheduler.h>
 #include <txmempool.h>
 #include <validation.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -16,7 +16,7 @@ class ArgsManager;
 class AddrMan;
 class BanMan;
 class BaseIndex;
-class CBlockPolicyEstimator;
+class FeeRateForecasterManager;
 class CConnman;
 class ValidationSignals;
 class CScheduler;
@@ -67,7 +67,7 @@ struct NodeContext {
     std::unique_ptr<CConnman> connman;
     std::unique_ptr<CTxMemPool> mempool;
     std::unique_ptr<const NetGroupManager> netgroupman;
-    std::unique_ptr<CBlockPolicyEstimator> fee_estimator;
+    std::unique_ptr<FeeRateForecasterManager> forecasterman;
     std::unique_ptr<PeerManager> peerman;
     std::unique_ptr<ChainstateManager> chainman;
     std::unique_ptr<BanMan> banman;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -41,6 +41,7 @@
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
+#include <policy/fees/forecaster_man.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>
@@ -726,13 +727,13 @@ public:
     }
     CFeeRate estimateSmartFee(int num_blocks, bool conservative, FeeCalculation* calc) override
     {
-        if (!m_node.fee_estimator) return {};
-        return m_node.fee_estimator->estimateSmartFee(num_blocks, calc, conservative);
+        if (!m_node.forecasterman) return {};
+        return m_node.forecasterman->GetBlockPolicyEstimator()->estimateSmartFee(num_blocks, calc, conservative);
     }
     unsigned int estimateMaxBlocks() override
     {
-        if (!m_node.fee_estimator) return 0;
-        return m_node.fee_estimator->HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
+        if (!m_node.forecasterman) return 0;
+        return m_node.forecasterman->GetBlockPolicyEstimator()->MaximumTarget();
     }
     CFeeRate mempoolMinFee() override
     {

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -7,6 +7,7 @@
 
 #include <consensus/amount.h>
 #include <policy/feerate.h>
+#include <policy/fees/forecaster.h>
 #include <random.h>
 #include <sync.h>
 #include <threadsafety.h>
@@ -37,6 +38,8 @@ static constexpr bool DEFAULT_ACCEPT_STALE_FEE_ESTIMATES{false};
 
 class AutoFile;
 class TxConfirmStats;
+
+struct ForecastResult;
 struct RemovedMempoolTransactionInfo;
 struct NewMempoolTransactionInfo;
 
@@ -146,7 +149,7 @@ struct FeeCalculation
  * a certain number of blocks.  Every time a block is added to the best chain, this class records
  * stats on the transactions included in that block
  */
-class CBlockPolicyEstimator : public CValidationInterface
+class CBlockPolicyEstimator : public Forecaster, public CValidationInterface
 {
 private:
     /** Track confirm delays up to 12 blocks for short horizon */
@@ -263,6 +266,10 @@ public:
     /** Calculates the age of the file, since last modified */
     std::chrono::hours GetFeeEstimatorFileAge();
 
+    /** Overridden from Forecaster. */
+    unsigned int MaximumTarget() const override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
+
 protected:
     /** Overridden from CValidationInterface. */
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t /*unused*/) override
@@ -270,6 +277,10 @@ protected:
     void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason /*unused*/, uint64_t /*unused*/) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
     void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int nBlockHeight) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
+
+    /** Overridden from Forecaster. */
+    ForecastResult ForecastFeeRate(int target, bool conservative) const override
         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
 
 private:

--- a/src/policy/fees/forecaster.h
+++ b/src/policy/fees/forecaster.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_FEES_FORECASTER_H
+#define BITCOIN_POLICY_FEES_FORECASTER_H
+
+#include <policy/fees/forecaster_util.h>
+
+/** \class Forecaster
+ *  @brief Abstract base class for fee rate forecasters.
+ */
+class Forecaster
+{
+protected:
+    const ForecastType m_forecast_type;
+
+public:
+    explicit Forecaster(ForecastType forecast_type) : m_forecast_type(forecast_type) {}
+
+    ForecastType GetForecastType() const { return m_forecast_type; }
+
+    /**
+     * @brief Returns the estimated fee rate for a package to confirm within the given target.
+     * @param target Confirmation target in blocks.
+     * @param conservative If true, returns a higher fee rate for greater confirmation probability.
+     * @return Predicted fee rate.
+     */
+    virtual ForecastResult ForecastFeeRate(int target, bool conservative) const = 0;
+
+    /**
+     * @brief Returns the maximum supported confirmation target.
+     */
+    virtual unsigned int MaximumTarget() const = 0;
+
+    virtual ~Forecaster() = default;
+};
+
+#endif // BITCOIN_POLICY_FEES_FORECASTER_H

--- a/src/policy/fees/forecaster_man.cpp
+++ b/src/policy/fees/forecaster_man.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license. See the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/fees/forecaster.h>
 #include <policy/fees/forecaster_man.h>
 #include <policy/fees/forecaster_util.h>
@@ -11,4 +12,11 @@
 void FeeRateForecasterManager::RegisterForecaster(std::shared_ptr<Forecaster> forecaster)
 {
     forecasters.emplace(forecaster->GetForecastType(), forecaster);
+}
+
+CBlockPolicyEstimator* FeeRateForecasterManager::GetBlockPolicyEstimator()
+{
+    Assert(forecasters.contains(ForecastType::BLOCK_POLICY));
+    Forecaster* block_policy_estimator = forecasters.find(ForecastType::BLOCK_POLICY)->second.get();
+    return dynamic_cast<CBlockPolicyEstimator*>(block_policy_estimator);
 }

--- a/src/policy/fees/forecaster_man.cpp
+++ b/src/policy/fees/forecaster_man.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/fees/forecaster.h>
+#include <policy/fees/forecaster_man.h>
+#include <policy/fees/forecaster_util.h>
+
+#include <utility>
+
+void FeeRateForecasterManager::RegisterForecaster(std::shared_ptr<Forecaster> forecaster)
+{
+    forecasters.emplace(forecaster->GetForecastType(), forecaster);
+}

--- a/src/policy/fees/forecaster_man.cpp
+++ b/src/policy/fees/forecaster_man.cpp
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license. See the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <logging.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <policy/fees/forecaster.h>
 #include <policy/fees/forecaster_man.h>
 #include <policy/fees/forecaster_util.h>
 
+#include <algorithm>
 #include <utility>
 
 void FeeRateForecasterManager::RegisterForecaster(std::shared_ptr<Forecaster> forecaster)
@@ -19,4 +21,55 @@ CBlockPolicyEstimator* FeeRateForecasterManager::GetBlockPolicyEstimator()
     Assert(forecasters.contains(ForecastType::BLOCK_POLICY));
     Forecaster* block_policy_estimator = forecasters.find(ForecastType::BLOCK_POLICY)->second.get();
     return dynamic_cast<CBlockPolicyEstimator*>(block_policy_estimator);
+}
+
+std::pair<ForecastResult, std::vector<std::string>> FeeRateForecasterManager::ForecastFeeRateFromForecasters(
+    int target, bool conservative) const
+{
+    std::vector<std::string> err_messages;
+    ForecastResult feerate_forecast;
+
+    for (const auto& forecaster : forecasters) {
+        auto curr_forecast = forecaster.second->ForecastFeeRate(target, conservative);
+
+        if (curr_forecast.error.has_value()) {
+            err_messages.emplace_back(
+                strprintf("%s: %s", forecastTypeToString(forecaster.first), curr_forecast.error.value()));
+        }
+
+        // Handle case where the block policy forecaster does not have enough data.
+        if (forecaster.first == ForecastType::BLOCK_POLICY && curr_forecast.feerate.IsEmpty()) {
+            return {ForecastResult(), err_messages};
+        }
+
+        if (!curr_forecast.feerate.IsEmpty()) {
+            if (feerate_forecast.feerate.IsEmpty()) {
+                // If there's no selected forecast, choose curr_forecast as feerate_forecast.
+                feerate_forecast = curr_forecast;
+            } else {
+                // Otherwise, choose the smaller as feerate_forecast.
+                feerate_forecast = std::min(feerate_forecast, curr_forecast);
+            }
+        }
+    }
+
+    if (!feerate_forecast.feerate.IsEmpty()) {
+        Assume(feerate_forecast.forecaster);
+        LogInfo("Fee rate Forecaster %s: Block height %s, fee rate %s %s/kvB.\n",
+                forecastTypeToString(feerate_forecast.forecaster.value()),
+                feerate_forecast.current_block_height,
+                CFeeRate(feerate_forecast.feerate.fee, feerate_forecast.feerate.size).GetFeePerK(),
+                CURRENCY_ATOM);
+    }
+
+    return {feerate_forecast, err_messages};
+}
+
+unsigned int FeeRateForecasterManager::MaximumTarget() const
+{
+    unsigned int maximum_target{0};
+    for (const auto& forecaster : forecasters) {
+        maximum_target = std::max(maximum_target, forecaster.second->MaximumTarget());
+    }
+    return maximum_target;
 }

--- a/src/policy/fees/forecaster_man.h
+++ b/src/policy/fees/forecaster_man.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <unordered_map>
 
+class CBlockPolicyEstimator;
 class Forecaster;
 struct ForecastResult;
 
@@ -28,6 +29,11 @@ public:
      * @param[in] forecaster shared pointer to a Forecaster instance.
      */
     void RegisterForecaster(std::shared_ptr<Forecaster> forecaster);
+
+    /*
+     * Return the pointer to block policy estimator.
+     */
+    CBlockPolicyEstimator* GetBlockPolicyEstimator();
 };
 
 #endif // BITCOIN_POLICY_FEES_FORECASTER_MAN_H

--- a/src/policy/fees/forecaster_man.h
+++ b/src/policy/fees/forecaster_man.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_FEES_FORECASTER_MAN_H
+#define BITCOIN_POLICY_FEES_FORECASTER_MAN_H
+
+#include <memory>
+#include <unordered_map>
+
+class Forecaster;
+struct ForecastResult;
+
+enum class ForecastType;
+
+/** \class FeeRateForecasterManager
+ * Manages multiple fee rate forecasters.
+ */
+class FeeRateForecasterManager
+{
+private:
+    //! Map of all registered forecasters to their shared pointers.
+    std::unordered_map<ForecastType, std::shared_ptr<Forecaster>> forecasters;
+
+public:
+    /**
+     * Register a forecaster.
+     * @param[in] forecaster shared pointer to a Forecaster instance.
+     */
+    void RegisterForecaster(std::shared_ptr<Forecaster> forecaster);
+};
+
+#endif // BITCOIN_POLICY_FEES_FORECASTER_MAN_H

--- a/src/policy/fees/forecaster_man.h
+++ b/src/policy/fees/forecaster_man.h
@@ -6,7 +6,10 @@
 #define BITCOIN_POLICY_FEES_FORECASTER_MAN_H
 
 #include <memory>
+#include <optional>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 class CBlockPolicyEstimator;
 class Forecaster;
@@ -34,6 +37,22 @@ public:
      * Return the pointer to block policy estimator.
      */
     CBlockPolicyEstimator* GetBlockPolicyEstimator();
+
+    /**
+     * Get a fee rate forecast from all registered forecasters for a given confirmation target.
+     *
+     * Polls all registered forecasters and selects the lowest fee rate.
+     *
+     * @param[in] target The target within which the transaction should be confirmed.
+     * @param[in] conservative True if the package cannot be fee bumped later.
+     * @return A pair consisting of the forecast result and a vector of error messages.
+     */
+    std::pair<ForecastResult, std::vector<std::string>> ForecastFeeRateFromForecasters(int target, bool conservative) const;
+
+    /**
+     * @brief Returns the maximum supported confirmation target from all forecasters.
+     */
+    unsigned int MaximumTarget() const;
 };
 
 #endif // BITCOIN_POLICY_FEES_FORECASTER_MAN_H

--- a/src/policy/fees/forecaster_util.cpp
+++ b/src/policy/fees/forecaster_util.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/fees/forecaster_util.h>
+
+std::string forecastTypeToString(ForecastType forecastType)
+{
+    switch (forecastType) {
+    case ForecastType::BLOCK_POLICY:
+        return std::string("Block Policy Estimator");
+    }
+    // no default case, so the compiler can warn about missing cases
+    assert(false);
+}

--- a/src/policy/fees/forecaster_util.cpp
+++ b/src/policy/fees/forecaster_util.cpp
@@ -3,6 +3,46 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees/forecaster_util.h>
+#include <policy/policy.h>
+
+#include <algorithm>
+
+Percentiles CalculatePercentiles(const std::vector<FeeFrac>& package_feerates, const int32_t total_weight)
+{
+    if (package_feerates.empty()) return Percentiles{};
+    int32_t accumulated_weight{0};
+    const int32_t p25_weight = 0.25 * total_weight;
+    const int32_t p50_weight = 0.50 * total_weight;
+    const int32_t p75_weight = 0.75 * total_weight;
+    const int32_t p95_weight = 0.95 * total_weight;
+    auto last_tracked_feerate = package_feerates.front();
+    auto percentiles = Percentiles{};
+
+    // Process histogram entries while maintaining monotonicity
+    for (const auto& curr_feerate : package_feerates) {
+        accumulated_weight += curr_feerate.size * WITNESS_SCALE_FACTOR;
+        // Maintain monotonicity by taking the minimum between the current and last tracked fee rate
+        last_tracked_feerate = std::min(last_tracked_feerate, curr_feerate, [](const FeeFrac& a, const FeeFrac& b) {
+            return std::is_lt(FeeRateCompare(a, b));
+        });
+        if (accumulated_weight >= p25_weight && percentiles.p25.IsEmpty()) {
+            percentiles.p25 = last_tracked_feerate;
+        }
+        if (accumulated_weight >= p50_weight && percentiles.p50.IsEmpty()) {
+            percentiles.p50 = last_tracked_feerate;
+        }
+        if (accumulated_weight >= p75_weight && percentiles.p75.IsEmpty()) {
+            percentiles.p75 = last_tracked_feerate;
+        }
+        if (accumulated_weight >= p95_weight && percentiles.p95.IsEmpty()) {
+            percentiles.p95 = last_tracked_feerate;
+            break; // Early exit once all percentiles are calculated
+        }
+    }
+
+    // Return empty percentiles if we couldn't calculate the 95th percentile.
+    return percentiles.p95.IsEmpty() ? Percentiles{} : percentiles;
+}
 
 std::string forecastTypeToString(ForecastType forecastType)
 {

--- a/src/policy/fees/forecaster_util.cpp
+++ b/src/policy/fees/forecaster_util.cpp
@@ -47,6 +47,8 @@ Percentiles CalculatePercentiles(const std::vector<FeeFrac>& package_feerates, c
 std::string forecastTypeToString(ForecastType forecastType)
 {
     switch (forecastType) {
+    case ForecastType::MEMPOOL_FORECAST:
+        return std::string("Mempool Forecast");
     case ForecastType::BLOCK_POLICY:
         return std::string("Block Policy Estimator");
     }

--- a/src/policy/fees/forecaster_util.h
+++ b/src/policy/fees/forecaster_util.h
@@ -45,6 +45,36 @@ struct ForecastResult {
     }
 };
 
+// Block percentiles fee rate (in BTC/vB).
+struct Percentiles {
+    FeeFrac p25;
+    FeeFrac p50;
+    FeeFrac p75;
+    FeeFrac p95;
+
+    Percentiles() = default;
+
+    bool empty() const
+    {
+        return p25.IsEmpty() && p50.IsEmpty() && p75.IsEmpty() && p95.IsEmpty();
+    }
+};
+
+/**
+ * Calculates the percentile fee rates from a given vector of fee rates.
+ *
+ * This function assumes that the fee rates in the input vector are sorted in descending order
+ * based on mining score priority. It ensures that the calculated percentile fee rates
+ * are monotonically decreasing by filtering out outliers. Outliers can occur when
+ * the mining score of a transaction increases due to the inclusion of its ancestors
+ * in different transaction packages.
+ *
+ * @param[in] package_feerates A vector containing packages fee rates.
+ * @param[in] total_weight The total weight units to use for percentile fee rate calculations.
+ * @return Percentiles object containing the calculated percentile fee rates.
+ */
+Percentiles CalculatePercentiles(const std::vector<FeeFrac>& package_feerates, const int32_t total_weight);
+
 std::string forecastTypeToString(ForecastType forecastType);
 
 #endif // BITCOIN_POLICY_FEES_FORECASTER_UTIL_H

--- a/src/policy/fees/forecaster_util.h
+++ b/src/policy/fees/forecaster_util.h
@@ -16,6 +16,7 @@
  */
 enum class ForecastType {
     BLOCK_POLICY,
+    MEMPOOL_FORECAST,
 };
 
 /**

--- a/src/policy/fees/forecaster_util.h
+++ b/src/policy/fees/forecaster_util.h
@@ -45,4 +45,6 @@ struct ForecastResult {
     }
 };
 
+std::string forecastTypeToString(ForecastType forecastType);
+
 #endif // BITCOIN_POLICY_FEES_FORECASTER_UTIL_H

--- a/src/policy/fees/forecaster_util.h
+++ b/src/policy/fees/forecaster_util.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_FEES_FORECASTER_UTIL_H
+#define BITCOIN_POLICY_FEES_FORECASTER_UTIL_H
+
+#include <util/feefrac.h>
+
+#include <optional>
+#include <string>
+
+/**
+ * @enum ForecastType
+ * Identifier for fee rate forecasters.
+ */
+enum class ForecastType {};
+
+/**
+ * @struct ForecastResult
+ * Represents the response returned by a fee rate forecaster.
+ */
+struct ForecastResult {
+    //! This identifies which forecaster is providing this feerate forecast
+    std::optional<ForecastType> forecaster;
+
+    //! Fee rate sufficient to confirm a package within target.
+    FeeFrac feerate;
+
+    //! The block height at which the forecast was made.
+    unsigned int current_block_height{0};
+
+    std::optional<std::string> error; ///< Optional error message.
+
+    /**
+     * Compare two ForecastResult objects based on fee rate.
+     * @param other The other ForecastResult object to compare with.
+     * @return true if the current object's fee rate is less than the other, false otherwise.
+     */
+    bool operator<(const ForecastResult& other) const
+    {
+        return feerate << other.feerate;
+    }
+};
+
+#endif // BITCOIN_POLICY_FEES_FORECASTER_UTIL_H

--- a/src/policy/fees/forecaster_util.h
+++ b/src/policy/fees/forecaster_util.h
@@ -14,7 +14,9 @@
  * @enum ForecastType
  * Identifier for fee rate forecasters.
  */
-enum class ForecastType {};
+enum class ForecastType {
+    BLOCK_POLICY,
+};
 
 /**
  * @struct ForecastResult

--- a/src/policy/fees/mempool_forecaster.cpp
+++ b/src/policy/fees/mempool_forecaster.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <logging.h>
+#include <node/miner.h>
+#include <policy/fees/forecaster.h>
+#include <policy/fees/forecaster_util.h>
+#include <policy/fees/mempool_forecaster.h>
+#include <policy/policy.h>
+#include <validation.h>
+
+ForecastResult MemPoolForecaster::ForecastFeeRate(int target, bool conservative) const
+{
+    ForecastResult result;
+    result.forecaster = m_forecast_type;
+    LOCK2(cs_main, m_mempool->cs);
+    auto activeTip = m_chainstate->m_chainman.ActiveTip();
+    if (!activeTip) {
+        result.error = "No active chainstate available";
+        return result;
+    }
+    result.current_block_height = static_cast<unsigned int>(activeTip->nHeight);
+
+    if (target > MEMPOOL_FORECAST_MAX_TARGET) {
+        result.error = strprintf("Confirmation target %s exceeds the maximum limit of %s. mempool conditions might change",
+                                   target, MEMPOOL_FORECAST_MAX_TARGET);
+        return result;
+    }
+
+    node::BlockAssembler::Options options;
+    options.test_block_validity = false;
+    node::BlockAssembler assembler(*m_chainstate, m_mempool, options);
+
+    const auto pblocktemplate = assembler.CreateNewBlock();
+    const auto& m_package_feerates = pblocktemplate->m_package_feerates;
+    const auto percentiles = CalculatePercentiles(m_package_feerates, DEFAULT_BLOCK_MAX_WEIGHT);
+    if (percentiles.empty()) {
+        result.error = "Forecaster unable to provide a fee rate due to insufficient data";
+        return result;
+    }
+
+    LogDebug(BCLog::MEMPOOL,
+             "%s: Block height %s, Block template 25th percentile fee rate: %s %s/kvB, "
+             "50th percentile fee rate: %s %s/kvB, 75th percentile fee rate: %s %s/kvB, "
+             "95th percentile fee rate: %s %s/kvB\n",
+             forecastTypeToString(m_forecast_type), result.current_block_height,
+             CFeeRate(percentiles.p25.fee, percentiles.p25.size).GetFeePerK(), CURRENCY_ATOM,
+             CFeeRate(percentiles.p50.fee, percentiles.p50.size).GetFeePerK(), CURRENCY_ATOM,
+             CFeeRate(percentiles.p75.fee, percentiles.p75.size).GetFeePerK(), CURRENCY_ATOM,
+             CFeeRate(percentiles.p95.fee, percentiles.p95.size).GetFeePerK(), CURRENCY_ATOM);
+
+    result.feerate = conservative ? percentiles.p50 : percentiles.p75;
+    return result;
+}

--- a/src/policy/fees/mempool_forecaster.h
+++ b/src/policy/fees/mempool_forecaster.h
@@ -6,7 +6,15 @@
 #define BITCOIN_POLICY_FEES_MEMPOOL_FORECASTER_H
 
 
+#include <logging.h>
 #include <policy/fees/forecaster.h>
+#include <policy/fees/forecaster_util.h>
+#include <sync.h>
+#include <uint256.h>
+#include <util/time.h>
+
+
+#include <chrono>
 
 class Chainstate;
 class CTxMemPool;
@@ -14,6 +22,53 @@ class CTxMemPool;
 // Fee rate forecasts above this confirmation target are not reliable,
 // as mempool conditions are likely to change.
 constexpr int MEMPOOL_FORECAST_MAX_TARGET{2};
+constexpr std::chrono::seconds CACHE_LIFE{7};
+
+/**
+ * CachedMempoolForecast holds a cache of recent fee rate forecasts.
+ * We only provide fresh fee rate if the last saved cache ages more than CACHE_LIFE.
+ */
+struct CachedMempoolForecast {
+private:
+    mutable Mutex cache_mutex;
+    uint256 chain_tip_hash GUARDED_BY(cache_mutex);
+    Percentiles fee_rate GUARDED_BY(cache_mutex);
+    NodeClock::time_point last_updated GUARDED_BY(cache_mutex){NodeClock::now() - CACHE_LIFE - std::chrono::seconds(1)};
+
+public:
+    CachedMempoolForecast() = default;
+    CachedMempoolForecast(const CachedMempoolForecast&) = delete;
+    CachedMempoolForecast& operator=(const CachedMempoolForecast&) = delete;
+
+    bool isStale() const EXCLUSIVE_LOCKS_REQUIRED(cache_mutex)
+    {
+        AssertLockHeld(cache_mutex);
+        return (last_updated + CACHE_LIFE) < NodeClock::now();
+    }
+
+    std::optional<Percentiles> get_cached_forecast() const EXCLUSIVE_LOCKS_REQUIRED(!cache_mutex)
+    {
+        LOCK(cache_mutex);
+        if (isStale()) return std::nullopt;
+        LogDebug(BCLog::ESTIMATEFEE, "%s: cache is not stale, using cached value\n", forecastTypeToString(ForecastType::MEMPOOL_FORECAST));
+        return fee_rate;
+    }
+
+    uint256 get_chain_tip_hash() const EXCLUSIVE_LOCKS_REQUIRED(!cache_mutex)
+    {
+        LOCK(cache_mutex);
+        return chain_tip_hash;
+    }
+
+    void update(const Percentiles& new_fee_rate, uint256 current_tip_hash) EXCLUSIVE_LOCKS_REQUIRED(!cache_mutex)
+    {
+        LOCK(cache_mutex);
+        fee_rate = new_fee_rate;
+        last_updated = NodeClock::now();
+        chain_tip_hash = current_tip_hash;
+        LogDebug(BCLog::ESTIMATEFEE, "%s: updated cache\n", forecastTypeToString(ForecastType::MEMPOOL_FORECAST));
+    }
+};
 
 /** \class MemPoolForecaster
  * @brief Forecasts the fee rate required for a transaction to be included in the next block.
@@ -40,5 +95,6 @@ public:
 private:
     const CTxMemPool* m_mempool;
     Chainstate* m_chainstate;
+    mutable CachedMempoolForecast cache;
 };
 #endif // BITCOIN_POLICY_FEES_MEMPOOL_FORECASTER_H

--- a/src/policy/fees/mempool_forecaster.h
+++ b/src/policy/fees/mempool_forecaster.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_FEES_MEMPOOL_FORECASTER_H
+#define BITCOIN_POLICY_FEES_MEMPOOL_FORECASTER_H
+
+
+#include <policy/fees/forecaster.h>
+
+class Chainstate;
+class CTxMemPool;
+
+// Fee rate forecasts above this confirmation target are not reliable,
+// as mempool conditions are likely to change.
+constexpr int MEMPOOL_FORECAST_MAX_TARGET{2};
+
+/** \class MemPoolForecaster
+ * @brief Forecasts the fee rate required for a transaction to be included in the next block.
+ *
+ * This forecaster uses Bitcoin Core's block-building algorithm to generate the block
+ * template that will likely be mined from unconfirmed transactions in the mempool. It calculates percentile
+ * fee rates from the selected packages of the template: the 75th percentile fee rate is used as the economical
+ * forecast, and the 50th fee rate percentile as the conservative forecast.
+ */
+class MemPoolForecaster : public Forecaster
+{
+public:
+    MemPoolForecaster(const CTxMemPool* mempool, Chainstate* chainstate)
+        : Forecaster(ForecastType::MEMPOOL_FORECAST), m_mempool(mempool), m_chainstate(chainstate) {};
+    ~MemPoolForecaster() = default;
+
+    /** Overridden from Forecaster. */
+    ForecastResult ForecastFeeRate(int target, bool conservative) const override;
+    unsigned int MaximumTarget() const override
+    {
+        return MEMPOOL_FORECAST_MAX_TARGET;
+    };
+
+private:
+    const CTxMemPool* m_mempool;
+    Chainstate* m_chainstate;
+};
+#endif // BITCOIN_POLICY_FEES_MEMPOOL_FORECASTER_H

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -66,7 +66,7 @@ static RPCHelpMan estimatesmartfee()
             const CTxMemPool& mempool = EnsureMemPool(node);
 
             CHECK_NONFATAL(mempool.m_opts.signals)->SyncWithValidationInterfaceQueue();
-            unsigned int max_target = fee_estimator.HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
+            unsigned int max_target = fee_estimator.MaximumTarget();
             unsigned int conf_target = ParseConfirmTarget(request.params[0], max_target);
             FeeEstimateMode fee_mode;
             if (!FeeModeFromString(self.Arg<std::string_view>("estimate_mode"), fee_mode)) {

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -84,18 +84,19 @@ ChainstateManager& EnsureAnyChainman(const std::any& context)
     return EnsureChainman(EnsureAnyNodeContext(context));
 }
 
-CBlockPolicyEstimator& EnsureFeeEstimator(const NodeContext& node)
+FeeRateForecasterManager& EnsureForecasterMan(const NodeContext& node)
 {
-    if (!node.fee_estimator) {
+    if (!node.forecasterman) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Fee estimation disabled");
     }
-    return *node.fee_estimator;
+    return *node.forecasterman.get();
 }
 
-CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context)
+FeeRateForecasterManager& EnsureAnyForecasterMan(const std::any& context)
 {
-    return EnsureFeeEstimator(EnsureAnyNodeContext(context));
+    return EnsureForecasterMan(EnsureAnyNodeContext(context));
 }
+
 
 CConnman& EnsureConnman(const NodeContext& node)
 {

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -12,10 +12,10 @@
 class AddrMan;
 class ArgsManager;
 class CBlockIndex;
-class CBlockPolicyEstimator;
 class CConnman;
 class CTxMemPool;
 class ChainstateManager;
+class FeeRateForecasterManager;
 class PeerManager;
 class BanMan;
 namespace node {
@@ -34,8 +34,8 @@ ArgsManager& EnsureArgsman(const node::NodeContext& node);
 ArgsManager& EnsureAnyArgsman(const std::any& context);
 ChainstateManager& EnsureChainman(const node::NodeContext& node);
 ChainstateManager& EnsureAnyChainman(const std::any& context);
-CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
-CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
+FeeRateForecasterManager& EnsureForecasterMan(const node::NodeContext& node);
+FeeRateForecasterManager& EnsureAnyForecasterMan(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
 interfaces::Mining& EnsureMining(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_bitcoin
   key_tests.cpp
   logging_tests.cpp
   mempool_tests.cpp
+  mempoolforecaster_tests.cpp
   merkle_tests.cpp
   merkleblock_tests.cpp
   miner_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(test_bitcoin
   disconnected_transactions.cpp
   feefrac_tests.cpp
   feerounder_tests.cpp
+  forecaster_util_tests.cpp
   flatfile_tests.cpp
   fs_tests.cpp
   getarg_tests.cpp

--- a/src/test/forecaster_util_tests.cpp
+++ b/src/test/forecaster_util_tests.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+#include <policy/fees/forecaster_util.h>
+#include <policy/policy.h>
+
+#include <boost/test/unit_test.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(forecaster_util_tests)
+
+BOOST_AUTO_TEST_CASE(calculate_percentile_test)
+{
+    // Test that CalculatePercentiles returns empty when vector is empty
+    BOOST_CHECK(CalculatePercentiles({}, DEFAULT_BLOCK_MAX_WEIGHT).empty());
+
+    const int32_t package_size{10};
+    const int32_t individual_tx_vsize = static_cast<int32_t>(DEFAULT_BLOCK_MAX_WEIGHT / WITNESS_SCALE_FACTOR) / package_size;
+
+    const FeeFrac super_high_fee_rate{500 * individual_tx_vsize, individual_tx_vsize}; // Super High fee: 500 sat/kvB
+    const FeeFrac high_fee_rate{100 * individual_tx_vsize, individual_tx_vsize};       // High fee: 100 sat/kvB
+    const FeeFrac medium_fee_rate{50 * individual_tx_vsize, individual_tx_vsize};      // Medium fee: 50 sat/kvB
+    const FeeFrac low_fee_rate{10 * individual_tx_vsize, individual_tx_vsize};         // Low fee: 10 sat/kvB
+
+    std::vector<FeeFrac> package_feerates;
+    package_feerates.reserve(package_size);
+
+    // Populate the feerate histogram based on specified index ranges.
+    for (int i = 0; i < package_size; ++i) {
+        if (i < 3) {
+            package_feerates.emplace_back(super_high_fee_rate); // Super High fee rate for top 3
+        } else if (i < 5) {
+            package_feerates.emplace_back(high_fee_rate); // High fee rate for next 2
+        } else if (i < 8) {
+            package_feerates.emplace_back(medium_fee_rate);                                          // Medium fee rate for next 3
+            BOOST_CHECK(CalculatePercentiles(package_feerates, DEFAULT_BLOCK_MAX_WEIGHT).empty());   // CalculatePercentiles should return empty until reaching the 95th percentile
+        } else {
+            package_feerates.emplace_back(low_fee_rate); // Low fee rate for remaining 2
+        }
+    }
+
+    // Test percentile calculation on a complete histogram
+    {
+        const auto percentiles = CalculatePercentiles(package_feerates, DEFAULT_BLOCK_MAX_WEIGHT);
+        BOOST_CHECK(percentiles.p25 == super_high_fee_rate);
+        BOOST_CHECK(percentiles.p50 == high_fee_rate);
+        BOOST_CHECK(percentiles.p75 == medium_fee_rate);
+        BOOST_CHECK(percentiles.p95 == low_fee_rate);
+    }
+
+    // Test that CalculatePercentiles maintains monotonicity across all percentiles
+    {
+        package_feerates[7] = super_high_fee_rate; // Increase 8th index to a high fee rate
+        const auto percentiles = CalculatePercentiles(package_feerates, DEFAULT_BLOCK_MAX_WEIGHT);
+        BOOST_CHECK(percentiles.p25 == super_high_fee_rate);
+        BOOST_CHECK(percentiles.p50 == high_fee_rate);
+        BOOST_CHECK(percentiles.p75 == medium_fee_rate); // Should still reflect the previous medium rate
+        BOOST_CHECK(percentiles.p95 == low_fee_rate);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mempoolforecaster_tests.cpp
+++ b/src/test/mempoolforecaster_tests.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license. See the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/fees/forecaster.h>
+#include <policy/fees/forecaster_util.h>
+#include <policy/fees/mempool_forecaster.h>
+#include <random.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <uint256.h>
+#include <util/feefrac.h>
+#include <util/strencodings.h>
+#include <validation.h>
+
+
+#include <test/util/setup_common.h>
+
+#include <memory>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(mempoolforecaster_tests, TestChain100Setup)
+
+static inline CTransactionRef make_random_tx()
+{
+    auto rng = FastRandomContext();
+    auto tx = CMutableTransaction();
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vin[0].prevout.hash = Txid::FromUint256(rng.rand256());
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].scriptSig << OP_TRUE;
+    tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+    tx.vout[0].nValue = COIN;
+    return MakeTransactionRef(tx);
+}
+
+BOOST_AUTO_TEST_CASE(MempoolForecaster)
+{
+    auto mempool_forecaster = std::make_unique<MemPoolForecaster>(m_node.mempool.get(), &(m_node.chainman->ActiveChainstate()));
+    int conf_target = MEMPOOL_FORECAST_MAX_TARGET + 1;
+    LOCK2(cs_main, m_node.mempool->cs);
+    {
+        // Test when targetBlocks > MEMPOOL_FORECAST_MAX_TARGET
+        const auto result = mempool_forecaster->ForecastFeeRate(conf_target, /*conservative=*/true);
+        BOOST_CHECK(result.feerate.IsEmpty());
+        BOOST_CHECK(*result.error == strprintf("Confirmation target %s exceeds the maximum limit of %s. mempool conditions might change",
+                                                 conf_target, MEMPOOL_FORECAST_MAX_TARGET));
+    }
+
+    BOOST_CHECK(m_node.mempool->GetTotalTxSize() == 0);
+    TestMemPoolEntryHelper entry;
+
+    const CAmount low_fee{CENT / 3000};
+    const CAmount med_fee{CENT / 100};
+    const CAmount high_fee{CENT / 10};
+    std::string data_err = "Forecaster unable to provide a fee rate due to insufficient data";
+
+    conf_target = MEMPOOL_FORECAST_MAX_TARGET;
+    // Test when there are not enough mempool transactions to get an accurate forecast
+    {
+        // Add transactions with high_fee fee until mempool transactions weight is more than 25th percent of DEFAULT_BLOCK_MAX_WEIGHT
+        while (static_cast<int>(m_node.mempool->GetTotalTxSize() * WITNESS_SCALE_FACTOR) <= static_cast<int>(0.25 * DEFAULT_BLOCK_MAX_WEIGHT)) {
+            AddToMempool(*m_node.mempool, entry.Fee(high_fee).FromTx(make_random_tx()));
+        }
+        const auto result = mempool_forecaster->ForecastFeeRate(conf_target, /*conservative=*/true);
+        BOOST_CHECK(result.feerate.IsEmpty());
+        BOOST_CHECK(*result.error == data_err);
+    }
+
+    {
+        // Add transactions with med_fee fee until mempool transactions weight is more than 50th percent of DEFAULT_BLOCK_MAX_WEIGHT
+        while (static_cast<int>(m_node.mempool->GetTotalTxSize() * WITNESS_SCALE_FACTOR) <= static_cast<int>(0.5 * DEFAULT_BLOCK_MAX_WEIGHT)) {
+            AddToMempool(*m_node.mempool, entry.Fee(med_fee).FromTx(make_random_tx()));
+        }
+        const auto result = mempool_forecaster->ForecastFeeRate(conf_target, /*conservative=*/true);
+        BOOST_CHECK(result.feerate.IsEmpty());
+        BOOST_CHECK(*result.error == data_err);
+    }
+
+    // Mempool transactions are enough to provide feerate forecast
+    {
+        // Add low_fee transactions until mempool transactions weight is more than 95th percent of DEFAULT_BLOCK_MAX_WEIGHT
+        while (static_cast<int>(m_node.mempool->GetTotalTxSize() * WITNESS_SCALE_FACTOR) <= static_cast<int>(0.95 * DEFAULT_BLOCK_MAX_WEIGHT)) {
+            const auto txref = make_random_tx();
+            AddToMempool(*m_node.mempool, entry.Fee(low_fee).FromTx(make_random_tx()));
+        }
+
+        const auto result_conservative = mempool_forecaster->ForecastFeeRate(conf_target, /*conservative=*/true);
+        const auto result_economical = mempool_forecaster->ForecastFeeRate(conf_target, /*conservative=*/false);
+        BOOST_CHECK(!result_conservative.feerate.IsEmpty() && !result_economical.feerate.IsEmpty());
+        const auto tx_vsize = entry.FromTx(make_random_tx()).GetTxSize();
+        BOOST_CHECK(result_economical.feerate == FeeFrac(low_fee, tx_vsize));
+        BOOST_CHECK(result_conservative.feerate == FeeFrac(med_fee, tx_vsize));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -300,7 +300,7 @@ ChainTestingSetup::~ChainTestingSetup()
     m_node.netgroupman.reset();
     m_node.args = nullptr;
     m_node.mempool.reset();
-    Assert(!m_node.fee_estimator); // Each test must create a local object, if they wish to use the fee_estimator
+    Assert(!m_node.forecasterman); // Each test must create a local object, if they wish to use the forecasterman
     m_node.chainman.reset();
     m_node.validation_signals.reset();
     m_node.scheduler.reset();


### PR DESCRIPTION
- This PR implements the core component of #30392, introducing a new fee rate forecasting module. 
The primary addition is a `ForecasterManager` that coordinates multiple forecasting strategies to be able to provide better transaction fee rate predictions.


### Key Changes  

1. **Addition of Fee Rate Forecasting Utility Structures**  
   - `Forecaster` abstract class, serving as the base class for all fee rate forecasters.
   - `ForecastResult` (the response from a `Forecaster`) with all metadata.  
   - `ForecastType` enum, identify and distinguish forecasters.    

2. **Introduce `FeeRateForecasterManager` class**  
   - Adds the `FeeRateForecasterManager` class, responsible for managing all fee rate forecasters, including `CBlockPolicyEstimator`, which is now a forecaster.  
   - Updates the node context to hold a unique pointer to `FeeRateForecasterManager` instead of `CBlockPolicyEstimator`.  
   - Changes `CBlockPolicyEstimator` instance from `unique_ptr` to a `shared_pointer`, allowing it to be registered in the validation interface without requiring explicit unregistration during shutdown (current master behaviour). Registering for `CBlockPolicyEstimator` flushes also get a `shared_pointer`.  
   - Exposes a raw pointer of `CBlockPolicyEstimator` through `FeeRateForecasterManager` for compatibility with `estimateSmartFee`, friends, and node interfaces.  
   -   Modifies `CBlockPolicyEstimator` to inherit from the `Forecaster` class and implement the pure abstract classes

3. **Introduce `MempoolForecaster` class**  
   - Adds the `MempoolForecaster`, which forecast the fee rate required for a transaction to confirm as soon as possible. It generates a block template and returns the 75th and 50th percentile fee rates  as low-priority and high-priority fee rate forecasts.  
   - Implements caching for the last fee rate forecast, using a 30-second rate limit to avoid frequent block generation via the block assembler.


The `FeeRateForecasterManager` now includes a method `ForecastFeeRateFromForecasters`. This method polls forecasts from all registered forecasters and returns the lowest value. This behavior aligns with discussions and research outlined in [this post](https://delvingbitcoin.org/t/mempool-based-fee-estimation-on-bitcoin-core/703).  But the primary aim of the `FeeRateForecasterManager` is to be able to perform sanity checks and potentially apply heuristics to determine the most appropriate fee rate forecast from polled forecasters, for now it just return the lowest.

This PR also add unit tests for the classes.



In Draft because it depends on #33218
