### PR TITLE
qt: Update SetHexDeprecated to FromHex

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -276,8 +276,7 @@ void TransactionTableModel::updateAmountColumnTitle()
 
 void TransactionTableModel::updateTransaction(const QString &hash, int status, bool showTransaction)
 {
-    uint256 updated;
-    updated.SetHexDeprecated(hash.toStdString());
+    Txid updated = Txid::FromHex(hash.toStdString()).value();
 
     priv->updateWallet(walletModel->wallet(), updated, status, showTransaction);
 }

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
                    uint256{"0000000000000000000000000000000000000000000000000000000000000001"});
 }
 
-BOOST_AUTO_TEST_CASE(methods) // GetHex SetHexDeprecated FromHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
+BOOST_AUTO_TEST_CASE(methods) // GetHex FromHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
 {
     BOOST_CHECK_EQUAL(R1L.GetHex(), R1L.ToString());
     BOOST_CHECK_EQUAL(R2L.GetHex(), R2L.ToString());
@@ -155,9 +155,6 @@ BOOST_AUTO_TEST_CASE(methods) // GetHex SetHexDeprecated FromHex begin() end() s
     BOOST_CHECK_EQUAL(MaxL.GetHex(), MaxL.ToString());
     uint256 TmpL(R1L);
     BOOST_CHECK_EQUAL(TmpL, R1L);
-    // Verify previous values don't persist when setting to truncated string.
-    TmpL.SetHexDeprecated("21");
-    BOOST_CHECK_EQUAL(TmpL.ToString(), "0000000000000000000000000000000000000000000000000000000000000021");
     BOOST_CHECK_EQUAL(uint256::FromHex(R2L.ToString()).value(), R2L);
     BOOST_CHECK_EQUAL(uint256::FromHex(ZeroL.ToString()).value(), uint256());
 

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -18,32 +18,6 @@ std::string base_blob<BITS>::GetHex() const
 }
 
 template <unsigned int BITS>
-void base_blob<BITS>::SetHexDeprecated(const std::string_view str)
-{
-    std::fill(m_data.begin(), m_data.end(), 0);
-
-    const auto trimmed = util::RemovePrefixView(util::TrimStringView(str), "0x");
-
-    // Note: if we are passed a greater number of digits than would fit as bytes
-    // in m_data, we will be discarding the leftmost ones.
-    // str="12bc" in a WIDTH=1 m_data => m_data[] == "\0xbc", not "0x12".
-    size_t digits = 0;
-    for (const char c : trimmed) {
-        if (::HexDigit(c) == -1) break;
-        ++digits;
-    }
-    unsigned char* p1 = m_data.data();
-    unsigned char* pend = p1 + WIDTH;
-    while (digits > 0 && p1 < pend) {
-        *p1 = ::HexDigit(trimmed[--digits]);
-        if (digits > 0) {
-            *p1 |= ((unsigned char)::HexDigit(trimmed[--digits]) << 4);
-            p1++;
-        }
-    }
-}
-
-template <unsigned int BITS>
 std::string base_blob<BITS>::ToString() const
 {
     return (GetHex());
@@ -52,12 +26,10 @@ std::string base_blob<BITS>::ToString() const
 // Explicit instantiations for base_blob<160>
 template std::string base_blob<160>::GetHex() const;
 template std::string base_blob<160>::ToString() const;
-template void base_blob<160>::SetHexDeprecated(std::string_view);
 
 // Explicit instantiations for base_blob<256>
 template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;
-template void base_blob<256>::SetHexDeprecated(std::string_view);
 
 const uint256 uint256::ZERO(0);
 const uint256 uint256::ONE(1);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -69,11 +69,11 @@ public:
 
     /** @name Hex representation
      *
-     * The hex representation used by GetHex(), ToString(), FromHex() and
-     * SetHexDeprecated() is unusual, since it shows bytes of the base_blob in
-     * reverse order. For example, a 4-byte blob {0x12, 0x34, 0x56, 0x78} is
-     * represented as "78563412" instead of the more typical "12345678"
-     * representation that would be shown in a hex editor or used by typical
+     * The hex representation used by GetHex(), ToString(), and FromHex()
+     * is unusual, since it shows bytes of the base_blob in reverse order.
+     * For example, a 4-byte blob {0x12, 0x34, 0x56, 0x78} is represented
+     * as "78563412" instead of the more typical "12345678" representation
+     * that would be shown in a hex editor or used by typical
      * byte-array / hex conversion functions like python's bytes.hex() and
      * bytes.fromhex().
      *
@@ -92,20 +92,6 @@ public:
      *
      * @{*/
     std::string GetHex() const;
-    /** Unlike FromHex this accepts any invalid input, thus it is fragile and deprecated!
-     *
-     * - Hex numbers that don't specify enough bytes to fill the internal array
-     *   will be treated as setting the beginning of it, which corresponds to
-     *   the least significant bytes when converted to base_uint.
-     *
-     * - Hex numbers specifying too many bytes will have the numerically most
-     *   significant bytes (the beginning of the string) narrowed away.
-     *
-     * - An odd count of hex digits will result in the high bits of the leftmost
-     *   byte being zero.
-     *   "0x123" => {0x23, 0x1, 0x0, ..., 0x0}
-     */
-    void SetHexDeprecated(std::string_view str);
     std::string ToString() const;
     /**@}*/
 
@@ -158,7 +144,16 @@ std::optional<uintN_t> FromHex(std::string_view str)
 {
     if (uintN_t::size() * 2 != str.size() || !IsHex(str)) return std::nullopt;
     uintN_t rv;
-    rv.SetHexDeprecated(str);
+    unsigned char* p1 = rv.begin();
+    unsigned char* pend = rv.end();
+    size_t digits = str.size();
+    while (digits > 0 && p1 < pend) {
+        *p1 = ::HexDigit(str[--digits]);
+        if (digits > 0) {
+            *p1 |= ((unsigned char)::HexDigit(str[--digits]) << 4);
+            p1++;
+        }
+    }
     return rv;
 }
 /**


### PR DESCRIPTION
This is part of https://github.com/bitcoin/bitcoin/pull/32189. I'm separating this out because it's not immediately obvious that it's just a refactor. `SetHexDeprecated()` doesn't do any correctness checks on the input, while `FromHex()` does, so it's theoretically possible that there's a behavior change.

Replaces `uint256::SetHexDeprecated()` calls with `Txid::FromHex()` in four locations:
- `TransactionTableModel::updateTransaction`
- `TransactionView::contextualMenu`
- `TransactionView::abandonTx`
- `TransactionView::bumpFee`

The input strings in these cases aren't user input, so they should only be valid hex strings from `GetHex()` (through `TransactionRecord::getTxHash()`). These conversions should be safe without additional checks.