### PR TITLE
Update feature_pruning.py

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -41,7 +41,7 @@ def mine_large_blocks(node, n):
     # Set the nTime if this is the first time this function has been called.
     # A static variable ensures that time is monotonicly increasing and is therefore
     # different for each block created => blockhash is unique.
-    if "nTimes" not in mine_large_blocks.__dict__:
+    if "nTime" not in mine_large_blocks.__dict__:
         mine_large_blocks.nTime = 0
 
     # Get the block parameters for the first block


### PR DESCRIPTION
**Motivation:**

This PR addresses a small typo in the `mine_large_blocks` utility function within the `test/functional/feature_pruning.py` functional test. The code checked for the existence of `"nTimes"` (plural) as a function attribute before initializing `mine_large_blocks.nTime` (singular), while the intended variable was `nTime`.

**Improvement:**

Fixing this typo (`nTimes` -> `nTime`) improves code clarity and correctness by ensuring the initialization logic matches the variable name used throughout the function. This makes the code easier to understand and maintain, aligning it more closely with the intent described in the accompanying comment (to initialize the time variable only on the first call).

**Testing:**

This change modifies an existing functional test (`test/functional/feature_pruning.py`).

**Note:** As discussed previously (and reported by sipa on IRC), fixing this typo *might* cause the `feature_pruning.py` test to fail. The original code, due to the typo, had slightly different timestamp generation behavior on subsequent calls to `mine_large_blocks` compared to the corrected code. Further investigation and potential adjustments to the test assertions might be necessary if failures occur after this fix. This PR focuses solely on correcting the identified typo for code clarity.

closes #32249 