### PR TITLE
logging: Ensure -debug=0/none behaves consistently with -nodebug

### DIFF
--- a/doc/release-notes-31767.md
+++ b/doc/release-notes-31767.md
@@ -1,0 +1,3 @@
+Logging
+---
+Passing -debug=0 or -debug=none now behaves like -nodebug: previously set debug categories will be cleared, but subsequent -debug options will still be applied.

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -80,15 +80,17 @@ util::Result<void> SetLoggingLevel(const ArgsManager& args)
 util::Result<void> SetLoggingCategories(const ArgsManager& args)
 {
     if (args.IsArgSet("-debug")) {
-        // Special-case: if -debug=0/-nodebug is set, turn off debugging messages
         const std::vector<std::string> categories = args.GetArgs("-debug");
 
-        if (std::none_of(categories.begin(), categories.end(),
-            [](std::string cat){return cat == "0" || cat == "none";})) {
-            for (const auto& cat : categories) {
-                if (!LogInstance().EnableCategory(cat)) {
-                    return util::Error{strprintf(_("Unsupported logging category %s=%s."), "-debug", cat)};
-                }
+        // Special-case: Disregard any debugging categories appearing before -debug=0/none
+        const auto last_negated = std::find_if(categories.rbegin(), categories.rend(),
+                                               [](const std::string& cat) { return cat == "0" || cat == "none"; });
+
+        const auto categories_to_process = (last_negated == categories.rend()) ? categories : std::ranges::subrange(last_negated.base(), categories.end());
+
+        for (const auto& cat : categories_to_process) {
+            if (!LogInstance().EnableCategory(cat)) {
+                return util::Error{strprintf(_("Unsupported logging category %s=%s."), "-debug", cat)};
             }
         }
     }

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -99,8 +99,10 @@ class LoggingTest(BitcoinTestFramework):
             match=ErrorMatch.PARTIAL_REGEX,
         )
 
-        self.log.info("Test that -nodebug clears previously specified debug options")
+        self.log.info("Test that -nodebug,-debug=0,-debug=none clear previously specified debug options")
         disable_debug_options = [
+            '-debug=0',
+            '-debug=none',
             '-nodebug'
         ]
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -99,6 +99,19 @@ class LoggingTest(BitcoinTestFramework):
             match=ErrorMatch.PARTIAL_REGEX,
         )
 
+        self.log.info("Test that -nodebug clears previously specified debug options")
+        disable_debug_options = [
+            '-nodebug'
+        ]
+
+        for disable_debug_opt in disable_debug_options:
+            # Every category before disable_debug_opt will be ignored, including the invalid 'abc'
+            self.restart_node(0, ['-debug=http', '-debug=abc', disable_debug_opt, '-debug=rpc', '-debug=net'])
+            logging = self.nodes[0].logging()
+            assert not logging['http']
+            assert 'abc' not in logging
+            assert logging['rpc']
+            assert logging['net']
 
 if __name__ == '__main__':
     LoggingTest(__file__).main()


### PR DESCRIPTION
Previously, -nodebug cleared all prior -debug configurations in the command line while allowing subsequent debug options to be applied.
However, -debug=0 and -debug=none completely disabled debugging, even for categories specified afterward.
    
This commit ensures consistency by making -debug=0 and -debug=none behave like -nodebug: they now clear previously set debug configurations but do not disable debugging for categories specified later.

See https://github.com/bitcoin/bitcoin/pull/30529#discussion_r1930956563