### PR TITLE
test: add test for decoding PSBT with MuSig2 PSBT key types (BIP 373)

### DIFF
--- a/test/functional/test_framework/psbt.py
+++ b/test/functional/test_framework/psbt.py
@@ -50,6 +50,9 @@ PSBT_IN_TAP_LEAF_SCRIPT = 0x15
 PSBT_IN_TAP_BIP32_DERIVATION = 0x16
 PSBT_IN_TAP_INTERNAL_KEY = 0x17
 PSBT_IN_TAP_MERKLE_ROOT = 0x18
+PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS = 0x1a
+PSBT_IN_MUSIG2_PUB_NONCE = 0x1b
+PSBT_IN_MUSIG2_PARTIAL_SIG = 0x1c
 PSBT_IN_PROPRIETARY = 0xfc
 
 # per-output types
@@ -61,6 +64,7 @@ PSBT_OUT_SCRIPT = 0x04
 PSBT_OUT_TAP_INTERNAL_KEY = 0x05
 PSBT_OUT_TAP_TREE = 0x06
 PSBT_OUT_TAP_BIP32_DERIVATION = 0x07
+PSBT_OUT_MUSIG2_PARTICIPANT_PUBKEYS = 0x08
 PSBT_OUT_PROPRIETARY = 0xfc
 
 
@@ -88,6 +92,9 @@ class PSBTMap:
         for k,v in self.map.items():
             if isinstance(k, int) and 0 <= k and k <= 255:
                 k = bytes([k])
+            if isinstance(v, list):
+                assert all(type(elem) is bytes for elem in v)
+                v = b"".join(v)  # simply concatenate the byte-strings w/o size prefixes
             m += ser_compact_size(len(k)) + k
             m += ser_compact_size(len(v)) + v
         m += b"\x00"


### PR DESCRIPTION
This PR is a follow-up to #31247 (see https://github.com/bitcoin/bitcoin/pull/31247#pullrequestreview-2427834909) and adds a functional test for decoding PSBTs (using the `decodepsbt` RPC) with MuSig2 per-input and per-output types. The first commit adds the new MuSig2 key types to the test frameworks and extends the PSBT serialization to cope with lists of bytestrings.