### PR TITLE
contrib: remove bdb exception from FORTIFY check

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -130,9 +130,8 @@ def check_ELF_FORTIFY(binary) -> bool:
         if match:
             chk_funcs.add(match.group(0))
 
-    # ignore stack-protector and bdb
+    # ignore stack-protector
     chk_funcs.discard('__stack_chk')
-    chk_funcs.discard('__db_chk')
 
     return len(chk_funcs) >= 1
 


### PR DESCRIPTION
BDB has been removed (#28710), so we no-longer need to ignore functions from BDB in this check.

Guix building this branch, and looking for `*_chk` functions across all binaries produces:
```
# nm -C * | grep -i _chk | sort | uniq
                 U __fdelt_chk@GLIBC_2.15
                 U __fprintf_chk@GLIBC_2.3.4
                 U __fread_chk@GLIBC_2.7
                 U __longjmp_chk@GLIBC_2.11
                 U __memcpy_chk@GLIBC_2.3.4
                 U __printf_chk@GLIBC_2.3.4
                 U __snprintf_chk@GLIBC_2.3.4
                 U __sprintf_chk@GLIBC_2.3.4
                 U __stack_chk_fail@GLIBC_2.4
                 U __vsnprintf_chk@GLIBC_2.3.4
```