### PR TITLE
coins: replace manual `CDBBatch` size estimation with LevelDB's native `ApproximateSize`

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -168,8 +168,6 @@ CDBBatch::~CDBBatch() = default;
 void CDBBatch::Clear()
 {
     m_impl_batch->batch.Clear();
-    assert(m_impl_batch->batch.ApproximateSize() == kHeader);
-    size_estimate = kHeader; // TODO remove
 }
 
 void CDBBatch::WriteImpl(std::span<const std::byte> key, DataStream& ssValue)
@@ -178,26 +176,12 @@ void CDBBatch::WriteImpl(std::span<const std::byte> key, DataStream& ssValue)
     ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
     leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
     m_impl_batch->batch.Put(slKey, slValue);
-    // LevelDB serializes writes as:
-    // - byte: header
-    // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
-    // - byte[]: key
-    // - varint: value length
-    // - byte[]: value
-    // The formula below assumes the key and value are both less than 16k.
-    size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
 }
 
 void CDBBatch::EraseImpl(std::span<const std::byte> key)
 {
     leveldb::Slice slKey(CharCast(key.data()), key.size());
     m_impl_batch->batch.Delete(slKey);
-    // LevelDB serializes erases as:
-    // - byte: header
-    // - varint: key length
-    // - byte[]: key
-    // The formula below assumes the key is less than 16kB.
-    size_estimate += 2 + (slKey.size() > 127) + slKey.size();
 }
 
 size_t CDBBatch::ApproximateSize() const

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -200,6 +200,11 @@ void CDBBatch::EraseImpl(std::span<const std::byte> key)
     size_estimate += 2 + (slKey.size() > 127) + slKey.size();
 }
 
+size_t CDBBatch::ApproximateSize() const
+{
+    return m_impl_batch->batch.ApproximateSize();
+}
+
 struct LevelDBContext {
     //! custom environment this database is using (may be nullptr in case of default environment)
     leveldb::Env* penv;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -158,14 +158,18 @@ struct CDBBatch::WriteBatchImpl {
 
 CDBBatch::CDBBatch(const CDBWrapper& _parent)
     : parent{_parent},
-      m_impl_batch{std::make_unique<CDBBatch::WriteBatchImpl>()} {};
+      m_impl_batch{std::make_unique<CDBBatch::WriteBatchImpl>()}
+{
+    Clear();
+};
 
 CDBBatch::~CDBBatch() = default;
 
 void CDBBatch::Clear()
 {
     m_impl_batch->batch.Clear();
-    size_estimate = 0;
+    assert(m_impl_batch->batch.ApproximateSize() == kHeader);
+    size_estimate = kHeader; // TODO remove
 }
 
 void CDBBatch::WriteImpl(std::span<const std::byte> key, DataStream& ssValue)

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -119,7 +119,8 @@ public:
         ssKey.clear();
     }
 
-    size_t SizeEstimate() const { return size_estimate; }
+    size_t ApproximateSize() const;
+    size_t SizeEstimate() const { return size_estimate; } // TODO replace with ApproximateSize
 };
 
 class CDBIterator

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -75,6 +75,8 @@ class CDBBatch
     friend class CDBWrapper;
 
 private:
+    static constexpr size_t kHeader{12}; // See: src/leveldb/db/write_batch.cc#L27
+
     const CDBWrapper &parent;
 
     struct WriteBatchImpl;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -75,8 +75,6 @@ class CDBBatch
     friend class CDBWrapper;
 
 private:
-    static constexpr size_t kHeader{12}; // See: src/leveldb/db/write_batch.cc#L27
-
     const CDBWrapper &parent;
 
     struct WriteBatchImpl;
@@ -84,8 +82,6 @@ private:
 
     DataStream ssKey{};
     DataStream ssValue{};
-
-    size_t size_estimate{0};
 
     void WriteImpl(std::span<const std::byte> key, DataStream& ssValue);
     void EraseImpl(std::span<const std::byte> key);
@@ -120,7 +116,6 @@ public:
     }
 
     size_t ApproximateSize() const;
-    size_t SizeEstimate() const { return size_estimate; } // TODO replace with ApproximateSize
 };
 
 class CDBIterator

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -113,39 +113,27 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     // transition from old_tip to hashBlock.
     // A vector is used for future extensibility, as we may want to support
     // interrupting after partial writes from multiple independent reorgs.
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Erase(DB_BEST_BLOCK);
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
 
     for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent()) {
-                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
                 batch.Erase(entry);
-                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             } else {
-                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
                 batch.Write(entry, it->second.coin);
-                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             }
 
             changed++;
         }
         count++;
         it = cursor.NextAndMaybeErase(*it);
-        assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
-        if (batch.SizeEstimate() > m_options.batch_write_bytes) {
-            LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
+        if (batch.ApproximateSize() > m_options.batch_write_bytes) {
+            LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.ApproximateSize() * (1.0 / 1048576.0));
 
-            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             m_db->WriteBatch(batch);
-            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             batch.Clear();
-            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
-
             if (m_options.simulate_crash_ratio) {
                 static FastRandomContext rng;
                 if (rng.randrange(m_options.simulate_crash_ratio) == 0) {
@@ -157,15 +145,11 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     }
 
     // In the last batch, mark the database as consistent with hashBlock again.
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Erase(DB_HEAD_BLOCKS);
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Write(DB_BEST_BLOCK, hashBlock);
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
 
-    LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
+    LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() * (1.0 / 1048576.0));
     bool ret = m_db->WriteBatch(batch);
-    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);
     return ret;
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -113,24 +113,39 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     // transition from old_tip to hashBlock.
     // A vector is used for future extensibility, as we may want to support
     // interrupting after partial writes from multiple independent reorgs.
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Erase(DB_BEST_BLOCK);
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
 
     for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
-            if (it->second.coin.IsSpent())
+            if (it->second.coin.IsSpent()) {
+                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
                 batch.Erase(entry);
-            else
+                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
+            } else {
+                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
                 batch.Write(entry, it->second.coin);
+                assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
+            }
+
             changed++;
         }
         count++;
         it = cursor.NextAndMaybeErase(*it);
+        assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
         if (batch.SizeEstimate() > m_options.batch_write_bytes) {
             LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
+
+            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             m_db->WriteBatch(batch);
+            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
             batch.Clear();
+            assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
+
             if (m_options.simulate_crash_ratio) {
                 static FastRandomContext rng;
                 if (rng.randrange(m_options.simulate_crash_ratio) == 0) {
@@ -142,11 +157,15 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
     }
 
     // In the last batch, mark the database as consistent with hashBlock again.
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Erase(DB_HEAD_BLOCKS);
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     batch.Write(DB_BEST_BLOCK, hashBlock);
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
 
     LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
     bool ret = m_db->WriteBatch(batch);
+    assert(batch.ApproximateSize() == batch.SizeEstimate()); // TODO remove
     LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);
     return ret;
 }


### PR DESCRIPTION
### Summary

The manual batch size estimation of `CDBBatch` serialized size was [added](https://github.com/bitcoin/bitcoin/pull/10195/commits/e66dbde6d14cb5f253b3bf8850a98f4fda2d9f49) when LevelDB [didn't expose this functionality  yet](https://github.com/google/leveldb/commit/69e2bd2).
The PR refactors the logic to use the native `leveldb::WriteBatch::ApproximateSize()` function, structured in 3 focused commits to incrementally replace the old behavior safely.

### Context

The previous manual size calculation initialized the estimate to 0, instead of LevelDB's header size (containing an 8-byte sequence number followed by a 4-byte count).
This PR corrects that and transitions to the now-available native LevelDB function for improved accuracy and maintainability.

### Approach
The fix and refactor follow a strangle pattern over three commits:
* correct the initialization bug in the existing manual calculation, isolating the fix and ensuring the subsequent assertions use the corrected logic;
* introduce the native `ApproximateSize()` method alongside the corrected manual one, adding assertions to verify their equivalence at runtime;
* remove the verified manual calculation logic and assertions, leaving only the native method.

