### PR TITLE
build: don't show ccache summary with MSVC

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -23,6 +23,8 @@ if(NOT MSVC)
   else()
     set(WITH_CCACHE OFF)
   endif()
+else()
+  set(WITH_CCACHE OFF)
 endif()
 
 mark_as_advanced(CCACHE_EXECUTABLE)


### PR DESCRIPTION
Set `WITH_CCACHE` to `OFF` for MSVC, so it doesn't show as `ON` in the configure summary.

Fixes #31771.