### PR TITLE
descriptors: Multipath/PR 22838 follow-ups

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -288,11 +288,11 @@ For example, a descriptor of the form:
 
     multi(2,xpub.../<0;1;2>/0/*,xpub.../<2;3;4>/*)
 
-will expand to the two descriptors
+will expand to the 3 descriptors
 
-   multi(2,xpub.../0/0/*,xpub.../2/*)
-   multi(2,xpub.../1/0/*,xpub.../3/*)
-   multi(2,xpub.../2/0/*,xpub.../4*)
+    multi(2,xpub.../0/0/*,xpub.../2/*)
+    multi(2,xpub.../1/0/*,xpub.../3/*)
+    multi(2,xpub.../2/0/*,xpub.../4/*)
 
 When this tuple contains only two elements, wallet implementations can use the
 first descriptor for receiving addresses and the second descriptor for change addresses.

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1447,7 +1447,7 @@ std::optional<uint32_t> ParseKeyPathNum(std::span<const char> elem, bool& apostr
     for (size_t i = 1; i < split.size(); ++i) {
         const std::span<const char>& elem = split[i];
 
-        // Check if element contain multipath specifier
+        // Check if element contains multipath specifier
         if (!elem.empty() && elem.front() == '<' && elem.back() == '>') {
             if (!allow_multipath) {
                 error = strprintf("Key path value '%s' specifies multipath in a section where multipath is not allowed", std::string(elem.begin(), elem.end()));


### PR DESCRIPTION
Follows up on unresolved suggestions from #22838. In order of priority:

1. Fixes a couple of typos [^1][^2] and indentation to conform to Markdown.
2. Solves `for`-loop nit [^3] and also limits variable scope.
3. Clarifies data relationships [^4][^5] by introducing `struct` rather than comments.

[^1]: https://github.com/bitcoin/bitcoin/pull/22838#discussion_r1713711352
[^2]: https://github.com/bitcoin/bitcoin/pull/22838#discussion_r1735039600
[^3]: https://github.com/bitcoin/bitcoin/pull/22838#discussion_r1735041704
[^4]: https://github.com/bitcoin/bitcoin/pull/22838#discussion_r1715150336
[^5]: https://github.com/bitcoin/bitcoin/pull/22838#discussion_r1715151078