### PR TITLE
torcontrol: Add comment explaining Proxy credential randomization for Tor privacy

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -397,7 +397,11 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
 
     Assume(resolved.IsValid());
     LogDebug(BCLog::TOR, "Configuring onion proxy for %s\n", resolved.ToStringAddrPort());
-    Proxy addrOnion = Proxy(resolved, true);
+
+    // With m_randomize_credentials = true, generates unique SOCKS credentials per proxy connection (e.g., Tor).
+    // Prevents connection correlation and enhances privacy by forcing different Tor circuits.
+    // Requires Tor's IsolateSOCKSAuth (default enabled) for effective isolation (see IsolateSOCKSAuth section in https://2019.www.torproject.org/docs/tor-manual.html.en).
+    Proxy addrOnion = Proxy(resolved, /*_randomize_credentials*/ true);
     SetProxy(NET_ONION, addrOnion);
 
     const auto onlynets = gArgs.GetArgs("-onlynet");


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

When I reviewing bitcoin's torcontrol.cpp's source code, the `true` in:
https://github.com/bitcoin/bitcoin/blob/79bbb381a1fd13ad456fde736b3c195a791d4e58/src/torcontrol.cpp#L400
is not easy to understand, so I add a comment to help us read that. Friendly invite @luke-jr to review this.
