### PR TITLE
net: Block v2->v1 transport downgrade if !fNetworkActive

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1910,7 +1910,8 @@ void CConnman::DisconnectNodes()
     {
         LOCK(m_nodes_mutex);
 
-        if (!fNetworkActive) {
+        const bool network_active{fNetworkActive};
+        if (!network_active) {
             // Disconnect any connected nodes
             for (CNode* pnode : m_nodes) {
                 if (!pnode->fDisconnect) {
@@ -1932,7 +1933,7 @@ void CConnman::DisconnectNodes()
                 // Add to reconnection list if appropriate. We don't reconnect right here, because
                 // the creation of a connection is a blocking operation (up to several seconds),
                 // and we don't want to hold up the socket handler thread for that long.
-                if (pnode->m_transport->ShouldReconnectV1()) {
+                if (network_active && pnode->m_transport->ShouldReconnectV1()) {
                     reconnections_to_add.push_back({
                         .addr_connect = pnode->addr,
                         .grant = std::move(pnode->grantOutbound),


### PR DESCRIPTION
We might have just set `CNode::fDisconnect` in the first loop because of `!CConnman::fNetworkActive`.

Attempting to reconnect using v1 transport just because `fNetworkActive` was set to `false` at the "right" stage in the v2 handshake does not make sense.

Issue [discovered](https://github.com/bitcoin/bitcoin/pull/31633#discussion_r1930908304) by davidgumberg.