### PR TITLE
test: Fix intermittent issue in p2p_orphan_handling.py

### DIFF
--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -789,6 +789,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
         # Disconnect peer1. peer2 should become the new candidate for orphan resolution.
         peer1.peer_disconnect()
         self.wait_until(lambda: node.num_test_p2p_connections() == 1)
+        peer2.sync_with_ping()  # Sync with the 'net' thread which completes the disconnection fully
         node.bumpmocktime(TXREQUEST_TIME_SKIP)
         self.wait_until(lambda: len(node.getorphantxs(verbosity=2)[0]["from"]) == 1)
         # Both parents should be requested, now that they are both missing.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -827,7 +827,8 @@ class TestNode():
 
     def disconnect_p2ps(self):
         """Close all p2p connections to the node.
-        Use only after each p2p has sent a version message to ensure the wait works."""
+        The state of the peers (such as txrequests) may not be fully cleared
+        yet, even after this method returns."""
         for p in self.p2ps:
             p.peer_disconnect()
         del self.p2ps[:]


### PR DESCRIPTION
The test may fail intermittently when the `net` thread is lagging while calling `DeleteNode`. This may result in a split `getdata`, meaning that `peer2.wait_for_parent_requests([int(parent_peekaboo_AB["txid"], 16), int(parent_missing["txid"], 16)])` fails.

Fix it by adding a sync on the `net` thread.

Fixes #31700