### PR TITLE
test: Verify that a message is not in rpc errors raised (follow-up 31451)

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -160,6 +160,9 @@ def try_rpc(code, message, fun, *args, **kwds):
 
     Test against error code and message if the rpc fails.
     Returns whether a JSONRPCException was raised."""
+
+    unwanted_message = kwds.pop('unwanted_message', None)
+
     try:
         fun(*args, **kwds)
     except JSONRPCException as e:
@@ -170,6 +173,10 @@ def try_rpc(code, message, fun, *args, **kwds):
             raise AssertionError(
                 "Expected substring not found in error message:\nsubstring: '{}'\nerror message: '{}'.".format(
                     message, e.error['message']))
+        if (unwanted_message is not None) and (unwanted_message in e.error['message']):
+            raise AssertionError(
+                "Unwanted message substring found in error message:\nUnwanted substring: '{}'\nerror message: '{}'.".format(
+                    unwanted_message, e.error['message']))
         return True
     except Exception as e:
         raise AssertionError("Unexpected exception raised: " + type(e).__name__)

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -900,7 +900,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         self.old_node.unloadwallet("failed")
         shutil.copytree(self.old_node.wallets_path / "failed", self.master_node.wallets_path / "failed")
-        assert_raises_rpc_error(-4, "Failed to create database", self.master_node.migratewallet, "failed")
+        assert_raises_rpc_error(-4, "Failed to create database", self.master_node.migratewallet, "failed", unwanted_message="Unable to restore backup of wallet")
 
         assert all(wallet not in self.master_node.listwallets() for wallet in ["failed", "failed_watchonly", "failed_solvables"])
 


### PR DESCRIPTION
This follow-up was proposed in https://github.com/bitcoin/bitcoin/pull/31451#discussion_r1884067770.
 
Verify that an unwanted message is not among the errors raised by the rpc call, otherwise raise an exception with the details.