### PR TITLE
build: Drop option to disable hardening.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,6 @@ if(WITH_BDB)
 endif()
 cmake_dependent_option(BUILD_WALLET_TOOL "Build bitcoin-wallet tool." ${BUILD_TESTS} "ENABLE_WALLET" OFF)
 
-option(ENABLE_HARDENING "Attempt to harden the resulting executables." ON)
 option(REDUCE_EXPORTS "Attempt to reduce exported symbols in the resulting executables." OFF)
 option(WERROR "Treat compiler warnings as errors." OFF)
 option(WITH_CCACHE "Attempt to use ccache for compiling." ON)
@@ -481,74 +480,72 @@ try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
 # -fstack-reuse=none for all gcc builds. (Only gcc understands this flag).
 try_append_cxx_flags("-fstack-reuse=none" TARGET core_interface)
 
-if(ENABLE_HARDENING)
-  add_library(hardening_interface INTERFACE)
-  target_link_libraries(core_interface INTERFACE hardening_interface)
-  if(MSVC)
-    try_append_linker_flag("/DYNAMICBASE" TARGET hardening_interface)
-    try_append_linker_flag("/HIGHENTROPYVA" TARGET hardening_interface)
-    try_append_linker_flag("/NXCOMPAT" TARGET hardening_interface)
-  else()
+add_library(hardening_interface INTERFACE)
+target_link_libraries(core_interface INTERFACE hardening_interface)
+if(MSVC)
+  try_append_linker_flag("/DYNAMICBASE" TARGET hardening_interface)
+  try_append_linker_flag("/HIGHENTROPYVA" TARGET hardening_interface)
+  try_append_linker_flag("/NXCOMPAT" TARGET hardening_interface)
+else()
 
-    # _FORTIFY_SOURCE requires that there is some level of optimization,
-    # otherwise it does nothing and just creates a compiler warning.
-    try_append_cxx_flags("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
-      RESULT_VAR cxx_supports_fortify_source
-      SOURCE "int main() {
-              # if !defined __OPTIMIZE__ || __OPTIMIZE__ <= 0
-                #error
-              #endif
-              }"
+  # _FORTIFY_SOURCE requires that there is some level of optimization,
+  # otherwise it does nothing and just creates a compiler warning.
+  try_append_cxx_flags("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
+    RESULT_VAR cxx_supports_fortify_source
+    SOURCE "int main() {
+            # if !defined __OPTIMIZE__ || __OPTIMIZE__ <= 0
+              #error
+            #endif
+            }"
+  )
+  if(cxx_supports_fortify_source)
+    target_compile_options(hardening_interface INTERFACE
+      -U_FORTIFY_SOURCE
+      -D_FORTIFY_SOURCE=3
     )
-    if(cxx_supports_fortify_source)
-      target_compile_options(hardening_interface INTERFACE
-        -U_FORTIFY_SOURCE
-        -D_FORTIFY_SOURCE=3
-      )
-    endif()
-    unset(cxx_supports_fortify_source)
+  endif()
+  unset(cxx_supports_fortify_source)
 
-    try_append_cxx_flags("-Wstack-protector" TARGET hardening_interface SKIP_LINK)
-    try_append_cxx_flags("-fstack-protector-all" TARGET hardening_interface)
-    try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
+  try_append_cxx_flags("-Wstack-protector" TARGET hardening_interface SKIP_LINK)
+  try_append_cxx_flags("-fstack-protector-all" TARGET hardening_interface)
+  try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
 
-    if(MINGW)
-      # stack-clash-protection is a no-op for Windows.
-      # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
-    else()
-      try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)
-    endif()
+  if(MINGW)
+    # stack-clash-protection is a no-op for Windows.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
+  else()
+    try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)
+  endif()
 
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-      if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        try_append_cxx_flags("-mbranch-protection=bti" TARGET hardening_interface SKIP_LINK)
-      else()
-        try_append_cxx_flags("-mbranch-protection=standard" TARGET hardening_interface SKIP_LINK)
-      endif()
-    endif()
-
-    try_append_linker_flag("-Wl,--enable-reloc-section" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--dynamicbase" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--nxcompat" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
-    # TODO: This can be dropped once Bitcoin Core no longer supports
-    #       NetBSD 10.0 or if upstream fix is backported.
-    # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
-    # `PT_LOAD` segments and binaries linked with `-z separate-code`
-    # have 4 `PT_LOAD` segments.
-    # Relevant discussions:
-    # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
-    # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
-    if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
-      try_append_linker_flag("-Wl,-z,noseparate-code" TARGET hardening_interface)
-    else()
-      try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
-    endif()
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-      try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
+      try_append_cxx_flags("-mbranch-protection=bti" TARGET hardening_interface SKIP_LINK)
+    else()
+      try_append_cxx_flags("-mbranch-protection=standard" TARGET hardening_interface SKIP_LINK)
     endif()
+  endif()
+
+  try_append_linker_flag("-Wl,--enable-reloc-section" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,--dynamicbase" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,--nxcompat" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
+  # TODO: This can be dropped once Bitcoin Core no longer supports
+  #       NetBSD 10.0 or if upstream fix is backported.
+  # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
+  # `PT_LOAD` segments and binaries linked with `-z separate-code`
+  # have 4 `PT_LOAD` segments.
+  # Relevant discussions:
+  # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
+  # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
+  if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
+    try_append_linker_flag("-Wl,-z,noseparate-code" TARGET hardening_interface)
+  else()
+    try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
   endif()
 endif()
 
@@ -684,7 +681,6 @@ message("Cross compiling ....................... ${cross_status}")
 message("C++ compiler .......................... ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}, ${CMAKE_CXX_COMPILER}")
 include(FlagsSummary)
 flags_summary()
-message("Attempt to harden executables ......... ${ENABLE_HARDENING}")
 message("Treat compiler warnings as errors ..... ${WERROR}")
 message("Use ccache for compiling .............. ${WITH_CCACHE}")
 message("\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,12 +480,10 @@ try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
 # -fstack-reuse=none for all gcc builds. (Only gcc understands this flag).
 try_append_cxx_flags("-fstack-reuse=none" TARGET core_interface)
 
-add_library(hardening_interface INTERFACE)
-target_link_libraries(core_interface INTERFACE hardening_interface)
 if(MSVC)
-  try_append_linker_flag("/DYNAMICBASE" TARGET hardening_interface)
-  try_append_linker_flag("/HIGHENTROPYVA" TARGET hardening_interface)
-  try_append_linker_flag("/NXCOMPAT" TARGET hardening_interface)
+  try_append_linker_flag("/DYNAMICBASE" TARGET core_interface)
+  try_append_linker_flag("/HIGHENTROPYVA" TARGET core_interface)
+  try_append_linker_flag("/NXCOMPAT" TARGET core_interface)
 else()
 
   # _FORTIFY_SOURCE requires that there is some level of optimization,
@@ -499,38 +497,38 @@ else()
             }"
   )
   if(cxx_supports_fortify_source)
-    target_compile_options(hardening_interface INTERFACE
+    target_compile_options(core_interface INTERFACE
       -U_FORTIFY_SOURCE
       -D_FORTIFY_SOURCE=3
     )
   endif()
   unset(cxx_supports_fortify_source)
 
-  try_append_cxx_flags("-Wstack-protector" TARGET hardening_interface SKIP_LINK)
-  try_append_cxx_flags("-fstack-protector-all" TARGET hardening_interface)
-  try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
+  try_append_cxx_flags("-Wstack-protector" TARGET core_interface SKIP_LINK)
+  try_append_cxx_flags("-fstack-protector-all" TARGET core_interface)
+  try_append_cxx_flags("-fcf-protection=full" TARGET core_interface)
 
   if(MINGW)
     # stack-clash-protection is a no-op for Windows.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
   else()
-    try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)
+    try_append_cxx_flags("-fstack-clash-protection" TARGET core_interface)
   endif()
 
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-      try_append_cxx_flags("-mbranch-protection=bti" TARGET hardening_interface SKIP_LINK)
+      try_append_cxx_flags("-mbranch-protection=bti" TARGET core_interface SKIP_LINK)
     else()
-      try_append_cxx_flags("-mbranch-protection=standard" TARGET hardening_interface SKIP_LINK)
+      try_append_cxx_flags("-mbranch-protection=standard" TARGET core_interface SKIP_LINK)
     endif()
   endif()
 
-  try_append_linker_flag("-Wl,--enable-reloc-section" TARGET hardening_interface)
-  try_append_linker_flag("-Wl,--dynamicbase" TARGET hardening_interface)
-  try_append_linker_flag("-Wl,--nxcompat" TARGET hardening_interface)
-  try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
-  try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
-  try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
+  try_append_linker_flag("-Wl,--enable-reloc-section" TARGET core_interface)
+  try_append_linker_flag("-Wl,--dynamicbase" TARGET core_interface)
+  try_append_linker_flag("-Wl,--nxcompat" TARGET core_interface)
+  try_append_linker_flag("-Wl,--high-entropy-va" TARGET core_interface)
+  try_append_linker_flag("-Wl,-z,relro" TARGET core_interface)
+  try_append_linker_flag("-Wl,-z,now" TARGET core_interface)
   # TODO: This can be dropped once Bitcoin Core no longer supports
   #       NetBSD 10.0 or if upstream fix is backported.
   # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
@@ -540,12 +538,12 @@ else()
   # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
   # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
   if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
-    try_append_linker_flag("-Wl,-z,noseparate-code" TARGET hardening_interface)
+    try_append_linker_flag("-Wl,-z,noseparate-code" TARGET core_interface)
   else()
-    try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
+    try_append_linker_flag("-Wl,-z,separate-code" TARGET core_interface)
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
+    try_append_linker_flag("-Wl,-fixup_chains" TARGET core_interface)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,7 +533,19 @@ if(ENABLE_HARDENING)
     try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
     try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
     try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
+    # TODO: This can be dropped once Bitcoin Core no longer supports
+    #       NetBSD 10.0 or if upstream fix is backported.
+    # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
+    # `PT_LOAD` segments and binaries linked with `-z separate-code`
+    # have 4 `PT_LOAD` segments.
+    # Relevant discussions:
+    # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
+    # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
+    if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
+      try_append_linker_flag("-Wl,-z,noseparate-code" TARGET hardening_interface)
+    else()
+      try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
+    endif()
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
       try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
     endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,7 +77,6 @@
         "BUILD_UTIL_CHAINSTATE": "ON",
         "BUILD_WALLET_TOOL": "ON",
         "ENABLE_EXTERNAL_SIGNER": "ON",
-        "ENABLE_HARDENING": "ON",
         "ENABLE_WALLET": "ON",
         "WARN_INCOMPATIBLE_BDB": "OFF",
         "WITH_BDB": "ON",


### PR DESCRIPTION
Follow up to #32038 which dropped `NO_HARDEN` from depends builds, this PR drops the `ENABLE_HARDENING` build option since disabling hardening of binaries should not be a supported or maintained use case. With this change, hardening flags are always enabled.

Individual hardening flags and options can still be disabled by appending flags, e.g.:

```bash
cmake -B build \
  -DAPPEND_CPPFLAGS='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -fno-stack-protector -fcf-protection=none -fno-stack-clash-protection' \
  -DAPPEND_LDFLAGS='-Wl,-z,lazy -Wl,-z,norelro -Wl,-z,noseparate-code'
```

There is an issue with NetBSD 10.0's dynamic linker that makes one of the hardening linker flags, `-z separate-code`, [problematic](https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934), so this PR also introduces a check to prevent the use of this flag in NetBSD versions < 11.0, (where this issue is [fixed](https://github.com/NetBSD/src/commit/acf7fb3abf88f29f6b15c894b6b18cadc12763c0)). The fix for this [might be backported](https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013670.html) to NetBSD 10.0.

I suggest reviewing the diff with whitespace changes hidden (`git diff -w` or using github's hide whitespace option)