### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/src/secp256k1/src/modinv32_impl.h
+++ b/src/secp256k1/src/modinv32_impl.h
@@ -80,7 +80,7 @@ static void secp256k1_modinv32_normalize_30(secp256k1_modinv32_signed30 *r, int3
     /* In a first step, add the modulus if the input is negative, and then negate if requested.
      * This brings r from range (-2*modulus,modulus) to range (-modulus,modulus). As all input
      * limbs are in range (-2^30,2^30), this cannot overflow an int32_t. Note that the right
-     * shifts below are signed sign-extending shifts (see assumptions.h for tests that that is
+     * shifts below are signed sign-extending shifts (see assumptions.h for tests that is
      * indeed the behavior of the right shift operator). */
     cond_add = r8 >> 31;
     r0 += modinfo->modulus.v[0] & cond_add;

--- a/src/secp256k1/src/modinv64_impl.h
+++ b/src/secp256k1/src/modinv64_impl.h
@@ -104,7 +104,7 @@ static void secp256k1_modinv64_normalize_62(secp256k1_modinv64_signed62 *r, int6
     /* In a first step, add the modulus if the input is negative, and then negate if requested.
      * This brings r from range (-2*modulus,modulus) to range (-modulus,modulus). As all input
      * limbs are in range (-2^62,2^62), this cannot overflow an int64_t. Note that the right
-     * shifts below are signed sign-extending shifts (see assumptions.h for tests that that is
+     * shifts below are signed sign-extending shifts (see assumptions.h for tests that is
      * indeed the behavior of the right shift operator). */
     cond_add = r4 >> 63;
     r0 += modinfo->modulus.v[0] & cond_add;

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -178,7 +178,7 @@ struct DepGraphFormatter
             auto add_holes = SetType::Fill(idx) - done - depgraph.Positions();
             if (add_holes.None()) {
                 // The new transaction is to be inserted N positions back from the end of the
-                // cluster. Emit N to indicate that that many insertion choices are skipped.
+                // cluster. Emit N to indicate that many insertion choices are skipped.
                 auto skips = (done - SetType::Fill(idx)).Count();
                 s << VARINT(diff + skips);
             } else {

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -25,7 +25,7 @@
  * - Which peer announced it (through their NodeId)
  * - The txid or wtxid of the transaction (collectively called "txhash" in what follows)
  * - Whether it was a tx or wtx announcement (see BIP339).
- * - What the earliest permitted time is that that transaction can be requested from that peer (called "reqtime").
+ * - What the earliest permitted time is that transaction can be requested from that peer (called "reqtime").
  * - Whether it's from a "preferred" peer or not. Which announcements get this flag is determined by the caller, but
  *   this is designed for outbound peers, or other peers that we have a higher level of trust in. Even when the
  *   peers' preferredness changes, the preferred flag of existing announcements from that peer won't change.


### PR DESCRIPTION
remove redundant words in comment