### PR TITLE
test: test_inv_block, use mocktime instead of waiting

### DIFF
--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -105,6 +105,8 @@ class TxDownloadTest(BitcoinTestFramework):
         tx = self.wallet.create_self_transfer()
         wtxid = int(tx['wtxid'], 16)
 
+        self.nodes[0].setmocktime(int(time.time()))
+
         self.log.info(
             "Announce the transaction to all nodes from all {} incoming peers, but never send it".format(NUM_INBOUND))
         msg = msg_inv([CInv(t=MSG_WTX, h=wtxid)])
@@ -125,7 +127,10 @@ class TxDownloadTest(BitcoinTestFramework):
         assert self.nodes[1].getpeerinfo()[0]['inbound'] == False
         timeout = 2 + INBOUND_PEER_TX_DELAY + GETDATA_TX_INTERVAL
         self.log.info("Tx should be received at node 1 after {} seconds".format(timeout))
-        self.sync_mempools(timeout=timeout)
+        self.nodes[0].bumpmocktime(timeout)
+        self.sync_mempools()
+
+        self.nodes[0].setmocktime(0)
 
     def test_in_flight_max(self):
         self.log.info("Test that we don't load peers with more than {} transaction requests immediately".format(MAX_GETDATA_IN_FLIGHT))


### PR DESCRIPTION
Performance issue reported in https://github.com/bitcoin/bitcoin/pull/31437#issuecomment-2640221382

It seems that code as-is waits for wall-clock time to pass to synchronize mempools. Locally, sometimes the subtest takes a couple seconds, sometimes it takes an additional minute.

Just use mocktime?