### PR TITLE
Modernize use of UTF-8 in Windows code

### DIFF
--- a/cmake/windows-app.manifest.in
+++ b/cmake/windows-app.manifest.in
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity
       type="win32"
       name="org.bitcoincore.${target}"
       version="${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}.0"
   />
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+      <activeCodePage>UTF-8</activeCodePage>
+    </asmv3:windowsSettings>
+  </asmv3:application>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -35,8 +35,8 @@ wallet versions of Bitcoin Core are generally supported.
 Compatibility
 ==============
 
-Bitcoin Core is supported and tested on operating systems using the
-Linux Kernel 3.17+, macOS 14+, and Windows 10+. Bitcoin
+Bitcoin Core is supported and tested on the following operating systems or newer:
+Linux Kernel 3.17, macOS 14, and Windows 10 (version 1903). Bitcoin
 Core should also work on most other Unix-like systems but is not as
 frequently tested on them. It is not recommended to use Bitcoin Core on
 unsupported systems.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,6 +410,7 @@ if(BUILD_UTIL_CHAINSTATE)
   add_executable(bitcoin-chainstate
     bitcoin-chainstate.cpp
   )
+  add_windows_application_manifest(bitcoin-chainstate)
   # TODO: The `SKIP_BUILD_RPATH` property setting can be deleted
   #       in the future after reordering Guix script commands to
   #       perform binary checks after the installation step.

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -56,6 +56,8 @@ add_executable(bench_bitcoin
   verify_script.cpp
 )
 
+add_windows_application_manifest(bench_bitcoin)
+
 include(TargetDataSources)
 target_raw_data_sources(bench_bitcoin NAMESPACE benchmark::data
   data/block413567.raw

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1328,10 +1328,6 @@ static int CommandLineRPC(int argc, char *argv[])
 
 MAIN_FUNCTION
 {
-#ifdef WIN32
-    common::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#endif
     SetupEnvironment();
     if (!SetupNetworking()) {
         tfm::format(std::cerr, "Error: Initializing networking failed\n");

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -94,10 +94,6 @@ static std::optional<int> WalletAppInit(ArgsManager& args, int argc, char* argv[
 MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
-#ifdef WIN32
-    common::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#endif
 
     int exit_status;
     std::unique_ptr<interfaces::Init> init = interfaces::MakeWalletInit(argc, argv, exit_status);

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -6,6 +6,7 @@
 
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <util/fs.h>
 #include <util/exec.h>
 #include <util/strencodings.h>
@@ -61,6 +62,8 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view a
 
 int main(int argc, char* argv[])
 {
+    SetupEnvironment();
+
     try {
         CommandLine cmd{ParseCommandLine(argc, argv)};
         if (cmd.show_version) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -259,11 +259,6 @@ static bool AppInit(NodeContext& node)
 
 MAIN_FUNCTION
 {
-#ifdef WIN32
-    common::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#endif
-
     NodeContext node;
     int exit_status;
     std::unique_ptr<interfaces::Init> init = interfaces::MakeNodeInit(node, argc, argv, exit_status);

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -19,8 +19,6 @@
 #include <util/string.h>
 
 #ifdef WIN32
-#include <codecvt>
-#include <shellapi.h>
 #include <shlobj.h>
 #endif
 
@@ -879,30 +877,3 @@ void ArgsManager::LogArgs() const
     }
     logArgsPrefix("Command-line arg:", "", m_settings.command_line_options);
 }
-
-namespace common {
-#ifdef WIN32
-WinCmdLineArgs::WinCmdLineArgs()
-{
-    wchar_t** wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utf8_cvt;
-    argv = new char*[argc];
-    args.resize(argc);
-    for (int i = 0; i < argc; i++) {
-        args[i] = utf8_cvt.to_bytes(wargv[i]);
-        argv[i] = &*args[i].begin();
-    }
-    LocalFree(wargv);
-}
-
-WinCmdLineArgs::~WinCmdLineArgs()
-{
-    delete[] argv;
-}
-
-std::pair<int, char**> WinCmdLineArgs::get()
-{
-    return std::make_pair(argc, argv);
-}
-#endif
-} // namespace common

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -480,21 +480,4 @@ std::string HelpMessageGroup(const std::string& message);
  */
 std::string HelpMessageOpt(const std::string& option, const std::string& message);
 
-namespace common {
-#ifdef WIN32
-class WinCmdLineArgs
-{
-public:
-    WinCmdLineArgs();
-    ~WinCmdLineArgs();
-    std::pair<int, char**> get();
-
-private:
-    int argc;
-    char** argv;
-    std::vector<std::string> args;
-};
-#endif
-} // namespace common
-
 #endif // BITCOIN_COMMON_ARGS_H

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -12,6 +12,7 @@
 #include <util/time.h>
 
 #ifdef WIN32
+#include <cassert>
 #include <codecvt>
 #include <compat/compat.h>
 #include <windows.h>
@@ -83,6 +84,7 @@ void SetupEnvironment()
         setenv("LC_ALL", "C.UTF-8", 1);
     }
 #elif defined(WIN32)
+    assert(GetACP() == CP_UTF8);
     // Set the default input/output charset is utf-8
     SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -478,11 +478,6 @@ static void SetupUIArgs(ArgsManager& argsman)
 
 int GuiMain(int argc, char* argv[])
 {
-#ifdef WIN32
-    common::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#endif
-
     std::unique_ptr<interfaces::Init> init = interfaces::MakeGuiInit(argc, argv);
 
     SetupEnvironment();

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(test_bitcoin-qt
   ../../init/bitcoin-qt.cpp
 )
 
+add_windows_application_manifest(test_bitcoin-qt)
+
 target_link_libraries(test_bitcoin-qt
   core_interface
   bitcoinqt

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -134,6 +134,9 @@ add_executable(fuzz
   vecdeque.cpp
   versionbits.cpp
 )
+
+add_windows_application_manifest(fuzz)
+
 target_link_libraries(fuzz
   core_interface
   fuzzer_interface

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -12,7 +12,6 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #else
-#include <codecvt>
 #include <limits>
 #include <windows.h>
 #endif
@@ -28,8 +27,7 @@ FILE *fopen(const fs::path& p, const char *mode)
 #ifndef WIN32
     return ::fopen(p.c_str(), mode);
 #else
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t> utf8_cvt;
-    return ::_wfopen(p.wstring().c_str(), utf8_cvt.from_bytes(mode).c_str());
+    return ::fopen(p.utf8string().c_str(), mode);
 #endif
 }
 

--- a/src/util/syserror.cpp
+++ b/src/util/syserror.cpp
@@ -12,8 +12,6 @@
 
 #if defined(WIN32)
 #include <windows.h>
-#include <locale>
-#include <codecvt>
 #endif
 
 std::string SysErrorString(int err)
@@ -41,16 +39,13 @@ std::string SysErrorString(int err)
 #if defined(WIN32)
 std::string Win32ErrorString(int err)
 {
-    wchar_t buf[256];
+    char buf[256];
     buf[0] = 0;
-    if(FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+    if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
                        nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                       buf, ARRAYSIZE(buf), nullptr))
-    {
-        return strprintf("%s (%d)", std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf), err);
-    }
-    else
-    {
+                       buf, ARRAYSIZE(buf), nullptr)) {
+        return strprintf("%s (%d)", buf, err);
+    } else {
         return strprintf("Unknown error (%d)", err);
     }
 }


### PR DESCRIPTION
The main goal is to remove [deprecated](https://github.com/bitcoin/bitcoin/issues/32361) code (removed in C++26).

This PR employs Microsoft's modern [approach](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page) to handling UTF-8:
> Until recently, Windows has emphasized "Unicode" -W variants over -A APIs. However, recent releases have used the ANSI code page and -A APIs as a means to introduce UTF-8 support to apps. If the ANSI code page is configured for UTF-8, then -A APIs typically operate in UTF-8. This model has the benefit of supporting existing code built with -A APIs without any code changes.

TODO:
- [x] Handle application manifests properly when building with MSVC.
- [x] Bump the minimum supported Windows version to 1903 (May 2019 Update).
- [x] Remove all remaining use cases of the deprecated `std:wstring_convert`.
    - The instance in `subprocess.h` will be addressed in a follow-up PR, as additional tests are likely needed.
    - The usage in `common/system.cpp` is handled in https://github.com/bitcoin/bitcoin/pull/32566.

Resolves partially https://github.com/bitcoin/bitcoin/issues/32361.