### PR TITLE
feefrac: avoid integer overflow in temporary

### DIFF
--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -148,6 +148,8 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);
 
+    // Test for integer overflow issue (https://github.com/bitcoin/bitcoin/issues/32294)
+    BOOST_CHECK_EQUAL((FeeFrac{0x7ffffffdfffffffb, 0x7ffffffd}.EvaluateFeeDown(0x7fffffff)), 0x7fffffffffffffff);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -96,7 +96,7 @@ struct FeeFrac
         int64_t quot = n / d;
         int32_t mod = n % d;
         // Correct result if the / operator above rounded in the wrong direction.
-        return quot + (mod > 0) - (mod && round_down);
+        return quot + ((mod > 0) - (mod && round_down));
     }
 #else
     static constexpr auto Mul = MulFallback;


### PR DESCRIPTION
In `FeeFrac::Div(__int128 n, int32_t d, bool round_down)` in src/util/feefrac.h, the following line computes the result:

```c++
        return quot + (mod > 0) - (mod && round_down);
```

The function can only be called under conditions where the result is in range, and thus doesn't involve any integer overflow. However, the intermediary result computed by just `quot + (mod > 0)` may still overflow if it's going to be corrected by the `- (mod && round_down)` that follows.

Fix this by balancing the two correction steps with each other first:
```c++
        return quot + ((mod > 0) - (mod && round_down));
```

Fixes #32294.
