### PR TITLE
test: avoid disk space warning for non-regtest

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -24,6 +24,9 @@ class ConfArgsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
+        # Prune to prevent disk space warning on CI systems with limited space,
+        # when using networks other than regtest.
+        self.extra_args = [["-prune=550"]]
         self.supports_cli = False
         self.wallet_names = []
         self.disable_autoconnect = False
@@ -471,32 +474,21 @@ class ConfArgsTest(BitcoinTestFramework):
         self.log.info("Test testnet3 deprecation warning")
         t3_warning_log = "Warning: Support for testnet3 is deprecated and will be removed in an upcoming release. Consider switching to testnet4."
 
-        def warning_msg(node, approx_size):
-            return f'Warning: Disk space for "{node.datadir_path / node.chain / "blocks" }" may not accommodate the block files. Approximately {approx_size} GB of data will be stored in this directory.'
-
-        # Testnet3 node will log the warning
+        self.log.debug("Testnet3 node will log the deprecation warning")
         self.nodes[0].chain = 'testnet3'
         self.nodes[0].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
         with self.nodes[0].assert_debug_log([t3_warning_log]):
             self.start_node(0)
-        # Some CI environments will have limited space and some others won't
-        # so we need to handle both cases as a valid result.
-        self.nodes[0].stderr.seek(0)
-        err = self.nodes[0].stdout.read()
-        self.nodes[0].stderr.seek(0)
-        self.nodes[0].stderr.truncate()
-        if err != b'' and err != warning_msg(self.nodes[0], 42):
-            raise AssertionError("Unexpected stderr after shutdown of Testnet3 node")
         self.stop_node(0)
 
-        # Testnet4 node will not log the warning
+        self.log.debug("Testnet4 node will not log the deprecation warning")
         self.nodes[0].chain = 'testnet4'
         self.nodes[0].replace_in_config([('testnet=', 'testnet4='), ('[test]', '[testnet4]')])
         with self.nodes[0].assert_debug_log([], unexpected_msgs=[t3_warning_log]):
             self.start_node(0)
         self.stop_node(0)
 
-        # Reset to regtest
+        self.log.debug("Reset to regtest")
         self.nodes[0].chain = 'regtest'
         self.nodes[0].replace_in_config([('testnet4=', 'regtest='), ('[testnet4]', '[regtest]')])
 

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -26,12 +26,14 @@ signet_blocks = [
 
 class SignetParams:
     def __init__(self, challenge=None):
+        # Prune to prevent disk space warning on CI systems with limited space,
+        # when using networks other than regtest.
         if challenge is None:
             self.challenge = SIGNET_DEFAULT_CHALLENGE
-            self.shared_args = []
+            self.shared_args = ["-prune=550"]
         else:
             self.challenge = challenge
-            self.shared_args = [f"-signetchallenge={challenge}"]
+            self.shared_args = ["-prune=550", f"-signetchallenge={challenge}"]
 
 class SignetBasicTest(BitcoinTestFramework):
     def set_test_params(self):


### PR DESCRIPTION
`feature_config_args.py` incorrectly assumed that its testnet4 node would not log a disk space warning.

But when #31978 increased `m_assumed_blockchain_size` on testnet4 from 1 to 11 GiB, it triggered this bug on my RAM disk, see https://github.com/bitcoin/bitcoin/tree/master/test#speed-up-test-runs-with-a-ram-disk

This PR fixes the issue by using `-prune` which prevents the warning.