### PR TITLE
net: replace manual reference counting of CNode with shared_ptr

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3931,10 +3931,9 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 
 bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
 {
-    LOCK(m_nodes_mutex);
-    for (auto&& pnode : m_nodes) {
-        if(pnode->GetId() == id) {
-            return NodeFullyConnected(*pnode) && func(pnode.get());
+    for (auto& node : WITH_LOCK(m_nodes_mutex, return m_nodes)) {
+        if (node->GetId() == id) {
+            return NodeFullyConnected(*node) && func(node.get());
         }
     }
     return false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1931,13 +1931,11 @@ void CConnman::DisconnectNodes()
         }
 
         // Disconnect unused nodes
-        auto nodes_copy = m_nodes;
-        for (auto& pnode : nodes_copy)
-        {
+        for (auto it = m_nodes.begin(); it != m_nodes.end();) {
+            auto pnode{*it};
             if (pnode->fDisconnect)
             {
-                // remove from m_nodes
-                m_nodes.erase(remove(m_nodes.begin(), m_nodes.end(), pnode), m_nodes.end());
+                it = m_nodes.erase(it);
 
                 // Add to reconnection list if appropriate. We don't reconnect right here, because
                 // the creation of a connection is a blocking operation (up to several seconds),
@@ -1964,17 +1962,21 @@ void CConnman::DisconnectNodes()
                 // hold in disconnected pool until all refs are released
                 pnode->Release();
                 m_nodes_disconnected.push_back(pnode);
+            } else {
+                ++it;
             }
         }
     }
     {
         // Delete disconnected nodes
-        auto nodes_disconnected_copy = m_nodes_disconnected;
-        for (auto& pnode : nodes_disconnected_copy) {
+        for (auto it = m_nodes_disconnected.begin(); it != m_nodes_disconnected.end();) {
+            auto pnode{*it};
             // Destroy the object only after other threads have stopped using it.
             if (pnode->GetRefCount() <= 0) {
-                m_nodes_disconnected.remove(pnode);
+                it = m_nodes_disconnected.erase(it);
                 m_msgproc->FinalizeNode(*pnode);
+            } else {
+                ++it;
             }
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -1351,7 +1351,7 @@ private:
      */
     void FinalizeAndDeleteDisconnectedNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_disconnected_mutex);
 
-    void DisconnectNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_nodes_mutex, !m_nodes_disconnected_mutex);
+    void DisconnectNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_nodes_mutex, !m_nodes_disconnected_mutex, !mutexMsgProc);
     void NotifyNumConnectionsChanged();
     /** Return true if the peer is inactive and should be disconnected. */
     bool InactivityCheck(const CNode& node) const;

--- a/src/net.h
+++ b/src/net.h
@@ -732,7 +732,6 @@ public:
     // next time DisconnectNodes() runs
     std::atomic_bool fDisconnect{false};
     CountingSemaphoreGrant<> grantOutbound;
-    std::atomic<int> nRefCount{0};
 
     const uint64_t nKeyedNetGroup;
     std::atomic_bool fPauseRecv{false};
@@ -906,12 +905,6 @@ public:
         return nLocalHostNonce;
     }
 
-    int GetRefCount() const
-    {
-        assert(nRefCount >= 0);
-        return nRefCount;
-    }
-
     /**
      * Receive bytes from the buffer and deserialize them into messages.
      *
@@ -936,17 +929,6 @@ public:
     CService GetAddrLocal() const EXCLUSIVE_LOCKS_REQUIRED(!m_addr_local_mutex);
     //! May not be called more than once
     void SetAddrLocal(const CService& addrLocalIn) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_local_mutex);
-
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
 
     void CloseSocketDisconnect() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
@@ -1379,7 +1361,7 @@ private:
      * @param[in] nodes Select from these nodes' sockets.
      * @return sockets to check for readiness
      */
-    Sock::EventsPerSock GenerateWaitSockets(const std::vector<std::shared_ptr<CNode>>& nodes);
+    Sock::EventsPerSock GenerateWaitSockets(std::span<std::shared_ptr<CNode>> nodes);
 
     /**
      * Check connected and listening sockets for IO readiness and process them accordingly.
@@ -1716,43 +1698,6 @@ private:
      * unexpectedly use too much memory.
      */
     static constexpr size_t MAX_UNUSED_I2P_SESSIONS_SIZE{10};
-
-    /**
-     * RAII helper to atomically create a copy of `m_nodes` and add a reference
-     * to each of the nodes. The nodes are released when this object is destroyed.
-     */
-    class NodesSnapshot
-    {
-    public:
-        explicit NodesSnapshot(const CConnman& connman, bool shuffle)
-        {
-            {
-                LOCK(connman.m_nodes_mutex);
-                m_nodes_copy = connman.m_nodes;
-                for (auto& node : m_nodes_copy) {
-                    node->AddRef();
-                }
-            }
-            if (shuffle) {
-                std::shuffle(m_nodes_copy.begin(), m_nodes_copy.end(), FastRandomContext{});
-            }
-        }
-
-        ~NodesSnapshot()
-        {
-            for (auto& node : m_nodes_copy) {
-                node->Release();
-            }
-        }
-
-        const std::vector<std::shared_ptr<CNode>>& Nodes() const
-        {
-            return m_nodes_copy;
-        }
-
-    private:
-        std::vector<std::shared_ptr<CNode>> m_nodes_copy;
-    };
 
     const CChainParams& m_params;
 

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -50,15 +50,6 @@ FUZZ_TARGET(net, .init = initialize_net)
                 node.CopyStats(stats);
             },
             [&] {
-                const CNode* add_ref_node = node.AddRef();
-                assert(add_ref_node == &node);
-            },
-            [&] {
-                if (node.GetRefCount() > 0) {
-                    node.Release();
-                }
-            },
-            [&] {
                 const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
                 bool complete;
                 node.ReceiveMsgBytes(b, complete);
@@ -68,8 +59,6 @@ FUZZ_TARGET(net, .init = initialize_net)
     (void)node.GetAddrLocal();
     (void)node.GetId();
     (void)node.GetLocalNonce();
-    const int ref_count = node.GetRefCount();
-    assert(ref_count >= 0);
     (void)node.GetCommonVersion();
 
     const NetPermissionFlags net_permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -118,7 +118,7 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     BOOST_CHECK_EQUAL(nodes.back()->ConnectedThroughNetwork(), Network::NET_CJDNS);
 
     BOOST_TEST_MESSAGE("Call AddNode() for all the peers");
-    for (auto node : connman->TestNodes()) {
+    for (const auto& node : connman->TestNodes()) {
         BOOST_CHECK(connman->AddNode({/*m_added_node=*/node->addr.ToStringAddrPort(), /*m_use_v2transport=*/true}));
         BOOST_TEST_MESSAGE(strprintf("peer id=%s addr=%s", node->GetId(), node->addr.ToStringAddrPort()));
     }
@@ -135,7 +135,7 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     BOOST_CHECK(connman->GetAddedNodeInfo(/*include_connected=*/false).empty());
 
     // Test AddedNodesContain()
-    for (auto node : connman->TestNodes()) {
+    for (const auto& node : connman->TestNodes()) {
         BOOST_CHECK(connman->AddedNodesContain(node->addr));
     }
     AddPeer(id, nodes, *peerman, *connman, ConnectionType::OUTBOUND_FULL_RELAY);
@@ -157,7 +157,7 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     }
 
     // Clean up
-    for (auto node : connman->TestNodes()) {
+    for (const auto& node : connman->TestNodes()) {
         peerman->FinalizeNode(*node);
     }
     connman->ClearTestNodes();

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -114,9 +114,9 @@ bool ConnmanTestMsg::ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg) co
     return complete;
 }
 
-CNode* ConnmanTestMsg::ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
+std::shared_ptr<CNode> ConnmanTestMsg::ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
 {
-    CNode* node = ConnectNode(CAddress{}, pszDest, /*fCountFailure=*/false, conn_type, /*use_v2transport=*/true, /*proxy_override=*/std::nullopt);
+    auto node = ConnectNode(CAddress{}, pszDest, /*fCountFailure=*/false, conn_type, /*use_v2transport=*/true, /*proxy_override=*/std::nullopt);
     if (!node) return nullptr;
     node->SetCommonVersion(PROTOCOL_VERSION);
     peerman.InitializeNode(*node, ServiceFlags(NODE_NETWORK | NODE_WITNESS));

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -48,7 +48,7 @@ struct ConnmanTestMsg : public CConnman {
     void ResetAddrCache();
     void ResetMaxOutboundCycle();
 
-    std::vector<CNode*> TestNodes()
+    std::vector<std::shared_ptr<CNode>> TestNodes()
     {
         LOCK(m_nodes_mutex);
         return m_nodes;
@@ -57,7 +57,7 @@ struct ConnmanTestMsg : public CConnman {
     void AddTestNode(CNode& node)
     {
         LOCK(m_nodes_mutex);
-        m_nodes.push_back(&node);
+        m_nodes.push_back(std::shared_ptr<CNode>(&node));
 
         if (node.IsManualOrFullOutboundConn()) ++m_network_conn_counts[node.addr.GetNetwork()];
     }
@@ -65,9 +65,6 @@ struct ConnmanTestMsg : public CConnman {
     void ClearTestNodes()
     {
         LOCK(m_nodes_mutex);
-        for (CNode* node : m_nodes) {
-            delete node;
-        }
         m_nodes.clear();
     }
 
@@ -109,7 +106,7 @@ struct ConnmanTestMsg : public CConnman {
 
     bool AlreadyConnectedToAddressPublic(const CNetAddr& addr) { return AlreadyConnectedToAddress(addr); };
 
-    CNode* ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
+    std::shared_ptr<CNode> ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
         EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
 };
 


### PR DESCRIPTION
Before this change the code used to count references to `CNode` objects manually via `CNode::nRefCount`. Unneeded `CNode`s were scheduled for deletion by putting them in `CConnman::m_nodes_disconnected` and were deleted after their reference count reached zero. Deleting consists of calling `PeerManager::FinalizeNode()` and destroying the `CNode` object.

Replace this scheme with `std::shared_ptr`. This simplifies the code and removes:
`CNode::nRefCount`
`CNode::GetRefCount()`
`CNode::AddRef()`
`CNode::Release()`
`CConnman::m_nodes_disconnected`
`CConnman::NodesSnapshot`

Now creating a snapshot of `CConnman::m_nodes` is done by simply copying it (under the mutex).

Call `PeerManager::FinalizeNode()` from the destructor of `CNode`, which is called when the reference count reaches 0.

This removes brittle code and replaces it by a code from the standard library which is more robust. All the below are possible with the manual reference counting and not possible with `shared_ptr`:
* Use an object without adding a reference to it
* Add too many references to an object, mismatch the add/remove by having more "add"
* Forget to reduce the reference count, mismatch the add/remove by having less "remove"
* Go with negative reference count by mistakenly having too many "remove"
* Destroy an object while there are references to it

There is zero learning curve for the average C++ programmer who knows how `shared_ptr` works. Not so much with the manual reference counting because one has to learn about `AddRef()`, `Release()`, check and maintain where are they called and their relationship with `m_nodes_disconnected`.

---

This has some history in https://github.com/bitcoin/bitcoin/pull/28222 and https://github.com/bitcoin/bitcoin/pull/10738. See below https://github.com/bitcoin/bitcoin/pull/32015#issuecomment-2717384152 and https://github.com/bitcoin/bitcoin/pull/32015#issuecomment-2717860925.

---

Possible followup: change `ProcessMessages()` and `SendMessages()` to take `CNode&`: https://github.com/bitcoin/bitcoin/pull/32015#discussion_r2088731770