### PR TITLE
test: fix intermittent timeout in p2p_ibd_stalling.py

### DIFF
--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -78,7 +78,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         for id in range(NUM_PEERS):
             peers.append(node.add_outbound_p2p_connection(P2PStaller(stall_block), p2p_idx=id, connection_type="outbound-full-relay"))
             peers[-1].block_store = block_dict
-            peers[-1].send_without_ping(headers_message)
+            peers[-1].send_and_ping(headers_message)
 
         # Need to wait until 1023 blocks are received - the magic total bytes number is a workaround in lack of an rpc
         # returning the number of downloaded (but not connected) blocks.


### PR DESCRIPTION
After sending the headers message add a sync, so that we wait until the header message from the previous peer has been received before connecting additional peers. 
In the failed NetBSD run linked in #32090, the second node managed to complete the handshake and send its own headers message before the message from the first node was received.

Fixes #32090
