### PR TITLE
cmake: Add optional sources to `minisketch` library directly

### DIFF
--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -25,10 +25,6 @@ check_cxx_source_compiles_with_flags("${CLMUL_CXXFLAGS}" "
 )
 
 add_library(minisketch_common INTERFACE)
-target_compile_definitions(minisketch_common INTERFACE
-  DISABLE_DEFAULT_FIELDS
-  ENABLE_FIELD_32
-)
 if(MSVC)
   target_compile_options(minisketch_common INTERFACE
     /wd4060
@@ -36,29 +32,6 @@ if(MSVC)
     /wd4146
     /wd4244
     /wd4267
-  )
-endif()
-
-if(HAVE_CLMUL)
-  add_library(minisketch_clmul OBJECT EXCLUDE_FROM_ALL
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_1byte.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_2bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_3bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_4bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_5bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_6bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_7bytes.cpp
-    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_8bytes.cpp
-  )
-  target_compile_definitions(minisketch_clmul PUBLIC HAVE_CLMUL)
-  target_compile_options(minisketch_clmul PRIVATE ${CLMUL_CXXFLAGS})
-  target_link_libraries(minisketch_clmul
-    PRIVATE
-      core_interface
-      minisketch_common
-  )
-  set_target_properties(minisketch_clmul PROPERTIES
-    EXPORT_COMPILE_COMMANDS OFF
   )
 endif()
 
@@ -74,8 +47,11 @@ add_library(minisketch STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_8bytes.cpp
 )
 
-# Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/24058
-set_target_properties(minisketch PROPERTIES OPTIMIZE_DEPENDENCIES OFF)
+target_compile_definitions(minisketch
+  PRIVATE
+    DISABLE_DEFAULT_FIELDS
+    ENABLE_FIELD_32
+)
 
 target_include_directories(minisketch
   PUBLIC
@@ -86,9 +62,25 @@ target_link_libraries(minisketch
   PRIVATE
     core_interface
     minisketch_common
-    $<TARGET_NAME_IF_EXISTS:minisketch_clmul>
 )
 
 set_target_properties(minisketch PROPERTIES
   EXPORT_COMPILE_COMMANDS OFF
 )
+
+if(HAVE_CLMUL)
+  set(_minisketch_clmul_src
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_1byte.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_2bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_3bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_4bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_5bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_6bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_7bytes.cpp
+      ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_8bytes.cpp
+  )
+  target_sources(minisketch PRIVATE ${_minisketch_clmul_src})
+  set_property(SOURCE ${_minisketch_clmul_src} PROPERTY COMPILE_OPTIONS ${CLMUL_CXXFLAGS})
+  target_compile_definitions(minisketch PRIVATE HAVE_CLMUL)
+  unset(_minisketch_clmul_src)
+endif()


### PR DESCRIPTION
This PR is a continuation of https://github.com/bitcoin/bitcoin/pull/31268 and applies similar changes to the `minisketch` library, which addresses [this comment](https://github.com/bitcoin/bitcoin/pull/30911#discussion_r1953081930).

Additionally, a [workaround](https://github.com/bitcoin/bitcoin/blob/db36a92c02b83f2e6477a5a55fc061319f7cc6a3/cmake/minisketch.cmake#L77-L78) for a CMake bug has been removed.