### PR TITLE
depends: Switch from multilib to platform-specific toolchains

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -6,12 +6,13 @@
 
 export LC_ALL=C.UTF-8
 
-export HOST=i686-pc-linux-gnu
+export HOST=i686-linux-gnu
+export DPKG_ADD_ARCH="i386"
 export CONTAINER_NAME=ci_i686_no_multiprocess
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CI_IMAGE_PLATFORM="linux/amd64"
 export CI_CONTAINER_CAP="--security-opt seccomp=unconfined"
-export PACKAGES="g++-multilib"
+export PACKAGES="g++-i686-linux-gnu binutils-i686-linux-gnu libstdc++6:i386 libatomic1:i386"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1

--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -35,19 +35,13 @@ export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_G
 
 check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
 
-# Build the depends tree, overriding variables that assume multilib gcc
+# Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \
                                    ${build_CC+build_CC="$build_CC"} \
                                    ${build_CXX+build_CXX="$build_CXX"} \
-                                   x86_64_linux_CC=x86_64-linux-gnu-gcc \
-                                   x86_64_linux_CXX=x86_64-linux-gnu-g++ \
-                                   x86_64_linux_AR=x86_64-linux-gnu-gcc-ar \
-                                   x86_64_linux_RANLIB=x86_64-linux-gnu-gcc-ranlib \
-                                   x86_64_linux_NM=x86_64-linux-gnu-gcc-nm \
-                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip \
                                    NO_QT=1
 
 # CFLAGS

--- a/contrib/guix/libexec/build_linux_gui.sh
+++ b/contrib/guix/libexec/build_linux_gui.sh
@@ -35,19 +35,13 @@ export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_G
 
 check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
 
-# Build the depends tree, overriding variables that assume multilib gcc
+# Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \
                                    ${build_CC+build_CC="$build_CC"} \
-                                   ${build_CXX+build_CXX="$build_CXX"} \
-                                   x86_64_linux_CC=x86_64-linux-gnu-gcc \
-                                   x86_64_linux_CXX=x86_64-linux-gnu-g++ \
-                                   x86_64_linux_AR=x86_64-linux-gnu-gcc-ar \
-                                   x86_64_linux_RANLIB=x86_64-linux-gnu-gcc-ranlib \
-                                   x86_64_linux_NM=x86_64-linux-gnu-gcc-nm \
-                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip
+                                   ${build_CXX+build_CXX="$build_CXX"}
 
 # CFLAGS
 HOST_CFLAGS="-O2 -g"

--- a/depends/README.md
+++ b/depends/README.md
@@ -125,7 +125,7 @@ without gcc/g++), you could use the following to build all packages using clang:
 
 ## Cross compilation
 
-To build for another arch/OS:
+To build for another arch+OS:
 
     make HOST=host-platform-triplet
 
@@ -135,18 +135,18 @@ For example:
 
 Common `host-platform-triplet`s for cross compilation are:
 
-- `i686-pc-linux-gnu` for Linux x86 32 bit
-- `x86_64-pc-linux-gnu` for Linux x86 64 bit
+- `i686-linux-gnu` for Linux x86 32-bit
+- `x86_64-linux-gnu` for Linux x86 64-bit
 - `x86_64-w64-mingw32` for Windows using MSVCRT
 - `x86_64-w64-mingw32ucrt` for Windows using UCRT
 - `x86_64-apple-darwin` for Intel macOS
 - `arm64-apple-darwin` for ARM macOS
-- `arm-linux-gnueabihf` for Linux ARM 32 bit
-- `aarch64-linux-gnu` for Linux ARM 64 bit
-- `powerpc64-linux-gnu` for Linux POWER 64 bit (big endian)
-- `powerpc64le-linux-gnu` for Linux POWER 64 bit (little endian)
-- `riscv32-linux-gnu` for Linux RISC-V 32 bit
-- `riscv64-linux-gnu` for Linux RISC-V 64 bit
+- `arm-linux-gnueabihf` for Linux ARM 32-bit
+- `aarch64-linux-gnu` for Linux ARM 64-bit
+- `powerpc64-linux-gnu` for Linux POWER 64-bit (big endian)
+- `powerpc64le-linux-gnu` for Linux POWER 64-bit (little endian)
+- `riscv32-linux-gnu` for Linux RISC-V 32-bit
+- `riscv64-linux-gnu` for Linux RISC-V 64-bit
 - `s390x-linux-gnu` for Linux S390X
 
 The paths are automatically configured and no other options are needed.
@@ -168,29 +168,35 @@ For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-ex
 
     apt install g++-mingw-w64-ucrt64
 
-#### For linux (including i386, ARM) cross compilation
+#### For Linux cross compilation
 
-Common linux dependencies:
+Please note that package availability might depend on the arch+OS you are building on.
 
-    sudo apt-get install g++-multilib binutils
+For Linux x86 32-bit cross compilation:
 
-For linux ARM cross compilation:
+    sudo apt-get install g++-i686-linux-gnu binutils-i686-linux-gnu
+
+For Linux x86 64-bit cross compilation:
+
+    sudo apt-get install g++-x86-64-linux-gnu binutils-x86-64-linux-gnu
+
+For Linux ARM 32-bit cross compilation:
 
     sudo apt-get install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 
-For linux AARCH64 cross compilation:
+For Linux ARM 64-bit cross compilation:
 
     sudo apt-get install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
-For linux POWER 64-bit cross compilation (there are no packages for 32-bit):
+For Linux POWER 64-bit cross compilation (there are no packages for 32-bit):
 
     sudo apt-get install g++-powerpc64-linux-gnu binutils-powerpc64-linux-gnu g++-powerpc64le-linux-gnu binutils-powerpc64le-linux-gnu
 
-For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
+For Linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
     sudo apt-get install g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
 
-For linux S390X cross compilation:
+For Linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -19,27 +19,6 @@ linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 # https://libcxx.llvm.org/Hardening.html
 linux_debug_CPPFLAGS+=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG
 
-ifeq (86,$(findstring 86,$(build_arch)))
-i686_linux_CC=gcc -m32
-i686_linux_CXX=g++ -m32
-i686_linux_AR=ar
-i686_linux_RANLIB=ranlib
-i686_linux_NM=nm
-i686_linux_STRIP=strip
-
-x86_64_linux_CC=gcc -m64
-x86_64_linux_CXX=g++ -m64
-x86_64_linux_AR=ar
-x86_64_linux_RANLIB=ranlib
-x86_64_linux_NM=nm
-x86_64_linux_STRIP=strip
-else
-i686_linux_CC=$(default_host_CC) -m32
-i686_linux_CXX=$(default_host_CXX) -m32
-x86_64_linux_CC=$(default_host_CC) -m64
-x86_64_linux_CXX=$(default_host_CXX) -m64
-endif
-
 linux_cmake_system_name=Linux
 # Refer to doc/dependencies.md for the minimum required kernel.
 linux_cmake_system_version=3.17.0


### PR DESCRIPTION
Using the multilib GCC toolchain, as currently documented in [`depends/README.md`](https://github.com/bitcoin/bitcoin/blob/4c1906a500cacab385b09e780b54271b0addaf4b/depends/README.md), has several issues, such as:

1. The [`g++-multilib`](https://packages.ubuntu.com/noble/g++-multilib) package conflicts with platform-specific cross-compiler packages. This means it is not possible to cross compile for `i686` and other platforms using the same set of installed packages.

2. The [`g++-multilib`](https://packages.ubuntu.com/noble/g++-multilib) package is not available for `arm64`:
```sh
$ sudo apt install g++-multilib
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package g++-multilib
```

3. Managing the multilib GCC toolchain requires additional code in both depends and Guix scripts.

This PR addresses all the issues mentioned above by switching from multilib to platform-specific toolchains.

Also see https://github.com/bitcoin/bitcoin/pull/22456.

---

Here are examples of building for different scenarions:

- Linux, `x86_64` or `arm64`, building with depends natively:
```sh
$ gmake -C depends -j $(nproc)
$ cmake -B build --toolchain depends/$(./depends/config.sub $(./depends/config.guess))/toolchain.cmake
$ cmake --build build -j $(nproc)
```

- Linux, `x86_64` or `arm64`, cross compiling for `i686-pc-linux-gnu`:
```sh
$ sudo apt install g++-i686-linux-gnu binutils-i686-linux-gnu
$ export HOST=i686-linux-gnu
$ gmake -C depends -j $(nproc)
$ cmake -B build-${HOST} --toolchain depends/${HOST}/toolchain.cmake
$ cmake --build build-${HOST} -j $(nproc)
```

- Linux, `x86_64`, cross compiling for `arm64`:
```sh
$ sudo apt install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
$ export HOST=aarch64-linux-gnu
$ gmake -C depends -j $(nproc)
$ cmake -B build-${HOST} --toolchain depends/${HOST}/toolchain.cmake
$ cmake --build build-${HOST} -j $(nproc)
```

- Linux, `arm64`, cross compiling for `x86_64`:
```sh
$ sudo apt install g++-x86-64-linux-gnu binutils-x86-64-linux-gnu
$ export HOST=x86_64-linux-gnu
$ gmake -C depends -j $(nproc)
$ cmake -B build-${HOST} --toolchain depends/${HOST}/toolchain.cmake
$ cmake --build build-${HOST} -j $(nproc)
```
