### PR TITLE
fees: rpc: `estimatesmartfee` now returns a fee rate estimate during low network activity

### DIFF
--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -798,7 +798,9 @@ unsigned int CBlockPolicyEstimator::HistoricalBlockSpan() const
 unsigned int CBlockPolicyEstimator::MaxUsableEstimate() const
 {
     // Block spans are divided by 2 to make sure there are enough potential failing data points for the estimate
-    return std::min(longStats->GetMaxConfirms(), std::max(BlockSpan(), HistoricalBlockSpan()) / 2);
+    auto max = std::min(longStats->GetMaxConfirms(), std::max(BlockSpan(), HistoricalBlockSpan()) / 2);
+    if (max > 1) return max;
+    return 0;
 }
 
 /** Return a fee estimate at the required successThreshold from the shortest

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -78,7 +78,10 @@ static RPCHelpMan estimatesmartfee()
             FeeCalculation feeCalc;
             bool conservative{fee_mode == FeeEstimateMode::CONSERVATIVE};
             CFeeRate feeRate{fee_estimator.estimateSmartFee(conf_target, &feeCalc, conservative)};
-            if (feeRate != CFeeRate(0)) {
+            // Return the maximum of minrelaytxfee, mempoolminfee and estimateSmartFee fee rate when
+            //  a) estimateSmartFee successfully recommended a fee rate
+            //  b) fee rate estimator has recorded enough blocks to be able to provide an estimate for conf_target.
+            if (feeRate != CFeeRate(0) || (unsigned int)feeCalc.returnedTarget >= conf_target) {
                 CFeeRate min_mempool_feerate{mempool.GetMinFee()};
                 CFeeRate min_relay_feerate{mempool.m_opts.min_relay_feerate};
                 feeRate = std::max({feeRate, min_mempool_feerate, min_relay_feerate});


### PR DESCRIPTION
This PR fixes #32105 and related issues: #32178, #31116, and #31032.  
The main motivation is outlined in [this comment](https://github.com/bitcoin/bitcoin/issues/32178#issuecomment-2830820374)).

Bitcoin Core users have reported several issues where nodes are unable to provide fee rate estimates, despite having run long enough to do so for a given target. This typically occurs when there is low activity on the network.

As a result, the issue primarily affects nodes running on test networks `signet` and `testnetn`.

I think it is safe safe to return the maximum of `mempoolminfee` and `minrelaytxfee` but only **after** the node has run long enough to be able to provide an estimate for the target and still cannot.  
(_This avoids the issue of returning an unreliable estimate too early_, as described by [glozow](https://github.com/bitcoin/bitcoin/issues/32178#issuecomment-2831440563)).

The only potential downside is in scenarios where the user has very very poor peer connectivity and most incoming mempool transactions are not seen by the node.  
Even then, with the current full RBF  support,  txs can safely be fee bumped if needed.



#### This PR includes two commits:

- **Bugfix for `MaxUsableEstimate`**: It should not return `1` as a usable target, since this is effectively not usable.
- **Update to the `estimatesmartfee` RPC behavior**: Now returns the maximum of `minrelaytxfee` and `mempoolminfee` when the estimator has recorded enough blocks for the requested confirmation target, but cannot produce an estimate.



#### Additional Context:

The fee estimator should be able of providing an estimate for a confirmation target `n` after observing at least `n * 2` blocks from either historical or current stats. The method `MaxUsableEstimate` determines this.

In the `estimateSmartFee` RPC method, the value shown as `blocks` in the result corresponds to the `returnedTarget`, which is the **minimum** of the user provided`conf_target` and the output of `MaxUsableEstimate`.

Therefore, taking the maximum of `mempoolminfee` and `minrelaytxfee` when `returnedTarget >= conf_target` indicates that enough blocks have been recorded, but there is simply no activity on the network to provide estimate.  
In such cases, the mempool might be empty, and the transaction should pay enough to be relayed to peers making it likely to confirm since their is no demand.

**Note**: The condition uses `>=` because, for example, a `conf_target` of 1 will result in a `returnedTarget` of 2 internally, so it is possible for `returnedTarget` to be > `conf_target`.
