### PR TITLE
wallet, migration: Fix empty wallet crash

### DIFF
--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -47,11 +47,14 @@ BOOST_AUTO_TEST_CASE(walletdb_read_write_deadlock)
         // Create legacy spkm
         LOCK(wallet->cs_wallet);
         auto legacy_spkm = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        BOOST_CHECK(!HasLegacyRecords(*wallet));
         BOOST_CHECK(legacy_spkm->SetupGeneration(true));
+        BOOST_CHECK(HasLegacyRecords(*wallet));
         wallet->Flush();
 
         // Now delete all records, which performs a read write operation.
         BOOST_CHECK(wallet->GetLegacyScriptPubKeyMan()->DeleteRecords());
+        BOOST_CHECK(!HasLegacyRecords(*wallet));
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4534,13 +4534,13 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
         // First change to using SQLite
         if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};
 
-        // Do the migration of keys and scripts for non-blank wallets, and cleanup if it fails
-        success = local_wallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET);
-        if (!success) {
+        // Do the migration of keys and scripts for non-empty wallets, and cleanup if it fails
+        if (HasLegacyRecords(*local_wallet)) {
             success = DoMigration(*local_wallet, context, error, res);
         } else {
             // Make sure that descriptors flag is actually set
             local_wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+            success = true;
         }
     }
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -333,6 +333,10 @@ bool LoadKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, std::stri
 bool LoadCryptedKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, std::string& strErr);
 bool LoadEncryptionKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, std::string& strErr);
 bool LoadHDChain(CWallet* pwallet, DataStream& ssValue, std::string& strErr);
+
+//! Returns true if there are any DBKeys::LEGACY_TYPES record in the wallet db
+bool HasLegacyRecords(CWallet& wallet);
+bool HasLegacyRecords(CWallet& wallet, DatabaseBatch& batch);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETDB_H

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -445,6 +445,15 @@ class WalletMigrationTest(BitcoinTestFramework):
         # After migrating, the "keypool" is empty
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", watchonly1.getnewaddress)
 
+        self.log.info("Test migration of a watch-only empty wallet")
+        for idx, is_blank in enumerate([True, False], start=1):
+            wallet_name = f"watchonly_empty{idx}"
+            self.create_legacy_wallet(wallet_name, disable_private_keys=True, blank=is_blank)
+            _, watchonly_empty = self.migrate_and_get_rpc(wallet_name)
+            info = watchonly_empty.getwalletinfo()
+            assert_equal(info["private_keys_enabled"], False)
+            assert_equal(info["blank"], is_blank)
+
     def test_pk_coinbases(self):
         self.log.info("Test migration of a wallet using old pk() coinbases")
         wallet = self.create_legacy_wallet("pkcb")


### PR DESCRIPTION
Same as with a blank wallet (#28976), wallets with no legacy records (i.e. empty, non-blank, watch-only wallet) do not require to be migrated.

Steps to reproduce the issue:

1.- `createwallet "empty_wo_noblank_legacy_wallet" true false "" false false`
2.- `migratewallet`

```
wallet/wallet.cpp:4071 GetDescriptorsForLegacy: Assertion `legacy_spkm' failed.
Aborted (core dumped)
```