### PR TITLE
test: Treat executable paths in tests consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
         working-directory: build
         env:
           QT_PLUGIN_PATH: '${{ github.workspace }}\build\vcpkg_installed\x64-windows\Qt6\plugins'
+          BITCOINUTIL: '${{ github.workspace }}\build\bin\Release\bitcoin-util.exe'
+          BITCOINTX: '${{ github.workspace }}\build\bin\Release\bitcoin-tx.exe'
         run: |
           ctest --output-on-failure --stop-on-failure -j $NUMBER_OF_PROCESSORS -C Release
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -4,7 +4,7 @@
 
 if(TARGET bitcoin-util AND TARGET bitcoin-tx AND PYTHON_COMMAND)
   add_test(NAME util_test_runner
-    COMMAND ${CMAKE_COMMAND} -E env BITCOINUTIL=$<TARGET_FILE:bitcoin-util> BITCOINTX=$<TARGET_FILE:bitcoin-tx> ${PYTHON_COMMAND} ${PROJECT_BINARY_DIR}/test/util/test_runner.py
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_BINARY_DIR}/test/util/test_runner.py
   )
 endif()
 


### PR DESCRIPTION
When using multi-config CMake generators, executable paths include per-config subdirectories, which require special handling in tests. Using dedicated environment variables to specify executable paths works well in such scenarios. However, the `util_test_runner` test sets these variables for the `util/test_runner.py` script unconditionally, which diverges from the approach used when running `functional/test_runner.py`.

This change makes the usage of the aforementioned environment variables uniform.

Also see: https://github.com/bitcoin/bitcoin/pull/32183#discussion_r2022565111.