### PR TITLE
util: Ensure UninterruptibleSleep does not return too early

### DIFF
--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -17,7 +17,13 @@
 #include <string_view>
 #include <thread>
 
-void UninterruptibleSleep(const std::chrono::microseconds& n) { std::this_thread::sleep_for(n); }
+void UninterruptibleSleep(const std::chrono::microseconds& n)
+{
+    const auto end{SteadyClock::now() + n};
+    do {
+        std::this_thread::sleep_until(end);
+    } while (SteadyClock::now() < end);
+}
 
 static std::atomic<std::chrono::seconds> g_mock_time{}; //!< For testing
 std::atomic<bool> g_used_system_time{false};


### PR DESCRIPTION
Both, `sleep_for` and `sleep_until` may sleep less than the specified time, because the implementation is free to be susceptible to system clock adjustments (albeit it is recommended to not be).

Clock adjustments should be rare, and I don't think any caller of `UninterruptibleSleep` (except for one unit test) relies on it always sleeping at least that much.

However, it shouldn't hurt to fix this by ensuring a steady clock is used to measure the lower bound.

Presumably fixes https://github.com/bitcoin/bitcoin/issues/32197