### PR TITLE
[28.x] build: suppress `-Wunterminated-string-initialization` in secp256k1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1690,6 +1690,9 @@ CPPFLAGS_TEMP="$CPPFLAGS"
 unset CPPFLAGS
 CPPFLAGS="$CPPFLAGS_TEMP"
 
+
+AX_CHECK_COMPILE_FLAG([-Wno-unterminated-string-initialization], [export SECP_CFLAGS="$SECP_CFLAGS -Wno-unterminated-string-initialization"], [], [$CXXFLAG_WERROR])
+
 if test -n "$use_sanitizers"; then
   export SECP_CFLAGS="$SECP_CFLAGS $SANITIZER_CFLAGS"
 fi


### PR DESCRIPTION
Suppress `-Wunterminated-string-initialization` warnings from GCC 15, like:
```bash
In file included from src/secp256k1.c:830:
src/modules/schnorrsig/main_impl.h:48:46: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (14 chars into 13 available) [-Wunterminated-string-initialization]
   48 | static const unsigned char bip340_algo[13] = "BIP0340/nonce";
      |                                              ^~~~~~~~~~~~~~~
In file included from src/tests_exhaustive.c:28:
src/testrand_impl.h: In function ‘testrand_seed’:
src/testrand_impl.h:21:45: warning: initializer-string for array of ‘unsigned char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (20 chars into 19 available) [-Wunterminated-string-initialization]
   21 |     static const unsigned char PREFIX[19] = "secp256k1 test init";
      |                                             ^~~~~~~~~~~~~~~~~~~~~
src/modules/ellswift/tests_impl.h:411:53: warning: initializer-string for array of ‘unsigned char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (27 chars into 26 available) [-Wunterminated-string-initialization]
  411 |         static const unsigned char bip324_tag[26] = "bip324_ellswift_xonly_ecdh";
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This was fixed upstream in https://github.com/bitcoin-core/secp256k1/pull/1583, so only relevant for `28.x` and later. The code is fine, but the warnings may break builds under `-Werror`, leave users wondering if there is a real issue etc.