### PR TITLE
style: Fix spacing in script.h for OP_TRUE definition

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -81,7 +81,7 @@ enum opcodetype
     OP_1NEGATE = 0x4f,
     OP_RESERVED = 0x50,
     OP_1 = 0x51,
-    OP_TRUE=OP_1,
+    OP_TRUE = OP_1,
     OP_2 = 0x52,
     OP_3 = 0x53,
     OP_4 = 0x54,


### PR DESCRIPTION
This pull request fixes a spacing issue in `script.h` where the definition for `OP_TRUE` was formatted without a space before the assignment operator. The only modification is changing:

```diff
-    OP_TRUE=OP_1,
+    OP_TRUE = OP_1,
```

This update improves the code's readability and adheres to the project's style guidelines without affecting functionality.