### PR TITLE
doc: improve NODE_NETWORK_LIMITED documentation per BIP159

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -704,7 +704,7 @@ public:
         "           \"b\" - BLOOM: peer can handle bloom-filtered connections (see BIP 111)\n"
         "           \"w\" - WITNESS: peer can be asked for blocks and transactions with witness data (SegWit)\n"
         "           \"c\" - COMPACT_FILTERS: peer can handle basic block filter requests (see BIPs 157 and 158)\n"
-        "           \"l\" - NETWORK_LIMITED: peer limited to serving only the last 288 blocks (~2 days)\n"
+        "           \"l\" - NETWORK_LIMITED: peer can serve at least the last 288 blocks (~2 days); see BIP 159\n"
         "           \"2\" - P2P_V2: peer supports version 2 P2P transport protocol, as defined in BIP 324\n"
         "           \"u\" - UNKNOWN: unrecognized bit flag\n"
         "  v        Version of transport protocol used for the connection\n"

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1102,8 +1102,8 @@ static bool CanServeBlocks(const Peer& peer)
     return peer.m_their_services & (NODE_NETWORK|NODE_NETWORK_LIMITED);
 }
 
-/** Whether this peer can only serve limited recent blocks (e.g. because
- *  it prunes old blocks) */
+/** Whether this is a BIP159 peer that can only serve limited recent blocks
+ *  (e.g. because it prunes old blocks) */
 static bool IsLimitedPeer(const Peer& peer)
 {
     return (!(peer.m_their_services & NODE_NETWORK) &&
@@ -1476,7 +1476,7 @@ void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, c
                 return;
             }
 
-            // Don't request blocks that go further than what limited peers can provide
+            // Don't request blocks beyond the minimum number that BIP159 limited peers must be able to provide.
             if (is_limited_peer && (state->pindexBestKnownBlock->nHeight - pindex->nHeight >= static_cast<int>(NODE_NETWORK_LIMITED_MIN_BLOCKS) - 2 /* two blocks buffer for possible races */)) {
                 continue;
             }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -321,9 +321,8 @@ enum ServiceFlags : uint64_t {
     // NODE_COMPACT_FILTERS means the node will service basic block filter requests.
     // See BIP157 and BIP158 for details on how this is implemented.
     NODE_COMPACT_FILTERS = (1 << 6),
-    // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
-    // serving the last 288 (2 day) blocks
-    // See BIP159 for details on how this is implemented.
+    // NODE_NETWORK_LIMITED indicates that the node can serve at least the last
+    // 288 blocks (~2 days). See BIP159 for details on how this is implemented.
     NODE_NETWORK_LIMITED = (1 << 10),
 
     // NODE_P2P_V2 means the node supports BIP324 transport


### PR DESCRIPTION
Per BIP159, the definition is:

NODE_NETWORK_LIMITED || bit 10 (0x400) || If signaled, the peer <I>MUST</I> be capable of serving at least the last 288 blocks (~2 days).

Fix our documentation related to this, and add BIP159 mentions where relevant.

---

Originally this PR also tried to clarify the following, but it was dropped in response to review:

`NODE_NETWORK_LIMITED` is set by default, and it only signals a pruned or otherwise limited node if `NODE_NETWORK` is not also set. See the init setup logic or `IsLimitedPeer()` in `src/net_processing.cpp` for examples.
