### PR TITLE
mining: drop unused  -nFees and sigops from CBlockTemplate

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -34,9 +34,12 @@ public:
     virtual ~BlockTemplate() = default;
 
     virtual CBlockHeader getBlockHeader() = 0;
+    // Block contains a dummy coinbase transaction that should not be used.
     virtual CBlock getBlock() = 0;
 
+    // Fees per transaction, not including coinbase transaction.
     virtual std::vector<CAmount> getTxFees() = 0;
+    // Sigop cost per transaction, not including coinbase transaction.
     virtual std::vector<int64_t> getTxSigops() = 0;
 
     virtual CTransactionRef getCoinbaseTx() = 0;

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -37,7 +37,9 @@ static const bool DEFAULT_PRINT_MODIFIED_FEE = false;
 struct CBlockTemplate
 {
     CBlock block;
+    // Fees per transaction, not including coinbase transaction (unlike CBlock::vtx).
     std::vector<CAmount> vTxFees;
+    // Sigops per transaction, not including coinbase transaction (unlike CBlock::vtx).
     std::vector<int64_t> vTxSigOpsCost;
     std::vector<unsigned char> vchCoinbaseCommitment;
     /* A vector of package fee rates, ordered by the sequence in which

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -893,7 +893,7 @@ static RPCHelpMan getblocktemplate()
         }
         entry.pushKV("depends", std::move(deps));
 
-        int index_in_template = i - 1;
+        int index_in_template = i - 2;
         entry.pushKV("fee", tx_fees.at(index_in_template));
         int64_t nTxSigOps{tx_sigops.at(index_in_template)};
         if (fPreSegWit) {


### PR DESCRIPTION
For the coinbase `vTxFees` used a dummy value of -nFees.

Similarly the first `vTxSigOpsCost` entry was calculated from
the dummy coinbase transaction.

This was introduced in #2115, but the values were never returned by the RPC or used in a test.

Drop 'm and add code comments to prevent confusion.

This PR also adds test coverage for the `fees` and `sigops` fields in `getblocktemplate`, so it closes #32053.