### PR TITLE
torcontrol: Define tor reply code as const to improve our maintainability

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -403,7 +403,11 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
 
     Assume(resolved.IsValid());
     LogDebug(BCLog::TOR, "Configuring onion proxy for %s\n", resolved.ToStringAddrPort());
-    Proxy addrOnion = Proxy(resolved, true);
+
+    // With m_randomize_credentials = true, generates unique SOCKS credentials per proxy connection (e.g., Tor).
+    // Prevents connection correlation and enhances privacy by forcing different Tor circuits.
+    // Requires Tor's IsolateSOCKSAuth (default enabled) for effective isolation (see IsolateSOCKSAuth section in https://2019.www.torproject.org/docs/tor-manual.html.en).
+    Proxy addrOnion = Proxy(resolved, /*_randomize_credentials=*/ true);
     SetProxy(NET_ONION, addrOnion);
 
     const auto onlynets = gArgs.GetArgs("-onlynet");


### PR DESCRIPTION
This PR want to:
1. replace tor repy code with const to improve out maintainability.
2. cherry-picked https://github.com/bitcoin/bitcoin/pull/31973 , add comment to explain Proxy credential randomization for Tor privacy

