### PR TITLE
test: adds coverage to src/validation for invalid tx coinbase

### DIFF
--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -274,6 +274,20 @@ class NonStandardAndInvalid(BadTxTemplate):
             self.spend_tx, 0, script_sig=b'\x00' * 3 + b'\xab\x6a',
             amount=(self.spend_avail // 2))
 
+class IsCoinbase(BadTxTemplate):
+    reject_reason = "coinbase"
+    expect_disconnect = True
+    valid_in_block = False
+
+    def get_tx(self):
+        tx = CTransaction()
+        tx.vin.append(self.valid_txin)
+        tx.vin[0].prevout = COutPoint(hash=0, n=0xffffffff)
+        tx.vin[0].scriptSig = CScript([OP_0, b'\x00' * 2])
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_0])))
+        assert len(tx.vin) == 1
+        return tx
+
 # Disabled opcode tx templates (CVE-2010-5137)
 DisabledOpcodeTemplates = [getDisabledOpcodeTemplate(opcode) for opcode in [
     OP_CAT,

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -165,7 +165,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
             node.p2ps[0].send_txs_and_test([rejected_parent], node, success=False)
 
         self.log.info('Test that a peer disconnection causes erase its transactions from the orphan pool')
-        with node.assert_debug_log(['Erased 100 orphan transaction(s) from peer=26']):
+        with node.assert_debug_log(['Erased 100 orphan transaction(s) from peer=27']):
             self.reconnect_p2p(num_connections=1)
 
         self.log.info('Test that a transaction in the orphan pool is included in a new tip block causes erase this transaction from the orphan pool')


### PR DESCRIPTION
### Summary
This PR adds coverage to [`src/validation`](https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp#L787-L789) in the functional test suite when a transaction that is the coinbase is sent as a tx

This adds another tx to `invalid_txs.py`

### How to check for coverage

This is only covered currently in [mempool_accept.py](https://github.com/bitcoin/bitcoin/blob/master/test/functional/mempool_accept.py#L272-L280)

you can test this by modifying the `coinbase` message and then running the test suite and observing that only `mempool_accept.py` fails

You can also check that it is not covered by doing the following
`grep -nri "coinbase" ./test/functional/data/invalid_txs.py`
`grep -nri "assert_raises.*coinbase" ./test/functional`
`grep -nr "\"coinbase" ./test/functional`