### PR TITLE
[WIP] build: name install targets as components

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,7 +171,6 @@ target_link_libraries(bitcoin_common
 )
 
 
-set(installable_targets)
 if(ENABLE_WALLET)
   add_subdirectory(wallet)
 
@@ -189,7 +188,11 @@ if(ENABLE_WALLET)
       bitcoin_util
       Boost::headers
     )
-    list(APPEND installable_targets bitcoin-wallet)
+    install(TARGETS bitcoin-wallet
+      RUNTIME
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT BitcoinWallet
+    )
   endif()
 endif()
 
@@ -318,7 +321,11 @@ if(BUILD_DAEMON)
     bitcoin_node
     $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
-  list(APPEND installable_targets bitcoind)
+  install(TARGETS bitcoind
+    RUNTIME
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT BitcoinD
+  )
 endif()
 if(WITH_MULTIPROCESS AND BUILD_DAEMON)
   add_executable(bitcoin-node
@@ -331,7 +338,11 @@ if(WITH_MULTIPROCESS AND BUILD_DAEMON)
     bitcoin_ipc
     $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
-  list(APPEND installable_targets bitcoin-node)
+  install(TARGETS bitcoin-node
+    RUNTIME
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT BitcoinNode
+  )
 endif()
 
 if(WITH_MULTIPROCESS AND BUILD_TESTS)
@@ -374,7 +385,11 @@ if(BUILD_CLI)
     libevent::core
     libevent::extra
   )
-  list(APPEND installable_targets bitcoin-cli)
+  install(TARGETS bitcoin-cli
+    RUNTIME
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT BitcoinCli
+  )
 endif()
 
 
@@ -387,7 +402,11 @@ if(BUILD_TX)
     bitcoin_util
     univalue
   )
-  list(APPEND installable_targets bitcoin-tx)
+  install(TARGETS bitcoin-tx
+    RUNTIME
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT BitcoinTx
+  )
 endif()
 
 
@@ -399,7 +418,11 @@ if(BUILD_UTIL)
     bitcoin_common
     bitcoin_util
   )
-  list(APPEND installable_targets bitcoin-util)
+  install(TARGETS bitcoin-util
+    RUNTIME
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT BitcoinUtil
+  )
 endif()
 
 
@@ -446,11 +469,6 @@ if(BUILD_FUZZ_BINARY)
   add_subdirectory(test/fuzz)
 endif()
 
-
-install(TARGETS ${installable_targets}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-unset(installable_targets)
 
 if(INSTALL_MAN)
   # TODO: these stubs are no longer needed. man pages should be generated at install time.


### PR DESCRIPTION
Adds component names to the CMake install targets to allow for component-based installs. Such installs are helpful when a user only wants to install `bitcoind` or `bitcoin-cli` executables specifically, for example.

At present, the component names use Pascal case to follow the existing convention for the only pre-existing named component `Kernel`, however, there is a convincing case to be made for using kebab-case to more intuitively match the names of the executable binaries.

Component based installs can be performed using:
```
cmake -B build
cmake --build build --target bitcoind bitcoin-cli
cmake --install build --component BitcoinD BitcoinCli
```

Supported targets:
- `BitcoinWallet`
- `BitcoinD`
- `BitcoinNode`
- `BitcoinCli`
- `BitcoinTx`
- `BitcoinUtil`

Attempts to close #31745.

Possible improvements:
- Scour other nested `CMakeLists.txt` files for additional targets.
- Switch to kebab-case

New contributor here; new to Bitcoin, new to CMake, happy to help, learn and receive feedback.

Currently submitted as a draft to inspect build results as a PoC.