### PR TITLE
kernel: Replace leveldb-based BlockTreeDB with WAL and .dat file based store

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -49,7 +49,7 @@ Chain option                     | Data directory path
 Subdirectory       | File(s)               | Description
 -------------------|-----------------------|------------
 `blocks/`          |                       | Blocks directory; can be specified by `-blocksdir` option (except for `blocks/index/`)
-`blocks/index/`    | LevelDB database      | Block index; `-blocksdir` option does not affect this path
+`blocks/index/`    |                       | Block index; `-blocksdir` option does not affect this path
 `blocks/`          | `blkNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Actual Bitcoin blocks (dumped in network format, 128 MiB per file)
 `blocks/`          | `revNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Block undo data (custom format)
 `blocks/`          | `xor.dat`             | Rolling XOR pattern for block and undo data files

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   index/txindex.cpp
   index/txospenderindex.cpp
   init.cpp
+  kernel/blocktreestorage.cpp
   kernel/chain.cpp
   kernel/checks.cpp
   kernel/coinstats.cpp

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(bench_bitcoin
   txorphanage.cpp
   util_time.cpp
   verify_script.cpp
+  write_block_index.cpp
 )
 
 add_windows_application_manifest(bench_bitcoin)

--- a/src/bench/write_block_index.cpp
+++ b/src/bench/write_block_index.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <chain.h>
+#include <kernel/blocktreestorage.h>
+#include <kernel/cs_main.h>
+#include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/fs.h>
+#include <util/strencodings.h>
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
+using namespace util::hex_literals;
+using kernel::BlockTreeStore;
+using kernel::CBlockFileInfo;
+
+static std::vector<CBlockFileInfo> CreateUniqueFileInfo(int32_t count)
+{
+    std::vector<CBlockFileInfo> infos;
+    kernel::CBlockFileInfo info;
+    info.nBlocks = count;
+    info.nSize = count + 1;
+    info.nUndoSize = count + 2;
+    info.nHeightFirst = count + 3;
+    info.nHeightLast = count + 4;
+    info.nTimeFirst = count + 5;
+    info.nTimeLast = count + 6;
+    infos.emplace_back(info);
+    return infos;
+}
+
+static auto BuildFileInfo(std::span<CBlockFileInfo> infos)
+{
+    std::vector<std::pair<int, const CBlockFileInfo*>> file_info;
+    file_info.reserve(infos.size());
+    for (uint32_t i = 0; i < infos.size(); ++i) {
+        file_info.emplace_back(i, &infos[i]);
+    }
+    return file_info;
+}
+
+static void BuildBlockIndex(node::BlockMap& block_map)
+{
+    LOCK(cs_main);
+    CBlockIndex* prev{nullptr};
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{};
+    header.nTime = 0;
+    header.nBits = 0;
+    header.nNonce = 0;
+    const auto [it, inserted]{block_map.try_emplace(header.GetHash(), header)};
+    assert(inserted); // unique nNonce/nTime/hashPrev => unique hash
+    CBlockIndex* pindex{&it->second};
+    pindex->phashBlock = &it->first;
+    pindex->pprev = prev;
+    pindex->nHeight = 0;
+    pindex->nStatus = BLOCK_HAVE_DATA;
+    pindex->nTx = 1;
+    pindex->nFile = 0;
+    pindex->nDataPos = 0;
+    pindex->nUndoPos = 0;
+    prev = pindex;
+}
+
+static void WriteBlockIndexLevelDB(benchmark::Bench& bench)
+{
+    const auto setup{MakeNoLogFileContext<>(ChainType::MAIN)};
+    auto path = setup->m_path_root;
+    DBParams params{
+        .path = path,
+        .cache_bytes = 0,
+        .memory_only = false,
+        .wipe_data = true,
+        .obfuscate = false,
+    };
+    kernel::BlockTreeDB block_tree_db{params};
+    auto file_info = CreateUniqueFileInfo(0);
+    auto file_info_pointers = BuildFileInfo(file_info);
+    node::BlockMap block_map;
+    std::vector<const CBlockIndex*> blocks;
+    BuildBlockIndex(block_map);
+    for (auto& entry : block_map) {
+        blocks.push_back(&entry.second);
+    }
+
+    bench.run("leveldb", [&] {
+        block_tree_db.WriteBatchSync(file_info_pointers, 1, blocks);
+    });
+}
+
+static void WriteBlockIndexBlockTreeStore(benchmark::Bench& bench)
+{
+    const auto setup{MakeNoLogFileContext<>(ChainType::MAIN)};
+    auto file_info = CreateUniqueFileInfo(0);
+    auto file_info_pointers = BuildFileInfo(file_info);
+    node::BlockMap block_map;
+    std::vector<CBlockIndex*> blocks;
+    BuildBlockIndex(block_map);
+    for (auto& entry : block_map) {
+        blocks.push_back(&entry.second);
+    }
+
+    auto path = setup->m_path_root;
+    BlockTreeStore block_tree_store{path};
+
+    bench.run("block_tree_store", [&] {
+        LOCK(cs_main);
+        block_tree_store.WriteBatchSync(file_info_pointers, blocks);
+    });
+}
+
+
+BENCHMARK(WriteBlockIndexLevelDB);
+BENCHMARK(WriteBlockIndexBlockTreeStore);

--- a/src/bench/write_block_index.cpp
+++ b/src/bench/write_block_index.cpp
@@ -75,32 +75,6 @@ static void BuildBlockIndex(node::BlockMap& block_map)
     prev = pindex;
 }
 
-static void WriteBlockIndexLevelDB(benchmark::Bench& bench)
-{
-    const auto setup{MakeNoLogFileContext<>(ChainType::MAIN)};
-    auto path = setup->m_path_root;
-    DBParams params{
-        .path = path,
-        .cache_bytes = 0,
-        .memory_only = false,
-        .wipe_data = true,
-        .obfuscate = false,
-    };
-    kernel::BlockTreeDB block_tree_db{params};
-    auto file_info = CreateUniqueFileInfo(0);
-    auto file_info_pointers = BuildFileInfo(file_info);
-    node::BlockMap block_map;
-    std::vector<const CBlockIndex*> blocks;
-    BuildBlockIndex(block_map);
-    for (auto& entry : block_map) {
-        blocks.push_back(&entry.second);
-    }
-
-    bench.run("leveldb", [&] {
-        block_tree_db.WriteBatchSync(file_info_pointers, 1, blocks);
-    });
-}
-
 static void WriteBlockIndexBlockTreeStore(benchmark::Bench& bench)
 {
     const auto setup{MakeNoLogFileContext<>(ChainType::MAIN)};
@@ -122,6 +96,4 @@ static void WriteBlockIndexBlockTreeStore(benchmark::Bench& bench)
     });
 }
 
-
-BENCHMARK(WriteBlockIndexLevelDB);
 BENCHMARK(WriteBlockIndexBlockTreeStore);

--- a/src/chain.h
+++ b/src/chain.h
@@ -114,6 +114,12 @@ public:
     //! Byte offset within rev?????.dat where this block's undo data is stored
     unsigned int nUndoPos GUARDED_BY(::cs_main){0};
 
+    //! Sentinel for an unset header pos
+    static constexpr int64_t UNSET_HEADER_POS{-1};
+
+    //! (memory only) Byte offset within headers.dat where this class' data is stored
+    int64_t header_pos GUARDED_BY(::cs_main){UNSET_HEADER_POS};
+
     //! (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
     arith_uint256 nChainWork{};
 
@@ -373,6 +379,25 @@ public:
 
     uint256 GetBlockHash() = delete;
     std::string ToString() = delete;
+};
+
+/** A wrapper for creating a constant-sized serialization without varint encoding */
+struct DiskBlockIndexWrapper : CDiskBlockIndex {
+    static constexpr size_t SERIALIZED_SIZE{104};
+
+    DiskBlockIndexWrapper() = default;
+
+    explicit DiskBlockIndexWrapper(const CDiskBlockIndex* pindex) : CDiskBlockIndex(*pindex)
+    {
+    }
+
+    SERIALIZE_METHODS(DiskBlockIndexWrapper, obj)
+    {
+        LOCK(::cs_main);
+        READWRITE(obj.nHeight, obj.nStatus, obj.nTx, obj.nFile, obj.nDataPos, obj.nUndoPos);
+        // block header
+        READWRITE(obj.nVersion, obj.hashPrev, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
+    }
 };
 
 /** An in-memory indexed chain of blocks. */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1154,11 +1154,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         BlockManager::Options blockman_opts_dummy{
             .chainparams = chainman_opts_dummy.chainparams,
             .blocks_dir = args.GetBlocksDirPath(),
+            .block_tree_dir = args.GetDataDirNet() / "blocks" / "index",
             .notifications = chainman_opts_dummy.notifications,
-            .block_tree_db_params = DBParams{
-                .path = args.GetDataDirNet() / "blocks" / "index",
-                .cache_bytes = 0,
-            },
         };
         auto blockman_result{ApplyArgsManOptions(args, blockman_opts_dummy)};
         if (!blockman_result) {
@@ -1359,12 +1356,9 @@ static ChainstateLoadResult InitAndLoadChainstate(
     BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = args.GetBlocksDirPath(),
+        .block_tree_dir = args.GetDataDirNet() / "blocks" / "index",
+        .wipe_block_tree_data = do_reindex,
         .notifications = chainman_opts.notifications,
-        .block_tree_db_params = DBParams{
-            .path = args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = cache_sizes.block_tree_db,
-            .wipe_data = do_reindex,
-        },
     };
     Assert(ApplyArgsManOptions(args, blockman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 
@@ -1853,7 +1847,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const auto [index_cache_sizes, kernel_cache_sizes] = CalculateCacheSizes(args, g_enabled_filter_types.size());
 
     LogInfo("Cache configuration:");
-    LogInfo("* Using %.1f MiB for block index database", kernel_cache_sizes.block_tree_db / double(1_MiB));
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         LogInfo("* Using %.1f MiB for transaction index database", index_cache_sizes.tx_index / double(1_MiB));
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -37,6 +37,7 @@
 #include <interfaces/node.h>
 #include <ipc/exception.h>
 #include <kernel/blockmanager_opts.h>
+#include <kernel/blocktreestorage.h>
 #include <kernel/caches.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/checks.h>
@@ -1373,7 +1374,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.chainman); // Was reset above
     try {
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
-    } catch (dbwrapper_error& e) {
+    } catch (kernel::BlockTreeStoreError& e) {
         LogError("%s", e.what());
         return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
     } catch (std::exception& e) {

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -10,6 +10,7 @@ include(GNUInstallDirs)
 #       which are absolutely necessary.
 add_library(bitcoinkernel
   bitcoinkernel.cpp
+  blocktreestorage.cpp
   chain.cpp
   checks.cpp
   chainparams.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -10,7 +10,6 @@
 #include <coins.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
-#include <dbwrapper.h>
 #include <kernel/caches.h>
 #include <kernel/chainparams.h>
 #include <kernel/checks.h>
@@ -464,12 +463,11 @@ struct ChainstateManagerOptions {
           m_blockman_options{node::BlockManager::Options{
               .chainparams = *context->m_chainparams,
               .blocks_dir = blocks_dir,
+              .block_tree_dir = data_dir / "blocks" / "index",
               .notifications = *context->m_notifications,
-              .block_tree_db_params = DBParams{
-                  .path = data_dir / "blocks" / "index",
-                  .cache_bytes = kernel::CacheSizes{DEFAULT_KERNEL_CACHE}.block_tree_db,
-              }}},
-          m_context{context}, m_chainstate_load_options{node::ChainstateLoadOptions{}}
+          }},
+          m_context{context},
+          m_chainstate_load_options{node::ChainstateLoadOptions{}}
     {
     }
 };
@@ -999,18 +997,9 @@ int btck_chainstate_manager_options_set_wipe_dbs(btck_ChainstateManagerOptions* 
     }
     auto& opts{btck_ChainstateManagerOptions::get(chainman_opts)};
     LOCK(opts.m_mutex);
-    opts.m_blockman_options.block_tree_db_params.wipe_data = wipe_block_tree_db == 1;
+    opts.m_blockman_options.wipe_block_tree_data = wipe_block_tree_db == 1;
     opts.m_chainstate_load_options.wipe_chainstate_db = wipe_chainstate_db == 1;
     return 0;
-}
-
-void btck_chainstate_manager_options_update_block_tree_db_in_memory(
-    btck_ChainstateManagerOptions* chainman_opts,
-    int block_tree_db_in_memory)
-{
-    auto& opts{btck_ChainstateManagerOptions::get(chainman_opts)};
-    LOCK(opts.m_mutex);
-    opts.m_blockman_options.block_tree_db_params.memory_only = block_tree_db_in_memory == 1;
 }
 
 void btck_chainstate_manager_options_update_chainstate_db_in_memory(

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1194,16 +1194,6 @@ BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_o
     int wipe_chainstate_db) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Sets block tree db in memory in the options.
- *
- * @param[in] chainstate_manager_options   Non-null, created by @ref btck_chainstate_manager_options_create.
- * @param[in] block_tree_db_in_memory      Set block tree db in memory.
- */
-BITCOINKERNEL_API void btck_chainstate_manager_options_update_block_tree_db_in_memory(
-    btck_ChainstateManagerOptions* chainstate_manager_options,
-    int block_tree_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
  * @brief Sets chainstate db in memory in the options.
  *
  * @param[in] chainstate_manager_options Non-null, created by @ref btck_chainstate_manager_options_create.

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1149,11 +1149,6 @@ public:
         return btck_chainstate_manager_options_set_wipe_dbs(get(), wipe_block_tree, wipe_chainstate) == 0;
     }
 
-    void UpdateBlockTreeDbInMemory(bool block_tree_db_in_memory)
-    {
-        btck_chainstate_manager_options_update_block_tree_db_in_memory(get(), block_tree_db_in_memory);
-    }
-
     void UpdateChainstateDbInMemory(bool chainstate_db_in_memory)
     {
         btck_chainstate_manager_options_update_chainstate_db_in_memory(get(), chainstate_db_in_memory);

--- a/src/kernel/blockmanager_opts.h
+++ b/src/kernel/blockmanager_opts.h
@@ -27,8 +27,9 @@ struct BlockManagerOpts {
     uint64_t prune_target{0};
     bool fast_prune{false};
     const fs::path blocks_dir;
+    const fs::path block_tree_dir;
+    bool wipe_block_tree_data{false};
     Notifications& notifications;
-    DBParams block_tree_db_params;
 };
 
 } // namespace kernel

--- a/src/kernel/blocktreestorage.cpp
+++ b/src/kernel/blocktreestorage.cpp
@@ -20,6 +20,7 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/signalinterrupt.h>
+#include <util/time.h>
 
 #include <array>
 #include <cstddef>
@@ -36,7 +37,46 @@ namespace kernel {
 using Checksum = uint32_t;
 using FilePosition = int64_t;
 
+static constexpr const char* STORE_ACCESS_LOCK_NAME{".lock"};
 static constexpr const char* WRITER_LOCK_NAME{".writer-lock"};
+
+//! Blocks cross-process simultaneous read or write access to the data files.
+//! Only a single instance may be created per directory at any one time.
+class StoreAccessLock
+{
+    const fs::path m_dir;
+
+public:
+    explicit StoreAccessLock(const fs::path& dir) : m_dir{dir}
+    {
+        std::chrono::milliseconds timeout = 30s;
+        SteadyClock::time_point start{SteadyClock::now()};
+        for (;;) {
+            switch (util::LockDirectory(m_dir, STORE_ACCESS_LOCK_NAME)) {
+            case util::LockResult::Success:
+                return;
+            case util::LockResult::ErrorWrite:
+                throw BlockTreeStoreError(strprintf(
+                    "Cannot create write-lock file in %s", fs::PathToString(m_dir)));
+            case util::LockResult::ErrorLock: {
+                if (SteadyClock::now() > start + timeout) {
+                    throw BlockTreeStoreError(strprintf("Operation timed out waiting to acquire lock on %s", fs::PathToString(m_dir)));
+                }
+                // Read and write access is typically short, so wait a bit and try again.
+                UninterruptibleSleep(1ms);
+            }
+            }
+        }
+    }
+
+    ~StoreAccessLock()
+    {
+        UnlockDirectory(m_dir, STORE_ACCESS_LOCK_NAME);
+    }
+
+    StoreAccessLock(const StoreAccessLock&) = delete;
+    StoreAccessLock& operator=(const StoreAccessLock&) = delete;
+};
 
 /** A wrapper for creating a constant-sized serialization without varint encoding */
 struct BlockFileInfoWrapper : CBlockFileInfo {
@@ -164,16 +204,20 @@ BlockTreeStore::BlockTreeStore(const fs::path& path, const OpenMode open_mode)
       m_log_flag_file_path{path / LOG_FLAG_FILE_NAME},
       m_block_files_file_path{path / BLOCK_FILES_FILE_NAME},
       m_reindex_flag_file_path{path / REINDEX_FLAG_FILE_NAME},
-      m_prune_flag_file_path{path / PRUNE_FLAG_FILE_NAME}
+      m_prune_flag_file_path{path / PRUNE_FLAG_FILE_NAME},
+      m_mode{open_mode}
 {
     assert(GetSerializeSize(DiskBlockIndexWrapper{}) == DiskBlockIndexWrapper::SERIALIZED_SIZE);
     assert(GetSerializeSize(BlockFileInfoWrapper{}) == BlockFileInfoWrapper::SERIALIZED_SIZE);
+
+    if (m_mode == OpenMode::READ) return;
 
     LOCK(m_mutex);
     fs::create_directories(path);
     m_writer_lock.emplace(path);
 
-    if (open_mode == OpenMode::WIPE) {
+    if (m_mode == OpenMode::WIPE) {
+        StoreAccessLock lock_file{m_header_file_path.parent_path()};
         fs::remove(m_header_file_path);
         fs::remove(m_block_files_file_path);
         fs::remove(m_log_file_path);
@@ -195,6 +239,11 @@ BlockTreeStore::BlockTreeStore(const fs::path& path, const OpenMode open_mode)
     if (ApplyLog()) {
         LogInfo("Applied block tree store write-ahead log left over from a previous failure, potentially caused by unclean shutdown or intermittent hardware issue.");
     }
+}
+
+void BlockTreeStore::CheckWriteAccess() const
+{
+    if (m_mode == OpenMode::READ) throw std::logic_error("Block tree store writes are disabled when opened in read mode");
 }
 
 void BlockTreeStore::WriteFlag(const fs::path& path, bool value, bool directory_commit) const
@@ -222,12 +271,14 @@ void BlockTreeStore::ReadReindexing(bool& reindexing) const
 
 void BlockTreeStore::WriteReindexing(bool reindexing) const
 {
+    CheckWriteAccess();
     WriteFlag(m_reindex_flag_file_path, /*value=*/reindexing, /*directory_commit=*/true);
 }
 
 void BlockTreeStore::ReadLastBlockFile(int32_t& last_block_file) const
 {
     LOCK(m_mutex);
+    StoreAccessLock lock_file{m_log_file_path.parent_path()};
     auto file{OpenFileAndVerifyHeader(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION)};
 
     constexpr uint64_t entry_size = BlockFileInfoWrapper::SERIALIZED_SIZE + sizeof(Checksum);
@@ -245,6 +296,7 @@ void BlockTreeStore::ReadPruned(bool& pruned) const
 
 void BlockTreeStore::WritePruned(bool pruned) const
 {
+    CheckWriteAccess();
     WriteFlag(m_prune_flag_file_path, /*value=*/pruned, /*directory_commit=*/true);
 }
 
@@ -324,6 +376,7 @@ static void ReadDataValue(AutoFile& file, std::span<std::byte> value_buffer)
 bool BlockTreeStore::ReadBlockFileInfo(int file_index, CBlockFileInfo& info)
 {
     LOCK(m_mutex);
+    StoreAccessLock lock_file{m_log_file_path.parent_path()};
 
     auto file{OpenFileAndVerifyHeader(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION)};
     file.seek(CalculateBlockFileInfoPosition(file_index), SEEK_SET);
@@ -345,6 +398,7 @@ bool BlockTreeStore::ReadBlockFileInfo(int file_index, CBlockFileInfo& info)
 bool BlockTreeStore::ApplyLog() const
 {
     AssertLockHeld(m_mutex);
+    StoreAccessLock lock_file{m_log_file_path.parent_path()};
 
     if (!fs::exists(m_log_file_path) || !fs::exists(m_log_flag_file_path)) {
         return false;
@@ -426,6 +480,7 @@ bool BlockTreeStore::ApplyLog() const
 
 void BlockTreeStore::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& file_infos_to_write, const std::vector<CBlockIndex*>& block_indexes_to_write)
 {
+    CheckWriteAccess();
     AssertLockHeld(::cs_main);
     LOCK(m_mutex);
 
@@ -516,6 +571,7 @@ bool BlockTreeStore::LoadBlockIndexGuts(
 {
     AssertLockHeld(::cs_main);
     LOCK(m_mutex);
+    StoreAccessLock lock_file{m_log_file_path.parent_path()};
 
     auto file{OpenFileAndVerifyHeader(m_header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION)};
 

--- a/src/kernel/blocktreestorage.cpp
+++ b/src/kernel/blocktreestorage.cpp
@@ -6,9 +6,9 @@
 
 #include <chain.h>
 #include <crc32c/include/crc32c/crc32c.h>
+#include <crypto/common.h>
 #include <kernel/cs_main.h>
 #include <logging.h>
-#include <node/blockstorage.h>
 #include <pow.h>
 #include <serialize.h>
 #include <span.h>
@@ -23,6 +23,7 @@
 #include <util/time.h>
 
 #include <array>
+#include <compare>
 #include <cstddef>
 #include <cstdio>
 #include <exception>
@@ -116,6 +117,11 @@ WriterLock::WriterLock(const fs::path& dir) : m_dir{dir}
 }
 
 WriterLock::~WriterLock() { UnlockDirectory(m_dir, WRITER_LOCK_NAME); }
+
+std::string CBlockFileInfo::ToString() const
+{
+    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
+}
 
 static FilePosition CalculateBlockFileInfoPosition(int file_index)
 {

--- a/src/kernel/blocktreestorage.cpp
+++ b/src/kernel/blocktreestorage.cpp
@@ -36,6 +36,8 @@ namespace kernel {
 using Checksum = uint32_t;
 using FilePosition = int64_t;
 
+static constexpr const char* WRITER_LOCK_NAME{".writer-lock"};
+
 /** A wrapper for creating a constant-sized serialization without varint encoding */
 struct BlockFileInfoWrapper : CBlockFileInfo {
     static constexpr size_t SERIALIZED_SIZE{36};
@@ -57,6 +59,23 @@ struct BlockFileInfoWrapper : CBlockFileInfo {
         READWRITE(obj.nTimeLast);
     }
 };
+
+WriterLock::WriterLock(const fs::path& dir) : m_dir{dir}
+{
+    switch (util::LockDirectory(m_dir, WRITER_LOCK_NAME)) {
+    case util::LockResult::Success:
+        return;
+    case util::LockResult::ErrorWrite:
+        throw BlockTreeStoreError(strprintf(
+            "Cannot create writer-lock file in %s", fs::PathToString(m_dir)));
+    case util::LockResult::ErrorLock:
+        throw BlockTreeStoreError(strprintf(
+            "Another process is already writing to the block tree store in %s.", fs::PathToString(m_dir)));
+    }
+    assert(0);
+}
+
+WriterLock::~WriterLock() { UnlockDirectory(m_dir, WRITER_LOCK_NAME); }
 
 static FilePosition CalculateBlockFileInfoPosition(int file_index)
 {
@@ -152,6 +171,7 @@ BlockTreeStore::BlockTreeStore(const fs::path& path, const OpenMode open_mode)
 
     LOCK(m_mutex);
     fs::create_directories(path);
+    m_writer_lock.emplace(path);
 
     if (open_mode == OpenMode::WIPE) {
         fs::remove(m_header_file_path);

--- a/src/kernel/blocktreestorage.cpp
+++ b/src/kernel/blocktreestorage.cpp
@@ -1,0 +1,540 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kernel/blocktreestorage.h>
+
+#include <chain.h>
+#include <crc32c/include/crc32c/crc32c.h>
+#include <kernel/cs_main.h>
+#include <logging.h>
+#include <node/blockstorage.h>
+#include <pow.h>
+#include <serialize.h>
+#include <span.h>
+#include <streams.h>
+#include <sync.h>
+#include <tinyformat.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
+#include <util/signalinterrupt.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <exception>
+#include <ios>
+#include <span>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+namespace kernel {
+
+using Checksum = uint32_t;
+using FilePosition = int64_t;
+
+/** A wrapper for creating a constant-sized serialization without varint encoding */
+struct BlockFileInfoWrapper : CBlockFileInfo {
+    static constexpr size_t SERIALIZED_SIZE{36};
+
+    BlockFileInfoWrapper() = default;
+
+    explicit BlockFileInfoWrapper(const CBlockFileInfo* info) : CBlockFileInfo(*info)
+    {
+    }
+
+    SERIALIZE_METHODS(BlockFileInfoWrapper, obj)
+    {
+        READWRITE(obj.nBlocks);
+        READWRITE(obj.nSize);
+        READWRITE(obj.nUndoSize);
+        READWRITE(obj.nHeightFirst);
+        READWRITE(obj.nHeightLast);
+        READWRITE(obj.nTimeFirst);
+        READWRITE(obj.nTimeLast);
+    }
+};
+
+static FilePosition CalculateBlockFileInfoPosition(int file_index)
+{
+    assert(file_index >= 0);
+    return BLOCK_FILES_FILE_DATA_START_POSITION + file_index * (BlockFileInfoWrapper::SERIALIZED_SIZE + sizeof(Checksum));
+}
+
+const fs::path& BlockTreeStore::GetDataFilePath(ValueType value_type) const
+{
+    switch (value_type) {
+    case ValueType::BLOCK_FILE_INFO:
+        return m_block_files_file_path;
+    case ValueType::DISK_BLOCK_INDEX:
+        return m_header_file_path;
+    }
+    assert(false);
+}
+
+static uint8_t ValueSize(const ValueType value_type)
+{
+    switch (value_type) {
+    case ValueType::BLOCK_FILE_INFO:
+        return BlockFileInfoWrapper::SERIALIZED_SIZE;
+    case ValueType::DISK_BLOCK_INDEX:
+        return DiskBlockIndexWrapper::SERIALIZED_SIZE;
+    }
+    assert(false);
+}
+
+static ValueType ReadValueType(AutoFile& file)
+{
+    std::underlying_type_t<ValueType> raw;
+    file >> raw;
+    switch (auto value_type{static_cast<ValueType>(raw)}) {
+    case kernel::ValueType::BLOCK_FILE_INFO:
+    case kernel::ValueType::DISK_BLOCK_INDEX:
+        return value_type;
+    }
+    throw BlockTreeStoreError(strprintf("Unrecognized value type (%u) in block tree store", raw));
+}
+
+static void WriteMagicAndVersion(AutoFile& file, uint32_t magic, uint32_t version)
+{
+    file << magic;
+    file << version;
+}
+
+static AutoFile OpenFile(const fs::path& path, const std::string& mode)
+{
+    AutoFile file{fsbridge::fopen(path, mode.c_str())};
+    if (file.IsNull()) {
+        throw BlockTreeStoreError(strprintf("Unable to open file %s", fs::PathToString(path)));
+    }
+    return AutoFile{file.release()};
+}
+
+static void CreateDataFile(const fs::path& path, uint32_t magic, uint32_t version)
+{
+    auto file{OpenFile(path, "wb")};
+
+    WriteMagicAndVersion(file, magic, version);
+
+    if (!file.Commit()) {
+        throw BlockTreeStoreError(strprintf("Failed to write file %s", fs::PathToString(path)));
+    }
+    if (file.fclose() != 0) {
+        throw BlockTreeStoreError(strprintf("Failed to close after write to file %s", fs::PathToString(path)));
+    }
+}
+
+static AutoFile OpenFileAndVerifyHeader(const fs::path& path, uint32_t magic_expected, uint32_t version_expected)
+{
+    auto file{OpenFile(path, "rb")};
+    if (auto magic{ser_readdata32(file)}; magic != magic_expected) {
+        throw BlockTreeStoreError(strprintf("Invalid magic in %s: 0x%08x (expected: 0x%08x)", fs::PathToString(path), magic, magic_expected));
+    }
+    if (auto version{ser_readdata32(file)}; version != version_expected) {
+        throw BlockTreeStoreError(strprintf("Invalid version in %s: 0x%08x (expected: 0x%08x)", fs::PathToString(path), version, version_expected));
+    }
+    return AutoFile{file.release()};
+}
+
+BlockTreeStore::BlockTreeStore(const fs::path& path, const OpenMode open_mode)
+    : m_header_file_path{path / HEADER_FILE_NAME},
+      m_log_file_path{path / LOG_FILE_NAME},
+      m_log_flag_file_path{path / LOG_FLAG_FILE_NAME},
+      m_block_files_file_path{path / BLOCK_FILES_FILE_NAME},
+      m_reindex_flag_file_path{path / REINDEX_FLAG_FILE_NAME},
+      m_prune_flag_file_path{path / PRUNE_FLAG_FILE_NAME}
+{
+    assert(GetSerializeSize(DiskBlockIndexWrapper{}) == DiskBlockIndexWrapper::SERIALIZED_SIZE);
+    assert(GetSerializeSize(BlockFileInfoWrapper{}) == BlockFileInfoWrapper::SERIALIZED_SIZE);
+
+    LOCK(m_mutex);
+    fs::create_directories(path);
+
+    if (open_mode == OpenMode::WIPE) {
+        fs::remove(m_header_file_path);
+        fs::remove(m_block_files_file_path);
+        fs::remove(m_log_file_path);
+        fs::remove(m_log_flag_file_path);
+        fs::remove(m_reindex_flag_file_path);
+        fs::remove(m_prune_flag_file_path);
+    }
+    bool header_file_exists{fs::exists(m_header_file_path)};
+    bool block_files_file_exists{fs::exists(m_block_files_file_path)};
+    if (header_file_exists != block_files_file_exists) {
+        throw BlockTreeStoreError("Block tree store is in an inconsistent state");
+    }
+    if (!header_file_exists && !block_files_file_exists) {
+        CreateDataFile(m_header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION);
+        CreateDataFile(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION);
+    }
+    (void)OpenFileAndVerifyHeader(m_header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION);
+    (void)OpenFileAndVerifyHeader(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION);
+    if (ApplyLog()) {
+        LogInfo("Applied block tree store write-ahead log left over from a previous failure, potentially caused by unclean shutdown or intermittent hardware issue.");
+    }
+}
+
+void BlockTreeStore::WriteFlag(const fs::path& path, bool value, bool directory_commit) const
+{
+    if (value) {
+        if (auto file{AutoFile{fsbridge::fopen(path, "w")}}; file.IsNull() || file.fclose()) {
+            throw BlockTreeStoreError(strprintf("Could not create flag file %s", fs::PathToString(path)));
+        }
+    } else {
+        std::error_code ec;
+        fs::remove(path, ec);
+        if (ec && ec != std::errc::no_such_file_or_directory) {
+            throw BlockTreeStoreError(strprintf("Could not remove flag file %s", fs::PathToString(path)));
+        }
+    }
+    if (directory_commit) {
+        DirectoryCommit(path.parent_path());
+    }
+}
+
+void BlockTreeStore::ReadReindexing(bool& reindexing) const
+{
+    reindexing = fs::exists(m_reindex_flag_file_path);
+}
+
+void BlockTreeStore::WriteReindexing(bool reindexing) const
+{
+    WriteFlag(m_reindex_flag_file_path, /*value=*/reindexing, /*directory_commit=*/true);
+}
+
+void BlockTreeStore::ReadLastBlockFile(int32_t& last_block_file) const
+{
+    LOCK(m_mutex);
+    auto file{OpenFileAndVerifyHeader(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION)};
+
+    constexpr uint64_t entry_size = BlockFileInfoWrapper::SERIALIZED_SIZE + sizeof(Checksum);
+    const int64_t file_data_size{file.size() - BLOCK_FILES_FILE_DATA_START_POSITION};
+    if (file_data_size < 0 || file_data_size % entry_size != 0) {
+        throw BlockTreeStoreError("Invalid block files file data");
+    }
+    last_block_file = file_data_size == 0 ? 0 : file_data_size / entry_size - 1;
+}
+
+void BlockTreeStore::ReadPruned(bool& pruned) const
+{
+    pruned = fs::exists(m_prune_flag_file_path);
+}
+
+void BlockTreeStore::WritePruned(bool pruned) const
+{
+    WriteFlag(m_prune_flag_file_path, /*value=*/pruned, /*directory_commit=*/true);
+}
+
+static Checksum ExtendChecksum(Checksum checksum, std::span<const std::byte> value_data, FilePosition position)
+{
+    checksum = crc32c::Extend(checksum, UCharCast(value_data.data()), value_data.size());
+    std::array<std::byte, sizeof(FilePosition)> position_bytes;
+    WriteLE64(UCharCast(position_bytes.data()), static_cast<uint64_t>(position));
+    return crc32c::Extend(checksum, UCharCast(position_bytes.data()), position_bytes.size());
+}
+
+static Checksum SingleChecksum(std::span<const std::byte> value_data, FilePosition position)
+{
+    return ExtendChecksum(0, value_data, position);
+}
+
+static void WriteLogFileSectionHeader(AutoFile& log_file, ValueType value_type, uint64_t record_count)
+{
+    log_file << static_cast<std::underlying_type_t<ValueType>>(value_type);
+    log_file << record_count;
+}
+
+static std::pair<ValueType, uint64_t> ReadLogFileSectionHeader(AutoFile& log_file)
+{
+    const ValueType value_type{ReadValueType(log_file)};
+    uint64_t record_count;
+    log_file >> record_count;
+    return {value_type, record_count};
+}
+
+struct LogFileRecord {
+    std::vector<std::byte> m_value_buffer;
+    FilePosition m_position;
+    Checksum m_checksum;
+
+    LogFileRecord(ValueType value_type) : m_value_buffer(ValueSize(value_type)) {}
+};
+
+static void ReadLogFileRecord(AutoFile& log_file, LogFileRecord& record, Checksum& rolling_checksum)
+{
+    log_file.read(record.m_value_buffer);
+    log_file >> record.m_position;
+
+    record.m_checksum = SingleChecksum(record.m_value_buffer, record.m_position);
+    rolling_checksum = ExtendChecksum(rolling_checksum, record.m_value_buffer, record.m_position);
+
+    Checksum stored_checksum;
+    log_file >> stored_checksum;
+    if (stored_checksum != record.m_checksum) {
+        throw BlockTreeStoreError("Detected on-disk log file corruption: Checksum mismatch");
+    }
+}
+
+template <typename Wrapper>
+static void WriteLogFileRecord(AutoFile& log_file, const Wrapper& wrapper, FilePosition position, Checksum& rolling_checksum)
+{
+    std::array<std::byte, Wrapper::SERIALIZED_SIZE> value_buffer;
+    SpanWriter{value_buffer} << wrapper;
+    const Checksum checksum{SingleChecksum(value_buffer, position)};
+    rolling_checksum = ExtendChecksum(rolling_checksum, value_buffer, position);
+    log_file.write(value_buffer);
+    log_file << position;
+    log_file << checksum;
+}
+
+static void ReadDataValue(AutoFile& file, std::span<std::byte> value_buffer)
+{
+    const FilePosition position{file.tell()};
+    file.read(value_buffer);
+    Checksum checksum;
+    file >> checksum;
+    if (SingleChecksum(value_buffer, position) != checksum) {
+        throw BlockTreeStoreError("Record data failed integrity check");
+    }
+}
+
+bool BlockTreeStore::ReadBlockFileInfo(int file_index, CBlockFileInfo& info)
+{
+    LOCK(m_mutex);
+
+    auto file{OpenFileAndVerifyHeader(m_block_files_file_path, BLOCK_FILES_FILE_MAGIC, BLOCK_FILES_FILE_VERSION)};
+    file.seek(CalculateBlockFileInfoPosition(file_index), SEEK_SET);
+
+    BlockFileInfoWrapper info_wrapper;
+    std::array<std::byte, BlockFileInfoWrapper::SERIALIZED_SIZE> buffer;
+
+    try {
+        ReadDataValue(file, buffer);
+        SpanReader{buffer} >> info_wrapper;
+    } catch (std::exception&) {
+        return false;
+    }
+
+    info = info_wrapper;
+    return true;
+}
+
+bool BlockTreeStore::ApplyLog() const
+{
+    AssertLockHeld(m_mutex);
+
+    if (!fs::exists(m_log_file_path) || !fs::exists(m_log_flag_file_path)) {
+        return false;
+    }
+
+    auto log_file{OpenFileAndVerifyHeader(m_log_file_path, LOG_FILE_MAGIC, LOG_FILE_VERSION)};
+
+    Checksum rolling_checksum = 0;
+    Checksum stored_rolling_checksum = 0;
+    uint32_t number_of_types = 0;
+
+    // Do a dry run to check the integrity of the log file. This should help prevent cascading errors in case of log file corruption.
+    try {
+        log_file >> number_of_types;
+        for (uint32_t i = 0; i < number_of_types; i++) {
+            const auto [value_type, record_count] = ReadLogFileSectionHeader(log_file);
+            LogFileRecord record{value_type};
+
+            for (uint64_t j = 0; j < record_count; j++) {
+                ReadLogFileRecord(log_file, record, rolling_checksum);
+            }
+        }
+
+        log_file >> stored_rolling_checksum;
+        if (rolling_checksum != stored_rolling_checksum) {
+            throw BlockTreeStoreError("Detected on-disk log file corruption: Rolling checksum mismatch");
+        }
+    } catch (const std::ios_base::failure& e) {
+        throw BlockTreeStoreError(strprintf("Encountered exception while checking log file: %s", e.what()));
+    }
+
+    rolling_checksum = 0;
+    stored_rolling_checksum = 0;
+    // Seek back to the start of the log file data, but skip reading the number of types again
+    log_file.seek(LOG_FILE_DATA_START_POSITION + sizeof(number_of_types), SEEK_SET);
+
+    // Run through the file again, but this time write it to the target data files.
+    for (uint32_t i = 0; i < number_of_types; ++i) {
+        const auto [value_type, record_count] = ReadLogFileSectionHeader(log_file);
+        auto data_file_path{GetDataFilePath(value_type)};
+        auto data_file{OpenFile(data_file_path, "rb+")};
+        LogFileRecord record{value_type};
+
+        for (uint64_t j = 0; j < record_count; ++j) {
+            ReadLogFileRecord(log_file, record, rolling_checksum);
+
+            if (data_file.tell() != record.m_position) {
+                data_file.seek(record.m_position, SEEK_SET);
+            }
+
+            data_file.write(record.m_value_buffer);
+            data_file << record.m_checksum;
+
+            // TEST ONLY
+            if (m_incomplete_log_apply) {
+                (void)data_file.fclose();
+                return false;
+            }
+        }
+
+        if (!data_file.Commit()) {
+            throw BlockTreeStoreError(strprintf("Failed to commit write to data file %s", PathToString(data_file_path)));
+        }
+        if (data_file.fclose() != 0) {
+            throw BlockTreeStoreError(strprintf("Failed to close after write to data file %s", PathToString(data_file_path)));
+        }
+    }
+
+    log_file >> stored_rolling_checksum;
+    if (rolling_checksum != stored_rolling_checksum) {
+        throw BlockTreeStoreError("Detected on-disk log file corruption: Rolling checksum mismatch");
+    }
+
+    (void)log_file.fclose();
+    // Reapplying a complete log (in case of a later failure) is idempotent, so avoid an unnecessary directory commit.
+    WriteFlag(m_log_flag_file_path, /*value=*/false, /*directory_commit=*/false);
+    return true;
+}
+
+void BlockTreeStore::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& file_infos_to_write, const std::vector<CBlockIndex*>& block_indexes_to_write)
+{
+    AssertLockHeld(::cs_main);
+    LOCK(m_mutex);
+
+    // If there is a complete log waiting to be applied, write that first. An incomplete log is discarded.
+    // This may occur if a previous write threw an exception when writing the logged data to the .dat files.
+    if (ApplyLog()) {
+        LogInfo("Applied block tree store write-ahead log left over from a previous failure, potentially caused by unclean shutdown or intermittent hardware issue.");
+    }
+
+    if (file_infos_to_write.empty() && block_indexes_to_write.empty()) return;
+
+    std::vector<std::pair<CBlockIndex*, FilePosition>> pending_header_positions;
+    pending_header_positions.reserve(block_indexes_to_write.size());
+
+    // Use a write-ahead log file that gets applied to the target files.
+
+    { // start log_file scope
+    auto log_file{OpenFile(m_log_file_path, "wb")};
+    WriteMagicAndVersion(log_file, LOG_FILE_MAGIC, LOG_FILE_VERSION);
+    const uint32_t log_num_types{(file_infos_to_write.empty() || block_indexes_to_write.empty()) ? 1u : 2u};
+    log_file << log_num_types;
+
+    Checksum rolling_checksum = 0;
+
+    // Write the file_info entries to the log
+    if (!file_infos_to_write.empty()) {
+        WriteLogFileSectionHeader(log_file, ValueType::BLOCK_FILE_INFO, file_infos_to_write.size());
+        for (const auto& [file, info] : file_infos_to_write) {
+            WriteLogFileRecord(log_file, BlockFileInfoWrapper{info}, CalculateBlockFileInfoPosition(file), rolling_checksum);
+        }
+    }
+
+    // TEST ONLY
+    if (m_incomplete_log_write) {
+        (void)log_file.fclose();
+        throw std::runtime_error("failed to write file");
+    }
+
+    if (!block_indexes_to_write.empty()) {
+        // Read the header data end position
+        FilePosition header_data_end;
+        {
+            auto header_file{OpenFileAndVerifyHeader(m_header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION)};
+            header_data_end = header_file.size();
+        }
+
+        // Write the block_indexes_to_write data to the log
+        WriteLogFileSectionHeader(log_file, ValueType::DISK_BLOCK_INDEX, block_indexes_to_write.size());
+        for (CBlockIndex* block_index : block_indexes_to_write) {
+            FilePosition position = block_index->header_pos == CBlockIndex::UNSET_HEADER_POS ? header_data_end : block_index->header_pos;
+            CDiskBlockIndex disk_index{block_index};
+            WriteLogFileRecord(log_file, DiskBlockIndexWrapper{&disk_index}, position, rolling_checksum);
+            if (block_index->header_pos == CBlockIndex::UNSET_HEADER_POS) {
+                pending_header_positions.emplace_back(block_index, header_data_end);
+                header_data_end += DiskBlockIndexWrapper::SERIALIZED_SIZE + sizeof(Checksum);
+            }
+        }
+    }
+
+    // Finally write the rolling checksum and commit.
+    log_file << rolling_checksum;
+    if (!log_file.Commit()) {
+        throw BlockTreeStoreError(strprintf("Failed to commit write to log file %s", PathToString(m_log_file_path)));
+    }
+    if (log_file.fclose() != 0) {
+        throw BlockTreeStoreError(strprintf("Failed to close after write to log file %s", PathToString(m_log_file_path)));
+    }
+
+    } // end log_file scope
+
+    // Write the flag indicating log file completion (which also executes CommitDirectory)
+    WriteFlag(m_log_flag_file_path, /*value=*/true, /*directory_commit=*/true);
+
+    // Once committed, apply the header positions to the index and close the file.
+    for (const auto& [block_index, header_pos] : pending_header_positions) {
+        block_index->header_pos = header_pos;
+    }
+
+    if (!ApplyLog()) {
+        throw BlockTreeStoreError("Failed to apply write-ahead log to data files");
+    }
+}
+
+bool BlockTreeStore::LoadBlockIndexGuts(
+    const Consensus::Params& consensus_params,
+    std::function<CBlockIndex*(const uint256&)> insert_block_index,
+    const util::SignalInterrupt& interrupt)
+{
+    AssertLockHeld(::cs_main);
+    LOCK(m_mutex);
+
+    auto file{OpenFileAndVerifyHeader(m_header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION)};
+
+    FilePosition data_end_position = file.size();
+    file.seek(HEADER_FILE_DATA_START_POSITION, SEEK_SET);
+
+    DiskBlockIndexWrapper disk_index;
+    std::array<std::byte, DiskBlockIndexWrapper::SERIALIZED_SIZE> buffer;
+
+    while (file.tell() < data_end_position) {
+        if (interrupt) return false;
+
+        auto record_start{file.tell()};
+        ReadDataValue(file, buffer);
+        SpanReader{buffer} >> disk_index;
+
+        // Construct block index object
+        CBlockIndex* block_index = insert_block_index(disk_index.ConstructBlockHash());
+        block_index->pprev = insert_block_index(disk_index.hashPrev);
+        block_index->header_pos = record_start;
+        block_index->nHeight = disk_index.nHeight;
+        block_index->nFile = disk_index.nFile;
+        block_index->nDataPos = disk_index.nDataPos;
+        block_index->nUndoPos = disk_index.nUndoPos;
+        block_index->nVersion = disk_index.nVersion;
+        block_index->hashMerkleRoot = disk_index.hashMerkleRoot;
+        block_index->nTime = disk_index.nTime;
+        block_index->nBits = disk_index.nBits;
+        block_index->nNonce = disk_index.nNonce;
+        block_index->nStatus = disk_index.nStatus;
+        block_index->nTx = disk_index.nTx;
+
+        if (!CheckProofOfWork(block_index->GetBlockHash(), block_index->nBits, consensus_params)) {
+            LogError("CheckProofOfWork failed: %s", block_index->ToString());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace kernel

--- a/src/kernel/blocktreestorage.h
+++ b/src/kernel/blocktreestorage.h
@@ -7,7 +7,6 @@
 
 #include <kernel/cs_main.h>
 #include <serialize.h>
-#include <streams.h>
 #include <sync.h>
 #include <util/fs.h>
 
@@ -30,8 +29,6 @@ class SignalInterrupt;
 }
 
 namespace kernel {
-
-class CBlockFileInfo;
 
 // Checksums are calculated from the serialized value and its position in the
 // file. This protects against out of order data and allows the same checksum
@@ -93,6 +90,50 @@ public:
 
     WriterLock(const WriterLock&) = delete;
     WriterLock& operator=(const WriterLock&) = delete;
+};
+
+class CBlockFileInfo
+{
+public:
+    uint32_t nBlocks{};      //!< number of blocks stored in file
+    uint32_t nSize{};        //!< number of used bytes of block file
+    uint32_t nUndoSize{};    //!< number of used bytes in the undo file
+    uint32_t nHeightFirst{}; //!< lowest height of block in file
+    uint32_t nHeightLast{};  //!< highest height of block in file
+    uint64_t nTimeFirst{};   //!< earliest time of block in file
+    uint64_t nTimeLast{};    //!< latest time of block in file
+
+    // Note: The SERIALIZE_METHODS here use VARINT encoding for compatibility with
+    // the legacy leveldb block tree db, used during migration in CreateAndMigrateBlockTree.
+    // BlockFileInfoWrapper uses fixed-width encoding for the new flat file storage.
+    SERIALIZE_METHODS(CBlockFileInfo, obj)
+    {
+        READWRITE(VARINT(obj.nBlocks));
+        READWRITE(VARINT(obj.nSize));
+        READWRITE(VARINT(obj.nUndoSize));
+        READWRITE(VARINT(obj.nHeightFirst));
+        READWRITE(VARINT(obj.nHeightLast));
+        READWRITE(VARINT(obj.nTimeFirst));
+        READWRITE(VARINT(obj.nTimeLast));
+    }
+
+    CBlockFileInfo() = default;
+
+    std::string ToString() const;
+
+    /** update statistics (does not update nSize) */
+    void AddBlock(unsigned int nHeightIn, uint64_t nTimeIn)
+    {
+        if (nBlocks == 0 || nHeightFirst > nHeightIn)
+            nHeightFirst = nHeightIn;
+        if (nBlocks == 0 || nTimeFirst > nTimeIn)
+            nTimeFirst = nTimeIn;
+        nBlocks++;
+        if (nHeightIn > nHeightLast)
+            nHeightLast = nHeightIn;
+        if (nTimeIn > nTimeLast)
+            nTimeLast = nTimeIn;
+    }
 };
 
 class BlockTreeStore

--- a/src/kernel/blocktreestorage.h
+++ b/src/kernel/blocktreestorage.h
@@ -1,0 +1,147 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_BLOCKTREESTORAGE_H
+#define BITCOIN_KERNEL_BLOCKTREESTORAGE_H
+
+#include <kernel/cs_main.h>
+#include <serialize.h>
+#include <streams.h>
+#include <sync.h>
+#include <util/fs.h>
+
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+class CBlockIndex;
+class uint256;
+
+namespace Consensus {
+struct Params;
+}
+namespace util {
+class SignalInterrupt;
+}
+
+namespace kernel {
+
+class CBlockFileInfo;
+
+// Checksums are calculated from the serialized value and its position in the
+// file. This protects against out of order data and allows the same checksum
+// from the log file record to be used for the actual data files.
+
+//! The data layout of the headers file is as follows:
+//! <magic> <version> [<DiskBlockIndexWrapper> <checksum>]
+inline constexpr uint32_t HEADER_FILE_MAGIC{0x1d5e2eb2}; // sha256sum("BLOCK_HEADER_FILE_MAGIC")
+inline constexpr uint32_t HEADER_FILE_VERSION{1};
+inline constexpr int64_t HEADER_FILE_DATA_START_POSITION{8}; // after magic (4bytes), version (4bytes)
+inline constexpr const char* HEADER_FILE_NAME{"headers.dat"};
+
+//! The flag is persisted by presence or absence of this file.
+inline constexpr const char* REINDEX_FLAG_FILE_NAME{"reindex.dat"};
+
+//! The flag is persisted by presence or absence of this file.
+inline constexpr const char* PRUNE_FLAG_FILE_NAME{"prune.dat"};
+
+//! The flag is persisted by presence or absence of this file.
+//! This file is used to indicate a completed log write.
+inline constexpr const char* LOG_FLAG_FILE_NAME{"log_flag.dat"};
+
+//! The data layout of the block files file is as follows:
+//! <magic> <version> [<BlockFileInfoWrapper> <checksum>]
+inline constexpr uint32_t BLOCK_FILES_FILE_MAGIC{0x6e2e2f44}; // sha256sum("BLOCK_FILES_FILE_MAGIC")
+inline constexpr uint32_t BLOCK_FILES_FILE_VERSION{1};
+inline constexpr int64_t BLOCK_FILES_FILE_DATA_START_POSITION{8}; // after magic (4bytes), version (4bytes)
+inline constexpr const char* BLOCK_FILES_FILE_NAME{"blockfiles.dat"};
+
+//! The data layout of the log file is as follows:
+//! <magic> <version> <number of types>, [<type> <number of records> [<value> <target position> <checksum>]], rolling checksum
+//! uint32_t, uint32_t, uint32_t,        [uint8_t, uint64_t,         [variable size, int64_t, uint32_t]], uint32_t
+//! The (type, number of records) tuple is referred to as the section header.
+//! The (value, target position, checksum) tuple is referred to as a log file record.
+inline constexpr uint32_t LOG_FILE_MAGIC{0xa0346f91}; // sha256sum("LOG_FILE_MAGIC")
+inline constexpr uint32_t LOG_FILE_VERSION{1};
+inline constexpr int64_t LOG_FILE_DATA_START_POSITION{8}; // after magic (4bytes), version (4bytes)
+inline constexpr const char* LOG_FILE_NAME{"log.dat"};
+
+enum class ValueType : uint8_t {
+    BLOCK_FILE_INFO = 0,
+    DISK_BLOCK_INDEX = 1,
+};
+
+class BlockTreeStoreError : public std::runtime_error
+{
+public:
+    explicit BlockTreeStoreError(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+class BlockTreeStore
+{
+private:
+    fs::path m_header_file_path;
+    fs::path m_log_file_path;
+    fs::path m_log_flag_file_path;
+    fs::path m_block_files_file_path;
+    fs::path m_reindex_flag_file_path;
+    fs::path m_prune_flag_file_path;
+
+    // TEST ONLY
+    bool m_incomplete_log_write{false};
+    bool m_incomplete_log_apply{false};
+
+    mutable Mutex m_mutex;
+
+    void WriteFlag(const fs::path& path, bool value, bool directory_commit) const;
+
+    /**
+     * Apply a pending write-ahead log to the data files.
+     *
+     * @return true if a complete log was found and applied; false if there was
+     * nothing to apply, either by no log file existing, or it not being
+     * complete.
+     */
+    [[nodiscard]] bool ApplyLog() const EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
+public:
+    enum class OpenMode {
+        WRITE,
+        WIPE
+    };
+    BlockTreeStore(const fs::path& path, OpenMode open_mode = OpenMode::WRITE);
+
+    void ReadReindexing(bool& reindexing) const;
+    void WriteReindexing(bool reindexing) const;
+
+    //! Block files are zero indexed. Returns 0 when there are no block files indexed yet.
+    void ReadLastBlockFile(int32_t& last_block_file) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    void ReadPruned(bool& pruned) const;
+    void WritePruned(bool pruned) const;
+
+    const fs::path& GetDataFilePath(ValueType value_type) const;
+
+    // TEST ONLY
+    void SetSimulateIncompleteLogWrite(bool val) { m_incomplete_log_write = val; }
+    void SetSimulateIncompleteLogApply(bool val) { m_incomplete_log_apply = val; }
+
+    void WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& file_infos_to_write, const std::vector<CBlockIndex*>& block_indexes_to_write)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !m_mutex);
+
+    [[nodiscard]] bool ReadBlockFileInfo(int file_index, CBlockFileInfo& info) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    [[nodiscard]] bool LoadBlockIndexGuts(
+        const Consensus::Params& consensus_params,
+        std::function<CBlockIndex*(const uint256&)> insert_block_index,
+        const util::SignalInterrupt& interrupt)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !m_mutex);
+};
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_BLOCKTREESTORAGE_H

--- a/src/kernel/blocktreestorage.h
+++ b/src/kernel/blocktreestorage.h
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -81,6 +82,19 @@ public:
     explicit BlockTreeStoreError(const std::string& msg) : std::runtime_error(msg) {}
 };
 
+//! Excludes other processes writing to the block tree store.
+class WriterLock
+{
+    fs::path m_dir;
+
+public:
+    explicit WriterLock(const fs::path& dir);
+    ~WriterLock();
+
+    WriterLock(const WriterLock&) = delete;
+    WriterLock& operator=(const WriterLock&) = delete;
+};
+
 class BlockTreeStore
 {
 private:
@@ -95,6 +109,7 @@ private:
     bool m_incomplete_log_write{false};
     bool m_incomplete_log_apply{false};
 
+    std::optional<WriterLock> m_writer_lock;
     mutable Mutex m_mutex;
 
     void WriteFlag(const fs::path& path, bool value, bool directory_commit) const;

--- a/src/kernel/blocktreestorage.h
+++ b/src/kernel/blocktreestorage.h
@@ -97,6 +97,13 @@ public:
 
 class BlockTreeStore
 {
+public:
+    enum class OpenMode {
+        WRITE,
+        WIPE,
+        READ
+    };
+
 private:
     fs::path m_header_file_path;
     fs::path m_log_file_path;
@@ -111,6 +118,9 @@ private:
 
     std::optional<WriterLock> m_writer_lock;
     mutable Mutex m_mutex;
+    OpenMode m_mode;
+
+    void CheckWriteAccess() const;
 
     void WriteFlag(const fs::path& path, bool value, bool directory_commit) const;
 
@@ -124,10 +134,6 @@ private:
     [[nodiscard]] bool ApplyLog() const EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
 
 public:
-    enum class OpenMode {
-        WRITE,
-        WIPE
-    };
     BlockTreeStore(const fs::path& path, OpenMode open_mode = OpenMode::WRITE);
 
     void ReadReindexing(bool& reindexing) const;

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -14,21 +14,16 @@ static constexpr size_t DEFAULT_KERNEL_CACHE{450_MiB};
 //! Default LevelDB write batch size
 static constexpr size_t DEFAULT_DB_CACHE_BATCH{32_MiB};
 
-//! Max memory allocated to block tree DB specific cache (bytes)
-static constexpr size_t MAX_BLOCK_DB_CACHE{2_MiB};
 //! Max memory allocated to coin DB specific cache (bytes)
-static constexpr size_t MAX_COINS_DB_CACHE{8_MiB};
+static constexpr size_t MAX_COINS_DB_CACHE{10_MiB};
 
 namespace kernel {
 struct CacheSizes {
-    size_t block_tree_db;
     size_t coins_db;
     size_t coins;
 
     CacheSizes(size_t total_cache)
     {
-        block_tree_db = std::min(total_cache / 8, MAX_BLOCK_DB_CACHE);
-        total_cache -= block_tree_db;
         coins_db = std::min(total_cache / 2, MAX_COINS_DB_CACHE);
         total_cache -= coins_db;
         coins = total_cache; // the rest goes to the coins cache

--- a/src/node/blockmanager_args.cpp
+++ b/src/node/blockmanager_args.cpp
@@ -36,8 +36,6 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, BlockManager::Op
 
     if (auto value{args.GetBoolArg("-fastprune")}) opts.fast_prune = *value;
 
-    ReadDatabaseArgs(args, opts.block_tree_db_params.options);
-
     return {};
 }
 } // namespace node

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -12,6 +12,7 @@
 #include <flatfile.h>
 #include <hash.h>
 #include <kernel/blockmanager_opts.h>
+#include <kernel/blocktreestorage.h>
 #include <kernel/chainparams.h>
 #include <kernel/messagestartchars.h>
 #include <kernel/notifications_interface.h>
@@ -530,14 +531,13 @@ void BlockManager::WriteBlockIndexDB()
         vFiles.emplace_back(*it, &m_blockfile_info[*it]);
         m_dirty_fileinfo.erase(it++);
     }
-    std::vector<const CBlockIndex*> vBlocks;
+    std::vector<CBlockIndex*> vBlocks;
     vBlocks.reserve(m_dirty_blockindex.size());
     for (std::set<CBlockIndex*>::iterator it = m_dirty_blockindex.begin(); it != m_dirty_blockindex.end();) {
         vBlocks.push_back(*it);
         m_dirty_blockindex.erase(it++);
     }
-    int max_blockfile{this->MaxBlockfileNum()};
-    m_block_tree_db->WriteBatchSync(vFiles, max_blockfile, vBlocks);
+    m_block_tree_db->WriteBatchSync(vFiles, vBlocks);
 }
 
 bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
@@ -553,7 +553,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     m_blockfile_info.resize(max_blockfile_num + 1);
     LogInfo("Loading block index db: last block file = %i", max_blockfile_num);
     for (int nFile = 0; nFile <= max_blockfile_num; nFile++) {
-        m_block_tree_db->ReadBlockFileInfo(nFile, m_blockfile_info[nFile]);
+        (void)m_block_tree_db->ReadBlockFileInfo(nFile, m_blockfile_info[nFile]);
     }
     LogInfo("Loading block index db: last block file info: %s", m_blockfile_info[max_blockfile_num].ToString());
     for (int nFile = max_blockfile_num + 1; true; nFile++) {
@@ -589,7 +589,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     }
 
     // Check whether we have ever pruned block & undo files
-    m_block_tree_db->ReadFlag("prunedblockfiles", m_have_pruned);
+    m_block_tree_db->ReadPruned(m_have_pruned);
     if (m_have_pruned) {
         LogInfo("Loading block index db: Block files have previously been pruned");
     }
@@ -1231,6 +1231,107 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
     return Obfuscation{obfuscation};
 }
 
+std::unique_ptr<kernel::BlockTreeStore> BlockManager::CreateAndMigrateBlockTree()
+{
+    LOCK(::cs_main);
+
+    using OpenMode = kernel::BlockTreeStore::OpenMode;
+    OpenMode open_mode = m_opts.block_tree_db_params.wipe_data ? OpenMode::WIPE : OpenMode::WRITE;
+
+    // Check if there is a pre-existing leveldb blocktree db, if not short circuit the migration
+    if (!fs::exists(m_opts.block_tree_db_params.path / "CURRENT")) {
+        return std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, open_mode);
+    }
+
+    auto cleanup_leveldb{[&]() {
+        if (!DestroyDB(fs::PathToString(m_opts.block_tree_db_params.path))) {
+            throw kernel::BlockTreeStoreError(
+                strprintf("Failed to remove legacy leveldb block tree db at %s", fs::PathToString(m_opts.block_tree_db_params.path)));
+        }
+        if (fs::exists(m_opts.block_tree_db_params.path / "CURRENT")) {
+            throw kernel::BlockTreeStoreError(
+                strprintf("Legacy leveldb block tree db marker still exists at %s", fs::PathToString(m_opts.block_tree_db_params.path / "CURRENT")));
+        }
+    }};
+
+    // Check if we need to wipe existing data, and if so short circuit the migration
+    if (m_opts.block_tree_db_params.wipe_data) {
+        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, open_mode)};
+        LogInfo("Detected legacy leveldb block tree db - removing it");
+        cleanup_leveldb();
+        return block_tree_store;
+    }
+
+    std::vector<std::pair<int, CBlockFileInfo>> files;
+    int max_blockfile_num{0};
+    bool reindexing{false};
+    bool pruned_block_files{false};
+    BlockMap migration_index;
+
+    {
+        LogInfo("Migrating leveldb block tree db to new block tree store.");
+        auto insert_block_index{[&](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> CBlockIndex* {
+            if (hash.IsNull()) return nullptr;
+            const auto [mi, inserted]{migration_index.try_emplace(hash)};
+            CBlockIndex* pindex{&mi->second};
+            if (inserted) pindex->phashBlock = &mi->first;
+            return pindex;
+        }};
+        try {
+            auto block_tree_db{std::make_unique<BlockTreeDB>(m_opts.block_tree_db_params)};
+            LogInfo("   Reading data from existing leveldb block tree db...");
+            if (!block_tree_db->ReadLastBlockFile(max_blockfile_num)) {
+                throw std::runtime_error("Failed to read last block file.");
+            }
+            files.reserve(max_blockfile_num + 1);
+            for (int i = 0; i <= max_blockfile_num; i++) {
+                CBlockFileInfo info;
+                if (!block_tree_db->ReadBlockFileInfo(i, info)) {
+                    throw std::runtime_error(strprintf("Failed to read block file info for file %d", i));
+                }
+                files.emplace_back(i, info);
+            }
+
+            if (!block_tree_db->LoadBlockIndexGuts(GetConsensus(), insert_block_index, m_interrupt)) {
+                throw std::runtime_error("Failed to load block index guts");
+            }
+            block_tree_db->ReadReindexing(reindexing);
+            block_tree_db->ReadFlag("prunedblockfiles", pruned_block_files);
+        } catch (const std::exception& e) {
+            throw kernel::BlockTreeStoreError(strprintf("Failed to read existing leveldb block tree data: %s", e.what()));
+        }
+    }
+
+    {
+        // Cleanup a potentially previously failed migration by setting wipe_data
+        LogInfo("   Writing data back to a new block tree store, reindexing: %d, pruned: %d", reindexing, pruned_block_files);
+        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, OpenMode::WIPE)};
+        block_tree_store->WritePruned(pruned_block_files);
+        block_tree_store->WriteReindexing(reindexing);
+
+        std::vector<std::pair<int, const CBlockFileInfo*>> dump_files;
+        dump_files.reserve(files.size());
+        for (auto& file : files) {
+            dump_files.emplace_back(file.first, &file.second);
+        }
+        std::vector<CBlockIndex*> dump_blockindexes;
+        dump_blockindexes.reserve(migration_index.size());
+        for (auto& pair : migration_index) {
+            dump_blockindexes.push_back(&pair.second);
+        }
+
+        block_tree_store->WriteBatchSync(dump_files, dump_blockindexes);
+    }
+
+    // Re-open to ensure that the migration was successful
+    auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path)};
+    cleanup_leveldb();
+
+    LogInfo("   Successfully migrated the leveldb block tree db to new block tree store.");
+
+    return block_tree_store;
+}
+
 BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
     : m_prune_mode{opts.prune_target > 0},
       m_obfuscation{InitBlocksdirXorKey(opts)},
@@ -1239,7 +1340,7 @@ BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
       m_undo_file_seq{FlatFileSeq{m_opts.blocks_dir, "rev", UNDOFILE_CHUNK_SIZE}},
       m_interrupt{interrupt}
 {
-    m_block_tree_db = std::make_unique<BlockTreeDB>(m_opts.block_tree_db_params);
+    m_block_tree_db = CreateAndMigrateBlockTree();
 
     if (m_opts.block_tree_db_params.wipe_data) {
         m_block_tree_db->WriteReindexing(true);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1236,27 +1236,27 @@ std::unique_ptr<kernel::BlockTreeStore> BlockManager::CreateAndMigrateBlockTree(
     LOCK(::cs_main);
 
     using OpenMode = kernel::BlockTreeStore::OpenMode;
-    OpenMode open_mode = m_opts.block_tree_db_params.wipe_data ? OpenMode::WIPE : OpenMode::WRITE;
+    OpenMode open_mode = m_opts.wipe_block_tree_data ? OpenMode::WIPE : OpenMode::WRITE;
 
     // Check if there is a pre-existing leveldb blocktree db, if not short circuit the migration
-    if (!fs::exists(m_opts.block_tree_db_params.path / "CURRENT")) {
-        return std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, open_mode);
+    if (!fs::exists(m_opts.block_tree_dir / "CURRENT")) {
+        return std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_dir, open_mode);
     }
 
     auto cleanup_leveldb{[&]() {
-        if (!DestroyDB(fs::PathToString(m_opts.block_tree_db_params.path))) {
+        if (!DestroyDB(fs::PathToString(m_opts.block_tree_dir))) {
             throw kernel::BlockTreeStoreError(
-                strprintf("Failed to remove legacy leveldb block tree db at %s", fs::PathToString(m_opts.block_tree_db_params.path)));
+                strprintf("Failed to remove legacy leveldb block tree db at %s", fs::PathToString(m_opts.block_tree_dir)));
         }
-        if (fs::exists(m_opts.block_tree_db_params.path / "CURRENT")) {
+        if (fs::exists(m_opts.block_tree_dir / "CURRENT")) {
             throw kernel::BlockTreeStoreError(
-                strprintf("Legacy leveldb block tree db marker still exists at %s", fs::PathToString(m_opts.block_tree_db_params.path / "CURRENT")));
+                strprintf("Legacy leveldb block tree db marker still exists at %s", fs::PathToString(m_opts.block_tree_dir / "CURRENT")));
         }
     }};
 
     // Check if we need to wipe existing data, and if so short circuit the migration
-    if (m_opts.block_tree_db_params.wipe_data) {
-        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, open_mode)};
+    if (m_opts.wipe_block_tree_data) {
+        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_dir, open_mode)};
         LogInfo("Detected legacy leveldb block tree db - removing it");
         cleanup_leveldb();
         return block_tree_store;
@@ -1278,7 +1278,9 @@ std::unique_ptr<kernel::BlockTreeStore> BlockManager::CreateAndMigrateBlockTree(
             return pindex;
         }};
         try {
-            auto block_tree_db{std::make_unique<BlockTreeDB>(m_opts.block_tree_db_params)};
+            DBParams params{};
+            params.path = m_opts.block_tree_dir;
+            auto block_tree_db{std::make_unique<BlockTreeDB>(params)};
             LogInfo("   Reading data from existing leveldb block tree db...");
             if (!block_tree_db->ReadLastBlockFile(max_blockfile_num)) {
                 throw std::runtime_error("Failed to read last block file.");
@@ -1304,8 +1306,8 @@ std::unique_ptr<kernel::BlockTreeStore> BlockManager::CreateAndMigrateBlockTree(
 
     {
         // Cleanup a potentially previously failed migration by setting wipe_data
-        LogInfo("   Writing data back to a new block tree store, reindexing: %d, pruned: %d", reindexing, pruned_block_files);
-        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path, OpenMode::WIPE)};
+        LogInfo("   Writing data back to a new block tree store, reindexing: %s, pruned: %s", reindexing, pruned_block_files);
+        auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_dir, OpenMode::WIPE)};
         block_tree_store->WritePruned(pruned_block_files);
         block_tree_store->WriteReindexing(reindexing);
 
@@ -1324,7 +1326,7 @@ std::unique_ptr<kernel::BlockTreeStore> BlockManager::CreateAndMigrateBlockTree(
     }
 
     // Re-open to ensure that the migration was successful
-    auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_db_params.path)};
+    auto block_tree_store{std::make_unique<kernel::BlockTreeStore>(m_opts.block_tree_dir)};
     cleanup_leveldb();
 
     LogInfo("   Successfully migrated the leveldb block tree db to new block tree store.");
@@ -1342,7 +1344,7 @@ BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
 {
     m_block_tree_db = CreateAndMigrateBlockTree();
 
-    if (m_opts.block_tree_db_params.wipe_data) {
+    if (m_opts.wipe_block_tree_data) {
         m_block_tree_db->WriteReindexing(true);
         m_blockfiles_indexed = false;
         // If we're reindexing in prune mode, wipe away unusable block files and all undo data files

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -70,15 +70,6 @@ bool BlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo& info)
     return Read(std::make_pair(DB_BLOCK_FILES, nFile), info);
 }
 
-void BlockTreeDB::WriteReindexing(bool fReindexing)
-{
-    if (fReindexing) {
-        Write(DB_REINDEX_FLAG, uint8_t{'1'});
-    } else {
-        Erase(DB_REINDEX_FLAG);
-    }
-}
-
 void BlockTreeDB::ReadReindexing(bool& fReindexing)
 {
     fReindexing = Exists(DB_REINDEX_FLAG);
@@ -87,24 +78,6 @@ void BlockTreeDB::ReadReindexing(bool& fReindexing)
 bool BlockTreeDB::ReadLastBlockFile(int& nFile)
 {
     return Read(DB_LAST_BLOCK, nFile);
-}
-
-void BlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo)
-{
-    CDBBatch batch(*this);
-    for (const auto& [file, info] : fileInfo) {
-        batch.Write(std::make_pair(DB_BLOCK_FILES, file), *info);
-    }
-    batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (const CBlockIndex* bi : blockinfo) {
-        batch.Write(std::make_pair(DB_BLOCK_INDEX, bi->GetBlockHash()), CDiskBlockIndex{bi});
-    }
-    WriteBatch(batch, true);
-}
-
-void BlockTreeDB::WriteFlag(const std::string& name, bool fValue)
-{
-    Write(std::make_pair(DB_FLAG, name), fValue ? uint8_t{'1'} : uint8_t{'0'});
 }
 
 bool BlockTreeDB::ReadFlag(const std::string& name, bool& fValue)
@@ -556,14 +529,6 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
         (void)m_block_tree_db->ReadBlockFileInfo(nFile, m_blockfile_info[nFile]);
     }
     LogInfo("Loading block index db: last block file info: %s", m_blockfile_info[max_blockfile_num].ToString());
-    for (int nFile = max_blockfile_num + 1; true; nFile++) {
-        CBlockFileInfo info;
-        if (m_block_tree_db->ReadBlockFileInfo(nFile, info)) {
-            m_blockfile_info.push_back(info);
-        } else {
-            break;
-        }
-    }
 
     // Check presence of blk files
     LogInfo("Checking all blk files are present...");

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -37,7 +37,6 @@
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
-#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -163,10 +162,6 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
     return true;
 }
 
-std::string CBlockFileInfo::ToString() const
-{
-    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
-}
 } // namespace kernel
 
 namespace node {

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -10,11 +10,11 @@
 #include <dbwrapper.h>
 #include <flatfile.h>
 #include <kernel/blockmanager_opts.h>
+#include <kernel/blocktreestorage.h>
 #include <kernel/chainparams.h>
 #include <kernel/cs_main.h>
 #include <kernel/messagestartchars.h>
 #include <primitives/block.h>
-#include <serialize.h>
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
@@ -56,46 +56,6 @@ class SignalInterrupt;
 } // namespace util
 
 namespace kernel {
-class CBlockFileInfo
-{
-public:
-    uint32_t nBlocks{};      //!< number of blocks stored in file
-    uint32_t nSize{};        //!< number of used bytes of block file
-    uint32_t nUndoSize{};    //!< number of used bytes in the undo file
-    uint32_t nHeightFirst{}; //!< lowest height of block in file
-    uint32_t nHeightLast{};  //!< highest height of block in file
-    uint64_t nTimeFirst{};   //!< earliest time of block in file
-    uint64_t nTimeLast{};    //!< latest time of block in file
-
-    SERIALIZE_METHODS(CBlockFileInfo, obj)
-    {
-        READWRITE(VARINT(obj.nBlocks));
-        READWRITE(VARINT(obj.nSize));
-        READWRITE(VARINT(obj.nUndoSize));
-        READWRITE(VARINT(obj.nHeightFirst));
-        READWRITE(VARINT(obj.nHeightLast));
-        READWRITE(VARINT(obj.nTimeFirst));
-        READWRITE(VARINT(obj.nTimeLast));
-    }
-
-    CBlockFileInfo() = default;
-
-    std::string ToString() const;
-
-    /** update statistics (does not update nSize) */
-    void AddBlock(unsigned int nHeightIn, uint64_t nTimeIn)
-    {
-        if (nBlocks == 0 || nHeightFirst > nHeightIn)
-            nHeightFirst = nHeightIn;
-        if (nBlocks == 0 || nTimeFirst > nTimeIn)
-            nTimeFirst = nTimeIn;
-        nBlocks++;
-        if (nHeightIn > nHeightLast)
-            nHeightLast = nHeightIn;
-        if (nTimeIn > nTimeLast)
-            nTimeLast = nTimeIn;
-    }
-};
 
 /** Access to the block database (blocks/index/) */
 class BlockTreeDB : public CDBWrapper

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -57,7 +57,7 @@ class SignalInterrupt;
 
 namespace kernel {
 
-/** Access to the block database (blocks/index/) */
+/** Access to the legacy block database (blocks/index/) used during migration*/
 class BlockTreeDB : public CDBWrapper
 {
 public:
@@ -261,6 +261,8 @@ private:
 
     BlockfileType BlockfileTypeForHeight(int height);
 
+    std::unique_ptr<kernel::BlockTreeStore> CreateAndMigrateBlockTree();
+
     const kernel::BlockManagerOpts m_opts;
 
     const FlatFileSeq m_block_file_seq;
@@ -316,7 +318,7 @@ public:
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
     void AddUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
+    std::unique_ptr<kernel::BlockTreeStore> m_block_tree_db GUARDED_BY(::cs_main);
 
     void WriteBlockIndexDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -62,12 +62,9 @@ class BlockTreeDB : public CDBWrapper
 {
 public:
     using CDBWrapper::CDBWrapper;
-    void WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo& info);
     bool ReadLastBlockFile(int& nFile);
-    void WriteReindexing(bool fReindexing);
     void ReadReindexing(bool& fReindexing);
-    void WriteFlag(const std::string& name, bool fValue);
     bool ReadFlag(const std::string& name, bool& fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(test_bitcoin
   blockfilter_index_tests.cpp
   blockfilter_tests.cpp
   blockmanager_tests.cpp
+  blocktreestorage_tests.cpp
   bloom_tests.cpp
   bswap_tests.cpp
   btcsignals_tests.cpp

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -34,11 +34,8 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     const BlockManager::Options blockman_opts{
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .block_tree_dir = m_args.GetDataDirNet() / "blocks" / "index",
         .notifications = notifications,
-        .block_tree_db_params = DBParams{
-            .path = m_args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = 0,
-        },
     };
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
     // simulate adding a genesis block normally
@@ -238,11 +235,8 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
     node::BlockManager::Options blockman_opts{
         .chainparams = Params(),
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .block_tree_dir = m_args.GetDataDirNet() / "blocks" / "index",
         .notifications = notifications,
-        .block_tree_db_params = DBParams{
-            .path = m_args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = 0,
-        },
     };
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
 

--- a/src/test/blocktreestorage_tests.cpp
+++ b/src/test/blocktreestorage_tests.cpp
@@ -246,6 +246,17 @@ BOOST_AUTO_TEST_CASE(BlockTreeStoreInvalidFiles)
     BlockTreeStore{block_tree_store_dir};
 }
 
+BOOST_AUTO_TEST_CASE(BlockTreeStoreIsWriteExclusive)
+{
+    fs::path block_tree_store_dir{m_args.GetDataDirBase()};
+    BlockTreeStore store_write{block_tree_store_dir};
+    BlockTreeStore store_read{block_tree_store_dir, BlockTreeStore::OpenMode::READ};
+    LOCK(cs_main);
+    BOOST_CHECK_THROW(store_read.WriteBatchSync({}, {}), std::logic_error);
+    BOOST_CHECK_THROW(store_read.WriteReindexing(true), std::logic_error);
+    BOOST_CHECK_THROW(store_read.WritePruned(true), std::logic_error);
+}
+
 BOOST_AUTO_TEST_CASE(BlockTreeStoreIncompleteWrites)
 {
     LOCK(::cs_main);

--- a/src/test/blocktreestorage_tests.cpp
+++ b/src/test/blocktreestorage_tests.cpp
@@ -1,0 +1,486 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <kernel/blocktreestorage.h>
+#include <logging.h>
+#include <node/blockstorage.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <util/fs_helpers.h>
+#include <util/hasher.h>
+
+#include <boost/test/unit_test.hpp>
+
+using kernel::BLOCK_FILES_FILE_DATA_START_POSITION;
+using kernel::BLOCK_FILES_FILE_MAGIC;
+using kernel::BLOCK_FILES_FILE_NAME;
+using kernel::BLOCK_FILES_FILE_VERSION;
+using kernel::BlockTreeStore;
+using kernel::BlockTreeStoreError;
+using kernel::CBlockFileInfo;
+using kernel::HEADER_FILE_DATA_START_POSITION;
+using kernel::HEADER_FILE_MAGIC;
+using kernel::HEADER_FILE_NAME;
+using kernel::HEADER_FILE_VERSION;
+using kernel::LOG_FILE_NAME;
+using kernel::LOG_FLAG_FILE_NAME;
+
+BOOST_FIXTURE_TEST_SUITE(blocktreestorage_tests, BasicTestingSetup)
+
+CBlockIndex* InsertBlockIndex(node::BlockMap& block_map, const uint256& hash)
+{
+    if (hash.IsNull()) {
+        return nullptr;
+    }
+    const auto [mi, inserted]{block_map.try_emplace(hash)};
+    CBlockIndex* pindex = &(*mi).second;
+    if (inserted) {
+        pindex->phashBlock = &((*mi).first);
+    }
+    return pindex;
+}
+
+CBlockFileInfo CreateFileInfo(int32_t seed)
+{
+    CBlockFileInfo info;
+    info.nBlocks = seed;
+    info.nSize = seed + 1;
+    info.nUndoSize = seed + 2;
+    info.nHeightFirst = seed + 3;
+    info.nHeightLast = seed + 4;
+    info.nTimeFirst = seed + 5;
+    info.nTimeLast = seed + 6;
+    return info;
+}
+
+struct ExpectedStoreState {
+    std::map<int, CBlockFileInfo> file_infos{};
+    node::BlockMap block_map{};
+    bool pruned{false};
+    bool reindexing{false};
+    util::SignalInterrupt& interrupt;
+    const CChainParams& params;
+};
+
+void CheckBlockFileInfo(uint32_t file, CBlockFileInfo& file_info, BlockTreeStore& store)
+{
+    CBlockFileInfo retrieved_info;
+    BOOST_CHECK(store.ReadBlockFileInfo(file, retrieved_info));
+    BOOST_CHECK_EQUAL(file_info.nBlocks, retrieved_info.nBlocks);
+    BOOST_CHECK_EQUAL(file_info.nSize, retrieved_info.nSize);
+    BOOST_CHECK_EQUAL(file_info.nUndoSize, retrieved_info.nUndoSize);
+    BOOST_CHECK_EQUAL(file_info.nHeightFirst, retrieved_info.nHeightFirst);
+    BOOST_CHECK_EQUAL(file_info.nHeightLast, retrieved_info.nHeightLast);
+    BOOST_CHECK_EQUAL(file_info.nTimeFirst, retrieved_info.nTimeFirst);
+    BOOST_CHECK_EQUAL(file_info.nTimeLast, retrieved_info.nTimeLast);
+
+    DataStream a, b;
+    a << file_info;
+    b << retrieved_info;
+    BOOST_CHECK_EQUAL(a.str(), b.str());
+}
+
+void CheckBlockMap(const node::BlockMap& store_block_map, const node::BlockMap& expected_block_map)
+{
+    LOCK(::cs_main);
+    BOOST_CHECK_EQUAL(store_block_map.size(), expected_block_map.size());
+    for (const auto& [block_hash, store_index] : store_block_map) {
+        auto it = expected_block_map.find(block_hash);
+        BOOST_REQUIRE(it != expected_block_map.end());
+        const auto& expected_index = it->second;
+
+        BOOST_CHECK_EQUAL(expected_index.nHeight, store_index.nHeight);
+        BOOST_CHECK_EQUAL(expected_index.nStatus, store_index.nStatus);
+        BOOST_CHECK_EQUAL(expected_index.nTx, store_index.nTx);
+        BOOST_CHECK_EQUAL(expected_index.nFile, store_index.nFile);
+        BOOST_CHECK_EQUAL(expected_index.nDataPos, store_index.nDataPos);
+        BOOST_CHECK_EQUAL(expected_index.nUndoPos, store_index.nUndoPos);
+
+        BOOST_CHECK_EQUAL(expected_index.nVersion, store_index.nVersion);
+        if (expected_index.pprev == nullptr || store_index.pprev == nullptr) {
+            BOOST_CHECK_EQUAL(expected_index.pprev, store_index.pprev);
+        } else {
+            BOOST_CHECK_EQUAL(Assert(expected_index.pprev)->GetBlockHeader().GetHash().ToString(), Assert(store_index.pprev)->GetBlockHeader().GetHash().ToString());
+        }
+        BOOST_CHECK_EQUAL(expected_index.hashMerkleRoot.ToString(), store_index.hashMerkleRoot.ToString());
+        BOOST_CHECK_EQUAL(expected_index.nTime, store_index.nTime);
+        BOOST_CHECK_EQUAL(expected_index.nBits, store_index.nBits);
+        BOOST_CHECK_EQUAL(expected_index.nNonce, store_index.nNonce);
+
+        DataStream store, expected;
+        store << CDiskBlockIndex{&store_index};
+        expected << CDiskBlockIndex{&expected_index};
+        BOOST_CHECK_EQUAL(store.str(), expected.str());
+    }
+}
+
+void CheckStoreContents(BlockTreeStore& store,
+                        const ExpectedStoreState& expected_state,
+                        const std::string& context)
+{
+    BOOST_TEST_CONTEXT(context)
+    {
+        for (auto& [file, info] : expected_state.file_infos) {
+            CBlockFileInfo copy{info};
+            CheckBlockFileInfo(file, copy, store);
+        }
+        int32_t last_block;
+        store.ReadLastBlockFile(last_block);
+        int32_t expected_last = expected_state.file_infos.empty() ? 0 : expected_state.file_infos.size() - 1;
+        BOOST_CHECK_EQUAL(last_block, expected_last);
+
+        LOCK(::cs_main);
+        node::BlockMap block_map;
+        BOOST_CHECK(store.LoadBlockIndexGuts(
+            expected_state.params.GetConsensus(),
+            [&](const uint256& hash) { return InsertBlockIndex(block_map, hash); },
+            expected_state.interrupt));
+        CheckBlockMap(block_map, expected_state.block_map);
+
+        bool pruned, reindexing;
+        store.ReadPruned(pruned);
+        store.ReadReindexing(reindexing);
+        BOOST_CHECK_EQUAL(pruned, expected_state.pruned);
+        BOOST_CHECK_EQUAL(reindexing, expected_state.reindexing);
+    }
+}
+
+std::vector<CBlockIndex*> BlockMapToVector(node::BlockMap& test_block_map)
+{
+    std::vector<CBlockIndex*> blocks;
+    blocks.reserve(test_block_map.size());
+    for (auto& [hash, index] : test_block_map) {
+        blocks.push_back(&index);
+    }
+    return blocks;
+}
+
+std::vector<std::pair<int, const CBlockFileInfo*>> FileInfosToPairs(std::span<CBlockFileInfo> file_infos)
+{
+    std::vector<std::pair<int, const CBlockFileInfo*>> pairs;
+    pairs.reserve(file_infos.size());
+    for (size_t i{0}; i < file_infos.size(); ++i) {
+        pairs.emplace_back(static_cast<int>(i), &file_infos[i]);
+    }
+    return pairs;
+}
+
+std::vector<std::pair<int, const CBlockFileInfo*>> FileInfosToPairs(const std::map<int, CBlockFileInfo>& file_infos)
+{
+    std::vector<std::pair<int, const CBlockFileInfo*>> pairs;
+    pairs.reserve(file_infos.size());
+    for (const auto& [i, info] : file_infos) {
+        pairs.emplace_back(i, &info);
+    }
+    return pairs;
+}
+
+BOOST_AUTO_TEST_CASE(HeaderFilesFormat)
+{
+    fs::path block_tree_store_dir{m_args.GetDataDirBase()};
+    auto header_file_path{block_tree_store_dir / HEADER_FILE_NAME};
+    auto block_files_file_path{block_tree_store_dir / BLOCK_FILES_FILE_NAME};
+    BlockTreeStore store{block_tree_store_dir};
+
+    AutoFile header_file{fsbridge::fopen(header_file_path, "rb")};
+    uint32_t magic;
+    header_file >> magic;
+    BOOST_CHECK_EQUAL(magic, HEADER_FILE_MAGIC);
+    uint32_t version;
+    header_file >> version;
+    BOOST_CHECK_EQUAL(version, HEADER_FILE_VERSION);
+    header_file.seek(0, SEEK_END);
+    long filesize = header_file.tell();
+    BOOST_CHECK_EQUAL(filesize, HEADER_FILE_DATA_START_POSITION);
+    (void)header_file.fclose();
+
+    AutoFile block_files_file{fsbridge::fopen(block_files_file_path, "rb")};
+    block_files_file >> magic;
+    BOOST_CHECK_EQUAL(magic, BLOCK_FILES_FILE_MAGIC);
+    block_files_file >> version;
+    BOOST_CHECK_EQUAL(version, BLOCK_FILES_FILE_VERSION);
+    block_files_file.seek(0, SEEK_END);
+    filesize = block_files_file.tell();
+    BOOST_CHECK_EQUAL(filesize, BLOCK_FILES_FILE_DATA_START_POSITION);
+    (void)block_files_file.fclose();
+}
+
+BOOST_AUTO_TEST_CASE(BlockTreeStoreInvalidFiles)
+{
+    fs::path block_tree_store_dir{m_args.GetDataDirBase()};
+
+    auto header_file_path{block_tree_store_dir / HEADER_FILE_NAME};
+    auto block_files_file_path{block_tree_store_dir / BLOCK_FILES_FILE_NAME};
+
+    BlockTreeStore{block_tree_store_dir};
+    fs::remove(header_file_path);
+    BOOST_CHECK_THROW(BlockTreeStore{block_tree_store_dir}, BlockTreeStoreError);
+
+    // If both files are gone, a new store may be created
+    fs::remove(block_files_file_path);
+    BlockTreeStore{block_tree_store_dir};
+    BOOST_CHECK(fs::exists(header_file_path));
+    BOOST_CHECK(fs::exists(block_files_file_path));
+
+    fs::remove(block_files_file_path);
+    BOOST_CHECK_THROW(BlockTreeStore{block_tree_store_dir}, BlockTreeStoreError);
+    fs::remove(header_file_path);
+
+    auto write_magic_and_version{[](const fs::path& path, uint32_t magic, uint32_t version) {
+        AutoFile file{fsbridge::fopen(path, "rb+")};
+        file.seek(0, SEEK_SET);
+        file << magic;
+        file << version;
+        (void)file.fclose();
+    }};
+    BlockTreeStore{block_tree_store_dir};
+    write_magic_and_version(header_file_path, 0, 0);
+    BOOST_CHECK_THROW(BlockTreeStore{block_tree_store_dir}, BlockTreeStoreError);
+    write_magic_and_version(header_file_path, HEADER_FILE_MAGIC, 0);
+    BOOST_CHECK_THROW(BlockTreeStore{block_tree_store_dir}, BlockTreeStoreError);
+    write_magic_and_version(header_file_path, HEADER_FILE_MAGIC, HEADER_FILE_VERSION);
+    BlockTreeStore{block_tree_store_dir};
+}
+
+BOOST_AUTO_TEST_CASE(BlockTreeStoreIncompleteWrites)
+{
+    LOCK(::cs_main);
+    fs::path block_tree_store_dir{m_args.GetDataDirBase()};
+    auto log_file{block_tree_store_dir / LOG_FILE_NAME};
+    auto log_flag_file{block_tree_store_dir / LOG_FLAG_FILE_NAME};
+    auto params{CreateChainParams(gArgs, ChainType::REGTEST)};
+    auto store{std::make_unique<BlockTreeStore>(block_tree_store_dir)};
+
+    // Write and read a CBlockFileInfo and a CBlockIndex
+    ExpectedStoreState expected_state{.interrupt = m_interrupt, .params = *params};
+    int32_t seed{0};
+    expected_state.file_infos.insert({0, CreateFileInfo(seed)});
+    auto file_infos_to_write{FileInfosToPairs(expected_state.file_infos)};
+    expected_state.block_map.try_emplace(params->GenesisBlock().GetHash(), params->GenesisBlock());
+    CBlockIndex* block_index = &expected_state.block_map[params->GenesisBlock().GetHash()];
+    BOOST_CHECK_EQUAL(block_index->header_pos, CBlockIndex::UNSET_HEADER_POS);
+    auto block_indexes_to_write{BlockMapToVector(expected_state.block_map)};
+
+    store->SetSimulateIncompleteLogWrite(true);
+
+    // The log file should exist in an unclean state if we abort in the middle of writing to it
+    node::BlockMap block_map;
+    BOOST_CHECK_THROW(store->WriteBatchSync(file_infos_to_write, block_indexes_to_write), std::runtime_error);
+    BOOST_CHECK(fs::exists(log_file));
+    BOOST_CHECK(store->LoadBlockIndexGuts(
+        params->GetConsensus(),
+        [&](const uint256& hash) { return InsertBlockIndex(block_map, hash); },
+        m_interrupt));
+    BOOST_CHECK(block_map.empty());
+
+    // The constructor should ignore the log file and not apply any pending state
+    block_map.clear();
+    store = std::make_unique<BlockTreeStore>(block_tree_store_dir);
+    BOOST_CHECK(!fs::exists(log_flag_file));
+    BOOST_CHECK(store->LoadBlockIndexGuts(
+        params->GetConsensus(),
+        [&](const uint256& hash) { return InsertBlockIndex(block_map, hash); },
+        m_interrupt));
+    BOOST_CHECK(block_map.empty());
+
+    // Now simulate a crash in the middle of applying the log.
+    block_map.clear();
+    store->SetSimulateIncompleteLogApply(true);
+    BOOST_CHECK_THROW(store->WriteBatchSync(file_infos_to_write, block_indexes_to_write), std::runtime_error);
+    BOOST_CHECK(fs::exists(log_file));
+    BOOST_CHECK(fs::exists(log_flag_file));
+    BOOST_CHECK(store->LoadBlockIndexGuts(
+        params->GetConsensus(),
+        [&](const uint256& hash) { return InsertBlockIndex(block_map, hash); },
+        m_interrupt));
+    BOOST_CHECK(block_map.empty());
+
+    // The constructor should now apply the log file and remove the flag
+    block_map.clear();
+    BOOST_CHECK(fs::exists(log_flag_file));
+    store = std::make_unique<BlockTreeStore>(block_tree_store_dir);
+    BOOST_CHECK(!fs::exists(log_flag_file));
+    CheckStoreContents(*store, expected_state, "constructor applies log file");
+    BOOST_CHECK_EQUAL(block_index->header_pos, HEADER_FILE_DATA_START_POSITION);
+
+    // Simulate a write application failure and subsequent write application
+    store->SetSimulateIncompleteLogApply(true);
+    ++seed;
+    expected_state.file_infos.insert({1, CreateFileInfo(seed)});
+    file_infos_to_write = FileInfosToPairs(expected_state.file_infos);
+    BOOST_CHECK_THROW(store->WriteBatchSync(file_infos_to_write, block_indexes_to_write), std::runtime_error);
+    BOOST_CHECK(fs::exists(log_flag_file));
+    store->SetSimulateIncompleteLogApply(false);
+    store->WriteBatchSync({}, {});
+    BOOST_CHECK(!fs::exists(log_flag_file));
+    CheckStoreContents(*store, expected_state, "subsequent write applies log file");
+}
+
+BOOST_AUTO_TEST_CASE(BlockTreeStoreFlags)
+{
+    auto store{std::make_unique<BlockTreeStore>(m_args.GetDataDirBase())};
+    bool reindexing = true;
+    store->ReadReindexing(reindexing);
+    BOOST_CHECK(!reindexing);
+    store->WriteReindexing(true);
+    store->ReadReindexing(reindexing);
+    BOOST_CHECK(reindexing);
+    store->WriteReindexing(false);
+    store->ReadReindexing(reindexing);
+    BOOST_CHECK(!reindexing);
+
+    int last_block;
+    store->ReadLastBlockFile(last_block);
+    BOOST_CHECK_EQUAL(last_block, 0);
+
+    bool pruned = false;
+    store->ReadPruned(pruned);
+    BOOST_CHECK(!pruned);
+    store->WritePruned(true);
+    store->ReadPruned(pruned);
+    BOOST_CHECK(pruned);
+    store->WritePruned(false);
+    store->ReadPruned(pruned);
+    BOOST_CHECK(!pruned);
+
+    // Re-create the store and check that the data was persisted
+    store->WritePruned(true);
+    store->WriteReindexing(true);
+    store = std::make_unique<BlockTreeStore>(m_args.GetDataDirBase());
+    store->ReadPruned(pruned);
+    store->ReadReindexing(reindexing);
+    BOOST_CHECK(pruned);
+    BOOST_CHECK(reindexing);
+}
+
+CBlockIndex* AddTestBlockIndex(node::BlockMap& test_block_map, const CBlockHeader& header, CBlockIndex* prev)
+{
+    LOCK(::cs_main);
+    const auto [mi, inserted]{test_block_map.try_emplace(header.GetHash(), header)};
+    CBlockIndex* pindex{&mi->second};
+    pindex->phashBlock = &mi->first;
+    pindex->pprev = prev;
+    pindex->nHeight = prev ? prev->nHeight + 1 : 0;
+    pindex->nStatus = prev ? prev->nStatus ^ BLOCK_FAILED_VALID : 0;
+    pindex->nTx = prev ? prev->nTx + 3 : 0;
+    pindex->nFile = prev ? prev->nFile + 4 : 0;
+    pindex->nDataPos = prev ? prev->nDataPos + 100 : 0;
+    pindex->nUndoPos = prev ? prev->nUndoPos + 101 : 0;
+    return pindex;
+}
+
+void WriteAndCheckBlockIndex(BlockTreeStore& store,
+                             ExpectedStoreState& expected_state,
+                             node::BlockMap& block_map_to_write,
+                             std::span<CBlockFileInfo> file_infos_to_write,
+                             const std::string& context)
+{
+    LOCK(::cs_main);
+    const auto block_indexes_to_write{BlockMapToVector(block_map_to_write)};
+    const auto file_info_pairs_to_write{FileInfosToPairs(file_infos_to_write)};
+    store.WriteBatchSync(file_info_pairs_to_write, block_indexes_to_write);
+    CheckStoreContents(store, expected_state, context);
+}
+
+BOOST_AUTO_TEST_CASE(BlockTreeStoreRW)
+{
+    LOCK(::cs_main);
+    fs::path block_tree_store_dir{m_args.GetDataDirBase()};
+    auto header_file{block_tree_store_dir / HEADER_FILE_NAME};
+    auto block_files_file{block_tree_store_dir / BLOCK_FILES_FILE_NAME};
+    auto params{CreateChainParams(gArgs, ChainType::REGTEST)};
+    BlockTreeStore store{block_tree_store_dir};
+
+    node::BlockMap block_map_to_write;
+    std::vector<CBlockFileInfo> file_info_to_write;
+    ExpectedStoreState expected_state{.interrupt = m_interrupt, .params = *params};
+
+    // Check that the store is empty
+    CheckStoreContents(store, expected_state, "check empty store");
+
+    // Write and read a CBlockFileInfo and a CBlockIndex
+    int32_t counter = 0;
+    file_info_to_write.emplace_back(CreateFileInfo(counter));
+    expected_state.file_infos.emplace(counter, CreateFileInfo(counter));
+    CBlockIndex* block_index = AddTestBlockIndex(block_map_to_write, params->GenesisBlock(), /*prev=*/nullptr);
+    AddTestBlockIndex(expected_state.block_map, params->GenesisBlock(), /*prev*/ nullptr);
+    BOOST_CHECK_EQUAL(block_index->header_pos, CBlockIndex::UNSET_HEADER_POS);
+    WriteAndCheckBlockIndex(store, expected_state, block_map_to_write, file_info_to_write, "write and read single entries");
+    BOOST_CHECK_EQUAL(block_index->header_pos, HEADER_FILE_DATA_START_POSITION);
+
+    // Write another CBlockFileInfo and update the CBlockIndex
+    ++counter;
+    file_info_to_write.emplace_back(CreateFileInfo(counter));
+    expected_state.file_infos.emplace(counter, CreateFileInfo(counter));
+    block_index->nStatus = 120;
+    expected_state.block_map[block_index->GetBlockHash()].nStatus = 120;
+    block_index->nFile = 1;
+    expected_state.block_map[block_index->GetBlockHash()].nFile = 1;
+    WriteAndCheckBlockIndex(store, expected_state, block_map_to_write, file_info_to_write, "write another file info and update CBlockIndex");
+
+    // Write an empty block map
+    node::BlockMap empty_block_map{};
+    WriteAndCheckBlockIndex(store, expected_state, empty_block_map, file_info_to_write, "write empty block map");
+
+    // Write an empty file info vector
+    std::vector<CBlockFileInfo> empty_file_info;
+    WriteAndCheckBlockIndex(store, expected_state, block_map_to_write, empty_file_info, "write empty file info");
+
+    // Update the new CBlockFileInfo and the CBlockIndex and check that the file sizes are unchanged
+    block_index->nStatus = 99;
+    expected_state.block_map[block_index->GetBlockHash()].nStatus = 99;
+    block_index->nFile = 50;
+    expected_state.block_map[block_index->GetBlockHash()].nFile = 50;
+    file_info_to_write[1] = CreateFileInfo(3);
+    expected_state.file_infos[1] = CreateFileInfo(3);
+    auto header_file_size{fs::file_size(header_file)};
+    auto block_files_file_size{fs::file_size(block_files_file)};
+    WriteAndCheckBlockIndex(store, expected_state, block_map_to_write, file_info_to_write, "update existing entries");
+    BOOST_CHECK_EQUAL(header_file_size, fs::file_size(header_file));
+    BOOST_CHECK_EQUAL(block_files_file_size, fs::file_size(block_files_file));
+
+    // Add more CBlockIndex entries to the store
+    BOOST_CHECK_EQUAL(expected_state.block_map.size(), 1);
+    for (uint8_t i = 0; i < 10; ++i) {
+        CBlockHeader header;
+        header.hashPrevBlock = block_index->GetBlockHash();
+        header.nBits = params->GenesisBlock().nBits;
+        header.nTime = block_index->nTime + 1;
+        header.hashMerkleRoot = uint256{i};
+        while (!CheckProofOfWork(header.GetHash(), header.nBits, params->GetConsensus())) {
+            ++header.nNonce;
+        }
+        block_index = AddTestBlockIndex(expected_state.block_map, header, /*prev=*/block_index);
+        // Add a couple of forks too
+        if (i % 3 == 0) {
+            block_index = block_index->pprev;
+        }
+    }
+    BOOST_CHECK_EQUAL(expected_state.block_map.size(), 11);
+    WriteAndCheckBlockIndex(store, expected_state, expected_state.block_map, file_info_to_write, "add a tree of block indexes");
+
+    // Read and write back the same data and check that the file sizes are unchanged
+    header_file_size = fs::file_size(header_file);
+    node::BlockMap loaded_block_map;
+    BOOST_CHECK(store.LoadBlockIndexGuts(
+        params->GetConsensus(),
+        [&](const uint256& hash) { return InsertBlockIndex(loaded_block_map, hash); },
+        m_interrupt));
+    WriteAndCheckBlockIndex(store, expected_state, loaded_block_map, file_info_to_write, "read and write the same data leaves no changes");
+    BOOST_CHECK_EQUAL(header_file_size, fs::file_size(header_file));
+
+    // Writing an invalid CBlockIndex (with invalid PoW) should fail to load
+    block_map_to_write.begin()->second.nBits = 0;
+    loaded_block_map.clear();
+    store.WriteBatchSync(FileInfosToPairs(file_info_to_write), BlockMapToVector(block_map_to_write));
+    BOOST_CHECK(!store.LoadBlockIndexGuts(
+        params->GetConsensus(),
+        [&](const uint256& hash) { return InsertBlockIndex(loaded_block_map, hash); },
+        m_interrupt));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -4,6 +4,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <kernel/blocktreestorage.h>
 #include <node/blockstorage.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -57,11 +58,8 @@ void init_block_index()
 FUZZ_TARGET(block_index, .init = init_block_index)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    auto block_index = kernel::BlockTreeDB(DBParams{
-        .path = "", // Memory only.
-        .cache_bytes = 1_MiB,
-        .memory_only = true,
-    });
+    fs::path block_tree_store_dir{g_setup->m_args.GetDataDirBase()};
+    kernel::BlockTreeStore block_index{block_tree_store_dir, kernel::BlockTreeStore::OpenMode::WIPE};
 
     // Generate a number of block files to be stored in the index.
     int files_count = fuzzed_data_provider.ConsumeIntegralInRange(1, 100);
@@ -82,7 +80,7 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     int blocks_count = fuzzed_data_provider.ConsumeIntegralInRange(files_count * 10, files_count * 100);
     std::vector<std::unique_ptr<CBlockIndex>> blocks;
     blocks.reserve(blocks_count);
-    std::vector<const CBlockIndex*> blocks_info;
+    std::vector<CBlockIndex*> blocks_info;
     blocks_info.reserve(blocks_count);
     for (int i = 0; i < blocks_count; i++) {
         CBlockHeader header{ConsumeBlockHeader(fuzzed_data_provider)};
@@ -92,7 +90,7 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     }
 
     // Store these files and blocks in the block index. It should not fail.
-    block_index.WriteBatchSync(files_info, files_count - 1, blocks_info);
+    WITH_LOCK(::cs_main, block_index.WriteBatchSync(files_info, blocks_info));
 
     // We should be able to read every block file info we stored. Its value should correspond to
     // what we stored above.
@@ -104,7 +102,7 @@ FUZZ_TARGET(block_index, .init = init_block_index)
 
     // We should be able to read the last block file number. Its value should be consistent.
     int last_block_file;
-    assert(block_index.ReadLastBlockFile(last_block_file));
+    block_index.ReadLastBlockFile(last_block_file);
     assert(last_block_file == files_count - 1);
 
     // We should be able to flip and read the reindexing flag.
@@ -117,14 +115,16 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     assert(!reindexing);
 
     // We should be able to set and read the value of any random flag.
-    const std::string flag_name = fuzzed_data_provider.ConsumeRandomLengthString(100);
-    bool flag_value;
-    block_index.WriteFlag(flag_name, true);
-    block_index.ReadFlag(flag_name, flag_value);
-    assert(flag_value);
-    block_index.WriteFlag(flag_name, false);
-    block_index.ReadFlag(flag_name, flag_value);
-    assert(!flag_value);
+    bool pruning = true;
+    block_index.WritePruned(pruning);
+    pruning = false;
+    block_index.ReadPruned(pruning);
+    assert(pruning);
+    pruning = false;
+    block_index.WritePruned(pruning);
+    pruning = true;
+    block_index.ReadPruned(pruning);
+    assert(!pruning);
 
     // We should be able to load everything we've previously stored. Note to assert on the
     // return value we need to make sure all blocks pass the pow check.

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_in_memory_tests)
     }
 
     BOOST_CHECK(fs::exists(in_memory_test_directory.m_directory / "blocks"));
-    BOOST_CHECK(!fs::exists(in_memory_test_directory.m_directory / "blocks" / "index"));
+    BOOST_CHECK(fs::exists(in_memory_test_directory.m_directory / "blocks" / "index"));
     BOOST_CHECK(!fs::exists(in_memory_test_directory.m_directory / "chainstate"));
 
     BOOST_CHECK(context.interrupt());

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -786,7 +786,6 @@ BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
                                           bool reindex,
                                           bool wipe_chainstate,
-                                          bool block_tree_db_in_memory,
                                           bool chainstate_db_in_memory,
                                           Context& context)
 {
@@ -797,9 +796,6 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
     }
     if (wipe_chainstate) {
         chainman_opts.SetWipeDbs(/*wipe_block_tree=*/false, /*wipe_chainstate=*/wipe_chainstate);
-    }
-    if (block_tree_db_in_memory) {
-        chainman_opts.UpdateBlockTreeDbInMemory(block_tree_db_in_memory);
     }
     if (chainstate_db_in_memory) {
         chainman_opts.UpdateChainstateDbInMemory(chainstate_db_in_memory);
@@ -815,7 +811,7 @@ void chainman_reindex_test(TestDirectory& test_directory)
     auto context{create_context(notifications, ChainType::MAINNET)};
     auto chainman{create_chainman(
         test_directory, /*reindex=*/true, /*wipe_chainstate=*/false,
-        /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+        /*chainstate_db_in_memory=*/false, context)};
 
     std::vector<std::string> import_files;
     BOOST_CHECK(chainman->ImportBlocks(import_files));
@@ -860,7 +856,7 @@ void chainman_reindex_chainstate_test(TestDirectory& test_directory)
     auto context{create_context(notifications, ChainType::MAINNET)};
     auto chainman{create_chainman(
         test_directory, /*reindex=*/false, /*wipe_chainstate=*/true,
-        /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+        /*chainstate_db_in_memory=*/false, context)};
 
     std::vector<std::string> import_files;
     import_files.push_back(PathToString(test_directory.m_directory / "blocks" / "blk00000.dat"));
@@ -874,7 +870,7 @@ void chainman_mainnet_validation_test(TestDirectory& test_directory)
     auto context{create_context(notifications, ChainType::MAINNET, validation_interface)};
     auto chainman{create_chainman(
         test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
-        /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+        /*chainstate_db_in_memory=*/false, context)};
 
     // mainnet block 1
     auto raw_block = hex_string_to_byte_vec("010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e362990101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000");
@@ -1022,7 +1018,6 @@ BOOST_AUTO_TEST_CASE(btck_block_tree_entry_tests)
         test_directory,
         /*reindex=*/false,
         /*wipe_chainstate=*/false,
-        /*block_tree_db_in_memory=*/true,
         /*chainstate_db_in_memory=*/true,
         context)};
 
@@ -1068,7 +1063,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_in_memory_tests)
     auto context{create_context(notifications, ChainType::REGTEST)};
     auto chainman{create_chainman(
         in_memory_test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
-        /*block_tree_db_in_memory=*/true, /*chainstate_db_in_memory=*/true, context)};
+        /*chainstate_db_in_memory=*/true, context)};
 
     for (auto& raw_block : REGTEST_BLOCK_DATA) {
         Block block{hex_string_to_byte_vec(raw_block)};
@@ -1094,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     {
         auto chainman{create_chainman(
             test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
-            /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+            /*chainstate_db_in_memory=*/false, context)};
         for (const auto& data : REGTEST_BLOCK_DATA) {
             Block block{hex_string_to_byte_vec(data)};
             BlockHeader header = block.GetHeader();
@@ -1117,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     {
         auto chainman{create_chainman(
             test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
-            /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+            /*chainstate_db_in_memory=*/false, context)};
         for (size_t i{0}; i < mid; i++) {
             Block block{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[i])};
             bool new_block{false};
@@ -1128,7 +1123,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
 
     auto chainman{create_chainman(
         test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
-        /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+        /*chainstate_db_in_memory=*/false, context)};
 
     for (size_t i{mid}; i < REGTEST_BLOCK_DATA.size(); i++) {
         Block block{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[i])};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -317,13 +317,9 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
         const BlockManager::Options blockman_opts{
             .chainparams = chainman_opts.chainparams,
             .blocks_dir = m_args.GetBlocksDirPath(),
+            .block_tree_dir = m_args.GetDataDirNet() / "blocks" / "index",
+            .wipe_block_tree_data = m_args.GetBoolArg("-reindex", false),
             .notifications = chainman_opts.notifications,
-            .block_tree_db_params = DBParams{
-                .path = m_args.GetDataDirNet() / "blocks" / "index",
-                .cache_bytes = m_kernel_cache_sizes.block_tree_db,
-                .memory_only = opts.block_tree_db_in_memory,
-                .wipe_data = m_args.GetBoolArg("-reindex", false),
-            },
         };
         m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
@@ -377,7 +373,6 @@ TestingSetup::TestingSetup(
     : ChainTestingSetup(chainType, opts)
 {
     m_coins_db_in_memory = opts.coins_db_in_memory;
-    m_block_tree_db_in_memory = opts.block_tree_db_in_memory;
     // Ideally we'd move all the RPC tests to the functional testing framework
     // instead of unit tests, but for now we need these here.
     RegisterAllCoreRPCCommands(tableRPC);

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -46,7 +46,6 @@ void SetupCommonTestArgs(ArgsManager& argsman);
 struct TestOpts {
     std::vector<const char*> extra_args{};
     bool coins_db_in_memory{true};
-    bool block_tree_db_in_memory{true};
     bool setup_net{true};
     bool setup_validation_interface{true};
     bool min_validation_cache{false}; // Equivalent of -maxsigcachebytes=0
@@ -100,7 +99,6 @@ struct BasicTestingSetup {
 struct ChainTestingSetup : public BasicTestingSetup {
     kernel::CacheSizes m_kernel_cache_sizes{node::CalculateCacheSizes(m_args).kernel};
     bool m_coins_db_in_memory{true};
-    bool m_block_tree_db_in_memory{true};
     std::function<void()> m_make_chainman{};
 
     explicit ChainTestingSetup(ChainType chainType = ChainType::MAIN, TestOpts = {});

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -219,7 +219,6 @@ struct SnapshotTestSetup : TestChain100Setup {
                               {},
                               {
                                   .coins_db_in_memory = false,
-                                  .block_tree_db_in_memory = false,
                               },
                           }
     {
@@ -435,12 +434,8 @@ struct SnapshotTestSetup : TestChain100Setup {
             const BlockManager::Options blockman_opts{
                 .chainparams = chainman_opts.chainparams,
                 .blocks_dir = m_args.GetBlocksDirPath(),
+                .block_tree_dir = chainman.m_options.datadir / "blocks" / "index",
                 .notifications = chainman_opts.notifications,
-                .block_tree_db_params = DBParams{
-                    .path = chainman.m_options.datadir / "blocks" / "index",
-                    .cache_bytes = m_kernel_cache_sizes.block_tree_db,
-                    .memory_only = m_block_tree_db_in_memory,
-                },
             };
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2758,7 +2758,7 @@ bool Chainstate::FlushStateToDisk(
             if (!setFilesToPrune.empty()) {
                 fFlushForPrune = true;
                 if (!m_blockman.m_have_pruned) {
-                    m_blockman.m_block_tree_db->WriteFlag("prunedblockfiles", true);
+                    m_blockman.m_block_tree_db->WritePruned(true);
                     m_blockman.m_have_pruned = true;
                 }
             }

--- a/test/functional/feature_blocktree_migration.py
+++ b/test/functional/feature_blocktree_migration.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test migrating a v28.2 block tree to the flat file block tree store
+
+"""
+
+import shutil
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class BlockTreeMigrationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_previous_releases()
+
+    def setup_network(self):
+        self.add_nodes(
+            self.num_nodes,
+            versions=[
+                None,
+                280200,
+            ],
+        )
+
+    def run_test(self):
+        block_tree_store_node = self.nodes[0]
+        legacy_node = self.nodes[1]
+
+        self.start_node(1)
+        nblocks = 100
+        self.generate(legacy_node, nblocks, sync_fun=self.no_op)
+        assert_equal(legacy_node.getblockchaininfo()["blocks"], nblocks)
+        self.stop_node(1)
+
+        migrate_log = "Successfully migrated the leveldb block tree db to new block tree store."
+        detect_legacy_log = "Detected legacy leveldb block tree db - removing it"
+
+        self.log.info("Start the node with a legacy data directory to trigger migration")
+        shutil.copytree(legacy_node.chain_path, block_tree_store_node.chain_path)
+        with block_tree_store_node.assert_debug_log(expected_msgs=[migrate_log]):
+            self.start_node(0)
+        index_dir = block_tree_store_node.chain_path / "blocks" / "index"
+        assert (index_dir / "headers.dat").exists()
+        assert not (index_dir / "CURRENT").exists()
+        assert_equal(block_tree_store_node.getblockchaininfo()["blocks"], nblocks)
+        self.stop_node(0)
+
+        self.log.info("Re-starting the node to exercise non-migration path")
+        with block_tree_store_node.assert_debug_log(expected_msgs=[], unexpected_msgs=[migrate_log]):
+            self.start_node(0)
+        assert_equal(block_tree_store_node.getblockchaininfo()["blocks"], nblocks)
+        self.stop_node(0)
+
+        self.log.info("A corrupt legacy block index fails the migration and kills the node")
+        self.cleanup_folder(block_tree_store_node.chain_path)
+        shutil.copytree(legacy_node.chain_path, block_tree_store_node.chain_path)
+        manifests = list(block_tree_store_node.chain_path.glob("blocks/index/MANIFEST*"))
+        assert_equal(len(manifests), 1)
+        manifests[0].unlink()
+        with block_tree_store_node.assert_debug_log(expected_msgs=["Error opening block database"]):
+            block_tree_store_node.assert_start_raises_init_error()
+
+        self.log.info("Restarting with -reindex will create a block tree store and remove the corrupt leveldb data")
+        with block_tree_store_node.assert_debug_log(expected_msgs=[detect_legacy_log]):
+            self.start_node(0, extra_args=["-reindex"])
+        self.wait_until(lambda: block_tree_store_node.getblockchaininfo()["blocks"] == nblocks)
+        assert (index_dir / "headers.dat").exists()
+        assert not (index_dir / "CURRENT").exists()
+        self.stop_node(0)
+
+        self.log.info("A corrupt legacy block index prompts the user to reindex")
+        self.cleanup_folder(block_tree_store_node.chain_path)
+        shutil.copytree(legacy_node.chain_path, block_tree_store_node.chain_path)
+        manifests = list(block_tree_store_node.chain_path.glob("blocks/index/MANIFEST*"))
+        assert_equal(len(manifests), 1)
+        manifests[0].unlink()
+        with block_tree_store_node.assert_debug_log(expected_msgs=[detect_legacy_log]):
+            self.start_node(0, extra_args=["-test=reindex_after_failure_noninteractive_yes"])
+        self.wait_until(lambda: block_tree_store_node.getblockchaininfo()["blocks"] == nblocks)
+        assert (index_dir / "headers.dat").exists()
+        assert not (index_dir / "CURRENT").exists()
+        self.stop_node(0)
+
+        self.log.info("Recreate a pruned legacy node and test its migration")
+        self.start_node(1, extra_args=["-prune=1", "-fastprune"])
+        self.generate(legacy_node, 500, sync_fun=self.no_op)
+        legacy_node.pruneblockchain(400)
+        self.stop_node(1)
+        self.cleanup_folder(block_tree_store_node.chain_path)
+        shutil.copytree(legacy_node.chain_path, block_tree_store_node.chain_path)
+        with block_tree_store_node.assert_debug_log(expected_msgs=[migrate_log, "Loading block index db: Block files have previously been pruned"]):
+            block_tree_store_node.assert_start_raises_init_error()
+        with block_tree_store_node.assert_debug_log(expected_msgs=["Loading block index db: Block files have previously been pruned"]):
+            self.start_node(0, extra_args=["-prune=1"])
+        self.stop_node(0)
+
+if __name__ == '__main__':
+    BlockTreeMigrationTest(__file__).main()

--- a/test/functional/feature_coinstatsindex_compatibility.py
+++ b/test/functional/feature_coinstatsindex_compatibility.py
@@ -17,6 +17,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [["-coinstatsindex"],["-coinstatsindex"]]
+        self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_previous_releases()
@@ -37,7 +38,9 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
     def _test_coin_stats_index_compatibility(self):
         node = self.nodes[0]
+        self.generate(node, 10)
         legacy_node = self.nodes[1]
+        self.generate(legacy_node, 10)
         for n in self.nodes:
             self.wait_until(lambda: n.getindexinfo()['coinstatsindex']['synced'] is True)
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -121,7 +121,12 @@ class InitTest(BitcoinTestFramework):
 
         deletion_rounds = [
             {
-                'filepath_glob': 'blocks/index/*.ldb',
+                'filepath_glob': 'blocks/index/headers.dat',
+                'error_message': 'Error opening block database.',
+                'startup_args': [],
+            },
+            {
+                'filepath_glob': 'blocks/index/blockfiles.dat',
                 'error_message': 'Error opening block database.',
                 'startup_args': [],
             },
@@ -152,8 +157,8 @@ class InitTest(BitcoinTestFramework):
 
         perturbation_rounds = [
             {
-                'filepath_glob': 'blocks/index/*.ldb',
-                'error_message': 'Error loading block database.',
+                'filepath_glob': 'blocks/index/headers.dat',
+                'error_message': 'Error loading database.',
                 'startup_args': [],
             },
             {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -363,6 +363,7 @@ BASE_SCRIPTS = [
     'interface_ipc_mining.py',
     'feature_anchors.py',
     'mempool_datacarrier.py',
+    'feature_blocktree_migration.py',
     'feature_coinstatsindex.py',
     'feature_coinstatsindex_compatibility.py',
     'wallet_orphanedreward.py',

--- a/test/functional/tool_bitcoin_chainstate.py
+++ b/test/functional/tool_bitcoin_chainstate.py
@@ -52,7 +52,7 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         self.log.info("Test kernel process refuses a datadir owned by a running node")
         proc = run_chainstate(self.nodes[0].chain_path)
         assert proc.returncode != 0
-        expected_message = "Failed to create chainstate manager: Fatal LevelDB error: IO error"
+        expected_message = "Failed to create chainstate manager: Another process is already writing to the block tree store in"
         assert expected_message in proc.stdout
 
         self.log.info("Test kernel process on an unrelated datadir is unaffected")

--- a/test/functional/tool_bitcoin_chainstate.py
+++ b/test/functional/tool_bitcoin_chainstate.py
@@ -16,6 +16,7 @@ import subprocess
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.wallet import MiniWallet
+from pathlib import Path
 
 START_HEIGHT = 199
 # Hardcoded in regtest chainparams
@@ -36,6 +37,29 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         including blocks the other hasn't yet seen."""
         self.add_nodes(2)
         self.start_nodes()
+
+    def writer_lock_test(self):
+        assert self.nodes[0].is_node_stopped() is False
+
+        def run_chainstate(datadir):
+            return subprocess.run(
+                self.get_binaries().chainstate_argv() + ["-regtest", datadir],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+            )
+
+        self.log.info("Test kernel process refuses a datadir owned by a running node")
+        proc = run_chainstate(self.nodes[0].chain_path)
+        assert proc.returncode != 0
+        expected_message = "Failed to create chainstate manager: Fatal LevelDB error: IO error"
+        assert expected_message in proc.stdout
+
+        self.log.info("Test kernel process on an unrelated datadir is unaffected")
+        other_datadir = Path(self.options.tmpdir) / "chainstate_other"
+        proc = run_chainstate(other_datadir)
+        assert proc.returncode == 0
+        assert expected_message not in proc.stdout
 
     def generate_snapshot_chain(self):
         self.log.info(f"Generate deterministic chain up to block {SNAPSHOT_BASE_BLOCK_HEIGHT} for node0 while node1 disconnected")
@@ -98,6 +122,7 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         self.add_block(datadir, n0.getblock(new_tip_hash, 0), expected_stdout="Block tip changed")
 
     def run_test(self):
+        self.writer_lock_test()
         dump_output = self.generate_snapshot_chain()
         self.basic_test()
         self.assumeutxo_test(dump_output['path'])


### PR DESCRIPTION
This is motivated by the kernel library, where the internal usage of leveldb is a limiting factor to its future use cases. Specifically it is not possible to share leveldb databases between two processes. A notable use-case for the kernel library is accessing and analyzing existing block data. Currently this can only be done by first shutting down the node writing this data. Moving away from leveldb opens the door towards doing this in parallel. A flat file based approach was chosen, since the requirements for persistence here are fairly simple (no deletion, constant-size entries). The change also offers better performance by making node startup faster, and has a smaller on-disk footprint, though this is negligible in the grand scheme of things.

The BlockTreeStore introduces a new data format for storing block indexes and headers on disk. The class is very similar to the existing CBlockTreeDB, which stores the same data in a leveldb database. Unlike CBlockTreeDB, the data stored through the BlockTreeStore is directly serialized and written to flat .dat files. The storage schema introduced is simple. It relies on the assumption that no entry is ever deleted and that no duplicate entries are written. These assumptions hold for the current users of CBlockTreeDB.

A write ahead ahead log and boolean flags as file existence checks ensure write atomicity. Every data entry is also given a crc32c checksum to detect data corruption.

An alternative to this pull request, that could allow the same kernel feature, would be closing and opening the leveldb database only when reading and writing. This might incur a (negligible) performance penalty, but more importantly requires careful consideration of how to handle any contentions when opening, which might have complex side effects due to our current locking mode. It would also be possible to introduce an existing database with the required features for just the block tree, but that would introduce reliance on a new dependency and come with its own tradeoffs. For these reasons I chose this approach.