### PR TITLE
build: add `bitcoind-release` preset with only `BUILD_DAEMON` enabled with `release` build type

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,6 +87,37 @@
         "WITH_USDT": "ON",
         "WITH_ZMQ": "ON"
       }
+    },
+    {
+      "name": "bitcoind-release",
+      "displayName": "Minimal build with only bitcoind enabled in release mode",
+      "binaryDir": "${sourceDir}/build_bitcoind_release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_DAEMON": "ON",
+        "ENABLE_HARDENING": "ON",
+        "BUILD_BENCH": "OFF",
+        "BUILD_CLI": "OFF",
+        "BUILD_FUZZ_BINARY": "OFF",
+        "BUILD_GUI": "OFF",
+        "BUILD_GUI_TESTS": "OFF",
+        "BUILD_KERNEL_LIB": "OFF",
+        "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_TESTS": "OFF",
+        "BUILD_TX": "OFF",
+        "BUILD_UTIL": "OFF",
+        "BUILD_UTIL_CHAINSTATE": "OFF",
+        "BUILD_WALLET_TOOL": "OFF",
+        "ENABLE_EXTERNAL_SIGNER": "OFF",
+        "ENABLE_WALLET": "OFF",
+        "INSTALL_MAN": "OFF",
+        "WITH_BDB": "OFF",
+        "WITH_MULTIPROCESS": "OFF",
+        "WITH_QRENCODE": "OFF",
+        "WITH_SQLITE": "OFF",
+        "WITH_USDT": "OFF",
+        "WITH_ZMQ": "OFF"
+      }
     }
   ]
 }


### PR DESCRIPTION
When benchmarking IBD or reindex behavior we have to build bitcoind only, which currently looks like:
```bash
cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DBUILD_TESTS=OFF -DBUILD_TX=OFF -DBUILD_UTIL=OFF -DENABLE_EXTERNAL_SIGNER=OFF -DENABLE_WALLET=OFF -DINSTALL_MAN=OFF
```
After this change we can simplify that to
```bash
cmake --preset bitcoind-release
```

---

You can validate the change by comparing the outputs of before and after:
```bash
git clean -fxd >/dev/null 2>&1 \
&& stdbuf -oL cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DBUILD_TESTS=OFF -DBUILD_TX=OFF -DBUILD_UTIL=OFF -DENABLE_EXTERNAL_SIGNER=OFF -DENABLE_WALLET=OFF -DINSTALL_MAN=OFF 2>&1 | grep -E "( OFF| ON)|CMAKE_BUILD_TYPE"
```
vs
```bash
git clean -fxd >/dev/null 2>&1 \
&& stdbuf -oL cmake --preset bitcoind-release 2>&1 | grep -E "( OFF| ON)|CMAKE_BUILD_TYPE"
```
which will only contain a single `CMAKE_BUILD_TYPE="Release"` (but `CMAKE_BUILD_TYPE ...................... Release` should be present in both)
