### PR TITLE
ci: run test-each-commit on merge to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,13 @@ jobs:
         run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.FETCH_DEPTH }}
       - name: Determine commit range
         run: |
-          # Checkout HEAD~ and find the test base commit
-          # Checkout HEAD~ because it would be wasteful to rerun tests on the PR
+          # Checkout HEAD~~ and find the test base commit
+          # Checkout HEAD~~ because it would be wasteful to rerun tests on the PR
           # head commit that are already run by other jobs.
-          git checkout HEAD~
+          git checkout HEAD~~
           # Figure out test base commit by listing ancestors of HEAD, excluding
           # ancestors of the most recent merge commit, limiting the list to the
           # newest MAX_COUNT ancestors, ordering it from oldest to newest, and


### PR DESCRIPTION
Previously this CI job was checking out the head ref, which meant it is **not** being run on the result of merging into master.

Use the default checkout action `ref` (merge into default branch) to avoid this. Increment the checkout depth to HEAD~~ to compensate for the new merge commit.

This would have likely helped avoid both failures reported in #31946, and seems to me to be a more robust way of running this test job in any case.

(Probably) closes: #31946

cc @maflcko: Is there a historical reason I'm missing here why a merge-checkout was not chosen for this job in fafcd2e9ef1209d614de5763a2733098537919dd?