### PR TITLE
lint: Remove needless borrow to fix Clippy warning

### DIFF
--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -250,7 +250,7 @@ fn lint_scripted_diff() -> LintResult {
 
 fn lint_commit_msg() -> LintResult {
     let mut good = true;
-    let commit_hashes = check_output(git().args(&[
+    let commit_hashes = check_output(git().args([
         "-c",
         "log.showSignature=false",
         "log",


### PR DESCRIPTION

Pull Request Description

**Summary**
Removes a needless borrow in `test/lint/test_runner/src/main.rs` that triggered a
Clippy warning (`needless_borrows_for_generic_args`). This minor refactoring
makes the code cleaner without changing functionality.

**Rationale**
- Eliminates a Clippy warning when running:
  ```bash
  cargo clippy --manifest-path test/lint/test_runner/Cargo.toml -- -D warnings
