### PR TITLE
cmake: Add `NO_CACHE_IF_FAILED` option for checking linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,7 @@ if(SANITIZERS)
       int main() { return 0; }
     "
     RESULT_VAR linker_supports_sanitizers
+    NO_CACHE_IF_FAILED
   )
   if(NOT linker_supports_sanitizers)
     message(FATAL_ERROR "Linker did not accept requested flags, you are missing required libraries.")

--- a/cmake/module/TryAppendLinkerFlag.cmake
+++ b/cmake/module/TryAppendLinkerFlag.cmake
@@ -20,7 +20,7 @@ In configuration output, this function prints a string by the following pattern:
 function(try_append_linker_flag flag)
   cmake_parse_arguments(PARSE_ARGV 1
     TALF                              # prefix
-    ""                                # options
+    "NO_CACHE_IF_FAILED"              # options
     "TARGET;VAR;SOURCE;RESULT_VAR"    # one_value_keywords
     "IF_CHECK_PASSED"                 # multi_value_keywords
   )
@@ -67,6 +67,10 @@ function(try_append_linker_flag flag)
 
   if(DEFINED TALF_RESULT_VAR)
     set(${TALF_RESULT_VAR} "${${result}}" PARENT_SCOPE)
+  endif()
+
+  if(NOT ${result} AND TALF_NO_CACHE_IF_FAILED)
+    unset(${result} CACHE)
   endif()
 endfunction()
 


### PR DESCRIPTION
Use it for checking `-fsanitize`.

This change improves the user experience when the configuration step fails due to a missing library. Now, there is no need to manually clean the CMake cache after installing the required library.

Addresses [this](https://github.com/bitcoin/bitcoin/issues/31942#issuecomment-2703801270) comment from https://github.com/bitcoin/bitcoin/issues/31942.