### PR TITLE
guix: move `*-check.py` scripts under contrib/guix/

### DIFF
--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -31,13 +31,13 @@ function(add_maintenance_targets)
 
   add_custom_target(check-symbols
     COMMAND ${CMAKE_COMMAND} -E echo "Running symbol and dynamic library checks..."
-    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/devtools/symbol-check.py ${executables}
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/guix/symbol-check.py ${executables}
     VERBATIM
   )
 
   add_custom_target(check-security
     COMMAND ${CMAKE_COMMAND} -E echo "Checking binary security..."
-    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/devtools/security-check.py ${executables}
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/contrib/guix/security-check.py ${executables}
     VERBATIM
   )
 endfunction()

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -159,35 +159,6 @@ For example:
 BUILDDIR=$PWD/my-build-dir contrib/devtools/gen-bitcoin-conf.sh
 ```
 
-security-check.py
-=================
-
-Perform basic security checks on a series of executables.
-
-symbol-check.py
-===============
-
-A script to check that release executables only contain
-certain symbols and are only linked against allowed libraries.
-
-For Linux this means checking for allowed gcc, glibc and libstdc++ version symbols.
-This makes sure they are still compatible with the minimum supported distribution versions.
-
-For macOS and Windows we check that the executables are only linked against libraries we allow.
-
-Example usage:
-
-    find ../path/to/executables -type f -executable | xargs python3 contrib/devtools/symbol-check.py
-
-If no errors occur the return value will be 0 and the output will be empty.
-
-If there are any errors the return value will be 1 and output like this will be printed:
-
-    .../64/test_bitcoin: symbol memcpy from unsupported version GLIBC_2.14
-    .../64/test_bitcoin: symbol __fdelt_chk from unsupported version GLIBC_2.15
-    .../64/test_bitcoin: symbol std::out_of_range::~out_of_range() from unsupported version GLIBCXX_3.4.15
-    .../64/test_bitcoin: symbol _ZNSt8__detail15_List_nod from unsupported version GLIBCXX_3.4.15
-
 circular-dependencies.py
 ========================
 

--- a/contrib/guix/security-check.py
+++ b/contrib/guix/security-check.py
@@ -6,6 +6,10 @@
 Perform basic security checks on a series of executables.
 Exit status will be 0 if successful, and the program will be silent.
 Otherwise the exit status will be 1 and it will log which executables failed which checks.
+
+Example usage:
+
+    find ../path/to/guix/binaries -type f -executable | xargs python3 contrib/guix/security-check.py
 '''
 import re
 import sys

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -8,7 +8,7 @@ and are only linked against allowed libraries.
 
 Example usage:
 
-    find ../path/to/binaries -type f -executable | xargs python3 contrib/devtools/symbol-check.py
+    find ../path/to/guix/binaries -type f -executable | xargs python3 contrib/guix/symbol-check.py
 '''
 import sys
 

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -6,7 +6,7 @@ The package "mylib" will be used here as an example
 General tips:
 - mylib_foo is written as $(package)_foo in order to make recipes more similar.
 - Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
-  those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+  those not in `ALLOWED_LIBRARIES` in `contrib/guix/symbol-check.py`) don't
   need to be shared and should be built statically whenever possible. See
   [below](#secondary-dependencies) for more details.
 
@@ -184,7 +184,7 @@ the Autotools `--with-pic` flag, or `CMAKE_POSITION_INDEPENDENT_CODE` with CMake
 ## Secondary dependencies:
 
 Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
-those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+those not in `ALLOWED_LIBRARIES` in `contrib/guix/symbol-check.py`) don't
 need to be shared and should be built statically whenever possible. This
 improves general build reliability as illustrated by the following example:
 


### PR DESCRIPTION
These scripts are not meant for general developer usage. They are for use on the release binaries, which have been compiled in an environment that makes various assumptions in regards to c library, compiler options, hardening options, dependency patching etc.

Anyone is free to run these scripts against self-compiled binaries, but this isn't something we want to modify/generalize the scripts to support.