### PR TITLE
doc: Fix test_bitcoin path

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -22,7 +22,7 @@ and tests weren't explicitly disabled.
 The unit tests can be run with `ctest --test-dir build`, which includes unit
 tests from subtrees.
 
-Run `test_bitcoin --list_content` for the full list of tests.
+Run `build/bin/test_bitcoin --list_content` for the full list of tests.
 
 To run the unit tests manually, launch `build/bin/test_bitcoin`. To recompile
 after a test file was modified, run `cmake --build build` and then run the test again. If you
@@ -44,7 +44,7 @@ The `test_bitcoin` runner accepts command line arguments from the Boost
 framework. To see the list of arguments that may be passed, run:
 
 ```
-test_bitcoin --help
+build/bin/test_bitcoin --help
 ```
 
 For example, to run only the tests in the `getarg_tests` file, with full logging:


### PR DESCRIPTION
This commit fixes a couple command paths for interacting with the test_bitcoin binary within the Unit Test documentation.

If the commands are run as is a `command not found` error is returned.

```bash
❯ test_bitcoin --list_content
bash: test_bitcoin: command not found
```

```bash
❯ test_bitcoin --help
bash: test_bitcoin: command not found
```