### PR TITLE
[WIP] rpc: add `clearmempool` command for regtest mode

### DIFF
--- a/test/functional/rpc_clearmempool.py
+++ b/test/functional/rpc_clearmempool.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test the clearmempool RPC."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
+class RPCClearMempoolTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+
+        # Check that we're in regtest mode
+        assert_equal(node.getblockchaininfo()['chain'], 'regtest')
+
+        self.log.info("Generate blocks to create mature coinbase outputs")
+        # Generate 101 blocks to get mature coinbase outputs
+        self.wallet.generate(101, called_by_framework=True)
+        self.sync_all()
+
+        self.log.info("Create and send a transaction")
+        # Create and send a transaction
+        tx = self.wallet.send_self_transfer(from_node=node)
+        assert_equal(len(node.getrawmempool()), 1)
+
+        self.log.info("Clear the mempool")
+        # Clear the mempool
+        node.clearmempool()
+        assert_equal(len(node.getrawmempool()), 0)
+
+
+if __name__ == '__main__':
+    RPCClearMempoolTest(__file__).main() 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -352,6 +352,7 @@ BASE_SCRIPTS = [
     'feature_settings.py',
     'rpc_getdescriptorinfo.py',
     'rpc_mempool_info.py',
+    'rpc_clearmempool.py',
     'rpc_help.py',
     'p2p_handshake.py',
     'p2p_handshake.py --v2transport',


### PR DESCRIPTION
## Description

This commit adds a new RPC command called `clearmempool`. It is designed to remove all tranasctions from the mempool (including those from invalidated blocks), and return their TXIDs.

The purpose of this command is to clear the mempool, then use the returned TXIDs to perform additional cleanup.

When used in combination with `invalidateblock`, it allows me to roll-back the chain to a particular height, clear the mempool, then properly clean up wallets with `abandontransaction`.

Note that this command does not prevent the transactions from being re-inserted back into the mempool, either through mempool.dat or user wallets. You have to perform additional cleanup to make sure your changes persist.

I restricted this command to regtest mode as I only need it for running tests, but it could work in any mode.

## Rationale

My rationale for adding this command is that I need the ability to cleanly rollback the chain and wallets during testing, and I kept running into the following roadblock:

* `invalidateblock` will rollback the chain height, but all the transactions are dumped into the mempool, creating spending conflicts with the wallets.

* You can prevent this dump from happening, most notably with `-walletbroadcast=0`, however that just hides the problem.

* The real issue is that wallets are still tracking these transactions, and you need to pull their TXIDs from the mempool to properly purge them with `abandontransaction`.

* But if the transactions are in the mempool, then `abandontransaction` will fail, which puts you in a catch-22 situation.

`clearmempool` allows you to clear the mempool *and* capture a list of these transactions, so that you can perform the proper cleanup with `abandontransaction`.