### PR TITLE
doc: Add hint about avoiding spaces in paths when building on Windows

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -24,6 +24,8 @@ Download and install [Git for Windows](https://git-scm.com/download/win). Once i
 ### 3. Clone Bitcoin Repository
 
 Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+
+> **Hint:** Avoid using spaces in the path when cloning the repository — they have been known to cause build issues.
 ```
 git clone https://github.com/bitcoin/bitcoin.git
 ```


### PR DESCRIPTION
When running the configuration step

    cmake -B build --preset vs2022-static

from a directory with spaces in its path, CMake issues the following warning:

    Warning: Paths with embedded space may be handled incorrectly by configure

The build subsequently fails with error code 77.

While the underlying issue should ideally be resolved, this hint may help users avoid related build failures in the meantime.