### PR TITLE
doc: update unix build doc with build flags

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -7,8 +7,15 @@ Some notes on how to build Bitcoin Core in Unix.
 To Build
 ---------------------
 
+### 1. Configuration
+
 ```bash
 cmake -B build
+```
+Run `cmake -B build -LH` to see the full list of available options.
+
+### 2. Compile
+```
 cmake --build build    # use "-j N" for N parallel jobs
 cmake --install build  # optional
 ```
@@ -174,13 +181,6 @@ be compiled in disable-wallet mode with:
 In this case there is no dependency on SQLite or Berkeley DB.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
-
-Additional Configure Flags
---------------------------
-A list of additional configure flags can be displayed with:
-
-    cmake -B build -LH
-
 
 Setup and Build Example: Arch Linux
 -----------------------------------


### PR DESCRIPTION
I had trouble building bitcoin core the way I wanted since now more features require a flag while building. IMO it makes sense to make it a bit more prominent in the build docs how to get the needed flags.

Related issue: https://github.com/bitcoin/bitcoin/issues/32258