### PR TITLE
refactor: simplify GetAncestor

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -96,24 +96,20 @@ const CBlockIndex* CBlockIndex::GetAncestor(int height) const
         return nullptr;
     }
 
+    // Traverse back until we find the desired pindex.
     const CBlockIndex* pindexWalk = this;
-    int heightWalk = nHeight;
-    while (heightWalk > height) {
-        int heightSkip = GetSkipHeight(heightWalk);
-        int heightSkipPrev = GetSkipHeight(heightWalk - 1);
+    while (pindexWalk != nullptr && pindexWalk->nHeight != height) {
+        // Prefer the ancestor if there is one we can take.
         if (pindexWalk->pskip != nullptr &&
-            (heightSkip == height ||
-             (heightSkip > height && !(heightSkipPrev < heightSkip - 2 &&
-                                       heightSkipPrev >= height)))) {
-            // Only follow pskip if pprev->pskip isn't better than pskip->pprev.
+                GetSkipHeight(pindexWalk->nHeight) >= height) {
             pindexWalk = pindexWalk->pskip;
-            heightWalk = heightSkip;
         } else {
+            // We couldn't take the ancestor skip so traverse back to the parent.
             assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
-            heightWalk--;
         }
     }
+
     return pindexWalk;
 }
 


### PR DESCRIPTION
The if statement in GetAncestor was quite hard to make sense of.
Simplifying it improves readability and the added test ensures that
the performance remains the same.

I'm not quite sure if the test makes sense to have but including it as
it's the code used to make sure no loss in performance was made.
Tested locally up to height 1<<29.