### PR TITLE
chore(ci): bump docker/build-push-action to v6.16.0

### DIFF
--- a/src/secp256k1/.github/actions/run-in-docker-action/action.yml
+++ b/src/secp256k1/.github/actions/run-in-docker-action/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: docker/setup-buildx-action@v3
 
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       id: main_builder
       continue-on-error: true
       with:
@@ -26,7 +26,7 @@ runs:
         load: true
         cache-from: type=gha
 
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       id: retry_builder
       if: steps.main_builder.outcome == 'failure'
       with:

--- a/src/secp256k1/.github/workflows/ci.yml
+++ b/src/secp256k1/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
             network=host
 
       - name: Build container
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: ./ci/linux-debian.Dockerfile
           tags: linux-debian-image


### PR DESCRIPTION
• update workflow to latest major for security patches & Buildx features

[Reference](https://github.com/docker/build-push-action/releases/tag/v6.16.0) 