### PR TITLE
coins: Fix GetCoin to not return spent coins in CoinsViewBottom

### DIFF
--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -148,8 +148,12 @@ class CoinsViewBottom final : public CCoinsView
 public:
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const final
     {
-        // TODO GetCoin shouldn't return spent coins
-        if (auto it = m_data.find(outpoint); it != m_data.end()) return it->second;
+        if (auto it = m_data.find(outpoint); it != m_data.end()) {
+            // Don't return spent coins
+            if (!it->second.IsSpent()) {
+                return it->second;
+            }
+        }
         return std::nullopt;
     }
 


### PR DESCRIPTION
This commit modifies the GetCoin method in the CoinsViewBottom test class to 
not return spent coins. Previously, it would return any coin found in the map,
regardless of whether it was spent or not. Now it checks the IsSpent() status
before returning and only returns unspent coins, ensuring consistent behavior
with other implementations of the CCoinsView interface.