### PR TITLE
rpc: add cpu_load to getpeerinfo

### DIFF
--- a/doc/release-notes-31672.md
+++ b/doc/release-notes-31672.md
@@ -1,0 +1,9 @@
+RPC
+---
+
+A new field `cpu_load` has been added to the `getpeerinfo` RPC output. It
+shows the CPU time (user + system) spent processing messages to/from the
+peer, in per milles (‰) of the duration of the connection. The field is
+optional and will be omitted on platforms that do not support this or if not
+yet measured. Note that high CPU time is not necessarily a bad thing - new
+valid transactions and blocks require CPU time to be validated. (#31672)

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -419,6 +419,7 @@ private:
         int64_t last_send;
         int64_t last_trxn;
         int id;
+        int cpu_load;
         int mapped_as;
         int version;
         bool is_addr_relay_enabled;
@@ -552,6 +553,7 @@ public:
                 const int64_t last_trxn{peer["last_transaction"].getInt<int64_t>()};
                 const double min_ping{peer["minping"].isNull() ? -1 : peer["minping"].get_real()};
                 const double ping{peer["pingtime"].isNull() ? -1 : peer["pingtime"].get_real()};
+                const int cpu_load{peer["cpu_load"].isNull() ? -1 : static_cast<int>(round(peer["cpu_load"].get_real()))};
                 const std::string addr{peer["addr"].get_str()};
                 const std::string age{conn_time == 0 ? "" : ToString((time_now - conn_time) / 60)};
                 const std::string services{FormatServices(peer["servicesnames"])};
@@ -560,7 +562,30 @@ public:
                 const bool is_addr_relay_enabled{peer["addr_relay_enabled"].isNull() ? false : peer["addr_relay_enabled"].get_bool()};
                 const bool is_bip152_hb_from{peer["bip152_hb_from"].get_bool()};
                 const bool is_bip152_hb_to{peer["bip152_hb_to"].get_bool()};
-                m_peers.push_back({addr, sub_version, conn_type, NETWORK_SHORT_NAMES[network_id], age, services, transport, min_ping, ping, addr_processed, addr_rate_limited, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_addr_relay_enabled, is_bip152_hb_from, is_bip152_hb_to, is_outbound, is_tx_relay});
+                m_peers.push_back(Peer{.addr = addr,
+                                       .sub_version = sub_version,
+                                       .conn_type = conn_type,
+                                       .network = NETWORK_SHORT_NAMES[network_id],
+                                       .age = age,
+                                       .services = services,
+                                       .transport_protocol_type = transport,
+                                       .min_ping = min_ping,
+                                       .ping = ping,
+                                       .addr_processed = addr_processed,
+                                       .addr_rate_limited = addr_rate_limited,
+                                       .last_blck = last_blck,
+                                       .last_recv = last_recv,
+                                       .last_send = last_send,
+                                       .last_trxn = last_trxn,
+                                       .id = peer_id,
+                                       .cpu_load = cpu_load,
+                                       .mapped_as = mapped_as,
+                                       .version = version,
+                                       .is_addr_relay_enabled = is_addr_relay_enabled,
+                                       .is_bip152_hb_from = is_bip152_hb_from,
+                                       .is_bip152_hb_to = is_bip152_hb_to,
+                                       .is_outbound = is_outbound,
+                                       .is_tx_relay = is_tx_relay});
                 m_max_addr_length = std::max(addr.length() + 1, m_max_addr_length);
                 m_max_addr_processed_length = std::max(ToString(addr_processed).length(), m_max_addr_processed_length);
                 m_max_addr_rate_limited_length = std::max(ToString(addr_rate_limited).length(), m_max_addr_rate_limited_length);
@@ -578,7 +603,7 @@ public:
         // Report detailed peer connections list sorted by direction and minimum ping time.
         if (DetailsRequested() && !m_peers.empty()) {
             std::sort(m_peers.begin(), m_peers.end());
-            result += strprintf("<->   type   net %*s  v  mping   ping send recv  txn  blk  hb %*s%*s%*s ",
+            result += strprintf("<->   type   net %*s  v  mping   ping send recv  txn  blk  hb %*s%*s cpu%*s ",
                                 m_max_services_length, "serv",
                                 m_max_addr_processed_length, "addrp",
                                 m_max_addr_rate_limited_length, "addrl",
@@ -588,7 +613,7 @@ public:
             for (const Peer& peer : m_peers) {
                 std::string version{ToString(peer.version) + peer.sub_version};
                 result += strprintf(
-                    "%3s %6s %5s %*s %2s%7s%7s%5s%5s%5s%5s  %2s %*s%*s%*s%*i %*s %-*s%s\n",
+                    "%3s %6s %5s %*s %2s%7s%7s%5s%5s%5s%5s  %2s %*s%*s%4s%*s%*i %*s %-*s%s\n",
                     peer.is_outbound ? "out" : "in",
                     ConnectionTypeForNetinfo(peer.conn_type),
                     peer.network,
@@ -606,6 +631,7 @@ public:
                     peer.addr_processed ? ToString(peer.addr_processed) : peer.is_addr_relay_enabled ? "" : ".",
                     m_max_addr_rate_limited_length, // variable spacing
                     peer.addr_rate_limited ? ToString(peer.addr_rate_limited) : "",
+                    peer.cpu_load > 0 ? ToString(round(peer.cpu_load)) : "",
                     m_max_age_length, // variable spacing
                     peer.age,
                     m_is_asmap_on ? 7 : 0, // variable spacing
@@ -616,7 +642,7 @@ public:
                     IsAddressSelected() ? peer.addr : "",
                     IsVersionSelected() && version != "0" ? version : "");
             }
-            result += strprintf("                %*s         ms     ms  sec  sec  min  min                %*s\n\n", m_max_services_length, "", m_max_age_length, "min");
+            result += strprintf("                %*s         ms     ms  sec  sec  min  min                   ‰%*s\n\n", m_max_services_length, "", m_max_age_length, "min");
         }
 
         // Report peer connection totals by type.
@@ -733,6 +759,7 @@ public:
         "  addrp    Total number of addresses processed, excluding those dropped due to rate limiting\n"
         "           \".\" - we do not relay addresses to this peer (getpeerinfo \"addr_relay_enabled\" is false)\n"
         "  addrl    Total number of addresses dropped due to rate limiting\n"
+        "  cpu      CPU time processing messages to/from peer, per milles (‰) of age, rounded to nearest integer, if non-zero\n"
         "  age      Duration of connection to the peer, in minutes\n"
         "  asmap    Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying\n"
         "           peer selection (only displayed if the -asmap config option is set)\n"

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -656,6 +656,8 @@ void CNode::CopyStats(CNodeStats& stats)
     stats.addrLocal = addrLocalUnlocked.IsValid() ? addrLocalUnlocked.ToStringAddrPort() : "";
 
     X(m_conn_type);
+
+    X(m_cpu_time);
 }
 #undef X
 
@@ -3144,6 +3146,8 @@ void CConnman::ThreadMessageHandler()
             for (CNode* pnode : snap.Nodes()) {
                 if (pnode->fDisconnect)
                     continue;
+
+                CpuTimer timer{[&pnode](std::chrono::nanoseconds elapsed) { pnode->m_cpu_time += elapsed; }};
 
                 // Receive messages
                 bool fMoreNodeWork{m_msgproc->ProcessMessages(*pnode, flagInterruptMsgProc)};

--- a/src/net.h
+++ b/src/net.h
@@ -32,6 +32,7 @@
 #include <util/check.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
+#include <util/time.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -226,6 +227,8 @@ public:
     TransportProtocolType m_transport_type;
     /** BIP324 session id string in hex, if any. */
     std::string m_session_id;
+    /** CPU time spent processing messages to/from the peer. */
+    std::chrono::nanoseconds m_cpu_time;
 };
 
 
@@ -987,6 +990,9 @@ public:
         m_last_ping_time = ping_time;
         m_min_ping_time = std::min(m_min_ping_time.load(), ping_time);
     }
+
+    /** CPU time spent processing messages to/from the peer. */
+    std::atomic<std::chrono::nanoseconds> m_cpu_time;
 
 private:
     const NodeId id;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -157,6 +157,10 @@ static RPCMethod getpeerinfo()
                     {RPCResult::Type::NUM_TIME, "last_block", "The " + UNIX_EPOCH_TIME + " of the last block received from this peer"},
                     {RPCResult::Type::NUM, "bytessent", "The total bytes sent"},
                     {RPCResult::Type::NUM, "bytesrecv", "The total bytes received"},
+                    {RPCResult::Type::NUM, "cpu_load", /*optional=*/true, "Total CPU time spent processing "
+                        "messages to/from the peer, in per milles (‰) of the connection duration, if "
+                        "supported by the platform and measured. High CPU time is not necessarily a bad "
+                        "thing - new valid transactions and blocks require it be validated."},
                     {RPCResult::Type::NUM_TIME, "conntime", "The " + UNIX_EPOCH_TIME + " of the connection"},
                     {RPCResult::Type::NUM, "timeoffset", "The time offset in seconds"},
                     {RPCResult::Type::NUM, "pingtime", /*optional=*/true, "The last ping time in seconds, if any"},
@@ -218,6 +222,8 @@ static RPCMethod getpeerinfo()
 
     UniValue ret(UniValue::VARR);
 
+    const auto now{NodeClock::now()};
+
     for (const CNodeStats& stats : vstats) {
         UniValue obj(UniValue::VOBJ);
         CNodeStateStats statestats;
@@ -255,6 +261,9 @@ static RPCMethod getpeerinfo()
         obj.pushKV("bytessent", stats.nSendBytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", TicksSinceEpoch<std::chrono::seconds>(stats.m_connected));
+        if (stats.m_cpu_time > 0s && now > stats.m_connected) {
+            obj.pushKV("cpu_load", /* ‰ */1000.0 * stats.m_cpu_time / (now - stats.m_connected));
+        }
         obj.pushKV("timeoffset", Ticks<std::chrono::seconds>(statestats.time_offset));
         if (stats.m_last_ping_time > 0us) {
             obj.pushKV("pingtime", Ticks<SecondsDouble>(stats.m_last_ping_time));

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -19,8 +19,13 @@
 #include <thread>
 
 #ifdef WIN32
+#include <windows.h>
+#include <winnt.h>
 #include <winsock2.h>
+
+#include <processthreadsapi.h>
 #else
+#include <ctime>
 #include <sys/time.h>
 #endif
 
@@ -158,4 +163,55 @@ struct timeval MillisToTimeval(int64_t nTimeout)
 struct timeval MillisToTimeval(std::chrono::milliseconds ms)
 {
     return MillisToTimeval(count_milliseconds(ms));
+}
+
+std::chrono::nanoseconds ThreadCpuTime()
+{
+#ifdef CLOCK_THREAD_CPUTIME_ID
+    timespec t;
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t) == -1) {
+        return std::chrono::nanoseconds{0};
+    }
+    return std::chrono::seconds{t.tv_sec} + std::chrono::nanoseconds{t.tv_nsec};
+#elif defined(WIN32)
+    FILETIME creation;
+    FILETIME exit;
+    FILETIME kernel;
+    FILETIME user;
+    // GetThreadTimes():
+    // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadtimes
+    if (GetThreadTimes(GetCurrentThread(), &creation, &exit, &kernel, &user) == 0) {
+        return std::chrono::nanoseconds{0};
+    }
+
+    // https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
+    // "... you should copy the low- and high-order parts of the file time to a
+    // ULARGE_INTEGER structure, perform 64-bit arithmetic on the QuadPart
+    // member ..."
+
+    ULARGE_INTEGER kernel_;
+    kernel_.LowPart = kernel.dwLowDateTime;
+    kernel_.HighPart = kernel.dwHighDateTime;
+
+    ULARGE_INTEGER user_;
+    user_.LowPart = user.dwLowDateTime;
+    user_.HighPart = user.dwHighDateTime;
+
+    // The units of the returned values from GetThreadTimes() are "100-nanosecond periods".
+    // So, we multiply by 100 to get nanoseconds.
+    return std::chrono::nanoseconds{(kernel_.QuadPart + user_.QuadPart) * 100};
+#else
+    return std::chrono::nanoseconds{0};
+#endif
+}
+
+std::chrono::nanoseconds operator+=(std::atomic<std::chrono::nanoseconds>& a, std::chrono::nanoseconds b)
+{
+    std::chrono::nanoseconds expected;
+    std::chrono::nanoseconds desired;
+    do {
+        expected = a.load();
+        desired = expected + b;
+    } while (!a.compare_exchange_weak(expected, desired));
+    return desired;
 }

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -7,9 +7,11 @@
 #define BITCOIN_UTIL_TIME_H
 
 // The `util/time.h` header is designed to be a drop-in replacement for `chrono`.
+#include <atomic>
 #include <chrono> // IWYU pragma: export
 #include <cstdint>
 #include <ctime>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -166,5 +168,47 @@ struct timeval MillisToTimeval(int64_t nTimeout);
  * Convert milliseconds to a struct timeval for e.g. select.
  */
 struct timeval MillisToTimeval(std::chrono::milliseconds ms);
+
+/**
+ * Retrieve the CPU time (user + system) spent by the current thread.
+ */
+std::chrono::nanoseconds ThreadCpuTime();
+
+/**
+ * Measure CPU time spent by the current thread.
+ * A clock is started when a CpuTimer is created. When the object is destroyed
+ * the elapsed CPU time is calculated and a callback function is invoked,
+ * providing it the elapsed CPU time.
+ */
+class CpuTimer
+{
+public:
+    using FinishedCB = std::function<void(std::chrono::nanoseconds)>;
+
+    /**
+     * Construct a timer.
+     * @param[in] finished_cb A callback to invoke when this object is destroyed.
+     */
+    CpuTimer(const FinishedCB& finished_cb)
+        : m_start{ThreadCpuTime()},
+          m_finished_cb{finished_cb}
+    {
+    }
+
+    ~CpuTimer()
+    {
+        m_finished_cb(ThreadCpuTime() - m_start);
+    }
+
+private:
+    const std::chrono::nanoseconds m_start;
+    FinishedCB m_finished_cb;
+};
+
+/**
+ * Add `b` nanoseconds to a nanoseconds atomic.
+ * @return The value of `a` immediately after the operation.
+ */
+std::chrono::nanoseconds operator+=(std::atomic<std::chrono::nanoseconds>& a, std::chrono::nanoseconds b);
 
 #endif // BITCOIN_UTIL_TIME_H

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -145,6 +145,7 @@ class NetTest(BitcoinTestFramework):
         # The next two fields will vary for v2 connections because we send a rng-based number of decoy messages
         peer_info.pop("bytesrecv")
         peer_info.pop("bytessent")
+        peer_info.pop("cpu_load", None)
         assert_equal(
             peer_info,
             {


### PR DESCRIPTION
Add a new field `cpu_load` to the output of `getpeerinfo` RPC.

It represents the CPU time spent by the message handling thread for the given peer, weighted for the duration of the connection. That is, for example, if two peers are equally demanding and one is connected longer than the other, then they will have the same `cpu_load` number.

---

Monitoring CPU usage is useful on its own. Also related to https://github.com/bitcoin/bitcoin/issues/31033.

---

This PR uses `clock_gettime()` (POSIX) and `GetThreadTimes()` (Windows). An alternative to those, should this be explored are: `getrusage()` (POSIX) and `QueryThreadCycleTime()` (Windows, but it counts CPU cycles).