### PR TITLE
fuzz: coinselection: cover `SetBumpFeeDiscount`

### DIFF
--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -282,6 +282,7 @@ void FuzzCoinSelectionAlgorithm(std::span<const uint8_t> buffer) {
             assert(result_srd->GetSelectedValue() >= target);
             assert(result_srd->GetChange(CHANGE_LOWER, coin_params.m_change_fee) > 0);
             assert(result_srd->GetWeight() <= max_selection_weight);
+            result_srd->SetBumpFeeDiscount(ConsumeMoney(fuzzed_data_provider));
             result_srd->RecalculateWaste(coin_params.min_viable_change, coin_params.m_cost_of_change, coin_params.m_change_fee);
             (void)result_srd->GetShuffledInputVector();
             (void)result_srd->GetInputSet();
@@ -308,6 +309,7 @@ void FuzzCoinSelectionAlgorithm(std::span<const uint8_t> buffer) {
             result = *result_knapsack;
             assert(result_knapsack->GetSelectedValue() >= target);
             assert(result_knapsack->GetWeight() <= max_selection_weight);
+            result_knapsack->SetBumpFeeDiscount(ConsumeMoney(fuzzed_data_provider));
             result_knapsack->RecalculateWaste(coin_params.min_viable_change, coin_params.m_cost_of_change, coin_params.m_change_fee);
             (void)result_knapsack->GetShuffledInputVector();
             (void)result_knapsack->GetInputSet();


### PR DESCRIPTION
`SetBumpFeeDiscount` sets the bump fee discount which is used to calculate the waste. We currently have no fuzz coverage for this function, so this PR adds it by calling `SetBumpFeeDiscount` before `RecalculateWaste`.