### PR TITLE
crypto: disable ASan for sha256_sse4 with Clang

### DIFF
--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -13,12 +13,16 @@
 namespace sha256_sse4
 {
 void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
-#if defined(__clang__) && !defined(__OPTIMIZE__)
+#if defined(__clang__)
   /*
   clang is unable to compile this with -O0 and -fsanitize=address.
-  See upstream bug: https://github.com/llvm/llvm-project/issues/92182
+  See upstream bug: https://github.com/llvm/llvm-project/issues/92182.
+  This also fails to compile with -O2, -fcf-protection & -fsanitize=address.
+  See https://github.com/bitcoin/bitcoin/issues/31913.
   */
+#if __has_feature(address_sanitizer)
   __attribute__((no_sanitize("address")))
+#endif
 #endif
 {
     static const uint32_t K256 alignas(16) [] = {


### PR DESCRIPTION
This also fails to compile when optimisations are being used, see: https://github.com/bitcoin/bitcoin/issues/31913. 
So just disable ASan under any optimisation level.

Closes #31913.