### PR TITLE
feefrac test: avoid integer overflow (bugfix)

### DIFF
--- a/src/test/fuzz/feefrac.cpp
+++ b/src/test/fuzz/feefrac.cpp
@@ -220,9 +220,9 @@ FUZZ_TARGET(feefrac_mul_div)
         assert(res == res_fee);
 
         // Compare approximately with CFeeRate.
-        if (mul64 <= std::numeric_limits<int64_t>::max() / 1000 &&
-            mul64 >= std::numeric_limits<int64_t>::min() / 1000 &&
-            quot_abs <= arith_uint256{std::numeric_limits<int64_t>::max() / 1000}) {
+        if (mul64 < std::numeric_limits<int64_t>::max() / 1000 &&
+            mul64 > std::numeric_limits<int64_t>::min() / 1000 &&
+            quot_abs < arith_uint256{std::numeric_limits<int64_t>::max() / 1000}) {
             CFeeRate feerate(mul64, (uint32_t)div);
             CAmount feerate_fee{feerate.GetFee(mul32)};
             auto allowed_gap = static_cast<int64_t>(mul32 / 1000 + 3 + round_down);


### PR DESCRIPTION
The `feefrac_mul_div` fuzz test fails after #30535 with the following (base64) input: `Nb6Fc/97AACAAAD/ewAAgAAAAIAAAACAAAAAoA==` (see https://cirrus-ci.com/task/5240029192126464?logs=ci#L3353).

This is caused by an internal multiplication inside `CFeeRate` that *just* exceeds the limit of the `int64_t` type. Fix that by tightening the bounds slightly further.