### PR TITLE
doc: Add test coverage troubleshooting tip

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -513,6 +513,24 @@ To enable test parallelism:
 cmake -DJOBS=$(nproc) -P build/Coverage.cmake
 ```
 
+**Troubleshooting:** While running `cmake -P build/Coverage.cmake` above, you
+may encounter errors similar to the following:
+
+```
+geninfo: ERROR: mismatched end line for _ZN7Num30723SerI10DataStreamEEvRT_RKS_ at /home/espi3/src/bitcoin/src/crypto/muhash.h:62: 67 -> 62
+        (use "geninfo --ignore-errors mismatch ..." to bypass this error)
+
+geninfo: ERROR: Unexpected negative count '-185' for /home/espi3/src/bitcoin/src/secp256k1/src/field_5x52_impl.h:183.
+        Perhaps you need to compile with '-fprofile-update=atomic
+        (use "geninfo --ignore-errors negative ..." to bypass this error)
+```
+
+You can work around these issues using the aforementioned LCOV options:
+
+```
+cmake -DLCOV_OPTS="--ignore-errors mismatch,negative" -P build/Coverage.cmake
+```
+
 ### Performance profiling with perf
 
 Profiling is a good way to get a precise idea of where time is being spent in


### PR DESCRIPTION
This PR adds troubleshooting information to explain how to overcome two errors that may arise when running the tests with coverage as described in `doc/developer-notes.md`.

Specifically, running the `cmake -P build/Coverage.cmake` step may produce geninfo mismatch errors of the following sort (Ubuntu 24.04, GNU 13.3.0 compiler, LCOV version 2.0-1):

```
$ cmake -B build -DCMAKE_BUILD_TYPE=Coverage
$ cmake --build build
$ cmake -P build/Coverage.cmake

geninfo: ERROR: mismatched end line for _ZN7Num30723SerI10DataStreamEEvRT_RKS_ at /home/espi3/src/bitcoin/src/crypto/muhash.h:62: 67 -> 62
        (use "geninfo --ignore-errors mismatch ..." to bypass this error)
CMake Error at build/CoverageInclude.cmake:45 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 1"

Call Stack (most recent call first):
  build/Coverage.cmake:5 (include)
``````

This may be due to multiline macros such as `SERIALIZE_METHODS`, so I would expect others to run into the same issue.

Additionally, after suppressing the mismatch errors, I get a geninfo negative count error:

```
geninfo: ERROR: Unexpected negative count '-185' for /home/espi3/src/bitcoin/src/secp256k1/src/field_5x52_impl.h:183.
        Perhaps you need to compile with '-fprofile-update=atomic
        (use "geninfo --ignore-errors negative ..." to bypass this error)
CMake Error at build/Coverage.cmake:21 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 1"
```

I don't know the cause, and don't yet know enough C++ to investigate it properly. This PR takes the approach of describing a workaround.
