### PR TITLE
kernel: Avoid duplicating symbols in the kernel and downstream users

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -78,9 +78,25 @@ add_library(bitcoinkernel
   ../validationinterface.cpp
   ../versionbits.cpp
 )
+
+# Compiler warnings that apply only to the kernel and its dependencies.
+# These can be more strict and/or warnings that only apply to shared
+# libs.
+add_library(kernel_warn_interface INTERFACE)
+if(MSVC)
+else()
+  try_append_cxx_flags("-Wunique-object-duplication" TARGET kernel_warn_interface SKIP_LINK)
+endif()
+
+# Also manually apply the warnings to the kernel's internal dependencies
+target_link_libraries(bitcoin_clientversion PRIVATE kernel_warn_interface)
+target_link_libraries(bitcoin_crypto PRIVATE kernel_warn_interface)
+target_link_libraries(leveldb PRIVATE kernel_warn_interface)
+
 target_link_libraries(bitcoinkernel
   PRIVATE
     core_interface
+    kernel_warn_interface
     bitcoin_clientversion
     bitcoin_crypto
     leveldb

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -400,3 +400,10 @@ void LockedPoolManager::CreateInstance()
     static LockedPoolManager instance(std::move(allocator));
     LockedPoolManager::_instance = &instance;
 }
+
+LockedPoolManager& LockedPoolManager::Instance()
+{
+    static std::once_flag init_flag;
+    std::call_once(init_flag, LockedPoolManager::CreateInstance);
+    return *LockedPoolManager::_instance;
+}

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -219,12 +219,7 @@ class LockedPoolManager : public LockedPool
 {
 public:
     /** Return the current instance, or create it once */
-    static LockedPoolManager& Instance()
-    {
-        static std::once_flag init_flag;
-        std::call_once(init_flag, LockedPoolManager::CreateInstance);
-        return *LockedPoolManager::_instance;
-    }
+    static LockedPoolManager& Instance();
 
 private:
     explicit LockedPoolManager(std::unique_ptr<LockedPageAllocator> allocator);


### PR DESCRIPTION
The possibility of this happening came up in the discussion here: https://github.com/bitcoin/bitcoin/pull/31158#issuecomment-2635223309, and it turned that we already had a case of it in our code.

tl;dr: Certain symbols when defined in headers may end up existing in both the shared lib and the application using it, leading to subtle bugs. More info can be found [here](https://www.mail-archive.com/cfe-commits@lists.llvm.org/msg503669.html).

The solution is generally to avoid defining static/inline vars in headers if they aren't meant to be shared with downstream kernel users.

Clang has recently added a warning for this (see link above), so this PR enables that too. It adds a new place to specify warnings which only apply to the kernel. In this case, it's warnings that only apply to shared libs. But I can also imagine wanting to enable more aggressive warnings for the kernel than the rest of the code.

The warning is only enabled by clang 21 (which is not yet released), and only useful when our [kernel symbol visibility hack](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/CMakeLists.txt#L100) is disabled, which we can't do yet. So it's mostly a placeholder for the future. In the meantime it can be used manually by building clang from git and disabling our hack, which I've done, and can confirm that after this change there are no more warnings.