### PR TITLE
fuzz: doc: add info about `afl-system-config` for macOS

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -225,6 +225,8 @@ $ cmake -B build_fuzz \
 $ cmake --build build_fuzz
 # For macOS you may need to ignore x86 compilation checks when running "cmake --build". If so,
 # try compiling using: AFL_NO_X86=1 cmake --build build_fuzz
+# Also, it might be required to run "afl-system-config" to adjust the shared
+# memory parameters.
 $ mkdir -p inputs/ outputs/
 $ echo A > inputs/thin-air-input
 $ FUZZ=bech32 ./AFLplusplus/afl-fuzz -i inputs/ -o outputs/ -- build_fuzz/bin/fuzz


### PR DESCRIPTION
`afl-system-config` adjusts the shared memory segment size limits and configures kernel parameters for better fuzzing performance. Since macOS has more conservative values on shared memory, it's necessary to run `afl-system-config`, or manually adjust the values to fuzz with AFL++.

e.g.:
```sh
kern.sysv.shmmax: 524288000
kern.sysv.shmmin: 1
kern.sysv.shmseg: 48
kern.sysv.shmall: 131072000
```
