### PR TITLE
fuzz: Remove unused TimeoutExpired catch in fuzz runner

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -151,24 +151,21 @@ def main():
             )
             logging.info("Please consider adding a fuzz corpus at https://github.com/bitcoin-core/qa-assets")
 
-    try:
-        help_output = subprocess.run(
-            args=[
-                fuzz_bin,
-                '-help=1',
-            ],
-            env=get_fuzz_env(target=test_list_selection[0], source_dir=config['environment']['SRCDIR']),
-            timeout=20,
-            check=False,
-            stderr=subprocess.PIPE,
-            text=True,
-        ).stderr
-        using_libfuzzer = "libFuzzer" in help_output
-        if (args.generate or args.m_dir) and not using_libfuzzer:
-            logging.error("Must be built with libFuzzer")
-            sys.exit(1)
-    except subprocess.TimeoutExpired:
-        logging.error("subprocess timed out: Currently only libFuzzer is supported")
+    print("Check if using libFuzzer ... ", end='')
+    help_output = subprocess.run(
+        args=[
+            fuzz_bin,
+            '-help=1',
+        ],
+        env=get_fuzz_env(target=test_list_selection[0], source_dir=config['environment']['SRCDIR']),
+        check=False,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stderr
+    using_libfuzzer = "libFuzzer" in help_output
+    print(using_libfuzzer)
+    if (args.generate or args.m_dir) and not using_libfuzzer:
+        logging.error("Must be built with libFuzzer")
         sys.exit(1)
 
     with ThreadPoolExecutor(max_workers=args.par) as fuzz_pool:


### PR DESCRIPTION
Currently, the way to check for libFuzzer is to search the stderr of the fuzz executable when passed `-help=1` for the string `libFuzzer`. See also https://github.com/bitcoin/bitcoin/blob/14b8dfb2bd5e2ca2b7c0c9a7f7d50e1e60adf75c/contrib/devtools/deterministic-fuzz-coverage/src/main.rs#L90-L101

The python test runner additionally includes a timeout catch, which was needed before the plain `read_file` fallback was implemented, see https://github.com/bitcoin/bitcoin/blob/14b8dfb2bd5e2ca2b7c0c9a7f7d50e1e60adf75c/src/test/fuzz/fuzz.cpp#L251.

However, it is no longer needed and the printed error message would be wrong, so remove it.

(side-note: On Windows the fuzz executable seems to time out when an assert is hit in a debug build, see https://github.com/bitcoin/bitcoin/issues/32341#issuecomment-2842716175. However, no one is running fuzz debug on Windows. Also, the newly added debug logging is a preferable replacement in this case anyway.)