### PR TITLE
RFC: Generated headers with ""_hex user-defined literal

### DIFF
--- a/cmake/script/GenerateHeaderFromJson.cmake
+++ b/cmake/script/GenerateHeaderFromJson.cmake
@@ -5,18 +5,21 @@
 cmake_path(GET JSON_SOURCE_PATH STEM json_source_basename)
 
 file(READ ${JSON_SOURCE_PATH} hex_content HEX)
-string(REGEX REPLACE "................" "\\0\n" formatted_bytes "${hex_content}")
-string(REGEX REPLACE "[^\n][^\n]" "'\\\\x\\0'," formatted_bytes "${formatted_bytes}")
+string(STRIP "${hex_content}" hex_content)
 
 set(header_content
-"#include <string_view>
+"#include <util/strencodings.h>
+
+#include <string_view>
+#include <cstddef>
+
+using namespace util::hex_literals;
 
 namespace json_tests {
-inline constexpr char detail_${json_source_basename}_bytes[] {
-${formatted_bytes}
-};
+inline auto detail_${json_source_basename}_bytes = \"${hex_content}\"_hex;
 
-inline constexpr std::string_view ${json_source_basename}{std::begin(detail_${json_source_basename}_bytes), std::end(detail_${json_source_basename}_bytes)};
+inline std::string_view ${json_source_basename}{reinterpret_cast<const char*>(detail_${json_source_basename}_bytes.data()), detail_${json_source_basename}_bytes.size()};
 }
 ")
+
 file(WRITE ${HEADER_PATH} "${header_content}")

--- a/cmake/script/GenerateHeaderFromRaw.cmake
+++ b/cmake/script/GenerateHeaderFromRaw.cmake
@@ -5,19 +5,22 @@
 cmake_path(GET RAW_SOURCE_PATH STEM raw_source_basename)
 
 file(READ ${RAW_SOURCE_PATH} hex_content HEX)
-string(REGEX REPLACE "................" "\\0\n" formatted_bytes "${hex_content}")
-string(REGEX REPLACE "[^\n][^\n]" "std::byte{0x\\0}," formatted_bytes "${formatted_bytes}")
+string(STRIP "${hex_content}" hex_content)
 
 set(header_content
-"#include <cstddef>
+"#include <util/strencodings.h>
+
+#include <cstddef>
 #include <span>
 
-namespace ${RAW_NAMESPACE} {
-inline constexpr std::byte detail_${raw_source_basename}_raw[] {
-${formatted_bytes}
-};
+using namespace util::hex_literals;
 
-inline constexpr std::span ${raw_source_basename}{detail_${raw_source_basename}_raw};
-}
+namespace ${RAW_NAMESPACE} {
+
+inline constexpr auto ${raw_source_basename} = \"${hex_content}\"_hex;
+inline constexpr std::span<const std::byte> ${raw_source_basename}_span{${raw_source_basename}};
+
+} // namespace ${RAW_NAMESPACE}
 ")
+
 file(WRITE ${HEADER_PATH} "${header_content}")

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -97,7 +97,7 @@ static void runtest(std::string filename, const std::string& jdata)
 }
 
 #define TEST_FILE(name) {#name, json_tests::name}
-inline constexpr std::array tests{std::to_array<std::tuple<std::string_view, std::string_view>>({
+inline std::array tests{std::to_array<std::tuple<std::string_view, std::string_view>>({
     TEST_FILE(fail1),
     TEST_FILE(fail10),
     TEST_FILE(fail11),


### PR DESCRIPTION
This is based on a [suggestion by sipa](https://github.com/bitcoin/bitcoin/pull/28792#discussion_r1934116502) in #28792.

The generated header could be a lot smaller when using the ""_hex user-defined literal defined in `util/strencodings.h`. Primarily this would be nice for an embedded asmap file but since we already generate these headers it's a conversation that doesn't have to be tied to the asmap PR.

I am looking for feedback on:
- Do people take issue with including `util/strencodings.h` in the generated headers
- I found that this doesn't compile in my `clang` this doesn't compile without bumping template depth and constexpr steps (I set `-DAPPEND_CXXFLAGS='-ftemplate-depth=100000 -fconstexpr-steps=100000000'` and didn't try to find the cut-off point). We are dealing with data of up to 2MB, primarily the asmap file and the block we have in our test data. Would that be a dealbreaker for people?