### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
+# Ignore all files used by Visual Studio Code
+# and Visual Studio IDE.
+.vs*/**/*
+
 # Build subdirectories.
 /*build*
 !/build-aux
 !/build_msvc
+/out/**/*
 
 *.pyc
 


### PR DESCRIPTION
Build process on WIndows creates the "out" folder by default which is not excluded from changes tracked by git.
Also additional directories `.vs` and `.vscode` are created with files exclusively relevant to the local development environment: commits should not be dirtied by those.

This PR
* Excludes dirs used by VS family.
* Also exclude "out" build directory (default on WIndows)