### PR TITLE
depends: Avoid using the `-ffile-prefix-map` compiler option

### DIFF
--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -9,7 +9,7 @@ define $(package)_set_vars :=
   $(package)_config_opts := -DBUILD_TESTING=OFF
   $(package)_config_opts += -DWITH_OPENSSL=OFF
   $(package)_config_opts += -DWITH_ZLIB=OFF
-  $(package)_cxxflags += -ffile-prefix-map=$$($(package)_extract_dir)=/usr
+  $(package)_cxxflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -13,7 +13,7 @@ define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_BUILD_TYPE=None -DEVENT__DISABLE_BENCHMARK=ON -DEVENT__DISABLE_OPENSSL=ON
   $(package)_config_opts+=-DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON
   $(package)_config_opts+=-DEVENT__DISABLE_TESTS=ON -DEVENT__LIBRARY_TYPE=STATIC
-  $(package)_cflags += -ffile-prefix-map=$($(package)_extract_dir)=/usr
+  $(package)_cflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
   $(package)_cppflags += -D_GNU_SOURCE
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0A00
 

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -13,7 +13,7 @@ ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
 $(package)_config_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"
 endif
-$(package)_cxxflags += -ffile-prefix-map=$$($(package)_extract_dir)=/usr
+$(package)_cxxflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -17,7 +17,7 @@ define $(package)_set_vars
   $(package)_config_opts += -DWITH_LIBBSD=OFF -DENABLE_CURVE=OFF -DENABLE_CPACK=OFF
   $(package)_config_opts += -DBUILD_SHARED=OFF -DBUILD_TESTS=OFF -DZMQ_BUILD_TESTS=OFF
   $(package)_config_opts += -DENABLE_DRAFTS=OFF -DZMQ_BUILD_TESTS=OFF
-  $(package)_cxxflags += -ffile-prefix-map=$($(package)_extract_dir)=/usr
+  $(package)_cxxflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
   $(package)_config_opts_mingw32 += -DZMQ_WIN32_WINNT=0x0A00 -DZMQ_HAVE_IPC=OFF
 endef
 


### PR DESCRIPTION
This PR is similar to https://github.com/bitcoin/bitcoin/pull/31337 and applies analogous changes to all dependency packages.

The issue was [recently noticed](https://github.com/bitcoin/bitcoin/pull/31661#discussion_r1923896475) when `-ffile-prefix-map` was added to the `libevent` package, which is built in OSS-Fuzz.

This PR replaces `-ffile-prefix-map` in all packages for consistency.

Fixes https://github.com/bitcoin/bitcoin/issues/31770.