### PR TITLE
doc: Correct capitalization in release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -14,7 +14,7 @@ Release Process
 * Update [bips.md](bips.md) to account for changes since the last release.
 * Update version in `CMakeLists.txt` (don't forget to set `CLIENT_VERSION_RC` to `0`).
 * Update manpages (see previous section)
-* Write release notes (see "Write the release notes" below) in doc/release-notes.md. If necessary,
+* Write release notes (see "Write the release notes" below) in doc/release-notes.md. if necessary,
   archive the previous release notes as doc/release-notes/release-notes-${VERSION}.md.
 
 ### Before every major release


### PR DESCRIPTION
This PR corrects the capitalization of "if necessary" in the `doc/release-process.md` file.

The original sentence had "If necessary," with a capital "I". This has been corrected to "if necessary," with a lowercase "i" to maintain consistency.

This change improves the formatting and consistency of the documentation within the release process documentation file.