### PR TITLE
randomenv: remove some `/proc/` accesses

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -222,18 +222,6 @@ void RandAddDynamicEnv(CSHA512& hasher)
     if (getrusage(RUSAGE_SELF, &usage) == 0) hasher << usage;
 #endif
 
-#ifdef __linux__
-    AddFile(hasher, "/proc/diskstats");
-    AddFile(hasher, "/proc/vmstat");
-    AddFile(hasher, "/proc/schedstat");
-    AddFile(hasher, "/proc/zoneinfo");
-    AddFile(hasher, "/proc/meminfo");
-    AddFile(hasher, "/proc/softirqs");
-    AddFile(hasher, "/proc/stat");
-    AddFile(hasher, "/proc/self/schedstat");
-    AddFile(hasher, "/proc/self/status");
-#endif
-
 #ifdef HAVE_SYSCTL
 #  ifdef CTL_KERN
 #    if defined(KERN_PROC) && defined(KERN_PROC_ALL)


### PR DESCRIPTION
Any env data we try and gather is on a best-effort basis, however in this instance, for multiple users, it's just producing spam. This could probably be solved with further snap/apparmor configuration, however given that no-one is actively working on snap packaging, we could instead drop this source of env data.

Closes https://github.com/bitcoin-core/packaging/issues/115.
Also in https://github.com/bitcoin-core/packaging/issues/217.

Happy to close this if someone opens an alternative PR (in https://github.com/bitcoin-core/packaging) fixing the Snap AppArmor configuration.