### PR TITLE
cmake: Make implicit `libbitcoinkernel` dependencies explicit

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_target(generate_build_info
   COMMENT "Generating bitcoin-build-info.h"
   VERBATIM
 )
-add_library(bitcoin_clientversion OBJECT EXCLUDE_FROM_ALL
+add_library(bitcoin_clientversion STATIC EXCLUDE_FROM_ALL
   clientversion.cpp
 )
 target_link_libraries(bitcoin_clientversion

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -102,6 +102,10 @@ set_target_properties(bitcoinkernel PROPERTIES
   CXX_VISIBILITY_PRESET default
 )
 
+# Add a convenience libbitcoinkernel target as a synonym for bitcoinkernel.
+add_custom_target(libbitcoinkernel)
+add_dependencies(libbitcoinkernel bitcoinkernel)
+
 # When building the static library, install all static libraries the
 # bitcoinkernel depends on.
 if(NOT BUILD_SHARED_LIBS)
@@ -110,6 +114,7 @@ if(NOT BUILD_SHARED_LIBS)
     get_target_property(linked_libraries ${target} LINK_LIBRARIES)
     foreach(dep ${linked_libraries})
       if(TARGET ${dep})
+        add_dependencies(libbitcoinkernel ${dep})
         get_target_property(dep_type ${dep} TYPE)
         if(dep_type STREQUAL "STATIC_LIBRARY")
           list(APPEND ${libs_out} ${dep})
@@ -131,10 +136,6 @@ endif()
 
 configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT libbitcoinkernel)
-
-# Add a convenience libbitcoinkernel target as a synonym for bitcoinkernel.
-add_custom_target(libbitcoinkernel)
-add_dependencies(libbitcoinkernel bitcoinkernel)
 
 install(TARGETS bitcoinkernel
   RUNTIME

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -36,9 +36,6 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   ../sync.cpp
 )
 
-# Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/24058
-set_target_properties(bitcoin_util PROPERTIES OPTIMIZE_DEPENDENCIES OFF)
-
 target_link_libraries(bitcoin_util
   PRIVATE
     core_interface


### PR DESCRIPTION
This PR fixes two regressions introduced in https://github.com/bitcoin/bitcoin/pull/30911.

For example, on the master branch @ 28dec6c5f8bd35ef4e6cb8d7aa3f21b6879acf98:
- first regression:
```
$ cmake -B build -G "Ninja" -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/home/hebasto/INSTALL
$ cmake --build build -j $(nproc) -t libbitcoinkernel
$ cmake --install build --component libbitcoinkernel
- Install configuration: "RelWithDebInfo"
CMake Error at build/src/kernel/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/home/hebasto/dev/bitcoin/build/src/crypto/libbitcoin_crypto.a": No such
  file or directory.
Call Stack (most recent call first):
  build/src/cmake_install.cmake:172 (include)
  build/cmake_install.cmake:57 (include)


```

- second regression:
```
$ cmake -B build -G "Unix Makefiles" -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/home/hebasto/INSTALL
$ cmake --build build -j $(nproc) -t libbitcoinkernel
...
gmake[3]: *** No rule to make target 'src/CMakeFiles/bitcoin_clientversion.dir/clientversion.cpp.o', needed by 'src/kernel/libbitcoinkernel.a'.  Stop.
gmake[2]: *** [CMakeFiles/Makefile2:1360: src/kernel/CMakeFiles/bitcoinkernel.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:1367: src/kernel/CMakeFiles/bitcoinkernel.dir/rule] Error 2
gmake: *** [Makefile:647: bitcoinkernel] Error 2
```

With this PR:
```
$ cmake -B build -G "Ninja" -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/home/hebasto/INSTALL
$ cmake --build build -j $(nproc) -t libbitcoinkernel
$ cmake --install build --component libbitcoinkernel
```
and
```
$ cmake -B build -G "Unix Makefiles" -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/home/hebasto/INSTALL
$ cmake --build build -j $(nproc) -t libbitcoinkernel
$ cmake --install build --component libbitcoinkernel
```

---

**A note for reviewers:** An alternative approach would be to disable the `OPTIMIZE_DEPENDENCIES` property for the `bitcoinkernel` target. However, I contend that this PR is preferable because (1) it preserves parallel builds for the `libbitcoinkernel` target, and (2) the resulting code has one less workaround for a CMake bug.