### PR TITLE
depends: Avoid `warning: "_FORTIFY_SOURCE" redefined` for `libevent`

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -15,7 +15,7 @@ define $(package)_set_vars
   $(package)_config_opts+=-DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON
   $(package)_config_opts+=-DEVENT__DISABLE_TESTS=ON -DEVENT__LIBRARY_TYPE=STATIC
   $(package)_cflags += -fdebug-prefix-map=$($(package)_extract_dir)=/usr -fmacro-prefix-map=$($(package)_extract_dir)=/usr
-  $(package)_cppflags += -D_GNU_SOURCE -D_FORTIFY_SOURCE=3
+  $(package)_cppflags += -D_GNU_SOURCE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0A00
 endef
 


### PR DESCRIPTION
On Alpine Linux 3.12.3, compiling the `libevent` package produces multiple warnings:
```
$ gmake -C depends -j $(nproc) libevent
<snip>
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<built-in>: note: this is the location of the previous definition
<snip>
```

This PR fixes these warnings.