### PR TITLE
test: added coverage to bitcoin-chainstate testing invalid block header

### DIFF
--- a/test/functional/tool_bitcoin_chainstate.py
+++ b/test/functional/tool_bitcoin_chainstate.py
@@ -44,6 +44,7 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         self.add_block(datadir, block_one, "duplicate")
         self.add_block(datadir, "00", "Block decode failed")
         self.add_block(datadir, "", "Empty line found")
+        self.add_block(datadir, block_one[0] + "0" + block_one[2:], "invalid proof of work or time too old")
 
 if __name__ == "__main__":
     BitcoinChainstateTest(__file__).main()


### PR DESCRIPTION
## Summary
This adds coverage to `src/bitcoin-chainstate.cpp` where we get `BLOCK_INVALID_HEADER` and the error message `invalid proof of work or time too old`

[Where coverage is added](https://github.com/bitcoin/bitcoin/blob/master/src/bitcoin-chainstate.cpp#L239-L241)

this change was motivated by [this comment](https://github.com/bitcoin/bitcoin/pull/32145/files#r2014560812)

---

You can check that you cannot find this message with test coverage by using grep
`grep -nri "or time too old" ./test/functional/`