### PR TITLE
cmake: Get rid of undocumented `BITCOIN_GENBUILD_NO_GIT` environment variable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/clientversion.cpp export-subst
+src/CMakeLists.txt export-subst

--- a/cmake/script/GenerateBuildInfo.cmake
+++ b/cmake/script/GenerateBuildInfo.cmake
@@ -5,7 +5,7 @@
 macro(fatal_error)
   message(FATAL_ERROR "\n"
     "Usage:\n"
-    "  cmake -D BUILD_INFO_HEADER_PATH=<path> [-D SOURCE_DIR=<path>] -P ${CMAKE_CURRENT_LIST_FILE}\n"
+    "  cmake -D BUILD_INFO_HEADER_PATH=<path> -D GIT_EXECUTABLE=<path> [-D SOURCE_DIR=<path>] -P ${CMAKE_CURRENT_LIST_FILE}\n"
     "All specified paths must be absolute ones.\n"
   )
 endmacro()
@@ -31,8 +31,7 @@ endif()
 set(GIT_TAG)
 set(GIT_COMMIT)
 if(NOT "$ENV{BITCOIN_GENBUILD_NO_GIT}" STREQUAL "1")
-  find_package(Git QUIET)
-  if(Git_FOUND)
+  if(GIT_EXECUTABLE)
     execute_process(
       COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
       WORKING_DIRECTORY ${WORKING_DIR}

--- a/doc/release-notes-32220.md
+++ b/doc/release-notes-32220.md
@@ -1,0 +1,9 @@
+### Build System
+
+- The undocumented `BITCOIN_GENBUILD_NO_GIT` environment variable is no longer
+  required and has been removed. The build system now automatically detects
+  when it is being built from a source archive or as a subproject of a git-aware
+  parent project and skips git metadata fetching.
+
+  Users who need to disable git execution explicitly can still do so by
+  configuring with `-DCMAKE_DISABLE_FIND_PACKAGE_Git=ON`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,9 +37,10 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 endif()
 
+find_package(Git QUIET)
 add_custom_target(generate_build_info
   BYPRODUCTS ${PROJECT_BINARY_DIR}/src/bitcoin-build-info.h
-  COMMAND ${CMAKE_COMMAND} -DBUILD_INFO_HEADER_PATH=${PROJECT_BINARY_DIR}/src/bitcoin-build-info.h -DSOURCE_DIR=${PROJECT_SOURCE_DIR} -P ${PROJECT_SOURCE_DIR}/cmake/script/GenerateBuildInfo.cmake
+  COMMAND ${CMAKE_COMMAND} -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -DBUILD_INFO_HEADER_PATH=${PROJECT_BINARY_DIR}/src/bitcoin-build-info.h -DSOURCE_DIR=${PROJECT_SOURCE_DIR} -P ${PROJECT_SOURCE_DIR}/cmake/script/GenerateBuildInfo.cmake
   COMMENT "Generating bitcoin-build-info.h"
   VERBATIM
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,12 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 endif()
 
-find_package(Git QUIET)
+set(IS_SOURCE_TARBALL FALSE)
+# git will expand the next line to "set(IS_SOURCE_TARBALL TRUE)" inside archives:
+#$Format:%nset(IS_SOURCE_TARBALL TRUE)$
+if(NOT IS_SOURCE_TARBALL AND PROJECT_IS_TOP_LEVEL)
+  find_package(Git QUIET)
+endif()
 add_custom_target(generate_build_info
   BYPRODUCTS ${PROJECT_BINARY_DIR}/src/bitcoin-build-info.h
   COMMAND ${CMAKE_COMMAND} -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -DBUILD_INFO_HEADER_PATH=${PROJECT_BINARY_DIR}/src/bitcoin-build-info.h -DSOURCE_DIR=${PROJECT_SOURCE_DIR} -P ${PROJECT_SOURCE_DIR}/cmake/script/GenerateBuildInfo.cmake


### PR DESCRIPTION
In general, the Bitcoin Core build system attempts to fetch commit or tag details from git. This is handled by the [`cmake/script/GenerateBuildInfo.cmake`](https://github.com/bitcoin/bitcoin/blob/master/cmake/script/GenerateBuildInfo.cmake) script, which generates the [`src/bitcoin-build-info.h`](https://github.com/bitcoin/bitcoin/blob/65dcbec75661d1652beb927f03b1feab4fab932e/src/clientversion.cpp#L26-L31) header within the build tree.

However, there are cases where the retrieved details may be incorrect—for example, when building from a source tarball or as a subproject within a git-aware project.

In the Autotools-based build system, the `BITCOIN_GENBUILD_NO_GIT` environment variable was [introduced](https://github.com/bitcoin/bitcoin/pull/7522) in [v0.20.0](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.20.0.md) to address such scenarios:
> The process for generating the source code release ("tarball") has changed in an effort to make it more complete, however, there are a few regressions in this release:
> - Instead of running `make` simply, you should instead run `BITCOIN_GENBUILD_NO_GIT=1 make`.

This PR automagically handles both of the aforementioned cases and removes the need for `BITCOIN_GENBUILD_NO_GIT`.

The user is still able to configure the build with [`-DCMAKE_DISABLE_FIND_PACKAGE_Git=ON`](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) to disable git execution manually, for [reasons](https://github.com/bitcoin/bitcoin/pull/32220#issuecomment-2780115034) we don't know in advance.

Closes https://github.com/bitcoin/bitcoin/issues/31999.