### PR TITLE
msvc: Update vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,7 +24,17 @@
     "qt": {
       "description": "Build GUI, Qt 6",
       "dependencies": [
-        "qtbase",
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "gui",
+            "network",
+            "png",
+            "testlib",
+            "widgets"
+          ]
+        },
         "qttools",
         "libqrencode"
       ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "The builtin-baseline corresponds to 2024.09.30 Release",
+  "$comment": "The builtin-baseline corresponds to 2025.03.19 Release",
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "builtin-baseline": "c82f74667287d3dc386bce81e44964370c91a289",
+  "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
   "dependencies": [
     "boost-multi-index",
     "boost-signals2",


### PR DESCRIPTION
This PR:

1. Updates the vcpkg manifest baseline from the [2024.09.30 Release](https://github.com/microsoft/vcpkg/releases/tag/2024.09.30) to the [2025.03.19 Release](https://github.com/microsoft/vcpkg/releases/tag/2025.03.19), with the following package changes:

     - boost: 1.85.0#1,2 --> 1.87.0
     - qtbase: 6.7.2#3 -> 6.8.2#1
     - qttools: 6.7.2#1 -> 6.8.2
     - sqlite3: 3.46.1 --> 3.49.1

The previous update was made in https://github.com/bitcoin/bitcoin/pull/31186.

3. Explicitly specifies required features for the `qtbase` package, which makes vcpkg skip unused features such as `dnslookup`, `openssl`, etc.