### PR TITLE
test: Assert unused port to debug intermittent issue 30030

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -64,7 +64,7 @@ export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out}
 # The folder for previous release binaries.
 # This folder exists only on the ci guest, and on the ci host as a volume.
 export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/prev_releases}
-export CI_BASE_PACKAGES=${CI_BASE_PACKAGES:-build-essential pkgconf curl ca-certificates ccache python3 rsync git procps bison e2fsprogs cmake}
+export CI_BASE_PACKAGES=${CI_BASE_PACKAGES:-build-essential pkgconf curl ca-certificates ccache python3 rsync git procps bison e2fsprogs cmake lsof}
 export GOAL=${GOAL:-install}
 export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}
 export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry --"}

--- a/ci/test/00_setup_env_native_centos.sh
+++ b/ci/test/00_setup_env_native_centos.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_centos
 export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
-export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake"
+export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake lsof"
 export PIP_PACKAGES="pyzmq"
 export DEP_OPTS="DEBUG=1"  # Temporarily enable a DEBUG=1 build to check for GCC-bug-117966 regressions. This can be removed once the minimum GCC version is bumped to 12 in the previous releases task, see https://github.com/bitcoin/bitcoin/issues/31436#issuecomment-2530717875
 export GOAL="install"

--- a/test/functional/p2p_i2p_ports.py
+++ b/test/functional/p2p_i2p_ports.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021-2021 The Bitcoin Core developers
+# Copyright (c) 2021-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """
 Test ports handling for I2P hosts
 """
 
-
+import subprocess
+import platform
+from test_framework.util import assert_equal
 from test_framework.test_framework import BitcoinTestFramework
 
 PROXY = "127.0.0.1:60000"
+
 
 class I2PPorts(BitcoinTestFramework):
     def set_test_params(self):
@@ -27,9 +30,17 @@ class I2PPorts(BitcoinTestFramework):
 
         self.log.info("Ensure we try to connect if port=0 and get an error due to missing I2P proxy")
         addr = "h3r6bkn46qxftwja53pxiykntegfyfjqtnzbm6iv6r5mungmqgmq.b32.i2p:0"
+        if platform.system() == "Linux":
+            port_used = subprocess.run(
+                ["lsof", "-i", ":60000"],
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout
+            # Port must not be used. Added to debug https://github.com/bitcoin/bitcoin/issues/30030
+            assert_equal(port_used, "")
         with node.assert_debug_log(expected_msgs=[f"Error connecting to {addr}: Cannot connect to {PROXY}"]):
             node.addnode(node=addr, command="onetry")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     I2PPorts(__file__).main()


### PR DESCRIPTION
`p2p_i2p_ports.py` is intermittently failing in tests on Cirrus, GHA, and locally.

However, the reason is unclear.

Assert that the port is unused to possibly get more details for further actions.