### PR TITLE
build: move `rpc/external_signer` to node library

### DIFF
--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -50,9 +50,6 @@ SUPPRESS["init.cpp.o bdb.cpp.o _ZN6wallet27BerkeleyDatabaseSanityCheckEv"]=1
 # https://github.com/bitcoin/bitcoin/issues/10102
 SUPPRESS["common.cpp.o interface_ui.cpp.o _Z11InitWarningRK13bilingual_str"]=1
 SUPPRESS["common.cpp.o interface_ui.cpp.o _Z9InitErrorRK13bilingual_str"]=1
-# rpc/external_signer.cpp adds defines node RPC methods but is built as part of the
-# common library. It should be moved to the node library instead.
-SUPPRESS["external_signer.cpp.o server.cpp.o _ZN9CRPCTable13appendCommandERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPK11CRPCCommand"]=1
 
 usage() {
    echo "Usage: $(basename "${BASH_SOURCE[0]}") [BUILD_DIR]"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,7 +145,6 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   pow.cpp
   protocol.cpp
   psbt.cpp
-  rpc/external_signer.cpp
   rpc/rawtransaction_util.cpp
   rpc/request.cpp
   rpc/util.cpp
@@ -264,6 +263,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   policy/truc_policy.cpp
   rest.cpp
   rpc/blockchain.cpp
+  rpc/external_signer.cpp
   rpc/fees.cpp
   rpc/mempool.cpp
   rpc/mining.cpp


### PR DESCRIPTION
Move `rpc/external_signer` from `bitcoin_common` to `bitcoin_node`.
Remove the check-deps suppression.