### PR TITLE
doc: Amend Qt 6 dependency packages for Ubuntu

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -73,7 +73,7 @@ GUI dependencies:
 Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
-    sudo apt-get install qt6-base-dev qt6-tools-dev qt6-l10n-tools
+    sudo apt-get install qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev
 
 For Qt 6.5 and later, the `libxcb-cursor0` package must be installed at runtime.
 


### PR DESCRIPTION
On older systems, such as Ubuntu 22.04, `qt6-tools-dev-tools` and `libgl-dev` are not treated as dependencies of `qt6-tools-dev` and `qt6-base-dev`, respectively. This PR explicitly lists them in the installation documentation.

Fixes https://github.com/bitcoin/bitcoin/issues/32210.