### PR TITLE
contrib: Fix deterministic-unittest-coverage tool path

### DIFF
--- a/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
 
     let build_dir = Path::new(build_dir);
     let corpora_dir = Path::new(corpora_dir);
-    let fuzz_exe = build_dir.join("src/test/fuzz/fuzz");
+    let fuzz_exe = build_dir.join("bin/fuzz");
 
     sanity_check(corpora_dir, &fuzz_exe);
 

--- a/contrib/devtools/deterministic-unittest-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-unittest-coverage/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
     }
 
     let build_dir = Path::new(build_dir);
-    let test_exe = build_dir.join("src/test/test_bitcoin");
+    let test_exe = build_dir.join("bin/test_bitcoin");
 
     sanity_check(&test_exe);
 


### PR DESCRIPTION
Fix for the tooling introduced/modified in #31901 but the tool path is broken due to silent merge conflict introduced by #31161.

The `deterministic-unittest-coverage` and `deterministic-fuzz-coverage` tools uses the `fuzz` and `test_bitcoind` binaries, for which the location was modified in #31161. This patch updates the location to align with that change.