### PR TITLE
doc: add note to Windows build about stripping bins

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -35,6 +35,7 @@ If you want to build the Windows installer using the `deploy` build target, you 
 
     apt install nsis
 
+
 Acquire the source in the usual way:
 
     git clone https://github.com/bitcoin/bitcoin.git
@@ -61,9 +62,17 @@ After building using the Windows subsystem it can be useful to copy the compiled
 executables to a directory on the Windows drive in the same directory structure
 as they appear in the release `.zip` archive. This can be done in the following
 way. This will install to `c:\workspace\bitcoin`, for example:
+```shell
+cmake --install build --prefix /mnt/c/workspace/bitcoin
+```
 
-    cmake --install build --prefix /mnt/c/workspace/bitcoin
+Note that due to the presence of debug information, the binaries may be very large,
+if you do not need the debug information, you can prune it during install by calling:
+```shell
+cmake --install build --prefix /mnt/c/workspace/bitcoin --strip
+```
 
 You can also create an installer using:
-
-    cmake --build build --target deploy
+```shell
+cmake --build build --target deploy
+```


### PR DESCRIPTION
The Windows binaries are particularly big when they contain debug info, closing in on 500mb. Add a note to the Windows build instructions about using `--strip`.

I haven't tested this (the copying out to WSL). If we don't want to add this note, in favour of [user-presents or similar](https://github.com/bitcoin/bitcoin/issues/30593#issuecomment-2271304490), then we should just close #30593. 

Fixes #30593.