### PR TITLE
guix: Remove unused `file` package

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -137,8 +137,7 @@ export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
 # Make /usr/bin if it doesn't exist
 [ -e /usr/bin ] || mkdir -p /usr/bin
 
-# Symlink file and env to a conventional path
-[ -e /usr/bin/file ] || ln -s --no-dereference "$(command -v file)" /usr/bin/file
+# Symlink env to a conventional path
 [ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
 
 # Determine the correct value for -Wl,--dynamic-linker for the current $HOST

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -6,7 +6,6 @@
              (gnu packages commencement)
              (gnu packages compression)
              (gnu packages cross-base)
-             (gnu packages file)
              (gnu packages gawk)
              (gnu packages gcc)
              ((gnu packages installers) #:select (nsis-x86_64))
@@ -531,7 +530,6 @@ inspecting signatures in Mach-O binaries.")
         which
         coreutils-minimal
         ;; File(system) inspection
-        file
         grep
         diffutils
         findutils


### PR DESCRIPTION
The `file` utility has not been required since Guix builds were introduced in https://github.com/bitcoin/bitcoin/pull/15277.

My Guix build:
```
feeb8da87994724878ac8a62a6e9bfb9b1ece855f336327c900214d84d0a2bb9  guix-build-513e2020a9ac/output/aarch64-linux-gnu/SHA256SUMS.part
216b287ffbff054a14e60e14b3376acb8cd41dd224223ecd508bd46efad020ba  guix-build-513e2020a9ac/output/aarch64-linux-gnu/bitcoin-513e2020a9ac-aarch64-linux-gnu-debug.tar.gz
3e68be5a329cbf5f389ca0dde51c1b1dd16b63ec26f42b8aa97dbd455ee3f30e  guix-build-513e2020a9ac/output/aarch64-linux-gnu/bitcoin-513e2020a9ac-aarch64-linux-gnu.tar.gz
da2d239a78e7ceaa944bd20d15118577daf5cb3817cde4bfe39ea014707326bd  guix-build-513e2020a9ac/output/arm-linux-gnueabihf/SHA256SUMS.part
0c05b2ab0cd048d4b3b66b97f433895ca0258a68485d641a1c7aaec198114a59  guix-build-513e2020a9ac/output/arm-linux-gnueabihf/bitcoin-513e2020a9ac-arm-linux-gnueabihf-debug.tar.gz
8cf7ff862c9eccfa7ebfb573674485082b5b797f0a8e9ba058156d3131b144fd  guix-build-513e2020a9ac/output/arm-linux-gnueabihf/bitcoin-513e2020a9ac-arm-linux-gnueabihf.tar.gz
9464457cb7832b1805a25bb86cdc7c8670dd3c02333e229470d5348c587a73b8  guix-build-513e2020a9ac/output/arm64-apple-darwin/SHA256SUMS.part
21f0b343cfd5a85f5b563e92931b254874a6dfad21eec91d40b485320ea37a27  guix-build-513e2020a9ac/output/arm64-apple-darwin/bitcoin-513e2020a9ac-arm64-apple-darwin-codesigning.tar.gz
e34a91173eae3b5ebb6dfa5ca39aa5bb782a2bfd30331edfa0075edda766ac7b  guix-build-513e2020a9ac/output/arm64-apple-darwin/bitcoin-513e2020a9ac-arm64-apple-darwin-unsigned.tar.gz
6c42015d14fb82f124450498299db15147ee3d93d5192f2fa45d700db9ef0fb9  guix-build-513e2020a9ac/output/arm64-apple-darwin/bitcoin-513e2020a9ac-arm64-apple-darwin-unsigned.zip
ddd176d8fcf325c23cb1d9c17933f651b26ce3ef13d1c4962460b3bfdb9fd7ff  guix-build-513e2020a9ac/output/dist-archive/bitcoin-513e2020a9ac.tar.gz
92af97145e0dbeac11a49da48e567f3ee6e08c88c17aa434f10dc4ae13125a57  guix-build-513e2020a9ac/output/powerpc64-linux-gnu/SHA256SUMS.part
fe980f2d4a6a6c567f447bd86221887ea3f9dcceb14a42e20f9cb8682ff66efe  guix-build-513e2020a9ac/output/powerpc64-linux-gnu/bitcoin-513e2020a9ac-powerpc64-linux-gnu-debug.tar.gz
41c9f8c46acafec1c80fc1727eddeb8e0373ef06ffc221b16af82b6d61b9c49a  guix-build-513e2020a9ac/output/powerpc64-linux-gnu/bitcoin-513e2020a9ac-powerpc64-linux-gnu.tar.gz
42051e97efd6178630c65bd398db075342d2c4722f97ec774b4e506b28f7e83b  guix-build-513e2020a9ac/output/riscv64-linux-gnu/SHA256SUMS.part
f136a82ee58d10db1360d3aa00e695c8e4017db483fe84080e8050efe4436042  guix-build-513e2020a9ac/output/riscv64-linux-gnu/bitcoin-513e2020a9ac-riscv64-linux-gnu-debug.tar.gz
78d23a7b622e894fa150706a5981ef0bf5ec35b93caaaafdd4aa95c76689ca14  guix-build-513e2020a9ac/output/riscv64-linux-gnu/bitcoin-513e2020a9ac-riscv64-linux-gnu.tar.gz
7faaa7151d85482a48c73416f0efc124f92fdf26ef232ec0dc9aa131661b2aa8  guix-build-513e2020a9ac/output/x86_64-apple-darwin/SHA256SUMS.part
13b1bb0026c2441903210f13e61be6220abb75f50dd775bb0bea3bc388ed047c  guix-build-513e2020a9ac/output/x86_64-apple-darwin/bitcoin-513e2020a9ac-x86_64-apple-darwin-codesigning.tar.gz
80296525f4c797b24e0ac9617ef1e3d4edbce638be3dee823face9554ba9f373  guix-build-513e2020a9ac/output/x86_64-apple-darwin/bitcoin-513e2020a9ac-x86_64-apple-darwin-unsigned.tar.gz
58a2a3f7335a61c68f7023aa6e2668a958ea2a4acf241c0c9968866ca5da1a21  guix-build-513e2020a9ac/output/x86_64-apple-darwin/bitcoin-513e2020a9ac-x86_64-apple-darwin-unsigned.zip
511e2f63b1f25e7c4309d8328cd9fa09b8b65dbcce8124334f89445f127f1fd2  guix-build-513e2020a9ac/output/x86_64-linux-gnu/SHA256SUMS.part
6458af46a7960b668651c59a2a0fef9d44c3c17489fad06f92ca2c43a60b2b23  guix-build-513e2020a9ac/output/x86_64-linux-gnu/bitcoin-513e2020a9ac-x86_64-linux-gnu-debug.tar.gz
f259a3364bcc3a35346498fb224e061d37d30555aa263fe74bc45e701fb4c9a6  guix-build-513e2020a9ac/output/x86_64-linux-gnu/bitcoin-513e2020a9ac-x86_64-linux-gnu.tar.gz
246ea6cb2218518c490f9a92bcd1dcb5589ed50f11b3713e4d2721990e655e39  guix-build-513e2020a9ac/output/x86_64-w64-mingw32/SHA256SUMS.part
beb17556e14916e2af8463090c4f0787e16721961a88ef54975b61dde36d1503  guix-build-513e2020a9ac/output/x86_64-w64-mingw32/bitcoin-513e2020a9ac-win64-codesigning.tar.gz
85a46d84c0433a50410f1929babc1b22721e8ee7853e57ec5370a072c05146dc  guix-build-513e2020a9ac/output/x86_64-w64-mingw32/bitcoin-513e2020a9ac-win64-debug.zip
b7191d93cb1524cfd610cee6844119739b9301550b99babb0cefe10546e53445  guix-build-513e2020a9ac/output/x86_64-w64-mingw32/bitcoin-513e2020a9ac-win64-setup-unsigned.exe
f6615296b46fd064e02fa9b4007e5d59c255595530fc91a8303e417579a7fe80  guix-build-513e2020a9ac/output/x86_64-w64-mingw32/bitcoin-513e2020a9ac-win64-unsigned.zip
```