### PR TITLE
mining: rename gbt_force and gbt_force_name

### DIFF
--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -11,11 +11,11 @@
 const std::array<VBDeploymentInfo,Consensus::MAX_VERSION_BITS_DEPLOYMENTS> VersionBitsDeploymentInfo{
     VBDeploymentInfo{
         .name = "testdummy",
-        .gbt_force = true,
+        .gbt_optional_rule = true,
     },
     VBDeploymentInfo{
         .name = "taproot",
-        .gbt_force = true,
+        .gbt_optional_rule = true,
     },
 };
 

--- a/src/deploymentinfo.h
+++ b/src/deploymentinfo.h
@@ -15,7 +15,7 @@ struct VBDeploymentInfo {
     /** Deployment name */
     const char *name;
     /** Whether GBT clients can safely ignore this rule in simplified usage */
-    bool gbt_force;
+    bool gbt_optional_rule;
 };
 
 extern const std::array<VBDeploymentInfo,Consensus::MAX_VERSION_BITS_DEPLOYMENTS> VersionBitsDeploymentInfo;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -596,6 +596,7 @@ static UniValue BIP22ValidationResult(const BlockValidationState& state)
     return "valid?";
 }
 
+// Prefix rule name with ! if not optional, see BIP9
 static std::string gbt_rule_value(const std::string& name, bool gbt_optional_rule)
 {
     std::string s{name};

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -596,10 +596,10 @@ static UniValue BIP22ValidationResult(const BlockValidationState& state)
     return "valid?";
 }
 
-static std::string gbt_force_name(const std::string& name, bool gbt_force)
+static std::string gbt_rule_value(const std::string& name, bool gbt_optional_rule)
 {
     std::string s{name};
-    if (!gbt_force) {
+    if (!gbt_optional_rule) {
         s.insert(s.begin(), '!');
     }
     return s;
@@ -955,8 +955,8 @@ static RPCHelpMan getblocktemplate()
     const auto gbtstatus = chainman.m_versionbitscache.GBTStatus(*pindexPrev, consensusParams);
 
     for (const auto& [name, info] : gbtstatus.signalling) {
-        vbavailable.pushKV(gbt_force_name(name, info.gbt_force), info.bit);
-        if (!info.gbt_force && !setClientRules.count(name)) {
+        vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
+        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
             block.nVersion &= ~info.mask;
         }
@@ -964,16 +964,16 @@ static RPCHelpMan getblocktemplate()
 
     for (const auto& [name, info] : gbtstatus.locked_in) {
         block.nVersion |= info.mask;
-        vbavailable.pushKV(gbt_force_name(name, info.gbt_force), info.bit);
-        if (!info.gbt_force && !setClientRules.count(name)) {
+        vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
+        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
             block.nVersion &= ~info.mask;
         }
     }
 
     for (const auto& [name, info] : gbtstatus.active) {
-        aRules.push_back(gbt_force_name(name, info.gbt_force));
-        if (!info.gbt_force && !setClientRules.count(name)) {
+        aRules.push_back(gbt_rule_value(name, info.gbt_optional_rule));
+        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
             // Not supported by the client; make sure it's safe to proceed
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Support for '%s' rule requires explicit client support", name));
         }

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -235,7 +235,7 @@ BIP9GBTStatus VersionBitsCache::GBTStatus(const CBlockIndex& block_index, const 
         VersionBitsConditionChecker checker(params, pos);
         ThresholdState state = checker.GetStateFor(&block_index, m_caches[pos]);
         const VBDeploymentInfo& vbdepinfo = VersionBitsDeploymentInfo[pos];
-        BIP9GBTStatus::Info gbtinfo{.bit=params.vDeployments[pos].bit, .mask=checker.Mask(), .gbt_force=vbdepinfo.gbt_force};
+        BIP9GBTStatus::Info gbtinfo{.bit=params.vDeployments[pos].bit, .mask=checker.Mask(), .gbt_optional_rule=vbdepinfo.gbt_optional_rule};
 
         switch (state) {
         case DEFINED:

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -66,7 +66,7 @@ struct BIP9GBTStatus {
     struct Info {
         int bit;
         uint32_t mask;
-        bool gbt_force;
+        bool gbt_optional_rule;
     };
     std::map<std::string, const Info, std::less<>> signalling, locked_in, active;
 };


### PR DESCRIPTION
The term "force" is ambiguous and not used in [BIP9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki#getblocktemplate-changes) where there ! rule prefix is introduced.

E.g. this code is hard to read:

```cpp
if (!gbt_force) {
   s.insert(s.begin(), '!');
```

Additionally, #29039 renamed `gbt_vb_name` to `gbt_force_name` which, at least for me, further increased the confusion.

This is a pure (variable rename) refactor (plus documentation) and does not change behavior.

Reminder of how to verify a scripted diff:

```sh
test/lint/commit-script-check.sh origin/master..HEAD
```