### PR TITLE
refactor: Update `XOnlyPubKey::GetKeyIDs()` to return a pair of pubkeys

### DIFF
--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -282,10 +282,10 @@ public:
     /** Construct a Taproot tweaked output point with this point as internal key. */
     std::optional<std::pair<XOnlyPubKey, bool>> CreateTapTweak(const uint256* merkle_root) const;
 
-    /** Returns a list of CKeyIDs for the CPubKeys that could have been used to create this XOnlyPubKey.
+    /** Returns CKeyIDs for the even and odd CPubKeys that could have been used to create this XOnlyPubKey.
      * This is needed for key lookups since keys are indexed by CKeyID.
      */
-    std::vector<CKeyID> GetKeyIDs() const;
+    std::array<CKeyID, 2> GetKeyIDs() const;
 
     CPubKey GetEvenCorrespondingCPubKey() const;
 


### PR DESCRIPTION
Currently, `XOnlyPubKey::GetKeyIDs()` has `vector` as return type, but always returns a pair of public key IDs.

This PR changes the code for readability reasons. 
There may be negligible efficiency gains, but the goal is to make the code more readable and to make the intent of the function clear.
There is no change in behavior.