### PR TITLE
doc: fix minor typos in comments

### DIFF
--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -705,7 +705,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         {
             LOCK(cs_main);
             // The above calls don't guarantee the tip is actually updated, so
-            // we explictly check this.
+            // we explicitly check this.
             auto maybe_new_tip{Assert(m_node.chainman)->ActiveChain().Tip()};
             BOOST_REQUIRE_EQUAL(maybe_new_tip->GetBlockHash(), block.GetHash());
         }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -111,7 +111,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
         if (orphan_it != orphan.announcers.end()) {
             orphan.announcers.erase(peer);
 
-            // No remaining annnouncers: clean up entry
+            // No remaining announcers: clean up entry
             if (orphan.announcers.empty()) {
                 nErased += EraseTx(orphan.tx->GetWitnessHash());
             }

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -158,7 +158,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
             dumpfile_path = self.nodes[0].datadir_path / "noprivs_enc.dump"
             do_wallet_tool("-wallet=noprivs_enc", f"-dumpfile={dumpfile_path}", "dump")
             with open(dumpfile_path, "r", encoding="utf-8") as f:
-                # Check theres nothing with an 'mkey' prefix
+                # Check there's nothing with an 'mkey' prefix
                 assert_equal(all([not line.startswith("046d6b6579") for line in f]), True)
 
 


### PR DESCRIPTION
In the unrelated PR #31621 the linter reported a few typos, that are fixed in this commit. I used the "doc" prefix as it only modifies comments, so none of the more significant prefixes seem appropriate.