### PR TITLE
refactor: Enforces Txid and Wtxid types in RelayTransaction

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -106,7 +106,7 @@ public:
     virtual PeerManagerInfo GetInfo() const = 0;
 
     /** Relay transaction to all peers. */
-    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid) = 0;
+    virtual void RelayTransaction(const Txid& txid, const Wtxid& wtxid) = 0;
 
     /** Send ping message to all peers */
     virtual void SendPings() = 0;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -42,7 +42,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
 
     std::promise<void> promise;
     Txid txid = tx->GetHash();
-    uint256 wtxid = tx->GetWitnessHash();
+    Wtxid wtxid = tx->GetWitnessHash();
     bool callback_set = false;
 
     {


### PR DESCRIPTION
RelayTransaction expects to pass a TxId and Wtxid as arguments, but any uint256 type is really accepted. When calling RelayTransaction, most times we are already passing tx->GetHash() and  tx->GetWitnessHash() to it, and their value are downcasted.

Updates RelayTransaction and make sure we are consistent with its arguments