### PR TITLE
[WIP] mining: Quantum Computing Resistent Address, PQC - QNot address

### DIFF
--- a/src/test/script_qnot_tests.cpp
+++ b/src/test/script_qnot_tests.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2012-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/script.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(script_segwit_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Valid)
+{
+    uint256 dummy;
+    CScript p2wsh;
+    p2wsh << OP_0 << ToByteVector(dummy);
+    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash());
+
+    std::vector<unsigned char> bytes = {OP_0, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_NotOp0)
+{
+    uint256 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_1 << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Size)
+{
+    uint160 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_0 << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Nop)
+{
+    uint256 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_0 << OP_NOP << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_EmptyScript)
+{
+    CScript notp2wsh;
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Pushdata)
+{
+    // A script is not P2WSH if OP_PUSHDATA is used to push the hash.
+    std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+
+    bytes = {OP_0, OP_PUSHDATA2, 32, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+
+    bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+}
+
+namespace {
+
+bool IsExpectedWitnessProgram(const CScript& script, const int expectedVersion, const std::vector<unsigned char>& expectedProgram)
+{
+    int actualVersion;
+    std::vector<unsigned char> actualProgram;
+    if (!script.IsWitnessProgram(actualVersion, actualProgram)) {
+        return false;
+    }
+    BOOST_CHECK_EQUAL(actualVersion, expectedVersion);
+    BOOST_CHECK(actualProgram == expectedProgram);
+    return true;
+}
+
+bool IsNoWitnessProgram(const CScript& script)
+{
+    int dummyVersion;
+    std::vector<unsigned char> dummyProgram;
+    return !script.IsWitnessProgram(dummyVersion, dummyProgram);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Valid)
+{
+    // Witness programs have a minimum data push of 2 bytes.
+    std::vector<unsigned char> program = {42, 18};
+    CScript wit;
+    wit << OP_0 << program;
+    BOOST_CHECK(IsExpectedWitnessProgram(wit, 0, program));
+
+    wit.clear();
+    // Witness programs have a maximum data push of 40 bytes.
+    program.resize(40);
+    wit << OP_16 << program;
+    BOOST_CHECK(IsExpectedWitnessProgram(wit, 16, program));
+
+    program.resize(32);
+    std::vector<unsigned char> bytes = {OP_5, static_cast<unsigned char>(program.size())};
+    bytes.insert(bytes.end(), program.begin(), program.end());
+    BOOST_CHECK(IsExpectedWitnessProgram(CScript(bytes.begin(), bytes.end()), 5, program));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Version)
+{
+    std::vector<unsigned char> program(10);
+    CScript nowit;
+    nowit << OP_1NEGATE << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Size)
+{
+    std::vector<unsigned char> program(1);
+    CScript nowit;
+    nowit << OP_0 << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+
+    nowit.clear();
+    program.resize(41);
+    nowit << OP_0 << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Nop)
+{
+    std::vector<unsigned char> program(10);
+    CScript nowit;
+    nowit << OP_0 << OP_NOP << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_EmptyScript)
+{
+    CScript nowit;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Pushdata)
+{
+    // A script is no witness program if OP_PUSHDATA is used to push the hash.
+    std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+
+    bytes = {OP_0, OP_PUSHDATA2, 32, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+
+    bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## The problem:
Quantum computing can, in the future, breaks the ECDSA algorithm used by Bitcoin.

## Already proposed solution:
Hybrid signatures with the current signature algorithm plus a new computer-resistant algorithm. This solution has a serious problem where to a quantum computer breaks the UTXO and hack the blockchain its just necessary to know the public key used in the transaction. Right now, everybody shares its public key, so this is not solve the problem. 

## My proposal solution:
We had SegWit address type, then Taproot. Now I propose to create a new type of address called QNot. This address just use PQC algorithms.
I choose as PQC algorithm the CRYSTALS-Dilithium.
Every bitcoin migrated to this new QNot addresses will be quantum resistant.

## Benefits:
The decision to go to an address PQC keeps with the users of the network.
We don't change all already stabled addresses.
We don't increase the needed resources to running a bitcoin node because we just implement PQC algorithms for new addresses with interest on it.

## Trade-offs:
The resources needed for running a bitcoin node or mining bitcoin is increased as many as people migrate to the new QNot addresses.
