### PR TITLE
depends: Fix cross-compiling `qt` package from macOS to Windows

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -190,6 +190,14 @@ ifneq ($(host),$(build))
 $(package)_cmake_opts += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system_name)
 $(package)_cmake_opts += -DCMAKE_SYSTEM_VERSION=$($(host_os)_cmake_system_version)
 $(package)_cmake_opts += -DCMAKE_SYSTEM_PROCESSOR=$(host_arch)
+# Native packages cannot be used during cross-compiling. However,
+# Qt still unconditionally tries to find them, which causes issues
+# in some cases, such as when cross-compiling from macOS to Windows.
+# Explicitly disable this unnecessary Qt behaviour.
+$(package)_cmake_opts += -DCMAKE_DISABLE_FIND_PACKAGE_Libb2=TRUE
+$(package)_cmake_opts += -DCMAKE_DISABLE_FIND_PACKAGE_WrapSystemDoubleConversion=TRUE
+$(package)_cmake_opts += -DCMAKE_DISABLE_FIND_PACKAGE_WrapSystemMd4c=TRUE
+$(package)_cmake_opts += -DCMAKE_DISABLE_FIND_PACKAGE_WrapZSTD=TRUE
 endif
 ifeq ($(host_os),darwin)
 $(package)_cmake_opts += -DCMAKE_INSTALL_NAME_TOOL=true


### PR DESCRIPTION
Native packages cannot be used during cross-compiling. However, Qt still unconditionally tries to find them, which causes issues in some cases, such as when [cross-compiling from macOS to Windows](https://github.com/bitcoin/bitcoin/issues/32346).

This PR explicitly disables this unnecessary Qt behaviour.

Fixes https://github.com/bitcoin/bitcoin/issues/32346.

Here is a full workflow on my macOS Sequoia 15.4.1 (Intel):
```
% brew install make cmake ninja mingw-w64 nsis
% gmake -C depends -j 10 HOST=x86_64-w64-mingw32
% cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
% cmake --build build -j 10 -t deploy
```