### PR TITLE
init: Handle dropped UPnP support more gracefully

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -793,6 +793,32 @@ void InitParameterInteraction(ArgsManager& args)
             LogInfo("parameter interaction: -onlynet excludes IPv4 and IPv6 -> setting -dnsseed=0\n");
         }
     }
+
+    // If settings.json contains a "upnp" option, migrate it to use "natpmp" instead
+    bool settings_changed{false}; // Whether settings.json file needs to be rewritten
+    args.LockSettings([&](common::Settings& settings) {
+        if (auto* upnp{common::FindKey(settings.rw_settings, "upnp")}) {
+            if (common::FindKey(settings.rw_settings, "natpmp") == nullptr) {
+                LogWarning(R"(Adding "natpmp": %s to settings.json to replace obsolete "upnp" setting)", upnp->write());
+                settings.rw_settings["natpmp"] = *upnp;
+            }
+            LogWarning(R"(Removing obsolete "upnp" setting from settings.json)");
+            settings.rw_settings.erase("upnp");
+            settings_changed = true;
+        }
+    });
+    if (settings_changed) args.WriteSettingsFile();
+
+    // We dropped UPnP support but kept the arg as hidden for now to display a friendlier error to user who has the
+    // option in their config, and migrate the setting to -natpmp.
+    if (const auto arg{args.GetBoolArg("-upnp")}) {
+        std::string message;
+        if (args.SoftSetBoolArg("-natpmp", *arg)) {
+            message = strprintf(" Substituting '-natpmp=%s'.", *arg);
+        }
+        LogWarning("Option '-upnp=%s' is given but UPnP support was dropped in version 29.0.%s",
+                *arg, message);
+    }
 }
 
 /**
@@ -873,12 +899,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // ********************************************************* Step 2: parameter interactions
 
     // also see: InitParameterInteraction()
-
-    // We drop UPnP support but kept the arg as hidden for now to display a friendlier error to user who have the
-    // option in their config. TODO: remove (here and above) for version 30.0.
-    if (args.IsArgSet("-upnp")) {
-        InitWarning(_("Option '-upnp' is set but UPnP support was dropped in version 29.0. Consider using '-natpmp' instead."));
-    }
 
     // Error if network-specific options (-addnode, -connect, etc) are
     // specified in default section of config file, but not overridden


### PR DESCRIPTION
Closes bitcoin-core/gui#843.

In that issue it was brought up that users likely don't care what kind of port forwarding is used, and that the setting is opportunistic anyway, so instead of showing an extensive warning, we can simply "upgrade" from UPNP to NAT-PMP+PCP.
 
- Change the logic for removed runtime setting `-upnp` to set `-natpmp` instead, and log a message.

- Also remove any lingering `upnp` from `settings.json` and replace it with `natpmp`, when it makes sense (this is important so that the UI shows the right values in the settings):

```json
{
    "upnp": true
}
```
becomes
```json
{
    "natpmp": true
}
```

and

```json
{
    "upnp": false
}
```
becomes
```json
{
    "natpmp": false
}
```