### PR TITLE
build: consistently use `CLIENT_NAME` in libbitcoinkernel.pc.in

### DIFF
--- a/libbitcoinkernel.pc.in
+++ b/libbitcoinkernel.pc.in
@@ -4,7 +4,7 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @CLIENT_NAME@ kernel library
-Description: Experimental library for the Bitcoin Core validation engine.
+Description: Experimental library for the @CLIENT_NAME@ validation engine.
 Version: @CLIENT_VERSION_STRING@
 Libs: -L${libdir} -lbitcoinkernel
 Libs.private: -L${libdir} @LIBS_PRIVATE@


### PR DESCRIPTION
Follows up from when the `pc.in` was added.