### PR TITLE
Fix field name styling in `submitpackage` RPC results

### DIFF
--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -949,23 +949,23 @@ static RPCHelpMan submitpackage()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR, "package_msg", "The transaction package result message. \"success\" indicates all transactions were accepted into or are already in the mempool."},
-                {RPCResult::Type::OBJ_DYN, "tx-results", "transaction results keyed by wtxid",
+                {RPCResult::Type::OBJ_DYN, "tx_results", "transaction results keyed by wtxid",
                 {
                     {RPCResult::Type::OBJ, "wtxid", "transaction wtxid", {
                         {RPCResult::Type::STR_HEX, "txid", "The transaction hash in hex"},
-                        {RPCResult::Type::STR_HEX, "other-wtxid", /*optional=*/true, "The wtxid of a different transaction with the same txid but different witness found in the mempool. This means the submitted transaction was ignored."},
+                        {RPCResult::Type::STR_HEX, "other_wtxid", /*optional=*/true, "The wtxid of a different transaction with the same txid but different witness found in the mempool. This means the submitted transaction was ignored."},
                         {RPCResult::Type::NUM, "vsize", /*optional=*/true, "Sigops-adjusted virtual transaction size."},
                         {RPCResult::Type::OBJ, "fees", /*optional=*/true, "Transaction fees", {
                             {RPCResult::Type::STR_AMOUNT, "base", "transaction fee in " + CURRENCY_UNIT},
-                            {RPCResult::Type::STR_AMOUNT, "effective-feerate", /*optional=*/true, "if the transaction was not already in the mempool, the effective feerate in " + CURRENCY_UNIT + " per KvB. For example, the package feerate and/or feerate with modified fees from prioritisetransaction."},
-                            {RPCResult::Type::ARR, "effective-includes", /*optional=*/true, "if effective-feerate is provided, the wtxids of the transactions whose fees and vsizes are included in effective-feerate.",
+                            {RPCResult::Type::STR_AMOUNT, "effective_feerate", /*optional=*/true, "if the transaction was not already in the mempool, the effective feerate in " + CURRENCY_UNIT + " per KvB. For example, the package feerate and/or feerate with modified fees from prioritisetransaction."},
+                            {RPCResult::Type::ARR, "effective_includes", /*optional=*/true, "if effective_feerate is provided, the wtxids of the transactions whose fees and vsizes are included in effective_feerate.",
                                 {{RPCResult::Type::STR_HEX, "", "transaction wtxid in hex"},
                             }},
                         }},
                         {RPCResult::Type::STR, "error", /*optional=*/true, "The transaction error string, if it was rejected by the mempool"},
                     }}
                 }},
-                {RPCResult::Type::ARR, "replaced-transactions", /*optional=*/true, "List of txids of replaced transactions",
+                {RPCResult::Type::ARR, "replaced_transactions", /*optional=*/true, "List of txids of replaced transactions",
                 {
                     {RPCResult::Type::STR_HEX, "", "The transaction id"},
                 }},
@@ -1085,7 +1085,7 @@ static RPCHelpMan submitpackage()
                 const auto& tx_result = it->second;
                 switch(it->second.m_result_type) {
                 case MempoolAcceptResult::ResultType::DIFFERENT_WITNESS:
-                    result_inner.pushKV("other-wtxid", it->second.m_other_wtxid.value().GetHex());
+                    result_inner.pushKV("other_wtxid", it->second.m_other_wtxid.value().GetHex());
                     break;
                 case MempoolAcceptResult::ResultType::INVALID:
                     result_inner.pushKV("error", it->second.m_state.ToString());
@@ -1099,12 +1099,12 @@ static RPCHelpMan submitpackage()
                         // Effective feerate is not provided for MEMPOOL_ENTRY transactions even
                         // though modified fees is known, because it is unknown whether package
                         // feerate was used when it was originally submitted.
-                        fees.pushKV("effective-feerate", ValueFromAmount(tx_result.m_effective_feerate.value().GetFeePerK()));
+                        fees.pushKV("effective_feerate", ValueFromAmount(tx_result.m_effective_feerate.value().GetFeePerK()));
                         UniValue effective_includes_res(UniValue::VARR);
                         for (const auto& wtxid : tx_result.m_wtxids_fee_calculations.value()) {
                             effective_includes_res.push_back(wtxid.ToString());
                         }
-                        fees.pushKV("effective-includes", std::move(effective_includes_res));
+                        fees.pushKV("effective_includes", std::move(effective_includes_res));
                     }
                     result_inner.pushKV("fees", std::move(fees));
                     for (const auto& ptx : it->second.m_replaced_transactions) {
@@ -1114,10 +1114,10 @@ static RPCHelpMan submitpackage()
                 }
                 tx_result_map.pushKV(tx->GetWitnessHash().GetHex(), std::move(result_inner));
             }
-            rpc_result.pushKV("tx-results", std::move(tx_result_map));
+            rpc_result.pushKV("tx_results", std::move(tx_result_map));
             UniValue replaced_list(UniValue::VARR);
             for (const uint256& hash : replaced_txids) replaced_list.push_back(hash.ToString());
-            rpc_result.pushKV("replaced-transactions", std::move(replaced_list));
+            rpc_result.pushKV("replaced_transactions", std::move(replaced_list));
             return rpc_result;
         },
     };

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -134,20 +134,20 @@ static RPCHelpMan testmempoolaccept()
                 {
                     {RPCResult::Type::STR_HEX, "txid", "The transaction hash in hex"},
                     {RPCResult::Type::STR_HEX, "wtxid", "The transaction witness hash in hex"},
-                    {RPCResult::Type::STR, "package-error", /*optional=*/true, "Package validation error, if any (only possible if rawtxs had more than 1 transaction)."},
+                    {RPCResult::Type::STR, "package_error", /*optional=*/true, "Package validation error, if any (only possible if rawtxs had more than 1 transaction)."},
                     {RPCResult::Type::BOOL, "allowed", /*optional=*/true, "Whether this tx would be accepted to the mempool and pass client-specified maxfeerate. "
                                                        "If not present, the tx was not fully validated due to a failure in another tx in the list."},
                     {RPCResult::Type::NUM, "vsize", /*optional=*/true, "Virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted (only present when 'allowed' is true)"},
                     {RPCResult::Type::OBJ, "fees", /*optional=*/true, "Transaction fees (only present if 'allowed' is true)",
                     {
                         {RPCResult::Type::STR_AMOUNT, "base", "transaction fee in " + CURRENCY_UNIT},
-                        {RPCResult::Type::STR_AMOUNT, "effective-feerate", /*optional=*/false, "the effective feerate in " + CURRENCY_UNIT + " per KvB. May differ from the base feerate if, for example, there are modified fees from prioritisetransaction or a package feerate was used."},
-                        {RPCResult::Type::ARR, "effective-includes", /*optional=*/false, "transactions whose fees and vsizes are included in effective-feerate.",
+                        {RPCResult::Type::STR_AMOUNT, "effective_feerate", /*optional=*/false, "the effective feerate in " + CURRENCY_UNIT + " per KvB. May differ from the base feerate if, for example, there are modified fees from prioritisetransaction or a package feerate was used."},
+                        {RPCResult::Type::ARR, "effective_includes", /*optional=*/false, "transactions whose fees and vsizes are included in effective_feerate.",
                             {RPCResult{RPCResult::Type::STR_HEX, "", "transaction wtxid in hex"},
                         }},
                     }},
-                    {RPCResult::Type::STR, "reject-reason", /*optional=*/true, "Rejection reason (only present when 'allowed' is false)"},
-                    {RPCResult::Type::STR, "reject-details", /*optional=*/true, "Rejection details (only present when 'allowed' is false and rejection details exist)"},
+                    {RPCResult::Type::STR, "reject_reason", /*optional=*/true, "Rejection reason (only present when 'allowed' is false)"},
+                    {RPCResult::Type::STR, "reject_details", /*optional=*/true, "Rejection details (only present when 'allowed' is false and rejection details exist)"},
                 }},
             }
         },
@@ -204,7 +204,7 @@ static RPCHelpMan testmempoolaccept()
                 result_inner.pushKV("txid", tx->GetHash().GetHex());
                 result_inner.pushKV("wtxid", tx->GetWitnessHash().GetHex());
                 if (package_result.m_state.GetResult() == PackageValidationResult::PCKG_POLICY) {
-                    result_inner.pushKV("package-error", package_result.m_state.ToString());
+                    result_inner.pushKV("package_error", package_result.m_state.ToString());
                 }
                 auto it = package_result.m_tx_results.find(tx->GetWitnessHash());
                 if (exit_early || it == package_result.m_tx_results.end()) {
@@ -222,7 +222,7 @@ static RPCHelpMan testmempoolaccept()
                     const CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
                     if (max_raw_tx_fee && fee > max_raw_tx_fee) {
                         result_inner.pushKV("allowed", false);
-                        result_inner.pushKV("reject-reason", "max-fee-exceeded");
+                        result_inner.pushKV("reject_reason", "max-fee-exceeded");
                         exit_early = true;
                     } else {
                         // Only return the fee and vsize if the transaction would pass ATMP.
@@ -231,22 +231,22 @@ static RPCHelpMan testmempoolaccept()
                         result_inner.pushKV("vsize", virtual_size);
                         UniValue fees(UniValue::VOBJ);
                         fees.pushKV("base", ValueFromAmount(fee));
-                        fees.pushKV("effective-feerate", ValueFromAmount(tx_result.m_effective_feerate.value().GetFeePerK()));
+                        fees.pushKV("effective_feerate", ValueFromAmount(tx_result.m_effective_feerate.value().GetFeePerK()));
                         UniValue effective_includes_res(UniValue::VARR);
                         for (const auto& wtxid : tx_result.m_wtxids_fee_calculations.value()) {
                             effective_includes_res.push_back(wtxid.ToString());
                         }
-                        fees.pushKV("effective-includes", std::move(effective_includes_res));
+                        fees.pushKV("effective_includes", std::move(effective_includes_res));
                         result_inner.pushKV("fees", std::move(fees));
                     }
                 } else {
                     result_inner.pushKV("allowed", false);
                     const TxValidationState state = tx_result.m_state;
                     if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS) {
-                        result_inner.pushKV("reject-reason", "missing-inputs");
+                        result_inner.pushKV("reject_reason", "missing-inputs");
                     } else {
-                        result_inner.pushKV("reject-reason", state.GetRejectReason());
-                        result_inner.pushKV("reject-details", state.ToString());
+                        result_inner.pushKV("reject_reason", state.GetRejectReason());
+                        result_inner.pushKV("reject_details", state.ToString());
                     }
                 }
                 rpc_result.push_back(std::move(result_inner));

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -170,8 +170,8 @@ class BIP65Test(BitcoinTestFramework):
                     'txid': spendtx_txid,
                     'wtxid': spendtx_wtxid,
                     'allowed': False,
-                    'reject-reason': expected_cltv_reject_reason,
-                    'reject-details': expected_cltv_reject_reason + f", input 0 of {spendtx_txid} (wtxid {spendtx_wtxid}), spending {coin_txid}:{coin_vout}"
+                    'reject_reason': expected_cltv_reject_reason,
+                    'reject_details': expected_cltv_reject_reason + f", input 0 of {spendtx_txid} (wtxid {spendtx_wtxid}), spending {coin_txid}:{coin_vout}"
                 }],
                 self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
             )

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -123,8 +123,8 @@ class BIP66Test(BitcoinTestFramework):
                 'txid': spendtx_txid,
                 'wtxid': spendtx_wtxid,
                 'allowed': False,
-                'reject-reason': 'mandatory-script-verify-flag-failed (Non-canonical DER signature)',
-                'reject-details': 'mandatory-script-verify-flag-failed (Non-canonical DER signature), ' +
+                'reject_reason': 'mandatory-script-verify-flag-failed (Non-canonical DER signature)',
+                'reject_details': 'mandatory-script-verify-flag-failed (Non-canonical DER signature), ' +
                                   f"input 0 of {spendtx_txid} (wtxid {spendtx_wtxid}), spending {coin_txid}:0"
             }],
             self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -115,8 +115,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         reject_reason = "insufficient fee"
         reject_details = f"{reject_reason}, rejecting replacement {tx.hash}; new feerate 0.00300000 BTC/kvB <= old feerate 0.00300000 BTC/kvB"
         res = self.nodes[0].testmempoolaccept(rawtxs=[tx_hex])[0]
-        assert_equal(res["reject-reason"], reject_reason)
-        assert_equal(res["reject-details"], reject_details)
+        assert_equal(res["reject_reason"], reject_reason)
+        assert_equal(res["reject_details"], reject_details)
         assert_raises_rpc_error(-26, f"{reject_details}", self.nodes[0].sendrawtransaction, tx_hex, 0)
 
 
@@ -165,8 +165,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         reject_reason = "insufficient fee"
         reject_details = f"{reject_reason}, rejecting replacement {dbl_tx.hash}, less fees than conflicting txs; 3.00 < 4.00"
         res = self.nodes[0].testmempoolaccept(rawtxs=[dbl_tx_hex])[0]
-        assert_equal(res["reject-reason"], reject_reason)
-        assert_equal(res["reject-details"], reject_details)
+        assert_equal(res["reject_reason"], reject_reason)
+        assert_equal(res["reject_details"], reject_details)
         assert_raises_rpc_error(-26, f"{reject_details}", self.nodes[0].sendrawtransaction, dbl_tx_hex, 0)
 
 
@@ -308,8 +308,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         reject_reason = "bad-txns-spends-conflicting-tx"
         reject_details = f"{reject_reason}, {tx2.hash} spends conflicting transaction {tx1a['tx'].hash}"
         res = self.nodes[0].testmempoolaccept(rawtxs=[tx2_hex])[0]
-        assert_equal(res["reject-reason"], reject_reason)
-        assert_equal(res["reject-details"], reject_details)
+        assert_equal(res["reject_reason"], reject_reason)
+        assert_equal(res["reject_details"], reject_details)
         assert_raises_rpc_error(-26, f"{reject_details}", self.nodes[0].sendrawtransaction, tx2_hex, 0)
 
 
@@ -353,8 +353,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         reject_reason = "replacement-adds-unconfirmed"
         reject_details = f"{reject_reason}, replacement {tx2.hash} adds unconfirmed input, idx 1"
         res = self.nodes[0].testmempoolaccept(rawtxs=[tx2_hex])[0]
-        assert_equal(res["reject-reason"], reject_reason)
-        assert_equal(res["reject-details"], reject_details)
+        assert_equal(res["reject_reason"], reject_reason)
+        assert_equal(res["reject_details"], reject_details)
         assert_raises_rpc_error(-26, f"{reject_details}", self.nodes[0].sendrawtransaction, tx2_hex, 0)
 
 
@@ -401,8 +401,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         reject_reason = "too many potential replacements"
         reject_details = f"{reject_reason}, rejecting replacement {double_tx.hash}; too many potential replacements ({MAX_REPLACEMENT_LIMIT + 1} > {MAX_REPLACEMENT_LIMIT})"
         res = self.nodes[0].testmempoolaccept(rawtxs=[double_tx_hex])[0]
-        assert_equal(res["reject-reason"], reject_reason)
-        assert_equal(res["reject-details"], reject_details)
+        assert_equal(res["reject_reason"], reject_reason)
+        assert_equal(res["reject_details"], reject_details)
         assert_raises_rpc_error(-26, f"{reject_details}", self.nodes[0].sendrawtransaction, double_tx_hex, 0)
 
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -65,10 +65,10 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             # Skip these checks for now
             r.pop('wtxid')
             if "fees" in r:
-                r["fees"].pop("effective-feerate")
-                r["fees"].pop("effective-includes")
-            if "reject-details" in r:
-                r.pop("reject-details")
+                r["fees"].pop("effective_feerate")
+                r["fees"].pop("effective_includes")
+            if "reject_details" in r:
+                r.pop("reject_details")
         assert_equal(result_expected, result_test)
         assert_equal(self.nodes[0].getmempoolinfo()['size'], self.mempool_size)  # Must not change mempool state
 
@@ -110,7 +110,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         ))
         # ... 0.99 passes
         self.check_mempool_result(
-            result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject-reason': 'txn-already-known'}],
+            result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject_reason': 'txn-already-known'}],
             rawtxs=[raw_tx_in_block],
             maxfeerate=0.99,
         )
@@ -149,7 +149,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         node.sendrawtransaction(hexstring=raw_tx_0)
         self.mempool_size += 1
         self.check_mempool_result(
-            result_expected=[{'txid': txid_0, 'allowed': False, 'reject-reason': 'txn-already-in-mempool'}],
+            result_expected=[{'txid': txid_0, 'allowed': False, 'reject_reason': 'txn-already-in-mempool'}],
             rawtxs=[raw_tx_0],
         )
 
@@ -168,7 +168,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_0)
         tx.vin[0].prevout = COutPoint(hash=int('ff' * 32, 16), n=14)
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'missing-inputs'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'missing-inputs'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -190,11 +190,11 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.mempool_size = 0
         # Now see if we can add the coins back to the utxo set by sending the exact txs again
         self.check_mempool_result(
-            result_expected=[{'txid': txid_0, 'allowed': False, 'reject-reason': 'missing-inputs'}],
+            result_expected=[{'txid': txid_0, 'allowed': False, 'reject_reason': 'missing-inputs'}],
             rawtxs=[raw_tx_0],
         )
         self.check_mempool_result(
-            result_expected=[{'txid': txid_1, 'allowed': False, 'reject-reason': 'missing-inputs'}],
+            result_expected=[{'txid': txid_1, 'allowed': False, 'reject_reason': 'missing-inputs'}],
             rawtxs=[raw_tx_1],
         )
 
@@ -214,7 +214,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vout = []
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-vout-empty'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-vout-empty'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -222,7 +222,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vin = [tx.vin[0]] * math.ceil((MAX_BLOCK_WEIGHT // WITNESS_SCALE_FACTOR) / len(tx.vin[0].serialize()))
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-oversize'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-oversize'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -230,7 +230,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vout[0].nValue *= -1
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-vout-negative'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-vout-negative'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -239,7 +239,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vout[0].nValue = MAX_MONEY + 1
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-vout-toolarge'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-vout-toolarge'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -248,7 +248,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx.vout = [tx.vout[0]] * 2
         tx.vout[0].nValue = MAX_MONEY
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-txouttotal-toolarge'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-txouttotal-toolarge'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -256,7 +256,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vin = [tx.vin[0]] * 2
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-inputs-duplicate'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-inputs-duplicate'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -264,7 +264,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vin.append(CTxIn(COutPoint(hash=0, n=0xffffffff)))
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-prevout-null'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bad-txns-prevout-null'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -273,7 +273,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         raw_tx_coinbase_spent = node.getrawtransaction(txid=node.decoderawtransaction(hexstring=raw_tx_in_block)['vin'][0]['txid'])
         tx = tx_from_hex(raw_tx_coinbase_spent)
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'coinbase'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'coinbase'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -281,32 +281,32 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.version = 4  # A version currently non-standard
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'version'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'version'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         tx.vout[0].scriptPubKey = CScript([OP_0])  # Some non-standard script
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'scriptpubkey'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'scriptpubkey'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         _, pubkey = generate_keypair()
         tx.vout[0].scriptPubKey = keys_to_multisig_script([pubkey] * 3, k=2)  # Some bare multisig script (2-of-3)
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bare-multisig'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'bare-multisig'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         tx.vin[0].scriptSig = CScript([OP_HASH160])  # Some not-pushonly scriptSig
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'scriptsig-not-pushonly'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'scriptsig-not-pushonly'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         tx.vin[0].scriptSig = CScript([b'a' * 1648]) # Some too large scriptSig (>1650 bytes)
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'scriptsig-size'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'scriptsig-size'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
@@ -314,21 +314,21 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         num_scripts = 100000 // len(output_p2sh_burn.serialize())  # Use enough outputs to make the tx too large for our policy
         tx.vout = [output_p2sh_burn] * num_scripts
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'tx-size'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'tx-size'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         tx.vout[0] = output_p2sh_burn
         tx.vout[0].nValue -= 1  # Make output smaller, such that it is dust for our policy
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'dust'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'dust'}],
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
         tx.vout[0].scriptPubKey = CScript([OP_RETURN, b'\xff'])
         tx.vout = [tx.vout[0]] * 2
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'multi-op-return'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'multi-op-return'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -337,7 +337,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx.vin[0].nSequence -= 1  # Should be non-max, so locktime is not ignored
         tx.nLockTime = node.getblockcount() + 1
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'non-final'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'non-final'}],
             rawtxs=[tx.serialize().hex()],
         )
 
@@ -345,7 +345,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx = tx_from_hex(raw_tx_reference)
         tx.vin[0].nSequence = 2  # We could include it in the second block mined from now, but not the very next one
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'non-BIP68-final'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'non-BIP68-final'}],
             rawtxs=[tx.serialize().hex()],
             maxfeerate=0,
         )
@@ -366,7 +366,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         assert_greater_than(len(tx.serialize()), 64)
 
         self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'tx-size-small'}],
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject_reason': 'tx-size-small'}],
             rawtxs=[tx.serialize().hex()],
             maxfeerate=0,
         )
@@ -394,7 +394,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         anchor_nonempty_wit_spend.rehash()
 
         self.check_mempool_result(
-            result_expected=[{'txid': anchor_nonempty_wit_spend.rehash(), 'allowed': False, 'reject-reason': 'bad-witness-nonstandard'}],
+            result_expected=[{'txid': anchor_nonempty_wit_spend.rehash(), 'allowed': False, 'reject_reason': 'bad-witness-nonstandard'}],
             rawtxs=[anchor_nonempty_wit_spend.serialize().hex()],
             maxfeerate=0,
         )
@@ -432,7 +432,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         nested_anchor_spend.rehash()
 
         self.check_mempool_result(
-            result_expected=[{'txid': nested_anchor_spend.rehash(), 'allowed': False, 'reject-reason': 'non-mandatory-script-verify-flag (Witness version reserved for soft-fork upgrades)'}],
+            result_expected=[{'txid': nested_anchor_spend.rehash(), 'allowed': False, 'reject_reason': 'non-mandatory-script-verify-flag (Witness version reserved for soft-fork upgrades)'}],
             rawtxs=[nested_anchor_spend.serialize().hex()],
             maxfeerate=0,
         )

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -100,15 +100,15 @@ class MempoolWtxidTest(BitcoinTestFramework):
             "txid": child_one_txid,
             "wtxid": child_one_wtxid,
             "allowed": False,
-            "reject-reason": "txn-already-in-mempool",
-            "reject-details": "txn-already-in-mempool"
+            "reject_reason": "txn-already-in-mempool",
+            "reject_details": "txn-already-in-mempool"
         }])
         assert_equal(node.testmempoolaccept([child_two.serialize().hex()])[0], {
             "txid": child_two_txid,
             "wtxid": child_two_wtxid,
             "allowed": False,
-            "reject-reason": "txn-same-nonwitness-data-in-mempool",
-            "reject-details": "txn-same-nonwitness-data-in-mempool"
+            "reject_reason": "txn-same-nonwitness-data-in-mempool",
+            "reject_details": "txn-same-nonwitness-data-in-mempool"
         })
 
         # sendrawtransaction will not throw but quits early when the exact same transaction is already in mempool

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -66,7 +66,7 @@ class DustRelayFeeTest(BitcoinTestFramework):
             tx.vout[1].nValue -= 1
             res = node.testmempoolaccept([tx.serialize().hex()])[0]
             assert_equal(res['allowed'], False)
-            assert_equal(res['reject-reason'], 'dust')
+            assert_equal(res['reject_reason'], 'dust')
 
         # finally send the transaction to avoid running out of MiniWallet UTXOs
         self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_good_hex)

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -148,14 +148,14 @@ class EphemeralDustTest(BitcoinTestFramework):
         # When base fee is non-0, we report dust like usual
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+        assert_equal(res["tx_results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
 
         # Priority is ignored: rejected even if modified fee is 0
         self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-sats_fee)
         self.nodes[1].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-sats_fee)
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+        assert_equal(res["tx_results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
 
         # Will not be accepted if base fee is 0 with modified fee of non-0
         dusty_tx, sweep_tx = self.create_ephemeral_dust_package(tx_version=3)
@@ -171,7 +171,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         # Or as a package
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
+        assert_equal(res["tx_results"][dusty_tx["wtxid"]]["error"], "dust, tx with dust output must be 0-fee")
 
         assert_mempool_contents(self, self.nodes[0], expected=[])
 
@@ -183,7 +183,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "dust")
+        assert_equal(res["tx_results"][dusty_tx["wtxid"]]["error"], "dust")
         assert_equal(self.nodes[0].getrawmempool(), [])
 
     def test_nonzero_dust(self):
@@ -215,7 +215,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert_equal(res["tx-results"][dusty_tx["wtxid"]]["error"], "min relay fee not met, 0 < 147")
+        assert_equal(res["tx_results"][dusty_tx["wtxid"]]["error"], "min relay fee not met, 0 < 147")
 
         assert_equal(self.nodes[0].getrawmempool(), [])
 
@@ -233,7 +233,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         unspent_sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=2000, utxos_to_spend=[dusty_tx["new_utxos"][0]], version=3)
         assert_greater_than(unspent_sweep_tx["fee"], sweep_tx["fee"])
         res = self.nodes[0].submitpackage([dusty_tx["hex"], unspent_sweep_tx["hex"]])
-        assert_equal(res["tx-results"][unspent_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        assert_equal(res["tx_results"][unspent_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} did not spend parent's ephemeral dust")
         assert_raises_rpc_error(-26, f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} did not spend parent's ephemeral dust", self.nodes[0].sendrawtransaction, unspent_sweep_tx["hex"])
         assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]])
 
@@ -405,7 +405,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs] + [insufficient_sweep_tx["hex"]])
         assert_equal(res['package_msg'], "transaction failed")
-        assert_equal(res['tx-results'][insufficient_sweep_tx['wtxid']]['error'], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        assert_equal(res['tx_results'][insufficient_sweep_tx['wtxid']]['error'], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
         # Everything got in except for insufficient spend
         assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs])
 
@@ -418,7 +418,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         res = self.nodes[0].submitpackage([dusty_tx["hex"] for dusty_tx in dusty_txs] + [insufficient_sweep_tx["hex"]])
         assert_equal(res['package_msg'], "transaction failed")
-        assert_equal(res['tx-results'][insufficient_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
+        assert_equal(res['tx_results'][insufficient_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {insufficient_sweep_tx['txid']} did not spend parent's ephemeral dust")
         assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"] for dusty_tx in dusty_txs] + [sweep_all_but_one_tx["tx"]])
 
         # Cycle out the partial sweep to avoid triggering package RBF behavior which limits package to no in-mempool ancestors

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -88,7 +88,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         # Test doesn't work because lack of package feerates
         test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"], sweep_tx["hex"]])
         assert not test_res[0]["allowed"]
-        assert_equal(test_res[0]["reject-reason"], "min relay fee not met")
+        assert_equal(test_res[0]["reject_reason"], "min relay fee not met")
 
         # And doesn't work on its own
         assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, dusty_tx["hex"])
@@ -97,7 +97,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=COIN)
         test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"]])
         assert not test_res[0]["allowed"]
-        assert_equal(test_res[0]["reject-reason"], "dust")
+        assert_equal(test_res[0]["reject_reason"], "dust")
         # Reset priority
         self.nodes[0].prioritisetransaction(txid=dusty_tx["txid"], dummy=0, fee_delta=-COIN)
         assert_equal(self.nodes[0].getprioritisedtransactions(), {})
@@ -166,7 +166,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         # It's rejected submitted alone
         test_res = self.nodes[0].testmempoolaccept([dusty_tx["hex"]])
         assert not test_res[0]["allowed"]
-        assert_equal(test_res[0]["reject-reason"], "dust")
+        assert_equal(test_res[0]["reject_reason"], "dust")
 
         # Or as a package
         res = self.nodes[0].submitpackage([dusty_tx["hex"], sweep_tx["hex"]])

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -220,7 +220,7 @@ class MempoolLimitTest(BitcoinTestFramework):
             confirmed_only=True)
         package_hex.append(cpfp_parent["hex"])
         parent_utxos.append(cpfp_parent["new_utxo"])
-        assert_equal(node.testmempoolaccept([cpfp_parent["hex"]])[0]["reject-reason"], "mempool min fee not met")
+        assert_equal(node.testmempoolaccept([cpfp_parent["hex"]])[0]["reject_reason"], "mempool min fee not met")
 
         self.wallet.rescan_utxos()
 

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -83,7 +83,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         )
         res = node.submitpackage([tx_B["hex"], tx_C["hex"]])
         assert_equal(res["package_msg"], "transaction failed")
-        assert "too-long-mempool-chain" in res["tx-results"][tx_C["wtxid"]]["error"]
+        assert "too-long-mempool-chain" in res["tx_results"][tx_C["wtxid"]]["error"]
 
     def test_mid_package_eviction_success(self):
         node = self.nodes[0]
@@ -155,9 +155,9 @@ class MempoolLimitTest(BitcoinTestFramework):
         # be included. If trimming of a parent were to happen,
         # package evaluation would happen to reintrodce the evicted
         # parent.
-        assert_equal(len(package_res["tx-results"]), len(big_parent_wtxids) + 1)
+        assert_equal(len(package_res["tx_results"]), len(big_parent_wtxids) + 1)
         for wtxid in big_parent_wtxids + [child["wtxid"]]:
-            assert_equal(len(package_res["tx-results"][wtxid]["fees"]["effective-includes"]), 1)
+            assert_equal(len(package_res["tx_results"][wtxid]["fees"]["effective_includes"]), 1)
 
         # Maximum size must never be exceeded.
         assert_greater_than(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
@@ -328,7 +328,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # Package should be submitted, temporarily exceeding maxmempool, and then evicted.
         res = node.submitpackage(package_hex)
         assert_equal(res["package_msg"], "transaction failed")
-        assert len([tx_res for _, tx_res in res["tx-results"].items() if "error" in tx_res and tx_res["error"] == "bad-txns-inputs-missingorspent"])
+        assert len([tx_res for _, tx_res in res["tx_results"].items() if "error" in tx_res and tx_res["error"] == "bad-txns-inputs-missingorspent"])
 
         # Maximum size must never be exceeded.
         assert_greater_than(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
@@ -378,23 +378,23 @@ class MempoolLimitTest(BitcoinTestFramework):
         submitpackage_result = node.submitpackage([tx["hex"] for tx in package_txns])
         assert_equal(submitpackage_result["package_msg"], "success")
 
-        rich_parent_result = submitpackage_result["tx-results"][tx_rich["wtxid"]]
-        poor_parent_result = submitpackage_result["tx-results"][tx_poor["wtxid"]]
-        child_result = submitpackage_result["tx-results"][tx_child["tx"].getwtxid()]
+        rich_parent_result = submitpackage_result["tx_results"][tx_rich["wtxid"]]
+        poor_parent_result = submitpackage_result["tx_results"][tx_poor["wtxid"]]
+        child_result = submitpackage_result["tx_results"][tx_child["tx"].getwtxid()]
         assert_fee_amount(poor_parent_result["fees"]["base"], tx_poor["tx"].get_vsize(), relayfee)
         assert_equal(rich_parent_result["fees"]["base"], 0)
         assert_equal(child_result["fees"]["base"], DEFAULT_FEE)
         # The "rich" parent does not require CPFP so its effective feerate is just its individual feerate.
-        assert_fee_amount(DEFAULT_FEE, tx_rich["tx"].get_vsize(), rich_parent_result["fees"]["effective-feerate"])
-        assert_equal(rich_parent_result["fees"]["effective-includes"], [tx_rich["wtxid"]])
+        assert_fee_amount(DEFAULT_FEE, tx_rich["tx"].get_vsize(), rich_parent_result["fees"]["effective_feerate"])
+        assert_equal(rich_parent_result["fees"]["effective_includes"], [tx_rich["wtxid"]])
         # The "poor" parent and child's effective feerates are the same, composed of their total
         # fees divided by their combined vsize.
         package_fees = poor_parent_result["fees"]["base"] + child_result["fees"]["base"]
         package_vsize = tx_poor["tx"].get_vsize() + tx_child["tx"].get_vsize()
-        assert_fee_amount(package_fees, package_vsize, poor_parent_result["fees"]["effective-feerate"])
-        assert_fee_amount(package_fees, package_vsize, child_result["fees"]["effective-feerate"])
-        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective-includes"])
-        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective-includes"])
+        assert_fee_amount(package_fees, package_vsize, poor_parent_result["fees"]["effective_feerate"])
+        assert_fee_amount(package_fees, package_vsize, child_result["fees"]["effective_feerate"])
+        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective_includes"])
+        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective_includes"])
 
         # The node will broadcast each transaction, still abiding by its peer's fee filter
         peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
@@ -427,7 +427,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert_greater_than(package_fee / package_vsize, mempoolmin_feerate / 1000)
         res = node.submitpackage([tx_parent_just_below["hex"], tx_child_just_above["hex"]])
         for wtxid in [tx_parent_just_below["wtxid"], tx_child_just_above["wtxid"]]:
-            assert_equal(res["tx-results"][wtxid]["error"], "mempool full")
+            assert_equal(res["tx_results"][wtxid]["error"], "mempool full")
 
         self.log.info('Test passing a value below the minimum (5 MB) to -maxmempool throws an error')
         self.stop_node(0)

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -26,7 +26,7 @@ def check_package_limits(func):
         testres_error_expected = node.testmempoolaccept(rawtxs=package_hex)
         assert_equal(len(testres_error_expected), len(package_hex))
         for txres in testres_error_expected:
-            assert "package-mempool-limits" in txres["package-error"]
+            assert "package-mempool-limits" in txres["package_error"]
 
         # Clear mempool and check that the package passes now
         self.generate(node, 1)

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -58,7 +58,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         replaceable_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[chain[0]])
         txns = [replaceable_tx["tx"], self.wallet.create_self_transfer_multi(utxos_to_spend=replaceable_tx["new_utxos"])["tx"]]
         txns_hex = [tx.serialize().hex() for tx in txns]
-        assert_equal(self.nodes[0].testmempoolaccept(txns_hex)[0]["reject-reason"], "too-long-mempool-chain")
+        assert_equal(self.nodes[0].testmempoolaccept(txns_hex)[0]["reject_reason"], "too-long-mempool-chain")
         pkg_result = self.nodes[0].submitpackage(txns_hex)
         assert "too-long-mempool-chain" in pkg_result["tx_results"][txns[0].getwtxid()]["error"]
         assert_equal(pkg_result["tx_results"][txns[1].getwtxid()]["error"], "bad-txns-inputs-missingorspent")

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -60,8 +60,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         txns_hex = [tx.serialize().hex() for tx in txns]
         assert_equal(self.nodes[0].testmempoolaccept(txns_hex)[0]["reject-reason"], "too-long-mempool-chain")
         pkg_result = self.nodes[0].submitpackage(txns_hex)
-        assert "too-long-mempool-chain" in pkg_result["tx-results"][txns[0].getwtxid()]["error"]
-        assert_equal(pkg_result["tx-results"][txns[1].getwtxid()]["error"], "bad-txns-inputs-missingorspent")
+        assert "too-long-mempool-chain" in pkg_result["tx_results"][txns[0].getwtxid()]["error"]
+        assert_equal(pkg_result["tx_results"][txns[1].getwtxid()]["error"], "bad-txns-inputs-missingorspent")
         # But not if it chains directly off the first transaction
         self.nodes[0].sendrawtransaction(replaceable_tx["hex"])
         # and the second chain should work just fine

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -111,7 +111,7 @@ class PackageRBFTest(BitcoinTestFramework):
 
         # Test run rejected because conflicts are not allowed in subpackage evaluation
         testres = node.testmempoolaccept(package_hex2)
-        assert_equal(testres[0]["reject-reason"], "bip125-replacement-disallowed")
+        assert_equal(testres[0]["reject_reason"], "bip125-replacement-disallowed")
 
         # But accepted during normal submission
         submitres = node.submitpackage(package_hex2)

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -115,7 +115,7 @@ class PackageRBFTest(BitcoinTestFramework):
 
         # But accepted during normal submission
         submitres = node.submitpackage(package_hex2)
-        assert_equal(set(submitres["replaced-transactions"]), set([tx.rehash() for tx in package_txns1]))
+        assert_equal(set(submitres["replaced_transactions"]), set([tx.rehash() for tx in package_txns1]))
         self.assert_mempool_contents(expected=package_txns2)
 
         # Make sure 2nd node gets a basic package RBF over p2p
@@ -136,7 +136,7 @@ class PackageRBFTest(BitcoinTestFramework):
         package_hex, package_txns = self.create_simple_package(singleton_coin, DEFAULT_FEE, singleton_tx["fee"] * 2)
 
         submitres = node.submitpackage(package_hex)
-        assert_equal(submitres["replaced-transactions"], [singleton_tx["tx"].rehash()])
+        assert_equal(submitres["replaced_transactions"], [singleton_tx["tx"].rehash()])
         self.assert_mempool_contents(expected=package_txns)
 
         self.generate(node, 1)
@@ -541,7 +541,7 @@ class PackageRBFTest(BitcoinTestFramework):
 
         submitres2 = node.submitpackage(package_hex2)
         assert_equal(submitres2["package_msg"], "success")
-        assert_equal(set(submitres2["replaced-transactions"]), set([parent1["txid"], child1["txid"]]))
+        assert_equal(set(submitres2["replaced_transactions"]), set([parent1["txid"], child1["txid"]]))
         self.assert_mempool_contents([parent2["tx"], child2["tx"]])
 
         self.generate(node, 1)

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -170,7 +170,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
 
         # When we actually try to submit, the parent makes it into the mempool, but the child would exceed ancestor vsize limits
         res = self.nodes[0].submitpackage([tx_parent.serialize().hex(), tx_child.serialize().hex()])
-        assert "too-long-mempool-chain" in res["tx-results"][tx_child.getwtxid()]["error"]
+        assert "too-long-mempool-chain" in res["tx_results"][tx_child.getwtxid()]["error"]
         assert tx_parent.rehash() in self.nodes[0].getrawmempool()
 
         # Transactions are tiny in weight

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -166,7 +166,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         # here, it would get further in validation and give too-long-mempool-chain error instead.
         packet_test = self.nodes[0].testmempoolaccept([tx_parent.serialize().hex(), tx_child.serialize().hex()])
         expected_package_error = f"package-mempool-limits, package size {2*max_multisig_vsize} exceeds ancestor size limit [limit: 101000]"
-        assert_equal([x["package-error"] for x in packet_test], [expected_package_error] * 2)
+        assert_equal([x["package_error"] for x in packet_test], [expected_package_error] * 2)
 
         # When we actually try to submit, the parent makes it into the mempool, but the child would exceed ancestor vsize limits
         res = self.nodes[0].submitpackage([tx_parent.serialize().hex(), tx_child.serialize().hex()])

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -275,7 +275,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v3_child = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent["new_utxo"], version=3)
         tx_v3_grandchild = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_child["new_utxo"], version=3)
         result = node.testmempoolaccept([tx_v3_parent["hex"], tx_v3_child["hex"], tx_v3_grandchild["hex"]])
-        assert all([txresult["package-error"] == f"TRUC-violation, tx {tx_v3_grandchild['txid']} (wtxid={tx_v3_grandchild['wtxid']}) would have too many ancestors" for txresult in result])
+        assert all([txresult["package_error"] == f"TRUC-violation, tx {tx_v3_grandchild['txid']} (wtxid={tx_v3_grandchild['wtxid']}) would have too many ancestors" for txresult in result])
 
     @cleanup(extra_args=None)
     def test_truc_ancestors_package_and_mempool(self):
@@ -357,11 +357,11 @@ class MempoolTRUC(BitcoinTestFramework):
         # Fails with another non-related transaction via testmempoolaccept
         tx_unrelated = self.wallet.create_self_transfer(version=3)
         result_test_unrelated = node.testmempoolaccept([tx_sibling_1["hex"], tx_unrelated["hex"]])
-        assert_equal(result_test_unrelated[0]["reject-reason"], "TRUC-violation")
+        assert_equal(result_test_unrelated[0]["reject_reason"], "TRUC-violation")
 
         # Fails in a package via testmempoolaccept
         result_test_1p1c = node.testmempoolaccept([tx_sibling_1["hex"], tx_has_mempool_uncle["hex"]])
-        assert_equal(result_test_1p1c[0]["reject-reason"], "TRUC-violation")
+        assert_equal(result_test_1p1c[0]["reject_reason"], "TRUC-violation")
 
         # Allowed when tx is submitted in a package and evaluated individually.
         # Note that the child failed since it would be the 3rd generation.
@@ -421,11 +421,11 @@ class MempoolTRUC(BitcoinTestFramework):
 
         test_accept_v3_from_v2 = node.testmempoolaccept([tx_v2["hex"], tx_v3_from_v2["hex"]])
         expected_error_v3_from_v2 = f"TRUC-violation, version=3 tx {tx_v3_from_v2['txid']} (wtxid={tx_v3_from_v2['wtxid']}) cannot spend from non-version=3 tx {tx_v2['txid']} (wtxid={tx_v2['wtxid']})"
-        assert all([result["package-error"] == expected_error_v3_from_v2 for result in test_accept_v3_from_v2])
+        assert all([result["package_error"] == expected_error_v3_from_v2 for result in test_accept_v3_from_v2])
 
         test_accept_v2_from_v3 = node.testmempoolaccept([tx_v3["hex"], tx_v2_from_v3["hex"]])
         expected_error_v2_from_v3 = f"TRUC-violation, non-version=3 tx {tx_v2_from_v3['txid']} (wtxid={tx_v2_from_v3['wtxid']}) cannot spend from version=3 tx {tx_v3['txid']} (wtxid={tx_v3['wtxid']})"
-        assert all([result["package-error"] == expected_error_v2_from_v3 for result in test_accept_v2_from_v3])
+        assert all([result["package_error"] == expected_error_v2_from_v3 for result in test_accept_v2_from_v3])
 
         test_accept_pairs = node.testmempoolaccept([tx_v2["hex"], tx_v3["hex"], tx_v2_from_v2["hex"], tx_v3_from_v3["hex"]])
         assert all([result["allowed"] for result in test_accept_pairs])
@@ -437,7 +437,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v3_child_2 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent["new_utxos"][1], version=3)
         test_accept_2children = node.testmempoolaccept([tx_v3_parent["hex"], tx_v3_child_1["hex"], tx_v3_child_2["hex"]])
         expected_error_2children = f"TRUC-violation, tx {tx_v3_parent['txid']} (wtxid={tx_v3_parent['wtxid']}) would exceed descendant count limit"
-        assert all([result["package-error"] == expected_error_2children for result in test_accept_2children])
+        assert all([result["package_error"] == expected_error_2children for result in test_accept_2children])
 
         # Extra TRUC transaction does not get incorrectly marked as extra descendant
         test_accept_1child_with_exra = node.testmempoolaccept([tx_v3_parent["hex"], tx_v3_child_1["hex"], tx_v3_independent["hex"]])
@@ -446,11 +446,11 @@ class MempoolTRUC(BitcoinTestFramework):
         # Extra TRUC transaction does not make us ignore the extra descendant
         test_accept_2children_with_exra = node.testmempoolaccept([tx_v3_parent["hex"], tx_v3_child_1["hex"], tx_v3_child_2["hex"], tx_v3_independent["hex"]])
         expected_error_extra = f"TRUC-violation, tx {tx_v3_parent['txid']} (wtxid={tx_v3_parent['wtxid']}) would exceed descendant count limit"
-        assert all([result["package-error"] == expected_error_extra for result in test_accept_2children_with_exra])
+        assert all([result["package_error"] == expected_error_extra for result in test_accept_2children_with_exra])
         # Same result if the parent is already in mempool
         node.sendrawtransaction(tx_v3_parent["hex"])
         test_accept_2children_with_in_mempool_parent = node.testmempoolaccept([tx_v3_child_1["hex"], tx_v3_child_2["hex"]])
-        assert all([result["package-error"] == expected_error_extra for result in test_accept_2children_with_in_mempool_parent])
+        assert all([result["package_error"] == expected_error_extra for result in test_accept_2children_with_in_mempool_parent])
 
     @cleanup(extra_args=None)
     def test_reorg_2child_rbf(self):

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -369,7 +369,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_mempool_parent["txid"], tx_sibling_1["txid"]])
         expected_error_gen3 = f"TRUC-violation, tx {tx_has_mempool_uncle['txid']} (wtxid={tx_has_mempool_uncle['wtxid']}) would have too many ancestors"
 
-        assert_equal(result_package_indiv["tx-results"][tx_has_mempool_uncle['wtxid']]['error'], expected_error_gen3)
+        assert_equal(result_package_indiv["tx_results"][tx_has_mempool_uncle['wtxid']]['error'], expected_error_gen3)
 
         # Allowed when tx is submitted in a package with in-mempool parent (which is deduplicated).
         node.submitpackage([tx_mempool_parent["hex"], tx_sibling_2["hex"]])
@@ -380,7 +380,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_mempool_parent["txid"], tx_sibling_2["txid"]])
         expected_error_cpfp = f"TRUC-violation, tx {tx_mempool_parent['txid']} (wtxid={tx_mempool_parent['wtxid']}) would exceed descendant count limit"
 
-        assert_equal(result_package_cpfp["tx-results"][tx_sibling_3['wtxid']]['error'], expected_error_cpfp)
+        assert_equal(result_package_cpfp["tx_results"][tx_sibling_3['wtxid']]['error'], expected_error_cpfp)
 
 
     @cleanup(extra_args=["-datacarriersize=1000"])

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -619,8 +619,8 @@ class SegWitTest(BitcoinTestFramework):
             # Just check mempool acceptance, but don't add the transaction to the mempool, since witness is disallowed
             # in blocks and the tx is impossible to mine right now.
             testres3 = self.nodes[0].testmempoolaccept([tx3.serialize_with_witness().hex()])
-            testres3[0]["fees"].pop("effective-feerate")
-            testres3[0]["fees"].pop("effective-includes")
+            testres3[0]["fees"].pop("effective_feerate")
+            testres3[0]["fees"].pop("effective_includes")
             assert_equal(testres3,
                 [{
                     'txid': tx3.hash,
@@ -638,8 +638,8 @@ class SegWitTest(BitcoinTestFramework):
             tx3.vout = [tx3_out]
             tx3.rehash()
             testres3_replaced = self.nodes[0].testmempoolaccept([tx3.serialize_with_witness().hex()])
-            testres3_replaced[0]["fees"].pop("effective-feerate")
-            testres3_replaced[0]["fees"].pop("effective-includes")
+            testres3_replaced[0]["fees"].pop("effective_feerate")
+            testres3_replaced[0]["fees"].pop("effective_includes")
             assert_equal(testres3_replaced,
                 [{
                     'txid': tx3.hash,

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -335,7 +335,7 @@ class TxDownloadTest(BitcoinTestFramework):
         mempoolminfee = node.getmempoolinfo()['mempoolminfee']
         peer = node.add_p2p_connection(TestP2PConn())
         low_fee_tx = self.wallet.create_self_transfer(fee_rate=Decimal("0.9")*mempoolminfee)
-        assert_equal(node.testmempoolaccept([low_fee_tx['hex']])[0]["reject-reason"], "mempool min fee not met")
+        assert_equal(node.testmempoolaccept([low_fee_tx['hex']])[0]["reject_reason"], "mempool min fee not met")
         peer.send_and_ping(msg_tx(low_fee_tx['tx']))
         peer.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(low_fee_tx['wtxid'], 16))]))
         node.setmocktime(int(time.time()))

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -262,18 +262,18 @@ class RPCPackagesTest(BitcoinTestFramework):
         ])
 
         submitres = node.submitpackage([tx1["hex"], tx2["hex"], tx_child["hex"]])
-        assert_equal(submitres, {'package_msg': 'conflict-in-package', 'tx-results': {}, 'replaced-transactions': []})
+        assert_equal(submitres, {'package_msg': 'conflict-in-package', 'tx_results': {}, 'replaced_transactions': []})
 
         # Submit tx1 to mempool, then try the same package again
         node.sendrawtransaction(tx1["hex"])
 
         submitres = node.submitpackage([tx1["hex"], tx2["hex"], tx_child["hex"]])
-        assert_equal(submitres, {'package_msg': 'conflict-in-package', 'tx-results': {}, 'replaced-transactions': []})
+        assert_equal(submitres, {'package_msg': 'conflict-in-package', 'tx_results': {}, 'replaced_transactions': []})
         assert tx_child["txid"] not in node.getrawmempool()
 
         # ... and without the in-mempool ancestor tx1 included in the call
         submitres = node.submitpackage([tx2["hex"], tx_child["hex"]])
-        assert_equal(submitres, {'package_msg': 'package-not-child-with-unconfirmed-parents', 'tx-results': {}, 'replaced-transactions': []})
+        assert_equal(submitres, {'package_msg': 'package-not-child-with-unconfirmed-parents', 'tx_results': {}, 'replaced_transactions': []})
 
         # Regardless of error type, the child can never enter the mempool
         assert tx_child["txid"] not in node.getrawmempool()
@@ -321,7 +321,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         """
         for testres_tx in testmempoolaccept_result:
             # Grab this result from the submitpackage_result
-            submitres_tx = submitpackage_result["tx-results"][testres_tx["wtxid"]]
+            submitres_tx = submitpackage_result["tx_results"][testres_tx["wtxid"]]
             assert_equal(submitres_tx["txid"], testres_tx["txid"])
             # No "allowed" if the tx was already in the mempool
             if "allowed" in testres_tx and testres_tx["allowed"]:
@@ -353,16 +353,16 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(submitpackage_result["package_msg"], "success")
         for package_txn in package_txns:
             tx = package_txn["tx"]
-            assert tx.getwtxid() in submitpackage_result["tx-results"]
+            assert tx.getwtxid() in submitpackage_result["tx_results"]
             wtxid = tx.getwtxid()
-            assert wtxid in submitpackage_result["tx-results"]
-            tx_result = submitpackage_result["tx-results"][wtxid]
+            assert wtxid in submitpackage_result["tx_results"]
+            tx_result = submitpackage_result["tx_results"][wtxid]
             assert_equal(tx_result["txid"], tx.rehash())
             assert_equal(tx_result["vsize"], tx.get_vsize())
             assert_equal(tx_result["fees"]["base"], DEFAULT_FEE)
             if wtxid not in presubmitted_wtxids:
-                assert_fee_amount(DEFAULT_FEE, tx.get_vsize(), tx_result["fees"]["effective-feerate"])
-                assert_equal(tx_result["fees"]["effective-includes"], [wtxid])
+                assert_fee_amount(DEFAULT_FEE, tx.get_vsize(), tx_result["fees"]["effective_feerate"])
+                assert_equal(tx_result["fees"]["effective_includes"], [wtxid])
 
         # submitpackage result should be consistent with testmempoolaccept and getmempoolentry
         self.assert_equal_package_results(node, testmempoolaccept_result, submitpackage_result)
@@ -411,9 +411,9 @@ class RPCPackagesTest(BitcoinTestFramework):
         res = node.submitpackage(hex_partial_acceptance)
         assert_equal(res["package_msg"], "transaction failed")
         first_wtxid = txs[0]["tx"].getwtxid()
-        assert "error" not in res["tx-results"][first_wtxid]
+        assert "error" not in res["tx_results"][first_wtxid]
         sec_wtxid = bad_child.getwtxid()
-        assert_equal(res["tx-results"][sec_wtxid]["error"], "version")
+        assert_equal(res["tx_results"][sec_wtxid]["error"], "version")
         peer.wait_for_broadcast([first_wtxid])
 
     def test_maxfeerate_submitpackage(self):
@@ -430,8 +430,8 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         # First tx failed in single transaction evaluation, so package message is generic
         assert_equal(pkg_result["package_msg"], "transaction failed")
-        assert_equal(pkg_result["tx-results"][chained_txns[0]["wtxid"]]["error"], "max feerate exceeded")
-        assert_equal(pkg_result["tx-results"][chained_txns[1]["wtxid"]]["error"], "bad-txns-inputs-missingorspent")
+        assert_equal(pkg_result["tx_results"][chained_txns[0]["wtxid"]]["error"], "max feerate exceeded")
+        assert_equal(pkg_result["tx_results"][chained_txns[1]["wtxid"]]["error"], "bad-txns-inputs-missingorspent")
         assert_equal(node.getrawmempool(), [])
 
         # Make chain of two transactions where parent doesn't make minfee threshold
@@ -462,8 +462,8 @@ class RPCPackagesTest(BitcoinTestFramework):
         # Child is connected even though parent is invalid and still reports fee exceeded
         # this implies sub-package evaluation of both entries together.
         assert_equal(pkg_result["package_msg"], "transaction failed")
-        assert "mempool min fee not met" in pkg_result["tx-results"][parent["wtxid"]]["error"]
-        assert_equal(pkg_result["tx-results"][child["wtxid"]]["error"], "max feerate exceeded")
+        assert "mempool min fee not met" in pkg_result["tx_results"][parent["wtxid"]]["error"]
+        assert_equal(pkg_result["tx_results"][child["wtxid"]]["error"], "max feerate exceeded")
         assert parent["txid"] not in node.getrawmempool()
         assert child["txid"] not in node.getrawmempool()
 
@@ -496,8 +496,8 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         # Relax the restrictions for both and send it; parent gets through as own subpackage
         pkg_result = node.submitpackage(chained_burn_hex, maxfeerate=minrate_btc_kvb_burn, maxburnamount=chained_txns_burn[1]["new_utxo"]["value"])
-        assert "error" not in pkg_result["tx-results"][chained_txns_burn[0]["wtxid"]]
-        assert_equal(pkg_result["tx-results"][tx.getwtxid()]["error"], "scriptpubkey")
+        assert "error" not in pkg_result["tx_results"][chained_txns_burn[0]["wtxid"]]
+        assert_equal(pkg_result["tx_results"][tx.getwtxid()]["error"], "scriptpubkey")
         assert_equal(node.getrawmempool(), [chained_txns_burn[0]["txid"]])
 
 if __name__ == "__main__":

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -106,7 +106,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         # Package validation is atomic: if the node cannot find a UTXO for any single tx in the package,
         # it terminates immediately to avoid unnecessary, expensive signature verification.
         package_bad = self.independent_txns_hex + [garbage_tx]
-        testres_bad = self.independent_txns_testres_blank + [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "allowed": False, "reject-reason": "missing-inputs"}]
+        testres_bad = self.independent_txns_testres_blank + [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "allowed": False, "reject_reason": "missing-inputs"}]
         self.assert_testres_equal(package_bad, testres_bad)
 
         self.log.info("Check testmempoolaccept tells us when some transactions completed validation successfully")
@@ -122,8 +122,8 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(testres_bad_sig, self.independent_txns_testres + [{
             "txid": tx_bad_sig_txid,
             "wtxid": tx_bad_sig_wtxid, "allowed": False,
-            "reject-reason": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)",
-            "reject-details": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size), " +
+            "reject_reason": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)",
+            "reject_details": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size), " +
                               f"input 0 of {tx_bad_sig_txid} (wtxid {tx_bad_sig_wtxid}), spending {coin['txid']}:{coin['vout']}"
         }])
 
@@ -131,7 +131,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         tx_high_fee = self.wallet.create_self_transfer(fee=Decimal("0.999"))
         testres_high_fee = node.testmempoolaccept([tx_high_fee["hex"]])
         assert_equal(testres_high_fee, [
-            {"txid": tx_high_fee["txid"], "wtxid": tx_high_fee["wtxid"], "allowed": False, "reject-reason": "max-fee-exceeded"}
+            {"txid": tx_high_fee["txid"], "wtxid": tx_high_fee["wtxid"], "allowed": False, "reject_reason": "max-fee-exceeded"}
         ])
         package_high_fee = [tx_high_fee["hex"]] + self.independent_txns_hex
         testres_package_high_fee = node.testmempoolaccept(package_high_fee)
@@ -146,7 +146,7 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         self.log.info("Check that testmempoolaccept requires packages to be sorted by dependency")
         assert_equal(node.testmempoolaccept(rawtxs=chain_hex[::-1]),
-                [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "package-error": "package-not-sorted"} for tx in chain_txns[::-1]])
+                [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "package_error": "package-not-sorted"} for tx in chain_txns[::-1]])
 
         self.log.info("Testmempoolaccept a chain of 25 transactions")
         testres_multiple = node.testmempoolaccept(rawtxs=chain_hex)
@@ -236,15 +236,15 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.log.info("Test duplicate transactions in the same package")
         testres = node.testmempoolaccept([tx1["hex"], tx1["hex"]])
         assert_equal(testres, [
-            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "package-contains-duplicates"},
-            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "package-contains-duplicates"}
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package_error": "package-contains-duplicates"},
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package_error": "package-contains-duplicates"}
         ])
 
         self.log.info("Test conflicting transactions in the same package")
         testres = node.testmempoolaccept([tx1["hex"], tx2["hex"]])
         assert_equal(testres, [
-            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "conflict-in-package"},
-            {"txid": tx2["txid"], "wtxid": tx2["wtxid"], "package-error": "conflict-in-package"}
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package_error": "conflict-in-package"},
+            {"txid": tx2["txid"], "wtxid": tx2["wtxid"], "package_error": "conflict-in-package"}
         ])
 
         # Add a child that spends both at high feerate to submit via submitpackage
@@ -256,9 +256,9 @@ class RPCPackagesTest(BitcoinTestFramework):
         testres = node.testmempoolaccept([tx1["hex"], tx2["hex"], tx_child["hex"]])
 
         assert_equal(testres, [
-            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "conflict-in-package"},
-            {"txid": tx2["txid"], "wtxid": tx2["wtxid"], "package-error": "conflict-in-package"},
-            {"txid": tx_child["txid"], "wtxid": tx_child["wtxid"], "package-error": "conflict-in-package"}
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package_error": "conflict-in-package"},
+            {"txid": tx2["txid"], "wtxid": tx2["wtxid"], "package_error": "conflict-in-package"},
+            {"txid": tx_child["txid"], "wtxid": tx_child["wtxid"], "package_error": "conflict-in-package"}
         ])
 
         submitres = node.submitpackage([tx1["hex"], tx2["hex"], tx_child["hex"]])
@@ -290,15 +290,15 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert testres_replaceable["allowed"]
         assert_equal(testres_replaceable["vsize"], replaceable_tx["tx"].get_vsize())
         assert_equal(testres_replaceable["fees"]["base"], fee)
-        assert_fee_amount(fee, replaceable_tx["tx"].get_vsize(), testres_replaceable["fees"]["effective-feerate"])
-        assert_equal(testres_replaceable["fees"]["effective-includes"], [replaceable_tx["wtxid"]])
+        assert_fee_amount(fee, replaceable_tx["tx"].get_vsize(), testres_replaceable["fees"]["effective_feerate"])
+        assert_equal(testres_replaceable["fees"]["effective_includes"], [replaceable_tx["wtxid"]])
 
         # Replacement transaction is identical except has double the fee
         replacement_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, sequence=MAX_BIP125_RBF_SEQUENCE, fee = 2 * fee)
         testres_rbf_conflicting = node.testmempoolaccept([replaceable_tx["hex"], replacement_tx["hex"]])
         assert_equal(testres_rbf_conflicting, [
-            {"txid": replaceable_tx["txid"], "wtxid": replaceable_tx["wtxid"], "package-error": "conflict-in-package"},
-            {"txid": replacement_tx["txid"], "wtxid": replacement_tx["wtxid"], "package-error": "conflict-in-package"}
+            {"txid": replaceable_tx["txid"], "wtxid": replaceable_tx["wtxid"], "package_error": "conflict-in-package"},
+            {"txid": replacement_tx["txid"], "wtxid": replacement_tx["wtxid"], "package_error": "conflict-in-package"}
         ])
 
         self.log.info("Test that packages cannot conflict with mempool transactions, even if a valid BIP125 RBF")
@@ -308,8 +308,8 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert testres_rbf_single[0]["allowed"]
         testres_rbf_package = self.independent_txns_testres_blank + [{
             "txid": replacement_tx["txid"], "wtxid": replacement_tx["wtxid"], "allowed": False,
-            "reject-reason": "bip125-replacement-disallowed",
-            "reject-details": "bip125-replacement-disallowed"
+            "reject_reason": "bip125-replacement-disallowed",
+            "reject_details": "bip125-replacement-disallowed"
         }]
         self.assert_testres_equal(self.independent_txns_hex + [replacement_tx["hex"]], testres_rbf_package)
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -408,7 +408,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([tx['hex']], 0.00001000)[0]
         assert_equal(testres['allowed'], False)
-        assert_equal(testres['reject-reason'], 'max-fee-exceeded')
+        assert_equal(testres['reject_reason'], 'max-fee-exceeded')
         # and sendrawtransaction should throw
         assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'], 0.00001000)
         # and the following calls should both succeed
@@ -422,7 +422,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([tx['hex']])[0]
         assert_equal(testres['allowed'], False)
-        assert_equal(testres['reject-reason'], 'max-fee-exceeded')
+        assert_equal(testres['reject_reason'], 'max-fee-exceeded')
         # and sendrawtransaction should throw
         assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'])
         # and the following calls should both succeed
@@ -435,7 +435,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for node in self.nodes:
             testres = node.testmempoolaccept([tx['hex']])[0]
             assert_equal(testres['allowed'], False)
-            assert_equal(testres['reject-reason'], 'txn-already-known')
+            assert_equal(testres['reject_reason'], 'txn-already-known')
             assert_raises_rpc_error(-27, 'Transaction outputs already in utxo set', node.sendrawtransaction, tx['hex'])
 
     def decoderawtransaction_tests(self):

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -406,7 +406,7 @@ class WalletSendTest(BitcoinTestFramework):
         # hex = res["hex"]
         # res = self.nodes[0].testmempoolaccept([hex])
         # assert not res[0]["allowed"]
-        # assert_equal(res[0]["reject-reason"], "...") # low fee
+        # assert_equal(res[0]["reject_reason"], "...") # low fee
         # assert_fee_amount(fee, Decimal(len(res["hex"]) / 2), Decimal("0.000001"))
 
         self.log.info("If inputs are specified, do not automatically add more...")
@@ -447,7 +447,7 @@ class WalletSendTest(BitcoinTestFramework):
         hex = self.nodes[0].gettransaction(res["txid"])["hex"]
         res = self.nodes[0].testmempoolaccept([hex])
         assert not res[0]["allowed"]
-        assert_equal(res[0]["reject-reason"], "non-final")
+        assert_equal(res[0]["reject_reason"], "non-final")
         # It shouldn't be confirmed in the next block
         self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].gettransaction(txid)["confirmations"], 0)


### PR DESCRIPTION
Previously, the `submitpackage` RPC call returned a response key named `package_msg`, which is inconsistent with the other field names that are using `-` as a delimiter. Here, we align the style of `package-msg`.

cc @glozow @instagibbs 