### PR TITLE
test: get rid of redundant TODO tag in fuzz tests

### DIFF
--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -314,7 +314,6 @@ T FuzzedDataProvider::PickValueInArray(const std::array<T, size> &array) {
 
 template <typename T>
 T FuzzedDataProvider::PickValueInArray(std::initializer_list<const T> list) {
-  // TODO(Dor1s): switch to static_assert once C++14 is allowed.
   if (!list.size())
     abort();
 


### PR DESCRIPTION
`list.size()` is determined at runtime, so using `static_assert` on it as suggested by the TODO comment is not feasible and produces the following error when done:

`error: static assertion expression is not an integral constant expression`