### PR TITLE
test: fixes p2p_ibd_txrelay wait time

### DIFF
--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -47,12 +47,14 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             assert node.getblockchaininfo()['initialblockdownload']
             self.wait_until(lambda: all(peer['minfeefilter'] == MAX_FEE_FILTER for peer in node.getpeerinfo()))
 
+        self.nodes[0].setmocktime(int(time.time()))
+
         self.log.info("Check that nodes don't send getdatas for transactions while still in IBD")
         peer_inver = self.nodes[0].add_p2p_connection(P2PDataStore())
         txid = 0xdeadbeef
         peer_inver.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=txid)]))
         # The node should not send a getdata, but if it did, it would first delay 2 seconds
-        self.nodes[0].setmocktime(int(time.time() + NONPREF_PEER_TX_DELAY))
+        self.nodes[0].bumpmocktime(NONPREF_PEER_TX_DELAY)
         peer_inver.sync_with_ping()
         with p2p_lock:
             assert txid not in peer_inver.getdata_requests


### PR DESCRIPTION
`p2p_ibd_txrelay` expects no GETDATA to have been received by a peer after announcing a transaction. The reason is that the node is doing IBD, so transaction requests are not replied to. However, the way this is checked is wrong, and the check will pass even if the node **was not** in IBD.

This is due to the mocktime not being properly initialized, so the check is always performed earlier than it should, making it impossible for the request to be there.

This can be checked by modifying the test so the peer **is not doing IBD**, and checking how the test succeeds on that assert (even though it fails later on, given the nature of the test):

```diff
index 882f5b5c13..3a69ae5860 100755
--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -34,7 +34,7 @@ NORMAL_FEE_FILTER = Decimal(100) / COIN

 class P2PIBDTxRelayTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        # self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [
             ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
@@ -43,9 +43,11 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):

     def run_test(self):
         self.log.info("Check that nodes set minfilter to MAX_MONEY while still in IBD")
-        for node in self.nodes:
-            assert node.getblockchaininfo()['initialblockdownload']
-            self.wait_until(lambda: all(peer['minfeefilter'] == MAX_FEE_FILTER for peer in node.getpeerinfo()))
+        # for node in self.nodes:
+        #     assert node.getblockchaininfo()['initialblockdownload']
+        #     self.wait_until(lambda: all(peer['minfeefilter'] == MAX_FEE_FILTER for peer in node.getpeerinfo()))
```