### PR TITLE
init: Take lock on blocks directory in BlockManager ctor

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1139,11 +1139,6 @@ static bool LockDirectory(const fs::path& dir, bool probeOnly)
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
-static bool LockDirectories(bool probeOnly)
-{
-    return LockDirectory(gArgs.GetDataDirNet(), probeOnly) && \
-           LockDirectory(gArgs.GetBlocksDirPath(), probeOnly);
-}
 
 bool AppInitSanityChecks(const kernel::Context& kernel)
 {
@@ -1161,7 +1156,8 @@ bool AppInitSanityChecks(const kernel::Context& kernel)
     // Probe the directory locks to give an early error message, if possible
     // We cannot hold the directory locks here, as the forking for daemon() hasn't yet happened,
     // and a fork will cause weird behavior to them.
-    return LockDirectories(true);
+    return LockDirectory(gArgs.GetDataDirNet(), /*probeOnly=*/true)
+        && LockDirectory(gArgs.GetBlocksDirPath(), /*probeOnly=*/true);
 }
 
 bool AppInitLockDirectories()
@@ -1169,11 +1165,7 @@ bool AppInitLockDirectories()
     // After daemonization get the directory locks again and hold on to them until exit
     // This creates a slight window for a race condition to happen, however this condition is harmless: it
     // will at most make us exit without printing a message to console.
-    if (!LockDirectories(false)) {
-        // Detailed error printed inside LockDirectory
-        return false;
-    }
-    return true;
+    return LockDirectory(gArgs.GetDataDirNet(), /*probeOnly=*/false);
 }
 
 bool AppInitInterfaces(NodeContext& node)

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -120,6 +120,7 @@ bool StartLogging(const ArgsManager& args)
     }
     LogInfo("Default data directory %s", fs::PathToString(GetDefaultDataDir()));
     LogInfo("Using data directory %s", fs::PathToString(gArgs.GetDataDirNet()));
+    LogInfo("Using blocks directory %s", fs::PathToString(gArgs.GetBlocksDirPath()));
 
     // Only log conf file usage message if conf file actually exists.
     fs::path config_file_path = args.GetConfigFilePath();

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -31,6 +31,7 @@
 #include <util/batchpriority.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/obfuscation.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
@@ -1190,7 +1191,8 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
 }
 
 BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
-    : m_prune_mode{opts.prune_target > 0},
+    : m_blocks_dir_lock{DirectoryLock(opts.blocks_dir, "blocks")},
+      m_prune_mode{opts.prune_target > 0},
       m_obfuscation{InitBlocksdirXorKey(opts)},
       m_opts{std::move(opts)},
       m_block_file_seq{FlatFileSeq{m_opts.blocks_dir, "blk", m_opts.fast_prune ? 0x4000 /* 16kB */ : BLOCKFILE_CHUNK_SIZE}},

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -19,6 +19,7 @@
 #include <uint256.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/hasher.h>
 
 #include <array>
@@ -188,6 +189,7 @@ class BlockManager
     friend ChainstateManager;
 
 private:
+    DirectoryLock m_blocks_dir_lock;
     const CChainParams& GetParams() const { return m_opts.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_opts.chainparams.GetConsensus(); }
     /**

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1029,13 +1029,13 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
     BOOST_CHECK_EQUAL(util::LockDirectory(dirname, lockname), util::LockResult::Success);
 
     // Another lock on the directory from the same thread should succeed
-    BOOST_CHECK_EQUAL(util::LockDirectory(dirname, lockname), util::LockResult::Success);
+    BOOST_CHECK_EQUAL(util::LockDirectory(dirname, lockname), util::LockResult::ErrorLock);
 
     // Another lock on the directory from a different thread within the same process should succeed
     util::LockResult threadresult;
     std::thread thr([&] { threadresult = util::LockDirectory(dirname, lockname); });
     thr.join();
-    BOOST_CHECK_EQUAL(threadresult, util::LockResult::Success);
+    BOOST_CHECK_EQUAL(threadresult, util::LockResult::ErrorLock);
 #ifndef WIN32
     // Try to acquire lock in child process while we're holding it, this should fail.
     BOOST_CHECK_EQUAL(write(fd[1], &LockCommand, 1), 1);

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -51,7 +51,8 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
 
     // If a lock for this directory already exists in the map, don't try to re-lock it
     if (dir_locks.count(fs::PathToString(pathLockFile))) {
-        return LockResult::Success;
+        LogError("Error while attempting to lock directory %s: Lock already taken", fs::PathToString(directory));
+        return LockResult::ErrorLock;
     }
 
     // Create empty lock file if it doesn't exist.

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -11,6 +11,7 @@
 #include <sync.h>
 #include <util/fs.h>
 #include <util/syserror.h>
+#include <util/translation.h>
 
 #include <cerrno>
 #include <fstream>
@@ -83,6 +84,50 @@ void ReleaseDirectoryLocks()
 {
     LOCK(cs_dir_locks);
     dir_locks.clear();
+}
+
+DirectoryLock::DirectoryLock(fs::path dir_path, std::string name)
+    : m_path{dir_path},
+      m_name{name}
+{
+    // Ensures only a single lock is taken on the provided directory.
+    switch (util::LockDirectory(m_path, ".lock", false)) {
+    case util::LockResult::ErrorWrite:
+        throw std::runtime_error(strprintf(_("Cannot write to %s directory '%s'; check permissions."), m_name, fs::PathToString(m_path)).original);
+    case util::LockResult::ErrorLock:
+        throw std::runtime_error(strprintf(_("Cannot obtain a lock on %s directory %s. %s is probably already running."), m_name, fs::PathToString(m_path), CLIENT_NAME).original);
+    case util::LockResult::Success:
+        return;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+DirectoryLock::DirectoryLock(DirectoryLock&& other) noexcept
+    : m_path{std::move(other.m_path)},
+      m_name{std::move(other.m_name)}
+{
+    other.m_path.clear();
+    other.m_name.clear();
+}
+
+DirectoryLock& DirectoryLock::operator=(DirectoryLock&& other) noexcept
+{
+    if (this != &other) {
+        if (!m_path.empty()) {
+            UnlockDirectory(m_path, ".lock");
+        }
+        m_path = std::move(other.m_path);
+        other.m_path.clear();
+        m_name = std::move(other.m_name);
+        other.m_name.clear();
+    }
+    return *this;
+}
+
+
+DirectoryLock::~DirectoryLock()
+{
+    if (!m_path.empty()) UnlockDirectory(m_path, ".lock");
 }
 
 bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -62,6 +62,23 @@ enum class LockResult {
 [[nodiscard]] LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only = false);
 } // namespace util
 void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name);
+
+class DirectoryLock
+{
+    fs::path m_path;
+    std::string m_name;
+
+public:
+    explicit DirectoryLock(fs::path dir_path, std::string name);
+    ~DirectoryLock();
+
+    DirectoryLock(const DirectoryLock&) = delete;
+    DirectoryLock& operator=(const DirectoryLock&) = delete;
+
+    DirectoryLock(DirectoryLock&& other) noexcept;
+    DirectoryLock& operator=(DirectoryLock&& other) noexcept;
+};
+
 bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 
 /** Get the size of a file by scanning it.


### PR DESCRIPTION
This ensures consistent directory locking for users of the kernel library by disallowing mistakenly creating multiple BlockManagers that might write into the same block or undo files.

The change here makes `LockDirectory` more strict: It now returns an error even if it is called again on the same directory from the same process. However from the description in https://github.com/bitcoin/bitcoin/pull/12422 , where this feature was introduced, it is not immediately clear what its usage was at the time. Supporting multiple wallets in the same directory is mentioned there, but it is not said why that might be a desirable feature.