### PR TITLE
rpc: generateblock to allow multiple outputs

### DIFF
--- a/doc/release-notes-32468.md
+++ b/doc/release-notes-32468.md
@@ -1,0 +1,5 @@
+# RPC
+
+- The RPC `generateblock` takes `outputs` as an argument. This argument allows to specify where to distribute the reward of the block. It takes an address, a descriptor or a list of multiple addresses and descriptors. If `outputs` is not set, the reward is burnt in an OP_RETURN output. The reward is split in equal parts through all addresses and descriptors provided.
+
+- The argument `transactions` is optional in `generateblock`. If no set of transactions is provided, the ones from the mempool are used. If an empty set is provided, an empty block is mined. If a set of transactions is provided, that set of transactions is mined.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -64,6 +64,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generatetoaddress", 2, "maxtries" },
     { "generatetodescriptor", 0, "num_blocks" },
     { "generatetodescriptor", 2, "maxtries" },
+    { "generateblock", 0, "output", ParamFormat::JSON_OR_STRING },
     { "generateblock", 1, "transactions" },
     { "generateblock", 2, "submit" },
     { "getnetworkhashps", 0, "nblocks" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -309,9 +309,11 @@ static RPCMethod generateblock()
         "Transaction fees are not collected in the block reward.",
         {
             {"output", RPCArg::Type::STR, RPCArg::Optional::NO, "The address or descriptor to send the newly generated bitcoin to."},
-            {"transactions", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of hex strings which are either txids or raw transactions.\n"
+            {"transactions", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "An array of hex strings which are either txids or raw transactions.\n"
                 "Txids must reference transactions currently in the mempool.\n"
-                "All transactions must be valid and in valid order, otherwise the block will be rejected.",
+                "All transactions must be valid and in valid order, otherwise the block will be rejected.\n"
+                "If no transactions are provided the ones in the mempool will be used.\n"
+                "If an empty array of transactions is provided the block will be empty.",
                 {
                     {"rawtx/txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, ""},
                 },
@@ -328,6 +330,7 @@ static RPCMethod generateblock()
         RPCExamples{
             "\nGenerate a block to myaddress, with txs rawtx and mempool_txid\n"
             + HelpExampleCli("generateblock", R"("myaddress" '["rawtx", "mempool_txid"]')")
+            + HelpExampleCli("generateblock", R"("myaddress" [])")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -349,44 +352,46 @@ static RPCMethod generateblock()
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     std::vector<CTransactionRef> txs;
-    const auto raw_txs_or_txids = request.params[1].get_array();
-    for (size_t i = 0; i < raw_txs_or_txids.size(); i++) {
-        const auto& str{raw_txs_or_txids[i].get_str()};
+    bool mine_mempool = true;
 
-        CMutableTransaction mtx;
-        if (auto txid{Txid::FromHex(str)}) {
-            const auto tx{mempool.get(*txid)};
-            if (!tx) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Transaction %s not in mempool.", str));
+    UniValue raw_txs_or_txids = UniValue(UniValue::VARR);
+    if (!request.params[1].isNull()) {
+        mine_mempool = false;
+        raw_txs_or_txids = request.params[1].get_array();
+        for (size_t i = 0; i < raw_txs_or_txids.size(); i++) {
+            const auto& str{raw_txs_or_txids[i].get_str()};
+            CMutableTransaction mtx;
+            if (auto txid{Txid::FromHex(str)}) {
+                const auto tx{mempool.get(*txid)};
+                if (!tx) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Transaction %s not in mempool.", str));
+                }
+                txs.emplace_back(tx);
+            } else if (DecodeHexTx(mtx, str)) {
+                txs.push_back(MakeTransactionRef(std::move(mtx)));
+            } else {
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("Transaction decode failed for %s. Make sure the tx has at least one input.", str));
             }
-
-            txs.emplace_back(tx);
-
-        } else if (DecodeHexTx(mtx, str)) {
-            txs.push_back(MakeTransactionRef(std::move(mtx)));
-
-        } else {
-            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("Transaction decode failed for %s. Make sure the tx has at least one input.", str));
         }
     }
-
-    const bool process_new_block{request.params[2].isNull() ? true : request.params[2].get_bool()};
+    const bool process_new_block = self.Arg<bool>("submit");
     CBlock block;
 
     ChainstateManager& chainman = EnsureChainman(node);
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
+            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = mine_mempool, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
             CHECK_NONFATAL(block_template);
-
             block = block_template->getBlock();
         }
 
-        CHECK_NONFATAL(block.vtx.size() == 1);
+        // Add transactions if mempool is not used
+        if (!mine_mempool) {
+            CHECK_NONFATAL(block.vtx.size() == 1);
+            block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
+        }
 
-        // Add transactions
-        block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
         RegenerateCommitments(block, chainman);
 
         if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -305,10 +305,17 @@ static RPCMethod generatetoaddress()
 static RPCMethod generateblock()
 {
     return RPCMethod{"generateblock",
-        "Mine a set of ordered transactions to a specified address or descriptor and return the block hash.\n"
+        "Mine a block with set of ordered transactions or mempool transactions to a specified group of addresses or descriptors and return the block hash.\n"
         "Transaction fees are not collected in the block reward.",
         {
-            {"output", RPCArg::Type::STR, RPCArg::Optional::NO, "The address or descriptor to send the newly generated bitcoin to."},
+            {"output", RPCArg::Type::ARR, RPCArg::Optional::NO, "The address or descriptor to split, in equal parts, the coinbase reward among.\n"
+                "If no outputs are provided the coinbase transaction will burn the coins into an OP_RETURN output.\n"
+                "If only one output is desired a simple address or descriptor can be provided without using JSON format",
+                {
+                    {"output", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A valid address or descriptor"},
+                },
+                RPCArgOptions{.skip_type_check = true},
+            },
             {"transactions", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "An array of hex strings which are either txids or raw transactions.\n"
                 "Txids must reference transactions currently in the mempool.\n"
                 "All transactions must be valid and in valid order, otherwise the block will be rejected.\n"
@@ -331,20 +338,38 @@ static RPCMethod generateblock()
             "\nGenerate a block to myaddress, with txs rawtx and mempool_txid\n"
             + HelpExampleCli("generateblock", R"("myaddress" '["rawtx", "mempool_txid"]')")
             + HelpExampleCli("generateblock", R"("myaddress" [])")
+            + HelpExampleCli("generateblock", R"('["myaddress1", "myaddress2"]')")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
-    const auto address_or_descriptor = request.params[0].get_str();
-    CScript coinbase_output_script;
-    std::string error;
-
-    if (!getScriptFromDescriptor(address_or_descriptor, coinbase_output_script, error)) {
-        const auto destination = DecodeDestination(address_or_descriptor);
-        if (!IsValidDestination(destination)) {
+    UniValue address_or_descriptor = UniValue(UniValue::VARR);
+    UniValue parsed;
+    if (!request.params[0].isNull()) {
+        if (request.params[0].isArray()) {
+            address_or_descriptor = request.params[0].get_array();
+        } else if (request.params[0].isStr()) {
+            address_or_descriptor.push_back(request.params[0]);
+        } else {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address or descriptor");
         }
+    }
 
-        coinbase_output_script = GetScriptForDestination(destination);
+    CScript coinbase_output_script;
+    std::string error;
+    std::vector<CScript> coinbase_outputs_scripts;
+    if (address_or_descriptor.empty()) {
+        coinbase_outputs_scripts.push_back(CScript() << OP_RETURN);
+    }
+    for (size_t i = 0; i < address_or_descriptor.size(); i++) {
+        if (!getScriptFromDescriptor(address_or_descriptor[i].get_str(), coinbase_output_script, error)) {
+            const auto destination = DecodeDestination(address_or_descriptor[i].get_str());
+            if (!IsValidDestination(destination)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address or descriptor");
+            }
+            coinbase_outputs_scripts.push_back(GetScriptForDestination(destination));
+        } else {
+            coinbase_outputs_scripts.push_back(coinbase_output_script);
+        }
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
@@ -353,7 +378,6 @@ static RPCMethod generateblock()
 
     std::vector<CTransactionRef> txs;
     bool mine_mempool = true;
-
     UniValue raw_txs_or_txids = UniValue(UniValue::VARR);
     if (!request.params[1].isNull()) {
         mine_mempool = false;
@@ -381,7 +405,7 @@ static RPCMethod generateblock()
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = mine_mempool, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
+            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = mine_mempool, .coinbase_output_script = coinbase_outputs_scripts.at(0)}, /*cooldown=*/false)};
             CHECK_NONFATAL(block_template);
             block = block_template->getBlock();
         }
@@ -392,6 +416,31 @@ static RPCMethod generateblock()
             block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
         }
 
+        const auto num_outputs = coinbase_outputs_scripts.size();
+        CAmount total_reward = block.vtx[0]->vout[0].nValue;
+        CAmount reward_parted = total_reward / num_outputs;
+        CAmount remainder = total_reward % num_outputs;
+
+        CMutableTransaction mutable_coinbase(*block.vtx.at(0));
+        int witness_index = GetWitnessCommitmentIndex(block);
+
+        CTxOut witness_output;
+        bool has_witness_commitment{false};
+        if (witness_index != -1) {
+            witness_output = mutable_coinbase.vout.at(witness_index);
+            has_witness_commitment = true;
+        }
+
+        mutable_coinbase.vout.clear();
+        for (size_t i = 0; i < num_outputs; ++i) {
+            CAmount out_reward = (i < static_cast<size_t>(remainder) ? reward_parted +1 : reward_parted);
+            CTxOut new_tx_out(out_reward, coinbase_outputs_scripts[i]);
+            mutable_coinbase.vout.push_back(new_tx_out);
+        }
+        if (has_witness_commitment) {
+            mutable_coinbase.vout.push_back(witness_output);
+        }
+        block.vtx.at(0) = MakeTransactionRef(mutable_coinbase);
         RegenerateCommitments(block, chainman);
 
         if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -427,7 +427,7 @@ class AssumeutxoTest(BitcoinTestFramework):
                 # Create a stale block that forks off the main chain before the snapshot.
                 temp_invalid = n0.getbestblockhash()
                 n0.invalidateblock(temp_invalid)
-                stale_hash = self.generateblock(n0, output="raw(aaaa)", transactions=[], sync_fun=self.no_op)["hash"]
+                stale_hash = self.generateblock(n0, transactions=[], sync_fun=self.no_op)["hash"]
                 n0.invalidateblock(stale_hash)
                 n0.reconsiderblock(temp_invalid)
                 stale_block = n0.getblock(stale_hash, 0)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -147,14 +147,14 @@ class FullBlockTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(max_size_spendable_output)
         tx.vout.append(CTxOut(0, CScript([])))
-        block = self.generateblock(self.nodes[0], output="raw(55)", transactions=[tx.serialize().hex()])
+        block = self.generateblock(self.nodes[0], transactions=[tx.serialize().hex()])
         assert_equal(block["hash"], self.nodes[0].getbestblockhash())
         self.nodes[0].invalidateblock(block["hash"])
         assert_equal(self.nodes[0].getrawmempool(), [])
 
         # MAX_SCRIPT_SIZE + 1 wasn't added to the utxo set
         tx.vin[0] = min_size_unspendable_output
-        assert_raises_rpc_error(-25, f'TestBlockValidity failed: bad-txns-inputs-missingorspent, CheckTxInputs: inputs missing/spent in transaction {tx.txid_hex}', self.generateblock, self.nodes[0],  output="raw(55)", transactions=[tx.serialize().hex()])
+        assert_raises_rpc_error(-25, f'TestBlockValidity failed: bad-txns-inputs-missingorspent, CheckTxInputs: inputs missing/spent in transaction {tx.txid_hex}', self.generateblock, self.nodes[0], transactions=[tx.serialize().hex()])
 
         # collect spendable outputs now to avoid cluttering the code later on
         out = []

--- a/test/functional/feature_fastprune.py
+++ b/test/functional/feature_fastprune.py
@@ -21,7 +21,7 @@ class FeatureFastpruneTest(BitcoinTestFramework):
         tx = wallet.create_self_transfer()['tx']
         annex = b"\x50" + b"\xff" * 0x10000
         tx.wit.vtxinwit[0].scriptWitness.stack.append(annex)
-        self.generateblock(self.nodes[0], output="raw(55)", transactions=[tx.serialize().hex()])
+        self.generateblock(self.nodes[0], transactions=[tx.serialize().hex()])
         assert_equal(self.nodes[0].getblockcount(), 201)
 
 

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -217,7 +217,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         self.nodes[0].sendrawtransaction(std_tx.serialize().hex())
 
         # Make sure the original, non-standard, transaction can be mined.
-        self.generateblock(self.nodes[0], output="raw(42)", transactions=[nonstd_tx.serialize().hex()])
+        self.generateblock(self.nodes[0], transactions=[nonstd_tx.serialize().hex()])
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -194,7 +194,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_chain_3 = self.wallet.create_self_transfer(utxo_to_spend=tx_chain_2["new_utxo"], version=3)
 
         tx_to_mine = [tx_v3_block["hex"], tx_v2_block["hex"], tx_v3_block2["hex"], tx_chain_1["hex"], tx_chain_2["hex"], tx_chain_3["hex"]]
-        self.generateblock(node, output="raw(42)", transactions=tx_to_mine)
+        self.generateblock(node, transactions=tx_to_mine)
 
         self.check_mempool([])
 

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -189,7 +189,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "too-large-cluster", self.nodes[0].sendrawtransaction, chain[-2]["hex"])
 
         # Mine a block with all but last transaction, non-standardly long chain
-        self.generateblock(self.nodes[0], output="raw(42)", transactions=[tx["hex"] for tx in chain[:-1]])
+        self.generateblock(self.nodes[0], transactions=[tx["hex"] for tx in chain[:-1]])
         assert_equal(self.nodes[0].getrawmempool(), [])
 
         # Last tx fits now

--- a/test/functional/p2p_outbound_eviction.py
+++ b/test/functional/p2p_outbound_eviction.py
@@ -80,14 +80,14 @@ class P2POutEvict(BitcoinTestFramework):
 
         self.log.info("Mine a block so our peer starts lagging")
         prev_prev_hash = tip_header.hashPrevBlock
-        best_block_hash = self.generateblock(node, output="raw(42)", transactions=[])["hash"]
+        best_block_hash = self.generateblock(node, transactions=[])["hash"]
         peer.sync_with_ping()
 
         self.log.info("The peer keeps catching up with the old tip; check that the node does not evict the peer")
         for i in range(10):
             # Generate an additional block so the peers is 2 blocks behind
             prev_header = from_hex(CBlockHeader(), node.getblockheader(best_block_hash, False))
-            best_block_hash = self.generateblock(node, output="raw(42)", transactions=[])["hash"]
+            best_block_hash = self.generateblock(node, transactions=[])["hash"]
             tip_header = from_hex(CBlockHeader(), node.getblockheader(best_block_hash, False))
             peer.sync_with_ping()
 
@@ -136,7 +136,7 @@ class P2POutEvict(BitcoinTestFramework):
         peer.send_and_ping(msg_headers([tip_header]))
 
         self.log.info("Mine a new block and sync with our peer")
-        self.generateblock(node, output="raw(42)", transactions=[])
+        self.generateblock(node, transactions=[])
         peer.sync_with_ping()
 
         self.log.info("Let enough time pass for the timeouts to go off")
@@ -191,7 +191,7 @@ class P2POutEvict(BitcoinTestFramework):
         self.log.info("Mine a new block and keep the unprotected honest peer on sync, all the rest off-sync")
         # Mine a block so all peers become outdated
         target_hash = prev_header.hash_int
-        tip_hash = self.generateblock(node, output="raw(42)", transactions=[])["hash"]
+        tip_hash = self.generateblock(node, transactions=[])["hash"]
         tip_header = from_hex(CBlockHeader(), node.getblockheader(tip_hash, False))
         tip_headers_message = msg_headers([tip_header])
 
@@ -227,7 +227,7 @@ class P2POutEvict(BitcoinTestFramework):
         peer.send_and_ping(msg_headers([tip_header]))
 
         self.log.info("Mine a new block and sync with our peer")
-        self.generateblock(node, output="raw(42)", transactions=[])
+        self.generateblock(node, transactions=[])
         peer.sync_with_ping()
 
         self.log.info("Let enough time pass for the timeouts to go off")

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -283,7 +283,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
 
         self.log.info("Check that verificationprogress is less than 1 as soon as a new header comes in")
-        self.nodes[0].submitheader(self.generateblock(self.nodes[0], output="raw(55)", transactions=[], submit=False, sync_fun=self.no_op)["hex"])
+        self.nodes[0].submitheader(self.generateblock(self.nodes[0], transactions=[], submit=False, sync_fun=self.no_op)["hex"])
         assert_greater_than(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
 
     def _test_y2106(self):

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -37,17 +37,38 @@ class RPCGenerateTest(BitcoinTestFramework):
         node.submitblock(hexdata=generated_block['hex'])
         assert_equal(generated_block['hash'], node.getbestblockhash())
 
+        self.log.info('Generate an empty block without address and fallback to OP_RETURN')
+        hash = self.generateblock(node, transactions=[])['hash']
+        block = node.getblock(blockhash=hash, verbose=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['asm'], 'OP_RETURN')
+
         self.log.info('Generate an empty block to address')
         hash = self.generateblock(node, output=address, transactions=[])['hash']
         block = node.getblock(blockhash=hash, verbose=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
 
+        self.log.info('Generate an empty block to a list of addresses')
+        address2 = miniwallet.get_address()
+        hash = self.generateblock(node, output=[address, address2], transactions=[])['hash']
+        block = node.getblock(blockhash=hash, verbose=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+        assert_equal(block['tx'][0]['vout'][1]['scriptPubKey']['address'], address2)
+
         self.log.info('Generate an empty block to a descriptor')
         hash = self.generateblock(node, 'addr(' + address + ')', [])['hash']
         block = node.getblock(blockhash=hash, verbosity=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+
+        self.log.info('Generate an empty block to a list of descriptors')
+        hash = self.generateblock(node, ['addr(' + address + ')', 'addr('+ address2 + ')'], [])['hash']
+        block = node.getblock(blockhash=hash, verbosity=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+        assert_equal(block['tx'][0]['vout'][1]['scriptPubKey']['address'], address2)
 
         self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
         combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
@@ -68,6 +89,7 @@ class RPCGenerateTest(BitcoinTestFramework):
         # Generate some extra mempool transactions to verify that they are mined if no txs are provided
         for _ in range(10):
             miniwallet.send_self_transfer(from_node=node)
+
         self.log.info("Generate a block with mempool txs")
         hash = self.generateblock(node, address)['hash']
         block = node.getblock(hash, 1)
@@ -89,7 +111,8 @@ class RPCGenerateTest(BitcoinTestFramework):
         txs = []
         for _ in range(3):
             txs.append(miniwallet.send_self_transfer(from_node=node)['txid'])
-        #Generate some extra mempool transactions to verify they don't get mined
+
+        # Generate some extra mempool transactions to verify they don't get mined
         for _ in range(10):
             miniwallet.send_self_transfer(from_node=node)
         hash = self.generateblock(node, address, txs)['hash']
@@ -97,9 +120,9 @@ class RPCGenerateTest(BitcoinTestFramework):
         assert_equal(len(block['tx']), 4)
         for i, tx in enumerate(txs):
             assert_equal(block['tx'][i+1], tx)
+
         # Clean the mempool for next test by mining a block
         self.generateblock(node, address)
-
 
         self.log.info('Generate block with raw tx')
         rawtx = miniwallet.create_self_transfer()['hex']

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -65,6 +65,14 @@ class RPCGenerateTest(BitcoinTestFramework):
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], combo_address)
 
+        # Generate some extra mempool transactions to verify that they are mined if no txs are provided
+        for _ in range(10):
+            miniwallet.send_self_transfer(from_node=node)
+        self.log.info("Generate a block with mempool txs")
+        hash = self.generateblock(node, address)['hash']
+        block = node.getblock(hash, 1)
+        assert_equal(len(block['tx']), 11)
+
         # Generate some extra mempool transactions to verify they don't get mined
         for _ in range(10):
             miniwallet.send_self_transfer(from_node=node)
@@ -75,6 +83,23 @@ class RPCGenerateTest(BitcoinTestFramework):
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)
         assert_equal(block['tx'][1], txid)
+
+        self.log.info('Generate block with multiple txid')
+        # Generate some transactions to get mined
+        txs = []
+        for _ in range(3):
+            txs.append(miniwallet.send_self_transfer(from_node=node)['txid'])
+        #Generate some extra mempool transactions to verify they don't get mined
+        for _ in range(10):
+            miniwallet.send_self_transfer(from_node=node)
+        hash = self.generateblock(node, address, txs)['hash']
+        block = node.getblock(hash, 1)
+        assert_equal(len(block['tx']), 4)
+        for i, tx in enumerate(txs):
+            assert_equal(block['tx'][i+1], tx)
+        # Clean the mempool for next test by mining a block
+        self.generateblock(node, address)
+
 
         self.log.info('Generate block with raw tx')
         rawtx = miniwallet.create_self_transfer()['hex']

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -183,7 +183,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(tip_stats["utxo_size_inc_actual"], 296)
 
         self.log.info("Test when only header is known")
-        block = self.generateblock(self.nodes[0], output="raw(55)", transactions=[], submit=False)
+        block = self.generateblock(self.nodes[0], transactions=[], submit=False)
         self.nodes[0].submitheader(block["hex"])
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", lambda: self.nodes[0].getblockstats(block['hash']))
 

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -69,7 +69,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         # We can't get the proof if we specify a non-existent block
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].gettxoutproof, [txid_spent], "0000000000000000000000000000000000000000000000000000000000000000")
         # We can't get the proof if we only have the header of the specified block
-        block = self.generateblock(self.nodes[0], output="raw(55)", transactions=[], submit=False)
+        block = self.generateblock(self.nodes[0], transactions=[], submit=False)
         self.nodes[0].submitheader(block["hex"])
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].gettxoutproof, [txid_spent], block['hash'])
         # We can get the proof if the transaction is unspent

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -688,7 +688,7 @@ def test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address):
     # then invalidate the block so the rbf tx will be put back in the mempool.
     # This makes it possible to check whether the rbf tx outputs are
     # spendable before the rbf tx is confirmed.
-    block = self.generateblock(rbf_node, output="raw(51)", transactions=[rbftx])
+    block = self.generateblock(rbf_node, transactions=[rbftx])
     # Can not abandon conflicted tx
     assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: rbf_node.abandontransaction(txid=bumpid))
     rbf_node.invalidateblock(block["hash"])


### PR DESCRIPTION
## Generatetomany

First approach was to create a `generatetomany` rpc call. That approach can be seen here https://github.com/polespinasa/bitcoin/pull/3

## Generateblock
Modifies `generateblock` to allow a user to set multiple outputs in the coinbase transaction. If an empty set is provided, the block will be empty. If no set of transactions is provided, the block will mine the mempool. If a set of transactions is provided only that set of txs will be mined.

```
$./bitcoin-cli -rpcport=18443 generateblock bcrt1qw6qkj8wtw5hraxwxjp08m4aymkntms3yhqyacj
{
  "hash": "7359a3ed7af0f18f4016e6cb29193bd787a2452c584781135c585d5204b9ec5b"
}

$ ./bitcoin-cli -rpcport=18443 generateblock '["bcrt1qal6p633hvwz2yp5mav0qy7u2az8gkn2xywnj6v", "bcrt1qvr3qgyhw6y0e0zj97v0j5yc40xtpea4wqj0g43"]'
{
  "hash": "6db028454b26d6667dd6df45be2772844121fb44f86433f6bbfbafa429974684"
}

$ ./bitcoin-cli -rpcport=18443 generateblock '["bcrt1qal6p633hvwz2yp5mav0qy7u2az8gkn2xywnj6v", "bcrt1qvr3qgyhw6y0e0zj97v0j5yc40xtpea4wqj0g43"]' []

{
  "hash": "33e2ddc52546ddb0edf28bef5b295ee8fbd487b8aca19c97018467e2477877df"
}

```

### Motivation
https://x.com/SuperTestnet/status/1921220086645342550

Citating @supertestnet 
> When mining a block on regtest, the command "generatetoaddress" is available if you want to send the entire coinbase to 1 address. Let's add generatetomany in case you want to split up the coinbase among multiple addresses, similar to how the "sendtoaddress" and "sendmany" commands both exist and let you send money to (1) one address or (2) multiple addresses. The generatetomany command would be particularly useful for simulating protocols that send money to multiple recipients directly from a coinbase, as several pools do now, like ocean and braidpool.