### PR TITLE
ci: Bump fuzz task timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -182,6 +182,7 @@ task:
   persistent_worker:
     labels:
       type: medium
+  timeout_in: 240m  # larger timeout, due to the high CPU demand
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
 


### PR DESCRIPTION
The fuzz task seems to be the most CPU intense task (going through GB of data through all fuzz inputs for all fuzz targets).

Normally, the task takes 44 minutes (example https://cirrus-ci.com/task/5077976091459584), but under higher load, it may take longer (https://cirrus-ci.com/task/5966231095738368).

I tried to move it to GHA to see how it compares, but it will be even slower there: https://github.com/maflcko/bitcoin-core-with-ci/actions/runs/13182526514/job/36796629409.

The CI machines were recently updated to increase the CI performance, so in theory they could be updated again, but this can take some time and seems like the wrong fix anyway, because it will just hide the problem:

Ideally fuzzing is fast and when evaluating a fuzz input takes more than 10 seconds, it feels more like a slow unit test loop. So ideally fuzz timeouts should be fixed (https://github.com/bitcoin/bitcoin/issues/31066, https://github.com/bitcoin/bitcoin/issues/30498, ...). However, this can also take time.

So temporarily bump the fuzz timeout for now.