### PR TITLE
test, tracing: don't use problematic `bpf_usdt_readarg_p()`

### DIFF
--- a/contrib/tracing/log_raw_p2p_msgs.py
+++ b/contrib/tracing/log_raw_p2p_msgs.py
@@ -78,6 +78,7 @@ BPF_PERF_OUTPUT(outbound_messages);
 int trace_inbound_message(struct pt_regs *ctx) {
     int idx = 0;
     struct p2p_message *msg = msg_arr.lookup(&idx);
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
 
     // lookup() does not return a NULL pointer. However, the BPF verifier
     // requires an explicit check that that the `msg` pointer isn't a NULL
@@ -85,11 +86,15 @@ int trace_inbound_message(struct pt_regs *ctx) {
     if (msg == NULL) return 1;
 
     bpf_usdt_readarg(1, ctx, &msg->peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg->peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg->peer_addr, sizeof(msg->peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg->peer_conn_type, sizeof(msg->peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
+    bpf_probe_read_user_str(&msg->msg_type, sizeof(msg->msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg->msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg->msg, _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg(6, ctx, &pmsg);
+    bpf_probe_read_user(&msg->msg, _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH), pmsg);
 
     inbound_messages.perf_submit(ctx, msg, sizeof(*msg));
     return 0;
@@ -99,17 +104,23 @@ int trace_outbound_message(struct pt_regs *ctx) {
     int idx = 0;
     struct p2p_message *msg = msg_arr.lookup(&idx);
 
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
+
     // lookup() does not return a NULL pointer. However, the BPF verifier
     // requires an explicit check that that the `msg` pointer isn't a NULL
     // pointer. See https://github.com/iovisor/bcc/issues/2595
     if (msg == NULL) return 1;
 
     bpf_usdt_readarg(1, ctx, &msg->peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg->peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg->peer_addr, sizeof(msg->peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg->peer_conn_type, sizeof(msg->peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
+    bpf_probe_read_user_str(&msg->msg_type, sizeof(msg->msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg->msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg->msg,  _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg(6, ctx, &pmsg);
+    bpf_probe_read_user(&msg->msg, _TRACEPOINT_TEST_MIN(msg->msg_size, MAX_MSG_DATA_LENGTH), pmsg);
 
     outbound_messages.perf_submit(ctx, msg, sizeof(*msg));
     return 0;

--- a/contrib/tracing/mempool_monitor.py
+++ b/contrib/tracing/mempool_monitor.py
@@ -65,8 +65,9 @@ BPF_PERF_OUTPUT(replaced_events);
 
 int trace_added(struct pt_regs *ctx) {
   struct added_event added = {};
-
-  bpf_usdt_readarg_p(1, ctx, &added.hash, HASH_LENGTH);
+  void *phash = NULL;
+  bpf_usdt_readarg(1, ctx, phash);
+  bpf_probe_read_user(&added.hash, sizeof(added.hash), phash);
   bpf_usdt_readarg(2, ctx, &added.vsize);
   bpf_usdt_readarg(3, ctx, &added.fee);
 
@@ -76,9 +77,11 @@ int trace_added(struct pt_regs *ctx) {
 
 int trace_removed(struct pt_regs *ctx) {
   struct removed_event removed = {};
-
-  bpf_usdt_readarg_p(1, ctx, &removed.hash, HASH_LENGTH);
-  bpf_usdt_readarg_p(2, ctx, &removed.reason, MAX_REMOVAL_REASON_LENGTH);
+  void *phash = NULL, *preason = NULL;
+  bpf_usdt_readarg(1, ctx, phash);
+  bpf_probe_read_user(&removed.hash, sizeof(removed.hash), phash);
+  bpf_usdt_readarg(1, ctx, preason);
+  bpf_probe_read_user_str(&removed.reason, sizeof(removed.reason), preason);
   bpf_usdt_readarg(3, ctx, &removed.vsize);
   bpf_usdt_readarg(4, ctx, &removed.fee);
   bpf_usdt_readarg(5, ctx, &removed.entry_time);
@@ -89,22 +92,25 @@ int trace_removed(struct pt_regs *ctx) {
 
 int trace_rejected(struct pt_regs *ctx) {
   struct rejected_event rejected = {};
-
-  bpf_usdt_readarg_p(1, ctx, &rejected.hash, HASH_LENGTH);
-  bpf_usdt_readarg_p(2, ctx, &rejected.reason, MAX_REJECT_REASON_LENGTH);
-
+  void *phash = NULL, *preason = NULL;
+  bpf_usdt_readarg(1, ctx, phash);
+  bpf_probe_read_user(&rejected.hash, sizeof(rejected.hash), phash);
+  bpf_usdt_readarg(1, ctx, preason);
+  bpf_probe_read_user_str(&rejected.reason, sizeof(rejected.reason), preason);
   rejected_events.perf_submit(ctx, &rejected, sizeof(rejected));
   return 0;
 }
 
 int trace_replaced(struct pt_regs *ctx) {
   struct replaced_event replaced = {};
-
-  bpf_usdt_readarg_p(1, ctx, &replaced.replaced_hash, HASH_LENGTH);
+  void *phash_replaced = NULL, *phash_replacement = NULL;
+  bpf_usdt_readarg(1, ctx, phash_replaced);
+  bpf_probe_read_user(&replaced.replaced_hash, sizeof(replaced.replaced_hash), phash_replaced);
   bpf_usdt_readarg(2, ctx, &replaced.replaced_vsize);
   bpf_usdt_readarg(3, ctx, &replaced.replaced_fee);
   bpf_usdt_readarg(4, ctx, &replaced.replaced_entry_time);
-  bpf_usdt_readarg_p(5, ctx, &replaced.replacement_hash, HASH_LENGTH);
+  bpf_usdt_readarg(5, ctx, phash_replacement);
+  bpf_probe_read_user(&replaced.replacement_hash, sizeof(replaced.replacement_hash), phash_replacement);
   bpf_usdt_readarg(6, ctx, &replaced.replacement_vsize);
   bpf_usdt_readarg(7, ctx, &replaced.replacement_fee);
 

--- a/contrib/tracing/p2p_monitor.py
+++ b/contrib/tracing/p2p_monitor.py
@@ -47,11 +47,15 @@ BPF_PERF_OUTPUT(outbound_messages);
 
 int trace_inbound_message(struct pt_regs *ctx) {
     struct p2p_message msg = {};
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL;
 
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 
     inbound_messages.perf_submit(ctx, &msg, sizeof(msg));
@@ -60,11 +64,15 @@ int trace_inbound_message(struct pt_regs *ctx) {
 
 int trace_outbound_message(struct pt_regs *ctx) {
     struct p2p_message msg = {};
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL;
 
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 
     outbound_messages.perf_submit(ctx, &msg, sizeof(msg));

--- a/test/functional/interface_usdt_coinselection.py
+++ b/test/functional/interface_usdt_coinselection.py
@@ -49,10 +49,13 @@ BPF_QUEUE(coin_selection_events, struct event_data, 1024);
 
 int trace_selected_coins(struct pt_regs *ctx) {
     struct event_data data;
+    void *pwallet_name = NULL, *palgo = NULL;
     __builtin_memset(&data, 0, sizeof(data));
     data.type = 1;
-    bpf_usdt_readarg_p(1, ctx, &data.wallet_name, WALLET_NAME_LENGTH);
-    bpf_usdt_readarg_p(2, ctx, &data.algo, ALGO_NAME_LENGTH);
+    bpf_usdt_readarg(1, ctx, &pwallet_name);
+    bpf_probe_read_user_str(&data.wallet_name, WALLET_NAME_LENGTH, pwallet_name);
+    bpf_usdt_readarg(2, ctx, &palgo);
+    bpf_probe_read_user_str(&data.algo, ALGO_NAME_LENGTH, palgo);
     bpf_usdt_readarg(3, ctx, &data.target);
     bpf_usdt_readarg(4, ctx, &data.waste);
     bpf_usdt_readarg(5, ctx, &data.selected_value);
@@ -62,9 +65,11 @@ int trace_selected_coins(struct pt_regs *ctx) {
 
 int trace_normal_create_tx(struct pt_regs *ctx) {
     struct event_data data;
+    void *pwallet_name = NULL;
     __builtin_memset(&data, 0, sizeof(data));
     data.type = 2;
-    bpf_usdt_readarg_p(1, ctx, &data.wallet_name, WALLET_NAME_LENGTH);
+    bpf_usdt_readarg(1, ctx, &pwallet_name);
+    bpf_probe_read_user_str(&data.wallet_name, WALLET_NAME_LENGTH, pwallet_name);
     bpf_usdt_readarg(2, ctx, &data.success);
     bpf_usdt_readarg(3, ctx, &data.fee);
     bpf_usdt_readarg(4, ctx, &data.change_pos);
@@ -74,18 +79,22 @@ int trace_normal_create_tx(struct pt_regs *ctx) {
 
 int trace_attempt_aps(struct pt_regs *ctx) {
     struct event_data data;
+    void *pwallet_name = NULL;
     __builtin_memset(&data, 0, sizeof(data));
     data.type = 3;
-    bpf_usdt_readarg_p(1, ctx, &data.wallet_name, WALLET_NAME_LENGTH);
+    bpf_usdt_readarg(1, ctx, &pwallet_name);
+    bpf_probe_read_user_str(&data.wallet_name, WALLET_NAME_LENGTH, pwallet_name);
     coin_selection_events.push(&data, 0);
     return 0;
 }
 
 int trace_aps_create_tx(struct pt_regs *ctx) {
     struct event_data data;
+    void *pwallet_name = NULL;
     __builtin_memset(&data, 0, sizeof(data));
     data.type = 4;
-    bpf_usdt_readarg_p(1, ctx, &data.wallet_name, WALLET_NAME_LENGTH);
+    bpf_usdt_readarg(1, ctx, &pwallet_name);
+    bpf_probe_read_user_str(&data.wallet_name, WALLET_NAME_LENGTH, pwallet_name);
     bpf_usdt_readarg(2, ctx, &data.use_aps);
     bpf_usdt_readarg(3, ctx, &data.success);
     bpf_usdt_readarg(4, ctx, &data.fee);

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -320,10 +320,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
         assert_equal(1, len(events))
         event = events[0]
         assert_equal(bytes(event.hash)[::-1].hex(), tx["tx"].hash)
-        # The next test is already known to fail, so disable it to avoid
-        # wasting CPU time and developer time. See
-        # https://github.com/bitcoin/bitcoin/issues/27380
-        #assert_equal(event.reason.decode("UTF-8"), "min relay fee not met")
+        assert_equal(event.reason.decode("UTF-8"), "min relay fee not met")
 
         bpf.cleanup()
         self.generate(self.wallet, 1)

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -75,8 +75,9 @@ BPF_PERF_OUTPUT(replaced_events);
 
 int trace_added(struct pt_regs *ctx) {
   struct added_event added = {};
-
-  bpf_usdt_readarg_p(1, ctx, &added.hash, HASH_LENGTH);
+  void *phash = NULL;
+  bpf_usdt_readarg(1, ctx, &phash);
+  bpf_probe_read_user(&added.hash, sizeof(added.hash), phash);
   bpf_usdt_readarg(2, ctx, &added.vsize);
   bpf_usdt_readarg(3, ctx, &added.fee);
 
@@ -86,9 +87,11 @@ int trace_added(struct pt_regs *ctx) {
 
 int trace_removed(struct pt_regs *ctx) {
   struct removed_event removed = {};
-
-  bpf_usdt_readarg_p(1, ctx, &removed.hash, HASH_LENGTH);
-  bpf_usdt_readarg_p(2, ctx, &removed.reason, MAX_REMOVAL_REASON_LENGTH);
+  void *phash = NULL, *preason = NULL;
+  bpf_usdt_readarg(1, ctx, &phash);
+  bpf_probe_read_user(&removed.hash, sizeof(removed.hash), phash);
+  bpf_usdt_readarg(2, ctx, &preason);
+  bpf_probe_read_user_str(&removed.reason, sizeof(removed.reason), preason);
   bpf_usdt_readarg(3, ctx, &removed.vsize);
   bpf_usdt_readarg(4, ctx, &removed.fee);
   bpf_usdt_readarg(5, ctx, &removed.entry_time);
@@ -99,22 +102,25 @@ int trace_removed(struct pt_regs *ctx) {
 
 int trace_rejected(struct pt_regs *ctx) {
   struct rejected_event rejected = {};
-
-  bpf_usdt_readarg_p(1, ctx, &rejected.hash, HASH_LENGTH);
-  bpf_usdt_readarg_p(2, ctx, &rejected.reason, MAX_REJECT_REASON_LENGTH);
-
+  void *phash = NULL, *preason = NULL;
+  bpf_usdt_readarg(1, ctx, &phash);
+  bpf_probe_read_user(&rejected.hash, sizeof(rejected.hash), phash);
+  bpf_usdt_readarg(2, ctx, &preason);
+  bpf_probe_read_user_str(&rejected.reason, sizeof(rejected.reason), preason);
   rejected_events.perf_submit(ctx, &rejected, sizeof(rejected));
   return 0;
 }
 
 int trace_replaced(struct pt_regs *ctx) {
   struct replaced_event replaced = {};
-
-  bpf_usdt_readarg_p(1, ctx, &replaced.replaced_hash, HASH_LENGTH);
+  void *preplaced_hash = NULL, *preplacement_hash = NULL;
+  bpf_usdt_readarg(1, ctx, &preplaced_hash);
+  bpf_probe_read_user(&replaced.replaced_hash, sizeof(replaced.replaced_hash), preplaced_hash);
   bpf_usdt_readarg(2, ctx, &replaced.replaced_vsize);
   bpf_usdt_readarg(3, ctx, &replaced.replaced_fee);
   bpf_usdt_readarg(4, ctx, &replaced.replaced_entry_time);
-  bpf_usdt_readarg_p(5, ctx, &replaced.replacement_hash, HASH_LENGTH);
+  bpf_usdt_readarg(5, ctx, &preplacement_hash);
+  bpf_probe_read_user(&replaced.replacement_hash, sizeof(replaced.replacement_hash), preplacement_hash);
   bpf_usdt_readarg(6, ctx, &replaced.replacement_vsize);
   bpf_usdt_readarg(7, ctx, &replaced.replacement_fee);
   bpf_usdt_readarg(8, ctx, &replaced.replaced_by_transaction);

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -91,12 +91,17 @@ struct MisbehavingConnection
 BPF_PERF_OUTPUT(inbound_messages);
 int trace_inbound_message(struct pt_regs *ctx) {
     struct p2p_message msg = {};
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
+    bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg.msg, _TRACEPOINT_TEST_MIN(msg.msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg(6, ctx, &pmsg);
+    bpf_probe_read_user(&msg.msg, _TRACEPOINT_TEST_MIN(msg.msg_size, MAX_MSG_DATA_LENGTH), pmsg);
     inbound_messages.perf_submit(ctx, &msg, sizeof(msg));
     return 0;
 }
@@ -104,12 +109,18 @@ int trace_inbound_message(struct pt_regs *ctx) {
 BPF_PERF_OUTPUT(outbound_messages);
 int trace_outbound_message(struct pt_regs *ctx) {
     struct p2p_message msg = {};
+    void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
-    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
-    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(1, ctx, &msg.peer_id);
+    bpf_usdt_readarg(2, ctx, &paddr);
+    bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
+    bpf_usdt_readarg(3, ctx, &pconn_type);
+    bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
+    bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
-    bpf_usdt_readarg_p(6, ctx, &msg.msg, _TRACEPOINT_TEST_MIN(msg.msg_size, MAX_MSG_DATA_LENGTH));
+    bpf_usdt_readarg(6, ctx, &pmsg);
+    bpf_probe_read_user(&msg.msg, _TRACEPOINT_TEST_MIN(msg.msg_size, MAX_MSG_DATA_LENGTH), pmsg);
     outbound_messages.perf_submit(ctx, &msg, sizeof(msg));
     return 0;
 };

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -35,7 +35,9 @@ struct utxocache_change
 BPF_PERF_OUTPUT(utxocache_add);
 int trace_utxocache_add(struct pt_regs *ctx) {
     struct utxocache_change add = {};
-    bpf_usdt_readarg_p(1, ctx, &add.txid, 32);
+    void *ptxid = NULL;
+    bpf_usdt_readarg(1, ctx, &ptxid);
+    bpf_probe_read_user(&add.txid, sizeof(add.txid), ptxid);
     bpf_usdt_readarg(2, ctx, &add.index);
     bpf_usdt_readarg(3, ctx, &add.height);
     bpf_usdt_readarg(4, ctx, &add.value);
@@ -47,7 +49,9 @@ int trace_utxocache_add(struct pt_regs *ctx) {
 BPF_PERF_OUTPUT(utxocache_spent);
 int trace_utxocache_spent(struct pt_regs *ctx) {
     struct utxocache_change spent = {};
-    bpf_usdt_readarg_p(1, ctx, &spent.txid, 32);
+    void *ptxid = NULL;
+    bpf_usdt_readarg(1, ctx, &ptxid);
+    bpf_probe_read_user(&spent.txid, sizeof(spent.txid), ptxid);
     bpf_usdt_readarg(2, ctx, &spent.index);
     bpf_usdt_readarg(3, ctx, &spent.height);
     bpf_usdt_readarg(4, ctx, &spent.value);
@@ -59,7 +63,9 @@ int trace_utxocache_spent(struct pt_regs *ctx) {
 BPF_PERF_OUTPUT(utxocache_uncache);
 int trace_utxocache_uncache(struct pt_regs *ctx) {
     struct utxocache_change uncache = {};
-    bpf_usdt_readarg_p(1, ctx, &uncache.txid, 32);
+    void *ptxid = NULL;
+    bpf_usdt_readarg(1, ctx, &ptxid);
+    bpf_probe_read_user(&uncache.txid, sizeof(uncache.txid), ptxid);
     bpf_usdt_readarg(2, ctx, &uncache.index);
     bpf_usdt_readarg(3, ctx, &uncache.height);
     bpf_usdt_readarg(4, ctx, &uncache.value);

--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -39,7 +39,9 @@ struct connected_block
 BPF_PERF_OUTPUT(block_connected);
 int trace_block_connected(struct pt_regs *ctx) {
     struct connected_block block = {};
-    bpf_usdt_readarg_p(1, ctx, &block.hash, 32);
+    void *phash = NULL;
+    bpf_usdt_readarg(1, ctx, &phash);
+    bpf_probe_read_user(&block.hash, sizeof(block.hash), phash);
     bpf_usdt_readarg(2, ctx, &block.height);
     bpf_usdt_readarg(3, ctx, &block.transactions);
     bpf_usdt_readarg(4, ctx, &block.inputs);


### PR DESCRIPTION
Instead of using the undocumented bcc helper `bpf_usdt_readarg_p()`, use [`bpf_usdt_readarg()`][1] and [`bpf_probe_read_user()`][2]/[`bpf_probe_read_user_str()`][3] as documented in the [bcc USDT reference guide][1].

Note that the `bpf_probe_read_user()` documentation says the following:
> For safety, all user address space memory reads must pass through bpf_probe_read_user().

It's [assumed](https://github.com/bitcoin/bitcoin/issues/27380#issuecomment-2286505348) that using `bpf_usdt_readarg_p()` caused a lifetime issue. With `bpf_usdt_readarg()` and `bpf_probe_read_user()`, this doesn't [seem](https://github.com/bitcoin/bitcoin/issues/27380#issuecomment-2528671656) to be a problem anymore.

This allows to revert https://github.com/bitcoin/bitcoin/commit/faed5337435f025811caeb5f782ecbf9683a24b3 and closes #27380.

  [1]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#6-usdt-probes
  [2]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#10-bpf_probe_read_user
  [3]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#11-bpf_probe_read_user_str