### PR TITLE
cli: return local services in -netinfo

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -463,6 +463,17 @@ private:
         }
         return str;
     }
+    static std::string ServicesList(const UniValue& services)
+    {
+        std::string str{services.size() ? services[0].get_str() : ""};
+        for (size_t i{1}; i < services.size(); ++i) {
+            str += ", " + services[i].get_str();
+        }
+        for (auto& c: str) {
+            c = (c == '_' ? ' ' : ToLower(c));
+        }
+        return str;
+    }
 
 public:
     static constexpr int ID_PEERINFO = 0;
@@ -636,7 +647,8 @@ public:
             }
         }
 
-        // Report local addresses, ports, and scores.
+        // Report local services, addresses, ports, and scores.
+        result += strprintf("\n\nLocal services: %s", ServicesList(networkinfo["localservicesnames"]));
         result += "\n\nLocal addresses";
         const std::vector<UniValue>& local_addrs{networkinfo["localaddresses"].getValues()};
         if (local_addrs.empty()) {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -566,7 +566,8 @@ public:
         }
 
         // Generate report header.
-        std::string result{strprintf("%s client %s%s - server %i%s\n\n", CLIENT_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].getInt<int>(), networkinfo["subversion"].get_str())};
+        const std::string services{DetailsRequested() ? strprintf(" - services %s", FormatServices(networkinfo["localservicesnames"])) : ""};
+        std::string result{strprintf("%s client %s%s - server %i%s%s\n\n", CLIENT_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].getInt<int>(), networkinfo["subversion"].get_str(), services)};
 
         // Report detailed peer connections list sorted by direction and minimum ping time.
         if (DetailsRequested() && !m_peers.empty()) {
@@ -648,7 +649,9 @@ public:
         }
 
         // Report local services, addresses, ports, and scores.
-        result += strprintf("\n\nLocal services: %s", ServicesList(networkinfo["localservicesnames"]));
+        if (!DetailsRequested()) {
+            result += strprintf("\n\nLocal services: %s", ServicesList(networkinfo["localservicesnames"]));
+        }
         result += "\n\nLocal addresses";
         const std::vector<UniValue>& local_addrs{networkinfo["localaddresses"].getValues()};
         if (local_addrs.empty()) {


### PR DESCRIPTION
Add local services info to -netinfo dashboard that already provides this info for each of the peer connections.

- `bitcoin-cli -netinfo` with no args passed provides a nice easy-to-understand services list:

```
Bitcoin Core client v28.99.0 - server 70016/Satoshi:28.99.0/

         ipv4    ipv6   onion     i2p   cjdns   total   block  manual
in          0       0      12       8       0      20
out         6       0       4       3       2      15       3       4
total       6       0      16      11       2      35

Local services: network, bloom, witness, compact filters, network limited, p2p v2

Local addresses
```

- With a details level passed, e.g. `-netinfo 3`, print the services in the versions header instead (to avoid adding a line for more static information), in the same format as the peers list (see `-netinfo help` for info on the output of the `serv` column):

```
Bitcoin Core client v28.99.0 - server 70016/Satoshi:28.99.0/ - services nbwcl2

<->   type   net   serv  v  mping   ping send recv  txn  blk  hb addrp addrl  age  asmap  id version
 in        onion         1    283    498   48   48    *              .         77        388 70016
 in        onion   nwl2  2    318    485    5  111                             79        372 70016/Satoshi:28.0.0/
 in        onion    nwl  1    342    344    4    1   53             96         84        344 70016/Satoshi:26.0.0/
 in        onion    nwl  1    411    601    4    1   35            124         85        339 70016/Satoshi:26.0.0/
 in        onion  nwcl2  2    436   4330    2    2    2             31         13        623 70016/Satoshi:28.0.0/
 in        onion    wl2  2    445    503    4    4    6            138         81        363 70016/Satoshi:28.0.0/
 in        onion    nwl  1    462    726    4    1   56             92         81        365 70016/Satoshi:23.0.0/
 in        onion    nwl  1    500    765    4    1   34             94         83        351 70016/Satoshi:25.0.0/
 in        onion   nwl2  2    578    684    4    0    1            134         87        327 70016/Satoshi:28.0.0/
 in          i2p   nwl2  2    712   1322    4    2   35            204     1   93        308 70016/Satoshi:27.2.0/
 in        onion   nwl2  2    727    873    5    5   56            162         85        342 70016/Satoshi:27.1.0/
 in          i2p   nwl2  2    749    976    4    2   25            120         72        408 70016/Satoshi:27.1.0/
 in          i2p   nwl2  2    776    954    4    1    0             72         68        426 70016/Satoshi:28.0.0/
 in          i2p   nbwl  1    883   1735    4    4                  53         34        551 70016/Satoshi:26.0.0/
 in          i2p  nwcl2  2    920   1044    2    0    0            131         83        350 70016/Satoshi:28.0.0/
 in        onion     wl  1   1021  20832   29   67                   3         49        501 70016/Satoshi:23.0.0/
 in          i2p  nwcl2  2   1830   1830    5    0                   3          3        668 70016/Satoshi:27.1.0/
 in        onion    nwl  1  41155  41155   87  204                              4        658 70016/Satoshi:25.0.0/
out   full  ipv4   nwl2  2     74     93    0    0    0           1028         85   1221 338 70016/Satoshi:27.1.0/
out   full  ipv4    nwl  1     82    104    0    2    0    5  .   1076         95  13536 301 70016/Satoshi:26.0.0/
out   full  ipv4    nwl  1    147    178    2    2    0   28  .   1104         95 395570 300 70016/Satoshi:25.0.0/
out  block  ipv4   nwl2  2    166    513    2    2    *              .         88  38001 324 70016/Satoshi:27.2.0/
out   full  ipv4     wl  1    193    201    0    4    0           1035         94  31376 307 70016/Satoshi:25.99.0/
out   full  ipv4   nwl2  2    199    796    1    1    0           1027         94   9723 304 70016/Satoshi:27.2.0/
out manual cjdns   nwl2  2    213    235    1    9    0           1109         83        353 70016/Satoshi:28.99.0/
out   full onion   nbwl  1    282    457    3    3    1           1130         73        404 70016/Satoshi:25.0.0/
out  block onion   nbwl  1    324    353   23   23    *              .         85        341 70016/Satoshi:26.0.0/
out manual cjdns   nwl2  2    340    445    1    1    7           1059         82        361 70016/Satoshi:27.0.0/
out manual onion    wl2  2    386    386    1    1    1           1048         84        345 70016/Satoshi:28.99.0/
out manual   i2p  nwcl2  2    697   1084    1    1    8           1113     3   93        310 70016/Satoshi:27.0.0/
out   full   i2p  nwcl2  2    730   1254    1    9    0           1128         89        318 70016/Satoshi:28.0.0/
out   full   i2p  nwcl2  2    765   1804    1    1    1           1132         72        409 70016/Satoshi:28.0.0/
                               ms     ms  sec  sec  min  min                  min

         ipv4    ipv6   onion     i2p   cjdns   total   block  manual
in          0       0      12       6       0      18
out         6       0       3       3       2      14       2       4
total       6       0      15       9       2      32

Local addresses
```