### PR TITLE
guix: accomodate migration to codeberg

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -319,7 +319,7 @@ Source: https://logs.guix.gnu.org/guix/2020-11-12.log#232527
 Start by cloning Guix:
 
 ```
-git clone https://git.savannah.gnu.org/git/guix.git
+git clone https://codeberg.org/guix/guix.git
 cd guix
 ```
 
@@ -607,7 +607,7 @@ checklist.
    ```
    Generation 38   Feb 22 2021 16:39:31    (current)
      guix f350df4
-       repository URL: https://git.savannah.gnu.org/git/guix.git
+       repository URL: https://codeberg.org/guix/guix.git
        branch: version-1.2.0
        commit: f350df405fbcd5b9e27e6b6aa500da7f101f41e7
    ```
@@ -760,8 +760,8 @@ Please see the following links for more details:
 
 - An upstream coreutils bug has been filed: [debbugs#47940](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=47940)
 - A Guix bug detailing the underlying problem has been filed: [guix-issues#47935](https://issues.guix.gnu.org/47935), [guix-issues#49985](https://issues.guix.gnu.org/49985#5)
-- A commit to skip this test in Guix has been merged into the core-updates branch:
-[savannah/guix@6ba1058](https://git.savannah.gnu.org/cgit/guix.git/commit/?id=6ba1058df0c4ce5611c2367531ae5c3cdc729ab4)
+- A commit to skip this test is included since Guix 1.4.0:
+[codeberg/guix@6ba1058](https://codeberg.org/guix/guix/commit/6ba1058df0c4ce5611c2367531ae5c3cdc729ab4)
 
 
 [install-script]: #options-1-and-2-using-the-official-shell-installer-script-or-binary-tarball

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -50,7 +50,7 @@ fi
 # across time.
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
+    guix time-machine --url=https://codeberg.org/guix/guix.git \
                       --commit=53396a22afc04536ddf75d8f82ad2eafa5082725 \
                       --cores="$JOBS" \
                       --keep-failed \


### PR DESCRIPTION
See https://guix.gnu.org/blog/2025/migrating-to-codeberg/.