### PR TITLE
doc: build: Fix instructions for msvc gui builds

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -59,6 +59,17 @@ ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests
 cmake --install build --config Release         # Optional.
 ```
 
+If building with `BUILD_GUI=ON`, vcpkg installation during the build
+configuration step might fail because of extremely long paths required during
+vcpkg installation if your vcpkg instance is installed in the default Visual
+Studio directory. This can be avoided without modifying your vcpkg root
+directory by changing vcpkg's intermediate build directory with the
+`--x-buildtrees-root` argument to something shorter, for example:
+
+```powershell
+cmake -B build --preset vs2022-static -DVCPKG_INSTALL_OPTIONS="--x-buildtrees-root=C:\vcpkg"
+```
+
 ### 5. Building with Dynamic Linking without GUI
 
 ```


### PR DESCRIPTION
If the instructions in `doc/build-windows-msvc.md` are followed as-is, and "Developer (PowerShell|Command Prompt) for VS 2022" is used to execute the suggested build commands, the root directory of vcpkg (e.g. in VS 2022 Community edition: `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg`), is too long, and when vcpkg attempts to build any of the QT packages, it will fail because of build steps that require path lengths greater than Windows' `MAX_PATH` 260 character limit. This can be avoided without needing to move the vcpkg root dir by setting [`--x-buildtrees-root`](https://learn.microsoft.com/en-us/vcpkg/commands/common-options#buildtrees-root) to a short path, like `C:\vcpkg`.

See e.g. https://github.com/microsoft/vcpkg/issues/28451, https://github.com/microsoft/vcpkg/issues/28083, https://github.com/microsoft/vcpkg/issues/24751.