### PR TITLE
ci: drop -priority-level from bench in win cross CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           ./src/univalue/unitester.exe
 
       - name: Run benchmarks
-        run: ./bin/bench_bitcoin.exe -sanity-check -priority-level=high
+        run: ./bin/bench_bitcoin.exe -sanity-check
 
       - name: Adjust paths in test/config.ini
         shell: pwsh


### PR DESCRIPTION
So there's at least one CI sanity checking all benchmarks.

Related to #32277.