### PR TITLE
fuzz: provide more realistic values to the base58(check) decoders

### DIFF
--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -22,38 +22,38 @@ FUZZ_TARGET(base58_encode_decode)
 {
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
     const auto random_string{provider.ConsumeRandomLengthString(100)};
-    const int max_ret_len{provider.ConsumeIntegralInRange<int>(-1, 100)};
 
-    // Decode/Encode roundtrip
-    if (std::vector<unsigned char> decoded; DecodeBase58(random_string, decoded, max_ret_len)) {
-        const auto encoded_string{EncodeBase58(decoded)};
-        assert(encoded_string == TrimStringView(random_string));
-        assert(decoded.empty() || !DecodeBase58(encoded_string, decoded, provider.ConsumeIntegralInRange<int>(0, decoded.size() - 1)));
-    }
-    // Encode/Decode roundtrip
     const auto encoded{EncodeBase58(MakeUCharSpan(random_string))};
-    std::vector<unsigned char> roundtrip_decoded;
-    assert(DecodeBase58(encoded, roundtrip_decoded, random_string.size())
-        && std::ranges::equal(roundtrip_decoded, MakeUCharSpan(random_string)));
+    const auto decode_input{provider.ConsumeBool() ? random_string : encoded};
+    const int max_ret_len{provider.ConsumeIntegralInRange<int>(-1, decode_input.size() + 1)};
+    if (std::vector<unsigned char> decoded; DecodeBase58(decode_input, decoded, max_ret_len)) {
+        const auto encoded_string{EncodeBase58(decoded)};
+        assert(encoded_string == TrimStringView(decode_input));
+        if (decoded.size() > 0) {
+            assert(max_ret_len > 0);
+            assert(decoded.size() <= static_cast<size_t>(max_ret_len));
+            assert(!DecodeBase58(encoded_string, decoded, provider.ConsumeIntegralInRange<int>(0, decoded.size() - 1)));
+        }
+    }
 }
 
 FUZZ_TARGET(base58check_encode_decode)
 {
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
     const auto random_string{provider.ConsumeRandomLengthString(100)};
-    const int max_ret_len{provider.ConsumeIntegralInRange<int>(-1, 100)};
 
-    // Decode/Encode roundtrip
-    if (std::vector<unsigned char> decoded; DecodeBase58Check(random_string, decoded, max_ret_len)) {
-        const auto encoded_string{EncodeBase58Check(decoded)};
-        assert(encoded_string == TrimStringView(random_string));
-        assert(decoded.empty() || !DecodeBase58Check(encoded_string, decoded, provider.ConsumeIntegralInRange<int>(0, decoded.size() - 1)));
-    }
-    // Encode/Decode roundtrip
     const auto encoded{EncodeBase58Check(MakeUCharSpan(random_string))};
-    std::vector<unsigned char> roundtrip_decoded;
-    assert(DecodeBase58Check(encoded, roundtrip_decoded, random_string.size())
-        && std::ranges::equal(roundtrip_decoded, MakeUCharSpan(random_string)));
+    const auto decode_input{provider.ConsumeBool() ? random_string : encoded};
+    const int max_ret_len{provider.ConsumeIntegralInRange<int>(-1, decode_input.size() + 1)};
+    if (std::vector<unsigned char> decoded; DecodeBase58Check(decode_input, decoded, max_ret_len)) {
+        const auto encoded_string{EncodeBase58Check(decoded)};
+        assert(encoded_string == TrimStringView(decode_input));
+        if (decoded.size() > 0) {
+            assert(max_ret_len > 0);
+            assert(decoded.size() <= static_cast<size_t>(max_ret_len));
+            assert(!DecodeBase58Check(encoded_string, decoded, provider.ConsumeIntegralInRange<int>(0, decoded.size() - 1)));
+        }
+    }
 }
 
 FUZZ_TARGET(base32_encode_decode)


### PR DESCRIPTION
This is a follow-up to https://github.com/bitcoin/bitcoin/pull/30746, expanding coverage by:
* restricting every input for the base58 conversions, capping max sizes to `100` instead of `1000` or all available input (suggested by marcofleon in https://github.com/bitcoin/bitcoin/pull/30746#discussion_r1963718683) since most actual usage has lengths of e.g. `21`, `34`, `78`.
* providing more valid values to the decoder (suggested by maflcko in https://github.com/bitcoin/bitcoin/pull/30746#discussion_r1957847712) by randomly providing a random input or a valid encoded one; this also enables unifying the roundtrip tests to a single roundtrip per fuzz.