### PR TITLE
Move some tests and documentation from testnet3 to testnet4

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -7,7 +7,7 @@
     ZMQ example using python3's asyncio
 
     Bitcoin should be started with the command line arguments:
-        bitcoind -testnet -daemon \
+        bitcoind -testnet4 -daemon \
                 -zmqpubrawtx=tcp://127.0.0.1:28332 \
                 -zmqpubrawblock=tcp://127.0.0.1:28332 \
                 -zmqpubhashtx=tcp://127.0.0.1:28332 \

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -410,7 +410,7 @@ to see it.
 ### Signet, testnet, and regtest modes
 
 If you are testing multi-machine code that needs to operate across the internet,
-you can run with either the `-signet` or the `-testnet` config option to test
+you can run with either the `-signet` or the `-testnet4` config option to test
 with "play bitcoins" on a test network.
 
 If you are testing something that can run on one machine, run with the

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -648,22 +648,17 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
     const auto regtest = std::make_pair("-regtest", ArgsManager::ALLOW_ANY);
     test_args.SetupArgs({testnet, testnet4, regtest});
 
-    const char* argv_testnet[] = {"cmd", "-testnet"};
     const char* argv_testnet4[] = {"cmd", "-testnet4"};
     const char* argv_regtest[] = {"cmd", "-regtest"};
-    const char* argv_test_no_reg[] = {"cmd", "-testnet", "-noregtest"};
-    const char* argv_both[] = {"cmd", "-testnet", "-regtest"};
+    const char* argv_test_no_reg[] = {"cmd", "-testnet4", "-noregtest"};
+    const char* argv_both[] = {"cmd", "-testnet4", "-regtest"};
 
-    // equivalent to "-testnet"
-    // regtest in testnet section is ignored
-    const char* testnetconf = "testnet=1\nregtest=0\n[test]\nregtest=1";
+    // regtest in test network section is ignored
+    const char* testnetconf = "testnet4=1\nregtest=0\n[testnet4]\nregtest=1";
     std::string error;
 
-    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet4, error));
     BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "main");
-
-    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet, error));
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
 
     BOOST_CHECK(test_args.ParseParameters(0, argv_testnet4, error));
     BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "main");
@@ -675,18 +670,18 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
     BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "regtest");
 
     BOOST_CHECK(test_args.ParseParameters(3, argv_test_no_reg, error));
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(3, argv_both, error));
     BOOST_CHECK_THROW(test_args.GetChainTypeString(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet4, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
-    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet4, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(2, argv_regtest, error));
     test_args.ReadConfigString(testnetconf);
@@ -694,23 +689,23 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 
     BOOST_CHECK(test_args.ParseParameters(3, argv_test_no_reg, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(3, argv_both, error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainTypeString(), std::runtime_error);
 
-    // check setting the network to test (and thus making
-    // [test] regtest=1 potentially relevant) doesn't break things
-    test_args.SelectConfigNetwork("test");
+    // check setting the network to testnet4 (and thus making
+    // [testnet4] regtest=1 potentially relevant) doesn't break things
+    test_args.SelectConfigNetwork("testnet4");
 
-    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet4, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
-    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet4, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(2, argv_regtest, error));
     test_args.ReadConfigString(testnetconf);
@@ -718,7 +713,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 
     BOOST_CHECK(test_args.ParseParameters(2, argv_test_no_reg, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(3, argv_both, error));
     test_args.ReadConfigString(testnetconf);
@@ -739,7 +734,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 //
 // - Combining SoftSet and ForceSet calls.
 //
-// - Testing "main" and "test" network values to make sure settings from network
+// - Testing "main" and "testnet4" network values to make sure settings from network
 //   sections are applied and to check for mainnet-specific behaviors like
 //   inheriting settings from the default section.
 //
@@ -956,11 +951,11 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
         TestArgsManager parser;
         LOCK(parser.cs_args);
         parser.AddArg("-regtest", "regtest", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-        parser.AddArg("-testnet", "testnet", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        parser.AddArg("-testnet4", "testnet4", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
-        auto arg = [](Action action) { return action == ENABLE_TEST  ? "-testnet=1"   :
-                                              action == DISABLE_TEST ? "-testnet=0"   :
-                                              action == NEGATE_TEST  ? "-notestnet=1" :
+        auto arg = [](Action action) { return action == ENABLE_TEST  ? "-testnet4=1"   :
+                                              action == DISABLE_TEST ? "-testnet4=0"   :
+                                              action == NEGATE_TEST  ? "-notestnet4=1" :
                                               action == ENABLE_REG   ? "-regtest=1"   :
                                               action == DISABLE_REG  ? "-regtest=0"   :
                                               action == NEGATE_REG   ? "-noregtest=1" : nullptr; };
@@ -1024,7 +1019,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "9e60306e1363528bbc19a47f22bcede88e5d6815212f18ec8e6cdc4638dddab4");
+    BOOST_CHECK_EQUAL(out_sha_hex, "c0e33aab0c74e040ddcee9edad59e8148d8e1cacb3cccd9ea1a1f485cb6bad21");
 }
 
 BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -19,7 +19,7 @@
         "mzK2FFDEhxqHcmrJw1ysqFkVyhUULo45hZ",
         "76a914ce28b26c57472737f5c3561a1761185bd8589a4388ac",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],
@@ -27,7 +27,7 @@
         "2NC2hEhe28ULKAJkW5MjZ3jtTMJdvXmByvK",
         "a914ce0bba75891ff9ec60148d4bd4a09ee2dc5c933187",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],
@@ -85,7 +85,7 @@
         "92ZdE5HoLafywnTBbzPxbvRmp75pSfzvdU3XaZGh1cToipgdHVh",
         "80c32d81e91bdea04cd7a3819b32275fc3298af4c7ec87eb0099527d041ced5c",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -94,7 +94,7 @@
         "cV83kKisF3RQSvXbUCm9ox3kaz5JjEUBWcx8tNydfGJcyeUxuH47",
         "e0fcd4ce4e3d0e3de091f21415bb7cd011fac288c42020a879f28c2a4387df9b",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -175,7 +175,7 @@
         "tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54",
         "0014c0ef1202759fff90ff19128936814321ee59e111",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -184,7 +184,7 @@
         "tb1quyl9ujpgwr2chdzdnnalen48sup245vdfnh2jxhsuq3yx80rrwlq5hqfe4",
         "0020e13e5e482870d58bb44d9cfbfccea78702aad18d4ceea91af0e022431de31bbe",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -193,7 +193,7 @@
         "tb1p35n52jy6xkm4wd905tdy8qtagrn73kqdz73xe4zxpvq9t3fp50aqk3s6gz",
         "51208d2745489a35b75734afa2da43817d40e7e8d80d17a26cd4460b0055c521a3fa",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -202,7 +202,7 @@
         "tb1rgv5m6uvdk3kc7qsuz0c79v88ycr5w4wa",
         "53104329bd718db46d8f021c13f1e2b0e726",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -299,7 +299,7 @@
         "n4YNbYuFdPwFrxSP8sjHFbAhUbLMUiY9jE",
         "76a914fc8f9851f3c1e4719cd0b8e4816dd4e88c72e52888ac",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],
@@ -307,7 +307,7 @@
         "2NAeQVZayzVFAtgeC3iYJsjpjWDmsDph71A",
         "a914bedc797342c03fd7a346c4c7857ca03d467013b687",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],
@@ -365,7 +365,7 @@
         "921M1RNxghFcsVGqAJksQVbSgx36Yz4u6vebfz1wDujNvgNt93B",
         "3777b341c45e2a9b9bf6bfb71dc7d129f64f1b9406ed4f93ade8f56065f1b732",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -374,7 +374,7 @@
         "cNEnbfF2fcxmmCLWqMAaq6fxJvVkwMbyU3kCbpQznz4Z1j6TZDGb",
         "1397b0d4a03e1ab2c54dd9af99ce1ecbfb90c80a58886da95e1181a55703d96b",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -455,7 +455,7 @@
         "tb1ql4k5ayv7p7w0t0ge7tpntgpkgw53g2payxkszr",
         "0014fd6d4e919e0f9cf5bd19f2c335a03643a914283d",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -464,7 +464,7 @@
         "tb1q9jx3x2qqdpempxrcfgyrkjd5fzeacaqj4ua7cs7fe2sfd2wdaueq5wn26y",
         "00202c8d1328006873b098784a083b49b448b3dc7412af3bec43c9caa096a9cdef32",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -473,7 +473,7 @@
         "tb1pdswckwd9ym5yf5eyzg8j4jjwnzla8y0tf9cp7aasfkek0u29sz9qfr00yf",
         "51206c1d8b39a526e844d324120f2aca4e98bfd391eb49701f77b04db367f145808a",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -482,7 +482,7 @@
         "tb1r0ecpfxg2udhtc556gqrpwwhk4sw3f0kc",
         "53107e7014990ae36ebc529a4006173af6ac",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -579,7 +579,7 @@
         "mwgS2HRbjyfYxFnR1nF9VKLvmdgMfFBmGq",
         "76a914b14ce7070b53cb0e4b5b5f6e253e876990aeca2e88ac",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],
@@ -587,7 +587,7 @@
         "2MwBVrJQ76BdaGD76CTmou8cZzQYLpe4NqU",
         "a9142b2c149cde619eae3d7fe995243b76a3417541aa87",
         {
-            "chain": "test",
+            "chain": "testnet4",
             "isPrivkey": false
         }
     ],

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -23,10 +23,11 @@ from test_framework.compressor import (
 from test_framework.messages import (
     CBlockHeader,
     from_hex,
-    msg_headers,
-    tx_from_hex,
-    ser_varint,
+    MAGIC_BYTES,
     MAX_MONEY,
+    msg_headers,
+    ser_varint,
+    tx_from_hex,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -102,15 +103,15 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.log.info("  - snapshot file with mismatching network magic")
         invalid_magics = [
             # magic, name, real
-            [0xf9beb4d9, "main", True],
-            [0x0b110907, "test", True],
-            [0x0a03cf40, "signet", True],
-            [0x00000000, "", False],
-            [0xffffffff, "", False],
+            [MAGIC_BYTES["mainnet"], "main", True],
+            [MAGIC_BYTES["testnet4"], "testnet4", True],
+            [MAGIC_BYTES["signet"], "signet", True],
+            [0x00000000.to_bytes(4, 'big'), "", False],
+            [0xffffffff.to_bytes(4, 'big'), "", False],
         ]
         for [magic, name, real] in invalid_magics:
             with open(bad_snapshot_path, 'wb') as f:
-                f.write(valid_snapshot_contents[:7] + magic.to_bytes(4, 'big') + valid_snapshot_contents[11:])
+                f.write(valid_snapshot_contents[:7] + magic + valid_snapshot_contents[11:])
             if real:
                 assert_raises_rpc_error(parsing_error_code, f"Unable to parse metadata: The network of the snapshot ({name}) does not match the network of this node (regtest).", node.loadtxoutset, bad_snapshot_path)
             else:

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -80,6 +80,7 @@ DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 MAGIC_BYTES = {
     "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
     "testnet3": b"\x0b\x11\x09\x07",  # testnet3
+    "testnet4": b"\x1c\x16\x3f\x28",  # testnet4
     "regtest": b"\xfa\xbf\xb5\xda",   # regtest
     "signet": b"\x0a\x03\xcf\x40",    # signet
 }

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -78,11 +78,10 @@ MAX_OP_RETURN_RELAY = 83
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
 MAGIC_BYTES = {
-    "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
-    "testnet3": b"\x0b\x11\x09\x07",  # testnet3
-    "testnet4": b"\x1c\x16\x3f\x28",  # testnet4
-    "regtest": b"\xfa\xbf\xb5\xda",   # regtest
-    "signet": b"\x0a\x03\xcf\x40",    # signet
+    "mainnet": b"\xf9\xbe\xb4\xd9",
+    "testnet4": b"\x1c\x16\x3f\x28",
+    "regtest": b"\xfa\xbf\xb5\xda",
+    "signet": b"\x0a\x03\xcf\x40",
 }
 
 def sha256(s):


### PR DESCRIPTION
In preparation for dropping testnet3 entirely in #31974 this PR migrates a few things to testnet4:

* the ZMQ examples
* developer docs
* various unit tests
* the snapshot magic byte check in `feature_assumeutxo.py`

It drops `testnet3` from `MAGIC_BYTES` in the test framework, since no test uses it.