### PR TITLE
doc: Explain that .gitignore is not for IDE-specific excludes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Patterns that are specific to a text editor, IDE, operating system, or user
+# environment are not added here. They should be added to your local gitignore
+# file instead:
+# https://docs.github.com/en/get-started/git-basics/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
+
 # Build subdirectories.
 /*build*
 !/build-aux


### PR DESCRIPTION
This comes up frequently, so document it.

Examples:

* https://github.com/bitcoin/bitcoin/pull/27275
* https://github.com/bitcoin/bitcoin/pull/21894
* https://github.com/bitcoin/bitcoin/pull/32392
* https://github.com/bitcoin/bitcoin/pull/17868

...