### PR TITLE
i2p: make a time gap between creating transient sessions and using them

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -132,6 +132,13 @@ Session::Session(const Proxy& control_host, std::shared_ptr<CThreadInterrupt> in
       m_interrupt{interrupt},
       m_transient{true}
 {
+    try {
+        LOCK(m_mutex);
+        CreateIfNotCreatedAlready();
+    } catch (const std::runtime_error&) {
+        // This was just an eager optimistic attempt to create the session.
+        // If it fails, then it will be reattempted again when `Connect()` is called.
+    }
 }
 
 Session::~Session()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -381,7 +381,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                              bool use_v2transport,
                              const std::optional<Proxy>& proxy_override)
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     assert(conn_type != ConnectionType::INBOUND);
 
     if (pszDest == nullptr) {
@@ -461,20 +461,19 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                     connected = m_i2p_sam_session->Connect(target_addr, conn, proxyConnectionFailed);
                 } else {
                     {
-                        LOCK(m_unused_i2p_sessions_mutex);
-                        if (m_unused_i2p_sessions.empty()) {
+                        LOCK(m_unused_i2p_transient_session_mutex);
+                        if (!m_unused_i2p_transient_session) {
                             i2p_transient_session =
                                 std::make_unique<i2p::sam::Session>(*use_proxy, m_interrupt_net);
                         } else {
-                            i2p_transient_session.swap(m_unused_i2p_sessions.front());
-                            m_unused_i2p_sessions.pop();
+                            i2p_transient_session.swap(m_unused_i2p_transient_session);
                         }
                     }
                     connected = i2p_transient_session->Connect(target_addr, conn, proxyConnectionFailed);
                     if (!connected) {
-                        LOCK(m_unused_i2p_sessions_mutex);
-                        if (m_unused_i2p_sessions.size() < MAX_UNUSED_I2P_SESSIONS_SIZE) {
-                            m_unused_i2p_sessions.emplace(i2p_transient_session.release());
+                        LOCK(m_unused_i2p_transient_session_mutex);
+                        if (!m_unused_i2p_transient_session) {
+                            m_unused_i2p_transient_session.swap(i2p_transient_session);
                         }
                     }
                 }
@@ -1875,7 +1874,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
 
 bool CConnman::AddConnection(const std::string& address, ConnectionType conn_type, bool use_v2transport = false)
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     std::optional<int> max_connections;
     switch (conn_type) {
     case ConnectionType::INBOUND:
@@ -2409,7 +2408,7 @@ void CConnman::DumpAddresses()
 
 void CConnman::ProcessAddrFetch()
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     std::string strDest;
     {
         LOCK(m_addr_fetches_mutex);
@@ -2529,7 +2528,7 @@ bool CConnman::MaybePickPreferredNetwork(std::optional<Network>& network)
 
 void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std::span<const std::string> seed_nodes)
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
     FastRandomContext rng;
     // Connect to specific addresses
@@ -2973,7 +2972,7 @@ std::vector<AddedNodeInfo> CConnman::GetAddedNodeInfo(bool include_connected) co
 
 void CConnman::ThreadOpenAddedConnections()
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
     while (true)
     {
@@ -3010,7 +3009,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect,
                                      bool use_v2transport,
                                      const std::optional<Proxy>& proxy_override)
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     assert(conn_type != ConnectionType::INBOUND);
 
     //
@@ -3211,7 +3210,7 @@ void CConnman::ThreadI2PAcceptIncoming()
 
 void CConnman::ThreadPrivateBroadcast()
 {
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
 
     size_t addrman_num_bad_addresses{0};
     while (!m_interrupt_net->interrupted()) {
@@ -4151,7 +4150,7 @@ uint64_t CConnman::CalculateKeyedNetGroup(const CNetAddr& address) const
 void CConnman::PerformReconnections()
 {
     AssertLockNotHeld(m_reconnections_mutex);
-    AssertLockNotHeld(m_unused_i2p_sessions_mutex);
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
     while (true) {
         // Move first element of m_reconnections to todo (avoiding an allocation inside the lock).
         decltype(m_reconnections) todo;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -437,6 +437,10 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
         connect_to.push_back(addrConnect);
     }
 
+    // Pre-create an I2P transient session if needed and store it for later.
+    // This makes a time gap between session creation and usage.
+    SaveI2PTransientSession(GetI2PTransientSession());
+
     // Connect
     std::unique_ptr<Sock> sock;
     CService addr_bind;
@@ -455,26 +459,18 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 bool connected{false};
 
                 // If an I2P SAM session already exists, normally we would re-use it. But in the case of
-                // private broadcast we force a new transient session. A Connect() using m_i2p_sam_session
-                // would use our permanent I2P address as a source address.
+                // private broadcast we use a transient session. A Connect() using m_i2p_sam_session
+                // would use our permanent I2P address as a source address, revealing it to the peer.
                 if (m_i2p_sam_session && conn_type != ConnectionType::PRIVATE_BROADCAST) {
                     connected = m_i2p_sam_session->Connect(target_addr, conn, proxyConnectionFailed);
                 } else {
-                    {
-                        LOCK(m_unused_i2p_transient_session_mutex);
-                        if (!m_unused_i2p_transient_session) {
-                            i2p_transient_session =
-                                std::make_unique<i2p::sam::Session>(*use_proxy, m_interrupt_net);
-                        } else {
-                            i2p_transient_session.swap(m_unused_i2p_transient_session);
-                        }
+                    i2p_transient_session = GetI2PTransientSession();
+                    if (!i2p_transient_session) {
+                        return nullptr;
                     }
                     connected = i2p_transient_session->Connect(target_addr, conn, proxyConnectionFailed);
                     if (!connected) {
-                        LOCK(m_unused_i2p_transient_session_mutex);
-                        if (!m_unused_i2p_transient_session) {
-                            m_unused_i2p_transient_session.swap(i2p_transient_session);
-                        }
+                        SaveI2PTransientSession(std::move(i2p_transient_session));
                     }
                 }
 
@@ -3407,6 +3403,38 @@ uint16_t CConnman::GetDefaultPort(const std::string& addr) const
 {
     CNetAddr a;
     return a.SetSpecial(addr) ? GetDefaultPort(a.GetNetwork()) : m_params.GetDefaultPort();
+}
+
+std::unique_ptr<i2p::sam::Session> CConnman::GetI2PTransientSession()
+{
+    AssertLockNotHeld(m_unused_i2p_transient_session_mutex);
+
+    const auto opt_i2p_proxy{GetProxy(NET_I2P)};
+
+    if (!g_reachable_nets.Contains(NET_I2P) || // Not using I2P at all.
+        m_i2p_sam_session || // Using a single persistent session, transient sessions are not needed.
+        !opt_i2p_proxy.has_value()) {
+        return nullptr;
+    }
+
+    {
+        LOCK(m_unused_i2p_transient_session_mutex);
+        if (m_unused_i2p_transient_session) {
+            return std::move(m_unused_i2p_transient_session);
+        }
+    }
+
+    return std::make_unique<i2p::sam::Session>(opt_i2p_proxy.value(), m_interrupt_net);
+}
+
+void CConnman::SaveI2PTransientSession(std::unique_ptr<i2p::sam::Session>&& session)
+{
+    LOCK(m_unused_i2p_transient_session_mutex);
+    if (!m_unused_i2p_transient_session) {
+        m_unused_i2p_transient_session = std::move(session);
+    } else {
+        session.reset();
+    }
 }
 
 bool CConnman::Bind(const CService& addr_, unsigned int flags, NetPermissionFlags permissions)

--- a/src/net.h
+++ b/src/net.h
@@ -42,7 +42,6 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <queue>
 #include <string_view>
 #include <thread>
 #include <unordered_set>
@@ -1186,7 +1185,7 @@ public:
                                ConnectionType conn_type,
                                bool use_v2transport,
                                const std::optional<Proxy>& proxy_override = std::nullopt)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
 
     /// Group of private broadcast related members.
     class PrivateBroadcast
@@ -1349,7 +1348,7 @@ public:
      *                          - Max total outbound connection capacity filled
      *                          - Max connection capacity for type is filled
      */
-    bool AddConnection(const std::string& address, ConnectionType conn_type, bool use_v2transport) EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+    bool AddConnection(const std::string& address, ConnectionType conn_type, bool use_v2transport) EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
 
     size_t GetNodeCount(ConnectionDirection) const;
     std::map<CNetAddr, LocalServiceInfo> getNetLocalAddresses() const;
@@ -1422,13 +1421,13 @@ private:
     bool Bind(const CService& addr, unsigned int flags, NetPermissionFlags permissions);
     bool InitBinds(const Options& options);
 
-    void ThreadOpenAddedConnections() EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_unused_i2p_sessions_mutex, !m_reconnections_mutex);
+    void ThreadOpenAddedConnections() EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_unused_i2p_transient_session_mutex, !m_reconnections_mutex);
     void AddAddrFetch(const std::string& strDest) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex);
-    void ProcessAddrFetch() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_unused_i2p_sessions_mutex);
-    void ThreadOpenConnections(std::vector<std::string> connect, std::span<const std::string> seed_nodes) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex, !m_unused_i2p_sessions_mutex, !m_reconnections_mutex);
+    void ProcessAddrFetch() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_unused_i2p_transient_session_mutex);
+    void ThreadOpenConnections(std::vector<std::string> connect, std::span<const std::string> seed_nodes) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex, !m_unused_i2p_transient_session_mutex, !m_reconnections_mutex);
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     void ThreadI2PAcceptIncoming();
-    void ThreadPrivateBroadcast() EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+    void ThreadPrivateBroadcast() EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
     void AcceptConnection(const ListenSocket& hListenSocket);
 
     /**
@@ -1522,7 +1521,7 @@ private:
                        ConnectionType conn_type,
                        bool use_v2transport,
                        const std::optional<Proxy>& proxy_override)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
 
     void AddWhitelistPermissionFlags(NetPermissionFlags& flags, std::optional<CNetAddr> addr, const std::vector<NetWhitelistPermissions>& ranges) const;
 
@@ -1756,18 +1755,23 @@ private:
     bool m_capture_messages{false};
 
     /**
-     * Mutex protecting m_i2p_sam_sessions.
+     * Mutex protecting `m_unused_i2p_transient_session`.
      */
-    Mutex m_unused_i2p_sessions_mutex;
+    Mutex m_unused_i2p_transient_session_mutex;
 
     /**
-     * A pool of created I2P SAM transient sessions that should be used instead
-     * of creating new ones in order to reduce the load on the I2P network.
-     * Creating a session in I2P is not cheap, thus if this is not empty, then
-     * pick an entry from it instead of creating a new session. If connecting to
-     * a host fails, then the created session is put to this pool for reuse.
+     * A pre-created I2P SAM transient session that should be used instead
+     * of creating new one. This has two purposes:
+     * 1. If we create a session, try to connect to a peer, but the connection
+     *    fails then we store the session here to be used by the next connection
+     *    attempt. Creating a session in I2P is not cheap, so this reduces the
+     *    load on the I2P network by avoiding useless session creation and
+     *    destruction.
+     * 2. Pre-creating a session some time before using it makes it harder to
+     *    correlate session creation and session usage.
      */
-    std::queue<std::unique_ptr<i2p::sam::Session>> m_unused_i2p_sessions GUARDED_BY(m_unused_i2p_sessions_mutex);
+    std::unique_ptr<i2p::sam::Session> m_unused_i2p_transient_session
+        GUARDED_BY(m_unused_i2p_transient_session_mutex);
 
     /**
      * Mutex protecting m_reconnections.
@@ -1790,13 +1794,7 @@ private:
     std::list<ReconnectionInfo> m_reconnections GUARDED_BY(m_reconnections_mutex);
 
     /** Attempt reconnections, if m_reconnections non-empty. */
-    void PerformReconnections() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_unused_i2p_sessions_mutex);
-
-    /**
-     * Cap on the size of `m_unused_i2p_sessions`, to ensure it does not
-     * unexpectedly use too much memory.
-     */
-    static constexpr size_t MAX_UNUSED_I2P_SESSIONS_SIZE{10};
+    void PerformReconnections() EXCLUSIVE_LOCKS_REQUIRED(!m_reconnections_mutex, !m_unused_i2p_transient_session_mutex);
 
     /**
      * RAII helper to atomically create a copy of `m_nodes` and add a reference

--- a/src/net.h
+++ b/src/net.h
@@ -1567,6 +1567,20 @@ private:
     uint16_t GetDefaultPort(Network net) const;
     uint16_t GetDefaultPort(const std::string& addr) const;
 
+    /**
+     * Create an I2P transient session or get the one from
+     * `m_unused_i2p_transient_session` if it is not empty.
+     * @return session or empty unique_ptr if transient sessions are not needed.
+     */
+    std::unique_ptr<i2p::sam::Session> GetI2PTransientSession()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
+
+    /**
+     * Store an I2P session in `m_unused_i2p_transient_session` if it is empty.
+     */
+    void SaveI2PTransientSession(std::unique_ptr<i2p::sam::Session>&& session)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
+
     // Network usage totals
     mutable Mutex m_total_bytes_sent_mutex;
     std::atomic<uint64_t> nTotalBytesRecv{0};

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -115,7 +116,7 @@ struct ConnmanTestMsg : public CConnman {
     bool AlreadyConnectedToAddressPublic(const CNetAddr& addr) { return AlreadyConnectedToAddress(addr); };
 
     CNode* ConnectNodePublic(PeerManager& peerman, const char* pszDest, ConnectionType conn_type)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_transient_session_mutex);
 };
 
 constexpr ServiceFlags ALL_SERVICE_FLAGS[]{


### PR DESCRIPTION
Connecting to an I2P peer consists of creating a session (the
`SESSION CREATE` command) and then connecting to the peer using that
session (`STREAM CONNECT ID=session_id ...`).

This change is only relevant for transient sessions because when a
persistent session is used it is created once and used for all
connections.

Before this change Bitcoin Core would create the session and use it in
quick succession. That is, the `SESSION CREATE` command would be
immediately followed by `STREAM CONNECT`. This could ease network
activity monitoring by an adversary.

To mitigate that, this change creates sessions upfront without an
immediate demand for new sessions and later uses them. This creates a
time gap between `SESSION CREATE` and `STREAM CONNECT`. Note that there
is always some demand for new I2P connections due to disconnects.

---

Summary of the changes in the code:

* Create the session from the `Session` constructor (send `SESSION CREATE`
  to the I2P SAM proxy). This constructor was only called when transient
  sessions were needed and was immediately followed by `Connect()` which
  would have created the session. So this is a noop change if viewed
  in isolation.

* Every time we try to connect to any peer (not just I2P) create a new
  I2P session, up to a limit (currently 10). This way a bunch of
  sessions are created (`SESSION CREATE`) at times that are decoupled
  from the time when sessions will be used (`STREAM CONNECT`).

* Tweak the code in `CConnman::ConnectNode()` to avoid creating session
  objects while holding `m_unused_i2p_sessions_mutex` because now
  creating `i2p::sam::Session` involves network activity and could take
  a few seconds.

---

Before (note the timestamps):

2025-03-13T09:23:40Z [opencon] [i2p:info] Transient SAM session cd7ea49a7e created
2025-03-13T09:23:43Z [opencon] [i2p] -> STREAM CONNECT ID=cd7ea49a7e DESTINATION=...

2025-03-13T09:23:51Z [opencon] [i2p:info] Transient SAM session cb0956207e created
2025-03-13T09:23:52Z [opencon] [i2p] -> STREAM CONNECT ID=cb0956207e DESTINATION=...

2025-03-13T09:24:04Z [opencon] [i2p:info] Transient SAM session 35ad67f343 created
2025-03-13T09:24:04Z [opencon] [i2p] -> STREAM CONNECT ID=35ad67f343 DESTINATION=...

After:

2025-03-13T17:08:58Z [opencon] [i2p:info] Transient SAM session 16098cd4ea created
2025-03-13T17:09:34Z [opencon] [i2p] -> STREAM CONNECT ID=16098cd4ea DESTINATION=...

2025-03-13T17:09:38Z [opencon] [i2p:info] Transient SAM session 5d209bf1bc created
2025-03-13T17:09:59Z [opencon] [i2p] -> STREAM CONNECT ID=5d209bf1bc DESTINATION=...

2025-03-13T17:09:50Z [opencon] [i2p:info] Transient SAM session e78aa6d2e7 created
2025-03-13T17:12:09Z [opencon] [i2p] -> STREAM CONNECT ID=e78aa6d2e7 DESTINATION=...

---

This was suggested by @eyedeekay some time ago (in 2023 actually) and has been lingering in my TODO since then :eyes:. A further suggestion is to also add a time gap between the activity cease and the closing of the session. For this, when `CNode` is destroyed `CNode::m_i2p_sam_session` would have to be moved elsewhere and destroyed at a later time. cc @zzzi2p