### PR TITLE
util: fix compiler warning about deprecated space before _MiB

### DIFF
--- a/src/util/byte_units.h
+++ b/src/util/byte_units.h
@@ -10,7 +10,7 @@
 #include <stdexcept>
 
 //! Overflow-safe conversion of MiB to bytes.
-constexpr size_t operator"" _MiB(unsigned long long mebibytes)
+constexpr size_t operator""_MiB(unsigned long long mebibytes)
 {
     auto bytes{CheckedLeftShift(mebibytes, 20)};
     if (!bytes || *bytes > std::numeric_limits<size_t>::max()) {


### PR DESCRIPTION
```
src/util/byte_units.h:13:29: error: identifier '_MiB' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
   13 | constexpr size_t operator"" _MiB(unsigned long long mebibytes)
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_MiB
1 error generated.
```

Clang 20.0.0