### PR TITLE
Add mainnet assumeutxo param at height 880,000

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -191,6 +191,12 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"a2a5521b1b5ab65f67818e5e8eccabb7171a517f9e2382208f77687310768f96"}},
                 .m_chain_tx_count = 991032194,
                 .blockhash = consteval_ctor(uint256{"0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5"}),
+            },
+            {
+                .height = 880'000,
+                .hash_serialized = AssumeutxoHash{uint256{"dbd190983eaf433ef7c15f78a278ae42c00ef52e0fd2a54953782175fbadcea9"}},
+                .m_chain_tx_count = 1145604538,
+                .blockhash = consteval_ctor(uint256{"000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"}),
             }
         };
 


### PR DESCRIPTION
#31940 suggests adding a snapshot at every major release.

This snapshot should be suitable for v29. I picked the most recent multiple of 10K blocks.

You can either download this torrent:

```
magnet:?xt=urn:btih:559bd78170502971e15e97d7572e4c824f033492&dn=utxo-880000.dat&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969
```

Or generate the snapshot yourself:

```sh
bitcoin-cli -rpcclienttimeout=0 -named dumptxoutset utxo-880000.dat rollback=880000
```

The SHA-256 hash should be:

```
shasum -a 256 utxo-880000.dat
43b3b1ad6e1005ffc0ff49514d0ffcc3e3ce671cc8d02da7fa7bac5405f89de4
```

And then load it on a fresh node during IBD with:

```
bitcoin-cli -rpcclienttimeout=0 loadtxoutset utxo-880000.dat
```

Note that it's more performant to turn off networking while the snapshot is loading, see #29993:

```sh
bitcoin-cli setnetworkactive false
```

Once the snapshot is loaded:

```sh
bitcoin-cli setnetworkactive true
```

And enjoy a speedy ride to the tip.