### PR TITLE
rpc: collect transaction fees on generateblock

### DIFF
--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_NODE_MINER_H
 #define BITCOIN_NODE_MINER_H
 
+#include <consensus/amount.h>
 #include <node/types.h>
 #include <policy/policy.h>
 #include <primitives/block.h>

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -60,6 +60,10 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+    /**
+     * Transactions from the mempool to be included in this block.
+     */
+    std::vector<uint256> txs = {};
 };
 } // namespace node
 


### PR DESCRIPTION
Fixes #31684 

Currently `generateblock` will insert the specified transactions directly into the new block without collecting fees in the coinbase transaction.

This patch changes the code to take transaction fees into account and make it behave closer to the expected miner behavior in mainnet.