### PR TITLE
contrib: Fix `gen-bitcoin-conf.sh`

### DIFF
--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -50,7 +50,8 @@ EOF
 # adding newlines is a bit funky to ensure portability for BSD
 # see here for more details: https://stackoverflow.com/a/24575385
 ${BITCOIND} --help \
-    | sed '1,/Print this help message and exit/d' \
+    | sed '1,/Options:/d' \
+    | sed -E '/^[[:space:]]{2}-help/,/^[[:space:]]*$/d' \
     | sed -E 's/^[[:space:]]{2}\-/#/' \
     | sed -E 's/^[[:space:]]{7}/# /' \
     | sed -E '/[=[:space:]]/!s/#.*$/&=1/' \


### PR DESCRIPTION
In #31118, the format of bitcoind's `--help` output changed slightly in a way that breaks `gen-bitcoin-conf.sh`, modify the script to accommodate the new format, by starting after the line that says "Options:" and stripping the `-help` options and descriptions from the script output.

Before this PR, all options above `-help` were excluded from the example bitcoin.conf.
