### PR TITLE
doc: add missing copyright headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ License
 -------
 
 Bitcoin Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
-information or see https://opensource.org/licenses/MIT.
+information or see https://opensource.org/license/MIT.
 
 Development Process
 -------------------

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -121,17 +121,6 @@ Comment:
  You should have received a copy of the GNU General Public License along
  with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-License: GPL-3+
- Permission is granted to copy, distribute and/or modify this document
- under the terms of the GNU General Public License, Version 3 or any
- later version published by the Free Software Foundation.
-Comment:
- On Debian systems the GNU General Public License (GPL) version 3 is
- located in '/usr/share/common-licenses/GPL-3'.
- .
- You should have received a copy of the GNU General Public License along
- with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 License: public-domain
  This work is in the public domain.
 

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -22,7 +22,6 @@ EXCLUDE = [
     'src/test/fuzz/FuzzedDataProvider.h',
     'src/tinyformat.h',
     'src/bench/nanobench.h',
-    'test/functional/test_framework/bignum.py',
     # python init:
     '*__init__.py',
 ]
@@ -94,7 +93,6 @@ EXPECTED_HOLDER_NAMES = [
     r"Satoshi Nakamoto",
     r"The Bitcoin Core developers",
     r"BitPay Inc\.",
-    r"University of Illinois at Urbana-Champaign\.",
     r"Pieter Wuille",
     r"Wladimir J\. van der Laan",
     r"Jeff Garzik",

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -96,6 +96,6 @@ std::string LicenseInfo()
            "\n" +
            "\n" +
            _("This is experimental software.") + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/licenses/MIT>").translated +
+           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/license/MIT>").translated +
            "\n";
 }

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #include <node/peerman_args.h>
 
 #include <common/args.h>

--- a/src/node/peerman_args.h
+++ b/src/node/peerman_args.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #ifndef BITCOIN_NODE_PEERMAN_ARGS_H
 #define BITCOIN_NODE_PEERMAN_ARGS_H
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024
+// Copyright (c) 2024-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024
+// Copyright (c) 2024-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #include <arith_uint256.h>
 #include <chain.h>
 #include <chainparams.h>

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #include <blockencodings.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>

--- a/src/univalue/include/univalue_escapes.h
+++ b/src/univalue/include/univalue_escapes.h
@@ -1,3 +1,8 @@
+// Copyright 2014 BitPay Inc.
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #ifndef BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_ESCAPES_H
 #define BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_ESCAPES_H
 static const char *escapes[256] = {

--- a/src/univalue/test/test_json.cpp
+++ b/src/univalue/test/test_json.cpp
@@ -1,3 +1,8 @@
+// Copyright 2014 BitPay Inc.
+// Copyright (c) 2017-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 // Test program that can be called by the JSON test suite at
 // https://github.com/nst/JSONTestSuite.
 //

--- a/src/util/transaction_identifier.h
+++ b/src/util/transaction_identifier.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
 #ifndef BITCOIN_UTIL_TRANSACTION_IDENTIFIER_H
 #define BITCOIN_UTIL_TRANSACTION_IDENTIFIER_H
 

--- a/test/lint/lint_ignore_dirs.py
+++ b/test/lint/lint_ignore_dirs.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
 SHARED_EXCLUDED_SUBTREES = ["src/leveldb/",
                  "src/crc32c/",
                  "src/secp256k1/",


### PR DESCRIPTION
Add & amends a number of copyright headers.
Remove some now obselete doc/code.