### PR TITLE
test: fix an incorrect `feature_fee_estimation.py` subtest

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -146,8 +146,8 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.noban_tx_relay = True
         self.extra_args = [
             [],
-            ["-blockmaxweight=68000"],
-            ["-blockmaxweight=32000"],
+            ["-blockmaxweight=72000"],
+            ["-blockmaxweight=36000"],
         ]
 
     def setup_network(self):

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -91,19 +91,20 @@ def check_smart_estimates(node, fees_seen):
     """Call estimatesmartfee and verify that the estimates meet certain invariants."""
 
     delta = 1.0e-6  # account for rounding error
-    last_feerate = float(max(fees_seen))
     all_smart_estimates = [node.estimatesmartfee(i) for i in range(1, 26)]
     mempoolMinFee = node.getmempoolinfo()["mempoolminfee"]
     minRelaytxFee = node.getmempoolinfo()["minrelaytxfee"]
+    feerate_ceiling = max(max(fees_seen), float(mempoolMinFee), float(minRelaytxFee))
+    last_feerate = feerate_ceiling
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1
         feerate = float(e["feerate"])
         assert_greater_than(feerate, 0)
         assert_greater_than_or_equal(feerate, float(mempoolMinFee))
         assert_greater_than_or_equal(feerate, float(minRelaytxFee))
 
-        if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
+        if feerate + delta < min(fees_seen) or feerate - delta > feerate_ceiling:
             raise AssertionError(
-                f"Estimated fee ({feerate}) out of range ({min(fees_seen)},{max(fees_seen)})"
+                f"Estimated fee ({feerate}) out of range ({min(fees_seen)},{feerate_ceiling})"
             )
         if feerate - delta > last_feerate:
             raise AssertionError(
@@ -238,10 +239,10 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.log.info("Final estimates after emptying mempools")
         check_estimates(self.nodes[1], self.fees_per_kb)
 
-    def test_feerate_mempoolminfee(self):
-        high_val = 3 * self.nodes[1].estimatesmartfee(1)["feerate"]
+    def test_estimates_with_highminrelaytxfee(self):
+        high_val = 3 * self.nodes[1].estimatesmartfee(2)["feerate"]
         self.restart_node(1, extra_args=[f"-minrelaytxfee={high_val}"])
-        check_estimates(self.nodes[1], self.fees_per_kb)
+        check_smart_estimates(self.nodes[1], self.fees_per_kb)
         self.restart_node(1)
 
     def sanity_check_rbf_estimates(self, utxos):
@@ -452,11 +453,11 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.log.info("Test fee_estimates.dat is flushed periodically")
         self.test_estimate_dat_is_flushed_periodically()
 
-        # check that the effective feerate is greater than or equal to the mempoolminfee even for high mempoolminfee
+        # check that estimatesmartfee feerate is greater than or equal to maximum of mempoolminfee and minrelaytxfee
         self.log.info(
-            "Test fee rate estimation after restarting node with high MempoolMinFee"
+            "Test fee rate estimation after restarting node with high minrelaytxfee"
         )
-        self.test_feerate_mempoolminfee()
+        self.test_estimates_with_highminrelaytxfee()
 
         self.log.info("Test acceptstalefeeestimates option")
         self.test_acceptstalefeeestimates_option()


### PR DESCRIPTION
Attempt to fix #32461 and #31944

In the `estimatesmartfee` RPC, we return the maximum of the following: the feerate estimate for the target, `minrelaytxfee`, and `mempoolminfee`.

https://github.com/bitcoin/bitcoin/blob/9a05b45da60d214cb1e5a50c3d2293b1defc9bb0/src/rpc/fees.cpp#L85

The test `test_feerate_mempoolminfee`, originally introduced in https://github.com/bitcoin/bitcoin/commit/ea31caf6b4c182c6f10f136548f84e603800511c, is incorrect. 

It should calculate the fee rate ceiling by taking the maximum of the custom `minrelaytxfee`, `mempoolminfee`, and the highest fee rate observed during the test (`check_smart_estimates`). This is necessary because:

* There is no guarantee that the generated fee rates will exceed both `minrelaytxfee` and `mempoolminfee`.
* Users can start a node with custom fee settings.

Due to the non-deterministic nature of the `feature_fee_estimation.py` test, it often passes by chance. The randomly generated fees typically include a value higher than the custom `minrelaytxfee`, inadvertently hiding the issue.

Issue #32461 identified a random seeds that consistently fails the test because the generated fees never exceed the custom `minrelaytxfee`:

e.g
```
build/test/functional/feature_fee_estimation.py --random=3450808900320758527
```

This PR has two commits which :

* Correctly fixes the test by calculating the fee rate ceiling as the maximum of the node `minrelaytxfee`, `mempoolminfee`, and the highest seen fee rate, when verifying smart fee estimates.
* Improves the subtest name and comment for clarity.
* Restores the original test behavior by appending 4000 WU to the custom `blockmaxweight`.


It also fixes #31944

Before this PR we shrank the blocks by 4000, reducing the number of txs that are mined, which effectively causes the long stats to not have insufficient data.
See https://github.com/bitcoin/bitcoin/issues/31944#issuecomment-2699259294

Increasing the weight by 4000 (matching the original test block weight) allows for more transactions to be mined and the long stats to have enough data.  

credits to maflcko for noticing the test no longer fails after this https://github.com/bitcoin/bitcoin/issues/31944#issuecomment-3982398137
