### PR TITLE
cmake: Fix `-pthread` flags presentation in summary

### DIFF
--- a/cmake/module/GetTargetInterface.cmake
+++ b/cmake/module/GetTargetInterface.cmake
@@ -32,7 +32,18 @@ endfunction()
 function(get_target_interface var config target property)
   get_target_property(result ${target} INTERFACE_${property})
   if(result)
-    evaluate_generator_expressions(result "${config}")
+    # On systems where pthread functionality is not provided by
+    # the C library implementation, the CMake FindThreads module
+    # sets the Threads::Threads target's compile options to
+    # generator expressions that evaluate to `-pthread` in this
+    # project.
+    # To improve the readability of the configuration summary,
+    # we skip these generator expressions.
+    if(${target} STREQUAL "Threads::Threads" AND ${property} STREQUAL "COMPILE_OPTIONS")
+      set(result -pthread)
+    else()
+      evaluate_generator_expressions(result "${config}")
+    endif()
     list(JOIN result " " result)
   else()
     set(result)


### PR DESCRIPTION
This PR removes the raw CMake generator expressions from the summary output.

Fixes https://github.com/bitcoin/bitcoin/issues/31482.

Here are a few examples of the summary:
- on FreeBSD: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12930644678/job/36062648395
- on OpenBSD: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12930647880/job/36062659528
- on NetBSD: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12930651817/job/36062672223
- on OmniOS: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12930654711/job/36062682690