### PR TITLE
[IBD] specialize block serialization

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -52,7 +52,7 @@ static void DeserializeBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
+    stream.write(std::span{&a, 1}); // Prevent compaction
 
     bench.unit("block").run([&] {
         CBlock block;
@@ -66,7 +66,7 @@ static void DeserializeAndCheckBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
+    stream.write(std::span{&a, 1}); // Prevent compaction
 
     ArgsManager bench_args;
     const auto chainParams = CreateChainParams(bench_args, ChainType::MAIN);

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -21,11 +21,34 @@
 #include <optional>
 #include <vector>
 
+static void SizeComputerBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    bench.unit("block").run([&] {
+        SizeComputer size_computer;
+        size_computer << TX_WITH_WITNESS(block);
+        assert(size_computer.size() == benchmark::data::block413567.size());
+    });
+}
+
+static void SerializeBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    // Create output stream and verify first serialization matches input
+    bench.unit("block").run([&] {
+        DataStream output_stream(benchmark::data::block413567.size());
+        output_stream << TX_WITH_WITNESS(block);
+        assert(output_stream.size() == benchmark::data::block413567.size());
+    });
+}
+
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
-static void DeserializeBlockTest(benchmark::Bench& bench)
+static void DeserializeBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -39,7 +62,7 @@ static void DeserializeBlockTest(benchmark::Bench& bench)
     });
 }
 
-static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
+static void DeserializeAndCheckBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -60,5 +83,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(DeserializeBlockTest);
-BENCHMARK(DeserializeAndCheckBlockTest);
+BENCHMARK(SizeComputerBlock);
+BENCHMARK(SerializeBlock);
+BENCHMARK(DeserializeBlock);
+BENCHMARK(DeserializeAndCheckBlock);

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -33,7 +33,7 @@ struct TestBlockAndIndex {
     {
         DataStream stream{benchmark::data::block413567};
         std::byte a{0};
-        stream.write({&a, 1}); // Prevent compaction
+        stream.write(std::span{&a, 1}); // Prevent compaction
 
         stream >> TX_WITH_WITNESS(block);
 

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -721,6 +721,21 @@ CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
     }
     return *this;
 }
+CSHA256& CSHA256::Write(unsigned char data)
+{
+    size_t bufsize = bytes % 64;
+
+    // Add the single byte to the buffer
+    buf[bufsize] = data;
+    bytes += 1;
+
+    if (bufsize == 63) {
+        // Process the buffer if full
+        Transform(s, buf, 1);
+    }
+
+    return *this;
+}
 
 void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
 {

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -22,6 +22,7 @@ public:
 
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);
+    CSHA256& Write(unsigned char data);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();
 };

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -240,41 +240,47 @@ const Out& AsBase(const In& x)
 template<class T>
 concept CharNotInt8 = std::same_as<T, char> && !std::same_as<T, int8_t>;
 
-// clang-format off
-template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, int8_t a)    { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint8_t a)   { ser_writedata8(s, a); }
-template <typename Stream> void Serialize(Stream& s, int16_t a)   { ser_writedata16(s, uint16_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint16_t a)  { ser_writedata16(s, a); }
-template <typename Stream> void Serialize(Stream& s, int32_t a)   { ser_writedata32(s, uint32_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint32_t a)  { ser_writedata32(s, a); }
-template <typename Stream> void Serialize(Stream& s, int64_t a)   { ser_writedata64(s, uint64_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint64_t a)  { ser_writedata64(s, a); }
+template <typename T>
+concept ByteOrIntegral = std::is_same_v<T, std::byte> ||
+    (std::is_integral_v<T> && !std::is_same_v<T, char>);
 
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const B (&a)[N])           { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, std::span<B, N> span)      { s.write(std::as_bytes(span)); }
-template <typename Stream, BasicByte B>           void Serialize(Stream& s, std::span<B> span)         { s.write(std::as_bytes(span)); }
+template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
+template <typename Stream, ByteOrIntegral T> void Serialize(Stream& s, T a)
+{
+    if constexpr (sizeof(T) == 1) {
+        ser_writedata8(s, static_cast<uint8_t>(a));   // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        ser_writedata16(s, static_cast<uint16_t>(a)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        ser_writedata32(s, static_cast<uint32_t>(a)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        ser_writedata64(s, static_cast<uint64_t>(a)); // (u)int64_t
+    }
+}
+template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N]) { s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span) { s.write(std::as_bytes(span)); }
+template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span) { s.write(std::as_bytes(span)); }
 
 template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, int8_t& a)    { a = int8_t(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint8_t& a)   { a = ser_readdata8(s); }
-template <typename Stream> void Unserialize(Stream& s, int16_t& a)   { a = int16_t(ser_readdata16(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint16_t& a)  { a = ser_readdata16(s); }
-template <typename Stream> void Unserialize(Stream& s, int32_t& a)   { a = int32_t(ser_readdata32(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint32_t& a)  { a = ser_readdata32(s); }
-template <typename Stream> void Unserialize(Stream& s, int64_t& a)   { a = int64_t(ser_readdata64(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint64_t& a)  { a = ser_readdata64(s); }
-
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, B (&a)[N])            { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::array<B, N>& a)  { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
-template <typename Stream, BasicByte B>           void Unserialize(Stream& s, std::span<B> span)    { s.read(std::as_writable_bytes(span)); }
-
-template <typename Stream> void Serialize(Stream& s, bool a)    { uint8_t f = a; ser_writedata8(s, f); }
-template <typename Stream> void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
+template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
+{
+    if constexpr (sizeof(T) == 1) {
+        a = static_cast<T>(ser_readdata8(s));  // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        a = static_cast<T>(ser_readdata16(s)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        a = static_cast<T>(ser_readdata32(s)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        a = static_cast<T>(ser_readdata64(s)); // (u)int64_t
+    }
+}
+template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
+template <typename Stream, BasicByte B> void Unserialize(Stream& s, std::span<B> span) { s.read(std::as_writable_bytes(span)); }
 // clang-format on
 
 
@@ -480,7 +486,7 @@ public:
  * serialization, and Unser(stream, object&) for deserialization. Serialization routines (inside
  * READWRITE, or directly with << and >> operators), can then use Using<Formatter>(object).
  *
- * This works by constructing a Wrapper<Formatter, T>-wrapped version of object, where T is
+ * This works by constructing a Wrapper<Formatter, T&>-wrapped version of object, where T is
  * const during serialization, and non-const during deserialization, which maintains const
  * correctness.
  */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1111,6 +1111,10 @@ public:
     {
         m_size += src.size();
     }
+    void write(std::span<const std::byte, 1>)
+    {
+        this->m_size += 1;
+    }
 
     /** Pretend this many bytes are written, without specifying them. */
     void seek(uint64_t num)
@@ -1161,7 +1165,9 @@ public:
     template <typename U> ParamsStream& operator<<(const U& obj) { ::Serialize(*this, obj); return *this; }
     template <typename U> ParamsStream& operator>>(U&& obj) { ::Unserialize(*this, obj); return *this; }
     void write(std::span<const std::byte> src) { GetStream().write(src); }
+    void write(std::span<const std::byte, 1> src) { GetStream().write(src); }
     void read(std::span<std::byte> dst) { GetStream().read(dst); }
+    void read(std::span<std::byte, 1> dst) { GetStream().read(dst); }
     void ignore(size_t num) { GetStream().ignore(num); }
     bool eof() const { return GetStream().eof(); }
     size_t size() const { return GetStream().size(); }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -53,56 +53,56 @@ constexpr deserialize_type deserialize {};
  */
 template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
 {
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint8_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
 {
     obj = htole16_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint16_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
 {
     obj = htobe32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
     obj = htole64_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint64_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
 {
     uint8_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint8_t, 1>{&obj, 1}));
     return obj;
 }
 template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint16_t, 1>{&obj, 1}));
     return le16toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return le32toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return be32toh_internal(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint64_t, 1>{&obj, 1}));
     return le64toh_internal(obj);
 }
 
@@ -280,7 +280,6 @@ template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
 template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
-template <typename Stream, BasicByte B> void Unserialize(Stream& s, std::span<B> span) { s.read(std::as_writable_bytes(span)); }
 // clang-format on
 
 
@@ -533,10 +532,10 @@ struct CustomUintFormatter
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
         if (BigEndian) {
             uint64_t raw = htobe64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).last(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template last<Bytes>());
         } else {
             uint64_t raw = htole64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).first(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template first<Bytes>());
         }
     }
 
@@ -546,10 +545,10 @@ struct CustomUintFormatter
         static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
         uint64_t raw = 0;
         if (BigEndian) {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).last(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).last<Bytes>());
             v = static_cast<I>(be64toh_internal(raw));
         } else {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).first(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).first<Bytes>());
             v = static_cast<I>(le64toh_internal(raw));
         }
     }

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -78,6 +78,13 @@ void AutoFile::read(std::span<std::byte> dst)
     }
 }
 
+void AutoFile::read(std::span<std::byte, 1> dst)
+{
+    if (detail_fread(dst) != 1) {
+        throw std::ios_base::failure(feof() ? "AutoFile::read: end of file" : "AutoFile::read: fread failed");
+    }
+}
+
 void AutoFile::ignore(size_t nSize)
 {
     if (!m_file) throw std::ios_base::failure("AutoFile::ignore: file handle is nullptr");
@@ -110,6 +117,12 @@ void AutoFile::write(std::span<const std::byte> src)
             src = src.subspan(buf_now.size());
         }
     }
+}
+
+void AutoFile::write(std::span<const std::byte, 1> src)
+{
+    std::byte temp_byte = src[0];
+    write_buffer(std::span(&temp_byte, 1));
 }
 
 void AutoFile::write_buffer(std::span<std::byte> src)

--- a/src/streams.h
+++ b/src/streams.h
@@ -145,6 +145,7 @@ public:
     typedef vector_type::reverse_iterator reverse_iterator;
 
     explicit DataStream() = default;
+    explicit DataStream(size_type n) { reserve(n); }
     explicit DataStream(std::span<const uint8_t> sp) : DataStream{std::as_bytes(sp)} {}
     explicit DataStream(std::span<const value_type> sp) : vch(sp.data(), sp.data() + sp.size()) {}
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -65,6 +65,17 @@ public:
         }
         nPos += src.size();
     }
+    void write(std::span<const std::byte, 1> src)
+    {
+        assert(nPos <= vchData.size());
+        const auto byte{*UCharCast(&src[0])};
+        if (nPos < vchData.size()) {
+            vchData[nPos] = byte;
+        } else {
+            vchData.push_back(byte);
+        }
+        nPos += 1;
+    }
     template <typename T>
     VectorWriter& operator<<(const T& obj)
     {
@@ -236,6 +247,10 @@ public:
     {
         // Write to the end of the buffer
         vch.insert(vch.end(), src.begin(), src.end());
+    }
+    void write(std::span<const value_type, 1> src)
+    {
+        vch.push_back(src[0]);
     }
 
     template<typename T>
@@ -452,8 +467,10 @@ public:
     // Stream subset
     //
     void read(std::span<std::byte> dst);
+    void read(std::span<std::byte, 1> dst);
     void ignore(size_t nSize);
     void write(std::span<const std::byte> src);
+    void write(std::span<const std::byte, 1> src);
 
     template <typename T>
     AutoFile& operator<<(const T& obj)

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -1079,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(sha256d64)
             in[j] = m_rng.randbits(8);
         }
         for (int j = 0; j < i; ++j) {
-            CHash256().Write({in + 64 * j, 64}).Finalize({out1 + 32 * j, 32});
+            CHash256().Write(std::span{in + 64 * j, 64}).Finalize({out1 + 32 * j, 32});
         }
         SHA256D64(out2, in, i);
         BOOST_CHECK(memcmp(out1, out2, 32 * i) == 0);

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -31,14 +31,14 @@ FUZZ_TARGET(autofile)
             [&] {
                 std::array<std::byte, 4096> arr{};
                 try {
-                    auto_file.read({arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
+                    auto_file.read(std::span{arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
                 } catch (const std::ios_base::failure&) {
                 }
             },
             [&] {
                 const std::array<std::byte, 4096> arr{};
                 try {
-                    auto_file.write({arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
+                    auto_file.write(std::span{arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
                 } catch (const std::ios_base::failure&) {
                 }
             },

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(xor_file)
     {
         // Check errors for missing file
         AutoFile xor_file{raw_file("rb"), obfuscation};
-        BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
+        BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"file handle is nullptr"});
+        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"file handle is nullptr"});
+        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"file handle is nullptr"});
         BOOST_CHECK_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
     }
     {


### PR DESCRIPTION
This change is part of [[IBD] - Tracking PR for speeding up Initial Block Download](https://github.com/bitcoin/bitcoin/pull/32043)

---

This PR is drafted until I remeasure everything after the recent merges and I need to find a way to simplify the 1 byte writes more nicely, I don't like all the specializations.

---

**Summary:** This PR contains a few different optimizations found by IBD profiling and via the newly added block serialization benchmarks. It also takes advantage of the recently merged [`std::span` changes](https://github.com/bitcoin/bitcoin/pull/31519) enabling propagating static extents.

The commits merge similar (de)serialization methods and separate them internally with `if constexpr`, similarly to how it has been [done here before](https://github.com/bitcoin/bitcoin/pull/28203). This enables further `SizeComputer` optimizations as well.

**Context:** Since single byte writes are used very often (for every `(u)int8_t`, `std::byte`, or `bool`, and for every `VarInt`'s first byte, which is also needed for every `(pre)Vector`), it makes sense to avoid the generalized serialization infrastructure that isn't needed:
* `AutoFile` write doesn't need to allocate a 4k buffer for a single byte now;
* `VectorWriter` and `DataStream` avoid `memcpy`/`insert` calls;
* `CSHA256::Write` can avoid `memcpy`.

`DeserializeBlock` is dominated by hash calculations, so the optimizations barely affect it.

**Measurements:**
<details>
<summary>C compiler ............................ AppleClang 16.0.0.16000026</summary>

> Before:
|            ns/block |             block/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          195,610.62 |            5,112.20 |    0.3% |     11.00 | `SerializeBlock`
|           12,061.83 |           82,906.19 |    0.1% |     11.01 | `SizeComputerBlock`
> After:
|            ns/block |             block/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          174,569.19 |            5,728.39 |    0.6% |     10.89 | `SerializeBlock`
|           10,241.16 |           97,645.21 |    0.0% |     11.00 | `SizeComputerBlock`
</details>

> `SerializeBlock` - ~12.% faster
> `SizeComputerBlock` - ~17.7% faster
-----
<details>
<summary>C++ compiler .......................... GNU 13.3.0</summary>

> Before:
|            ns/block |             block/s |    err% |       ins/block |       cyc/block |    IPC |      bra/block |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          867,857.55 |            1,152.26 |    0.0% |    8,015,883.90 |    3,116,099.08 |  2.572 |   1,517,035.87 |    0.5% |     10.81 | `SerializeBlock`
|           30,928.27 |           32,332.88 |    0.0% |      221,683.03 |      111,055.84 |  1.996 |      53,037.03 |    0.8% |     11.03 | `SizeComputerBlock`
> After:
|            ns/block |             block/s |    err% |       ins/block |       cyc/block |    IPC |      bra/block |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          615,000.56 |            1,626.01 |    0.0% |    8,015,883.64 |    2,208,340.88 |  3.630 |   1,517,035.62 |    0.5% |     10.56 | `SerializeBlock`
|           25,676.76 |           38,945.72 |    0.0% |      159,390.03 |       92,202.10 |  1.729 |      42,131.03 |    0.9% |     11.00 | `SizeComputerBlock`
</details>

> `SerializeBlock` - ~41.1% faster
> `SizeComputerBlock` - ~20.4% faster
----

While this wasn't the main motivation for the change, IBD on Ubuntu/GCC on SSD with i9 indicates a 2% speedup as well:
<details>
<summary>Details</summary>
```bash
COMMITS="05314bde0b06b820225f10c6529b5afae128ff81 1cd94ec2511874ec68b92db34ad7ec7d9534fed1"; \
STOP_HEIGHT=880000; DBCACHE=10000; \
C_COMPILER=gcc; CXX_COMPILER=g++; \
hyperfine \
--export-json "/mnt/my_storage/ibd-${COMMITS// /-}-${STOP_HEIGHT}-${DBCACHE}-${C_COMPILER}.json" \
--runs 3 \
--parameter-list COMMIT ${COMMITS// /,} \
--prepare "killall bitcoind || true; rm -rf /mnt/my_storage/BitcoinData/*; git checkout {COMMIT}; git clean -fxd; git reset --hard; cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_WALLET=OFF -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER && cmake --build build -j$(nproc) --target bitcoind && ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=1 -printtoconsole=0 || true" \
--cleanup "cp /mnt/my_storage/BitcoinData/debug.log /mnt/my_storage/logs/debug-{COMMIT}-$(date +%s).log || true" \
"COMPILER=$C_COMPILER COMMIT={COMMIT} ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=$STOP_HEIGHT -dbcache=$DBCACHE -prune=550 -printtoconsole=0"
Benchmark 1: COMPILER=gcc COMMIT=05314bde0b06b820225f10c6529b5afae128ff81 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=880000 -dbcache=10000 -prune=550 -printtoconsole=0
  Time (mean ± σ):     33647.918 s ± 508.655 s    [User: 71503.409 s, System: 4404.899 s]
  Range (min … max):   33283.439 s … 34229.026 s    3 runs
 
Benchmark 2: COMPILER=gcc COMMIT=1cd94ec2511874ec68b92db34ad7ec7d9534fed1 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=880000 -dbcache=10000 -prune=550 -printtoconsole=0
  Time (mean ± σ):     33062.491 s ± 183.335 s    [User: 71246.532 s, System: 4318.490 s]
  Range (min … max):   32888.211 s … 33253.706 s    3 runs
 
Summary
  COMPILER=gcc COMMIT=1cd94ec2511874ec68b92db34ad7ec7d9534fed1 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=880000 -dbcache=10000 -prune=550 -printtoconsole=0 ran
    1.02 ± 0.02 times faster than COMPILER=gcc COMMIT=05314bde0b06b820225f10c6529b5afae128ff81 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=880000 -dbcache=10000 -prune=550 -printtoconsole=0
```

</details>