### PR TITLE
Bugfix: Only use git for build info if the repository is actually the right one

### DIFF
--- a/cmake/script/GenerateBuildInfo.cmake
+++ b/cmake/script/GenerateBuildInfo.cmake
@@ -41,6 +41,22 @@ if(NOT "$ENV{BITCOIN_GENBUILD_NO_GIT}" STREQUAL "1")
       ERROR_QUIET
     )
     if(IS_INSIDE_WORK_TREE)
+      # This check ensures that we are actually part of the intended git repository, and not just getting info about some unrelated git repository that the code happens to be in a directory under
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} status --porcelain -uall --ignored cmake/script/GenerateBuildInfo.cmake
+        WORKING_DIRECTORY ${WORKING_DIR}
+        RESULT_VARIABLE SCRIPT_STATUS_EXITCODE
+        OUTPUT_VARIABLE SCRIPT_STATUS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if(SCRIPT_STATUS_EXITCODE)
+        set(IS_INSIDE_WORK_TREE 0)
+      elseif(SCRIPT_STATUS MATCHES "\\?")
+        set(IS_INSIDE_WORK_TREE 0)
+      endif()
+    endif()
+    if(IS_INSIDE_WORK_TREE)
       # Clean 'dirty' status of touched files that haven't been modified.
       execute_process(
         COMMAND ${GIT_EXECUTABLE} diff


### PR DESCRIPTION
cmake port of fix originally fixed for autotools in #7522