### PR TITLE
cmake: Fail if `Libmultiprocess` is missing when `WITH_MULTIPROCESS=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,8 @@ cmake_dependent_option(WITH_DBUS "Enable DBus support." ON "CMAKE_SYSTEM_NAME ST
 
 option(WITH_MULTIPROCESS "Build multiprocess bitcoin-node and bitcoin-gui executables in addition to monolithic bitcoind and bitcoin-qt executables. Requires libmultiprocess library. Experimental." OFF)
 if(WITH_MULTIPROCESS)
-  find_package(Libmultiprocess COMPONENTS Lib)
-  find_package(LibmultiprocessNative COMPONENTS Bin
+  find_package(Libmultiprocess REQUIRED COMPONENTS Lib)
+  find_package(LibmultiprocessNative REQUIRED COMPONENTS Bin
     NAMES Libmultiprocess
   )
 endif()


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/31708:
```
$ cmake -B build -DWITH_MULTIPROCESS=ON
-- The CXX compiler identification is GNU 13.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found SQLite3: /usr/include (found suitable version "3.45.1", minimum required is "3.7.17") 
CMake Error at CMakeLists.txt:146 (find_package):
  By not providing "FindLibmultiprocess.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "Libmultiprocess", but CMake did not find one.

  Could not find a package configuration file provided by "Libmultiprocess"
  with any of the following names:

    LibmultiprocessConfig.cmake
    libmultiprocess-config.cmake

  Add the installation prefix of "Libmultiprocess" to CMAKE_PREFIX_PATH or
  set "Libmultiprocess_DIR" to a directory containing one of the above files.
  If "Libmultiprocess" provides a separate development package or SDK, be
  sure it has been installed.


-- Configuring incomplete, errors occurred!
```