### PR TITLE
ci: Skip read-write of default env vars

### DIFF
--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -7,14 +7,12 @@
 export LC_ALL=C.UTF-8
 export CI_IMAGE_LABEL="bitcoin-ci-test"
 
-set -ex
+set -o errexit -o pipefail -o xtrace
 
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   # Export all env vars to avoid missing some.
   # Though, exclude those with newlines to avoid parsing problems.
   python3 -c 'import os; [print(f"{key}={value}") for key, value in os.environ.items() if "\n" not in value and "HOME" != key and "PATH" != key and "USER" != key]' | tee "/tmp/env-$USER-$CONTAINER_NAME"
-  # System-dependent env vars must be kept as is. So read them from the container.
-  docker run --platform="${CI_IMAGE_PLATFORM}" --rm "${CI_IMAGE_NAME_TAG}" bash -c "env | grep --extended-regexp '^(HOME|PATH|USER)='" | tee --append "/tmp/env-$USER-$CONTAINER_NAME"
 
   # Env vars during the build can not be changed. For example, a modified
   # $MAKEJOBS is ignored in the build process. Use --cpuset-cpus as an


### PR DESCRIPTION
If they remain unset, they use the default anyway. Except for `USER`, but this seems unused anyway.

Can be checked via:

```
sh-5.2# touch /tmp/empty_env
sh-5.2# podman run --rm --env-file /tmp/empty_env 'ubuntu:24.04' env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
container=podman
HOME=/root
HOSTNAME=19ece5c9e052
