### PR TITLE
doc: fix minor typo

### DIFF
--- a/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -10,7 +10,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]


### PR DESCRIPTION
# Motivation
This PR fixes a typo: "occurences" is changed to "occurrences" to improve clarity and professionalism in the codebase. There are no tests associated with this typo change, as it is purely a spelling correction. Hope this helps.