### PR TITLE
build: set build type and per-build-type flags as early as possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,15 @@ include(ProcessConfigurations)
 include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)
 
+# Redefine/adjust per-configuration flags.
+target_compile_definitions(core_interface_debug INTERFACE
+  DEBUG
+  DEBUG_LOCKORDER
+  DEBUG_LOCKCONTENTION
+  RPC_DOC_CHECK
+  ABORT_ON_FAILED_ASSUME
+)
+
 if(WIN32)
   #[=[
   This build system supports two ways to build binaries for Windows.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/module)
+include(ProcessConfigurations)
 
 #=============================
 # Configurable options
@@ -229,8 +230,6 @@ if(BUILD_FOR_FUZZING)
     FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   )
 endif()
-
-include(ProcessConfigurations)
 
 include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)

--- a/cmake/module/ProcessConfigurations.cmake
+++ b/cmake/module/ProcessConfigurations.cmake
@@ -119,14 +119,6 @@ endfunction()
 
 set_default_config(RelWithDebInfo)
 
-# Redefine/adjust per-configuration flags.
-target_compile_definitions(core_interface_debug INTERFACE
-  DEBUG
-  DEBUG_LOCKORDER
-  DEBUG_LOCKCONTENTION
-  RPC_DOC_CHECK
-  ABORT_ON_FAILED_ASSUME
-)
 # We leave assertions on.
 if(MSVC)
   remove_cxx_flag_from_all_configs(/DNDEBUG)

--- a/cmake/module/ProcessConfigurations.cmake
+++ b/cmake/module/ProcessConfigurations.cmake
@@ -4,8 +4,6 @@
 
 include_guard(GLOBAL)
 
-include(TryAppendCXXFlags)
-
 macro(normalize_string string)
   string(REGEX REPLACE " +" " " ${string} "${${string}}")
   string(STRIP "${${string}}" ${string})
@@ -118,6 +116,8 @@ function(replace_cxx_flag_in_config config old_flag new_flag)
 endfunction()
 
 set_default_config(RelWithDebInfo)
+
+include(TryAppendCXXFlags)
 
 # We leave assertions on.
 if(MSVC)


### PR DESCRIPTION
This ensures that most compiler tests are not run with the wrong build type's flags. The initial c++ checks are an exception to that because many internal CMake variables are unset until a language is selected, so it's problematic to change our build type before that.

The difference can be seen in `build/CMakeFiles/CMakeConfigureLog.yaml`. Before, `Debug` was used for many of the earlly checks. After this PR, it's only the first 2 checks.