### PR TITLE
ci: [lint] Use Cirrus dockerfile cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,21 +96,15 @@ task:
   name: 'lint'
   << : *BASE_TEMPLATE
   container:
-    image: debian:bookworm
+    dockerfile: ci/lint_imagefile
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters
   << : *CREDITS_TEMPLATE
-  test_runner_cache:
-    folder: "/lint_test_runner"
-    fingerprint_script: echo $CIRRUS_TASK_NAME $(git rev-parse HEAD:test/lint/test_runner)
-  python_cache:
-    folder: "/python_build"
-    fingerprint_script: cat .python-version /etc/os-release
   unshallow_script:
     - git fetch --unshallow --no-tags
   lint_script:
-    - ./ci/lint_run_all.sh
+    - ./ci/lint_run.sh
 
 task:
   name: 'tidy'

--- a/ci/lint_run.sh
+++ b/ci/lint_run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+set -o errexit -o pipefail -o xtrace
+
+# Only used in .cirrus.yml. Refer to test/lint/README.md on how to run locally.
+export PATH="/python_build/bin:${PATH}"
+export LINT_RUNNER_PATH="/lint_test_runner"
+./ci/lint/06_script.sh

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -6,7 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
-# Only used in .cirrus.yml. Refer to test/lint/README.md on how to run locally.
+# Only used in .cirrus.yml for stale re-runs of old pull request tasks. This
+# file can be removed in September 2025.
 
 cp "./ci/retry/retry" "/ci_retry"
 cp "./.python-version" "/.python-version"


### PR DESCRIPTION
The lint task is problematic, because:

* It doesn't check modifications to `ci/lint_imagefile`
* It calls a separate script that installs packages on every run (taking time)
* It uses `*_cache` instructions to cache some installed parts, but not all

Fix all issues by using `ci/lint_imagefile` (https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment)