### PR TITLE
Make TxGraph fuzz tests more deterministic

### DIFF
--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -206,11 +206,14 @@ struct SimTxGraph
                 ret.push_back(ptr);
             }
         }
-        // Deduplicate.
-        std::sort(ret.begin(), ret.end());
-        ret.erase(std::unique(ret.begin(), ret.end()), ret.end());
-        // Replace input.
-        arg = std::move(ret);
+        // Construct deduplicated version in input (do not use std::sort/std::unique for
+        // deduplication as it'd rely on non-deterministic pointer comparison).
+        arg.clear();
+        for (auto ptr : ret) {
+            if (std::find(arg.begin(), arg.end(), ptr) == arg.end()) {
+                arg.push_back(ptr);
+            }
+        }
     }
 };
 


### PR DESCRIPTION
Part of cluster mempool: #30289 

The implicit transaction ordering for transactions in a TxGraphImpl is defined by:
1. higher chunk feerate first
2. lower Cluster* object pointer first
3. lower position within cluster linearization first.

Number (2) is not deterministic, as it intricately depends on the heap allocation algorithm. Fix this by giving each Cluster a unique `uint64_t m_sequence` value, and sorting by those instead.

The second commit then uses this new approach to optimize GroupClusters a bit more, avoiding some repeated checks and dereferences, by making a local copy of the involved sequence numbers.

Thanks to @dergoegge for pointing this out.