### PR TITLE
cmake: Improve safety and robustness during building `crc32c` subtree

### DIFF
--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -2,11 +2,18 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-# This file is part of the transition from Autotools to CMake. Once CMake
-# support has been merged we should switch to using the upstream CMake
-# buildsystem.
-
 set(crc32c_subtree_dir ${PROJECT_SOURCE_DIR}/src/crc32c)
+
+# We do not use the upstream CMake-based buildsystem.
+# See the discussion in https://github.com/bitcoin/bitcoin/pull/30905.
+# However, we want to ensure that no changes upstream remain unnoticed.
+file(READ ${crc32c_subtree_dir}/CMakeLists.txt upstream_cmakelists_content)
+string(SHA256 upstream_cmakelists_hash "${upstream_cmakelists_content}")
+if(NOT upstream_cmakelists_hash STREQUAL "f5c90773b3afd4ee95e792356a802758a29a3751878d0388c555c575c19ed4ce")
+  message(FATAL_ERROR "${crc32c_subtree_dir}/CMakeLists.txt has been modified.")
+endif()
+unset(upstream_cmakelists_content)
+unset(upstream_cmakelists_hash)
 
 include(CheckCXXSourceCompiles)
 

--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -6,6 +6,8 @@
 # support has been merged we should switch to using the upstream CMake
 # buildsystem.
 
+set(crc32c_subtree_dir ${PROJECT_SOURCE_DIR}/src/crc32c)
+
 include(CheckCXXSourceCompiles)
 
 # Check for __builtin_prefetch support in the compiler.
@@ -92,19 +94,19 @@ target_link_libraries(crc32c_common INTERFACE
 )
 
 add_library(crc32c STATIC EXCLUDE_FROM_ALL
-  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
-  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_portable.cc
+  ${crc32c_subtree_dir}/src/crc32c.cc
+  ${crc32c_subtree_dir}/src/crc32c_portable.cc
 )
 target_include_directories(crc32c
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/crc32c/include>
+    $<BUILD_INTERFACE:${crc32c_subtree_dir}/include>
 )
 target_link_libraries(crc32c PRIVATE crc32c_common)
 set_target_properties(crc32c PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 
 if(HAVE_SSE42)
   add_library(crc32c_sse42 STATIC EXCLUDE_FROM_ALL
-    ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_sse42.cc
+    ${crc32c_subtree_dir}/src/crc32c_sse42.cc
   )
   target_compile_options(crc32c_sse42 PRIVATE ${SSE42_CXXFLAGS})
   target_link_libraries(crc32c_sse42 PRIVATE crc32c_common)
@@ -114,10 +116,12 @@ endif()
 
 if(HAVE_ARM64_CRC32C)
   add_library(crc32c_arm64 STATIC EXCLUDE_FROM_ALL
-    ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_arm64.cc
+    ${crc32c_subtree_dir}/src/crc32c_arm64.cc
   )
   target_compile_options(crc32c_arm64 PRIVATE ${ARM64_CRC_CXXFLAGS})
   target_link_libraries(crc32c_arm64 PRIVATE crc32c_common)
   set_target_properties(crc32c_arm64 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
   target_link_libraries(crc32c PRIVATE crc32c_arm64)
 endif()
+
+unset(crc32c_source_dir)

--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -15,7 +15,15 @@ endif()
 unset(upstream_cmakelists_content)
 unset(upstream_cmakelists_hash)
 
+# Checks that are used exclusively in the crc32c subtree code
+# are performed in this script below. Additionally, we ensure
+# that shared checks are performed before this script is included.
+if(NOT DEFINED HAVE_STRONG_GETAUXVAL)
+  message(FATAL_ERROR "HAVE_STRONG_GETAUXVAL is not defined.")
+endif()
+
 include(CheckCXXSourceCompiles)
+include(CheckSourceCompilesAndLinks)
 
 # Check for __builtin_prefetch support in the compiler.
 check_cxx_source_compiles("


### PR DESCRIPTION
It was [agreed](https://github.com/bitcoin/bitcoin/pull/30905#issuecomment-2426263301) not to adopt the upstream buildsystem the `crc32c` subtree.

So this PR ensures that our custom build script properly handles potentially harmful situations, including:
1. The upstream buildsystem changes remaining unnoticed during the subtree update, even when some of those changes need to be reflected in `crc32c.cmake`.

2. The order of `include(cmake/introspection.cmake)` and `include(cmake/crc32c.cmake)` being inadvertently altered during refactoring or other changes in the main buildsystem.