### PR TITLE
[IBD] Tracking PR for speeding up Initial Block Download

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -52,7 +52,7 @@ static void DeserializeBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
+    stream.write(std::span{&a, 1}); // Prevent compaction
 
     bench.unit("block").run([&] {
         CBlock block;
@@ -66,7 +66,7 @@ static void DeserializeAndCheckBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
+    stream.write(std::span{&a, 1}); // Prevent compaction
 
     ArgsManager bench_args;
     const auto chainParams = CreateChainParams(bench_args, ChainType::MAIN);

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <vector>
 
-static void SizeComputerBlock(benchmark::Bench& bench) {
+static void SizeComputerBlockBench(benchmark::Bench& bench) {
     CBlock block;
     DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
 
@@ -32,7 +32,7 @@ static void SizeComputerBlock(benchmark::Bench& bench) {
     });
 }
 
-static void SerializeBlock(benchmark::Bench& bench) {
+static void SerializeBlockBench(benchmark::Bench& bench) {
     CBlock block;
     DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
 
@@ -48,7 +48,7 @@ static void SerializeBlock(benchmark::Bench& bench) {
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
-static void DeserializeBlock(benchmark::Bench& bench)
+static void DeserializeBlockBench(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -83,7 +83,7 @@ static void DeserializeAndCheckBlock(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(SizeComputerBlock, benchmark::PriorityLevel::HIGH);
-BENCHMARK(SerializeBlock, benchmark::PriorityLevel::HIGH);
-BENCHMARK(DeserializeBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SizeComputerBlockBench, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SerializeBlockBench, benchmark::PriorityLevel::HIGH);
+BENCHMARK(DeserializeBlockBench, benchmark::PriorityLevel::HIGH);
 BENCHMARK(DeserializeAndCheckBlock, benchmark::PriorityLevel::HIGH);

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -21,11 +21,34 @@
 #include <optional>
 #include <vector>
 
+static void SizeComputerBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    bench.unit("block").run([&] {
+        SizeComputer size_computer;
+        size_computer << TX_WITH_WITNESS(block);
+        assert(size_computer.size() == benchmark::data::block413567.size());
+    });
+}
+
+static void SerializeBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    // Create output stream and verify first serialization matches input
+    bench.unit("block").run([&] {
+        DataStream output_stream(benchmark::data::block413567.size());
+        output_stream << TX_WITH_WITNESS(block);
+        assert(output_stream.size() == benchmark::data::block413567.size());
+    });
+}
+
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
-static void DeserializeBlockTest(benchmark::Bench& bench)
+static void DeserializeBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -39,7 +62,7 @@ static void DeserializeBlockTest(benchmark::Bench& bench)
     });
 }
 
-static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
+static void DeserializeAndCheckBlock(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -60,5 +83,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(DeserializeBlockTest, benchmark::PriorityLevel::HIGH);
-BENCHMARK(DeserializeAndCheckBlockTest, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SizeComputerBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SerializeBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(DeserializeBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(DeserializeAndCheckBlock, benchmark::PriorityLevel::HIGH);

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -16,7 +16,7 @@
 
 static const size_t BATCHES = 101;
 static const size_t BATCH_SIZE = 30;
-static const int PREVECTOR_SIZE = 28;
+static const int PREVECTOR_SIZE = 36;
 static const unsigned int QUEUE_BATCH_SIZE = 128;
 
 // This Benchmark tests the CheckQueue with a slightly realistic workload,

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <bench/bench.h>
 #include <crypto/muhash.h>
 #include <crypto/ripemd160.h>
@@ -12,9 +11,11 @@
 #include <crypto/sha512.h>
 #include <crypto/siphash.h>
 #include <random.h>
-#include <span.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <primitives/transaction.h>
+#include <util/hasher.h>
+#include <unordered_set>
 
 #include <cstdint>
 #include <vector>
@@ -205,6 +206,98 @@ static void SipHash_32b(benchmark::Bench& bench)
     });
 }
 
+static void SaltedOutpointHasherBench_hash(benchmark::Bench& bench)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    constexpr size_t size{1000};
+
+    std::vector<COutPoint> outpoints(size);
+    for (auto& outpoint : outpoints) {
+        outpoint = {Txid::FromUint256(rng.rand256()), rng.rand32()};
+    }
+
+    const SaltedOutpointHasher hasher;
+    bench.batch(size).run([&] {
+        size_t result{0};
+        for (const auto& outpoint : outpoints) {
+            result ^= hasher(outpoint);
+        }
+        ankerl::nanobench::doNotOptimizeAway(result);
+    });
+}
+
+static void SaltedOutpointHasherBench_match(benchmark::Bench& bench)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    constexpr size_t size{1000};
+
+    std::unordered_set<COutPoint, SaltedOutpointHasher> values;
+    std::vector<COutPoint> value_vector;
+    values.reserve(size);
+    value_vector.reserve(size);
+
+    for (size_t i{0}; i < size; ++i) {
+        COutPoint outpoint{Txid::FromUint256(rng.rand256()), rng.rand32()};
+        values.emplace(outpoint);
+        value_vector.push_back(outpoint);
+        assert(values.contains(outpoint));
+    }
+
+    bench.batch(size).run([&] {
+        bool result{true};
+        for (const auto& outpoint : value_vector) {
+            result ^= values.contains(outpoint);
+        }
+        ankerl::nanobench::doNotOptimizeAway(result);
+    });
+}
+
+static void SaltedOutpointHasherBench_mismatch(benchmark::Bench& bench)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    constexpr size_t size{1000};
+
+    std::unordered_set<COutPoint, SaltedOutpointHasher> values;
+    std::vector<COutPoint> missing_value_vector;
+    values.reserve(size);
+    missing_value_vector.reserve(size);
+
+    for (size_t i{0}; i < size; ++i) {
+        values.emplace(Txid::FromUint256(rng.rand256()), rng.rand32());
+        COutPoint missing_outpoint{Txid::FromUint256(rng.rand256()), rng.rand32()};
+        missing_value_vector.push_back(missing_outpoint);
+        assert(!values.contains(missing_outpoint));
+    }
+
+    bench.batch(size).run([&] {
+        bool result{false};
+        for (const auto& outpoint : missing_value_vector) {
+            result ^= values.contains(outpoint);
+        }
+        ankerl::nanobench::doNotOptimizeAway(result);
+    });
+}
+
+static void SaltedOutpointHasherBench_create_set(benchmark::Bench& bench)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    constexpr size_t size{1000};
+
+    std::vector<COutPoint> outpoints(size);
+    for (auto& outpoint : outpoints) {
+        outpoint = {Txid::FromUint256(rng.rand256()), rng.rand32()};
+    }
+
+    bench.batch(size).run([&] {
+        std::unordered_set<COutPoint, SaltedOutpointHasher> set;
+        set.reserve(size);
+        for (const auto& outpoint : outpoints) {
+            set.emplace(outpoint);
+        }
+        ankerl::nanobench::doNotOptimizeAway(set.size());
+    });
+}
+
 static void MuHash(benchmark::Bench& bench)
 {
     MuHash3072 acc;
@@ -276,6 +369,10 @@ BENCHMARK(SHA256_32b_SSE4, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256_32b_AVX2, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256_32b_SHANI, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SipHash_32b, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SaltedOutpointHasherBench_hash, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SaltedOutpointHasherBench_match, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SaltedOutpointHasherBench_mismatch, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SaltedOutpointHasherBench_create_set, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_STANDARD, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_SSE4, benchmark::PriorityLevel::HIGH);
 BENCHMARK(SHA256D64_1024_AVX2, benchmark::PriorityLevel::HIGH);

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -27,22 +27,22 @@ template <typename T>
 static void PrevectorDestructor(benchmark::Bench& bench)
 {
     bench.batch(2).run([&] {
-        prevector<28, T> t0;
-        prevector<28, T> t1;
-        t0.resize(28);
-        t1.resize(29);
+        prevector<36, T> t0;
+        prevector<36, T> t1;
+        t0.resize(36);
+        t1.resize(37);
     });
 }
 
 template <typename T>
 static void PrevectorClear(benchmark::Bench& bench)
 {
-    prevector<28, T> t0;
-    prevector<28, T> t1;
+    prevector<36, T> t0;
+    prevector<36, T> t1;
     bench.batch(2).run([&] {
-        t0.resize(28);
+        t0.resize(36);
         t0.clear();
-        t1.resize(29);
+        t1.resize(37);
         t1.clear();
     });
 }
@@ -50,12 +50,12 @@ static void PrevectorClear(benchmark::Bench& bench)
 template <typename T>
 static void PrevectorResize(benchmark::Bench& bench)
 {
-    prevector<28, T> t0;
-    prevector<28, T> t1;
+    prevector<36, T> t0;
+    prevector<36, T> t1;
     bench.batch(4).run([&] {
-        t0.resize(28);
+        t0.resize(36);
         t0.resize(0);
-        t1.resize(29);
+        t1.resize(37);
         t1.resize(0);
     });
 }
@@ -64,8 +64,8 @@ template <typename T>
 static void PrevectorDeserialize(benchmark::Bench& bench)
 {
     DataStream s0{};
-    prevector<28, T> t0;
-    t0.resize(28);
+    prevector<36, T> t0;
+    t0.resize(36);
     for (auto x = 0; x < 900; ++x) {
         s0 << t0;
     }
@@ -74,7 +74,7 @@ static void PrevectorDeserialize(benchmark::Bench& bench)
         s0 << t0;
     }
     bench.batch(1000).run([&] {
-        prevector<28, T> t1;
+        prevector<36, T> t1;
         for (auto x = 0; x < 1000; ++x) {
             s0 >> t1;
         }
@@ -86,7 +86,7 @@ template <typename T>
 static void PrevectorFillVectorDirect(benchmark::Bench& bench)
 {
     bench.run([&] {
-        std::vector<prevector<28, T>> vec;
+        std::vector<prevector<36, T>> vec;
         vec.reserve(260);
         for (size_t i = 0; i < 260; ++i) {
             vec.emplace_back();
@@ -99,11 +99,11 @@ template <typename T>
 static void PrevectorFillVectorIndirect(benchmark::Bench& bench)
 {
     bench.run([&] {
-        std::vector<prevector<28, T>> vec;
+        std::vector<prevector<36, T>> vec;
         vec.reserve(260);
         for (size_t i = 0; i < 260; ++i) {
             // force allocation
-            vec.emplace_back(29, T{});
+            vec.emplace_back(37, T{});
         }
     });
 }

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -33,7 +33,7 @@ struct TestBlockAndIndex {
     {
         DataStream stream{benchmark::data::block413567};
         std::byte a{0};
-        stream.write({&a, 1}); // Prevent compaction
+        stream.write(std::span{&a, 1}); // Prevent compaction
 
         stream >> TX_WITH_WITNESS(block);
 

--- a/src/bench/xor.cpp
+++ b/src/bench/xor.cpp
@@ -6,19 +6,28 @@
 #include <random.h>
 #include <span.h>
 #include <streams.h>
+#include <util/byte_units.h>
 
+#include <cmath>
 #include <cstddef>
+#include <map>
 #include <vector>
 
-static void Xor(benchmark::Bench& bench)
+static void XorObfuscationBench(benchmark::Bench& bench)
 {
-    FastRandomContext frc{/*fDeterministic=*/true};
-    auto data{frc.randbytes<std::byte>(1024)};
-    auto key{frc.randbytes<std::byte>(31)};
+    FastRandomContext rng{/*fDeterministic=*/true};
+    constexpr size_t bytes{10_MiB};
+    auto test_data{rng.randbytes<std::byte>(bytes)};
 
-    bench.batch(data.size()).unit("byte").run([&] {
-        util::Xor(data, key);
+    std::vector key_bytes{rng.randbytes<std::byte>(8)};
+    uint64_t key;
+    std::memcpy(&key, key_bytes.data(), 8);
+
+    size_t offset{0};
+    bench.batch(bytes / 1_MiB).unit("MiB").run([&] {
+        util::Xor(test_data, key_bytes, offset++);
+        ankerl::nanobench::doNotOptimizeAway(test_data);
     });
 }
 
-BENCHMARK(Xor, benchmark::PriorityLevel::HIGH);
+BENCHMARK(XorObfuscationBench, benchmark::PriorityLevel::HIGH);

--- a/src/bench/xor.cpp
+++ b/src/bench/xor.cpp
@@ -19,13 +19,12 @@ static void XorObfuscationBench(benchmark::Bench& bench)
     constexpr size_t bytes{10_MiB};
     auto test_data{rng.randbytes<std::byte>(bytes)};
 
-    std::vector key_bytes{rng.randbytes<std::byte>(8)};
-    uint64_t key;
-    std::memcpy(&key, key_bytes.data(), 8);
+    const Obfuscation obfuscation{rng.rand64()};
+    assert(obfuscation);
 
     size_t offset{0};
     bench.batch(bytes / 1_MiB).unit("MiB").run([&] {
-        util::Xor(test_data, key_bytes, offset++);
+        obfuscation(test_data, offset++);
         ankerl::nanobench::doNotOptimizeAway(test_data);
     });
 }

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -45,10 +45,16 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
             }
         }
     } else {
-        std::set<COutPoint> vInOutPoints;
-        for (const auto& txin : tx.vin) {
-            if (!vInOutPoints.insert(txin.prevout).second) {
+        if (tx.vin.size() == 2) {
+            if (tx.vin[0].prevout == tx.vin[1].prevout) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
+            }
+        } else {
+            std::set<COutPoint> vInOutPoints;
+            for (const auto& txin : tx.vin) {
+                if (!vInOutPoints.insert(txin.prevout).second) {
+                    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
+                }
             }
         }
 

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -50,11 +50,14 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
             }
         } else {
-            std::set<COutPoint> vInOutPoints;
+            std::vector<COutPoint> sortedPrevouts;
+            sortedPrevouts.reserve(tx.vin.size());
             for (const auto& txin : tx.vin) {
-                if (!vInOutPoints.insert(txin.prevout).second) {
-                    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
-                }
+                sortedPrevouts.push_back(txin.prevout);
+            }
+            std::sort(sortedPrevouts.begin(), sortedPrevouts.end());
+            if (std::ranges::adjacent_find(sortedPrevouts) != sortedPrevouts.end()) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
             }
         }
 

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -723,6 +723,21 @@ CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
     }
     return *this;
 }
+CSHA256& CSHA256::Write(unsigned char data)
+{
+    size_t bufsize = bytes % 64;
+
+    // Add the single byte to the buffer
+    buf[bufsize] = data;
+    bytes += 1;
+
+    if (bufsize == 63) {
+        // Process the buffer if full
+        Transform(s, buf, 1);
+    }
+
+    return *this;
+}
 
 void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
 {

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -22,6 +22,7 @@ public:
 
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);
+    CSHA256& Write(unsigned char data);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();
 };

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -17,10 +17,10 @@
 
 CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
 {
-    v[0] = 0x736f6d6570736575ULL ^ k0;
-    v[1] = 0x646f72616e646f6dULL ^ k1;
-    v[2] = 0x6c7967656e657261ULL ^ k0;
-    v[3] = 0x7465646279746573ULL ^ k1;
+    v[0] = C0 ^ k0;
+    v[1] = C1 ^ k1;
+    v[2] = C2 ^ k0;
+    v[3] = C3 ^ k1;
     count = 0;
     tmp = 0;
 }
@@ -97,10 +97,10 @@ uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val)
     /* Specialized implementation for efficiency */
     uint64_t d = val.GetUint64(0);
 
-    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
-    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
-    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
-    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
+    uint64_t v0 = CSipHasher::C0 ^ k0;
+    uint64_t v1 = CSipHasher::C1 ^ k1;
+    uint64_t v2 = CSipHasher::C2 ^ k0;
+    uint64_t v3 = CSipHasher::C3 ^ k1 ^ d;
 
     SIPROUND;
     SIPROUND;
@@ -137,10 +137,11 @@ uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint3
     /* Specialized implementation for efficiency */
     uint64_t d = val.GetUint64(0);
 
-    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
-    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
-    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
-    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
+    // TODO moved in next commit
+    uint64_t v0 = CSipHasher::C0 ^ k0;
+    uint64_t v1 = CSipHasher::C1 ^ k1;
+    uint64_t v2 = CSipHasher::C2 ^ k0;
+    uint64_t v3 = CSipHasher::C3 ^ k1 ^ d;
 
     SIPROUND;
     SIPROUND;

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -132,17 +132,12 @@ uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val)
     return v0 ^ v1 ^ v2 ^ v3;
 }
 
-uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra)
+/* Specialized implementation for efficiency */
+uint64_t Uint256ExtraSipHasher::operator()(const uint256& val, uint32_t extra) const noexcept
 {
-    /* Specialized implementation for efficiency */
+    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
     uint64_t d = val.GetUint64(0);
-
-    // TODO moved in next commit
-    uint64_t v0 = CSipHasher::C0 ^ k0;
-    uint64_t v1 = CSipHasher::C1 ^ k1;
-    uint64_t v2 = CSipHasher::C2 ^ k0;
-    uint64_t v3 = CSipHasher::C3 ^ k1 ^ d;
-
+    v3 ^= d;
     SIPROUND;
     SIPROUND;
     v0 ^= d;

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -19,6 +19,11 @@ private:
     uint8_t count; // Only the low 8 bits of the input size matter.
 
 public:
+    static constexpr uint64_t C0{0x736f6d6570736575ULL};
+    static constexpr uint64_t C1{0x646f72616e646f6dULL};
+    static constexpr uint64_t C2{0x6c7967656e657261ULL};
+    static constexpr uint64_t C3{0x7465646279746573ULL};
+
     /** Construct a SipHash calculator initialized with 128-bit key (k0, k1) */
     CSipHasher(uint64_t k0, uint64_t k1);
     /** Hash a 64-bit integer worth of data

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -48,6 +48,19 @@ public:
  *      .Finalize()
  */
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
-uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
+
+class Uint256ExtraSipHasher {
+    uint64_t v[4];
+
+public:
+    Uint256ExtraSipHasher(const uint64_t k0, const uint64_t k1) noexcept {
+        v[0] = CSipHasher::C0 ^ k0;
+        v[1] = CSipHasher::C1 ^ k1;
+        v[2] = CSipHasher::C2 ^ k0;
+        v[3] = CSipHasher::C3 ^ k1;
+    }
+
+    uint64_t operator()(const uint256& val, uint32_t extra) const noexcept;
+};
 
 #endif // BITCOIN_CRYPTO_SIPHASH_H

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -173,7 +173,7 @@ void CDBBatch::Clear()
 void CDBBatch::WriteImpl(std::span<const std::byte> key, DataStream& ssValue)
 {
     leveldb::Slice slKey(CharCast(key.data()), key.size());
-    ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
+    dbwrapper_private::GetObfuscation(parent)(ssValue);
     leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
     m_impl_batch->batch.Put(slKey, slValue);
 }
@@ -215,6 +215,7 @@ struct LevelDBContext {
 CDBWrapper::CDBWrapper(const DBParams& params)
     : m_db_context{std::make_unique<LevelDBContext>()},
       m_name{fs::PathToString(params.path.stem())},
+      m_obfuscation{0},
       m_path{params.path},
       m_is_memory{params.memory_only}
 {
@@ -252,21 +253,22 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     }
 
     {
-        obfuscate_key = std::vector<unsigned char>(OBFUSCATE_KEY_NUM_BYTES, '\000'); // Needed for unobfuscated Read
-        const bool key_missing{!Read(OBFUSCATE_KEY_KEY, obfuscate_key)};
+        m_obfuscation = 0; // Needed for unobfuscated Read
+        std::vector<unsigned char> obfuscate_key_vector(Obfuscation::SIZE_BYTES, '\000');
+        const bool key_missing{!Read(OBFUSCATE_KEY_KEY, obfuscate_key_vector)};
         if (key_missing && params.obfuscate && IsEmpty()) {
             // Initialize non-degenerate obfuscation if it won't upset existing, non-obfuscated data.
-            std::vector<uint8_t> new_key(OBFUSCATE_KEY_NUM_BYTES);
+            std::vector<uint8_t> new_key(Obfuscation::SIZE_BYTES);
             GetRandBytes(new_key);
 
             // Write `new_key` so we don't obfuscate the key with itself
             Write(OBFUSCATE_KEY_KEY, new_key);
-            obfuscate_key = new_key;
+            obfuscate_key_vector = new_key;
 
-            LogPrintf("Wrote new obfuscate key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key));
+            LogPrintf("Wrote new obfuscate key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key_vector));
         }
-
-        LogPrintf("Using obfuscation key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key));
+        LogPrintf("Using obfuscation key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key_vector));
+        m_obfuscation = obfuscate_key_vector;
     }
 }
 
@@ -317,9 +319,6 @@ size_t CDBWrapper::DynamicMemoryUsage() const
 // We must use a string constructor which specifies length so that we copy
 // past the null-terminator.
 const std::string CDBWrapper::OBFUSCATE_KEY_KEY("\000obfuscate_key", 14);
-
-const unsigned int CDBWrapper::OBFUSCATE_KEY_NUM_BYTES = 8;
-
 std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) const
 {
     leveldb::Slice slKey(CharCast(key.data()), key.size());
@@ -402,6 +401,5 @@ void CDBIterator::SeekToFirst() { m_impl_iter->iter->SeekToFirst(); }
 void CDBIterator::Next() { m_impl_iter->iter->Next(); }
 
 namespace dbwrapper_private {
-const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper& w) { return w.obfuscate_key; }
-
+Obfuscation GetObfuscation(const CDBWrapper& w) { return w.m_obfuscation; }
 } // namespace dbwrapper_private

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -196,8 +196,6 @@ private:
     //! the length of the obfuscate key in number of bytes
     static const unsigned int OBFUSCATE_KEY_NUM_BYTES;
 
-    std::vector<unsigned char> CreateObfuscateKey() const;
-
     //! path to filesystem storage
     const fs::path m_path;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -63,8 +63,7 @@ namespace dbwrapper_private {
  * Database obfuscation should be considered an implementation detail of the
  * specific database.
  */
-const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
-
+Obfuscation GetObfuscation(const CDBWrapper&);
 }; // namespace dbwrapper_private
 
 bool DestroyDB(const std::string& path_str);
@@ -166,7 +165,7 @@ public:
     template<typename V> bool GetValue(V& value) {
         try {
             DataStream ssValue{GetValueImpl()};
-            ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
+            dbwrapper_private::GetObfuscation(parent)(ssValue);
             ssValue >> value;
         } catch (const std::exception&) {
             return false;
@@ -179,7 +178,7 @@ struct LevelDBContext;
 
 class CDBWrapper
 {
-    friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
+    friend Obfuscation dbwrapper_private::GetObfuscation(const CDBWrapper&);
 private:
     //! holds all leveldb-specific fields of this class
     std::unique_ptr<LevelDBContext> m_db_context;
@@ -188,13 +187,10 @@ private:
     std::string m_name;
 
     //! a key used for optional XOR-obfuscation of the database
-    std::vector<unsigned char> obfuscate_key;
+    Obfuscation m_obfuscation;
 
     //! the key under which the obfuscation key is stored
     static const std::string OBFUSCATE_KEY_KEY;
-
-    //! the length of the obfuscate key in number of bytes
-    static const unsigned int OBFUSCATE_KEY_NUM_BYTES;
 
     //! path to filesystem storage
     const fs::path m_path;
@@ -226,7 +222,7 @@ public:
         }
         try {
             DataStream ssValue{MakeByteSpan(*strValue)};
-            ssValue.Xor(obfuscate_key);
+            m_obfuscation(ssValue);
             ssValue >> value;
         } catch (const std::exception&) {
             return false;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -235,7 +235,7 @@ private:
 
     const bool m_prune_mode;
 
-    const std::vector<std::byte> m_xor_key;
+    const Obfuscation m_obfuscation;
 
     /** Dirty block index entries. */
     std::set<CBlockIndex*> m_dirty_blockindex;

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -60,12 +60,11 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
         file >> version;
 
         if (version == MEMPOOL_DUMP_VERSION_NO_XOR_KEY) {
-            std::vector<std::byte> xor_key;
-            file.SetXor(xor_key);
+            file.SetObfuscation(0);
         } else if (version == MEMPOOL_DUMP_VERSION) {
-            std::vector<std::byte> xor_key;
-            file >> xor_key;
-            file.SetXor(xor_key);
+            Obfuscation obfuscation{0};
+            file >> obfuscation;
+            file.SetObfuscation(obfuscation);
         } else {
             return false;
         }
@@ -181,13 +180,11 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
         file << version;
 
         if (!pool.m_opts.persist_v1_dat) {
-            std::vector<std::byte> xor_key(8);
-            FastRandomContext{}.fillrand(xor_key);
-            file << xor_key;
-            file.SetXor(xor_key);
+            const Obfuscation obfuscation{FastRandomContext{}.rand64()};
+            file << obfuscation;
+            file.SetObfuscation(obfuscation);
         } else {
-            std::vector<std::byte> xor_key(8);
-            file.SetXor(xor_key);
+            file.SetObfuscation(0);
         }
 
         uint64_t mempool_transactions_to_write(vinfo.size());

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -58,15 +58,18 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
     try {
         uint64_t version;
         file >> version;
-        std::vector<std::byte> xor_key;
+
         if (version == MEMPOOL_DUMP_VERSION_NO_XOR_KEY) {
-            // Leave XOR-key empty
+            std::vector<std::byte> xor_key;
+            file.SetXor(xor_key);
         } else if (version == MEMPOOL_DUMP_VERSION) {
+            std::vector<std::byte> xor_key;
             file >> xor_key;
+            file.SetXor(xor_key);
         } else {
             return false;
         }
-        file.SetXor(xor_key);
+
         uint64_t total_txns_to_load;
         file >> total_txns_to_load;
         uint64_t txns_tried = 0;
@@ -177,12 +180,15 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
         const uint64_t version{pool.m_opts.persist_v1_dat ? MEMPOOL_DUMP_VERSION_NO_XOR_KEY : MEMPOOL_DUMP_VERSION};
         file << version;
 
-        std::vector<std::byte> xor_key(8);
         if (!pool.m_opts.persist_v1_dat) {
+            std::vector<std::byte> xor_key(8);
             FastRandomContext{}.fillrand(xor_key);
             file << xor_key;
+            file.SetXor(xor_key);
+        } else {
+            std::vector<std::byte> xor_key(8);
+            file.SetXor(xor_key);
         }
-        file.SetXor(xor_key);
 
         uint64_t mempool_transactions_to_write(vinfo.size());
         file << mempool_transactions_to_write;

--- a/src/obfuscation.h
+++ b/src/obfuscation.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_OBFUSCATION_H
+#define BITCOIN_OBFUSCATION_H
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <random>
+#include <span.h>
+#include <util/check.h>
+#include <cstring>
+#include <climits>
+#include <serialize.h>
+
+class Obfuscation
+{
+public:
+    static constexpr size_t SIZE_BYTES{sizeof(uint64_t)};
+
+private:
+    std::array<uint64_t, SIZE_BYTES> rotations; // Cached key rotations
+    void SetRotations(const uint64_t key)
+    {
+        for (size_t i{0}; i < SIZE_BYTES; ++i) {
+            size_t key_rotation_bits{CHAR_BIT * i};
+            if constexpr (std::endian::native == std::endian::big) key_rotation_bits *= -1;
+            rotations[i] = std::rotr(key, key_rotation_bits);
+        }
+    }
+
+    static uint64_t ToUint64(const std::span<const std::byte, SIZE_BYTES> key_span)
+    {
+        uint64_t key{};
+        std::memcpy(&key, key_span.data(), SIZE_BYTES);
+        return key;
+    }
+
+    static void Xor(std::span<std::byte> write, const uint64_t key, const size_t size)
+    {
+        assert(size <= write.size());
+        uint64_t raw{};
+        std::memcpy(&raw, write.data(), size);
+        raw ^= key;
+        std::memcpy(write.data(), &raw, size);
+    }
+
+public:
+    Obfuscation(const uint64_t key) { SetRotations(key); }
+    Obfuscation(const std::span<const std::byte, SIZE_BYTES> key_span) : Obfuscation(ToUint64(key_span)) {}
+    Obfuscation(const std::vector<uint8_t>& key_vec) : Obfuscation(MakeByteSpan(key_vec).first<SIZE_BYTES>()) {}
+    Obfuscation(const std::vector<std::byte>& key_vec) : Obfuscation(std::span(key_vec).first<SIZE_BYTES>()) {}
+
+    uint64_t Key() const { return rotations[0]; }
+    operator bool() const { return Key() != 0; }
+    void operator()(std::span<std::byte> write, const size_t key_offset_bytes = 0) const
+    {
+        if (!*this) return;
+        const uint64_t rot_key{rotations[key_offset_bytes % SIZE_BYTES]}; // Continue obfuscation from where we left off
+        for (; write.size() >= SIZE_BYTES; write = write.subspan(SIZE_BYTES)) { // Process multiple bytes at a time
+            Xor(write, rot_key, SIZE_BYTES);
+        }
+        Xor(write, rot_key, write.size());
+    }
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        std::vector<std::byte> bytes(SIZE_BYTES);
+        std::memcpy(bytes.data(), &rotations[0], SIZE_BYTES);
+        s << bytes;
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        std::vector<std::byte> bytes(SIZE_BYTES);
+        s >> bytes;
+        SetRotations(ToUint64(MakeByteSpan(bytes).first<SIZE_BYTES>()));
+    }
+};
+
+#endif // BITCOIN_OBFUSCATION_H

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -406,7 +406,7 @@ private:
  * Tests in October 2015 showed use of this reduced dbcache memory usage by 23%
  *  and made an initial sync 13% faster.
  */
-typedef prevector<28, unsigned char> CScriptBase;
+typedef prevector<36, unsigned char> CScriptBase;
 
 bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -60,11 +60,6 @@ template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
     obj = htole16_internal(obj);
     s.write(std::as_bytes(std::span{&obj, 1}));
 }
-template<typename Stream> inline void ser_writedata16be(Stream &s, uint16_t obj)
-{
-    obj = htobe16_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
-}
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32_internal(obj);
@@ -91,12 +86,6 @@ template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
     uint16_t obj;
     s.read(std::as_writable_bytes(std::span{&obj, 1}));
     return le16toh_internal(obj);
-}
-template<typename Stream> inline uint16_t ser_readdata16be(Stream &s)
-{
-    uint16_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
-    return be16toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -241,38 +241,47 @@ const Out& AsBase(const In& x)
 template<class T>
 concept CharNotInt8 = std::same_as<T, char> && !std::same_as<T, int8_t>;
 
+template <typename T>
+concept ByteOrIntegral = std::is_same_v<T, std::byte> ||
+    (std::is_integral_v<T> && !std::is_same_v<T, char>);
+
 template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
-template<typename Stream> inline void Serialize(Stream& s, int8_t a  ) { ser_writedata8(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, uint8_t a ) { ser_writedata8(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, int16_t a ) { ser_writedata16(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, uint16_t a) { ser_writedata16(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, int32_t a ) { ser_writedata32(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, uint32_t a) { ser_writedata32(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, int64_t a ) { ser_writedata64(s, a); }
-template<typename Stream> inline void Serialize(Stream& s, uint64_t a) { ser_writedata64(s, a); }
+template <typename Stream, ByteOrIntegral T> void Serialize(Stream& s, T a)
+{
+    if constexpr (sizeof(T) == 1) {
+        ser_writedata8(s, static_cast<uint8_t>(a));   // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        ser_writedata16(s, static_cast<uint16_t>(a)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        ser_writedata32(s, static_cast<uint32_t>(a)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        ser_writedata64(s, static_cast<uint64_t>(a)); // (u)int64_t
+    }
+}
 template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N]) { s.write(MakeByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span) { s.write(std::as_bytes(span)); }
 template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span) { s.write(std::as_bytes(span)); }
 
 template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte{ser_readdata8(s)}; }
-template<typename Stream> inline void Unserialize(Stream& s, int8_t& a  ) { a = ser_readdata8(s); }
-template<typename Stream> inline void Unserialize(Stream& s, uint8_t& a ) { a = ser_readdata8(s); }
-template<typename Stream> inline void Unserialize(Stream& s, int16_t& a ) { a = ser_readdata16(s); }
-template<typename Stream> inline void Unserialize(Stream& s, uint16_t& a) { a = ser_readdata16(s); }
-template<typename Stream> inline void Unserialize(Stream& s, int32_t& a ) { a = ser_readdata32(s); }
-template<typename Stream> inline void Unserialize(Stream& s, uint32_t& a) { a = ser_readdata32(s); }
-template<typename Stream> inline void Unserialize(Stream& s, int64_t& a ) { a = ser_readdata64(s); }
-template<typename Stream> inline void Unserialize(Stream& s, uint64_t& a) { a = ser_readdata64(s); }
+template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
+{
+    if constexpr (sizeof(T) == 1) {
+        a = static_cast<T>(ser_readdata8(s));  // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        a = static_cast<T>(ser_readdata16(s)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        a = static_cast<T>(ser_readdata32(s)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        a = static_cast<T>(ser_readdata64(s)); // (u)int64_t
+    }
+}
 template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
 template <typename Stream, BasicByte B> void Unserialize(Stream& s, std::span<B> span) { s.read(std::as_writable_bytes(span)); }
-
-template <typename Stream> inline void Serialize(Stream& s, bool a) { uint8_t f = a; ser_writedata8(s, f); }
-template <typename Stream> inline void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
 // clang-format on
 
 
@@ -478,7 +487,7 @@ public:
  * serialization, and Unser(stream, object&) for deserialization. Serialization routines (inside
  * READWRITE, or directly with << and >> operators), can then use Using<Formatter>(object).
  *
- * This works by constructing a Wrapper<Formatter, T>-wrapped version of object, where T is
+ * This works by constructing a Wrapper<Formatter, T&>-wrapped version of object, where T is
  * const during serialization, and non-const during deserialization, which maintains const
  * correctness.
  */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1112,6 +1112,10 @@ public:
     {
         this->nSize += src.size();
     }
+    void write(std::span<const std::byte, 1>)
+    {
+        this->nSize += 1;
+    }
 
     /** Pretend _nSize bytes are written, without specifying them. */
     void seek(size_t _nSize)
@@ -1161,7 +1165,9 @@ public:
     template <typename U> ParamsStream& operator<<(const U& obj) { ::Serialize(*this, obj); return *this; }
     template <typename U> ParamsStream& operator>>(U&& obj) { ::Unserialize(*this, obj); return *this; }
     void write(std::span<const std::byte> src) { GetStream().write(src); }
+    void write(std::span<const std::byte, 1> src) { GetStream().write(src); }
     void read(std::span<std::byte> dst) { GetStream().read(dst); }
+    void read(std::span<std::byte, 1> dst) { GetStream().read(dst); }
     void ignore(size_t num) { GetStream().ignore(num); }
     bool eof() const { return GetStream().eof(); }
     size_t size() const { return GetStream().size(); }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -53,56 +53,56 @@ constexpr deserialize_type deserialize {};
  */
 template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
 {
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint8_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
 {
     obj = htole16_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint16_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
 {
     obj = htobe32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
     obj = htole64_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint64_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
 {
     uint8_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint8_t, 1>{&obj, 1}));
     return obj;
 }
 template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint16_t, 1>{&obj, 1}));
     return le16toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return le32toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return be32toh_internal(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint64_t, 1>{&obj, 1}));
     return le64toh_internal(obj);
 }
 
@@ -281,7 +281,6 @@ template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
 template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
 template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
-template <typename Stream, BasicByte B> void Unserialize(Stream& s, std::span<B> span) { s.read(std::as_writable_bytes(span)); }
 // clang-format on
 
 
@@ -534,10 +533,10 @@ struct CustomUintFormatter
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
         if (BigEndian) {
             uint64_t raw = htobe64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).last(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template last<Bytes>());
         } else {
             uint64_t raw = htole64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).first(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template first<Bytes>());
         }
     }
 
@@ -547,10 +546,10 @@ struct CustomUintFormatter
         static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
         uint64_t raw = 0;
         if (BigEndian) {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).last(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).last<Bytes>());
             v = static_cast<I>(be64toh_internal(raw));
         } else {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).first(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).first<Bytes>());
             v = static_cast<I>(le64toh_internal(raw));
         }
     }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -48,6 +48,16 @@ static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 struct deserialize_type {};
 constexpr deserialize_type deserialize {};
 
+class SizeComputer;
+
+//! Check if type contains a stream by seeing if it has a GetStream() method.
+template<typename T>
+concept ContainsStream = requires(T t) { t.GetStream(); };
+
+template<typename T>
+concept ContainsSizeComputer = ContainsStream<T> &&
+    std::is_same_v<std::remove_reference_t<decltype(std::declval<T>().GetStream())>, SizeComputer>;
+
 /*
  * Lowest-level serialization and conversion.
  */
@@ -106,8 +116,6 @@ template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
     return le64toh_internal(obj);
 }
 
-
-class SizeComputer;
 
 /**
  * Convert any argument to a reference to X, maintaining constness.
@@ -248,7 +256,9 @@ concept ByteOrIntegral = std::is_same_v<T, std::byte> ||
 template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
 template <typename Stream, ByteOrIntegral T> void Serialize(Stream& s, T a)
 {
-    if constexpr (sizeof(T) == 1) {
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(sizeof(T));
+    } else if constexpr (sizeof(T) == 1) {
         ser_writedata8(s, static_cast<uint8_t>(a));   // (u)int8_t or std::byte or bool
     } else if constexpr (sizeof(T) == 2) {
         ser_writedata16(s, static_cast<uint16_t>(a)); // (u)int16_t
@@ -259,10 +269,38 @@ template <typename Stream, ByteOrIntegral T> void Serialize(Stream& s, T a)
         ser_writedata64(s, static_cast<uint64_t>(a)); // (u)int64_t
     }
 }
-template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N]) { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span) { s.write(std::as_bytes(span)); }
-template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span) { s.write(std::as_bytes(span)); }
+template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N])
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(MakeByteSpan(a));
+    }
+}
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(MakeByteSpan(a));
+    }
+}
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(std::as_bytes(span));
+    }
+}
+template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(span.size());
+    } else {
+        s.write(std::as_bytes(span));
+    }
+}
 
 template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
 template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
@@ -299,12 +337,14 @@ constexpr inline unsigned int GetSizeOfCompactSize(uint64_t nSize)
     else                         return sizeof(unsigned char) + sizeof(uint64_t);
 }
 
-inline void WriteCompactSize(SizeComputer& os, uint64_t nSize);
-
 template<typename Stream>
 void WriteCompactSize(Stream& os, uint64_t nSize)
 {
-    if (nSize < 253)
+    if constexpr (ContainsSizeComputer<Stream>)
+    {
+        os.GetStream().seek(GetSizeOfCompactSize(nSize));
+    }
+    else if (nSize < 253)
     {
         ser_writedata8(os, nSize);
     }
@@ -411,7 +451,7 @@ struct CheckVarIntMode {
 };
 
 template<VarIntMode Mode, typename I>
-inline unsigned int GetSizeOfVarInt(I n)
+constexpr unsigned int GetSizeOfVarInt(I n)
 {
     CheckVarIntMode<Mode, I>();
     int nRet = 0;
@@ -424,25 +464,26 @@ inline unsigned int GetSizeOfVarInt(I n)
     return nRet;
 }
 
-template<typename I>
-inline void WriteVarInt(SizeComputer& os, I n);
-
 template<typename Stream, VarIntMode Mode, typename I>
 void WriteVarInt(Stream& os, I n)
 {
-    CheckVarIntMode<Mode, I>();
-    unsigned char tmp[(sizeof(n)*8+6)/7];
-    int len=0;
-    while(true) {
-        tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
-        if (n <= 0x7F)
-            break;
-        n = (n >> 7) - 1;
-        len++;
+    if constexpr (ContainsSizeComputer<Stream>) {
+        os.GetStream().seek(GetSizeOfVarInt<Mode, I>(n));
+    } else {
+        CheckVarIntMode<Mode, I>();
+        unsigned char tmp[(sizeof(n)*8+6)/7];
+        int len=0;
+        while(true) {
+            tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
+            if (n <= 0x7F)
+                break;
+            n = (n >> 7) - 1;
+            len++;
+        }
+        do {
+            ser_writedata8(os, tmp[len]);
+        } while(len--);
     }
-    do {
-        ser_writedata8(os, tmp[len]);
-    } while(len--);
 }
 
 template<typename Stream, VarIntMode Mode, typename I>
@@ -531,7 +572,9 @@ struct CustomUintFormatter
     template <typename Stream, typename I> void Ser(Stream& s, I v)
     {
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
-        if (BigEndian) {
+        if constexpr (ContainsSizeComputer<Stream>) {
+            s.GetStream().seek(Bytes);
+        } else if (BigEndian) {
             uint64_t raw = htobe64_internal(v);
             s.write(std::as_bytes(std::span{&raw, 1}).template last<Bytes>());
         } else {
@@ -1062,6 +1105,9 @@ protected:
 public:
     SizeComputer() = default;
 
+    SizeComputer& GetStream() { return *this; }
+    const SizeComputer& GetStream() const { return *this; };
+
     void write(std::span<const std::byte> src)
     {
         this->nSize += src.size();
@@ -1085,26 +1131,11 @@ public:
     }
 };
 
-template<typename I>
-inline void WriteVarInt(SizeComputer &s, I n)
-{
-    s.seek(GetSizeOfVarInt<I>(n));
-}
-
-inline void WriteCompactSize(SizeComputer &s, uint64_t nSize)
-{
-    s.seek(GetSizeOfCompactSize(nSize));
-}
-
 template <typename T>
 size_t GetSerializeSize(const T& t)
 {
     return (SizeComputer() << t).size();
 }
-
-//! Check if type contains a stream by seeing if has a GetStream() method.
-template<typename T>
-concept ContainsStream = requires(T t) { t.GetStream(); };
 
 /** Wrapper that overrides the GetParams() function of a stream. */
 template <typename SubStream, typename Params>

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -9,8 +9,7 @@
 
 #include <array>
 
-AutoFile::AutoFile(std::FILE* file, std::vector<std::byte> data_xor)
-    : m_file{file}, m_xor{std::move(data_xor)}
+AutoFile::AutoFile(std::FILE* file, const Obfuscation& obfuscation) : m_file{file}, m_obfuscation{obfuscation}
 {
     if (!IsNull()) {
         auto pos{std::ftell(m_file)};
@@ -21,12 +20,12 @@ AutoFile::AutoFile(std::FILE* file, std::vector<std::byte> data_xor)
 std::size_t AutoFile::detail_fread(std::span<std::byte> dst)
 {
     if (!m_file) throw std::ios_base::failure("AutoFile::read: file handle is nullptr");
-    size_t ret = std::fread(dst.data(), 1, dst.size(), m_file);
-    if (!m_xor.empty()) {
-        if (!m_position.has_value()) throw std::ios_base::failure("AutoFile::read: position unknown");
-        util::Xor(dst.subspan(0, ret), m_xor, *m_position);
+    const size_t ret = std::fread(dst.data(), 1, dst.size(), m_file);
+    if (m_obfuscation) {
+        if (!m_position) throw std::ios_base::failure("AutoFile::read: position unknown");
+        m_obfuscation(dst, *m_position);
     }
-    if (m_position.has_value()) *m_position += ret;
+    if (m_position) *m_position += ret;
     return ret;
 }
 
@@ -81,7 +80,7 @@ void AutoFile::ignore(size_t nSize)
 void AutoFile::write(std::span<const std::byte> src)
 {
     if (!m_file) throw std::ios_base::failure("AutoFile::write: file handle is nullptr");
-    if (m_xor.empty()) {
+    if (!m_obfuscation) {
         if (std::fwrite(src.data(), 1, src.size(), m_file) != src.size()) {
             throw std::ios_base::failure("AutoFile::write: write failed");
         }
@@ -100,9 +99,9 @@ void AutoFile::write(std::span<const std::byte> src)
 void AutoFile::write_buffer(std::span<std::byte> src)
 {
     if (!m_file) throw std::ios_base::failure("AutoFile::write_buffer: file handle is nullptr");
-    if (m_xor.size()) {
+    if (m_obfuscation) {
         if (!m_position) throw std::ios_base::failure("AutoFile::write_buffer: obfuscation position unknown");
-        util::Xor(src, m_xor, *m_position); // obfuscate in-place
+        m_obfuscation(src, *m_position); // obfuscate in-place
     }
     if (std::fwrite(src.data(), 1, src.size(), m_file) != src.size()) {
         throw std::ios_base::failure("AutoFile::write_buffer: write failed");

--- a/src/streams.h
+++ b/src/streams.h
@@ -141,6 +141,7 @@ public:
     typedef vector_type::reverse_iterator reverse_iterator;
 
     explicit DataStream() = default;
+    explicit DataStream(size_type n) { reserve(n); }
     explicit DataStream(std::span<const uint8_t> sp) : DataStream{std::as_bytes(sp)} {}
     explicit DataStream(std::span<const value_type> sp) : vch(sp.data(), sp.data() + sp.size()) {}
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -62,6 +62,17 @@ public:
         }
         nPos += src.size();
     }
+    void write(std::span<const std::byte, 1> src)
+    {
+        assert(nPos <= vchData.size());
+        const auto byte{*UCharCast(&src[0])};
+        if (nPos < vchData.size()) {
+            vchData[nPos] = byte;
+        } else {
+            vchData.push_back(byte);
+        }
+        nPos += 1;
+    }
     template <typename T>
     VectorWriter& operator<<(const T& obj)
     {
@@ -232,6 +243,10 @@ public:
     {
         // Write to the end of the buffer
         vch.insert(vch.end(), src.begin(), src.end());
+    }
+    void write(std::span<const value_type, 1> src)
+    {
+        vch.push_back(src[0]);
     }
 
     template<typename T>
@@ -427,8 +442,10 @@ public:
     // Stream subset
     //
     void read(std::span<std::byte> dst);
+    void read(std::span<std::byte, 1> dst);
     void ignore(size_t nSize);
     void write(std::span<const std::byte> src);
+    void write(std::span<const std::byte, 1> src);
 
     template <typename T>
     AutoFile& operator<<(const T& obj)

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -1079,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(sha256d64)
             in[j] = m_rng.randbits(8);
         }
         for (int j = 0; j < i; ++j) {
-            CHash256().Write({in + 64 * j, 64}).Finalize({out1 + 32 * j, 32});
+            CHash256().Write(std::span{in + 64 * j, 64}).Finalize({out1 + 32 * j, 32});
         }
         SHA256D64(out2, in, i);
         BOOST_CHECK(memcmp(out1, out2, 32 * i) == 0);

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -14,16 +14,6 @@
 
 using util::ToString;
 
-// Test if a string consists entirely of null characters
-static bool is_null_key(const std::vector<unsigned char>& key) {
-    bool isnull = true;
-
-    for (unsigned int i = 0; i < key.size(); i++)
-        isnull &= (key[i] == '\x00');
-
-    return isnull;
-}
-
 BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(dbwrapper)
@@ -37,7 +27,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
         uint256 res;
 
         // Ensure that we're doing real obfuscation when obfuscate=true
-        BOOST_CHECK(obfuscate != is_null_key(dbwrapper_private::GetObfuscateKey(dbw)));
+        BOOST_CHECK(obfuscate == dbwrapper_private::GetObfuscation(dbw));
 
         BOOST_CHECK(dbw.Write(key, in));
         BOOST_CHECK(dbw.Read(key, res));
@@ -57,7 +47,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
         bool res_bool;
 
         // Ensure that we're doing real obfuscation when obfuscate=true
-        BOOST_CHECK(obfuscate != is_null_key(dbwrapper_private::GetObfuscateKey(dbw)));
+        BOOST_CHECK(obfuscate == dbwrapper_private::GetObfuscation(dbw));
 
         //Simulate block raw data - "b + block hash"
         std::string key_block = "b" + m_rng.rand256().ToString();
@@ -232,7 +222,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     BOOST_CHECK_EQUAL(res2.ToString(), in.ToString());
 
     BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
-    BOOST_CHECK(is_null_key(dbwrapper_private::GetObfuscateKey(odbw))); // The key should be an empty string
+    BOOST_CHECK(!dbwrapper_private::GetObfuscation(odbw));
 
     uint256 in2 = m_rng.rand256();
     uint256 res3;
@@ -269,7 +259,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
     BOOST_CHECK(!odbw.Read(key, res2));
-    BOOST_CHECK(!is_null_key(dbwrapper_private::GetObfuscateKey(odbw)));
+    BOOST_CHECK(dbwrapper_private::GetObfuscation(odbw));
 
     uint256 in2 = m_rng.rand256();
     uint256 res3;

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -20,7 +20,7 @@ FUZZ_TARGET(autofile)
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
     AutoFile auto_file{
         fuzzed_file_provider.open(),
-        ConsumeRandomLengthByteVector<std::byte>(fuzzed_data_provider),
+        fuzzed_data_provider.ConsumeIntegral<uint64_t>()
     };
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
     {

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -29,14 +29,14 @@ FUZZ_TARGET(autofile)
             [&] {
                 std::array<std::byte, 4096> arr{};
                 try {
-                    auto_file.read({arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
+                    auto_file.read(std::span{arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
                 } catch (const std::ios_base::failure&) {
                 }
             },
             [&] {
                 const std::array<std::byte, 4096> arr{};
                 try {
-                    auto_file.write({arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
+                    auto_file.write(std::span{arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)});
                 } catch (const std::ios_base::failure&) {
                 }
             },

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -22,7 +22,7 @@ FUZZ_TARGET(buffered_file)
     std::optional<BufferedFile> opt_buffered_file;
     AutoFile fuzzed_file{
         fuzzed_file_provider.open(),
-        ConsumeRandomLengthByteVector<std::byte>(fuzzed_data_provider),
+        fuzzed_data_provider.ConsumeIntegral<uint64_t>()
     };
     try {
         auto n_buf_size = fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096);

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -236,10 +236,6 @@ FUZZ_TARGET(integer, .init = initialize_integer)
         const uint16_t deserialized_u16 = ser_readdata16(stream);
         assert(u16 == deserialized_u16 && stream.empty());
 
-        ser_writedata16be(stream, u16);
-        const uint16_t deserialized_u16be = ser_readdata16be(stream);
-        assert(u16 == deserialized_u16be && stream.empty());
-
         ser_writedata8(stream, u8);
         const uint8_t deserialized_u8 = ser_readdata8(stream);
         assert(u8 == deserialized_u8 && stream.empty());

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -119,7 +119,7 @@ FUZZ_TARGET(integer, .init = initialize_integer)
     (void)MillisToTimeval(i64);
     (void)SighashToStr(uch);
     (void)SipHashUint256(u64, u64, u256);
-    (void)SipHashUint256Extra(u64, u64, u256, u32);
+    (void)Uint256ExtraSipHasher(u64, u64)(u256, u32);
     (void)ToLower(ch);
     (void)ToUpper(ch);
     {

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -133,18 +133,18 @@ BOOST_AUTO_TEST_CASE(siphash)
     // Check consistency between CSipHasher and SipHashUint256[Extra].
     FastRandomContext ctx;
     for (int i = 0; i < 16; ++i) {
+        uint64_t k0 = ctx.rand64();
         uint64_t k1 = ctx.rand64();
-        uint64_t k2 = ctx.rand64();
         uint256 x = m_rng.rand256();
         uint32_t n = ctx.rand32();
         uint8_t nb[4];
         WriteLE32(nb, n);
-        CSipHasher sip256(k1, k2);
+        CSipHasher sip256(k0, k1);
         sip256.Write(x);
         CSipHasher sip288 = sip256;
         sip288.Write(nb);
-        BOOST_CHECK_EQUAL(SipHashUint256(k1, k2, x), sip256.Finalize());
-        BOOST_CHECK_EQUAL(SipHashUint256Extra(k1, k2, x, n), sip288.Finalize());
+        BOOST_CHECK_EQUAL(SipHashUint256(k0, k1, x), sip256.Finalize());
+        BOOST_CHECK_EQUAL(SipHashUint256Extra(k0, k1, x, n), sip288.Finalize()); // TODO modified in follow-up commit
     }
 }
 

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(siphash)
     ss << TX_WITH_WITNESS(tx);
     BOOST_CHECK_EQUAL(SipHashUint256(1, 2, ss.GetHash()), 0x79751e980c2a0a35ULL);
 
-    // Check consistency between CSipHasher and SipHashUint256[Extra].
+    // Check consistency between CSipHasher and SipHashUint256 and Uint256ExtraSipHasher.
     FastRandomContext ctx;
     for (int i = 0; i < 16; ++i) {
         uint64_t k0 = ctx.rand64();
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(siphash)
         CSipHasher sip288 = sip256;
         sip288.Write(nb);
         BOOST_CHECK_EQUAL(SipHashUint256(k0, k1, x), sip256.Finalize());
-        BOOST_CHECK_EQUAL(SipHashUint256Extra(k0, k1, x, n), sip288.Finalize()); // TODO modified in follow-up commit
+        BOOST_CHECK_EQUAL(Uint256ExtraSipHasher(k0, k1)(x, n), sip288.Finalize());
     }
 }
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1131,10 +1131,10 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
 
 BOOST_AUTO_TEST_CASE(script_size_and_capacity_test)
 {
-    BOOST_CHECK_EQUAL(sizeof(prevector<28, unsigned char>), 32);
-    BOOST_CHECK_EQUAL(sizeof(CScriptBase), 32);
-    BOOST_CHECK_EQUAL(sizeof(CScript), 32);
-    BOOST_CHECK_EQUAL(sizeof(CTxOut), 40);
+    BOOST_CHECK_EQUAL(sizeof(prevector<34, uint8_t>), sizeof(prevector<36, uint8_t>));
+    BOOST_CHECK_EQUAL(sizeof(CScriptBase), 40);
+    BOOST_CHECK_EQUAL(sizeof(CScript), 40);
+    BOOST_CHECK_EQUAL(sizeof(CTxOut), 48);
 
     CKey dummyKey;
     dummyKey.MakeNewKey(true);
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE(script_size_and_capacity_test)
         const auto scriptSmallOpReturn{CScript() << OP_RETURN << std::vector<uint8_t>(10, 0xaa)};
         BOOST_CHECK_EQUAL(Solver(scriptSmallOpReturn, dummyVSolutions), TxoutType::NULL_DATA);
         BOOST_CHECK_EQUAL(scriptSmallOpReturn.size(), 12);
-        BOOST_CHECK_EQUAL(scriptSmallOpReturn.capacity(), 28);
+        BOOST_CHECK_EQUAL(scriptSmallOpReturn.capacity(), 36);
         BOOST_CHECK_EQUAL(scriptSmallOpReturn.allocated_memory(), 0);
     }
 
@@ -1155,7 +1155,7 @@ BOOST_AUTO_TEST_CASE(script_size_and_capacity_test)
         const auto scriptP2WPKH{GetScriptForDestination(WitnessV0KeyHash{PKHash{CKeyID{CPubKey{dummyKey.GetPubKey()}.GetID()}}})};
         BOOST_CHECK_EQUAL(Solver(scriptP2WPKH, dummyVSolutions), TxoutType::WITNESS_V0_KEYHASH);
         BOOST_CHECK_EQUAL(scriptP2WPKH.size(), 22);
-        BOOST_CHECK_EQUAL(scriptP2WPKH.capacity(), 28);
+        BOOST_CHECK_EQUAL(scriptP2WPKH.capacity(), 36);
         BOOST_CHECK_EQUAL(scriptP2WPKH.allocated_memory(), 0);
     }
 
@@ -1164,7 +1164,7 @@ BOOST_AUTO_TEST_CASE(script_size_and_capacity_test)
         const auto scriptP2SH{GetScriptForDestination(ScriptHash{CScript{} << OP_TRUE})};
         BOOST_CHECK(scriptP2SH.IsPayToScriptHash());
         BOOST_CHECK_EQUAL(scriptP2SH.size(), 23);
-        BOOST_CHECK_EQUAL(scriptP2SH.capacity(), 28);
+        BOOST_CHECK_EQUAL(scriptP2SH.capacity(), 36);
         BOOST_CHECK_EQUAL(scriptP2SH.allocated_memory(), 0);
     }
 
@@ -1173,35 +1173,35 @@ BOOST_AUTO_TEST_CASE(script_size_and_capacity_test)
         const auto scriptP2PKH{GetScriptForDestination(PKHash{CKeyID{CPubKey{dummyKey.GetPubKey()}.GetID()}})};
         BOOST_CHECK_EQUAL(Solver(scriptP2PKH, dummyVSolutions), TxoutType::PUBKEYHASH);
         BOOST_CHECK_EQUAL(scriptP2PKH.size(), 25);
-        BOOST_CHECK_EQUAL(scriptP2PKH.capacity(), 28);
+        BOOST_CHECK_EQUAL(scriptP2PKH.capacity(), 36);
         BOOST_CHECK_EQUAL(scriptP2PKH.allocated_memory(), 0);
     }
 
-    // P2WSH is heap allocated
+    // P2WSH is stack allocated
     {
         const auto scriptP2WSH{GetScriptForDestination(WitnessV0ScriptHash{CScript{} << OP_TRUE})};
         BOOST_CHECK(scriptP2WSH.IsPayToWitnessScriptHash());
         BOOST_CHECK_EQUAL(scriptP2WSH.size(), 34);
-        BOOST_CHECK_EQUAL(scriptP2WSH.capacity(), 34);
-        BOOST_CHECK_EQUAL(scriptP2WSH.allocated_memory(), 34);
+        BOOST_CHECK_EQUAL(scriptP2WSH.capacity(), 36);
+        BOOST_CHECK_EQUAL(scriptP2WSH.allocated_memory(), 0);
     }
 
-    // P2TR is heap allocated
+    // P2TR is stack allocated
     {
         const auto scriptTaproot{GetScriptForDestination(WitnessV1Taproot{XOnlyPubKey{CPubKey{dummyKey.GetPubKey()}}})};
         BOOST_CHECK_EQUAL(Solver(scriptTaproot, dummyVSolutions), TxoutType::WITNESS_V1_TAPROOT);
         BOOST_CHECK_EQUAL(scriptTaproot.size(), 34);
-        BOOST_CHECK_EQUAL(scriptTaproot.capacity(), 34);
-        BOOST_CHECK_EQUAL(scriptTaproot.allocated_memory(), 34);
+        BOOST_CHECK_EQUAL(scriptTaproot.capacity(), 36);
+        BOOST_CHECK_EQUAL(scriptTaproot.allocated_memory(), 0);
     }
 
-    // P2PK is heap allocated
+    // P2PK is stack allocated
     {
         const auto scriptPubKey{GetScriptForRawPubKey(CPubKey{dummyKey.GetPubKey()})};
         BOOST_CHECK_EQUAL(Solver(scriptPubKey, dummyVSolutions), TxoutType::PUBKEY);
         BOOST_CHECK_EQUAL(scriptPubKey.size(), 35);
-        BOOST_CHECK_EQUAL(scriptPubKey.capacity(), 35);
-        BOOST_CHECK_EQUAL(scriptPubKey.allocated_memory(), 35);
+        BOOST_CHECK_EQUAL(scriptPubKey.capacity(), 36);
+        BOOST_CHECK_EQUAL(scriptPubKey.allocated_memory(), 0);
     }
 
     // MULTISIG is always heap allocated

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -13,8 +13,67 @@
 #include <boost/test/unit_test.hpp>
 
 using namespace std::string_literals;
+using namespace util::hex_literals;
 
 BOOST_FIXTURE_TEST_SUITE(streams_tests, BasicTestingSetup)
+
+// Test that obfuscation can be properly reversed even with random chunk sizes.
+BOOST_AUTO_TEST_CASE(xor_roundtrip_random_chunks)
+{
+    auto apply_random_xor_chunks{[&](std::span<std::byte> write, const std::span<std::byte> key) {
+        for (size_t offset{0}; offset < write.size();) {
+            const size_t chunk_size{1 + m_rng.randrange(write.size() - offset)};
+            util::Xor(write.subspan(offset, chunk_size), key, offset);
+            offset += chunk_size;
+        }
+    }};
+
+    for (size_t test{0}; test < 100; ++test) {
+        const size_t write_size{1 + m_rng.randrange(100U)};
+        const std::vector original{m_rng.randbytes<std::byte>(write_size)};
+        std::vector roundtrip{original};
+
+        std::vector key_bytes{m_rng.randbytes<std::byte>(sizeof(uint64_t))};
+        uint64_t xor_key;
+        std::memcpy(&xor_key, key_bytes.data(), sizeof(xor_key));
+        apply_random_xor_chunks(roundtrip, key_bytes);
+
+        // Verify intermediate state is different from original (unless key is zero)
+        const bool all_zero = (xor_key == 0) || (HexStr(key_bytes).find_first_not_of('0') >= write_size * 2);
+        BOOST_CHECK_EQUAL(original != roundtrip, !all_zero);
+
+        apply_random_xor_chunks(roundtrip, key_bytes);
+        BOOST_CHECK(original == roundtrip);
+    }
+}
+
+// Compares optimized obfuscation against a trivial byte-by-byte reference implementation
+// with random offsets to ensure proper handling of key wrapping.
+BOOST_AUTO_TEST_CASE(xor_bytes_reference)
+{
+    auto expected_xor{[](std::span<std::byte> write, const std::span<const std::byte> key, size_t key_offset) {
+        for (auto& b : write) {
+            b ^= key[key_offset++ % key.size()];
+        }
+    }};
+
+    for (size_t test{0}; test < 100; ++test) {
+        const size_t write_size{1 + m_rng.randrange(100U)};
+        const size_t key_offset{m_rng.randrange(3 * 8U)}; // Should wrap around
+
+        std::vector key_bytes{m_rng.randbytes<std::byte>(sizeof(uint64_t))};
+        uint64_t xor_key;
+        std::memcpy(&xor_key, key_bytes.data(), sizeof(xor_key));
+
+        std::vector expected{m_rng.randbytes<std::byte>(write_size)};
+        std::vector actual{expected};
+
+        expected_xor(expected, key_bytes, key_offset);
+        util::Xor(actual, key_bytes, key_offset);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
+    }
+}
 
 BOOST_AUTO_TEST_CASE(xor_file)
 {
@@ -22,10 +81,13 @@ BOOST_AUTO_TEST_CASE(xor_file)
     auto raw_file{[&](const auto& mode) { return fsbridge::fopen(xor_path, mode); }};
     const std::vector<uint8_t> test1{1, 2, 3};
     const std::vector<uint8_t> test2{4, 5};
-    const std::vector<std::byte> xor_pat{std::byte{0xff}, std::byte{0x00}};
+    auto key_bytes{"ff00ff00ff00ff00"_hex_v};
+    uint64_t xor_key;
+    std::memcpy(&xor_key, key_bytes.data(), sizeof(xor_key));
+
     {
         // Check errors for missing file
-        AutoFile xor_file{raw_file("rb"), xor_pat};
+        AutoFile xor_file{raw_file("rb"), key_bytes};
         BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullpt"});
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullpt"});
         BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullpt"});
@@ -37,7 +99,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
 #else
         const char* mode = "wbx";
 #endif
-        AutoFile xor_file{raw_file(mode), xor_pat};
+        AutoFile xor_file{raw_file(mode), key_bytes};
         xor_file << test1 << test2;
     }
     {
@@ -50,7 +112,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
     }
     {
-        AutoFile xor_file{raw_file("rb"), xor_pat};
+        AutoFile xor_file{raw_file("rb"), key_bytes};
         std::vector<std::byte> read1, read2;
         xor_file >> read1 >> read2;
         BOOST_CHECK_EQUAL(HexStr(read1), HexStr(test1));
@@ -59,7 +121,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
     }
     {
-        AutoFile xor_file{raw_file("rb"), xor_pat};
+        AutoFile xor_file{raw_file("rb"), key_bytes};
         std::vector<std::byte> read2;
         // Check that ignore works
         xor_file.ignore(4);
@@ -75,7 +137,7 @@ BOOST_AUTO_TEST_CASE(streams_vector_writer)
 {
     unsigned char a(1);
     unsigned char b(2);
-    unsigned char bytes[] = { 3, 4, 5, 6 };
+    unsigned char bytes[] = {3, 4, 5, 6};
     std::vector<unsigned char> vch;
 
     // Each test runs twice. Serializing a second time at the same starting
@@ -227,29 +289,32 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     // Degenerate case
     {
         DataStream ds{in};
-        ds.Xor({0x00, 0x00});
+        ds.Xor("0000000000000000"_hex_v_u8);
         BOOST_CHECK_EQUAL(""s, ds.str());
     }
 
     in.push_back(std::byte{0x0f});
     in.push_back(std::byte{0xf0});
 
-    // Single character key
     {
+        const auto key_bytes{"ffffffffffffffff"_hex_v};
+        uint64_t xor_key;
+        std::memcpy(&xor_key, key_bytes.data(), sizeof(xor_key));
+
         DataStream ds{in};
-        ds.Xor({0xff});
+        ds.Xor("ffffffffffffffff"_hex_v_u8);
         BOOST_CHECK_EQUAL("\xf0\x0f"s, ds.str());
     }
-
-    // Multi character key
 
     in.clear();
     in.push_back(std::byte{0xf0});
     in.push_back(std::byte{0x0f});
 
     {
+        const auto key_bytes{"ff0fff0fff0fff0f"_hex_v};
+
         DataStream ds{in};
-        ds.Xor({0xff, 0x0f});
+        ds.Xor("ff0fff0fff0fff0f"_hex_v_u8);
         BOOST_CHECK_EQUAL("\x0f\x00"s, ds.str());
     }
 }
@@ -272,7 +337,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
         BOOST_CHECK(false);
     } catch (const std::exception& e) {
         BOOST_CHECK(strstr(e.what(),
-                        "Rewind limit must be less than buffer size") != nullptr);
+                           "Rewind limit must be less than buffer size") != nullptr);
     }
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
@@ -361,7 +426,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
         BOOST_CHECK(false);
     } catch (const std::exception& e) {
         BOOST_CHECK(strstr(e.what(),
-                        "BufferedFile::Fill: end of file") != nullptr);
+                           "BufferedFile::Fill: end of file") != nullptr);
     }
     // Attempting to read beyond the end sets the EOF indicator.
     BOOST_CHECK(bf.eof());

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -406,20 +406,110 @@ BOOST_AUTO_TEST_CASE(tx_oversized)
     }
 }
 
-BOOST_AUTO_TEST_CASE(basic_transaction_tests)
+static CMutableTransaction CreateTransaction()
 {
-    // Random real transaction (e2769b09e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436)
-    unsigned char ch[] = {0x01, 0x00, 0x00, 0x00, 0x01, 0x6b, 0xff, 0x7f, 0xcd, 0x4f, 0x85, 0x65, 0xef, 0x40, 0x6d, 0xd5, 0xd6, 0x3d, 0x4f, 0xf9, 0x4f, 0x31, 0x8f, 0xe8, 0x20, 0x27, 0xfd, 0x4d, 0xc4, 0x51, 0xb0, 0x44, 0x74, 0x01, 0x9f, 0x74, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x8c, 0x49, 0x30, 0x46, 0x02, 0x21, 0x00, 0xda, 0x0d, 0xc6, 0xae, 0xce, 0xfe, 0x1e, 0x06, 0xef, 0xdf, 0x05, 0x77, 0x37, 0x57, 0xde, 0xb1, 0x68, 0x82, 0x09, 0x30, 0xe3, 0xb0, 0xd0, 0x3f, 0x46, 0xf5, 0xfc, 0xf1, 0x50, 0xbf, 0x99, 0x0c, 0x02, 0x21, 0x00, 0xd2, 0x5b, 0x5c, 0x87, 0x04, 0x00, 0x76, 0xe4, 0xf2, 0x53, 0xf8, 0x26, 0x2e, 0x76, 0x3e, 0x2d, 0xd5, 0x1e, 0x7f, 0xf0, 0xbe, 0x15, 0x77, 0x27, 0xc4, 0xbc, 0x42, 0x80, 0x7f, 0x17, 0xbd, 0x39, 0x01, 0x41, 0x04, 0xe6, 0xc2, 0x6e, 0xf6, 0x7d, 0xc6, 0x10, 0xd2, 0xcd, 0x19, 0x24, 0x84, 0x78, 0x9a, 0x6c, 0xf9, 0xae, 0xa9, 0x93, 0x0b, 0x94, 0x4b, 0x7e, 0x2d, 0xb5, 0x34, 0x2b, 0x9d, 0x9e, 0x5b, 0x9f, 0xf7, 0x9a, 0xff, 0x9a, 0x2e, 0xe1, 0x97, 0x8d, 0xd7, 0xfd, 0x01, 0xdf, 0xc5, 0x22, 0xee, 0x02, 0x28, 0x3d, 0x3b, 0x06, 0xa9, 0xd0, 0x3a, 0xcf, 0x80, 0x96, 0x96, 0x8d, 0x7d, 0xbb, 0x0f, 0x91, 0x78, 0xff, 0xff, 0xff, 0xff, 0x02, 0x8b, 0xa7, 0x94, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xba, 0xde, 0xec, 0xfd, 0xef, 0x05, 0x07, 0x24, 0x7f, 0xc8, 0xf7, 0x42, 0x41, 0xd7, 0x3b, 0xc0, 0x39, 0x97, 0x2d, 0x7b, 0x88, 0xac, 0x40, 0x94, 0xa8, 0x02, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xc1, 0x09, 0x32, 0x48, 0x3f, 0xec, 0x93, 0xed, 0x51, 0xf5, 0xfe, 0x95, 0xe7, 0x25, 0x59, 0xf2, 0xcc, 0x70, 0x43, 0xf9, 0x88, 0xac, 0x00, 0x00, 0x00, 0x00, 0x00};
-    std::vector<unsigned char> vch(ch, ch + sizeof(ch) -1);
-    DataStream stream(vch);
+    // Serialized random real transaction (e2769b09e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436)
+    static constexpr auto ser_tx{"01000000016bff7fcd4f8565ef406dd5d63d4ff94f318fe82027fd4dc451b04474019f74b4000000008c493046022100da0dc6aecefe1e06efdf05773757deb168820930e3b0d03f46f5fcf150bf990c022100d25b5c87040076e4f253f8262e763e2dd51e7ff0be157727c4bc42807f17bd39014104e6c26ef67dc610d2cd192484789a6cf9aea9930b944b7e2db5342b9d9e5b9ff79aff9a2ee1978dd7fd01dfc522ee02283d3b06a9d03acf8096968d7dbb0f9178ffffffff028ba7940e000000001976a914badeecfdef0507247fc8f74241d73bc039972d7b88ac4094a802000000001976a914c10932483fec93ed51f5fe95e72559f2cc7043f988ac0000000000"_hex};
     CMutableTransaction tx;
-    stream >> TX_WITH_WITNESS(tx);
+    DataStream(ser_tx) >> TX_WITH_WITNESS(tx);
+    return tx;
+}
+
+BOOST_AUTO_TEST_CASE(transaction_duplicate_input_test)
+{
+    auto tx{CreateTransaction()};
+
     TxValidationState state;
     BOOST_CHECK_MESSAGE(CheckTransaction(CTransaction(tx), state) && state.IsValid(), "Simple deserialized transaction should be valid.");
 
-    // Check that duplicate txins fail
-    tx.vin.push_back(tx.vin[0]);
-    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with duplicate txins should be invalid.");
+    // Add duplicate input
+    tx.vin.emplace_back(tx.vin[0]);
+    std::ranges::shuffle(tx.vin, m_rng);
+    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with 2 duplicate txins should be invalid.");
+
+    // ... add a valid input for more complex check
+    tx.vin.emplace_back(COutPoint(Txid::FromUint256(uint256{1}), 1));
+    std::ranges::shuffle(tx.vin, m_rng);
+    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with 3 inputs (2 valid, 1 duplicate) should be invalid.");
+}
+
+BOOST_AUTO_TEST_CASE(transaction_duplicate_detection_test)
+{
+    // Randomized testing against hash- and tree-based duplicate check
+    auto reference_duplicate_check_hash{[](const std::vector<CTxIn>& vin) {
+        std::unordered_set<COutPoint, SaltedOutpointHasher> vInOutPoints;
+        for (const auto& txin : vin) {
+            if (!vInOutPoints.insert(txin.prevout).second) {
+                return false;
+            }
+        }
+        return true;
+    }};
+    auto reference_duplicate_check_tree{[](const std::vector<CTxIn>& vin) {
+        std::set<COutPoint> vInOutPoints;
+        for (const auto& txin : vin) {
+            if (!vInOutPoints.insert(txin.prevout).second) {
+                return false;
+            }
+        }
+        return true;
+    }};
+
+    std::vector<Txid> hashes;
+    std::vector<uint32_t> ns;
+    for (int i = 0; i < 10; ++i) {
+        hashes.emplace_back(Txid::FromUint256(m_rng.rand256()));
+        ns.emplace_back(m_rng.rand32());
+    }
+    auto tx{CreateTransaction()};
+    TxValidationState state;
+    for (int i{0}; i < 100; ++i) {
+        if (m_rng.randbool()) {
+            tx.vin.clear();
+        }
+        for (int j{0}, num_inputs{1 + m_rng.randrange(5)}; j < num_inputs; ++j) {
+            if (COutPoint outpoint(hashes[m_rng.randrange(hashes.size())], ns[m_rng.randrange(ns.size())]); !outpoint.IsNull()) {
+                tx.vin.emplace_back(outpoint);
+            }
+        }
+        std::ranges::shuffle(tx.vin, m_rng);
+
+        bool actual{CheckTransaction(CTransaction(tx), state)};
+        BOOST_CHECK_EQUAL(actual, reference_duplicate_check_hash(tx.vin));
+        BOOST_CHECK_EQUAL(actual, reference_duplicate_check_tree(tx.vin));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(transaction_null_prevout_detection_test)
+{
+    // Randomized testing against linear null prevout check
+    auto reference_null_prevout_check_hash{[](const std::vector<CTxIn>& vin) {
+        for (const auto& txin : vin) {
+            if (txin.prevout.IsNull()) {
+                return false;
+            }
+        }
+        return true;
+    }};
+
+    auto tx{CreateTransaction()};
+    TxValidationState state;
+    for (int i{0}; i < 100; ++i) {
+        if (m_rng.randbool()) {
+            tx.vin.clear();
+        }
+        for (int j{0}, num_inputs{1 + m_rng.randrange(5)}; j < num_inputs; ++j) {
+            switch (m_rng.randrange(5)) {
+            case 0: tx.vin.emplace_back(COutPoint()); break;                                               // Null prevout
+            case 1: tx.vin.emplace_back(Txid::FromUint256(uint256::ZERO), m_rng.rand32()); break;          // Null hash, random index
+            case 2: tx.vin.emplace_back(Txid::FromUint256(m_rng.rand256()), COutPoint::NULL_INDEX); break; // Random hash, Null index
+            default: tx.vin.emplace_back(Txid::FromUint256(m_rng.rand256()), m_rng.rand32());              // Random prevout
+            }
+        }
+        std::ranges::shuffle(tx.vin, m_rng);
+
+        BOOST_CHECK_EQUAL(CheckTransaction(CTransaction(tx), state), reference_null_prevout_check_hash(tx.vin));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_Get)
@@ -1046,6 +1136,118 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsStandard(t);
     t.vout[0].nValue = 239;
     CheckIsNotStandard(t, "dust");
+}
+
+BOOST_AUTO_TEST_CASE(test_uint256_sorting)
+{
+    // Sorting
+    std::vector original{
+        uint256{1},
+        uint256{2},
+        uint256{3}
+    };
+
+    std::vector shuffled{original};
+    std::ranges::shuffle(shuffled, m_rng);
+    std::sort(shuffled.begin(), shuffled.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(original.begin(), original.end(), shuffled.begin(), shuffled.end());
+
+    // Operators
+    constexpr auto a{uint256{1}},
+                   b{uint256{2}},
+                   c{uint256{3}};
+
+    BOOST_CHECK(a == a);
+    BOOST_CHECK(a == uint256{1});
+    BOOST_CHECK(b == b);
+    BOOST_CHECK(c == c);
+    BOOST_CHECK(a != b);
+    BOOST_CHECK(a != uint256{10});
+    BOOST_CHECK(a != c);
+    BOOST_CHECK(b != c);
+
+    BOOST_CHECK(a < b);
+    BOOST_CHECK(a < uint256{10});
+    BOOST_CHECK(b < c);
+    BOOST_CHECK(a < c);
+}
+
+BOOST_AUTO_TEST_CASE(test_transaction_identifier_sorting)
+{
+    std::vector original{
+        Txid::FromUint256(uint256{1}),
+        Txid::FromUint256(uint256{2}),
+        Txid::FromUint256(uint256{3})
+    };
+
+    std::vector shuffled{original};
+    std::ranges::shuffle(shuffled, m_rng);
+    std::sort(shuffled.begin(), shuffled.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(original.begin(), original.end(), shuffled.begin(), shuffled.end());
+
+    // Operators
+    const auto a(Txid::FromUint256(uint256{1})),
+               b(Txid::FromUint256(uint256{2})),
+               c(Txid::FromUint256(uint256{3}));
+
+    BOOST_CHECK(a == uint256{1});
+
+    BOOST_CHECK(a == a);
+    BOOST_CHECK(a == Txid::FromUint256(uint256{1}));
+    BOOST_CHECK(b == b);
+    BOOST_CHECK(c == c);
+    BOOST_CHECK(a != b);
+    BOOST_CHECK(a != Txid::FromUint256(uint256{10}));
+    BOOST_CHECK(a != c);
+    BOOST_CHECK(b != c);
+
+    BOOST_CHECK(a < b);
+    BOOST_CHECK(a < Txid::FromUint256(uint256{10}));
+    BOOST_CHECK(b < c);
+    BOOST_CHECK(a < c);
+}
+
+BOOST_AUTO_TEST_CASE(test_coutpoint_sorting)
+{
+    // Sorting
+    std::vector original{
+        COutPoint(Txid::FromUint256(uint256{1}), 1),
+        COutPoint(Txid::FromUint256(uint256{1}), 2),
+        COutPoint(Txid::FromUint256(uint256{1}), 3),
+        COutPoint(Txid::FromUint256(uint256{2}), 1),
+        COutPoint(Txid::FromUint256(uint256{2}), 2),
+        COutPoint(Txid::FromUint256(uint256{2}), 3),
+        COutPoint(Txid::FromUint256(uint256{3}), 1),
+        COutPoint(Txid::FromUint256(uint256{3}), 2),
+        COutPoint(Txid::FromUint256(uint256{3}), 3)
+    };
+
+    std::vector shuffled{original};
+    std::ranges::shuffle(shuffled, m_rng);
+    std::sort(shuffled.begin(), shuffled.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(original.begin(), original.end(), shuffled.begin(), shuffled.end());
+
+    // Operators
+    const auto a{COutPoint(Txid::FromUint256(uint256{1}), 1)},
+               b{COutPoint(Txid::FromUint256(uint256{1}), 2)},
+               c{COutPoint(Txid::FromUint256(uint256{2}), 1)};
+
+    BOOST_CHECK(a == a);
+    BOOST_CHECK(a == COutPoint(Txid::FromUint256(uint256{1}), 1));
+    BOOST_CHECK(b == b);
+    BOOST_CHECK(c == c);
+    BOOST_CHECK(a != b);
+    BOOST_CHECK(a != COutPoint(Txid::FromUint256(uint256{1}), 10));
+    BOOST_CHECK(a != c);
+    BOOST_CHECK(b != c);
+
+    BOOST_CHECK(a < b);
+    BOOST_CHECK(a < COutPoint(Txid::FromUint256(uint256{1}), 10));
+    BOOST_CHECK(b < c);
+    BOOST_CHECK(a < c);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -628,3 +628,8 @@ std::ostream& operator<<(std::ostream& os, const uint256& num)
 {
     return os << num.ToString();
 }
+
+std::ostream& operator<<(std::ostream& os, const COutPoint& outpoint)
+{
+    return os << outpoint.hash << ", " << outpoint.n;
+}

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -291,6 +291,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::optional<T>& v)
 std::ostream& operator<<(std::ostream& os, const arith_uint256& num);
 std::ostream& operator<<(std::ostream& os, const uint160& num);
 std::ostream& operator<<(std::ostream& os, const uint256& num);
+std::ostream& operator<<(std::ostream& os, const COutPoint& outpoint);
 // @}
 
 /**

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -26,10 +26,8 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     LOCK(::cs_main);
     auto& view = chainstate.CoinsTip();
 
-    // The number of bytes consumed by coin's heap data, i.e. CScript
-    // (prevector<28, unsigned char>) when assigned 56 bytes of data per above.
-    //
-    // See also: Coin::DynamicMemoryUsage().
+    // The number of bytes consumed by coin's heap data, i.e. CScript (prevector<36, unsigned char>)
+    // when assigned 56 bytes of data per above. See also: Coin::DynamicMemoryUsage().
     constexpr unsigned int COIN_SIZE = is_64_bit ? 80 : 64;
 
     auto print_view_mem_usage = [](CCoinsViewCache& view) {

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -11,9 +11,9 @@ SaltedTxidHasher::SaltedTxidHasher() :
     k0{FastRandomContext().rand64()},
     k1{FastRandomContext().rand64()} {}
 
-SaltedOutpointHasher::SaltedOutpointHasher(bool deterministic) :
-    k0{deterministic ? 0x8e819f2607a18de6 : FastRandomContext().rand64()},
-    k1{deterministic ? 0xf4020d2e3983b0eb : FastRandomContext().rand64()}
+SaltedOutpointHasher::SaltedOutpointHasher(bool deterministic) : hasher{
+    deterministic ? 0x8e819f2607a18de6 : FastRandomContext().rand64(),
+    deterministic ? 0xf4020d2e3983b0eb : FastRandomContext().rand64()}
 {}
 
 SaltedSipHasher::SaltedSipHasher() :

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -30,12 +30,10 @@ public:
 
 class SaltedOutpointHasher
 {
-private:
-    /** Salt */
-    const uint64_t k0, k1;
+    const Uint256ExtraSipHasher hasher;
 
 public:
-    SaltedOutpointHasher(bool deterministic = false);
+    explicit SaltedOutpointHasher(bool deterministic = false);
 
     /**
      * Having the hash noexcept allows libstdc++'s unordered_map to recalculate
@@ -47,7 +45,7 @@ public:
      * @see https://gcc.gnu.org/onlinedocs/gcc-13.2.0/libstdc++/manual/manual/unordered_associative.html
      */
     size_t operator()(const COutPoint& id) const noexcept {
-        return SipHashUint256Extra(k0, k1, id.hash, id.n);
+        return hasher(id.hash, id.n);
     }
 };
 


### PR DESCRIPTION
During the last Core Dev meeting, it was proposed to create a tracking PR aggregating the individual IBD optimizations - to illustrate how these changes contribute to the broader performance improvement efforts.

## Summary: **>20%** full IBD speedup
We don't have many low-hanging fruits anymore, but big speed improvements can also be achieved by many small, focused changes.
Many optimization opportunities are hiding in consensus critical code - this tracking PR provides justification for why those should also be considered.
The unmerged changes here collectively achieve a **>20%** speedup for full IBD (measured by multiple real runs until 886'000 blocks using 5GiB in-memory cache): from **8.59 hours** on master to **7.25 hours** for the PR.

Anyone can (and is encouraged to) reproduce the results by following this guide: https://gist.github.com/l0rinc/83d2bdfce378ad7396610095ceb7bed5

## Related issues:
* https://github.com/bitcoin/bitcoin/issues/32832
* https://github.com/bitcoin/bitcoin/issues/31494

## PRs included here (in review priority order):
* [x] https://github.com/bitcoin/bitcoin/pull/31490
* [x] https://github.com/bitcoin/bitcoin/pull/31551
* [x] https://github.com/bitcoin/bitcoin/pull/32487
* [x] https://github.com/bitcoin/bitcoin/pull/31144
* [x] https://github.com/bitcoin/bitcoin/pull/32827
* [x] https://github.com/bitcoin/bitcoin/pull/32279
* [x] https://github.com/bitcoin/bitcoin/pull/31645
* [x] https://github.com/bitcoin/bitcoin/pull/33602
* [x] https://github.com/bitcoin/bitcoin/pull/30442
* [ ] https://github.com/bitcoin/bitcoin/pull/32497
* [ ] https://github.com/bitcoin/bitcoin/pull/31132
* [ ] https://github.com/bitcoin/bitcoin/pull/31682
* [ ] https://github.com/bitcoin/bitcoin/pull/31868

## Changing trends
The UTXO count and average block size have drastically increased in the past few years, providing a better overall picture of how Bitcoin behaves under real load.
[<img width="500" alt="image" src="https://github.com/user-attachments/assets/d257b864-d9de-4f9d-b61b-acc6835f384f" />](https://www.blockchain.com/explorer/charts/avg-block-size)
Profiling IBD, given these circumstances, revealed many new optimization opportunities.

## Similar efforts in the past years

There were many efforts to make sure Bitcoin Core remains performant in light of these new trends, a few recent notable examples include:
* https://github.com/bitcoin/bitcoin/pull/25325 - use specialized pool allocator for in-memory cache (~21% faster IBD)
* https://github.com/bitcoin/bitcoin/pull/28358 - allow the full UTXO set to fit into memory
* https://github.com/bitcoin/bitcoin/pull/28280#issuecomment-2273368482 - fine-grained in-memory cache eviction for pruned nodes (~30% IBD speedup on pruned nodes)
* https://github.com/bitcoin/bitcoin/pull/30039#issuecomment-2397229720 - reduce LevelDB writes, compactions and open files (~30% faster IBD for small in-memory cache)
* https://github.com/bitcoin/bitcoin/pull/31490, https://github.com/bitcoin/bitcoin/pull/30849, https://github.com/bitcoin/bitcoin/pull/30906 - refactors derisking/enabling follow-up optimizations
* https://github.com/bitcoin/bitcoin/pull/30326 - favor the happy path for cache misses (~2% IBD speedup)
* https://github.com/bitcoin/bitcoin/pull/30884 - Windows regression fix

## Reliable macro benchmarks

The measurements here were done on a high-end Intel i9-9900K CPU (8 cores/16 threads, 3.6GHz base, 5.0GHz boost), 64GB RAM, and a RAID configuration with multiple NVMe drives (total ~1.4TB fast storage), a dedicated Hetzner Auction box running latest Ubuntu. Sometimes a lower-end i7 was used with an HDD for comparison.

To make sure the setup reflected a real user's experience, we ran multiple full IBDs per commit (connecting to real nodes), until block 886'000 with a 5GiB in-memory cache where hyperfine was used to measure the final time (assuming normal distribution, stabilizing the final result via statistical methods), producing reliable results even when individual measurements varied (when hyperfine indicated that the measurements were all over the place we reran the whole benchmark).
To reduce the instability of headers synchronization and peer acquisition, we first started `bitcoind` until block 1, followed by the actual benchmarks until block 886'000.

The top 2 PRs (https://github.com/bitcoin/bitcoin/pull/31551 and https://github.com/bitcoin/bitcoin/pull/31144) were measured together by multiple people with different settings (and varying results):
* @andrewtoth in https://github.com/bitcoin/bitcoin/pull/31144#issuecomment-2585403343 - 9% speedup with GCC
* @hodlinator in https://github.com/bitcoin/bitcoin/pull/31144#issuecomment-2588220255 - 11.9% speedup with GCC
* @mlori in https://github.com/bitcoin/bitcoin/pull/31144#issuecomment-2664077362 - 12% faster with GCC
* @Sjors in https://github.com/bitcoin/bitcoin/pull/31144#issuecomment-2575279833 - 3% speedup with Clang

Also note that there is a separate effort to [add a reliable macro-benchmarking suite](https://github.com/bitcoin/bitcoin/pull/31996) to track the performance of the most critical usecases end-to-end (including IBD, compact blocks, UTXO iteration) - still WIP, not yet used here.

## Current changes (in order of importance, reviews and reproducers are welcome):

Plotting the performance of the blocks from the produced `debug.log` files (taken from the last run for each commit - can differ slightly from the normalized average shown below) visualizing the effect of each commit:

<details>
<summary>debug.log visualizer</summary>

```python
import os
import sys
import re
from datetime import datetime
import matplotlib.pyplot as plt
import numpy as np


def process_log_files_and_plot(log_dir, output_file="block_height_progress.png"):
    if not os.path.exists(log_dir) or not os.path.isdir(log_dir):
        print(f"Error: '{log_dir}' is not a valid directory", file=sys.stderr)
        return

    debug_files = [f for f in os.listdir(log_dir) if
                   f.startswith('debug-') and os.path.isfile(os.path.join(log_dir, f))]
    if not debug_files:
        print(f"Warning: No debug files found in '{log_dir}'", file=sys.stderr)
        return

    height_pattern = re.compile(r'UpdateTip:.*height=(\d+)')
    results = {}

    for filename in debug_files:
        filepath = os.path.join(log_dir, filename)
        print(f"Processing {filename}...", file=sys.stderr)

        update_tips = []
        first_timestamp = None
        line_count = tip_count = 0
        found_shutdown_done = False

        try:
            with open(filepath, 'r', errors='ignore') as file:
                for line_number, line in enumerate(file, 1):
                    line_count += 1
                    if line_count % 100000 == 0:
                        print(f"  Processed {line_count} lines, found {tip_count} UpdateTips...", file=sys.stderr)

                    if not found_shutdown_done:
                        if "Shutdown: done" in line:
                            found_shutdown_done = True
                            print(f"  Found 'Shutdown: done' at line {line_number}, starting to record",
                                  file=sys.stderr)
                        continue

                    if len(line) < 20 or "UpdateTip:" not in line:
                        continue

                    try:
                        timestamp = datetime.strptime(line[:20], "%Y-%m-%dT%H:%M:%SZ")
                        height_match = height_pattern.search(line)
                        if not height_match:
                            continue

                        height = int(height_match.group(1))
                        if first_timestamp is None:
                            first_timestamp = timestamp

                        update_tips.append((int((timestamp - first_timestamp).total_seconds()), height))
                        tip_count += 1
                    except ValueError:
                        continue
        except Exception as e:
            print(f"Error processing {filename}: {e}", file=sys.stderr)
            continue

        print(f"Finished processing {filename}: {line_count} lines, {tip_count} UpdateTips", file=sys.stderr)

        if update_tips:
            time_dict = {}
            for time, height in update_tips:
                time_dict[time] = height
            results[filename[6:14]] = sorted(time_dict.items())

    if not results:
        print("No valid data found in any files.", file=sys.stderr)
        return

    print(f"Creating plots with data from {len(results)} files", file=sys.stderr)

    sorted_results = []
    for name, pairs in results.items():
        if pairs:
            sorted_results.append((name, pairs[-1][0] / 3600, pairs))

    sorted_results.sort(key=lambda x: x[1], reverse=True)
    colors = plt.cm.tab10(np.linspace(0, 1, len(sorted_results)))

    # Plot 1: Height vs Time
    plt.figure(figsize=(12, 8))

    final_points = []
    for idx, (name, last_time, pairs) in enumerate(sorted_results):
        times = [t / 3600 for t, _ in pairs]
        heights = [h for _, h in pairs]
        plt.plot(heights, times, label=f"{name} ({last_time:.2f}h)", color=colors[idx], linewidth=1)
        if pairs:
            final_points.append((last_time, pairs[-1][1], colors[idx]))

    for time, height, color in final_points:
        plt.axhline(y=time, color=color, linestyle='--', alpha=0.3)
        plt.axvline(x=height, color=color, linestyle='--', alpha=0.3)

    plt.title('Sync Time by Block Height')
    plt.xlabel('Block Height')
    plt.ylabel('Elapsed Time (hours)')
    plt.grid(True, linestyle='--', alpha=0.7)
    plt.legend(loc='center left')
    plt.tight_layout()

    plt.savefig(output_file.replace('.png', '_reversed.png'), dpi=300)

    # Plot 2: Performance Ratio by Time
    if len(sorted_results) > 1:
        plt.figure(figsize=(12, 8))

        baseline = sorted_results[0]
        baseline_time_by_height = {h: t for t, h in baseline[2]}

        for idx, (name, _, pairs) in enumerate(sorted_results[1:], 1):
            time_by_height = {h: t for t, h in pairs}

            common_heights = [h for h in baseline_time_by_height.keys()
                              if h >= 400000 and h in time_by_height]
            common_heights.sort()

            ratios = []
            base_times = []

            for h in common_heights:
                base_t = baseline_time_by_height[h]
                result_t = time_by_height[h]

                if result_t > 0:
                    ratios.append(base_t / result_t)
                    base_times.append(base_t / 3600)

            plt.plot(base_times, ratios,
                     label=f"{name} vs {baseline[0]}",
                     color=colors[idx], linewidth=1)

        plt.axhline(y=1, color='gray', linestyle='--', alpha=0.7)

        plt.title('Performance Improvement Over Time (Higher is Better)')
        plt.xlabel('Baseline Elapsed Time (hours)')
        plt.ylabel('Speedup Ratio (baseline_time / commit_time)')
        plt.grid(True, linestyle='--', alpha=0.7)
        plt.legend(loc='best')
        plt.tight_layout()

        plt.savefig(output_file.replace('.png', '_time_ratio.png'), dpi=300)

    with open(output_file.replace('.png', '.csv'), 'w') as f:
        for name, _, pairs in sorted_results:
            f.write(f"{name},{','.join(f'{t}:{h}' for t, h in pairs)}\n")

    plt.show()


if __name__ == "__main__":
    log_dir = sys.argv[1] if len(sys.argv) > 1 else "."
    output_file = sys.argv[2] if len(sys.argv) > 2 else "block_height_progress.png"
    process_log_files_and_plot(log_dir, output_file)

```

</details>

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a43b43da-209c-4736-b1ef-d4d57f838d74" />


<img width="1000" alt="image" src="https://github.com/user-attachments/assets/2d43d867-0c9e-4daf-9d47-bd1148c48b55" />


### Baseline
Base commit was 88debb3e42.

<details>
<summary>8.59 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=88debb3e4297ef4ebc8966ffe599359bc7b231d0 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     30932.610 s ± 156.891 s    [User: 58248.505 s, System: 2142.974 s]
  Range (min … max):   30821.671 s … 31043.549 s    2 runs
  ```

</details>

-----

* https://github.com/bitcoin/bitcoin/pull/31551

<details>
<summary>7.91 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=6a8ce46e32dae2ffef2a73d2314ca33a2039186e ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     28501.588 s ± 119.886 s    [User: 56419.060 s, System: 1833.126 s]
  Range (min … max):   28416.815 s … 28586.361 s    2 runs
```

We can serialize the blocks and undos to any `Stream` which implements the appropriate read/write methods.
`AutoFile` is one of these, writing the results "directly" to disk (through the OS file cache). Batching these in memory first and reading/writing these to disk is measurably faster (likely because of fewer native fread calls or less locking, as [observed](https://github.com/bitcoin/bitcoin/pull/28226#issuecomment-1666842501) by @martinus in a similar change).

Differential flame graphs indicate that the before/after speed change is because of fewer `AutoFile` reads and writes:
![writes](https://github.com/user-attachments/assets/c5e45ddf-3a94-4c5b-999a-94a139d5776d)
![reads](https://github.com/user-attachments/assets/f11982ea-f2dc-4fc6-afce-faa132724658)
</details>

-----

* https://github.com/bitcoin/bitcoin/pull/31144

<details>
<summary>7.60 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=c5cc54d10187c9cb3a6cba8cc10f652b4f882e2a ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     27394.210 s ± 565.877 s    [User: 54902.315 s, System: 1891.951 s]
  Range (min … max):   26994.075 s … 27794.346 s    2 runs
```
</details>

Current block obfuscations are done byte-by-byte, this PR batches them to 64 bit primitives to speed up obfuscating bigger memory batches.
This is especially relevant after https://github.com/bitcoin/bitcoin/pull/31551 where we end up with bigger obfuscatable chunks.

![obfuscation calls during IBD without batching](https://github.com/user-attachments/assets/b521e3fc-f8cd-42d8-9068-a9b23f65b45b)

-----

* https://github.com/bitcoin/bitcoin/pull/31645

<details>
<summary>7.50 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=9b4be912d20222b3b275ef056c1494a15ccde3f5 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     27019.086 s ± 112.340 s    [User: 54927.344 s, System: 1652.376 s]
  Range (min … max):   26939.649 s … 27098.522 s    2 runs
```

</details>

When the in-memory UTXO set is [flushed](https://github.com/bitcoin/bitcoin/blob/master/src/txdb.cpp#L130-L133) to LevelDB (after IBD or AssumeUTXO load), it does so in batches to manage memory usage during the flush.
While a hidden [-dbbatchsize](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp#L490) config option exists to modify this value, this PR introduces dynamic calculation of the batch size based on the -dbcache setting. By using larger batches when more memory is available (i.e., higher -dbcache), we can reduce the overhead from numerous small writes, minimize constant overhead per batch, improve I/O efficiency (especially on HDDs), and potentially allow LevelDB to optimize writes more effectively (e.g. by sorting the keys before write).

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/0a99e32e-6a9b-481e-a08a-7216c82fe722" />

Note that this PR mainly optimizes a critical section of IBD (memory to disk dump) - even if the effect on overall speed is modest:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/8b56674b-b3e3-43cf-a19b-574e66948e72" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ce56cfba-a59f-4360-a6d7-2cc3e74959a3" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e346414c-b009-47c5-92ff-a264b1e2c6c4" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/4db30a70-1ca9-401c-8c9c-2ddecd0d7516" />

-----


* https://github.com/bitcoin/bitcoin/pull/31868

<details>
<summary>7.41 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=817d7ac0767a3984295aa3cf6c961dcc5f29d571 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     26711.460 s ± 244.118 s    [User: 54654.348 s, System: 1652.087 s]
  Range (min … max):   26538.843 s … 26884.077 s    2 runs
```
</details>

The commits merge similar (de)serialization methods, and separates them internally with if constexpr - similarly to how it has been https://github.com/bitcoin/bitcoin/pull/28203. This enabled further SizeComputer optimizations as well.

Other than these, since single byte writes are used very often (used for every (u)int8_t or std::byte or bool and for every VarInt's first byte which is also needed for every (pre)Vector), it makes sense to avoid unnecessary generalized serialization infrastructure.

-----

* https://github.com/bitcoin/bitcoin/pull/31682

<details>
<summary>7.31 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=182745cec4c0baf2f3c8cff2f74f847eac3c4330 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     26326.867 s ± 45.887 s    [User: 54367.156 s, System: 1619.348 s]
  Range (min … max):   26294.420 s … 26359.314 s    2 runs
```
</details>

`CheckBlock`'s latency is critical for efficiently validating correct inputs during transaction validation, including mempool acceptance and new block creation.

This PR improves performance and maintainability by introducing the following changes:
* Simplified checks for the most common cases (1 or 2 inputs - [70-90% of transactions have a single input](https://transactionfee.info/charts/transactions-1in)).
* Optimized the general case by replacing `std::set` with sorted `std::vector` for improved locality.
* Simplified Null prevout checks from linear to constant time.

-----

* https://github.com/bitcoin/bitcoin/pull/30442

<details>
<summary>7.25 hour IBD time</summary>

```bash
COMPILER=gcc COMMIT=47d377bd0bb88dae6b34553a7789400170e0ccf6 ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=886000 -dbcache=5000 -blocksonly -printtoconsole=0
  Time (mean ± σ):     26084.429 s ± 473.611 s    [User: 54310.780 s, System: 1815.967 s]
  Range (min … max):   25749.536 s … 26419.323 s    2 runs
```

</details>

The in-memory representation of the UTXO set uses [(salted) SipHash](https://github.com/bitcoin/bitcoin/blob/master/src/coins.h#L226) for avoiding key collision attacks.

Hashing a `uint256` key is done so often that a specialized optimization was extracted to [SipHashUint256Extra](https://github.com/bitcoin/bitcoin/blob/master/src/crypto/siphash.cpp#L135). The constant salting operations were already extracted in the [general case](https://github.com/bitcoin/bitcoin/blob/master/src/crypto/siphash.cpp#L20-L23), this PR adjusts the main specialization similarly.


-----

* https://github.com/bitcoin/bitcoin/pull/32279

The current `prevector` size of 28 bytes (chosen to fill the `sizeof(CScript)` aligned size) was introduced in 2015 (https://github.com/bitcoin/bitcoin/pull/6914) before SegWit and TapRoot.
However, the increasingly common P2WSH and P2TR scripts are both 34 bytes, and are forced to use heap (re)allocation rather than efficient inline storage.

The core trade-off of this change is to eliminate heap allocations for common 29-36 byte scripts at the cost of increasing the base memory footprint of all `CScript` objects by 8 bytes (while still respecting peak memory usage defined by -dbcache).

![image](https://github.com/user-attachments/assets/284ce2ab-32b8-4c85-9ada-11aae0e2ff39)

-----

## Other similar efforts waiting for reviews or revives (not included in this tracking PR):
* https://github.com/bitcoin/bitcoin/pull/30611 - for very big in-memory caches make sure we still flush to disk regularly (no significant IBD speed change)
* https://github.com/bitcoin/bitcoin/pull/28945 - was meant to preallocate the memory of recreated caches (~6% IBD speedup for small caches)
* https://github.com/bitcoin/bitcoin/pull/31102 - was meant to try to evict entries selectively instead of dropping the whole cache when full
* https://github.com/bitcoin/bitcoin/pull/32128 - draft PR showcasing a few other possible caching speedups

-----

This PR is meant to stay in draft (not meant to be merged directly), to continually change based on comments received here and in the PRs.
Comments, reproducers and high-level discussions are welcome here - code reviews should rather be done in the individual PRs.
