### PR TITLE
test: Rename send_message to send_without_ping

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -183,7 +183,7 @@ way is the use the `profile_with_perf` context manager, e.g.
 with node.profile_with_perf("send-big-msgs"):
     # Perform activity on the node you're interested in profiling, e.g.:
     for _ in range(10000):
-        node.p2ps[0].send_message(some_large_message)
+        node.p2ps[0].send_without_ping(some_large_message)
 ```
 
 To see useful textual output, run

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -184,7 +184,7 @@ class ExampleTest(BitcoinTestFramework):
             block.solve()
             block_message = msg_block(block)
             # Send message is used to send a P2P message to the node over our P2PInterface
-            peer_messaging.send_message(block_message)
+            peer_messaging.send_without_ping(block_message)
             self.tip = block.sha256
             blocks.append(self.tip)
             self.block_time += 1
@@ -209,7 +209,7 @@ class ExampleTest(BitcoinTestFramework):
         getdata_request = msg_getdata()
         for block in blocks:
             getdata_request.inv.append(CInv(MSG_BLOCK, block))
-        peer_receiving.send_message(getdata_request)
+        peer_receiving.send_without_ping(getdata_request)
 
         # wait_until() will loop until a predicate condition is met. Use it to test properties of the
         # P2PInterface objects.

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -309,7 +309,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         msg = msg_headers()
         for block_num in range(1, miner.getblockcount()+1):
             msg.headers.append(from_hex(CBlockHeader(), miner.getblockheader(miner.getblockhash(block_num), verbose=False)))
-        headers_provider_conn.send_message(msg)
+        headers_provider_conn.send_without_ping(msg)
 
         # Ensure headers arrived
         default_value = {'status': ''}  # No status

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -58,7 +58,7 @@ class BaseNode(P2PInterface):
     def send_header_for_blocks(self, new_blocks):
         headers_message = msg_headers()
         headers_message.headers = [CBlockHeader(b) for b in new_blocks]
-        self.send_message(headers_message)
+        self.send_without_ping(headers_message)
 
 
 class AssumeValidTest(BitcoinTestFramework):
@@ -80,7 +80,7 @@ class AssumeValidTest(BitcoinTestFramework):
             if not p2p_conn.is_connected:
                 break
             try:
-                p2p_conn.send_message(msg_block(self.blocks[i]))
+                p2p_conn.send_without_ping(msg_block(self.blocks[i]))
             except IOError:
                 assert not p2p_conn.is_connected
                 break
@@ -157,7 +157,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Send all blocks to node1. All blocks will be accepted.
         for i in range(2202):
-            p2p1.send_message(msg_block(self.blocks[i]))
+            p2p1.send_without_ping(msg_block(self.blocks[i]))
         # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
         p2p1.sync_with_ping(timeout=960)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -124,7 +124,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # the test has been running so far).
         with self.nodes[0].assert_debug_log(expected_msgs=["historical block serving limit reached, disconnecting peer=0"]):
             for _ in range(3):
-                p2p_conns[0].send_message(getdata_request)
+                p2p_conns[0].send_without_ping(getdata_request)
             p2p_conns[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
         self.log.info("Peer 0 disconnected after downloading old block too many times")
@@ -148,7 +148,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # But if p2p_conns[1] tries for an old block, it gets disconnected too.
         getdata_request.inv = [CInv(MSG_BLOCK, big_old_block)]
         with self.nodes[0].assert_debug_log(expected_msgs=["historical block serving limit reached, disconnecting peer=1"]):
-            p2p_conns[1].send_message(getdata_request)
+            p2p_conns[1].send_without_ping(getdata_request)
             p2p_conns[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 1)
 
@@ -198,7 +198,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         self.log.info("Peer gets disconnected for a mempool request after limit is reached")
         with self.nodes[0].assert_debug_log(expected_msgs=["mempool request with bandwidth limit reached, disconnecting peer=0"]):
-            peer.send_message(msg_mempool())
+            peer.send_without_ping(msg_mempool())
             peer.wait_for_disconnect()
 
         self.log.info("Test passing an unparsable value to -maxuploadtarget throws an error")

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -47,7 +47,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         for _ in range(numblocks):
             block = create_block(tip, create_coinbase(height + 1), block_time, version=version)
             block.solve()
-            peer.send_message(msg_block(block))
+            peer.send_without_ping(msg_block(block))
             block_time += 1
             height += 1
             tip = block.sha256

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -473,7 +473,7 @@ class NetTracepointTest(BitcoinTestFramework):
         for _ in range(EXPECTED_MISBEHAVING_CONNECTIONS):
             testnode = P2PInterface()
             self.nodes[0].add_p2p_connection(testnode)
-            testnode.send_message(msg)
+            testnode.send_without_ping(msg)
             bpf.perf_buffer_poll(timeout=500)
             testnode.peer_disconnect()
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -76,9 +76,9 @@ class AddrReceiver(P2PInterface):
 
     def on_version(self, message):
         self.send_version()
-        self.send_message(msg_verack())
+        self.send_without_ping(msg_verack())
         if (self.send_getaddr):
-            self.send_message(msg_getaddr())
+            self.send_without_ping(msg_getaddr())
 
     def getaddr_received(self):
         return self.message_count['getaddr'] > 0
@@ -142,7 +142,7 @@ class AddrTest(BitcoinTestFramework):
 
         msg = self.setup_addr_msg(1010)
         with self.nodes[0].assert_debug_log(['addr message size = 1010']):
-            addr_source.send_message(msg)
+            addr_source.send_without_ping(msg)
             addr_source.wait_for_disconnect()
 
         self.nodes[0].disconnect_p2ps()

--- a/test/functional/p2p_addrfetch.py
+++ b/test/functional/p2p_addrfetch.py
@@ -62,7 +62,7 @@ class P2PAddrFetch(BitcoinTestFramework):
 
         self.log.info("Check that answering with larger addr messages leads to disconnect")
         msg.addrs = [ADDR] * 2
-        peer.send_message(msg)
+        peer.send_without_ping(msg)
         peer.wait_for_disconnect(timeout=5)
 
         self.log.info("Check timeout for addr-fetch peer that does not send addrs")

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -79,7 +79,7 @@ class AddrTest(BitcoinTestFramework):
         self.log.info('Check disconnection when sending sendaddrv2 after verack')
         conn = self.nodes[0].add_p2p_connection(P2PInterface())
         with self.nodes[0].assert_debug_log(['sendaddrv2 received after verack, disconnecting peer=0']):
-            conn.send_message(msg_sendaddrv2())
+            conn.send_without_ping(msg_sendaddrv2())
             conn.wait_for_disconnect()
 
         self.log.info('Create connection that sends addrv2 messages')
@@ -104,7 +104,7 @@ class AddrTest(BitcoinTestFramework):
         self.log.info('Send too-large addrv2 message')
         msg.addrs = ADDRS * 101
         with self.nodes[0].assert_debug_log(['addrv2 message size = 1010']):
-            addr_source.send_message(msg)
+            addr_source.send_without_ping(msg)
             addr_source.wait_for_disconnect()
 
 

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -212,7 +212,7 @@ class CompactFiltersTest(BitcoinTestFramework):
         for request in requests:
             peer_1 = self.nodes[1].add_p2p_connection(P2PInterface())
             with self.nodes[1].assert_debug_log(expected_msgs=["requested unsupported block filter type"]):
-                peer_1.send_message(request)
+                peer_1.send_without_ping(request)
                 peer_1.wait_for_disconnect()
 
         self.log.info("Check that invalid requests result in disconnection.")
@@ -259,7 +259,7 @@ class CompactFiltersTest(BitcoinTestFramework):
         for request, expected_log_msg in requests:
             peer_0 = self.nodes[0].add_p2p_connection(P2PInterface())
             with self.nodes[0].assert_debug_log(expected_msgs=[expected_log_msg]):
-                peer_0.send_message(request)
+                peer_0.send_without_ping(request)
                 peer_0.wait_for_disconnect()
 
         self.log.info("Test -peerblockfilters without -blockfilterindex raises an error")

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -34,7 +34,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
         self.log.info('Check that tx invs also violate the protocol')
         self.nodes[0].add_p2p_connection(P2PInterface())
         with self.nodes[0].assert_debug_log(['transaction (0000000000000000000000000000000000000000000000000000000000001234) inv sent in violation of protocol, disconnecting peer']):
-            self.nodes[0].p2ps[0].send_message(msg_inv([CInv(t=MSG_WTX, h=0x1234)]))
+            self.nodes[0].p2ps[0].send_without_ping(msg_inv([CInv(t=MSG_WTX, h=0x1234)]))
             self.nodes[0].p2ps[0].wait_for_disconnect()
             del self.nodes[0].p2ps[0]
 
@@ -68,7 +68,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
             # But if, for some reason, first_peer decides to relay transactions to us anyway, we should relay them to
             # second_peer since we gave relay permission to first_peer.
             # See https://github.com/bitcoin/bitcoin/issues/19943 for details.
-            first_peer.send_message(msg_tx(tx))
+            first_peer.send_without_ping(msg_tx(tx))
             self.log.info('Check that the peer with relay-permission is still connected after sending the transaction')
             assert_equal(first_peer.is_connected, True)
             second_peer.wait_for_tx(txid)
@@ -107,7 +107,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
     def check_p2p_inv_violation(self, peer):
         self.log.info("Check that tx-invs from P2P are rejected and result in disconnect")
         with self.nodes[0].assert_debug_log(["inv sent in violation of protocol, disconnecting peer"]):
-            peer.send_message(msg_inv([CInv(t=MSG_WTX, h=0x12345)]))
+            peer.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=0x12345)]))
             peer.wait_for_disconnect()
         self.nodes[0].disconnect_p2ps()
 
@@ -116,7 +116,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
         spendtx = self.miniwallet.create_self_transfer()
 
         with self.nodes[0].assert_debug_log(['transaction sent in violation of protocol, disconnecting peer=0']):
-            self.nodes[0].p2ps[0].send_message(msg_tx(spendtx['tx']))
+            self.nodes[0].p2ps[0].send_without_ping(msg_tx(spendtx['tx']))
             self.nodes[0].p2ps[0].wait_for_disconnect()
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 0)
         self.nodes[0].disconnect_p2ps()

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -112,7 +112,7 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
                 return False
             return p2p_conn_blocksonly.last_message['cmpctblock'].header_and_shortids.header.rehash() == block.sha256
 
-        p2p_conn_blocksonly.send_message(msg_getdata([CInv(MSG_CMPCT_BLOCK, block0.sha256)]))
+        p2p_conn_blocksonly.send_without_ping(msg_getdata([CInv(MSG_CMPCT_BLOCK, block0.sha256)]))
         p2p_conn_blocksonly.wait_until(lambda: test_for_cmpctblock(block0))
 
         # Request BIP152 high bandwidth mode from the -blocksonly node.

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -93,19 +93,16 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
 
         block1 = self.build_block_on_tip()
 
-        p2p_conn_blocksonly.send_message(msg_headers(headers=[CBlockHeader(block1)]))
-        p2p_conn_blocksonly.sync_with_ping()
+        p2p_conn_blocksonly.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
         assert_equal(p2p_conn_blocksonly.last_message['getdata'].inv, [CInv(MSG_BLOCK | MSG_WITNESS_FLAG, block1.sha256)])
 
-        p2p_conn_high_bw.send_message(msg_headers(headers=[CBlockHeader(block1)]))
-        p2p_conn_high_bw.sync_with_ping()
+        p2p_conn_high_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
         assert_equal(p2p_conn_high_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.sha256)])
 
         self.log.info("Test that getdata(CMPCT) is still sent on BIP152 low bandwidth connections"
                       " when no -blocksonly nodes are involved")
 
         p2p_conn_low_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
-        p2p_conn_low_bw.sync_with_ping()
         assert_equal(p2p_conn_low_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.sha256)])
 
         self.log.info("Test that -blocksonly nodes still serve compact blocks")

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -34,13 +34,13 @@ from test_framework.wallet import MiniWallet
 class SlowP2PDataStore(P2PDataStore):
     def on_ping(self, message):
         time.sleep(0.1)
-        self.send_message(msg_pong(message.nonce))
+        self.send_without_ping(msg_pong(message.nonce))
 
 
 class SlowP2PInterface(P2PInterface):
     def on_ping(self, message):
         time.sleep(0.1)
-        self.send_message(msg_pong(message.nonce))
+        self.send_without_ping(msg_pong(message.nonce))
 
 
 class P2PEvict(BitcoinTestFramework):
@@ -82,7 +82,7 @@ class P2PEvict(BitcoinTestFramework):
             txpeer.sync_with_ping()
 
             tx = self.wallet.create_self_transfer()['tx']
-            txpeer.send_message(msg_tx(tx))
+            txpeer.send_without_ping(msg_tx(tx))
             protected_peers.add(current_peer)
 
         self.log.info("Create 8 peers and protect them from eviction by having faster pings")

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -62,7 +62,7 @@ class P2PBloomFilter(P2PInterface):
             else:
                 want.inv.append(i)
         if len(want.inv):
-            self.send_message(want)
+            self.send_without_ping(want)
 
     def on_merkleblock(self, message):
         self._merkleblock_received = True
@@ -146,11 +146,11 @@ class FilterTest(BitcoinTestFramework):
         self.log.info("Send a mempool msg after connecting and check that the relevant tx is announced")
         self.nodes[0].add_p2p_connection(filter_peer)
         filter_peer.send_and_ping(filter_peer.watch_filter_init)
-        filter_peer.send_message(msg_mempool())
+        filter_peer.send_without_ping(msg_mempool())
         filter_peer.wait_for_tx(rel_txid)
 
         self.log.info("Request the irrelevant transaction even though it was not announced")
-        filter_peer.send_message(msg_getdata([CInv(t=MSG_WTX, h=int(irr_wtxid, 16))]))
+        filter_peer.send_without_ping(msg_getdata([CInv(t=MSG_WTX, h=int(irr_wtxid, 16))]))
         self.log.info("We should get it anyway because it was in the mempool on connection to peer")
         filter_peer.wait_for_tx(irr_txid)
 
@@ -242,7 +242,7 @@ class FilterTest(BitcoinTestFramework):
         version_without_fRelay.strSubVer = P2P_SUBVERSION
         version_without_fRelay.nServices = P2P_SERVICES
         version_without_fRelay.relay = 0
-        filter_peer_without_nrelay.send_message(version_without_fRelay)
+        filter_peer_without_nrelay.send_without_ping(version_without_fRelay)
         filter_peer_without_nrelay.wait_for_verack()
         assert not self.nodes[0].getpeerinfo()[0]['relaytxes']
         self.test_frelay_false(filter_peer_without_nrelay)

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -50,13 +50,13 @@ class P2PFingerprintTest(BitcoinTestFramework):
     def send_block_request(self, block_hash, node):
         msg = msg_getdata()
         msg.inv.append(CInv(MSG_BLOCK, block_hash))
-        node.send_message(msg)
+        node.send_without_ping(msg)
 
     # Send a getheaders request for a given single block hash
     def send_header_request(self, block_hash, node):
         msg = msg_getheaders()
         msg.hashstop = block_hash
-        node.send_message(msg)
+        node.send_without_ping(msg)
 
     # Checks that stale blocks timestamped more than a month ago are not served
     # by the node while recent stale blocks and old active chain blocks are.
@@ -78,7 +78,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
         new_blocks = self.build_chain(5, block_hash, height, block_time)
 
         # Force reorg to a longer chain
-        node0.send_message(msg_headers(new_blocks))
+        node0.send_without_ping(msg_headers(new_blocks))
         node0.wait_for_getdata([x.sha256 for x in new_blocks])
         for block in new_blocks:
             node0.send_and_ping(msg_block(block))

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -38,7 +38,7 @@ class P2PStaller(P2PDataStore):
             self.getdata_requests.append(inv.hash)
             if (inv.type & MSG_TYPE_MASK) == MSG_BLOCK:
                 if (inv.hash != self.stall_block):
-                    self.send_message(msg_block(self.block_store[inv.hash]))
+                    self.send_without_ping(msg_block(self.block_store[inv.hash]))
 
     def on_getheaders(self, message):
         pass
@@ -78,7 +78,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         for id in range(NUM_PEERS):
             peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
             peers[-1].block_store = block_dict
-            peers[-1].send_message(headers_message)
+            peers[-1].send_without_ping(headers_message)
 
         # Need to wait until 1023 blocks are received - the magic total bytes number is a workaround in lack of an rpc
         # returning the number of downloaded (but not connected) blocks.
@@ -96,7 +96,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         headers_message.headers = [CBlockHeader(b) for b in blocks]
         with node.assert_debug_log(expected_msgs=['Stall started']):
             for p in peers:
-                p.send_message(headers_message)
+                p.send_without_ping(headers_message)
             self.all_sync_send_with_ping(peers)
 
         self.log.info("Check that the stalling peer is disconnected after 2 seconds")
@@ -139,7 +139,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         with node.assert_debug_log(expected_msgs=['Decreased stalling timeout to 2 seconds']):
             for p in peers:
                 if p.is_connected and (stall_block in p.getdata_requests):
-                    p.send_message(msg_block(block_dict[stall_block]))
+                    p.send_without_ping(msg_block(block_dict[stall_block]))
 
         self.log.info("Check that all outstanding blocks get connected")
         self.wait_until(lambda: node.getblockcount() == NUM_BLOCKS)

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -45,7 +45,7 @@ class HeadersSyncTest(BitcoinTestFramework):
         # An empty reply will clear the outstanding getheaders request,
         # allowing additional getheaders requests to be sent to this peer in
         # the future.
-        peer1.send_message(msg_headers())
+        peer1.send_without_ping(msg_headers())
 
         self.log.info("Connecting two more peers to node0")
         # Connect 2 more peers; they should not receive a getheaders yet
@@ -66,7 +66,7 @@ class HeadersSyncTest(BitcoinTestFramework):
 
         self.log.info("Check that peer1 receives a getheaders in response")
         peer1.wait_for_getheaders(block_hash=best_block_hash)
-        peer1.send_message(msg_headers()) # Send empty response, see above
+        peer1.send_without_ping(msg_headers()) # Send empty response, see above
 
         self.log.info("Check that exactly 1 of {peer2, peer3} received a getheaders in response")
         count = 0
@@ -76,7 +76,7 @@ class HeadersSyncTest(BitcoinTestFramework):
                 if "getheaders" in p.last_message:
                     count += 1
                     peer_receiving_getheaders = p
-                    p.send_message(msg_headers()) # Send empty response, see above
+                    p.send_without_ping(msg_headers()) # Send empty response, see above
 
         assert_equal(count, 1)
 

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -24,14 +24,14 @@ class InvalidLocatorTest(BitcoinTestFramework):
             self.log.info('Wait for disconnect when sending {} hashes in locator'.format(MAX_LOCATOR_SZ + 1))
             exceed_max_peer = node.add_p2p_connection(P2PInterface())
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ + 1), -1)]
-            exceed_max_peer.send_message(msg)
+            exceed_max_peer.send_without_ping(msg)
             exceed_max_peer.wait_for_disconnect()
             node.disconnect_p2ps()
 
             self.log.info('Wait for response when sending {} hashes in locator'.format(MAX_LOCATOR_SZ))
             within_max_peer = node.add_p2p_connection(P2PInterface())
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ), -1)]
-            within_max_peer.send_message(msg)
+            within_max_peer.send_without_ping(msg)
             if type(msg) is msg_getheaders:
                 within_max_peer.wait_for_header(node.getbestblockhash())
             else:

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -261,7 +261,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         self.log.info("Test {} message of size {} is logged as misbehaving".format(msg_type, size))
         with self.nodes[0].assert_debug_log(['Misbehaving', '{} message size = {}'.format(msg_type, size)]):
             conn = self.nodes[0].add_p2p_connection(P2PInterface())
-            conn.send_message(msg)
+            conn.send_without_ping(msg)
             conn.wait_for_disconnect()
         self.nodes[0].disconnect_p2ps()
 
@@ -304,7 +304,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
             blockheader.nNonce += 1
             blockheader.rehash()
         with self.nodes[0].assert_debug_log(['Misbehaving', 'header with invalid proof of work']):
-            peer.send_message(msg_headers([blockheader]))
+            peer.send_without_ping(msg_headers([blockheader]))
             peer.wait_for_disconnect()
 
     def test_noncontinuous_headers_msg(self):
@@ -323,7 +323,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         # delete arbitrary block header somewhere in the middle to break link
         del block_headers[random.randrange(1, len(block_headers)-1)]
         with self.nodes[0].assert_debug_log(expected_msgs=MISBEHAVING_NONCONTINUOUS_HEADERS_MSGS):
-            peer.send_message(msg_headers(block_headers))
+            peer.send_without_ping(msg_headers(block_headers))
             peer.wait_for_disconnect()
         self.nodes[0].disconnect_p2ps()
 
@@ -338,7 +338,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
         self.log.info("(a) Send 80 messages, each of maximum valid data size (4MB)")
         for _ in range(80):
-            conn.send_message(msg_at_size)
+            conn.send_without_ping(msg_at_size)
 
         # Check that, even though the node is being hammered by nonsense from one
         # connection, it can still service other peers in a timely way.

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -84,8 +84,8 @@ class NoVerackIdlePeer(LazyPeer):
     # list!
     def on_version(self, message):
         self.version_received = True
-        self.send_message(msg_ping())
-        self.send_message(msg_getaddr())
+        self.send_without_ping(msg_ping())
+        self.send_without_ping(msg_getaddr())
 
 
 class P2PVersionStore(P2PInterface):
@@ -121,7 +121,7 @@ class P2PLeakTest(BitcoinTestFramework):
         # Pre-wtxidRelay peer that sends a version but not a verack and does not support feature negotiation
         # messages which start at nVersion == 70016
         pre_wtxidrelay_peer = self.nodes[0].add_p2p_connection(NoVerackIdlePeer(), send_version=False, wait_for_verack=False)
-        pre_wtxidrelay_peer.send_message(self.create_old_version(70015))
+        pre_wtxidrelay_peer.send_without_ping(self.create_old_version(70015))
 
         # Wait until the peer gets the verack in response to the version. Though, don't wait for the node to receive the
         # verack, since the peer never sent one
@@ -173,7 +173,7 @@ class P2PLeakTest(BitcoinTestFramework):
         self.log.info('Check that old peers are disconnected')
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(["using obsolete version 31799, disconnecting peer=5"]):
-            p2p_old_peer.send_message(self.create_old_version(31799))
+            p2p_old_peer.send_without_ping(self.create_old_version(31799))
             p2p_old_peer.wait_for_disconnect()
 
 

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -60,7 +60,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # Announce the new block via a compact block through the honest relayer
         cmpctblock = HeaderAndShortIDs()
         cmpctblock.initialize_from_block(block, use_witness=True)
-        honest_relayer.send_message(msg_cmpctblock(cmpctblock.to_p2p()))
+        honest_relayer.send_without_ping(msg_cmpctblock(cmpctblock.to_p2p()))
 
         # Wait for a `getblocktxn` that attempts to fetch the self-transfer
         def self_transfer_requested():
@@ -80,7 +80,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # Attempt to clear the honest relayer's download request by sending the
         # mutated block (as the attacker).
         with self.nodes[0].assert_debug_log(expected_msgs=["Block mutated: bad-txnmrklroot, hashMerkleRoot mismatch"]):
-            attacker.send_message(msg_block(mutated_block))
+            attacker.send_without_ping(msg_block(mutated_block))
         # Attacker should get disconnected for sending a mutated block
         attacker.wait_for_disconnect(timeout=5)
 
@@ -107,7 +107,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # Check that non-connecting block causes disconnect
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
         with self.nodes[0].assert_debug_log(expected_msgs=["AcceptBlock FAILED (prev-blk-not-found)"]):
-            attacker.send_message(msg_block(block_missing_prev))
+            attacker.send_without_ping(msg_block(block_missing_prev))
         attacker.wait_for_disconnect(timeout=5)
 
 

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -26,7 +26,7 @@ class P2PNoBloomFilterMessages(BitcoinTestFramework):
     def test_message_causes_disconnect(self, message):
         """Add a p2p connection that sends a message and check that it disconnects."""
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
-        peer.send_message(message)
+        peer.send_without_ping(message)
         peer.wait_for_disconnect()
         assert_equal(self.nodes[0].getconnectioncount(), 0)
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -40,7 +40,7 @@ class P2PIgnoreInv(P2PInterface):
     def send_getdata_for_block(self, blockhash):
         getdata_request = msg_getdata()
         getdata_request.inv.append(CInv(MSG_BLOCK, int(blockhash, 16)))
-        self.send_message(getdata_request)
+        self.send_without_ping(getdata_request)
 
 class NodeNetworkLimitedTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -249,7 +249,7 @@ class PackageRelayTest(BitcoinTestFramework):
         assert tx_orphan_bad_wit.rehash() not in node_mempool
 
         # 5. Have the other peer send the tx too, so that tx_orphan_bad_wit package is attempted.
-        bad_orphan_sender.send_message(msg_tx(low_fee_parent["tx"]))
+        bad_orphan_sender.send_without_ping(msg_tx(low_fee_parent["tx"]))
         bad_orphan_sender.wait_for_disconnect()
 
         # The peer that didn't provide the orphan should not be disconnected.

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -312,7 +312,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
         # Even though the peer would send a notfound for the "old" confirmed transaction, the node
         # doesn't give up on the orphan. Once all of the missing parents are received, it should be
         # submitted to mempool.
-        peer.send_message(msg_notfound(vec=[CInv(MSG_WITNESS_TX, int(txid_conf_old, 16))]))
+        peer.send_without_ping(msg_notfound(vec=[CInv(MSG_WITNESS_TX, int(txid_conf_old, 16))]))
         # Sync with ping to ensure orphans are reconsidered
         peer.send_and_ping(msg_tx(missing_tx["tx"]))
         assert_equal(node.getmempoolentry(orphan["txid"])["ancestorcount"], 3)
@@ -611,7 +611,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
             tx_child_1 = self.wallet.create_self_transfer(utxo_to_spend=tx_parent_1["new_utxo"])
             parent_orphans.append(tx_parent_1["tx"])
             orphans.append(tx_child_1["tx"])
-            peer_1.send_message(msg_tx(tx_child_1["tx"]))
+            peer_1.send_without_ping(msg_tx(tx_child_1["tx"]))
 
         peer_1.sync_with_ping()
         orphanage = node.getorphantxs()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -174,9 +174,9 @@ class TestP2PConn(P2PInterface):
             self.last_message.pop("getdata", None)
         if use_wtxid:
             wtxid = tx.calc_sha256(True)
-            self.send_message(msg_inv(inv=[CInv(MSG_WTX, wtxid)]))
+            self.send_without_ping(msg_inv(inv=[CInv(MSG_WTX, wtxid)]))
         else:
-            self.send_message(msg_inv(inv=[CInv(MSG_TX, tx.sha256)]))
+            self.send_without_ping(msg_inv(inv=[CInv(MSG_TX, tx.sha256)]))
 
         if success:
             if use_wtxid:
@@ -192,17 +192,17 @@ class TestP2PConn(P2PInterface):
         msg = msg_headers()
         msg.headers = [CBlockHeader(block)]
         if use_header:
-            self.send_message(msg)
+            self.send_without_ping(msg)
         else:
-            self.send_message(msg_inv(inv=[CInv(MSG_BLOCK, block.sha256)]))
+            self.send_without_ping(msg_inv(inv=[CInv(MSG_BLOCK, block.sha256)]))
             self.wait_for_getheaders(block_hash=block.hashPrevBlock, timeout=timeout)
-            self.send_message(msg)
+            self.send_without_ping(msg)
         self.wait_for_getdata([block.sha256], timeout=timeout)
 
     def request_block(self, blockhash, inv_type, timeout=60):
         with p2p_lock:
             self.last_message.pop("block", None)
-        self.send_message(msg_getdata(inv=[CInv(inv_type, blockhash)]))
+        self.send_without_ping(msg_getdata(inv=[CInv(inv_type, blockhash)]))
         self.wait_for_block(blockhash, timeout=timeout)
         return self.last_message["block"].block
 
@@ -373,7 +373,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Send an empty headers message, to clear out any prior getheaders
         # messages that our peer may be waiting for us on.
-        self.test_node.send_message(msg_headers())
+        self.test_node.send_without_ping(msg_headers())
 
         self.test_node.announce_block_and_wait_for_getdata(block1, use_header=False)
         assert self.test_node.last_message["getdata"].inv[0].type == blocktype
@@ -444,7 +444,7 @@ class SegWitTest(BitcoinTestFramework):
             # to announce this block.
             msg = msg_headers()
             msg.headers = [CBlockHeader(block4)]
-            self.old_node.send_message(msg)
+            self.old_node.send_without_ping(msg)
             self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
             assert block4.sha256 not in self.old_node.getdataset
 

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -31,7 +31,7 @@ class PeerNoVerack(P2PInterface):
         # comment in add_p2p_connection).
         self.send_version()
         if message.nVersion >= 70016 and self.wtxidrelay:
-            self.send_message(msg_wtxidrelay())
+            self.send_without_ping(msg_wtxidrelay())
 
 class SendTxrcnclReceiver(P2PInterface):
     def __init__(self):
@@ -92,7 +92,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         pre_wtxid_version_msg.strSubVer = P2P_SUBVERSION
         pre_wtxid_version_msg.nServices = P2P_SERVICES
         pre_wtxid_version_msg.relay = 1
-        peer.send_message(pre_wtxid_version_msg)
+        peer.send_without_ping(pre_wtxid_version_msg)
         peer.wait_for_verack()
         assert not peer.sendtxrcncl_msg_received
         self.nodes[0].disconnect_p2ps()
@@ -104,7 +104,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         no_txrelay_version_msg.strSubVer = P2P_SUBVERSION
         no_txrelay_version_msg.nServices = P2P_SERVICES
         no_txrelay_version_msg.relay = 0
-        peer.send_message(no_txrelay_version_msg)
+        peer.send_without_ping(no_txrelay_version_msg)
         peer.wait_for_verack()
         assert not peer.sendtxrcncl_msg_received
         self.nodes[0].disconnect_p2ps()
@@ -117,7 +117,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         no_txrelay_version_msg.strSubVer = P2P_SUBVERSION
         no_txrelay_version_msg.nServices = P2P_SERVICES
         no_txrelay_version_msg.relay = 0
-        peer.send_message(no_txrelay_version_msg)
+        peer.send_without_ping(no_txrelay_version_msg)
         peer.wait_for_verack()
         assert peer.nServices & NODE_BLOOM != 0
         assert not peer.sendtxrcncl_msg_received
@@ -166,17 +166,17 @@ class SendTxRcnclTest(BitcoinTestFramework):
         self.log.info('valid SENDTXRCNCL received')
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(["received: sendtxrcncl"]):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
         self.log.info('second SENDTXRCNCL triggers a disconnect')
         with self.nodes[0].assert_debug_log(["(sendtxrcncl received from already registered peer), disconnecting peer=0"]):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
             peer.wait_for_disconnect()
 
         self.restart_node(0, [])
         self.log.info('SENDTXRCNCL if no txreconciliation supported is ignored')
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(['ignored, as our node does not have txreconciliation enabled']):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
         self.nodes[0].disconnect_p2ps()
 
         self.restart_node(0, ["-txreconciliation"])
@@ -186,7 +186,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         sendtxrcncl_low_version.version = 0
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(["txreconciliation protocol violation"]):
-            peer.send_message(sendtxrcncl_low_version)
+            peer.send_without_ping(sendtxrcncl_low_version)
             peer.wait_for_disconnect()
 
         self.log.info('SENDTXRCNCL with version=2 is valid')
@@ -194,7 +194,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         sendtxrcncl_higher_version.version = 2
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(['Register peer=1']):
-            peer.send_message(sendtxrcncl_higher_version)
+            peer.send_without_ping(sendtxrcncl_higher_version)
         self.nodes[0].disconnect_p2ps()
 
         self.log.info('unexpected SENDTXRCNCL is ignored')
@@ -204,22 +204,22 @@ class SendTxRcnclTest(BitcoinTestFramework):
         old_version_msg.strSubVer = P2P_SUBVERSION
         old_version_msg.nServices = P2P_SERVICES
         old_version_msg.relay = 1
-        peer.send_message(old_version_msg)
+        peer.send_without_ping(old_version_msg)
         with self.nodes[0].assert_debug_log(['Ignore unexpected txreconciliation signal']):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
         self.nodes[0].disconnect_p2ps()
 
         self.log.info('sending SENDTXRCNCL after sending VERACK triggers a disconnect')
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         with self.nodes[0].assert_debug_log(["sendtxrcncl received after verack"]):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
             peer.wait_for_disconnect()
 
         self.log.info('SENDTXRCNCL without WTXIDRELAY is ignored (recon state is erased after VERACK)')
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(wtxidrelay=False), send_version=True, wait_for_verack=False)
         with self.nodes[0].assert_debug_log(['Forget txreconciliation state of peer']):
-            peer.send_message(create_sendtxrcncl_msg())
-            peer.send_message(msg_verack())
+            peer.send_without_ping(create_sendtxrcncl_msg())
+            peer.send_without_ping(msg_verack())
         self.nodes[0].disconnect_p2ps()
 
         # Now, *receiving* from *outbound*.
@@ -227,7 +227,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_outbound_p2p_connection(
             PeerNoVerack(), wait_for_verack=False, p2p_idx=0, connection_type="block-relay-only")
         with self.nodes[0].assert_debug_log(["we indicated no tx relay, disconnecting peer=5"]):
-            peer.send_message(create_sendtxrcncl_msg())
+            peer.send_without_ping(create_sendtxrcncl_msg())
             peer.wait_for_disconnect()
 
 

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -67,10 +67,10 @@ class TimeoutsTest(BitcoinTestFramework):
         assert no_send_node.is_connected
 
         with self.nodes[0].assert_debug_log(['Unsupported message "ping" prior to verack from peer=0']):
-            no_verack_node.send_message(msg_ping())
+            no_verack_node.send_without_ping(msg_ping())
 
         with self.nodes[0].assert_debug_log(['non-version message before version handshake. Message "ping" from peer=1']):
-            no_version_node.send_message(msg_ping())
+            no_version_node.send_without_ping(msg_ping())
 
         self.mock_forward(1)
         assert "version" in no_verack_node.last_message
@@ -79,8 +79,8 @@ class TimeoutsTest(BitcoinTestFramework):
         assert no_version_node.is_connected
         assert no_send_node.is_connected
 
-        no_verack_node.send_message(msg_ping())
-        no_version_node.send_message(msg_ping())
+        no_verack_node.send_without_ping(msg_ping())
+        no_version_node.send_without_ping(msg_ping())
 
         if self.options.v2transport:
             expected_timeout_logs = [

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -143,13 +143,13 @@ class TxDownloadTest(BitcoinTestFramework):
         mock_time = int(time.time() + 1)
         self.nodes[0].setmocktime(mock_time)
         for i in range(MAX_PEER_TX_REQUEST_IN_FLIGHT):
-            p.send_message(msg_inv([CInv(t=MSG_WTX, h=txids[i])]))
+            p.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=txids[i])]))
         p.sync_with_ping()
         mock_time += NONPREF_PEER_TX_DELAY
         self.nodes[0].setmocktime(mock_time)
         p.wait_until(lambda: p.tx_getdata_count >= MAX_PEER_TX_REQUEST_IN_FLIGHT)
         for i in range(MAX_PEER_TX_REQUEST_IN_FLIGHT, len(txids)):
-            p.send_message(msg_inv([CInv(t=MSG_WTX, h=txids[i])]))
+            p.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=txids[i])]))
         p.sync_with_ping()
         self.log.info("No more than {} requests should be seen within {} seconds after announcement".format(MAX_PEER_TX_REQUEST_IN_FLIGHT, NONPREF_PEER_TX_DELAY + OVERLOADED_PEER_TX_DELAY - 1))
         self.nodes[0].setmocktime(mock_time + NONPREF_PEER_TX_DELAY + OVERLOADED_PEER_TX_DELAY - 1)
@@ -166,7 +166,7 @@ class TxDownloadTest(BitcoinTestFramework):
         peer1 = self.nodes[0].add_p2p_connection(TestP2PConn())
         peer2 = self.nodes[0].add_p2p_connection(TestP2PConn())
         for p in [peer1, peer2]:
-            p.send_message(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
+            p.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
         # One of the peers is asked for the tx
         peer2.wait_until(lambda: sum(p.tx_getdata_count for p in [peer1, peer2]) == 1)
         with p2p_lock:
@@ -182,7 +182,7 @@ class TxDownloadTest(BitcoinTestFramework):
         peer1 = self.nodes[0].add_p2p_connection(TestP2PConn())
         peer2 = self.nodes[0].add_p2p_connection(TestP2PConn())
         for p in [peer1, peer2]:
-            p.send_message(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
+            p.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
         # One of the peers is asked for the tx
         peer2.wait_until(lambda: sum(p.tx_getdata_count for p in [peer1, peer2]) == 1)
         with p2p_lock:
@@ -198,7 +198,7 @@ class TxDownloadTest(BitcoinTestFramework):
         peer1 = self.nodes[0].add_p2p_connection(TestP2PConn())
         peer2 = self.nodes[0].add_p2p_connection(TestP2PConn())
         for p in [peer1, peer2]:
-            p.send_message(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
+            p.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=WTXID)]))
         # One of the peers is asked for the tx
         peer2.wait_until(lambda: sum(p.tx_getdata_count for p in [peer1, peer2]) == 1)
         with p2p_lock:
@@ -308,19 +308,19 @@ class TxDownloadTest(BitcoinTestFramework):
         self.log.info('Test how large inv batches are handled with relay permission')
         self.restart_node(0, extra_args=['-whitelist=relay@127.0.0.1'])
         peer = self.nodes[0].add_p2p_connection(TestP2PConn())
-        peer.send_message(msg_inv([CInv(t=MSG_WTX, h=wtxid) for wtxid in range(MAX_PEER_TX_ANNOUNCEMENTS + 1)]))
+        peer.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=wtxid) for wtxid in range(MAX_PEER_TX_ANNOUNCEMENTS + 1)]))
         peer.wait_until(lambda: peer.tx_getdata_count == MAX_PEER_TX_ANNOUNCEMENTS + 1)
 
         self.log.info('Test how large inv batches are handled without relay permission')
         self.restart_node(0)
         peer = self.nodes[0].add_p2p_connection(TestP2PConn())
-        peer.send_message(msg_inv([CInv(t=MSG_WTX, h=wtxid) for wtxid in range(MAX_PEER_TX_ANNOUNCEMENTS + 1)]))
+        peer.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=wtxid) for wtxid in range(MAX_PEER_TX_ANNOUNCEMENTS + 1)]))
         peer.wait_until(lambda: peer.tx_getdata_count == MAX_PEER_TX_ANNOUNCEMENTS)
         peer.sync_with_ping()
 
     def test_spurious_notfound(self):
         self.log.info('Check that spurious notfound is ignored')
-        self.nodes[0].p2ps[0].send_message(msg_notfound(vec=[CInv(MSG_TX, 1)]))
+        self.nodes[0].p2ps[0].send_without_ping(msg_notfound(vec=[CInv(MSG_TX, 1)]))
 
     def test_rejects_filter_reset(self):
         self.log.info('Check that rejected tx is not requested again')

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -229,8 +229,7 @@ class TxDownloadTest(BitcoinTestFramework):
         else:
             peer = self.nodes[0].add_p2p_connection(TestP2PConn())
 
-        peer.send_message(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
-        peer.sync_with_ping()
+        peer.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
         if connection_type != ConnectionType.INBOUND:
             peer.wait_until(lambda: peer.tx_getdata_count >= 1, timeout=1)
         else:
@@ -250,8 +249,7 @@ class TxDownloadTest(BitcoinTestFramework):
         # of which is preferred and one which is not
         unresponsive_peer = self.nodes[0].add_outbound_p2p_connection(
            TestP2PConn(), wait_for_verack=True, p2p_idx=0, connection_type="outbound-full-relay")
-        unresponsive_peer.send_message(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
-        unresponsive_peer.sync_with_ping()
+        unresponsive_peer.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
         unresponsive_peer.wait_until(lambda: unresponsive_peer.tx_getdata_count >= 1, timeout=1)
 
         # A bunch of incoming (non-preferred) connections that advertise the same tx
@@ -259,8 +257,7 @@ class TxDownloadTest(BitcoinTestFramework):
         NUM_INBOUND = 10
         for _ in range(NUM_INBOUND):
             non_pref_peers.append(self.nodes[0].add_p2p_connection(TestP2PConn()))
-            non_pref_peers[-1].send_message(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
-            non_pref_peers[-1].sync_with_ping()
+            non_pref_peers[-1].send_and_ping(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
 
         # Check that no request made due to in-flight
         self.nodes[0].bumpmocktime(NONPREF_PEER_TX_DELAY)
@@ -272,8 +269,7 @@ class TxDownloadTest(BitcoinTestFramework):
         # upon advertisement
         pref_peer = self.nodes[0].add_outbound_p2p_connection(
            TestP2PConn(), wait_for_verack=True, p2p_idx=1, connection_type="outbound-full-relay")
-        pref_peer.send_message(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
-        pref_peer.sync_with_ping()
+        pref_peer.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=0xff00ff00)]))
 
         assert_equal(len(self.nodes[0].getpeerinfo()), NUM_INBOUND + 2)
 
@@ -302,8 +298,7 @@ class TxDownloadTest(BitcoinTestFramework):
             # Add a second wtxid-relay connection otherwise TXID_RELAY_DELAY is waived in
             # lack of wtxid-relay peers
             self.nodes[0].add_p2p_connection(TestP2PConn(wtxidrelay=True))
-        peer.send_message(msg_inv([CInv(t=MSG_TX, h=0xff11ff11)]))
-        peer.sync_with_ping()
+        peer.send_and_ping(msg_inv([CInv(t=MSG_TX, h=0xff11ff11)]))
         with p2p_lock:
             assert_equal(peer.tx_getdata_count, 0 if glob_wtxid else 1)
         self.nodes[0].setmocktime(mock_time + TXID_RELAY_DELAY)

--- a/test/functional/p2p_tx_privacy.py
+++ b/test/functional/p2p_tx_privacy.py
@@ -39,7 +39,7 @@ class P2PTxSpy(P2PInterface):
         self.all_invs = []
 
     def on_version(self, message):
-        self.send_message(msg_wtxidrelay())
+        self.send_without_ping(msg_wtxidrelay())
 
     def on_inv(self, message):
         self.all_invs += message.inv

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -170,7 +170,7 @@ class AcceptBlockTest(BitcoinTestFramework):
             tip = next_block
 
         # Now send the block at height 5 and check that it wasn't accepted (missing header)
-        test_node.send_message(msg_block(all_blocks[1]))
+        test_node.send_without_ping(msg_block(all_blocks[1]))
         test_node.wait_for_disconnect()
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblock, all_blocks[1].hash)
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, all_blocks[1].hash)
@@ -179,13 +179,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # The block at height 5 should be accepted if we provide the missing header, though
         headers_message = msg_headers()
         headers_message.headers.append(CBlockHeader(all_blocks[0]))
-        test_node.send_message(headers_message)
+        test_node.send_without_ping(headers_message)
         test_node.send_and_ping(msg_block(all_blocks[1]))
         self.nodes[0].getblock(all_blocks[1].hash)
 
         # Now send the blocks in all_blocks
         for i in range(288):
-            test_node.send_message(msg_block(all_blocks[i]))
+            test_node.send_without_ping(msg_block(all_blocks[i]))
         test_node.sync_with_ping()
 
         # Blocks 1-287 should be accepted, block 288 should be ignored because it's too far ahead
@@ -215,7 +215,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         with p2p_lock:
             # Clear state so we can check the getdata request
             test_node.last_message.pop("getdata", None)
-            test_node.send_message(msg_inv([CInv(MSG_BLOCK, block_h3.sha256)]))
+            test_node.send_without_ping(msg_inv([CInv(MSG_BLOCK, block_h3.sha256)]))
 
         test_node.sync_with_ping()
         with p2p_lock:
@@ -262,13 +262,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert tip_entry_found
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_292.hash)
 
-        test_node.send_message(msg_block(block_289f))
+        test_node.send_without_ping(msg_block(block_289f))
         test_node.send_and_ping(msg_block(block_290f))
 
         self.nodes[0].getblock(block_289f.hash)
         self.nodes[0].getblock(block_290f.hash)
 
-        test_node.send_message(msg_block(block_291))
+        test_node.send_without_ping(msg_block(block_291))
 
         # At this point we've sent an obviously-bogus block, wait for full processing
         # and assume disconnection
@@ -287,7 +287,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         block_293.solve()
         headers_message = msg_headers()
         headers_message.headers.append(CBlockHeader(block_293))
-        test_node.send_message(headers_message)
+        test_node.send_without_ping(headers_message)
         test_node.wait_for_disconnect()
 
         # 9. Connect node1 to node0 and ensure it is able to sync

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -378,7 +378,7 @@ class P2PConnection(asyncio.Protocol):
 
     # Socket write methods
 
-    def send_message(self, message, is_decoy=False):
+    def send_without_ping(self, message, is_decoy=False):
         """Send a P2P message over the socket.
 
         This method takes a P2P payload, builds the P2P header and adds
@@ -564,10 +564,10 @@ class P2PInterface(P2PConnection):
             if i.type != 0:
                 want.inv.append(i)
         if len(want.inv):
-            self.send_message(want)
+            self.send_without_ping(want)
 
     def on_ping(self, message):
-        self.send_message(msg_pong(message.nonce))
+        self.send_without_ping(msg_pong(message.nonce))
 
     def on_verack(self, message):
         pass
@@ -580,14 +580,14 @@ class P2PInterface(P2PConnection):
             self.send_version()
             self.reconnect = False
         if message.nVersion >= 70016 and self.wtxidrelay:
-            self.send_message(msg_wtxidrelay())
+            self.send_without_ping(msg_wtxidrelay())
         if self.support_addrv2:
-            self.send_message(msg_sendaddrv2())
-        self.send_message(msg_verack())
+            self.send_without_ping(msg_sendaddrv2())
+        self.send_without_ping(msg_verack())
         self.nServices = message.nServices
         self.relay = message.relay
         if self.p2p_connected_to_node:
-            self.send_message(msg_getaddr())
+            self.send_without_ping(msg_getaddr())
 
     # Connection helper methods
 
@@ -694,11 +694,11 @@ class P2PInterface(P2PConnection):
 
     def send_version(self):
         if self.on_connection_send_msg:
-            self.send_message(self.on_connection_send_msg)
+            self.send_without_ping(self.on_connection_send_msg)
             self.on_connection_send_msg = None  # Never used again
 
     def send_and_ping(self, message, *, timeout=60):
-        self.send_message(message)
+        self.send_without_ping(message)
         self.sync_with_ping(timeout=timeout)
 
     def sync_with_ping(self, *, timeout=60):
@@ -706,8 +706,8 @@ class P2PInterface(P2PConnection):
         # Sending two pings back-to-back, requires that the node calls
         # `ProcessMessage` twice, and thus ensures `SendMessages` must have
         # been called at least once
-        self.send_message(msg_ping(nonce=0))
-        self.send_message(msg_ping(nonce=self.ping_counter))
+        self.send_without_ping(msg_ping(nonce=0))
+        self.send_without_ping(msg_ping(nonce=self.ping_counter))
 
         def test_function():
             return self.last_message.get("pong") and self.last_message["pong"].nonce == self.ping_counter
@@ -820,9 +820,9 @@ class P2PDataStore(P2PInterface):
             self.getdata_requests.append(inv.hash)
             invtype = inv.type & MSG_TYPE_MASK
             if (invtype == MSG_TX or invtype == MSG_WTX) and inv.hash in self.tx_store.keys():
-                self.send_message(msg_tx(self.tx_store[inv.hash]))
+                self.send_without_ping(msg_tx(self.tx_store[inv.hash]))
             elif invtype == MSG_BLOCK and inv.hash in self.block_store.keys():
-                self.send_message(msg_block(self.block_store[inv.hash]))
+                self.send_without_ping(msg_block(self.block_store[inv.hash]))
             else:
                 logger.debug('getdata message type {} received.'.format(hex(inv.type)))
 
@@ -855,7 +855,7 @@ class P2PDataStore(P2PInterface):
         response = msg_headers(headers_list)
 
         if response is not None:
-            self.send_message(response)
+            self.send_without_ping(response)
 
     def send_blocks_and_test(self, blocks, node, *, success=True, force_send=False, reject_reason=None, expect_disconnect=False, timeout=60, is_decoy=False):
         """Send blocks to test node and test whether the tip advances.
@@ -880,9 +880,9 @@ class P2PDataStore(P2PInterface):
                 force_send = True
             if force_send:
                 for b in blocks:
-                    self.send_message(msg_block(block=b), is_decoy)
+                    self.send_without_ping(msg_block(block=b), is_decoy)
             else:
-                self.send_message(msg_headers([CBlockHeader(block) for block in blocks]))
+                self.send_without_ping(msg_headers([CBlockHeader(block) for block in blocks]))
                 self.wait_until(
                     lambda: blocks[-1].sha256 in self.getdata_requests,
                     timeout=timeout,
@@ -915,7 +915,7 @@ class P2PDataStore(P2PInterface):
         reject_reason = [reject_reason] if reject_reason else []
         with node.assert_debug_log(expected_msgs=reject_reason):
             for tx in txs:
-                self.send_message(msg_tx(tx))
+                self.send_without_ping(msg_tx(tx))
 
             if expect_disconnect:
                 self.wait_for_disconnect()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -382,7 +382,13 @@ class P2PConnection(asyncio.Protocol):
         """Send a P2P message over the socket.
 
         This method takes a P2P payload, builds the P2P header and adds
-        the message to the send buffer to be sent over the socket."""
+        the message to the send buffer to be sent over the socket.
+
+        When a message does not lead to a disconnect, send_and_ping is usually
+        preferred to send a message. This can help to reduce intermittent test
+        failures due to a missing sync. Also, it includes a call to
+        sync_with_ping, allowing for concise test code.
+        """
         with self._send_lock:
             tmsg = self.build_message(message, is_decoy)
             self._log_message("send", message)


### PR DESCRIPTION
`send_message` is problematic, because it is easy to forget a `sync_with_ping` (or other `wait_until`), leading to intermittent test failures. (Example: https://github.com/bitcoin/bitcoin/pull/31837#discussion_r1950370246)

There are more uses of `send_and_ping` in the codebase than `send_message`, so in most cases `send_and_ping` is needed anyway.

For the remaining cases, clearly document that no sync happens by renaming `send_message` to `send_without_ping`.