### PR TITLE
test: switch wallet_crosschain.py to signet and drop testnet4

### DIFF
--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -11,7 +11,7 @@ class WalletCrossChain(BitcoinTestFramework):
         self.add_wallet_options(parser)
 
     def set_test_params(self):
-        self.num_nodes = 3
+        self.num_nodes = 2
         self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):
@@ -24,12 +24,6 @@ class WalletCrossChain(BitcoinTestFramework):
         self.nodes[1].chain = 'testnet3'
         self.nodes[1].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet sync
         self.nodes[1].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
-
-        # Switch node 2 to testnet4 before starting it.
-        self.nodes[2].chain = 'testnet4'
-        self.nodes[2].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet4 sync
-        self.nodes[2].replace_in_config([('regtest=', 'testnet4='), ('[regtest]', '[testnet4]')])
-
         self.start_nodes()
 
     def run_test(self):
@@ -45,40 +39,19 @@ class WalletCrossChain(BitcoinTestFramework):
         self.nodes[1].createwallet(node1_wallet)
         self.nodes[1].backupwallet(node1_wallet_backup)
         self.nodes[1].unloadwallet(node1_wallet)
-        node2_wallet = self.nodes[2].datadir_path / 'node2_wallet'
-        node2_wallet_backup = self.nodes[0].datadir_path / 'node2_wallet.bak'
-        self.nodes[2].createwallet(node2_wallet)
-        self.nodes[2].backupwallet(node2_wallet_backup)
-        self.nodes[2].unloadwallet(node2_wallet)
 
         self.log.info("Loading/restoring wallets into nodes with a different genesis block")
 
         if self.options.descriptors:
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].loadwallet, node1_wallet)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].loadwallet, node2_wallet)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].loadwallet, node0_wallet)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].loadwallet, node0_wallet)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].loadwallet, node2_wallet)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].loadwallet, node1_wallet)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].restorewallet, 'w', node1_wallet_backup)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].restorewallet, 'w', node2_wallet_backup)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].restorewallet, 'w', node0_wallet_backup)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].restorewallet, 'w', node0_wallet_backup)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].restorewallet, 'w', node2_wallet_backup)
-            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].restorewallet, 'w', node1_wallet_backup)
         else:
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].loadwallet, node1_wallet)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].loadwallet, node2_wallet)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].loadwallet, node0_wallet)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].loadwallet, node0_wallet)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].loadwallet, node2_wallet)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].loadwallet, node1_wallet)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].restorewallet, 'w', node1_wallet_backup)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].restorewallet, 'w', node2_wallet_backup)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].restorewallet, 'w', node0_wallet_backup)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].restorewallet, 'w', node0_wallet_backup)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].restorewallet, 'w', node2_wallet_backup)
-            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].restorewallet, 'w', node1_wallet_backup)
 
         if not self.options.descriptors:
             self.log.info("Override cross-chain wallet load protection")

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -20,10 +20,11 @@ class WalletCrossChain(BitcoinTestFramework):
     def setup_network(self):
         self.add_nodes(self.num_nodes)
 
-        # Switch node 1 to testnet before starting it.
-        self.nodes[1].chain = 'testnet3'
-        self.nodes[1].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet sync
-        self.nodes[1].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
+        # Switch node 1 to any network different from regtest before starting it.
+        self.nodes[1].chain = 'signet'
+        # Disable network sync and prevent disk space warning on low resource CI
+        self.nodes[1].extra_args = ['-maxconnections=0', '-prune=550']
+        self.nodes[1].replace_in_config([('regtest=', 'signet='), ('[regtest]', '[signet]')])
         self.start_nodes()
 
     def run_test(self):


### PR DESCRIPTION
It's sufficient to check only one test network, so this PR reverts the addition of testnet4 from #29775.

Testnet3 is deprecated. Instead of moving to testnet4, which might also be deprecated in the future, use signet.