### PR TITLE
Fix failing util_time_GetTime test on Windows

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -567,9 +567,9 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-BOOST_AUTO_TEST_CASE(util_time_GetTime)
+BOOST_AUTO_TEST_CASE(util_mocktime)
 {
-    SetMockTime(111);
+    SetMockTime(111s);
     // Check that mock time does not change after a sleep
     for (const auto& num_sleep : {0ms, 1ms}) {
         UninterruptibleSleep(num_sleep);
@@ -583,13 +583,6 @@ BOOST_AUTO_TEST_CASE(util_time_GetTime)
         BOOST_CHECK_EQUAL(111000000, GetTime<std::chrono::microseconds>().count());
     }
     SetMockTime(0s);
-
-    // Check that steady time changes after a sleep
-    const auto steady_ms_0 = Now<SteadyMilliseconds>();
-    const auto steady_0 = std::chrono::steady_clock::now();
-    UninterruptibleSleep(1ms);
-    BOOST_CHECK(steady_ms_0 < Now<SteadyMilliseconds>());
-    BOOST_CHECK(steady_0 + 1ms <= std::chrono::steady_clock::now());
 }
 
 BOOST_AUTO_TEST_CASE(test_IsDigit)


### PR DESCRIPTION
Remove unreliable steady clock time checking from the test that was causing CI failures primarily on Windows. The test previously tried to verify that  steady_clock time increases after a 1ms sleep, but this approach is not reliable on all platforms where such a short sleep interval may not consistently result in observable clock changes.

This addresses issue #32197 where the test was reporting failures in the  cross-built Windows CI environment. As noted in the discussion, the test is not critical to the functionality of Bitcoin Core, and removing the unreliable part is the most straightforward solution.
