### PR TITLE
test: Fix feature_pruning test after nTime typo fix

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -500,11 +500,11 @@ class PruneTest(BitcoinTestFramework):
             "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0, "basic", {"filter_false_positives": True})
 
     def test_pruneheight_undo_presence(self):
-        node = self.nodes[2]
+        node = self.nodes[5]
         pruneheight = node.getblockchaininfo()["pruneheight"]
         fetch_block = node.getblockhash(pruneheight - 1)
 
-        self.connect_nodes(1, 2)
+        self.connect_nodes(1, 5)
         peers = node.getpeerinfo()
         node.getblockfrompeer(fetch_block, peers[0]["id"])
         self.wait_until(lambda: not try_rpc(-1, "Block not available (pruned data)", node.getblock, fetch_block), timeout=5)

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -41,7 +41,7 @@ def mine_large_blocks(node, n):
     # Set the nTime if this is the first time this function has been called.
     # A static variable ensures that time is monotonicly increasing and is therefore
     # different for each block created => blockhash is unique.
-    if "nTimes" not in mine_large_blocks.__dict__:
+    if "nTime" not in mine_large_blocks.__dict__:
         mine_large_blocks.nTime = 0
 
     # Get the block parameters for the first block


### PR DESCRIPTION
This PR contains two commits:

1. Fixes a typo in feature_pruning.py where 'nTimes' was incorrectly
   used instead of 'nTime'. This typo caused the test to always reset
   mine_large_blocks.nTime to 0, rather than only on the first run.

2. Fixes the test failure exposed by the typo fix. The
   test_pruneheight_undo_presence test was failing because it was using
   node 2, which is involved in reorg testing and could be on a
   different chain than other nodes. The solution switches to using
   node 5, which is also a pruned node but isn't involved in reorg
   testing.

Testing:
- Ran test/functional/feature_pruning.py multiple times to verify
  consistent passing
- Verified that the test now passes with the correct nTime variable name
- Confirmed the test behavior matches the intended functionality of
  verifying pruned block availability
- Ran the full test suite to ensure the changes did not introduce any
  regressions or affect other tests

Thanks to fjahr for his assistance in diagnosing the issue and
suggesting the solution.

This fixes the test failure reported in #32249 