### PR TITLE
wallet: make coinbase that will mature on the next block available for selection

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3490,7 +3490,7 @@ int CWallet::GetTxBlocksToMaturity(const CWalletTx& wtx) const
     }
     int chain_depth = GetTxDepthInMainChain(wtx);
     assert(chain_depth >= 0); // coinbase tx should not be conflicted
-    return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
+    return std::max(0, COINBASE_MATURITY - chain_depth);
 }
 
 bool CWallet::IsTxImmatureCoinBase(const CWalletTx& wtx) const

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -20,11 +20,11 @@ from test_framework.util import (
 )
 import time
 
-# The block reward of coinbaseoutput.nValue (50) BTC/block matures after
-# COINBASE_MATURITY (100) blocks. Therefore, after mining 101 blocks we expect
-# node 0 to have a balance of (BLOCKS - COINBASE_MATURITY) * 50 BTC/block.
+# The block reward of coinbaseoutput.nValue (50) BTC/block becomes selectable
+# after COINBASE_MATURITY - 1 blocks. Therefore, after mining 101 blocks we expect
+# node 0 to have a balance of (BLOCKS - COINBASE_MATURITY - 1) * 50 BTC/block.
 BLOCKS = COINBASE_MATURITY + 1
-BALANCE = (BLOCKS - 100) * 50
+BALANCE = (BLOCKS - 99) * 50
 
 JSON_PARSING_ERROR = 'error: Error parsing JSON: foo'
 BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
@@ -222,7 +222,7 @@ class TestBitcoinCli(BitcoinTestFramework):
 
             # Setup to test -getinfo, -generate, and -rpcwallet= with multiple wallets.
             wallets = [self.default_wallet_name, 'Encrypted', 'secret']
-            amounts = [BALANCE + Decimal('9.999928'), Decimal(9), Decimal(31)]
+            amounts = [BALANCE + Decimal('9.99991240'), Decimal(9), Decimal(31)]
             self.nodes[0].createwallet(wallet_name=wallets[1])
             self.nodes[0].createwallet(wallet_name=wallets[2])
             w1 = self.nodes[0].get_wallet_rpc(wallets[0])

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -169,7 +169,7 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), 50)
         assert_equal(self.nodes[1].getbalance(), 50)
         assert_equal(self.nodes[2].getbalance(), 50)
-        assert_equal(self.nodes[3].getbalance(), 0)
+        assert_equal(self.nodes[3].getbalance(), 50)
 
         self.log.info("Creating transactions")
         # Five rounds of sending each other transactions.
@@ -199,8 +199,9 @@ class WalletBackupTest(BitcoinTestFramework):
         total = balance0 + balance1 + balance2 + balance3
 
         # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
-        # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
-        assert_equal(total, 5700)
+        # 114 are mature and one will become mature on the next block, so the sum of all
+        # wallets should be 114 * 50 + 50 = 5750.
+        assert_equal(total, 5750)
 
         ##
         # Test restoring spender wallets from backups

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -84,12 +84,12 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[0].listunspent(query_options={'include_immature_coinbase': True})), 1)
         assert_equal(len(self.nodes[0].listunspent(query_options={'include_immature_coinbase': False})), 0)
 
-        self.generatetoaddress(self.nodes[1], COINBASE_MATURITY + 1, ADDRESS_WATCHONLY)
+        self.generatetoaddress(self.nodes[1], COINBASE_MATURITY, ADDRESS_WATCHONLY)
 
         # Verify listunspent returns all immature coinbases if 'include_immature_coinbase' is set
         # For now, only the legacy wallet will see the coinbases going to the imported 'ADDRESS_WATCHONLY'
         assert_equal(len(self.nodes[0].listunspent(query_options={'include_immature_coinbase': False})), 1 if self.options.descriptors else 2)
-        assert_equal(len(self.nodes[0].listunspent(query_options={'include_immature_coinbase': True})), 1 if self.options.descriptors else COINBASE_MATURITY + 2)
+        assert_equal(len(self.nodes[0].listunspent(query_options={'include_immature_coinbase': True})), 1 if self.options.descriptors else COINBASE_MATURITY + 1)
 
         if not self.options.descriptors:
             # Tests legacy watchonly behavior which is not present (and does not need to be tested) in descriptor wallets
@@ -97,7 +97,7 @@ class WalletTest(BitcoinTestFramework):
             assert_equal(self.nodes[0].getwalletinfo()['balance'], 50)
             assert_equal(self.nodes[1].getbalances()['mine']['trusted'], 50)
 
-            assert_equal(self.nodes[0].getbalances()['watchonly']['immature'], 5000)
+            assert_equal(self.nodes[0].getbalances()['watchonly']['immature'], 4950)
             assert 'watchonly' not in self.nodes[1].getbalances()
 
             assert_equal(self.nodes[0].getbalance(), 50)
@@ -174,7 +174,7 @@ class WalletTest(BitcoinTestFramework):
             expected_balances_0 = {'mine':      {'immature':          Decimal('0E-8'),
                                                  'trusted':           Decimal('9.99'),  # change from node 0's send
                                                  'untrusted_pending': Decimal('60.0')},
-                                   'watchonly': {'immature':          Decimal('5000'),
+                                   'watchonly': {'immature':          Decimal('4950'),
                                                  'trusted':           Decimal('50.0'),
                                                  'untrusted_pending': Decimal('0E-8')}}
             expected_balances_1 = {'mine':      {'immature':          Decimal('0E-8'),

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -80,13 +80,13 @@ class WalletTest(BitcoinTestFramework):
         self.generate(self.nodes[1], COINBASE_MATURITY + 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
         assert_equal(self.nodes[0].getbalance(), 50)
-        assert_equal(self.nodes[1].getbalance(), 50)
+        assert_equal(self.nodes[1].getbalance(), 100)
         assert_equal(self.nodes[2].getbalance(), 0)
 
         # Check that only first and second nodes have UTXOs
         utxos = self.nodes[0].listunspent()
         assert_equal(len(utxos), 1)
-        assert_equal(len(self.nodes[1].listunspent()), 1)
+        assert_equal(len(self.nodes[1].listunspent()), 2)
         assert_equal(len(self.nodes[2].listunspent()), 0)
 
         self.log.info("Test gettxout")

--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -44,20 +44,20 @@ class CoinbaseCategoryTest(BitcoinTestFramework):
         # Coinbase transaction is immature after 1 confirmation
         self.assert_category("immature", address, txid, 0)
 
-        # Mine another 99 blocks on top
-        self.generate(self.nodes[0], 99)
-        # Coinbase transaction is still immature after 100 confirmations
-        self.assert_category("immature", address, txid, 99)
+        # Mine another 98 blocks on top
+        self.generate(self.nodes[0], 98)
+        # Coinbase transaction is still immature after 99 confirmations
+        self.assert_category("immature", address, txid, 98)
 
         # Mine one more block
         self.generate(self.nodes[0], 1)
-        # Coinbase transaction is now matured, so category is "generate"
-        self.assert_category("generate", address, txid, 100)
+        # Coinbase transaction is now immature (but available for selection), so category is "generate"
+        self.assert_category("generate", address, txid, 99)
 
         # Orphan block that paid to address
         self.nodes[0].invalidateblock(hash)
         # Coinbase transaction is now orphaned
-        self.assert_category("orphan", address, txid, 100)
+        self.assert_category("orphan", address, txid, 99)
 
 if __name__ == '__main__':
     CoinbaseCategoryTest(__file__).main()

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -78,7 +78,7 @@ class WalletLabelsTest(BitcoinTestFramework):
         # Note each time we call generate, all generated coins go into
         # the same address, so we call twice to get two addresses w/50 each
         self.generatetoaddress(node, nblocks=1, address=node.getnewaddress(label='coinbase'))
-        self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=node.getnewaddress(label='coinbase'))
+        self.generatetoaddress(node, nblocks=COINBASE_MATURITY, address=node.getnewaddress(label='coinbase'))
         assert_equal(node.getbalance(), 100)
 
         # there should be 2 address groups

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -232,7 +232,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-19, "Multiple wallets are loaded. Please select which wallet", node.getwalletinfo)
 
         w1, w2, w3, w4, *_ = wallets
-        self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=w1.getnewaddress(), sync_fun=self.no_op)
+        self.generatetoaddress(node, nblocks=COINBASE_MATURITY, address=w1.getnewaddress(), sync_fun=self.no_op)
         assert_equal(w1.getbalance(), 100)
         assert_equal(w2.getbalance(), 0)
         assert_equal(w3.getbalance(), 0)

--- a/test/functional/wallet_simulaterawtx.py
+++ b/test/functional/wallet_simulaterawtx.py
@@ -40,7 +40,7 @@ class SimulateTxTest(BitcoinTestFramework):
         w1 = node.get_wallet_rpc('w1')
         w2 = node.get_wallet_rpc('w2')
 
-        self.generatetoaddress(node, COINBASE_MATURITY + 1, w0.getnewaddress())
+        self.generatetoaddress(node, COINBASE_MATURITY, w0.getnewaddress())
         assert_equal(w0.getbalance(), 50.0)
         assert_equal(w1.getbalance(), 0.0)
 

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -47,10 +47,14 @@ class TxnMallTest(BitcoinTestFramework):
         else:
             output_type = "legacy"
 
-        # All nodes should start with 1,250 BTC:
+        # Node 0 starts with 1,300 BTC and the rest with 1,250 BTC
         starting_balance = 1250
+        starting_balance_node_0 = starting_balance + 50
         for i in range(3):
-            assert_equal(self.nodes[i].getbalance(), starting_balance)
+            if i == 0:
+                assert_equal(self.nodes[i].getbalance(), starting_balance_node_0)
+            else:
+                assert_equal(self.nodes[i].getbalance(), starting_balance)
 
         self.nodes[0].settxfee(.001)
 
@@ -64,7 +68,7 @@ class TxnMallTest(BitcoinTestFramework):
         node0_tx2 = self.nodes[0].gettransaction(node0_utxo2['txid'])
 
         assert_equal(self.nodes[0].getbalance(),
-                     starting_balance + node0_tx1["fee"] + node0_tx2["fee"])
+                     starting_balance_node_0 + node0_tx1["fee"] + node0_tx2["fee"])
 
         # Coins are sent to node1_address
         node1_address = self.nodes[1].getnewaddress()
@@ -100,7 +104,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Node0's balance should be starting balance, plus 50BTC for another
         # matured block, minus tx1 and tx2 amounts, and minus transaction fees:
-        expected = starting_balance + node0_tx1["fee"] + node0_tx2["fee"]
+        expected = starting_balance_node_0 + node0_tx1["fee"] + node0_tx2["fee"]
         if self.options.mine_block:
             expected += 50
         expected += tx1["amount"] + tx1["fee"]

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -184,12 +184,14 @@ class UpgradeWalletTest(BitcoinTestFramework):
 
         self.restart_node(0)
         copy_v16()
+        # this is necessary because the coin selection excluded coinbase outputs that would mature on the next block
+        coinbase_amt = 50
         wallet = node_master.get_wallet_rpc(self.default_wallet_name)
-        assert_equal(wallet.getbalance(), v16_3_balance)
+        assert_equal(wallet.getbalance() - coinbase_amt, v16_3_balance)
         self.log.info("Test upgradewallet without a version argument")
         self.test_upgradewallet(wallet, previous_version=159900, expected_version=169900)
         # wallet should still contain the same balance
-        assert_equal(wallet.getbalance(), v16_3_balance)
+        assert_equal(wallet.getbalance() - coinbase_amt, v16_3_balance)
 
         copy_non_hd()
         wallet = node_master.get_wallet_rpc(self.default_wallet_name)


### PR DESCRIPTION
Closes #32098.

Currently, only coinbase UTXOs that are mature at height **_h_** are available for coin selection. This PR makes UTXOs that mature at height **_h+1_** available for selection.

Since a transaction spending this output will be accepted by the mempool, it should be available for selection.

BDK implements this logic<sup>[1]</sup>, which I believe to be the correct one.


```diff
$ bitcoin-cli -regtest createwallet wallet
{
  "name": "wallet"
}

$ export ADDRESS=$(bitcoin-cli -regtest -rpcwallet=wallet getnewaddress)

$ bitcoin-cli -regtest generatetoaddress 101 $ADDRESS
[
  "467fd440d0ed89d0cad64fa64d0320968b33a32c681b6c3f5a5ed1d1c016f45a",
  "1b2246eaa35689710acc5d1bb2923197993233fb9186f0bd561cb546c7667ca7",
  ...
  "5d5ee44ada395ab1d978a77596ed3893be750840229e7234a85a01984057798a",
  "7f8a573a6824edc5342cf86e5e7c0a6ea5664305ef21808456fc98b2621b41cf"
]

$ bitcoin-cli -regtest -rpcwallet=wallet getbalance
- 50.00000000
+ 100.00000000
```

[1]: https://github.com/bitcoindevkit/bdk/issues/1878
