### PR TITLE
doc: update location of minisketch repository

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1230,7 +1230,7 @@ Current subtrees include:
   - Upstream at https://github.com/bitcoin-core/ctaes ; maintained by Core contributors.
 
 - src/minisketch
-  - Upstream at https://github.com/sipa/minisketch ; maintained by Core contributors.
+  - Upstream at https://github.com/bitcoin-core/minisketch ; maintained by Core contributors.
 
 Upgrading LevelDB
 ---------------------

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -96,7 +96,7 @@ maintained:
 * for `src/leveldb`: https://github.com/bitcoin-core/leveldb-subtree.git (branch bitcoin-fork)
 * for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)
 * for `src/crc32c`: https://github.com/bitcoin-core/crc32c-subtree.git (branch bitcoin-fork)
-* for `src/minisketch`: https://github.com/sipa/minisketch.git (branch master)
+* for `src/minisketch`: https://github.com/bitcoin-core/minisketch.git (branch master)
 
 To do so, add the upstream repository as remote:
 


### PR DESCRIPTION
This repository is now at https://github.com/bitcoin-core/minisketch.