### PR TITLE
build: CMake security checks workarounds

### DIFF
--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -16,10 +16,13 @@ def write_testcode(filename):
     with open(filename, 'w', encoding="utf8") as f:
         f.write('''
     #include <cstdio>
-    int main()
+    #include <cstring>
+    int main(int argc, char** argv)
     {
+        int ret;
+        memcpy(&ret, argv, argc);
         std::printf("the quick brown fox jumps over the lazy god\\n");
-        return 0;
+        return ret;
     }
     ''')
 

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -62,7 +62,7 @@ class TestSecurityChecks(unittest.TestCase):
         arch = get_arch(cxx, source, executable)
 
         if arch == lief.ARCHITECTURES.X86:
-            pass_flags = ['-D_FORTIFY_SOURCE=3', '-Wl,-znoexecstack', '-Wl,-zrelro', '-Wl,-z,now', '-pie', '-fPIE', '-Wl,-z,separate-code', '-fcf-protection=full']
+            pass_flags = ['-O2', '-D_FORTIFY_SOURCE=3', '-Wl,-znoexecstack', '-Wl,-zrelro', '-Wl,-z,now', '-pie', '-fPIE', '-Wl,-z,separate-code', '-fcf-protection=full']
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags + ['-Wl,-zexecstack']), (1, executable + ': failed NX'))
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags + ['-no-pie','-fno-PIE']), (1, executable + ': failed PIE'))
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags + ['-Wl,-znorelro']), (1, executable + ': failed RELRO'))
@@ -71,7 +71,7 @@ class TestSecurityChecks(unittest.TestCase):
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags + ['-U_FORTIFY_SOURCE']), (1, executable + ': failed FORTIFY'))
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags), (0, ''))
         else:
-            pass_flags = ['-D_FORTIFY_SOURCE=3', '-Wl,-znoexecstack', '-Wl,-zrelro', '-Wl,-z,now', '-pie', '-fPIE', '-Wl,-z,separate-code']
+            pass_flags = ['-O2', '-D_FORTIFY_SOURCE=3', '-Wl,-znoexecstack', '-Wl,-zrelro', '-Wl,-z,now', '-pie', '-fPIE', '-Wl,-z,separate-code']
             self.assertEqual(call_security_check(cxx, source, executable, pass_flags + ['-Wl,-zexecstack']), (1, executable + ': failed NX'))
             # LIEF fails to parse RISC-V with no PIE correctly, and doesn't detect the fortified function,
             # so skip this test for RISC-V (for now). See https://github.com/lief-project/LIEF/issues/1082.


### PR DESCRIPTION
This includes 2 hackish workarounds for our security checks, which are themselves quite hackish. It's unclear exactly what they're supposed to be testing and why.

Regardless, these changes are enough to fix the checks when no CXXFLAGS are passed in.

From what I can tell, the tests are intended to be self-contained and have a default set of flags, then each tests disables a default and verifies that security is weakened as intended. I'm not sure what the utility of that is, but in that spirit I've fixed up the default flags/compiles to work on their own.

The first is a real fix for the test source that gives us a better guarantee that fortification will be turned on. The second adds the flag that fortification requires rather than taking it from our build CXXFLAGS.