### PR TITLE
depends: remove `NO_HARDEN` option

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -43,7 +43,6 @@ NO_ZMQ ?=
 NO_USDT ?=
 MULTIPROCESS ?=
 LTO ?=
-NO_HARDEN ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
 C_STANDARD ?= c11
@@ -143,13 +142,13 @@ include packages/packages.mk
 #
 build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
                       AR='$(build_AR)' NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
-                      DEBUG='$(DEBUG)' NO_HARDEN='$(NO_HARDEN)' \
+                      DEBUG='$(DEBUG)' \
                       ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
 $(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(host_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
                                         CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' \
                                         AR='$(host_AR)' NM='$(host_NM)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
-                                        DEBUG='$(DEBUG)' LTO='$(LTO)' NO_HARDEN='$(NO_HARDEN)' \
+                                        DEBUG='$(DEBUG)' LTO='$(LTO)' \
                                         ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
 boost_packages_$(NO_BOOST) = $(boost_packages)
@@ -236,7 +235,6 @@ $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(fina
             -e 's|@bdb_packages@|$(bdb_packages_)|' \
             -e 's|@sqlite_packages@|$(sqlite_packages_)|' \
             -e 's|@usdt_packages@|$(usdt_packages_)|' \
-            -e 's|@no_harden@|$(NO_HARDEN)|' \
             -e 's|@multiprocess@|$(MULTIPROCESS)|' \
             $< > $@
 	touch $@

--- a/depends/README.md
+++ b/depends/README.md
@@ -127,7 +127,6 @@ The following can be set when running make: `make FOO=bar`
   resides in the `depends` directory, and the log file is printed out automatically in case
   of build error. After successful build log files are moved along with package archives
 - `LTO`: Enable options needed for LTO. Does not add `-flto` related options to *FLAGS.
-- `NO_HARDEN=1`: Don't use hardening options when building packages
 
 If some packages are not built, for example `make NO_WALLET=1`, the appropriate CMake cache
 variables will be set when generating the Bitcoin Core buildsystem. In this case, `-DENABLE_WALLET=OFF`.

--- a/depends/gen_id
+++ b/depends/gen_id
@@ -3,7 +3,7 @@
 # Usage: env [ CC=... ] [ C_STANDARD=...] [ CXX=... ] [CXX_STANDARD=...] \
 #            [ CPPFLAGS=... ] [CFLAGS=...] [CXXFLAGS=...] [LDFLAGS=...] \
 #            [ AR=... ] [ NM=... ] [ RANLIB=... ] [ STRIP=... ] [ DEBUG=... ] \
-#            [ LTO=... ] [ NO_HARDEN=... ] ./gen_id [ID_SALT]...
+#            [ LTO=... ] ./gen_id [ID_SALT]...
 #
 # Prints to stdout a SHA256 hash representing the current toolset, used by
 # depends/Makefile as a build id for caching purposes (detecting when the
@@ -92,10 +92,6 @@
     echo "BEGIN LTO"
     echo "LTO=${LTO}"
     echo "END LTO"
-
-    echo "BEGIN NO_HARDEN"
-    echo "NO_HARDEN=${NO_HARDEN}"
-    echo "END NO_HARDEN"
 
     echo "END ALL"
 ) | if [ -n "$DEBUG" ] && command -v tee > /dev/null 2>&1; then

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -15,12 +15,8 @@ define $(package)_set_vars
   $(package)_config_opts+=-DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON
   $(package)_config_opts+=-DEVENT__DISABLE_TESTS=ON -DEVENT__LIBRARY_TYPE=STATIC
   $(package)_cflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
-  $(package)_cppflags += -D_GNU_SOURCE
+  $(package)_cppflags += -D_GNU_SOURCE -D_FORTIFY_SOURCE=3
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0A00
-
-  ifeq ($(NO_HARDEN),)
-  $(package)_cppflags+=-D_FORTIFY_SOURCE=3
-  endif
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -146,12 +146,6 @@ else()
   set(WITH_USDT ON CACHE BOOL "")
 endif()
 
-if("@no_harden@")
-  set(ENABLE_HARDENING OFF CACHE BOOL "")
-else()
-  set(ENABLE_HARDENING ON CACHE BOOL "")
-endif()
-
 if("@multiprocess@" STREQUAL "1")
   set(WITH_MULTIPROCESS ON CACHE BOOL "")
   set(Libmultiprocess_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")


### PR DESCRIPTION
This was only needed to work around a (Libtool related iirc) Windows issue, when hardening was disabled. I can no-longer recreate this failure, so it'd be good to remove this Windows carveout.