### PR TITLE
Typo fix release-notes-0.10.0.md

### DIFF
--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -413,7 +413,7 @@ Block and transaction handling:
 - `bc42503` Use unordered_map for CCoinsViewCache with salted hash (optimization)
 - `d4d3fbd` Do not flush the cache after every block outside of IBD (optimization)
 - `ad08d0b` Bugfix: make CCoinsViewMemPool support pruned entries in underlying cache
-- `5734d4d` Only remove actualy failed blocks from setBlockIndexValid
+- `5734d4d` Only remove actually failed blocks from setBlockIndexValid
 - `d70bc52` Rework block processing benchmark code
 - `714a3e6` Only keep setBlockIndexValid entries that are possible improvements
 - `ea100c7` Reduce maximum coinscache size during verification (reduce memory usage)


### PR DESCRIPTION
# Typo Fix in `release-notes-0.10.0.md`

## Description
This pull request corrects the typo in the release notes from "actualy" to "actually."

## Changes
- Fixed the typo "actualy" to "actually" in the release notes for version 0.10.0.
