### PR TITLE
doc: Update translation generation instructions

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -18,7 +18,7 @@ We use automated scripts to help extract translations in both Qt, and non-Qt sou
 
 To automatically regenerate the `bitcoin_en.ts` file, run the following commands:
 ```sh
-cmake --preset dev-mode -DWITH_USDT=OFF
+cmake --preset dev-mode -DWITH_USDT=OFF -DWITH_MULTIPROCESS=OFF
 cmake --build build_dev_mode --target translate
 ```
 


### PR DESCRIPTION
This is a follow-up of #31731.

Technically this change [fixes](https://github.com/bitcoin/bitcoin/pull/31731#discussion_r1928888001) the preset configuration execution failure as it needs multiprocess to be enabled, so we disable it using `-DWITH_MULTIPROCESS=OFF`.

This code will need to be updated by removing `-DWITH_MULTIPROCESS=OFF` in https://github.com/bitcoin/bitcoin/pull/31741.