### PR TITLE
p2p: protect addnode peers during IBD

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5786,7 +5786,9 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
         // Detect whether we're stalling
         auto stalling_timeout = m_block_stalling_timeout.load();
-        if (state.m_stalling_since.count() && state.m_stalling_since < current_time - stalling_timeout) {
+        // Allow more time for addnode peers
+        const auto adjusted_timeout{pto->IsManualConn() ? BLOCK_STALLING_TIMEOUT_MAX : stalling_timeout};
+        if (state.m_stalling_since.count() && state.m_stalling_since < current_time - adjusted_timeout) {
             // Stalling only triggers when the block download window cannot move. During normal steady state,
             // the download window should be much larger than the to-be-downloaded set of blocks, so disconnection
             // should only happen during initial block download.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -307,7 +307,8 @@ static RPCHelpMan addnode()
     return RPCHelpMan{"addnode",
                 "\nAttempts to add or remove a node from the addnode list.\n"
                 "Or try a connection to a node once.\n"
-                "Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be\n"
+                "Nodes added using addnode (or -connect) are protected from disconnection due to DoS or IBD header/block\n"
+                "download timeouts (and given more time before considered to be stalling), and are not required to be\n"
                 "full nodes/support SegWit as other outbound peers are (though such peers will not be synced from).\n" +
                 strprintf("Addnode connections are limited to %u at a time", MAX_ADDNODE_CONNECTIONS) +
                 " and are counted separately from the -maxconnections limit.\n",


### PR DESCRIPTION
When an addnode peer is disconnected by our IBD headers/blocks download timeout or stalling logic, `ThreadOpenAddedConnections` attempts to immediately reconnect it (unless "onetry" was passed to the addnode RPC) up to the limit of 8 addnode connections that is separate from regular peer connection limits.

During IBD in a low-bandwidth environment, I see these disconnections+reconnections very frequently with high-quality addnode peers; see https://www.erisian.com.au/bitcoin-core-dev/log-2025-01-22.html#l-85. The logging for these disconnections was: "Peer is stalling block download, disconnecting <peer>." The ping times of the affected peers were often 20-100 seconds.

After IBD, I continue to see the following addnode peer disconnections, albeit much less frequently: "Timeout downloading block <hex>, disconnecting <peer>."

This is probably network, resource and time intensive to an extent, particularly in the case of I2P peers that involves destroying and rebuilding 2 tunnels per peer connection, and worth avoiding where it is simple to do so.

Automatic (non-manually added) peers are also disconnected, but they are a different category and case (non-trusted non-protected peers, no immediate reconnection) that would require monitoring over time to adjust the timeouts accordingly; mzumsande was looking into this (see https://www.erisian.com.au/bitcoin-core-dev/log-2025-01-22.html#l-105).

The goal of this pull is therefore to avoid unnecessary disconnections/immediate reconnections of addnode peers.
