### PR TITLE
util: Remove `fsbridge::get_filesystem_error_message()`

### DIFF
--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -170,7 +170,7 @@ void DeleteAuthCookie()
             fs::remove(GetAuthCookieFile());
         }
     } catch (const fs::filesystem_error& e) {
-        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, fsbridge::get_filesystem_error_message(e));
+        LogWarning("Unable to remove random auth cookie file %s: %s\n", fs::PathToString(e.path1()), e.code().message());
     }
 }
 

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -115,20 +115,4 @@ bool FileLock::TryLock()
 }
 #endif
 
-std::string get_filesystem_error_message(const fs::filesystem_error& e)
-{
-#ifndef WIN32
-    return e.what();
-#else
-    // Convert from Multi Byte to utf-16
-    std::string mb_string(e.what());
-    int size = MultiByteToWideChar(CP_ACP, 0, mb_string.data(), mb_string.size(), nullptr, 0);
-
-    std::wstring utf16_string(size, L'\0');
-    MultiByteToWideChar(CP_ACP, 0, mb_string.data(), mb_string.size(), &*utf16_string.begin(), size);
-    // Convert from utf-16 to utf-8
-    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>().to_bytes(utf16_string);
-#endif
-}
-
 } // namespace fsbridge

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -239,8 +239,6 @@ namespace fsbridge {
         void* hFile = (void*)-1; // INVALID_HANDLE_VALUE
 #endif
     };
-
-    std::string get_filesystem_error_message(const fs::filesystem_error& e);
 };
 
 // Disallow path operator<< formatting in tinyformat to avoid locale-dependent

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5636,8 +5636,8 @@ Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
                           fs::PathToString(node::SNAPSHOT_BLOCKHASH_FILENAME));
             }
         } catch (const fs::filesystem_error& e) {
-            LogPrintf("[snapshot] failed to remove file %s: %s\n",
-                    fs::PathToString(base_blockhash_path), fsbridge::get_filesystem_error_message(e));
+            LogWarning("[snapshot] failed to remove file %s: %s\n",
+                       fs::PathToString(base_blockhash_path), e.code().message());
         }
     }
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -702,7 +702,7 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
                     LogPrintf("copied %s to %s\n", strFile, fs::PathToString(pathDest));
                     return true;
                 } catch (const fs::filesystem_error& e) {
-                    LogPrintf("error copying %s to %s - %s\n", strFile, fs::PathToString(pathDest), fsbridge::get_filesystem_error_message(e));
+                    LogWarning("error copying %s to %s - %s\n", strFile, fs::PathToString(pathDest), e.code().message());
                     return false;
                 }
             }

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -722,7 +722,7 @@ bool BerkeleyRODatabase::Backup(const std::string& dest) const
         LogPrintf("copied %s to %s\n", fs::PathToString(m_filepath), fs::PathToString(dst));
         return true;
     } catch (const fs::filesystem_error& e) {
-        LogPrintf("error copying %s to %s - %s\n", fs::PathToString(m_filepath), fs::PathToString(dst), fsbridge::get_filesystem_error_message(e));
+        LogWarning("error copying %s to %s - %s\n", fs::PathToString(m_filepath), fs::PathToString(dst), e.code().message());
         return false;
     }
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1429,7 +1429,7 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     try {
         exists = fs::symlink_status(path).type() != fs::file_type::not_found;
     } catch (const fs::filesystem_error& e) {
-        error = Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), fsbridge::get_filesystem_error_message(e)));
+        error = Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()));
         status = DatabaseStatus::FAILED_BAD_PATH;
         return nullptr;
     }


### PR DESCRIPTION
The `fsbridge::get_filesystem_error_message()` function exhibits several drawbacks:

1. It was introduced in https://github.com/bitcoin/bitcoin/pull/14192 to account for platform-specific variations in
`boost::filesystem::filesystem_error::what()`. Since [migrating](https://github.com/bitcoin/bitcoin/pull/20744) to `std::filesystem`, those discrepancies no longer exist.

2. It fails to display UTF-8 paths correctly on Windows:
```
> build\bin\Release\bitcoind.exe -datadir="C:\Users\hebasto\dd_₿_🏃" -regtest
...
2025-04-30T00:17:48Z DeleteAuthCookie: Unable to remove random auth cookie file: remove: Access is denied.: "C:\Users\hebasto\dd_?_??\regtest\.cookie"
...
```

3. It relies on `std::wstring_convert`, which was deprecated in C++17 and removed in C++26 (also see https://github.com/bitcoin/bitcoin/issues/32361).

This PR removes the obsolete `fsbridge::get_filesystem_error_message()` function, thereby resolving all of the above issues.