### PR TITLE
test: fix two intermittent failures in wallet_basic.py

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -656,6 +656,9 @@ class WalletTest(BitcoinTestFramework):
 
         # check that it works again with -spendzeroconfchange set (=default)
         self.restart_node(0, ["-spendzeroconfchange=1"])
+        # Make sure the wallet knows the tx in the mempool
+        self.nodes[0].syncwithvalidationinterfacequeue()
+
         zeroconf_wallet = self.nodes[0].get_wallet_rpc("zeroconf")
         utxos = zeroconf_wallet.listunspent(minconf=0)
         assert_equal(len(utxos), 1)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -603,6 +603,8 @@ class WalletTest(BitcoinTestFramework):
         txid_a = self.nodes[0].sendtoaddress(addr_a, 0.01)
         txid_b = self.nodes[0].sendtoaddress(addr_b, 0.01)
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        # Prevent race of listunspent with outstanding TxAddedToMempool notifications
+        self.nodes[0].syncwithvalidationinterfacequeue()
         # Now import the descriptors, make sure we can identify on which descriptor each coin was received.
         self.nodes[0].createwallet(wallet_name="wo", descriptors=True, disable_private_keys=True)
         wo_wallet = self.nodes[0].get_wallet_rpc("wo")


### PR DESCRIPTION
Fixes two rare failures that happened in the CI:

#27249:
There could be a race with outstanding TxAddedToMempool notifications being applied to the soon-to-be created wallet:
1. importdescriptors during rescan sets status to `TxStateConfirmed`
2. old `transactionAddedToMempool` notification changes status back to  `TxStateInMempool`
3. If the listunspent call happens here the test will fail
4. blockConnected notification will change the status back to `TxStateConfirmed` (so it's not a persistent failure)

I could reproduce this by adding a 100 microsecond sleep to `AddToWallet()`, the fix is to add a sync, so `transactionAddedToMempool` notifications won't affect the new wallet anymore.

#32456:
During init, the test framework will start using rpc after the mempool was loaded.
It will not wait for `start()` / `postInitProcess` or outstanding `transactionAddedToMempool` notifications (which would both set the status to `TxStateInMempool`), leading to
a possible race, in which `listunspent` can be called while the tx is still in `Inactive` status. 

Can be reproduced by adding two sleeps: To init  before calling `start()` for the chain clients, plus to `transactionAddedToMempool` in `wallet.cpp`.
Prevent this by processing outstanding notifications.

Fixes #27249
Fixes #32456