### PR TITLE
test: Use rpc_deprecated only for testing deprecation

### DIFF
--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
+# Copyright (c) 2017-2025 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test deprecation of RPC calls."""
@@ -7,23 +7,23 @@ from test_framework.test_framework import BitcoinTestFramework
 
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [[], ['-deprecatedrpc=bumpfee']]
+        self.extra_args = [[]]
 
     def run_test(self):
-        # This test should be used to verify correct behaviour of deprecated
-        # RPC methods with and without the -deprecatedrpc flags. For example:
+        # This test should be used to verify the errors of the currently
+        # deprecated RPC methods (without the -deprecatedrpc flag) until
+        # such RPCs are fully removed. For example:
         #
-        # In set_test_params:
-        # self.extra_args = [[], ["-deprecatedrpc=generate"]]
-        #
-        # In run_test:
         # self.log.info("Test generate RPC")
         # assert_raises_rpc_error(-32, 'The wallet generate rpc method is deprecated', self.nodes[0].rpc.generate, 1)
-        # self.generate(self.nodes[1], 1)
+        #
+        # Please ensure that for all the RPC methods tested here, there is
+        # at least one other functional test that still tests the RPCs
+        # functionality using the respective -deprecatedrpc flag.
 
-        self.log.info("No tested deprecated RPC methods")
+        self.log.info("Currently no tests for deprecated RPC methods")
 
 if __name__ == '__main__':
     DeprecatedRpcTest(__file__).main()


### PR DESCRIPTION
The comment in `functional/rpc_deprecated.py` says "This test should be used to verify correct behaviour of deprecated RPC methods with and without the -deprecatedrpc flags." I think we can get rid of the "with" part since we can assume that every deprecated RPC is already tested in at least one other functional test. (I didn't look but I could verify in our coverage if someone has doubts about that.) In order for this test to continue working, the flag will need to be used there. Otherwise this seems to prescribe copy+pasting a basic test from another file and I don't see a good reason for that.