### PR TITLE
rpc: Undeprecate rpcuser/rpcpassword, store all credentials hashed in memory

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -314,7 +314,8 @@ static bool InitRPCAuthentication()
             LogInfo("Using random cookie authentication.");
         }
     } else {
-        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcauth for rpcauth auth generation.\n");
+        LogInfo("Using rpcuser/rpcpassword authentication.");
+        LogWarning("The use of rpcuser/rpcpassword is less secure, because credentials are configured in plain text. It is recommended that locally-run instances switch to cookie-based auth, or otherwise to use hashed rpcauth credentials. See share/rpcauth in the source directory for more information.");
         strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
     }
 

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -23,8 +23,25 @@ UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params,
 UniValue JSONRPCReplyObj(UniValue result, UniValue error, std::optional<UniValue> id, JSONRPCVersion jsonrpc_version);
 UniValue JSONRPCError(int code, const std::string& message);
 
-/** Generate a new RPC authentication cookie and write it to disk */
-bool GenerateAuthCookie(std::string* cookie_out, std::optional<fs::perms> cookie_perms=std::nullopt);
+enum class GenerateAuthCookieResult : uint8_t {
+    DISABLED, // -norpccookiefile
+    ERR,
+    OK,
+};
+
+/**
+ * Generate a new RPC authentication cookie and write it to disk
+ * @param[in] cookie_perms Filesystem permissions to use for the cookie file.
+ * @param[out] user Generated username, only set if `OK` is returned.
+ * @param[out] pass Generated password, only set if `OK` is returned.
+ * @retval GenerateAuthCookieResult::DISABLED Authentication via cookie is disabled.
+ * @retval GenerateAuthCookieResult::ERROR Error occurred, auth data could not be saved to disk.
+ * @retval GenerateAuthCookieResult::OK Auth data was generated, saved to disk and in `user` and `pass`.
+ */
+GenerateAuthCookieResult GenerateAuthCookie(const std::optional<fs::perms>& cookie_perms,
+                                            std::string& user,
+                                            std::string& pass);
+
 /** Read the RPC authentication cookie from disk */
 bool GetAuthCookie(std::string *cookie_out);
 /** Delete RPC authentication cookie from disk */


### PR DESCRIPTION
This PR does two things:

### Undeprecate rpcuser/rpcpassword, change message to security warning

Back in 2015, in https://github.com/bitcoin/bitcoin/pull/7044, we added configuration option `rpcauth` for multiple RPC users. At the same time the old settings for single-user configuration `rpcuser` and `rpcpassword` were "soon" to be deprecated.

The main reason for this deprecation is that while `rpcpassword` stores the password in plain text, `rpcauth` stores a hash, so it doesn't appear in the configuration in plain text.

As the options are still in active use, actually removing them is expected to be a hassle to many, and it's not clear that is worth it. As for the security risk, in many kinds of setups (no wallet, containerized, single-user-single-application, local-only, etc) it is an unlikely point of escalation.

In the end, it is good to encourage secure practices, but it is the responsibility of the user. Log a clear warning but remove the deprecation notice (this is also the only place where the options appear as deprecated, they were never marked as such in the -help output).

<hr>

### Store all credentials hashed in memory

This gets rid of the special-casing of `strRPCUserColonPass` by hashing cookies as well as manually provided `-rpcuser`/`-rpcpassword` with a random salt before storing them.

Also take the opportunity to modernize the surrounding code a bit. There should be no end-user visible differences in behavior.

<hr>

Closes #29240.