### PR TITLE
fuzz: extract unsequenced operations with side-effects

### DIFF
--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -92,5 +92,6 @@ FUZZ_TARGET(psbt_base64_decode)
 
     PartiallySignedTransaction psbt;
     std::string error;
-    assert(DecodeBase64PSBT(psbt, random_string, error) == error.empty());
+    const bool ok{DecodeBase64PSBT(psbt, random_string, error)};
+    assert(ok == error.empty());
 }


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/30746#discussion_r1817851827 introduced unsequenced operations with side-effects - which is undefined behavior, i.e. the right hand side can be evaluated before the left hand side, which happens to mutate it.

<details>
<summary>Tried to find other occurrences</summary>

```bash
clang++ --analyze -std=c++20 -I./src -I./src/test -I./src/test/fuzz src/test/fuzz/base_encode_decode.cpp src/psbt.cpp
```
but it didn't warn about UB.

Grepped for similar ones, but could find any other one in the codebase:
```bash
> grep -rnE --include='*.cpp' --include='*.h' '\b(\w+)\(([^)]*\b(\w+)\b[^)]*)\)\s*==\s*\3\.' .

./src/test/arith_uint256_tests.cpp:373:    BOOST_CHECK(R1L.GetHex() == R1L.ToString());
./src/test/arith_uint256_tests.cpp:374:    BOOST_CHECK(R2L.GetHex() == R2L.ToString());
./src/test/arith_uint256_tests.cpp:375:    BOOST_CHECK(OneL.GetHex() == OneL.ToString());
./src/test/arith_uint256_tests.cpp:376:    BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
./src/test/fuzz/cluster_linearize.cpp:565:        assert(depgraph.FeeRate(best_anc.transactions) == best_anc.feerate);
./src/test/fuzz/cluster_linearize.cpp:646:        assert(depgraph.FeeRate(found.transactions) == found.feerate);
./src/test/fuzz/cluster_linearize.cpp:765:            assert(depgraph.FeeRate(chunk_info.transactions) == chunk_info.feerate);
./src/test/fuzz/base_encode_decode.cpp:95:    assert(DecodeBase64PSBT(psbt, random_string, error) == error.empty());
./src/test/fuzz/key.cpp:102:        assert(pubkey.data() == pubkey.begin());
./src/test/skiplist_tests.cpp:42:        BOOST_CHECK(vIndex[from].GetAncestor(0) == vIndex.data());
./src/script/signingprovider.cpp:535:                   ComputeTapbranchHash(node.sub[1]->hash, node.sub[1]->hash) == node.hash) {
./src/pubkey.h:78:      return vch.size() > 0 && GetLen(vch[0]) == vch.size();
./src/cluster_linearize.h:881:            Assume(elem.inc.feerate.IsEmpty() == elem.pot_feerate.IsEmpty());
```

</details>

Hodlinator deduced the UB on Windows in https://github.com/bitcoin/bitcoin/issues/32135#issuecomment-2751723855

Fixes #32135