### PR TITLE
doc: Add note for building on macOS (Intel) with CMake ≥ 4.0

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -145,6 +145,8 @@ It is required that you have `python` and `zip` installed.
 
 ### 1. Configuration
 
+Note: On macOS (x86_64), users with CMake ≥ 4.0 and Homebrew installed in `/usr/local` should pass `-DCMAKE_OSX_SYSROOT=macosx` or `export SDKROOT=macosx` when not building with Homebrew-provided tools.
+
 There are many ways to configure Bitcoin Core, here are a few common examples:
 
 ##### Wallet (BDB + SQlite) Support, No GUI:


### PR DESCRIPTION
Due to [changes](https://cmake.org/cmake/help/latest/release/4.0.html#other-changes) in CMake 4.0, building on macOS (Intel) no longer silences warnings from Homebrew-installed packages, such as `boost` or `libevent`.

This PR adds a note to the [_macOS Build Guide_](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md) to work around this issue.

For technical background, see the following discussions:
- https://gitlab.kitware.com/cmake/cmake/-/issues/19180
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10636