### PR TITLE
depends: Fix cross-compiling on macOS

### DIFF
--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -88,6 +88,10 @@ $(package)_config_opts += -no-feature-qtplugininfo
 
 $(package)_config_env := CC="$$(build_CC)"
 $(package)_config_env += CXX="$$(build_CXX)"
+ifeq ($(build_os),darwin)
+$(package)_config_env += OBJC="$$(build_CC)"
+$(package)_config_env += OBJCXX="$$(build_CXX)"
+endif
 
 $(package)_cmake_opts := -DCMAKE_EXE_LINKER_FLAGS="$$(build_LDFLAGS)"
 ifneq ($(V),)

--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -152,5 +152,5 @@ endef
 
 define $(package)_postprocess_cmds
   rm -rf doc/ && \
-  mv -t .. translations/
+  mv translations/ ..
 endef


### PR DESCRIPTION
This PR:
1. Specifies Objective C/C++ compilers for `native_qt` package.
2. Removes the `-t` option, which is incompatible with `mv` on macOS.

Fixes https://github.com/bitcoin/bitcoin/issues/32208.