### PR TITLE
ci: Temporarily revert "Drop bench -priority-level in win cross CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           ./src/univalue/unitester.exe
 
       - name: Run benchmarks
-        run: ./bin/bench_bitcoin.exe -sanity-check
+        run: ./bin/bench_bitcoin.exe -sanity-check -priority-level=high
 
       - name: Adjust paths in test/config.ini
         shell: pwsh


### PR DESCRIPTION
This reverts commit 27f11217ca63e0f8f78f14db139150052dcd9962.

The commit was nice and useful. However, CI doesn't pass, see https://github.com/bitcoin/bitcoin/issues/32291. Temporarily revert it, so that it can be enabled again along with the issue fixed.