### PR TITLE
depends: avoid an unset `CMAKE_OBJDUMP`

### DIFF
--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -9,6 +9,7 @@ default_host_RANLIB = $(host_toolchain)ranlib
 default_host_STRIP = $(host_toolchain)strip
 default_host_NM = $(host_toolchain)nm
 default_host_OBJCOPY = $(host_toolchain)objcopy
+default_host_OBJDUMP = $(host_toolchain)objdump
 
 define add_host_tool_func
 ifneq ($(filter $(origin $1),undefined default),)


### PR DESCRIPTION
Similar to #31840, currently our Linux toolchain file contains:
```bash
set(CMAKE_AR "aarch64-linux-gnu-ar")
set(CMAKE_RANLIB "aarch64-linux-gnu-ranlib")
set(CMAKE_STRIP "aarch64-linux-gnu-strip")
set(CMAKE_OBJCOPY "aarch64-linux-gnu-objcopy")
set(CMAKE_OBJDUMP "")
```

`objdump` is currently only used for the macOS cross build, where it's `llvm-objdump`, but we should be consistent in producing a toolchain file that points to actual tools, rather than leaving variables unset.