### PR TITLE
ci: run in worktrees

### DIFF
--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -6,12 +6,52 @@
 
 export LC_ALL=C.UTF-8
 
-# Only used in .cirrus.yml. Refer to test/lint/README.md on how to run locally.
+set -eo pipefail
 
-cp "./ci/retry/retry" "/ci_retry"
-cp "./.python-version" "/.python-version"
-mkdir --parents "/test/lint"
-cp --recursive "./test/lint/test_runner" "/test/lint/"
-set -o errexit; source ./ci/lint/04_install.sh
-set -o errexit
-./ci/lint/06_script.sh
+if [ -n "$CIRRUS_PR" ]; then
+  # For CI runs
+  cp "./ci/retry/retry" "/ci_retry"
+  cp "./.python-version" "/.python-version"
+  mkdir --parents "/test/lint"
+  cp --recursive "./test/lint/test_runner" "/test/lint/"
+  set -o errexit
+  # shellcheck source=/dev/null
+  source ./ci/lint/04_install.sh
+  set -o errexit
+  ./ci/lint/06_script.sh
+else
+  # For local runs
+  error() {
+    echo "ERROR: $1" >&2
+    exit 1
+  }
+
+
+  echo "Building Docker image..."
+  DOCKER_BUILDKIT=1 docker build \
+      -t bitcoin-linter \
+      --file "./ci/lint_imagefile" \
+      ./ || error "Docker build failed"
+
+  echo "Running linter..."
+  DOCKER_ARGS=(
+    --rm
+    -v "$(pwd):/bitcoin"
+    -it
+  )
+
+  # Check if we are working in a worktree
+  GIT_DIR=$(git rev-parse --git-dir)
+  if [[ "$GIT_DIR" == *".git/worktrees/"* ]]; then
+    # If we are, mount the git toplevel dir to the expected location.
+    # This is required both so the linter knows which dir to run lint tests from.
+    # A writeable mount is required so test/lint/commit-script-check.sh can
+    # write to the index.
+    echo "Detected git worktree..."
+    WORKTREE_ROOT=$(echo "$GIT_DIR" | sed 's/\.git\/worktrees\/.*/\.git/')
+    echo "Worktree root: $WORKTREE_ROOT"
+    DOCKER_ARGS+=(--mount "type=bind,src=$WORKTREE_ROOT,dst=$WORKTREE_ROOT")
+  fi
+
+  RUST_BACKTRACE=1 docker run "${DOCKER_ARGS[@]}" bitcoin-linter
+fi

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -4,10 +4,10 @@ Running locally
 ===============
 
 To run linters locally with the same versions as the CI environment, use the included
-Dockerfile:
+Dockerfile run via helper script to manage worktree workflows:
 
 ```sh
-DOCKER_BUILDKIT=1 docker build -t bitcoin-linter --file "./ci/lint_imagefile" ./ && docker run --rm -v $(pwd):/bitcoin -it bitcoin-linter
+./ci/lint_run_all.sh
 ```
 
 Building the container can be done every time, because it is fast when the

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -178,8 +178,8 @@ fn check_output(cmd: &mut std::process::Command) -> Result<String, LintError> {
         .to_string())
 }
 
-/// Return the git root as utf8, or panic
-fn get_git_root() -> PathBuf {
+/// Return the git toplevel directory as utf8, or panic
+fn get_git_toplevel() -> PathBuf {
     PathBuf::from(check_output(git().args(["rev-parse", "--show-toplevel"])).unwrap())
 }
 
@@ -691,7 +691,7 @@ Markdown link errors found:
 
 fn run_all_python_linters() -> LintResult {
     let mut good = true;
-    let lint_dir = get_git_root().join("test/lint");
+    let lint_dir = get_git_toplevel().join("test/lint");
     for entry in fs::read_dir(lint_dir).unwrap() {
         let entry = entry.unwrap();
         let entry_fn = entry.file_name().into_string().unwrap();
@@ -723,7 +723,7 @@ fn main() -> ExitCode {
         get_linter_list()
     };
 
-    let git_root = get_git_root();
+    let git_toplevel = get_git_toplevel();
     let commit_range = commit_range();
     let commit_log = check_output(git().args(["log", "--no-merges", "--oneline", &commit_range]))
         .expect("check_output failed");
@@ -731,8 +731,8 @@ fn main() -> ExitCode {
 
     let mut test_failed = false;
     for linter in linters_to_run {
-        // chdir to root before each lint test
-        env::set_current_dir(&git_root).unwrap();
+        // chdir to git toplevel before each lint test
+        env::set_current_dir(&git_toplevel).unwrap();
         if let Err(err) = (linter.lint_fn)() {
             println!(
                 "^^^\n{err}\n^---- ⚠️ Failure generated from lint check '{}' ({})!\n\n",


### PR DESCRIPTION
Fixes: #30028

- Run CI in worktrees by mounting the .git root target into the container
- Run the linter in worktrees by mounting the .git root target into the container

AFAIK mounting the git root should not present any additional security issues, as this would already be mounted (in RO mode) when not using a worktree.