### PR TITLE
test: Increase stack size for "Debug" builds with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,11 @@ if(WIN32)
       /Zc:__cplusplus
       /sdl
     )
+    target_link_options(core_interface INTERFACE
+      # Increase stack size to accommodate the deep recursion
+      # in the FindChallenges() function used in miniscript_tests.
+      $<$<CONFIG:Debug>:/STACK:2097152>
+    )
     # Improve parallelism in MSBuild.
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
     list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")


### PR DESCRIPTION
This PR accommodates the deep recursion in the `FindChallenges()` function used in `test/miniscript_tests.cpp`.

Fixes https://github.com/bitcoin/bitcoin/issues/32341#issuecomment-2829441596.

CI log: https://github.com/hebasto/bitcoin/actions/runs/14664806617/job/41156972137