### PR TITLE
ci: Temporarily disable failing bpf checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,11 +405,6 @@ jobs:
           key: ${{ github.job }}-ccache-${{ github.run_id }}
           restore-keys: ${{ github.job }}-ccache-
 
-      - name: Enable bpfcc script
-        # In the image build step, no external environment variables are available,
-        # so any settings will need to be written to the settings env file:
-        run: sed -i "s|\${INSTALL_BCC_TRACING_TOOLS}|true|g" ./ci/test/00_setup_env_native_asan.sh
-
       - name: CI script
         run: ./ci/test_run_all.sh
 


### PR DESCRIPTION
The ` interface_usdt_coinselection.py` seems to consistently fail under Linux kernel 6.11.

I don't have a VM with that kernel right now to test, and https://github.com/bitcoin/bitcoin/issues/32322 is open since two days, so I don't think anyone else has either.

So temporarily disable the failing tests, to allow for more time while unbreaking the CI.