### PR TITLE
streams: Add stream position validation in BufferedFile::AdvanceStream

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -516,6 +516,9 @@ private:
 
         size_t buffer_offset{static_cast<size_t>(m_read_pos % vchBuf.size())};
         size_t buffer_available{static_cast<size_t>(vchBuf.size() - buffer_offset)};
+        if (nSrcPos < m_read_pos) {
+            throw std::ios_base::failure("Invalid stream position");
+        }
         size_t bytes_until_source_pos{static_cast<size_t>(nSrcPos - m_read_pos)};
         size_t advance{std::min({length, buffer_available, bytes_until_source_pos})};
         m_read_pos += advance;


### PR DESCRIPTION
Description:
Add safety check in BufferedFile::AdvanceStream to prevent potential integer overflow when calculating bytes_until_source_pos. This ensures that m_read_pos never exceeds nSrcPos, which could lead to undefined behavior.

The change:
- Adds validation before calculating (nSrcPos - m_read_pos)
- Throws std::ios_base::failure if invalid state is detected