### PR TITLE
ci: Bump lint imagefile FROM base

### DIFF
--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -4,7 +4,7 @@
 
 # See test/lint/README.md for usage.
 
-FROM mirror.gcr.io/debian:bookworm
+FROM mirror.gcr.io/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
According to https://wiki.debian.org/DebianReleases#Production_Releases, the current image will be EOL in about one year, so it seems fine to slowly bump it to something more recent.

(As a side-effect, this should also fix the erroneous lint CI failures on Cirrus that can be seen since today, by triggering a fresh build from the ground up.)