### PR TITLE
tests: Improve stderr validation in test_runner.py

### DIFF
--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -164,6 +164,11 @@ def bctest(testDir, testObj, buildenv):
         if want_error not in res.stderr:
             logging.error(f"Error mismatch:\nExpected: {want_error}\nReceived: {res.stderr.rstrip()}\nres: {str(res)}")
             raise Exception
+    else:
+        # If no error is expected, stderr should be empty except for known cases
+        if res.stderr and not (testObj.get("exec") == "./bitcoin-tx" and "wine" in os.environ.get("WINEPREFIX", "")):
+            logging.error(f"Unexpected stderr output when no error expected:\n{res.stderr.rstrip()}\nres: {str(res)}")
+            raise Exception
 
 def parse_output(a, fmt):
     """Parse the output according to specified format.

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -156,7 +156,6 @@ def bctest(testDir, testObj, buildenv):
     if "error_txt" in testObj:
         want_error = testObj["error_txt"]
         # Compare error text
-        # TODO: ideally, we'd compare the strings exactly and also assert
         # That stderr is empty if no errors are expected. However, bitcoin-tx
         # emits DISPLAY errors when running as a windows application on
         # linux through wine. Just assert that the expected error text appears


### PR DESCRIPTION
This PR implements the improvement suggested in a TODO comment in test/util/test_runner.py. 
It adds validation that stderr is empty when no errors are expected in test cases.

The change adds a check that verifies stderr is empty when no error_txt is specified in 
the test object, with a special exception for bitcoin-tx running under Wine, which was 
mentioned in the original TODO comment.

This improvement helps catch unexpected error messages that might otherwise go unnoticed 
during testing, making the test framework more robust.

The implementation:
1. Checks if stderr contains output when no error is expected
2. Makes an exception for the known case of bitcoin-tx running under Wine
3. Raises an exception with a detailed error message if unexpected stderr output is found

This change improves test coverage by ensuring that tests don't silently pass when they 
produce unexpected error output.