### PR TITLE
cmake: Add application manifests when cross-compiling for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,15 @@ jobs:
         run: |
           cmake --build . -j $NUMBER_OF_PROCESSORS --config Release
 
+      - name: Get bitcoind manifest
+        if: matrix.job-type == 'standard'
+        working-directory: build
+        run: |
+          mt.exe -nologo -inputresource:bin/Release/bitcoind.exe -out:bitcoind.manifest
+          cat bitcoind.manifest
+          echo
+          mt.exe -nologo -inputresource:bin/Release/bitcoind.exe -validate_manifest
+
       - name: Run test suite
         if: matrix.job-type == 'standard'
         working-directory: build
@@ -346,6 +355,20 @@ jobs:
 
       - name: Run bitcoind.exe
         run: ./bin/bitcoind.exe -version
+
+      - name: Find mt.exe tool
+        shell: pwsh
+        run: |
+          $sdk_dir = (Get-ItemProperty 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' -Name KitsRoot10).KitsRoot10
+          $sdk_latest = (Get-ChildItem "$sdk_dir\bin" -Directory | Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } | Sort-Object Name -Descending | Select-Object -First 1).Name
+          "MT_EXE=${sdk_dir}bin\${sdk_latest}\x64\mt.exe" >> $env:GITHUB_ENV
+
+      - name: Get bitcoind manifest
+        shell: pwsh
+        run: |
+          & $env:MT_EXE -nologo -inputresource:bin\bitcoind.exe -out:bitcoind.manifest
+          Get-Content bitcoind.manifest
+          & $env:MT_EXE -nologo -inputresource:bin\bitcoind.exe -validate_manifest
 
       - name: Run unit tests
         # Can't use ctest here like other jobs as we don't have a CMake build tree.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ if(WIN32)
       /Zc:__cplusplus
       /sdl
     )
+    target_link_options(core_interface INTERFACE
+      # We embed our own manifests.
+      /MANIFEST:NO
+    )
     # Improve parallelism in MSBuild.
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
     list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")

--- a/cmake/module/AddWindowsResources.cmake
+++ b/cmake/module/AddWindowsResources.cmake
@@ -4,11 +4,24 @@
 
 include_guard(GLOBAL)
 
-macro(add_windows_resources target rc_file)
+function(add_windows_resources target rc_file)
   if(WIN32)
     target_sources(${target} PRIVATE ${rc_file})
     set_property(SOURCE ${rc_file}
       APPEND PROPERTY COMPILE_DEFINITIONS WINDRES_PREPROC
     )
   endif()
-endmacro()
+endfunction()
+
+# Add a fusion manifest to Windows executables.
+# See: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
+function(add_windows_application_manifest target)
+  if(WIN32)
+    configure_file(${PROJECT_SOURCE_DIR}/cmake/windows-app.manifest.in ${target}.manifest USE_SOURCE_PERMISSIONS)
+    file(CONFIGURE
+      OUTPUT ${target}-manifest.rc
+      CONTENT "1 /* CREATEPROCESS_MANIFEST_RESOURCE_ID */ 24 /* RT_MANIFEST */ \"${target}.manifest\""
+    )
+    add_windows_resources(${target} ${CMAKE_CURRENT_BINARY_DIR}/${target}-manifest.rc)
+  endif()
+endfunction()

--- a/cmake/windows-app.manifest.in
+++ b/cmake/windows-app.manifest.in
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+      type="win32"
+      name="org.bitcoincore.${target}"
+      version="${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}.0"
+  />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -278,6 +278,14 @@ def check_PE_subsystem_version(binary) -> bool:
         return True
     return False
 
+def check_PE_application_manifest(binary) -> bool:
+    if not binary.has_resources:
+        # No resources at all.
+        return False
+
+    rm = binary.resources_manager
+    return rm.has_manifest
+
 def check_ELF_interpreter(binary) -> bool:
     expected_interpreter = ELF_INTERPRETER_NAMES[binary.header.machine_type][binary.abstract.header.endianness]
 
@@ -307,6 +315,7 @@ lief.EXE_FORMATS.MACHO: [
 lief.EXE_FORMATS.PE: [
     ('DYNAMIC_LIBRARIES', check_PE_libraries),
     ('SUBSYSTEM_VERSION', check_PE_subsystem_version),
+    ('APPLICATION_MANIFEST', check_PE_application_manifest),
 ]
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,6 +206,7 @@ if(ENABLE_WALLET)
       wallet/wallettool.cpp
     )
     add_windows_resources(bitcoin-wallet bitcoin-wallet-res.rc)
+    add_windows_application_manifest(bitcoin-wallet)
     target_link_libraries(bitcoin-wallet
       core_interface
       bitcoin_wallet
@@ -339,6 +340,7 @@ if(BUILD_DAEMON)
     init/bitcoind.cpp
   )
   add_windows_resources(bitcoind bitcoind-res.rc)
+  add_windows_application_manifest(bitcoind)
   target_link_libraries(bitcoind
     core_interface
     bitcoin_node
@@ -392,6 +394,7 @@ target_link_libraries(bitcoin_cli
 if(BUILD_CLI)
   add_executable(bitcoin-cli bitcoin-cli.cpp)
   add_windows_resources(bitcoin-cli bitcoin-cli-res.rc)
+  add_windows_application_manifest(bitcoin-cli)
   target_link_libraries(bitcoin-cli
     core_interface
     bitcoin_cli
@@ -407,6 +410,7 @@ endif()
 if(BUILD_TX)
   add_executable(bitcoin-tx bitcoin-tx.cpp)
   add_windows_resources(bitcoin-tx bitcoin-tx-res.rc)
+  add_windows_application_manifest(bitcoin-tx)
   target_link_libraries(bitcoin-tx
     core_interface
     bitcoin_common
@@ -420,6 +424,7 @@ endif()
 if(BUILD_UTIL)
   add_executable(bitcoin-util bitcoin-util.cpp)
   add_windows_resources(bitcoin-util bitcoin-util-res.rc)
+  add_windows_application_manifest(bitcoin-util)
   target_link_libraries(bitcoin-util
     core_interface
     bitcoin_common

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -256,6 +256,7 @@ add_executable(bitcoin-qt
 )
 
 add_windows_resources(bitcoin-qt res/bitcoin-qt-res.rc)
+add_windows_application_manifest(bitcoin-qt)
 
 target_link_libraries(bitcoin-qt
   core_interface

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -142,6 +142,8 @@ target_raw_data_sources(test_bitcoin NAMESPACE test::data
   data/asmap.raw
 )
 
+add_windows_application_manifest(test_bitcoin)
+
 target_link_libraries(test_bitcoin
   core_interface
   test_util


### PR DESCRIPTION
Windows [application manifests ](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests) provide several benefits—such as enhanced security settings, and the ability to set a process-wide code page (required for https://github.com/bitcoin/bitcoin/pull/32380), as well as granular control over supported Windows versions. Most of these benefits lie beyond the scope of this PR and will be evaluated separately.

On the current master branch @ fc6346dbc8dc3db40aad4079210332b5f8b332ed, the linker generates and embeds a manifest only when building with MSVC:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>
      <requestedPrivileges>
        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
      </requestedPrivileges>
    </security>
  </trustInfo>
</assembly>
```

However, this manifest fails validation:
```
> mt.exe -nologo -inputresource:build\bin\Release\bitcoind.exe -validate_manifest

mt.exe : general error 10100ba: The manifest is missing the definition identity.
```

This PR unifies manifest embedding for both native and cross-compilation builds.

Here is the change in the manifest on Windows:
```diff
--- bitcoind-master.manifest
+++ bitcoind-pr.manifest
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="org.bitcoincore.bitcoind" version="29.99.0.0"></assemblyIdentity>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
```

which effectively resolves the "missing the definition identity" error.

Finally, “Get bitcoind manifest” steps have been added to the Windows CI jobs to ensure the manifest is embedded and validated.