### PR TITLE
build: let CMake determine the year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CLIENT_VERSION_MINOR 99)
 set(CLIENT_VERSION_BUILD 0)
 set(CLIENT_VERSION_RC 0)
 set(CLIENT_VERSION_IS_RELEASE "false")
-set(COPYRIGHT_YEAR "2025")
+string(TIMESTAMP COPYRIGHT_YEAR "%Y" UTC)
 
 # During the enabling of the CXX and CXXOBJ languages, we modify
 # CMake's compiler/linker invocation strings by appending the content


### PR DESCRIPTION
Then we no-longer have to "bump" it.

See https://cmake.org/cmake/help/latest/command/string.html#timestamp.

Note:

> If the SOURCE_DATE_EPOCH environment variable is set, its value
> will be used instead of the current time. See https://reproducible-builds.org/specs/source-date-epoch/ for details.