### PR TITLE
test: Update coverage.cpp to drop linux restriction

### DIFF
--- a/src/test/util/coverage.cpp
+++ b/src/test/util/coverage.cpp
@@ -4,19 +4,18 @@
 
 #include <test/util/coverage.h>
 
-#if defined(__clang__) && defined(__linux__)
-extern "C" void __llvm_profile_reset_counters(void) __attribute__((weak));
-extern "C" void __gcov_reset(void) __attribute__((weak));
+#if defined(__clang__)
+extern "C" __attribute__((weak)) void __llvm_profile_reset_counters(void);
+extern "C" __attribute__((weak)) void __gcov_reset(void);
 
-void ResetCoverageCounters()
-{
-    if (__llvm_profile_reset_counters) {
-        __llvm_profile_reset_counters();
-    }
+// Fallback implementations
+extern "C" __attribute__((weak)) void __llvm_profile_reset_counters(void) {}
+extern "C" __attribute__((weak)) void __gcov_reset(void) {}
 
-    if (__gcov_reset) {
-        __gcov_reset();
-    }
+void ResetCoverageCounters() {
+    // These will call the real ones if available, or our dummies if not
+    __llvm_profile_reset_counters();
+    __gcov_reset();
 }
 #else
 void ResetCoverageCounters() {}


### PR DESCRIPTION
In PR [#31901](https://github.com/bitcoin/bitcoin/pull/31901), Coverage.cpp was introduced as a separate utility file, based on existing code. However, the macro defined in Coverage.cpp was limited to Clang and Linux, which caused issues for users on macOS when using the newly introduced deterministic test tooling.

This change adds fallback functions which are used when building without code coverage on non linux env.
This adds support for macOS to ResetCoverageCounters. ResetCoverageCounters is used by the unit tests in `g_rng_temp_path_init` to support the deterministic unit test tooling. It is also used in fuzz tests to completely suppress coverage from anything init-related.

See [Readme](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md) on how to test this for deterministic unit & fuzz test.  

Suggestion for test files: 

- for  unit test: `util_string_tests`
- for fuzz test: `addition_overflow `

These files should give deterministic results