### PR TITLE
Shuffle depends instructions and recommend modern make for macOS

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -18,6 +18,17 @@ To build dependencies for the current arch+OS:
 
     make
 
+### macOS
+
+Install Xcode Command Line Tools and Homebrew Package Manager,
+see [build-osx.md](../doc/build-osx.md).
+
+    brew install cmake make ninja
+
+To build dependencies for the current arch+OS:
+
+    gmake
+
 ### FreeBSD
 
     pkg install bash

--- a/depends/README.md
+++ b/depends/README.md
@@ -35,7 +35,7 @@ To build dependencies for the current arch+OS:
 
 To build dependencies for the current arch+OS:
 
-    make
+    gmake
 
 ### NetBSD
 

--- a/depends/README.md
+++ b/depends/README.md
@@ -1,8 +1,88 @@
-### Usage
+# Depends build
+
+This is a system of building and caching dependencies necessary for building
+Bitcoin Core. It supports cross-compilation. For more details see [description.md](description.md),
+as well as [packages.md](packages.md) for how to add packages.
+
+## Usage
+
+### Ubuntu & Debian
+
+    apt install cmake curl make patch
+
+Skip the following packages if you don't intend to use the GUI and will build with [`NO_QT=1`](#dependency-options):
+
+    apt install bison g++ ninja-build pkgconf python3 xz-utils
 
 To build dependencies for the current arch+OS:
 
     make
+
+### FreeBSD
+
+    pkg install bash
+
+To build dependencies for the current arch+OS:
+
+    make
+
+### NetBSD
+
+    pkgin install bash gmake
+
+To build dependencies for the current arch+OS:
+
+    gmake
+
+### OpenBSD
+
+    pkg_add bash gmake gtar
+
+To build dependencies for the current arch+OS:
+
+    gmake
+
+## Configuring Bitcoin Core
+
+**When configuring Bitcoin Core, CMake by default will ignore the depends output.** In
+order for it to pick up libraries, tools, and settings from the depends build,
+you must specify the toolchain file.
+In the above example for Ubuntu, a file named `depends/x86_64-pc-linux-gnu/toolchain.cmake` will be
+created. To use it during configuring Bitcoin Core:
+
+    cmake -B build --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake
+
+## Dependency Options
+
+The following can be set when running make: `make FOO=bar`
+
+- `SOURCES_PATH`: Downloaded sources will be placed here
+- `BASE_CACHE`: Built packages will be placed here
+- `SDK_PATH`: Path where SDKs can be found (used by macOS)
+- `FALLBACK_DOWNLOAD_PATH`: If a source file can't be fetched, try here before giving up
+- `C_STANDARD`: Set the C standard version used. Defaults to `c11`.
+- `CXX_STANDARD`: Set the C++ standard version used. Defaults to `c++20`.
+- `NO_BOOST`: Don't download/build/cache Boost
+- `NO_LIBEVENT`: Don't download/build/cache Libevent
+- `NO_QT`: Don't download/build/cache Qt and its dependencies
+- `NO_QR`: Don't download/build/cache packages needed for enabling qrencode
+- `NO_ZMQ`: Don't download/build/cache packages needed for enabling ZeroMQ
+- `NO_WALLET`: Don't download/build/cache libs needed to enable the wallet (SQLite)
+- `NO_BDB`: Don't download/build/cache BerkeleyDB
+- `NO_USDT`: Don't download/build/cache packages needed for enabling USDT tracepoints
+- `MULTIPROCESS`: Build libmultiprocess (experimental)
+- `DEBUG`: Disable some optimizations and enable more runtime checking
+- `HOST_ID_SALT`: Optional salt to use when generating host package ids
+- `BUILD_ID_SALT`: Optional salt to use when generating build package ids
+- `LOG`: Use file-based logging for individual packages. During a package build its log file
+  resides in the `depends` directory, and the log file is printed out automatically in case
+  of build error. After successful build log files are moved along with package archives
+- `LTO`: Enable options needed for LTO. Does not add `-flto` related options to *FLAGS.
+
+If some packages are not built, for example `make NO_WALLET=1`, the appropriate CMake cache
+variables will be set when generating the Bitcoin Core buildsystem. In this case, `-DENABLE_WALLET=OFF`.
+
+## Cross compilation
 
 To build for another arch/OS:
 
@@ -11,14 +91,6 @@ To build for another arch/OS:
 For example:
 
     make HOST=x86_64-w64-mingw32 -j4
-
-**When configuring Bitcoin Core, CMake by default will ignore the depends output.** In
-order for it to pick up libraries, tools, and settings from the depends build,
-you must specify the toolchain file.
-In the above example, a file named `depends/x86_64-w64-mingw32/toolchain.cmake` will be
-created. To use it during configuring Bitcoin Core:
-
-    cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
 
 Common `host-platform-triplet`s for cross compilation are:
 
@@ -36,18 +108,6 @@ Common `host-platform-triplet`s for cross compilation are:
 - `s390x-linux-gnu` for Linux S390X
 
 The paths are automatically configured and no other options are needed.
-
-### Install the required dependencies: Ubuntu & Debian
-
-#### Common
-
-    apt install cmake curl make patch
-
-#### GUI
-
-Skip the following packages if you don't intend to use the GUI and will build with [`NO_QT=1`](#dependency-options):
-
-    apt install bison g++ ninja-build pkgconf python3 xz-utils
 
 #### For macOS cross compilation
 
@@ -88,57 +148,9 @@ For linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 
-### Install the required dependencies: FreeBSD
-
-    pkg install bash
-
-### Install the required dependencies: NetBSD
-
-    pkgin install bash gmake
-
-### Install the required dependencies: OpenBSD
-
-    pkg_add bash gmake gtar
-
-### Dependency Options
-
-The following can be set when running make: `make FOO=bar`
-
-- `SOURCES_PATH`: Downloaded sources will be placed here
-- `BASE_CACHE`: Built packages will be placed here
-- `SDK_PATH`: Path where SDKs can be found (used by macOS)
-- `FALLBACK_DOWNLOAD_PATH`: If a source file can't be fetched, try here before giving up
-- `C_STANDARD`: Set the C standard version used. Defaults to `c11`.
-- `CXX_STANDARD`: Set the C++ standard version used. Defaults to `c++20`.
-- `NO_BOOST`: Don't download/build/cache Boost
-- `NO_LIBEVENT`: Don't download/build/cache Libevent
-- `NO_QT`: Don't download/build/cache Qt and its dependencies
-- `NO_QR`: Don't download/build/cache packages needed for enabling qrencode
-- `NO_ZMQ`: Don't download/build/cache packages needed for enabling ZeroMQ
-- `NO_WALLET`: Don't download/build/cache libs needed to enable the wallet (SQLite)
-- `NO_BDB`: Don't download/build/cache BerkeleyDB
-- `NO_USDT`: Don't download/build/cache packages needed for enabling USDT tracepoints
-- `MULTIPROCESS`: Build libmultiprocess (experimental)
-- `DEBUG`: Disable some optimizations and enable more runtime checking
-- `HOST_ID_SALT`: Optional salt to use when generating host package ids
-- `BUILD_ID_SALT`: Optional salt to use when generating build package ids
-- `LOG`: Use file-based logging for individual packages. During a package build its log file
-  resides in the `depends` directory, and the log file is printed out automatically in case
-  of build error. After successful build log files are moved along with package archives
-- `LTO`: Enable options needed for LTO. Does not add `-flto` related options to *FLAGS.
-
-If some packages are not built, for example `make NO_WALLET=1`, the appropriate CMake cache
-variables will be set when generating the Bitcoin Core buildsystem. In this case, `-DENABLE_WALLET=OFF`.
-
 ### Additional targets
 
     download: run 'make download' to fetch all sources without building them
     download-osx: run 'make download-osx' to fetch all sources needed for macOS builds
     download-win: run 'make download-win' to fetch all sources needed for win builds
     download-linux: run 'make download-linux' to fetch all sources needed for linux builds
-
-
-### Other documentation
-
-- [description.md](description.md): General description of the depends system
-- [packages.md](packages.md): Steps for adding packages


### PR DESCRIPTION
macOS ships with GNU Make 3.81 from 2006. This has caused
difficult to debug issues, e.g. #32070 and #30978.

Tell users / developers who use the depends system to install a modern version of `make`.

This PR does not change the non-depends build.

Although Homebrew allows overriding the system `make`, we instead just instruct users to build with `gmake`. This way there should be no impact on other projects they wish to compile.

To increase the likeliness of anyone actually seeing and following this instruction, the first commit moves things around in `depends/README.md`. It now starts with instructions for a local build and moves cross-compilation to the end. For each platform it shows what to install (`apt install`, `brew install`, etc) and what command to run (`make` or `gmake`).

There previously was no macOS specific section, so this is added. It points to the general `build-osx.md` for how to install the Xcode Command Line Tools and Homebrew Package Manager.

I didn't test on an empty system.

Preview: https://github.com/Sjors/bitcoin/tree/2025/03/mc-make/depends#depends-build