### PR TITLE
build: Remove bitness suffix from Windows installer

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -1,4 +1,4 @@
-Name "@CLIENT_NAME@ (64-bit)"
+Name "@CLIENT_NAME@"
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma


### PR DESCRIPTION
Since support for 32-bit Windows has been dropped, the suffix is no longer necessary.