### PR TITLE
qa: clarify and document one assumeutxo test case with malleated snapshot

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -16,11 +16,16 @@ from test_framework.blocktools import (
         create_block,
         create_coinbase
 )
+from test_framework.compressor import (
+    compress_amount,
+)
 from test_framework.messages import (
     CBlockHeader,
     from_hex,
     msg_headers,
-    tx_from_hex
+    tx_from_hex,
+    ser_varint,
+    MAX_MONEY,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -139,7 +144,14 @@ class AssumeutxoTest(BitcoinTestFramework):
             [b"\x81", 34, "3da966ba9826fb6d2604260e01607b55ba44e1a5de298606b08704bc62570ea8", None],  # wrong coin code VARINT
             [b"\x80", 34, "091e893b3ccb4334378709578025356c8bcb0a623f37c7c4e493133c988648e5", None],  # another wrong coin code
             [b"\x84\x58", 34, None, "Bad snapshot data after deserializing 0 coins"],  # wrong coin case with height 364 and coinbase 0
-            [b"\xCA\xD2\x8F\x5A", 39, None, "Bad snapshot data after deserializing 0 coins - bad tx out value"],  # Amount exceeds MAX_MONEY
+            [
+                # compressed txout value + scriptpubkey
+                ser_varint(compress_amount(MAX_MONEY + 1)) + ser_varint(0),
+                # txid + coins per txid + vout + coin height
+                32 + 1 + 1 + 2,
+                None,
+                "Bad snapshot data after deserializing 0 coins - bad tx out value"
+            ],  # Amount exceeds MAX_MONEY
         ]
 
         for content, offset, wrong_hash, custom_message in cases:

--- a/test/functional/feature_framework_unit_tests.py
+++ b/test/functional/feature_framework_unit_tests.py
@@ -18,6 +18,7 @@ TEST_FRAMEWORK_MODULES = [
     "address",
     "crypto.bip324_cipher",
     "blocktools",
+    "compressor",
     "crypto.chacha20",
     "crypto.ellswift",
     "key",

--- a/test/functional/test_framework/compressor.py
+++ b/test/functional/test_framework/compressor.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Routines for compressing transaction output amounts and scripts."""
+import unittest
+
+from .messages import COIN
+
+
+def compress_amount(n):
+    if n == 0:
+        return 0
+    e = 0
+    while ((n % 10) == 0) and (e < 9):
+        n //= 10
+        e += 1
+    if e < 9:
+        d = n % 10
+        assert (d >= 1 and d <= 9)
+        n //= 10
+        return 1 + (n*9 + d - 1)*10 + e
+    else:
+        return 1 + (n - 1)*10 + 9
+
+
+def decompress_amount(x):
+    if x == 0:
+        return 0
+    x -= 1
+    e = x % 10
+    x //= 10
+    n = 0
+    if e < 9:
+        d = (x % 9) + 1
+        x //= 9
+        n = x * 10 + d
+    else:
+        n = x + 1
+    while e > 0:
+        n *= 10
+        e -= 1
+    return n
+
+
+class TestFrameworkCompressor(unittest.TestCase):
+    def test_amount_compress_decompress(self):
+        def check_amount(amount, expected_compressed):
+            self.assertEqual(compress_amount(amount), expected_compressed)
+            self.assertEqual(decompress_amount(expected_compressed), amount)
+
+        # test cases from compress_tests.cpp:compress_amounts
+        check_amount(0, 0x0)
+        check_amount(1, 0x1)
+        check_amount(1000000, 0x7)
+        check_amount(COIN, 0x9)
+        check_amount(50*COIN, 0x32)
+        check_amount(21000000*COIN, 0x1406f40)


### PR DESCRIPTION
The `feature_assumeutxo.py` functional test checks various errors with malleated snapshots. Some of these cases are brittle or use confusing and undocumented values. Fix one of those by using a clear, documented and forward-compatible value.

I ran across those when working on an unrelated changeset which affected the snapshot. It took me a while to understand where the seemingly magic byte string was coming from, so i figured it was worth proposing this patch on its own for the sake of making the test more maintainable.

See commit messages for details.