### PR TITLE
test: Introduce `SUPPRESS_ABORT_MESSAGE` environment variable

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -73,6 +73,23 @@ using node::LoadChainstate;
 using node::RegenerateCommitments;
 using node::VerifyLoadedChainstate;
 
+#if defined(_MSC_VER)
+// By default, when an app is built with the debug runtime library, the `abort()`
+// routine displays an error message in a message box before `SIGABRT` is raised.
+// When running test or fuzz executables unattended—for example, in CI—the message
+// box may cause timeouts.
+// To suppress it, define the `SUPPRESS_ABORT_MESSAGE` environment variable.
+// See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/abort
+#include <stdlib.h>
+static const bool g_ci_environment_setup = []() {
+    if (std::getenv("SUPPRESS_ABORT_MESSAGE")) {
+        _set_abort_behavior(0, _WRITE_ABORT_MSG);
+        return true;
+    }
+    return false;
+}();
+#endif // _MSC_VER
+
 const TranslateFn G_TRANSLATION_FUN{nullptr};
 
 constexpr inline auto TEST_DIR_PATH_ELEMENT{"test_common bitcoin"}; // Includes a space to catch possible path escape issues.


### PR DESCRIPTION
This PR adds a way to suppress the abort message box when running `test_bitcoin.exe` and `fuzz.exe` built with the debug runtime library on Windows.

Otherwise, a failing `assert()` triggers the `abort` routine, which displays a message box and causes a timeout in CI.

Here are CI jobs for the "Debug" configuration:
 - on the master branch: https://github.com/maflcko/bitcoin-core-with-ci/actions/runs/14759346479/job/41435857332
 - with this PR: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/15038743417/job/42265371841

Addresses this [comment](https://github.com/bitcoin/bitcoin/issues/32341#issuecomment-2842716175).

According to Microsoft's [docs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/abort), this behavior is MSCV-specific.