### PR TITLE
doc: shallow clone `qa-assets`

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -89,7 +89,7 @@ The project's collection of seed corpora is found in the [`bitcoin-core/qa-asset
 To fuzz `process_message` using the [`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) seed corpus:
 
 ```sh
-$ git clone https://github.com/bitcoin-core/qa-assets
+$ git clone --depth=1 https://github.com/bitcoin-core/qa-assets
 $ FUZZ=process_message build_fuzz/bin/fuzz qa-assets/fuzz_corpora/process_message/
 INFO: Seed: 1346407872
 INFO: Loaded 1 modules   (424174 inline 8-bit counters): 424174 [0x55d8a9004ab8, 0x55d8a906c3a6),


### PR DESCRIPTION
While reviewing https://github.com/bitcoin/bitcoin/pull/31457#pullrequestreview-2690077410 I noticed that cloning `qa-assets` takes a lot of time - shallow cloning should suffice here.

I haven't checked the other clones in this file but suggestion are welcome.