### PR TITLE
validation: Do less work in NeedsRedownload

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -177,9 +177,7 @@ public:
 
     //! Verification status of this block. See enum BlockStatus
     //!
-    //! Note: this value is modified to show BLOCK_OPT_WITNESS during UTXO snapshot
-    //! load to avoid a spurious startup failure requiring -reindex.
-    //! @sa NeedsRedownload
+    //! Note: this value is modified to show BLOCK_OPT_WITNESS during UTXO snapshot load.
     //! @sa ActivateSnapshot
     uint32_t nStatus GUARDED_BY(::cs_main){0};
 


### PR DESCRIPTION
`NeedsRedownload` exists to detect when a non-segwit client upgrades to segwit after segwit activation. In #21009, it was simplified from an upgrade algorithm to a simple check / recommendation to reindex.

Still, iterating over hundred thousands of block indexes with each startup for this purpose doesn't seem necessary more than 7 years after segwit activation.
This PR suggests to only check the first segwit block instead. This is less thorough, but it will speed up init a little bit and the typical case of upgrading a non-segwit client that has already synced beyond the segwit height would still lead to an error.
I also thought about removing `NeedsRedownload()` completely if reviewers prefer that alternative.