### PR TITLE
doc: fix typo and update subtree to resolve CI errors (#31949)

### DIFF
--- a/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -10,7 +10,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]


### PR DESCRIPTION
# Description
This PR addresses a simple typo in the file src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json, correcting the word "occurences" to "occurrences."

In addition to this typo fix, I updated the subtree for src/secp256k1 to ensure compatibility with the latest changes in the upstream repository. This was necessary due to CI errors related to the previous version of the subtree.

This is related to [PR #31949](https://github.com/bitcoin/bitcoin/pull/31949#issue-2878432508), where the initial typo was identified.