### PR TITLE
fuzz: Make partially_downloaded_block more deterministic

### DIFF
--- a/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
@@ -108,6 +108,11 @@ fn deterministic_coverage(
     par: usize,
 ) -> AppResult {
     let using_libfuzzer = using_libfuzzer(fuzz_exe)?;
+    if using_libfuzzer {
+        println!("Warning: The fuzz executable was compiled with libFuzzer as sanitizer.");
+        println!("This tool may be tripped by libFuzzer misbehavior.");
+        println!("It is recommended to compile without libFuzzer.");
+    }
     let corpus_dir = corpora_dir.join(fuzz_target);
     let mut entries = read_dir(&corpus_dir)
         .map_err(|err| {

--- a/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-fuzz-coverage/src/main.rs
@@ -161,6 +161,8 @@ fn deterministic_coverage(
                 "--show-line-counts-or-regions",
                 "--show-branches=count",
                 "--show-expansions",
+                "--show-instantiation-summary",
+                "-Xdemangler=llvm-cxxfilt",
                 &format!("--instr-profile={}", profdata_file.display()),
             ])
             .arg(fuzz_exe)

--- a/contrib/devtools/deterministic-unittest-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-unittest-coverage/src/main.rs
@@ -104,6 +104,8 @@ fn deterministic_coverage(build_dir: &Path, test_exe: &Path, filter: &str) -> Ap
                 "--show-line-counts-or-regions",
                 "--show-branches=count",
                 "--show-expansions",
+                "--show-instantiation-summary",
+                "-Xdemangler=llvm-cxxfilt",
                 &format!("--instr-profile={}", profdata_file.display()),
             ])
             .arg(test_exe)

--- a/contrib/devtools/deterministic-unittest-coverage/src/main.rs
+++ b/contrib/devtools/deterministic-unittest-coverage/src/main.rs
@@ -71,7 +71,7 @@ fn app() -> AppResult {
 fn deterministic_coverage(build_dir: &Path, test_exe: &Path, filter: &str) -> AppResult {
     let profraw_file = build_dir.join("test_det_cov.profraw");
     let profdata_file = build_dir.join("test_det_cov.profdata");
-    let run_single = |run_id: u8| -> Result<PathBuf, AppError> {
+    let run_single = |run_id: char| -> Result<PathBuf, AppError> {
         println!("Run with id {run_id}");
         let cov_txt_path = build_dir.join(format!("test_det_cov.show.{run_id}.txt"));
         if !Command::new(test_exe)
@@ -131,10 +131,10 @@ fn deterministic_coverage(build_dir: &Path, test_exe: &Path, filter: &str) -> Ap
         }
         Ok(())
     };
-    let r0 = run_single(0)?;
-    let r1 = run_single(1)?;
+    let r0 = run_single('a')?;
+    let r1 = run_single('b')?;
     check_diff(&r0, &r1)?;
-    println!("The coverage was deterministic across two runs.");
+    println!("✨ The coverage was deterministic across two runs. ✨");
     Ok(())
 }
 
@@ -142,7 +142,7 @@ fn main() -> ExitCode {
     match app() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("⚠️\n{}", err);
             ExitCode::FAILURE
         }
     }


### PR DESCRIPTION
This should make the `partially_downloaded_block` fuzz target even more deterministic.

Follow-up to https://github.com/bitcoin/bitcoin/pull/31841. Tracking issue: https://github.com/bitcoin/bitcoin/issues/29018.

This bundles several changes:

* First, speed up the `deterministic-fuzz-coverage` helper by introducing parallelism.
* Then, a fix to remove spawned test threads or spawn them deterministically. (While testing this, high parallelism and thread contention may be needed)

### Testing

It can be tested via (setting 32 parallel threads):

```
cargo run --manifest-path ./contrib/devtools/deterministic-fuzz-coverage/Cargo.toml -- $PWD/bld-cmake/ $PWD/../b-c-qa-assets/fuzz_corpora/ partially_downloaded_block 32
```

Locally, on a failure, the output would look like:

```diff
 ....
-  150|      0|            m_worker_threads.emplace_back([this, n]() {
-  151|      0|                util::ThreadRename(strprintf("scriptch.%i", n));
+  150|      1|            m_worker_threads.emplace_back([this, n]() {
+  151|      1|                util::ThreadRename(strprintf("scriptch.%i", n));
 ...
```

This excerpt likely indicates that the script threads were started after the fuzz init function returned.

Similarly, for the scheduler thread, it would look like:

```diff
 ...
   227|      0|        m_node.scheduler = std::make_unique<CScheduler>();
-  228|      1|        m_node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
+  228|      0|        m_node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
   229|      0|        m_node.validation_signals =
 ...
```