### PR TITLE
RFC: Add `operator""_uint256` compile-time user-defined literal

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -88,17 +88,17 @@ public:
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
-            uint256{"00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"}, SCRIPT_VERIFY_NONE);
+            "00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"_uint256, SCRIPT_VERIFY_NONE);
         consensus.script_flag_exceptions.emplace( // Taproot exception
-            uint256{"0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad"}, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS);
+            "0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad"_uint256, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS);
         consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256{"000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"};
+        consensus.BIP34Hash = "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"_uint256;
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.CSVHeight = 419328; // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
         consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
-        consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+        consensus.powLimit = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_uint256;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
@@ -117,8 +117,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
-        consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000b1f3b93b65b16d035a82be84"};
-        consensus.defaultAssumeValid = uint256{"00000000000000000001b658dd1120e82e66d2790811f89ede9742ada3ed6d77"}; // 886157
+        consensus.nMinimumChainWork = "0000000000000000000000000000000000000000b1f3b93b65b16d035a82be84"_uint256;
+        consensus.defaultAssumeValid = "00000000000000000001b658dd1120e82e66d2790811f89ede9742ada3ed6d77"_uint256; // 886157
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -136,8 +136,8 @@ public:
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"});
-        assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
+        assert(consensus.hashGenesisBlock == "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_uint256);
+        assert(genesis.hashMerkleRoot == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_uint256);
 
         // Note that of those which support the service bits prefix, most only support a subset of
         // possible options.
@@ -170,15 +170,15 @@ public:
         m_assumeutxo_data = {
             {
                 .height = 840'000,
-                .hash_serialized = AssumeutxoHash{uint256{"a2a5521b1b5ab65f67818e5e8eccabb7171a517f9e2382208f77687310768f96"}},
+                .hash_serialized = AssumeutxoHash{"a2a5521b1b5ab65f67818e5e8eccabb7171a517f9e2382208f77687310768f96"_uint256},
                 .m_chain_tx_count = 991032194,
-                .blockhash = consteval_ctor(uint256{"0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5"}),
+                .blockhash = consteval_ctor("0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5"_uint256),
             },
             {
                 .height = 880'000,
-                .hash_serialized = AssumeutxoHash{uint256{"dbd190983eaf433ef7c15f78a278ae42c00ef52e0fd2a54953782175fbadcea9"}},
+                .hash_serialized = AssumeutxoHash{"dbd190983eaf433ef7c15f78a278ae42c00ef52e0fd2a54953782175fbadcea9"_uint256},
                 .m_chain_tx_count = 1145604538,
-                .blockhash = consteval_ctor(uint256{"000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"}),
+                .blockhash = consteval_ctor("000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"_uint256),
             }
         };
 
@@ -202,15 +202,15 @@ public:
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
-            uint256{"00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"}, SCRIPT_VERIFY_NONE);
+            "00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"_uint256, SCRIPT_VERIFY_NONE);
         consensus.BIP34Height = 21111;
-        consensus.BIP34Hash = uint256{"0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"};
+        consensus.BIP34Hash = "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"_uint256;
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.CSVHeight = 770112; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
         consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
         consensus.MinBIP9WarningHeight = 836640; // segwit activation height + miner confirmation window
-        consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+        consensus.powLimit = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_uint256;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -229,8 +229,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000015f5e0c9f13455b0eb17"};
-        consensus.defaultAssumeValid = uint256{"00000000000003fc7967410ba2d0a8a8d50daedc318d43e8baf1a9782c236a57"}; // 3974606
+        consensus.nMinimumChainWork = "0000000000000000000000000000000000000000000015f5e0c9f13455b0eb17"_uint256;
+        consensus.defaultAssumeValid = "00000000000003fc7967410ba2d0a8a8d50daedc318d43e8baf1a9782c236a57"_uint256; // 3974606
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
@@ -243,8 +243,8 @@ public:
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"});
-        assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
+        assert(consensus.hashGenesisBlock == "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"_uint256);
+        assert(genesis.hashMerkleRoot == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_uint256);
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -271,9 +271,9 @@ public:
         m_assumeutxo_data = {
             {
                 .height = 2'500'000,
-                .hash_serialized = AssumeutxoHash{uint256{"f841584909f68e47897952345234e37fcd9128cd818f41ee6c3ca68db8071be7"}},
+                .hash_serialized = AssumeutxoHash{"f841584909f68e47897952345234e37fcd9128cd818f41ee6c3ca68db8071be7"_uint256},
                 .m_chain_tx_count = 66484552,
-                .blockhash = consteval_ctor(uint256{"0000000000000093bcb68c03a9a168ae252572d348a2eaeba2cdf9231d73206f"}),
+                .blockhash = consteval_ctor("0000000000000093bcb68c03a9a168ae252572d348a2eaeba2cdf9231d73206f"_uint256),
             }
         };
 
@@ -303,7 +303,7 @@ public:
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+        consensus.powLimit = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_uint256;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -322,8 +322,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000001d6dce8651b6094e4c1"};
-        consensus.defaultAssumeValid = uint256{"0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3"}; // 72600
+        consensus.nMinimumChainWork = "0000000000000000000000000000000000000000000001d6dce8651b6094e4c1"_uint256;
+        consensus.defaultAssumeValid = "0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3"_uint256; // 72600
 
         pchMessageStart[0] = 0x1c;
         pchMessageStart[1] = 0x16;
@@ -344,8 +344,8 @@ public:
                 1,
                 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043"});
-        assert(genesis.hashMerkleRoot == uint256{"7aa0a7ae1e223414cb807e40cd57e667b718e42aaf9306db9102fe28912b7b4e"});
+        assert(consensus.hashGenesisBlock == "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043"_uint256);
+        assert(genesis.hashMerkleRoot == "7aa0a7ae1e223414cb807e40cd57e667b718e42aaf9306db9102fe28912b7b4e"_uint256);
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -396,8 +396,8 @@ public:
             vSeeds.emplace_back("seed.signet.bitcoin.sprovoost.nl.");
             vSeeds.emplace_back("seed.signet.achownodes.xyz."); // Ava Chow, only supports x1, x5, x9, x49, x809, x849, xd, x400, x404, x408, x448, xc08, xc48, x40c
 
-            consensus.nMinimumChainWork = uint256{"000000000000000000000000000000000000000000000000000002b517f3d1a1"};
-            consensus.defaultAssumeValid = uint256{"000000895a110f46e59eb82bbc5bfb67fa314656009c295509c21b4999f5180a"}; // 237722
+            consensus.nMinimumChainWork = "000000000000000000000000000000000000000000000000000002b517f3d1a1"_uint256;
+            consensus.defaultAssumeValid = "000000895a110f46e59eb82bbc5bfb67fa314656009c295509c21b4999f5180a"_uint256; // 237722
             m_assumed_blockchain_size = 9;
             m_assumed_chain_state_size = 1;
             chainTxData = ChainTxData{
@@ -442,7 +442,7 @@ public:
         consensus.nRuleChangeActivationThreshold = 1815; // 90% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256{"00000377ae000000000000000000000000000000000000000000000000000000"};
+        consensus.powLimit = "00000377ae000000000000000000000000000000000000000000000000000000"_uint256;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -465,15 +465,15 @@ public:
 
         genesis = CreateGenesisBlock(1598918400, 52613770, 0x1e0377ae, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"});
-        assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
+        assert(consensus.hashGenesisBlock == "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"_uint256);
+        assert(genesis.hashMerkleRoot == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_uint256);
 
         m_assumeutxo_data = {
             {
                 .height = 160'000,
-                .hash_serialized = AssumeutxoHash{uint256{"fe0a44309b74d6b5883d246cb419c6221bcccf0b308c9b59b7d70783dbdf928a"}},
+                .hash_serialized = AssumeutxoHash{"fe0a44309b74d6b5883d246cb419c6221bcccf0b308c9b59b7d70783dbdf928a"_uint256},
                 .m_chain_tx_count = 2289496,
-                .blockhash = consteval_ctor(uint256{"0000003ca3c99aff040f2563c2ad8f8ec88bd0fd6b8f0895cfaf1ef90353a62c"}),
+                .blockhash = consteval_ctor("0000003ca3c99aff040f2563c2ad8f8ec88bd0fd6b8f0895cfaf1ef90353a62c"_uint256),
             }
         };
 
@@ -510,7 +510,7 @@ public:
         consensus.CSVHeight = 1;    // Always active unless overridden
         consensus.SegwitHeight = 0; // Always active unless overridden
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256{"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+        consensus.powLimit = "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_uint256;
         consensus.nPowTargetTimespan = 24 * 60 * 60; // one day
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -569,8 +569,8 @@ public:
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"});
-        assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
+        assert(consensus.hashGenesisBlock == "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"_uint256);
+        assert(genesis.hashMerkleRoot == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_uint256);
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();
@@ -582,23 +582,23 @@ public:
         m_assumeutxo_data = {
             {   // For use by unit tests
                 .height = 110,
-                .hash_serialized = AssumeutxoHash{uint256{"6657b736d4fe4db0cbc796789e812d5dba7f5c143764b1b6905612f1830609d1"}},
+                .hash_serialized = AssumeutxoHash{"6657b736d4fe4db0cbc796789e812d5dba7f5c143764b1b6905612f1830609d1"_uint256},
                 .m_chain_tx_count = 111,
-                .blockhash = consteval_ctor(uint256{"696e92821f65549c7ee134edceeeeaaa4105647a3c4fd9f298c0aec0ab50425c"}),
+                .blockhash = consteval_ctor("696e92821f65549c7ee134edceeeeaaa4105647a3c4fd9f298c0aec0ab50425c"_uint256),
             },
             {
                 // For use by fuzz target src/test/fuzz/utxo_snapshot.cpp
                 .height = 200,
-                .hash_serialized = AssumeutxoHash{uint256{"4f34d431c3e482f6b0d67b64609ece3964dc8d7976d02ac68dd7c9c1421738f2"}},
+                .hash_serialized = AssumeutxoHash{"4f34d431c3e482f6b0d67b64609ece3964dc8d7976d02ac68dd7c9c1421738f2"_uint256},
                 .m_chain_tx_count = 201,
-                .blockhash = consteval_ctor(uint256{"5e93653318f294fb5aa339d00bbf8cf1c3515488ad99412c37608b139ea63b27"}),
+                .blockhash = consteval_ctor("5e93653318f294fb5aa339d00bbf8cf1c3515488ad99412c37608b139ea63b27"_uint256),
             },
             {
                 // For use by test/functional/feature_assumeutxo.py
                 .height = 299,
-                .hash_serialized = AssumeutxoHash{uint256{"a4bf3407ccb2cc0145c49ebba8fa91199f8a3903daf0883875941497d2493c27"}},
+                .hash_serialized = AssumeutxoHash{"a4bf3407ccb2cc0145c49ebba8fa91199f8a3903daf0883875941497d2493c27"_uint256},
                 .m_chain_tx_count = 334,
-                .blockhash = consteval_ctor(uint256{"3bb7ce5eba0be48939b7a521ac1ba9316afee2c7bada3a0cca24188e6d7d96c0"}),
+                .blockhash = consteval_ctor("3bb7ce5eba0be48939b7a521ac1ba9316afee2c7bada3a0cca24188e6d7d96c0"_uint256),
             },
         };
 

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -339,4 +339,12 @@ BOOST_AUTO_TEST_CASE(FromHex_vs_uint256)
     BOOST_CHECK_EQUAL(consteval_uint, runtime_uint);
 }
 
+BOOST_AUTO_TEST_CASE(_uint256_user_defined_literal)
+{
+    constexpr auto expected{uint256{"000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"}};
+    constexpr auto actual{          "000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"_uint256};
+    BOOST_CHECK_EQUAL(actual.ToString(), expected.ToString());
+    BOOST_CHECK_EQUAL(actual, expected);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <string_view>
 
+using namespace util::hex_literals;
+
 /** Template base class for fixed-sized opaque blobs. */
 template<unsigned int BITS>
 class base_blob
@@ -209,5 +211,13 @@ public:
     static const uint256 ZERO;
     static const uint256 ONE;
 };
+
+template <util::detail::Hex<65> str>
+constexpr auto operator""_uint256()
+{
+    auto res{operator""_hex_u8<str>()};
+    std::ranges::reverse(res);
+    return uint256{res};
+}
 
 #endif // BITCOIN_UINT256_H


### PR DESCRIPTION
Follow-up to [Add mainnet assumeutxo param at height 880,000](https://github.com/bitcoin/bitcoin/pull/31969#discussion_r1980186558), looking to simplify specifying explicit hashes in the source code.
It's not a full implementation yet, I'm looking for concept ack/nack and full CI feedback for now - applying it to the whole codebase may follow based on that.

-------

This is also a follow-up to [refactor: Replace ParseHex with consteval ""_hex literals](https://github.com/bitcoin/bitcoin/pull/30377), meant to simplify the usages (values beginning with the hexadecimal data, followed by the type conversion, similarly to `sizeof(uint256)` vs `uint256::size()`) and unifying hex parsing code.
Similarly to `""_hex`, the `""_uint256` has the same compile-time constraints as its constructor (properly sized with actual hexadecimal values), but uses [`detail::Hex` parser (reversed)](https://github.com/bitcoin/bitcoin/blob/master/src/util/strencodings.h#L382-L395) (used in most other places for hex parsing) instead of [`base_blob(std::string_view hex_str)`](https://github.com/bitcoin/bitcoin/blob/master/src/uint256.h#L138-L147).
The [new implementation](https://github.com/bitcoin/bitcoin/pull/31991/files#diff-800776e2dda39116e889839f69409571a5d397de048a141da7e4003bc099e3e2R219) also makes it obvious that the values are reversed in this case.

I thought of removing the `consteval_ctor` hack as well, now that [consteval conversion is claimed to work in visual studio](https://developercommunity.visualstudio.com/t/consteval-conversion-function-fails/1579014#T-N10721450), but since https://godbolt.org/z/j837req5h still seems to fail for latest `x64 msvc v19`, I postponed doing that.