### PR TITLE
contrib: fix BUILDDIR in gen-bitcoin-conf script and gen-manpages.py

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -82,12 +82,12 @@ gen-manpages.py
 A small script to automatically create manpages in ../../doc/man by running the release binaries with the -help option.
 This requires help2man which can be found at: https://www.gnu.org/software/help2man/
 
-With in-tree builds this tool can be run from any directory within the
-repository. To use this tool with out-of-tree builds set `BUILDDIR`. For
-example:
+This script assumes a build directory named `build` as suggested by example build documentation.
+To use it with a different build directory, set `BUILDDIR`.
+For example:
 
 ```bash
-BUILDDIR=$PWD/build contrib/devtools/gen-manpages.py
+BUILDDIR=$PWD/my-build-dir contrib/devtools/gen-manpages.py
 ```
 
 headerssync-params.py
@@ -107,12 +107,12 @@ Generates a bitcoin.conf file in `share/examples/` by parsing the output from `b
 release process to include a bitcoin.conf with the release binaries and can also be run by users to generate a file locally.
 When generating a file as part of the release process, make sure to commit the changes after running the script.
 
-With in-tree builds this tool can be run from any directory within the
-repository. To use this tool with out-of-tree builds set `BUILDDIR`. For
-example:
+This script assumes a build directory named `build` as suggested by example build documentation.
+To use it with a different build directory, set `BUILDDIR`.
+For example:
 
 ```bash
-BUILDDIR=$PWD/build contrib/devtools/gen-bitcoin-conf.sh
+BUILDDIR=$PWD/my-build-dir contrib/devtools/gen-bitcoin-conf.sh
 ```
 
 security-check.py and test-security-check.py

--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -5,7 +5,7 @@
 
 export LC_ALL=C
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
-BUILDDIR=${BUILDDIR:-$TOPDIR}
+BUILDDIR=${BUILDDIR:-$TOPDIR/build}
 BINDIR=${BINDIR:-$BUILDDIR/src}
 BITCOIND=${BITCOIND:-$BINDIR/bitcoind}
 SHARE_EXAMPLES_DIR=${SHARE_EXAMPLES_DIR:-$TOPDIR/share/examples}

--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -40,7 +40,7 @@ if not topdir:
     topdir = r.stdout.rstrip()
 
 # Get input and output directories.
-builddir = os.getenv('BUILDDIR', topdir)
+builddir = os.getenv('BUILDDIR', os.path.join(topdir, 'build'))
 mandir = os.getenv('MANDIR', os.path.join(topdir, 'doc/man'))
 
 # Verify that all the required binaries are usable, and extract copyright


### PR DESCRIPTION
The `gen-bitcoin-conf.sh` and `gen-manpages.py` scripts assume a top level `src/` build dir, but in-tree builds are no longer allowed, nor recommended in the build steps. If a user builds `bitcoind` as recommended, these scripts fail. To fix it, we update the `BUILDDIR` env var and update the README accordingly. 
Follows up on initial work and discussion in #31332 . 