### PR TITLE
test: Added coverage to the waitfornewblock rpc

### DIFF
--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -549,6 +549,7 @@ class BlockchainTest(BitcoinTestFramework):
         # The chain has probably already been restored by the time reconsiderblock returns,
         # but poll anyway.
         self.wait_until(lambda: node.waitfornewblock(timeout=100)['hash'] == current_hash)
+        assert_raises_rpc_error(-1, "Negative timeout", node.waitfornewblock, -1)
 
     def _test_waitforblockheight(self):
         self.log.info("Test waitforblockheight")


### PR DESCRIPTION
Added a test for the Negative timeout error if the rpc is given a negative value for its timeout arg

This adds coverage to the `waitfornewblock` rpc

you can check to see there is no coverage for this error by doing 
`grep -nri "Negative timeout" ./test/`

and nothing shows up, you can also see by manually checking where we call `waitfornewblock` in the functional tests