### PR TITLE
fs: remove `_POSIX_C_SOURCE` defining

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -55,13 +55,6 @@ check_cxx_source_compiles("
 
 # Check for posix_fallocate().
 check_cxx_source_compiles("
-  // same as in src/util/fs_helpers.cpp
-  #ifdef __linux__
-  #ifdef _POSIX_C_SOURCE
-  #undef _POSIX_C_SOURCE
-  #endif
-  #define _POSIX_C_SOURCE 200112L
-  #endif // __linux__
   #include <fcntl.h>
 
   int main()

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -22,17 +22,6 @@
 #include <utility>
 
 #ifndef WIN32
-// for posix_fallocate, in cmake/introspection.cmake we check if it is present after this
-#ifdef __linux__
-
-#ifdef _POSIX_C_SOURCE
-#undef _POSIX_C_SOURCE
-#endif
-
-#define _POSIX_C_SOURCE 200112L
-
-#endif // __linux__
-
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <unistd.h>


### PR DESCRIPTION
On Linux systems, `_POSIX_C_SOURCE` will default to `200809L` (since glibc 2.10). There's currently no reason for us to undefine it, and then set it to an earlier value. Also tested with musl libc.
 
I think if anything, the project should be settings macros like `_POSIX_C_SOURCE`, globally.