### PR TITLE
contrib: Support re-writing linearize-data dumps

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -157,6 +157,7 @@ class BlockDataCopier:
     def writeBlock(self, inhdr, blk_hdr, rawblock):
         blockSizeOnDisk = len(inhdr) + len(blk_hdr) + len(rawblock)
         if not self.fileOutput and ((self.outsz + blockSizeOnDisk) > self.maxOutSz):
+            os.ftruncate(self.outF.fileno(), self.outF.tell())
             self.outF.close()
             if self.setFileTime:
                 os.utime(self.outFname, (int(time.time()), self.highTS))
@@ -170,6 +171,7 @@ class BlockDataCopier:
             print("New month " + blkDate.strftime("%Y-%m") + " @ " + self.hash_str)
             self.lastDate = blkDate
             if self.outF:
+                os.ftruncate(self.outF.fileno(), self.outF.tell())
                 self.outF.close()
                 if self.setFileTime:
                     os.utime(self.outFname, (int(time.time()), self.highTS))
@@ -184,7 +186,10 @@ class BlockDataCopier:
             else:
                 self.outFname = os.path.join(self.settings['output'], "blk%05d.dat" % self.outFn)
             print("Output file " + self.outFname)
-            self.outF = open(self.outFname, "wb")
+            try:
+                self.outF = open(self.outFname, "xb+")
+            except FileExistsError:
+                self.outF = open(self.outFname, "rb+")
 
         self.outF.write(inhdr)
         self.outF.write(blk_hdr)


### PR DESCRIPTION
For tools using the linearization scripts to continuously create a data dump it is undesirable to truncate the dumped file every time it is written. Doing so makes it harder to be directly consumed by an external tool. To fix this, change the file open mode to not truncate the entire file. After this change dumps are byte-for-byte overwritten. Some trailing data at the end of the file might be left over from a previous run in case of a reorg. To guard against this, clip off any remaining data at the end of the file once the dump is completed.

(small patch being passed around which I did not write but thought would be helpful to the community)
