### PR TITLE
Pass custom DEP_OPTS and CONFIG_FLAGS to guix-build

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -296,7 +296,7 @@ mkdir -p "$OUTDIR_BASE"
 # Download the depends sources now as we won't have internet access in the build
 # container
 for host in $HOSTS; do
-    make -C "${PWD}/depends" -j"$JOBS" download-"$(host_to_commonname "$host")" ${V:+V=1} ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
+    make -C "${PWD}/depends" -j"$JOBS" download-"$(host_to_commonname "$host")" ${DEP_OPTS:+"$DEP_OPTS"} ${V:+V=1} ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
 done
 
 # Usage: outdir_for_host HOST SUFFIX
@@ -361,6 +361,7 @@ INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
           ...bind-mounted in container to: '$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")'
       ...outputting in: '$(outdir_for_host "$HOST")'
           ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")'
+      DEP_OPTS: ${DEP_OPTS}
       ADDITIONAL FLAGS (if set)
           ADDITIONAL_GUIX_COMMON_FLAGS: ${ADDITIONAL_GUIX_COMMON_FLAGS}
           ADDITIONAL_GUIX_ENVIRONMENT_FLAGS: ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS}
@@ -462,6 +463,7 @@ EOF
                                         DISTSRC="$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")" \
                                         OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")" \
                                         DIST_ARCHIVE_BASE=/outdir-base/dist-archive \
+                                        DEP_OPTS="$DEP_OPTS" \
                                       bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
     )
 

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -315,6 +315,7 @@ profiledir_for_host() {
     echo "${PROFILES_BASE}/${1}${2:+-${2}}"
 }
 
+CONFIG_FLAGS="${CONFIG_FLAGS:--DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD_FUZZ_BINARY=OFF}"
 
 #########
 # BUILD #
@@ -362,6 +363,7 @@ INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
       ...outputting in: '$(outdir_for_host "$HOST")'
           ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")'
       DEP_OPTS: ${DEP_OPTS}
+      CONFIG_FLAGS: ${CONFIG_FLAGS}
       ADDITIONAL FLAGS (if set)
           ADDITIONAL_GUIX_COMMON_FLAGS: ${ADDITIONAL_GUIX_COMMON_FLAGS}
           ADDITIONAL_GUIX_ENVIRONMENT_FLAGS: ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS}
@@ -464,6 +466,7 @@ EOF
                                         OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")" \
                                         DIST_ARCHIVE_BASE=/outdir-base/dist-archive \
                                         DEP_OPTS="$DEP_OPTS" \
+                                        CONFIG_FLAGS="$CONFIG_FLAGS" \
                                       bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
     )
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -206,9 +206,6 @@ mkdir -p "$OUTDIR"
 # Binary Tarball Building #
 ###########################
 
-# CONFIGFLAGS
-CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD_FUZZ_BINARY=OFF"
-
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
 HOST_CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
@@ -243,7 +240,7 @@ mkdir -p "$DISTSRC"
     cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
           -DWITH_CCACHE=OFF \
-          ${CONFIGFLAGS}
+          ${CONFIG_FLAGS}
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS" ${V:+--verbose}

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -167,6 +167,7 @@ export TZ="UTC"
 
 # Build the depends tree, overriding variables that assume multilib gcc
 make -C depends --jobs="$JOBS" HOST="$HOST" \
+                                   ${DEP_OPTS:+"$DEP_OPTS"} \
                                    ${V:+V=1} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \


### PR DESCRIPTION
This allows building deterministic binaries with multiprocess like so:

```sh
DEP_OPTS="MULTIPROCESS=1" contrib/guix/guix-build
```

Additionally custom options can be passed to `cmake -B` using `CONFIG_FLAGS`. Example (turns off external signer support, the rest is default):

```sh
CONFIG_FLAGS="-DENABLE_EXTERNAL_SIGNER=OFF -DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD_FUZZ_BINARY=OFF" contrib/guix/guix-build
```

The `CONFIG_FLAGS` is less useful in practice, because:

1. Some options will cause the Guix build to fail, e.g. because the packaging step assumes their presence.
2. Some options are already indirectly controlled though `DEP_OPTS`