### PR TITLE
build: Fix `macdeployqtplus` after switching to Qt 6

### DIFF
--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 # Homebrew's python@3.12 is marked as externally managed (PEP 668).
 # Therefore, `--break-system-packages` is needed.
 export PIP_PACKAGES="--break-system-packages zmq"
-export GOAL="install"
+export GOAL="install deploy"
 export CMAKE_GENERATOR="Ninja"
 export BITCOIN_CONFIG="-DBUILD_GUI=ON -DWITH_ZMQ=ON -DREDUCE_EXPORTS=ON"
 export CI_OS_NAME="macos"

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -181,7 +181,7 @@ class DeploymentInfo(object):
                     return True
         return False
 
-def getFrameworks(binaryPath: str, verbose: int) -> list[FrameworkInfo]:
+def getFrameworks(binaryPath: str, verbose: int, rpath: str = '') -> list[FrameworkInfo]:
     objdump = os.getenv("OBJDUMP", "objdump")
     if verbose:
         print(f"Inspecting with {objdump}: {binaryPath}")
@@ -195,17 +195,19 @@ def getFrameworks(binaryPath: str, verbose: int) -> list[FrameworkInfo]:
     lines.pop(0) # First line is the inspected binary
     if ".framework" in binaryPath or binaryPath.endswith(".dylib"):
         lines.pop(0) # Frameworks and dylibs list themselves as a dependency.
-    
+
     libraries = []
     for line in lines:
         line = line.replace("@loader_path", os.path.dirname(binaryPath))
+        if rpath:
+            line = line.replace("@rpath", rpath)
         info = FrameworkInfo.fromLibraryLine(line.strip())
         if info is not None:
             if verbose:
                 print("Found framework:")
                 print(info)
             libraries.append(info)
-    
+
     return libraries
 
 def runInstallNameTool(action: str, *args):
@@ -318,7 +320,7 @@ def deployFrameworks(frameworks: list[FrameworkInfo], bundlePath: str, binaryPat
         # install_name_tool it a new id.
         changeIdentification(framework.deployedInstallName, deployedBinaryPath, verbose)
         # Check for framework dependencies
-        dependencies = getFrameworks(deployedBinaryPath, verbose)
+        dependencies = getFrameworks(deployedBinaryPath, verbose, rpath=framework.frameworkDirectory)
         
         for dependency in dependencies:
             changeInstallName(dependency.installName, dependency.deployedInstallName, deployedBinaryPath, verbose)

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -157,20 +157,19 @@ class DeploymentInfo(object):
         self.qtPath = None
         self.pluginPath = None
         self.deployedFrameworks = []
-    
+
     def detectQtPath(self, frameworkDirectory: str):
         parentDir = os.path.dirname(frameworkDirectory)
-        if os.path.exists(os.path.join(parentDir, "translations")):
-            # Classic layout, e.g. "/usr/local/Trolltech/Qt-4.x.x"
+        if os.path.exists(os.path.join(parentDir, "share", "qt", "translations")):
             self.qtPath = parentDir
         else:
             self.qtPath = os.getenv("QTDIR", None)
 
         if self.qtPath is not None:
-            pluginPath = os.path.join(self.qtPath, "plugins")
+            pluginPath = os.path.join(self.qtPath, "share", "qt", "plugins")
             if os.path.exists(pluginPath):
                 self.pluginPath = pluginPath
-    
+
     def usesFramework(self, name: str) -> bool:
         for framework in self.deployedFrameworks:
             if framework.endswith(".framework"):


### PR DESCRIPTION
Homebrew's Qt 6 package — namely `qt` or `qt@6` — introduces a few differences that must be properly handled by the `macdeployqtplus` script:

1. Use of `@rpath` references:
```
% objdump --macho --dylibs-used $(brew --prefix qt@5)/Frameworks/QtGui.framework/QtGui
/usr/local/opt/qt@5/Frameworks/QtGui.framework/QtGui:
	/usr/local/opt/qt@5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.15.0, current version 5.15.16)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2575.30.19)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 367.6.0)
	/usr/local/Cellar/qt@5/5.15.16_1/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.15.0, current version 5.15.16)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1889.2.7)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3208.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 64.0.0, current version 64.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices (compatibility version 1.0.0, current version 65.0.0)
	/usr/local/opt/md4c/lib/libmd4c.0.dylib (compatibility version 0.0.0, current version 0.5.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.105.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3208.0.0)
	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText (compatibility version 1.0.0, current version 844.2.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
% objdump --macho --dylibs-used $(brew --prefix qt@6)/Frameworks/QtGui.framework/QtGui
/usr/local/opt/qt/Frameworks/QtGui.framework/QtGui:
	/usr/local/opt/qt/lib/QtGui.framework/Versions/A/QtGui (compatibility version 6.0.0, current version 6.9.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2575.30.19)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 170.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3208.0.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1889.2.7)
	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText (compatibility version 1.0.0, current version 844.2.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3208.0.0)
	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore (compatibility version 1.2.0, current version 1.11.0)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 367.6.0)
	/usr/local/opt/glib/lib/libglib-2.0.0.dylib (compatibility version 8401.0.0, current version 8401.0.0)
	@rpath/QtDBus.framework/Versions/A/QtDBus (compatibility version 6.0.0, current version 6.9.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 64.0.0, current version 64.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	/usr/local/opt/harfbuzz/lib/libharfbuzz.0.dylib (compatibility version 61100.0.0, current version 61100.0.0)
	/usr/local/opt/md4c/lib/libmd4c.0.dylib (compatibility version 0.0.0, current version 0.5.2)
	/usr/local/opt/freetype/lib/libfreetype.6.dylib (compatibility version 27.0.0, current version 27.2.0)
	/usr/local/opt/glib/lib/libgthread-2.0.0.dylib (compatibility version 8401.0.0, current version 8401.0.0)
	@rpath/QtCore.framework/Versions/A/QtCore (compatibility version 6.0.0, current version 6.9.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/UniformTypeIdentifiers.framework/Versions/A/UniformTypeIdentifiers (compatibility version 1.0.0, current version 709.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.105.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

2. Different directory layout:
```
% ls -l $(brew --prefix qt@5)/         
total 544
drwxr-xr-x   79 hebasto  admin    2528 13 Nov 06:22 Frameworks
-rw-r--r--    1 hebasto  admin    7533 16 Apr 09:09 INSTALL_RECEIPT.json
-rw-r--r--    1 hebasto  admin   22961 13 Nov 06:22 LICENSE.FDL
-rw-r--r--    1 hebasto  admin   36363 13 Nov 06:22 LICENSE.GPL3-EXCEPT
-rw-r--r--    1 hebasto  admin   15351 13 Nov 06:22 LICENSE.GPLv2
-rw-r--r--    1 hebasto  admin   35641 13 Nov 06:22 LICENSE.GPLv3
-rw-r--r--    1 hebasto  admin   26828 13 Nov 06:22 LICENSE.LGPLv21
-rw-r--r--    1 hebasto  admin    8174 13 Nov 06:22 LICENSE.LGPLv3
-rw-r--r--    1 hebasto  admin  106262 13 Nov 06:22 LICENSE.QT-LICENSE-AGREEMENT
-rw-r--r--    1 hebasto  admin    3842 13 Nov 06:22 README
drwxr-xr-x   57 hebasto  admin    1824 16 Apr 09:09 bin
drwxr-xr-x    4 hebasto  admin     128 13 Nov 06:22 doc
drwxr-xr-x   95 hebasto  admin    3040 13 Nov 06:22 include
drwxr-xr-x  119 hebasto  admin    3808 16 Apr 09:09 lib
drwxr-xr-x    8 hebasto  admin     256 13 Nov 06:22 libexec
drwxr-xr-x   79 hebasto  admin    2528 16 Apr 09:09 mkspecs
drwxr-xr-x   15 hebasto  admin     480 13 Nov 06:22 phrasebooks
drwxr-xr-x   31 hebasto  admin     992 13 Nov 06:22 plugins
drwxr-xr-x   28 hebasto  admin     896 13 Nov 06:22 qml
-rw-r--r--    1 hebasto  admin    6952 16 Apr 09:09 sbom.spdx.json
drwxr-xr-x    3 hebasto  admin      96 13 Nov 06:22 share
drwxr-xr-x  347 hebasto  admin   11104 13 Nov 06:22 translations
% ls -l $(brew --prefix qt@6)/share/qt/
total 0
drwxr-xr-x    4 hebasto  admin   128 30 Mar 09:49 doc
drwxr-xr-x   35 hebasto  admin  1120 16 Apr 09:16 libexec
drwxr-xr-x  167 hebasto  admin  5344 30 Mar 09:49 metatypes
drwxr-xr-x   70 hebasto  admin  2240 16 Apr 09:16 mkspecs
drwxr-xr-x  178 hebasto  admin  5696 30 Mar 09:49 modules
drwxr-xr-x   15 hebasto  admin   480 30 Mar 09:49 phrasebooks
drwxr-xr-x   31 hebasto  admin   992 30 Mar 09:49 plugins
drwxr-xr-x   34 hebasto  admin  1088 30 Mar 09:49 qml
drwxr-xr-x   45 hebasto  admin  1440 30 Mar 09:49 sbom
drwxr-xr-x  285 hebasto  admin  9120 30 Mar 09:49 translations
```

This PR addresses both issues and additionally adds a `deploy` target to the native macOS CI job to prevent any similar recessions in the future.

Fixes https://github.com/bitcoin/bitcoin/issues/32267.