### PR TITLE
tests: Add unix timestamp tests for OP_CLTV and max mediantimepast tests

### DIFF
--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -7,6 +7,7 @@
 Test that the CHECKLOCKTIMEVERIFY soft-fork activates.
 """
 
+import time
 from test_framework.blocktools import (
     TIME_GENESIS_BLOCK,
     create_block,
@@ -25,7 +26,7 @@ from test_framework.script import (
     OP_DROP,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_not_equal
 from test_framework.wallet import (
     MiniWallet,
     MiniWalletMode,
@@ -70,12 +71,12 @@ def cltv_invalidate(tx, failure_reason):
 
 def cltv_validate(tx, height):
     # Modify the signature in vin 0 and nSequence/nLockTime of the tx to pass CLTV
-    scheme = [[CScriptNum(height), OP_CHECKLOCKTIMEVERIFY, OP_DROP], 0, height]
+    scheme = [[CScriptNum.encode(CScriptNum(height))[1:], OP_CHECKLOCKTIMEVERIFY, OP_DROP], 0, height]
 
     cltv_modify_tx(tx, prepend_scriptsig=scheme[0], nsequence=scheme[1], nlocktime=scheme[2])
 
 
-CLTV_HEIGHT = 111
+CLTV_HEIGHT = 112
 
 
 class BIP65Test(BitcoinTestFramework):
@@ -105,8 +106,9 @@ class BIP65Test(BitcoinTestFramework):
         self.test_cltv_info(is_active=False)
 
         self.log.info("Mining %d blocks", CLTV_HEIGHT - 2)
-        self.generate(wallet, 10)
-        self.generate(self.nodes[0], CLTV_HEIGHT - 2 - 10)
+        num_utxos = 12
+        self.generate(wallet, num_utxos)
+        self.generate(self.nodes[0], CLTV_HEIGHT - 2 - num_utxos)
         assert_equal(self.nodes[0].getblockcount(), CLTV_HEIGHT - 2)
 
         self.log.info("Test that invalid-according-to-CLTV transactions can still appear in a block")
@@ -198,6 +200,40 @@ class BIP65Test(BitcoinTestFramework):
         peer.send_and_ping(msg_block(block))
         self.test_cltv_info(is_active=True)  # Active as of current tip
         assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
+
+        # test wall clock time
+        tip = block.hash_int
+
+        current_time = int(time.time())
+        locktime = current_time + (60 * 60) # 1 hour
+        spendtx = wallet.create_self_transfer()['tx']
+        self.log.info("Test that one block mined with correct wall clock time does not satisfy median-time-past")
+        cltv_validate(spendtx, locktime)
+        block2 = create_block(tip, height=CLTV_HEIGHT + 1, ntime=locktime, version=4)
+        block2.vtx.append(spendtx)
+        block2.hashMerkleRoot = block2.calc_merkle_root()
+        block2.solve()
+        # expect failure as we haven't satisfied wall clock time yet
+        with self.nodes[0].assert_debug_log(expected_msgs=['bad-txns-nonfinal']):
+            peer.send_and_ping(msg_block(block2))
+            assert_not_equal(int(self.nodes[0].getbestblockhash(), 16), block2.hash_int)
+
+        self.log.info("Test 7 blocks mined with current wall clock time can satisfy the median-time-past")
+        num = 7
+        for i in range(num):
+            b = create_block(tip, height=CLTV_HEIGHT + i + 1, ntime=locktime + i, version=4)
+            b.solve()
+            peer.send_and_ping(msg_block(b))
+            tip = b.hash_int
+
+        # now our median-past-time should allow for a transaction with
+        # a locktime of +1 hour to be confirmed
+        block2 = create_block(tip, height=CLTV_HEIGHT + num + 1, ntime=locktime + num, version=4)
+        block2.vtx.append(spendtx)
+        block2.hashMerkleRoot = block2.calc_merkle_root()
+        block2.solve()
+        peer.send_and_ping(msg_block(block2))
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block2.hash_int)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -52,6 +52,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
     softfork_active,
 )
 from test_framework.wallet import (
@@ -60,7 +61,8 @@ from test_framework.wallet import (
 )
 
 TESTING_TX_COUNT = 83  # Number of testing transactions: 1 BIP113 tx, 16 BIP68 txs, 66 BIP112 txs (see comments above)
-COINBASE_BLOCK_COUNT = TESTING_TX_COUNT  # Number of coinbase blocks we need to generate as inputs for our txs
+MTP_EDGE_CASE_INPUT_COUNT = 2  # Extra inputs for the "median-time-past can never reach UINT32_MAX" BIP113 test
+COINBASE_BLOCK_COUNT = TESTING_TX_COUNT + MTP_EDGE_CASE_INPUT_COUNT  # Number of coinbase blocks we need to generate as inputs for our txs
 BASE_RELATIVE_LOCKTIME = 10
 SEQ_DISABLE_FLAG = 1 << 31
 SEQ_RANDOM_HIGH_BIT = 1 << 25
@@ -231,13 +233,17 @@ class BIP68_112_113Test(BitcoinTestFramework):
         # 1 normal input
         bip113input = self.send_generic_input_tx(self.coinbase_blocks)
 
+        # 2 normal inputs, used later to test that a transaction locked to UINT32_MAX can
+        # never be mined once median-time-past reaches UINT32_MAX - 1
+        mtp_edge_case_inputs = [self.send_generic_input_tx(self.coinbase_blocks) for _ in range(MTP_EDGE_CASE_INPUT_COUNT)]
+
         self.nodes[0].setmocktime(self.last_block_time + 600)
         inputblockhash = self.generate(self.nodes[0], 1)[0]  # 1 block generated for inputs to be in chain at height 431
         self.nodes[0].setmocktime(0)
         self.tip = int(inputblockhash, 16)
         self.tipheight += 1
         self.last_block_time += 600
-        assert_equal(len(self.nodes[0].getblock(inputblockhash, True)["tx"]), TESTING_TX_COUNT + 1)
+        assert_equal(len(self.nodes[0].getblock(inputblockhash, True)["tx"]), TESTING_TX_COUNT + MTP_EDGE_CASE_INPUT_COUNT + 1)
 
         # 2 more version 4 blocks
         test_blocks = self.generate_blocks(2)
@@ -473,6 +479,64 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
         self.send_blocks([self.create_test_block(time_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+
+        self.log.info("Test that a transaction locked to UINT32_MAX can never be mined, since MTP can never exceed UINT32_MAX")
+        UINT32_MAX = 2 ** 32 - 1
+        # Advance the node's own clock so that headers/blocks with a timestamp this far in
+        # the future aren't rejected outright for being too far ahead of adjusted time.
+        self.nodes[0].setmocktime(UINT32_MAX)
+        # setmocktime() times out the existing p2p connection, so re-add it
+        self.helper_peer = self.nodes[0].add_p2p_connection(P2PDataStore())
+
+        def mtp_edge_case_tx(input_tx, locktime):
+            tx = self.create_self_transfer_from_utxo(input_tx)
+            tx.vin[0].nSequence = 0xFFFFFFFE  # not SEQUENCE_FINAL, so nLockTime is enforced
+            tx.nLockTime = locktime
+            self.miniwallet.sign_tx(tx)
+            return tx
+
+        # Mine 6 blocks at UINT32_MAX - 1 so that MTP (the median of the last 11 blocks) becomes UINT32_MAX - 1
+        for _ in range(6):
+            block = create_block(self.tip, height=self.tipheight + 1, ntime=UINT32_MAX - 1)
+            block.solve()
+            self.send_blocks([block])
+            self.tip = block.hash_int
+            self.tipheight += 1
+        assert_equal(self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())['mediantime'], UINT32_MAX - 1)
+
+        # UINT32_MAX - 2 is the highest locktime that can be included in the next block:
+        # BIP113 requires nLockTime to be strictly less than the MTP of the previous block
+        max_locktime_tx = mtp_edge_case_tx(mtp_edge_case_inputs[0], UINT32_MAX - 2)
+        block = create_block(self.tip, height=self.tipheight + 1, ntime=UINT32_MAX, txlist=[max_locktime_tx])
+        block.solve()
+        self.send_blocks([block])
+        self.tip = block.hash_int
+        self.tipheight += 1
+
+        # A transaction locked to UINT32_MAX itself is never final: MTP can never exceed
+        # UINT32_MAX, so "nLockTime < MTP" can never be satisfied for nLockTime == UINT32_MAX
+        never_final_tx = mtp_edge_case_tx(mtp_edge_case_inputs[1], UINT32_MAX)
+        block = create_block(self.tip, height=self.tipheight + 1, ntime=UINT32_MAX, txlist=[never_final_tx])
+        block.solve()
+        self.send_blocks([block], success=False, reject_reason='bad-txns-nonfinal')
+
+        # max out MTP on the network to UINT32_MAX, so that the next block's nTime can't exceed it (and thus any block will be rejected for time-too-old)
+        while self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())['mediantime'] < UINT32_MAX:
+            block = create_block(self.tip, height=self.tipheight + 1, ntime=UINT32_MAX)
+            block.solve()
+            self.send_blocks([block])
+            self.tip = block.hash_int
+            self.tipheight += 1
+
+        assert_equal(self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())['mediantime'], UINT32_MAX)
+
+        # submitting a transaction to the mempool with nLockTime at UINT32_MAX fails
+        assert_raises_rpc_error(-26, 'non-final', self.nodes[0].sendrawtransaction, never_final_tx.serialize().hex())
+
+        # try to create another block with UINT32_MAX nTime, which is now too old to be valid (MTP == UINT32_MAX)
+        empty_block = create_block(self.tip, height=self.tipheight + 1, ntime=UINT32_MAX)
+        empty_block.solve()
+        self.helper_peer.send_blocks_and_test([empty_block], self.nodes[0], success=False, reject_reason='time-too-old', force_send=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a functional (p2p/block-validation) test for `OP_CHECKLOCKTIMEVERIFY` (BIP65) using unix-timestamp locktimes in test/functional/feature_cltv.py. It also adds tests around the maximum possible median-time-past (MTP) value, `UINT32_MAX`, and how that interacts with transaction finality.

The unix-timestamp portion of BIP65 already has unit-level coverage in `transaction_tests.cpp` (via `tx_valid.json`/`tx_invalid.json`), but those tests call `VerifyScript()` directly and never exercise median-time-past (MTP) or block connection. MTP-vs-nLockTime behavior itself is covered separately in `miner_tests.cpp` (lines 525-534) and `feature_csv_activation.py` (lines 340-355), but neither exercises `OP_CLTV` specifically. This test closes that gap: it builds and submits full blocks over p2p and checks that a block containing an `OP_CLTV`-locked output is only accepted once BIP113 MTP actually satisfies the requested locktime.

This PR also adds a BIP113 test to `feature_csv_activation.py` showing that MTP can never advance past `UINT32_MAX` - 1, so an output with a plain nLockTime of `UINT32_MAX` can never be confirmed. This is a general BIP113 property independent of `OP_CLTV`.

Thanks to @mabu44 and @sedited for the review so far.