### PR TITLE
depends: Update libmultiprocess library to fix CI failures

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=07c917f7ca910d66abc6d3873162fc9061704074
+$(package)_version=1954f7f65661d49e700c344eae0fc8092decf975
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=ac9db311e3b22aac3c7b7b7b3f6b7fee5cf3043ebb3c3bf412049e8b17166de8
+$(package)_sha256_hash=fc014bd74727c1d5d30b396813685012c965d079244dd07b53bc1c75c610a2cb
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds


### PR DESCRIPTION
Bump libmultiprocess library to include bugfix https://github.com/chaincodelabs/libmultiprocess/pull/159 which should fix intermittent CI failures reported in https://github.com/bitcoin/bitcoin/issues/31921

This change is bumping the libmultiprocess version instead of cherry picking the bugfix. It could cherry-pick the bugfix instead, but there are reasons to prefer bumping the version:

- Bugfix might interact with earlier PRs, and the latest version is better tested with testing done in many CI configurations in [#30975](https://github.com/bitcoin/bitcoin/pull/30975) and [#31802](https://github.com/bitcoin/bitcoin/pull/31802)

- Even though we are in feature freeze for a release, the MULTIPROCESS=1 option is currently not enabled for release, so this PR only affect CI builds and local builds, not the release build.

This update brings in the following changes:

https://github.com/chaincodelabs/libmultiprocess/pull/140 build: don't clobber user/superproject c++ version
https://github.com/chaincodelabs/libmultiprocess/pull/142 build: add option for external mpgen binary
https://github.com/chaincodelabs/libmultiprocess/pull/143 cleanup: initialize vars in the EventLoop constructor in the correct order
https://github.com/chaincodelabs/libmultiprocess/pull/146 cmake: Suppress compiler warnings from capnproto headers
https://github.com/chaincodelabs/libmultiprocess/pull/147 cmake: EXTERNAL_MPGEN cleanups
https://github.com/chaincodelabs/libmultiprocess/pull/148 util: fix -Wpessimizing-move warning
https://github.com/chaincodelabs/libmultiprocess/pull/145 CTest: Module must be included at the top level
https://github.com/chaincodelabs/libmultiprocess/pull/149 Avoid `-Wundef` compiler warnings
https://github.com/chaincodelabs/libmultiprocess/pull/152 refactor: Fix compiler and clang-tidy warnings
https://github.com/chaincodelabs/libmultiprocess/pull/155 scripted-diff: s/Libmultiprocess_EXTERNAL_MPGEN/MPGEN_EXECUTABLE/g
https://github.com/chaincodelabs/libmultiprocess/pull/156 refactor: Remove locale-dependent function calls
https://github.com/chaincodelabs/libmultiprocess/pull/157 refactor: Avoid using std::format
https://github.com/chaincodelabs/libmultiprocess/pull/159 bugfix: Do not lock EventLoop::mutex after EventLoop is done
https://github.com/chaincodelabs/libmultiprocess/pull/161 cmake: Avoid including CTest if not top level project
https://github.com/chaincodelabs/libmultiprocess/pull/164 Bump minimum required cmake to 3.12

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/issues/28722).