### PR TITLE
ci: Temporarily disable `WalletMigration` benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,8 @@ jobs:
           ./src/univalue/unitester.exe
 
       - name: Run benchmarks
-        run: ./bin/bench_bitcoin.exe -sanity-check
+        # TODO: Fix the `WalletMigration` benchmark and re-enable it.
+        run: ./bin/bench_bitcoin.exe -sanity-check -filter='^(?!WalletMigration$).+$'
 
       - name: Adjust paths in test/config.ini
         shell: pwsh


### PR DESCRIPTION
The `WalletMigration` benchmark is currently failing on CI.

This PR temporarily disables it until the issue is resolved.

An alternative to https://github.com/bitcoin/bitcoin/pull/32302.