### PR TITLE
build: simplify *ifaddr handling

### DIFF
--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -55,13 +55,8 @@
    */
 #cmakedefine01 HAVE_DECL_FORK
 
-/* Define to 1 if you have the declaration of `freeifaddrs', and to 0 if you
-   don't. */
-#cmakedefine01 HAVE_DECL_FREEIFADDRS
-
-/* Define to 1 if you have the declaration of `getifaddrs', and to 0 if you
-   don't. */
-#cmakedefine01 HAVE_DECL_GETIFADDRS
+/* Define to 1 if '*ifaddrs' are available. */
+#cmakedefine HAVE_IFADDRS 1
 
 /* Define to 1 if you have the declaration of `pipe2', and to 0 if you don't.
    */

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -4,7 +4,6 @@
 
 include(CheckCXXSourceCompiles)
 include(CheckCXXSymbolExists)
-include(CheckIncludeFileCXX)
 
 check_cxx_symbol_exists(O_CLOEXEC "fcntl.h" HAVE_O_CLOEXEC)
 check_cxx_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
@@ -12,9 +11,7 @@ check_cxx_symbol_exists(fork "unistd.h" HAVE_DECL_FORK)
 check_cxx_symbol_exists(pipe2 "unistd.h" HAVE_DECL_PIPE2)
 check_cxx_symbol_exists(setsid "unistd.h" HAVE_DECL_SETSID)
 
-check_include_file_cxx(sys/types.h HAVE_SYS_TYPES_H)
-check_include_file_cxx(ifaddrs.h HAVE_IFADDRS_H)
-if(HAVE_SYS_TYPES_H AND HAVE_IFADDRS_H)
+if(NOT WIN32)
   include(TestAppendRequiredLibraries)
   test_append_socket_library(core_interface)
 endif()

--- a/cmake/module/TestAppendRequiredLibraries.cmake
+++ b/cmake/module/TestAppendRequiredLibraries.cmake
@@ -38,8 +38,7 @@ function(test_append_socket_library target)
       message(FATAL_ERROR "Cannot figure out how to use getifaddrs/freeifaddrs.")
     endif()
   endif()
-  set(HAVE_DECL_GETIFADDRS TRUE PARENT_SCOPE)
-  set(HAVE_DECL_FREEIFADDRS TRUE PARENT_SCOPE)
+  set(HAVE_IFADDRS TRUE PARENT_SCOPE)
 endfunction()
 
 # Clang, when building for 32-bit,

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -29,6 +29,11 @@
 #include <sys/sysctl.h>
 #endif
 
+#ifdef HAVE_IFADDRS
+#include <sys/types.h>
+#include <ifaddrs.h>
+#endif
+
 namespace {
 
 //! Return CNetAddr for the specified OS-level network address.
@@ -325,7 +330,7 @@ std::vector<CNetAddr> GetLocalAddresses()
             }
         }
     }
-#elif (HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS)
+#elif defined(HAVE_IFADDRS)
     struct ifaddrs* myaddrs;
     if (getifaddrs(&myaddrs) == 0) {
         for (struct ifaddrs* ifa = myaddrs; ifa != nullptr; ifa = ifa->ifa_next)

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -20,7 +20,6 @@
 #else
 #include <arpa/inet.h>   // IWYU pragma: export
 #include <fcntl.h>       // IWYU pragma: export
-#include <ifaddrs.h>     // IWYU pragma: export
 #include <net/if.h>      // IWYU pragma: export
 #include <netdb.h>       // IWYU pragma: export
 #include <netinet/in.h>  // IWYU pragma: export

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -41,10 +41,6 @@
 #include <string.h>
 #endif
 
-#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
-#include <ifaddrs.h>
-#endif
-
 #include <algorithm>
 #include <array>
 #include <cmath>

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -38,7 +38,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #endif
-#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
+#ifdef HAVE_IFADDRS
 #include <ifaddrs.h>
 #endif
 #ifdef HAVE_SYSCTL
@@ -330,7 +330,7 @@ void RandAddStaticEnv(CSHA512& hasher)
     }
 #endif
 
-#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
+#ifdef HAVE_IFADDRS
     // Network interfaces
     struct ifaddrs *ifad = nullptr;
     getifaddrs(&ifad);


### PR DESCRIPTION
We really just want to skip this when building for Windows. So do that,
and remove the two header checks (we also already use both of these
headers, unguarded, in the !windows part of the codebase).

Squash the two *iffaddrs defines into one, as I haven't seen an
`iffaddrs.h` that implements one, but not the other.