### PR TITLE
depends: Update libmultiprocess library before converting to subtree

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=abe254b9734f2e2b220d1456de195532d6e6ac1e
+$(package)_version=07c917f7ca910d66abc6d3873162fc9061704074
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=85777073259fdc75d24ac5777a19991ec1156c5f12db50b252b861c95dcb4f46
+$(package)_sha256_hash=ac9db311e3b22aac3c7b7b7b3f6b7fee5cf3043ebb3c3bf412049e8b17166de8
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds

--- a/src/ipc/capnp/echo-types.h
+++ b/src/ipc/capnp/echo-types.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_CAPNP_ECHO_TYPES_H
+#define BITCOIN_IPC_CAPNP_ECHO_TYPES_H
+
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+#include <mp/type-string.h>
+
+#endif // BITCOIN_IPC_CAPNP_ECHO_TYPES_H

--- a/src/ipc/capnp/echo.capnp
+++ b/src/ipc/capnp/echo.capnp
@@ -9,7 +9,7 @@ $Cxx.namespace("ipc::capnp::messages");
 
 using Proxy = import "/mp/proxy.capnp";
 $Proxy.include("interfaces/echo.h");
-$Proxy.include("ipc/capnp/echo.capnp.h");
+$Proxy.includeTypes("ipc/capnp/echo-types.h");
 
 interface Echo $Proxy.wrap("interfaces::Echo") {
     destroy @0 (context :Proxy.Context) -> ();

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -73,7 +73,7 @@ public:
     }
     void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
     {
-        mp::ProxyTypeRegister::types().at(type)(iface).cleanup.emplace_back(std::move(cleanup));
+        mp::ProxyTypeRegister::types().at(type)(iface).cleanup_fns.emplace_back(std::move(cleanup));
     }
     Context& context() override { return m_context; }
     void startLoop(const char* exe_name)

--- a/src/test/ipc_test.capnp
+++ b/src/test/ipc_test.capnp
@@ -20,4 +20,5 @@ interface FooInterface $Proxy.wrap("FooImplementation") {
     passTransaction @3 (arg :Data) -> (result :Data);
     passVectorChar @4 (arg :Data) -> (result :Data);
     passBlockState @5 (arg :Mining.BlockValidationState) -> (result :Mining.BlockValidationState);
+    passScript @6 (arg :Data) -> (result :Data);
 }

--- a/src/test/ipc_test.cpp
+++ b/src/test/ipc_test.cpp
@@ -121,6 +121,10 @@ void IpcPipeTest()
     BOOST_CHECK_EQUAL(bs3.GetRejectReason(), bs4.GetRejectReason());
     BOOST_CHECK_EQUAL(bs3.GetDebugMessage(), bs4.GetDebugMessage());
 
+    auto script1{CScript() << OP_11};
+    auto script2{foo->passScript(script1)};
+    BOOST_CHECK_EQUAL(HexStr(script1), HexStr(script2));
+
     // Test cleanup: disconnect pipe and join thread
     disconnect_client();
     thread.join();

--- a/src/test/ipc_test.h
+++ b/src/test/ipc_test.h
@@ -6,6 +6,7 @@
 #define BITCOIN_TEST_IPC_TEST_H
 
 #include <primitives/transaction.h>
+#include <script/script.h>
 #include <univalue.h>
 #include <util/fs.h>
 #include <validation.h>
@@ -19,6 +20,7 @@ public:
     CTransactionRef passTransaction(CTransactionRef t) { return t; }
     std::vector<char> passVectorChar(std::vector<char> v) { return v; }
     BlockValidationState passBlockState(BlockValidationState s) { return s; }
+    CScript passScript(CScript s) { return s; }
 };
 
 void IpcPipeTest();


### PR DESCRIPTION
This should be the final update to the libmultiprocess package via the depends system. It brings in the libmultiprocess cmake changes from https://github.com/chaincodelabs/libmultiprocess/pull/136 needed to support building as subtree. After this, followup PR #31741 will add libmultiprocess as a git subtree and depends will just use the git subtree instead of hardcoding its own version hash.

Since there have been libmultiprocess API changes since the last update, this commit also updates bitcoin code to be compatible with them.

This update has the following new changes since previous update #31105:

https://github.com/chaincodelabs/libmultiprocess/pull/121 ProxyClientBase: avoid static_cast to partially constructed object
https://github.com/chaincodelabs/libmultiprocess/pull/120 proxy-types.h: add static_assert to detect int/enum size mismatch
https://github.com/chaincodelabs/libmultiprocess/pull/127 ProxyClientBase: avoid static_cast to partially destructed object
https://github.com/chaincodelabs/libmultiprocess/pull/129 Fix "disconnected: write(m_post_fd, &buffer, 1): Broken pipe" EventLoop shutdown races.
https://github.com/chaincodelabs/libmultiprocess/pull/130 refactor: Add CleanupRun function to dedup clean list code
https://github.com/chaincodelabs/libmultiprocess/pull/131 doc: fix startAsyncThread comment
https://github.com/chaincodelabs/libmultiprocess/pull/133 Fix debian "libatomic not found" error in downstream builds
https://github.com/chaincodelabs/libmultiprocess/pull/94 c++ 20 cleanups
https://github.com/chaincodelabs/libmultiprocess/pull/135 refactor: proxy-types.h API cleanup
https://github.com/chaincodelabs/libmultiprocess/pull/136 cmake: Support being included with add_subdirectory
https://github.com/chaincodelabs/libmultiprocess/pull/137 doc: Fix broken markdown links
