### PR TITLE
docs: remove passing CI section in guidelines for PR merging as it's common sense

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -728,15 +728,6 @@ General Bitcoin Core
   - *Rationale*: RPC allows for better automatic testing. The test suite for
     the GUI is very limited.
 
-- Make sure pull requests pass CI before merging.
-
-  - *Rationale*: Makes sure that they pass thorough testing, and that the tester will keep passing
-     on the master branch. Otherwise, all new pull requests will start failing the tests, resulting in
-     confusion and mayhem.
-
-  - *Explanation*: If the test suite is to be updated for a change, this has to
-    be done first.
-
 Logging
 -------
 

--- a/doc/files.md
+++ b/doc/files.md
@@ -83,7 +83,7 @@ Wallets are Berkeley DB (BDB) or SQLite databases.
 
 3. A wallet database path can be specified with the `-wallet` option.
 
-4. `wallet.dat` files must not be shared across different node instances, as that can result in key-reuse and double-spends due the lack of synchronization between instances.
+4. `wallet.dat` files must not be shared across different node instances, as that can result in key-reuse and double-spends due to the lack of synchronization between instances.
 
 5. Any copy or backup of the wallet should be done through a `backupwallet` call in order to update and lock the wallet, preventing any file corruption caused by updates during the copy.
 


### PR DESCRIPTION
Removing passing CI section in guidelines for PR merging as it's common sens