### PR TITLE
random: Use modern Windows randomness functions

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -153,7 +153,8 @@ MACHO_ALLOWED_LIBRARIES = {
 }
 
 PE_ALLOWED_LIBRARIES = {
-'ADVAPI32.dll', # security & registry
+'ADVAPI32.dll', # legacy security & registry
+'bcrypt.dll', # newer security and identity API
 'IPHLPAPI.DLL', # IP helper API
 'KERNEL32.dll', # win32 base APIs
 'msvcrt.dll', # C standard library for MSVC

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(bitcoinkernel
     bitcoin_crypto
     leveldb
     secp256k1
+    $<$<PLATFORM_ID:Windows>:bcrypt>
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
   PUBLIC
     Boost::headers

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -43,4 +43,5 @@ target_link_libraries(bitcoin_util
     bitcoin_crypto
     $<$<PLATFORM_ID:Windows>:ws2_32>
     $<$<PLATFORM_ID:Windows>:iphlpapi>
+    $<$<PLATFORM_ID:Windows>:bcrypt>
 )


### PR DESCRIPTION
This change resolves #32391 and is a follow-up to #14089.

The old randomness API has been deprecated and will be removed at some point according to Microsoft.[^1] This PR removes all uses of that API from Bitcoin Core code, but the deprecated API is still invoked in Bitcoin Core binaries compiled after this PR because of upstream use, see this comment: https://github.com/bitcoin/bitcoin/pull/32400#issuecomment-2846972614.

For reference on `BCryptGenRandom`, see: https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom.

[`STATUS_SUCCESS`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55) gets defined here since including `ntstatus.h` is [more trouble](https://github.com/bitcoin-core/secp256k1/blob/70f149b9a1bf4ed3266f97774d0ae9577534bf40/examples/examples_util.h#L19-L28) than it's worth.

[^1]: https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptacquirecontextw & https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptgenrandom