### PR TITLE
RFC: Accept non-std transactions in Testnet4 by default again

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -630,7 +630,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
 
     SetupChainParamsBaseOptions(argsman);
 
-    argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (test networks only; default: %u)", DEFAULT_ACCEPT_NON_STD_TXN), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (test networks only; default: %u, testnet4: %u)", DEFAULT_ACCEPT_NON_STD_TXN, false), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kvB) used to define cost of relay, used for mempool limiting and replacement policy. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kvB) used to define dust, the value of an output such that it will cost more than its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-acceptstalefeeestimates", strprintf("Read fee estimates even if they are stale (%sdefault: %u) fee estimates are considered stale if they are %s hours old", "regtest only; ", DEFAULT_ACCEPT_STALE_FEE_ESTIMATES, Ticks<std::chrono::hours>(MAX_FILE_AGE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -87,8 +87,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
         mempool_opts.max_datacarrier_bytes = std::nullopt;
     }
 
-    mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", DEFAULT_ACCEPT_NON_STD_TXN);
-    if (!chainparams.IsTestChain() && !mempool_opts.require_standard) {
+    mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", chainparams.GetChainType() == ChainType::TESTNET4 ? true : DEFAULT_ACCEPT_NON_STD_TXN); if (!chainparams.IsTestChain() && !mempool_opts.require_standard) {
         return util::Error{Untranslated(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.GetChainTypeString()))};
     }
 


### PR DESCRIPTION
Feel free to ignore the code, just looking for conceptual discussion for now.

It used to be the case that we would accept non-std transactions by default in Testnet3 but this was changed in #28354 because RSK had shot themselves in the foot because of this (see #26348). In discussions on Testnet4 [this came up again as a potential feature](https://github.com/bitcoin/bitcoin/pull/29775#issuecomment-2041139129) but the idea to revert this was rejected then because the 20-min exception rule could be used as a way to get non-std transactions in the chain instead. We now know that the attention the 20-min got from the discussions in that PR and elsewhere has led to an exploitation of the rule that has basically made it unusable. While the frequent re-orgs are interesting to some as a robustness test, the ability to get non-std transactions in the chain does not seem to be there anymore. Recently [darosior has suggested on the ML to remove the 20-min exception rule because of this development](https://groups.google.com/g/bitcoindev/c/iVLHJ1HWhoU/m/ydjeTH6rAwAJ). If we go through with this, the question is why we are not also moving back on this setting, too, so that people can use non-std transactions on Testnet4. The only alternative left would be that they have to go to a different network or get their transaction to a testnet4 miner out of band.

The frequent argument I hear/read is that Testnet should behave like Mainnet but the reality is that we don't want it to behave like mainnet in all the ways because that would mean we can't really do all the testing we want. For example, we have introduced the timewarp attack protection as well on Testnet4. We also have kept the `-acceptnonstdtxn` setting around which but it is available on Mainnet. If we really wanted Testnet to always behave like mainnet we should have removed the setting too. Next time RSK could just have a connection to a miner who has set it to true and then they don't detect the error and shoot themselves in the foot yet again.

And we do have `testmempoolaccept`. This is the part that I really don't understand. By taking the stance of "Testnet should behave like Mainnet" people will rely on it even more but I don't think it's true that testing on testnet gives people 100% security their stuff will work on mainnet and people should not solely rely on that. The stance should be: If you want to make sure your tx propagates on mainnet then use `testmempoolaccept` on a mainnet node. There is no alternative to that, don't rely only on testnet behavior when it's very important for you.