### PR TITLE
build: remove ENABLE_HARDENING condition from check-security

### DIFF
--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -35,15 +35,11 @@ function(add_maintenance_targets)
     VERBATIM
   )
 
-  if(ENABLE_HARDENING)
-    add_custom_target(check-security
-      COMMAND ${CMAKE_COMMAND} -E echo "Checking binary security..."
-      COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/devtools/security-check.py ${executables}
-      VERBATIM
-    )
-  else()
-    add_custom_target(check-security)
-  endif()
+  add_custom_target(check-security
+    COMMAND ${CMAKE_COMMAND} -E echo "Checking binary security..."
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/devtools/security-check.py ${executables}
+    VERBATIM
+  )
 endfunction()
 
 function(add_windows_deploy_target)


### PR DESCRIPTION
This check is only used in release builds, where hardening should always be enabled. I can't think of a reason we'd want to silently skip these checks if hardening was inadvertently disabled.