### PR TITLE
test: Run all benchmarks in the sanity check

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -79,8 +79,8 @@ if(ENABLE_WALLET)
   target_link_libraries(bench_bitcoin bitcoin_wallet)
 endif()
 
-add_test(NAME bench_sanity_check_high_priority
-  COMMAND bench_bitcoin -sanity-check -priority-level=high
+add_test(NAME bench_sanity_check
+  COMMAND bench_bitcoin -sanity-check
 )
 
 install_binary_component(bench_bitcoin)


### PR DESCRIPTION
It is unclear why not all benchmarks are run, given that:

* they only run as a sanity check (fastest version)
* no one otherwise runs them, not even CI
* issues have been missed due to this