### PR TITLE
test: fix intermittent timeout in p2p_1p1c_network.py

### DIFF
--- a/test/functional/p2p_1p1c_network.py
+++ b/test/functional/p2p_1p1c_network.py
@@ -144,6 +144,11 @@ class PackageRelayTest(BitcoinTestFramework):
             for tx in transactions_to_presend[i]:
                 peer.send_and_ping(msg_tx(tx))
 
+        # Disconnect python peers to clear outstanding orphan requests with them, avoiding timeouts.
+        # We are only interested in the syncing behavior between real nodes.
+        for i in range(self.num_nodes):
+            self.nodes[i].disconnect_p2ps()
+
         self.log.info("Submit full packages to node0")
         for package_hex in packages_to_submit:
             submitpackage_result = self.nodes[0].submitpackage(package_hex)


### PR DESCRIPTION
The timeout is due to outstanding txrequests with python peers, which have the same timeout (`60s`) as the mempool sync timeout.
I explained this in more detail in https://github.com/bitcoin/bitcoin/issues/31721#issuecomment-2620169640 and also mentioned there how to reproduce it.

Fix this by disconnecting the python peers after they send their txns, they aren't needed after this point anyway because the main goal of the test is the sync between the 4 full nodes.

Fixes #31721