### PR TITLE
build: use make < 3.82 syntax for define directive

### DIFF
--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -6,7 +6,7 @@ $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_patches=abi_placement_new.patch
 
-define $(package)_set_vars :=
+define $(package)_set_vars
   $(package)_config_opts := -DBUILD_TESTING=OFF
   $(package)_config_opts += -DWITH_OPENSSL=OFF
   $(package)_config_opts += -DWITH_ZLIB=OFF

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -8,7 +8,7 @@ ifneq ($(host),$(build))
 $(package)_dependencies += native_capnp
 endif
 
-define $(package)_set_vars :=
+define $(package)_set_vars
 ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
 $(package)_config_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"


### PR DESCRIPTION
From the GNU make 3.82 [release announcement](https://lists.gnu.org/archive/html/info-gnu/2010-07/msg00023.html) (2010):

> The 'define' make directive now allows a variable assignment operator
  after the variable name, to allow for simple, conditional, or appending
  multi-line variable assignment.

macOS ships with 3.81 (2006). This caused the multiprocess config options to be ignored.

Fixes #32068

