### PR TITLE
test: fix intermittent failure in p2p_orphan_handling.py

### DIFF
--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -788,6 +788,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
 
         # Disconnect peer1. peer2 should become the new candidate for orphan resolution.
         peer1.peer_disconnect()
+        self.wait_until(lambda: node.num_test_p2p_connections() == 1)
         node.bumpmocktime(TXREQUEST_TIME_SKIP)
         self.wait_until(lambda: len(node.getorphantxs(verbosity=2)[0]["from"]) == 1)
         # Both parents should be requested, now that they are both missing.


### PR DESCRIPTION
If the mocktime is bumped before the node has successfully disconnected the peer, the requests for both parents could be spread over two GETDATAS: The first time `GetRequestsToSend` is invoked it would only request one tx from peer2, because the other one would only be available after peer1  was disconnected and its outstanding txrequest cleared.
So two GETDATAs would be sent, which would make the test fail.

Fixes #31700
