### PR TITLE
Remove support for RNDR/RNDRRS for aarch64

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -41,9 +41,6 @@
 #ifdef HAVE_SYSCTL_ARND
 #include <sys/sysctl.h>
 #endif
-#if defined(HAVE_STRONG_GETAUXVAL) && defined(__aarch64__)
-#include <sys/auxv.h>
-#endif
 
 namespace {
 
@@ -189,62 +186,6 @@ uint64_t GetRdSeed() noexcept
 #endif
 }
 
-#elif defined(__aarch64__) && defined(HWCAP2_RNG)
-
-bool g_rndr_supported = false;
-
-void InitHardwareRand()
-{
-    if (getauxval(AT_HWCAP2) & HWCAP2_RNG) {
-        g_rndr_supported = true;
-    }
-}
-
-void ReportHardwareRand()
-{
-    // This must be done in a separate function, as InitHardwareRand() may be indirectly called
-    // from global constructors, before logging is initialized.
-    if (g_rndr_supported) {
-        LogPrintf("Using RNDR and RNDRRS as additional entropy sources\n");
-    }
-}
-
-/** Read 64 bits of entropy using rndr.
- *
- * Must only be called when RNDR is supported.
- */
-uint64_t GetRNDR() noexcept
-{
-    uint8_t ok = 0;
-    uint64_t r1;
-    do {
-        // https://developer.arm.com/documentation/ddi0601/2022-12/AArch64-Registers/RNDR--Random-Number
-        __asm__ volatile("mrs %0, s3_3_c2_c4_0; cset %w1, ne;"
-                         : "=r"(r1), "=r"(ok)::"cc");
-        if (ok) break;
-        __asm__ volatile("yield");
-    } while (true);
-    return r1;
-}
-
-/** Read 64 bits of entropy using rndrrs.
- *
- * Must only be called when RNDRRS is supported.
- */
-uint64_t GetRNDRRS() noexcept
-{
-    uint8_t ok = 0;
-    uint64_t r1;
-    do {
-        // https://developer.arm.com/documentation/ddi0601/2022-12/AArch64-Registers/RNDRRS--Reseeded-Random-Number
-        __asm__ volatile("mrs %0, s3_3_c2_c4_1; cset %w1, ne;"
-                         : "=r"(r1), "=r"(ok)::"cc");
-        if (ok) break;
-        __asm__ volatile("yield");
-    } while (true);
-    return r1;
-}
-
 #else
 /* Access to other hardware random number generators could be added here later,
  * assuming it is sufficiently fast (in the order of a few hundred CPU cycles).
@@ -260,12 +201,6 @@ void SeedHardwareFast(CSHA512& hasher) noexcept {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
     if (g_rdrand_supported) {
         uint64_t out = GetRdRand();
-        hasher.Write((const unsigned char*)&out, sizeof(out));
-        return;
-    }
-#elif defined(__aarch64__) && defined(HWCAP2_RNG)
-    if (g_rndr_supported) {
-        uint64_t out = GetRNDR();
         hasher.Write((const unsigned char*)&out, sizeof(out));
         return;
     }
@@ -290,14 +225,6 @@ void SeedHardwareSlow(CSHA512& hasher) noexcept {
         for (int i = 0; i < 4; ++i) {
             uint64_t out = 0;
             for (int j = 0; j < 1024; ++j) out ^= GetRdRand();
-            hasher.Write((const unsigned char*)&out, sizeof(out));
-        }
-        return;
-    }
-#elif defined(__aarch64__) && defined(HWCAP2_RNG)
-    if (g_rndr_supported) {
-        for (int i = 0; i < 4; ++i) {
-            uint64_t out = GetRNDRRS();
             hasher.Write((const unsigned char*)&out, sizeof(out));
         }
         return;


### PR DESCRIPTION
This hardware feature is

- Rarely supported on SoCs (and broken on like half of the chips that support it in the first place) (#31817). It is not clear if, or how, the brokenness will be worked around in the kernel, but working around it in user space seems the wrong thing to do, this is not the place to maintain special workarounds for specific hardware (which despite that, was attempted in #31826, but had to be reverted in #31908 due to other problems).
- Apparently not compiled into the release binary anymore (https://github.com/bitcoin/bitcoin/issues/31817#issuecomment-2795885962). Did check this at the time, but a build system change must have caused this, and went undetected.
- Hard to test in CI (as well as manually), due to unavailability of hardware.

Better to remove it.

This reverts commit aee5404e02e203a256c1a97b629b9b107cc8bb07 from #26839.

Closes #31817.

