### PR TITLE
doc: update translation generation cmake example

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -18,8 +18,8 @@ We use automated scripts to help extract translations in both Qt, and non-Qt sou
 
 To automatically regenerate the `bitcoin_en.ts` file, run the following commands:
 ```sh
-cmake -B build --preset dev-mode -DWITH_BDB=ON -DBUILD_GUI=ON
-cmake --build build --target translate
+cmake --preset dev-mode -DWITH_USDT=OFF
+cmake --build build_dev_mode --target translate
 ```
 
 **Example Qt translation**


### PR DESCRIPTION
While investigating https://github.com/bitcoin/bitcoin/pull/31730 I noticed that
* the `dev-mode` preset already contained [`-DWITH_BDB=ON`](https://github.com/bitcoin/bitcoin/blob/master/CMakePresets.json#L83) and [`-DBUILD_GUI=ON`](https://github.com/bitcoin/bitcoin/blob/master/CMakePresets.json#L70);
* the preset already contained a [default binary dir](https://github.com/bitcoin/bitcoin/blob/master/CMakePresets.json#L64) which we could use;
* the command only runs on my Mac if we disable `USDT`, and `MULTIPROCESS` and on Linux also without `MULTIPROCESS`.