### PR TITLE
ci: Add missing -Wno-error=array-bounds to valgrind fuzz

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -17,4 +17,5 @@ export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="all"
 export BITCOIN_CONFIG="\
  -DBUILD_FOR_FUZZING=ON \
+ -DCMAKE_CXX_FLAGS='-Wno-error=array-bounds' \
 "


### PR DESCRIPTION
Due to an upstream GCC issue, any debug/fuzz build which aborts on failed assumes will print a false positive array-bounds warning in `src/test/fuzz/txgraph.cpp`.

This also affects one CI task.

Fix the CI task by ignoring the error for now.

Fixes https://github.com/bitcoin/bitcoin/issues/32276