### PR TITLE
cli: add -usefile option

### DIFF
--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -53,7 +53,6 @@ class MaxUploadTest(BitcoinTestFramework):
             f"-maxuploadtarget={UPLOAD_TARGET_MB}M",
             "-datacarriersize=100000",
         ]]
-        self.supports_cli = False
 
     def assert_uploadtarget_state(self, *, target_reached, serve_historical_blocks):
         """Verify the node's current upload target state via the `getnettotals` RPC call."""

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -69,7 +69,6 @@ class PruneTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 6
-        self.supports_cli = False
         self.uses_wallet = None
 
         # Create nodes 0 and 1 to mine.

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -32,7 +32,6 @@ class MempoolLimitTest(BitcoinTestFramework):
             "-datacarriersize=100000",
             "-maxmempool=5",
         ]]
-        self.supports_cli = False
 
     def test_rbf_carveout_disallowed(self):
         node = self.nodes[0]

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -74,7 +74,6 @@ class MiningTest(BitcoinTestFramework):
             ["-fastprune", "-prune=1"]
         ]
         self.setup_clean_chain = True
-        self.supports_cli = False
 
     def mine_chain(self):
         self.log.info('Create some old blocks')

--- a/test/functional/p2p_1p1c_network.py
+++ b/test/functional/p2p_1p1c_network.py
@@ -44,7 +44,6 @@ class PackageRelayTest(BitcoinTestFramework):
             "-datacarriersize=100000",
             "-maxmempool=5",
         ]] * self.num_nodes
-        self.supports_cli = False
 
     def raise_network_minfee(self):
         fill_mempool(self, self.nodes[0])

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -62,7 +62,6 @@ class PackageRelayTest(BitcoinTestFramework):
             "-datacarriersize=100000",
             "-maxmempool=5",
         ]]
-        self.supports_cli = False
 
     def create_tx_below_mempoolminfee(self, wallet):
         """Create a 1-input 1sat/vB transaction using a confirmed UTXO. Decrement and use

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -221,7 +221,6 @@ class SegWitTest(BitcoinTestFramework):
             ["-acceptnonstdtxn=1", f"-testactivationheight=segwit@{SEGWIT_HEIGHT}", "-par=1"],
             ["-acceptnonstdtxn=0", f"-testactivationheight=segwit@{SEGWIT_HEIGHT}"],
         ]
-        self.supports_cli = False
 
     # Helper functions
 

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -191,7 +191,6 @@ class WalletTaprootTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = True
         self.extra_args = [['-keypool=100'], ['-keypool=100']]
-        self.supports_cli = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Running large commands via `bitcoin-cli` (such as submitting a large tx or block) runs into the `MAX_ARG_STRLEN` limit, which is 128KB on many systems. (see e.g. https://trofi.github.io/posts/299-maximum-argument-count-on-linux-and-in-gcc.html for more info).

This PR suggests to make it possible to bypass this limit by allowing to put the command and all of its args into a file. The functional test framework is then adjusted to automatically use this option (using a temporary file) if `--usecli` is specified and there is an arg that is too large.
This might also be helpful for users outside of the functional tests (although there is always the option to use the rpc interface directly instead of `bitcoin-cli`).

This is something many of our functional tests run into when executed with `--usecli` on master: (`OSError: [Errno 7] Argument list too long: 'bitcoin-cli'`)
The third commit enables several of them - there are a few more tests than those mentioned there, that could be enabled in a follow-up, but need some more adjustments beyond that.
