### PR TITLE
depends: set `CMAKE_*_COMPILER_TARGET` in toolchain

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -203,6 +203,7 @@ endif
 $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(final_build_id)
 	@mkdir -p $(@D)
 	sed -e 's|@depends_crosscompiling@|$(crosscompiling)|' \
+            -e 's|@host@|$(host)|' \
             -e 's|@host_system_name@|$($(host_os)_cmake_system_name)|' \
             -e 's|@host_system_version@|$($(host_os)_cmake_system_version)|' \
             -e 's|@host_arch@|$(host_arch)|' \

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -13,6 +13,10 @@ if(@depends_crosscompiling@)
   set(CMAKE_SYSTEM_NAME @host_system_name@)
   set(CMAKE_SYSTEM_VERSION @host_system_version@)
   set(CMAKE_SYSTEM_PROCESSOR @host_arch@)
+
+  set(CMAKE_C_COMPILER_TARGET @host@)
+  set(CMAKE_CXX_COMPILER_TARGET @host@)
+  set(CMAKE_OBJCXX_COMPILER_TARGET @host@)
 endif()
 
 if(NOT DEFINED CMAKE_C_FLAGS_INIT)


### PR DESCRIPTION
According to the CMake docs, this is the correct way to setup a toolchain file for cross-compilation using Clang. See https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-using-clang

Internally it looks like CMake will only take this variable into account if it detects the compiler to be Clang, so this shouldn't effect other builds, but in the case of our Apple cross builds, we'd end up with a duplicated `--target=$ARCH-apple-darwin` on the compiler line, given we are already setting `--target` for Darwin builds.

Would fix #31748.