### PR TITLE
test: remove strict restrictions on rpc_deprecated test

### DIFF
--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -15,10 +15,6 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.extra_args = [[]]
 
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         # This test should be used to verify the errors of the currently
         # deprecated RPC methods (without the -deprecatedrpc flag) until
@@ -31,8 +27,14 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # at least one other functional test that still tests the RPCs
         # functionality using the respective -deprecatedrpc flag.
 
-        self.log.info("Test settxfee RPC")
-        assert_raises_rpc_error(-32, 'settxfee is deprecated and will be fully removed in v31.0.', self.nodes[0].rpc.settxfee, 0.01)
+        # Please don't delete nor modify this comment
+        self.log.info("Tests for deprecated RPC methods (if any)")
+
+        if self.is_wallet_compiled():
+            self.log.info("Tests for deprecated wallet-related RPC methods (if any)")
+            self.log.info("Test settxfee RPC deprecation")
+            self.nodes[0].createwallet("settxfeerpc")
+            assert_raises_rpc_error(-32, 'settxfee is deprecated and will be fully removed in v31.0.', self.nodes[0].rpc.settxfee, 0.01)
 
 if __name__ == '__main__':
     DeprecatedRpcTest(__file__).main()


### PR DESCRIPTION
Removed the wallet restrictions for `rpc_deprecated.py` and added specific test case for the current deprecated rpc. 
`skip_test_if_missing_module` will skip the whole test when the wallet is missing, even if a part of the test is non-wallet related. This PR ensures that other tests not related to wallet can be ran and only this specific test will be skipped if there's no wallet 

For more context check https://github.com/bitcoin/bitcoin/pull/31278#discussion_r2011661090