### PR TITLE
doc: update .lldbinit configuration for cmake builds to see source code in debugger

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -380,10 +380,14 @@ For `gdb` create or append to [`.gdbinit` file](https://sourceware.org/gdb/curre
 set substitute-path ./src /path/to/project/root/src
 ```
 
-For `lldb` create or append to [`.lldbinit` file](https://lldb.llvm.org/man/lldb.html#configuration-files):
+For `lldb` create or append to [`~/.lldbinit` file](https://lldb.llvm.org/man/lldb.html#configuration-files):
 ```
-settings set target.source-map ./src /path/to/project/root/src
+settings set target.source-map /path/to/bitcoin/build/src /path/to/bitcoin/src
 ```
+
+Note that both target (`build/` or whatever directory you created with `cmake -B`)
+and replacement paths must be absolute. A `.lldbinit` file in the root of the
+working directory will be ignored without specific settings to include it.
 
 2. Add a symlink to the `./src` directory:
 ```


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/31204

To reproduce:

1. build bitcoin with `-DCMAKE_BUILD_TYPE=Debug`
2. run with lldb, add a breakpoint and trigger it (with a second local bitcoind peer, for example):
    - `lldb buld/bin/bitcoind`
    - `(lldb) b ProcessMessage`
    - `(lldb) r -regtest`
Output will probably look like this:
```
Process 6764 stopped
* thread #34, name = 'b-msghand', stop reason = breakpoint 1.1
    frame #0: 0x00000001003380c0 bitcoind`(anonymous namespace)::PeerManagerImpl::ProcessMessages(this=0x000000013e80e400, pfrom=0x000000013c70a830, interruptMsgProc=0x000000013d009d40) at net_processing.cpp:4933:5

```

To fix (following the doc in this PR)
Create or append to `~/.lldbinit` in your $HOME directory, using absolute paths. (My example)

```
settings set target.source-map /Users/matthewzipkin/Desktop/work/bitcoin/build/src /Users/matthewzipkin/Desktop/work/bitcoin/src
```

Improved output:
```
Process 6811 stopped
* thread #34, name = 'b-msghand', stop reason = breakpoint 1.1
    frame #0: 0x00000001003380c0 bitcoind`(anonymous namespace)::PeerManagerImpl::ProcessMessages(this=0x000000011c808800, pfrom=0x0000000104004080, interruptMsgProc=0x000000011d009140) at net_processing.cpp:4933:5
   4930
   4931 bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
   4932 {
-> 4933     AssertLockNotHeld(m_tx_download_mutex);
   4934     AssertLockHeld(g_msgproc_mutex);
   4935
   4936     PeerRef peer = GetPeerRef(pfrom->GetId());

```