### PR TITLE
fuzz: Properly setup wallet in wallet_fees target

### DIFF
--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,31 +6,31 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
-#include <wallet/wallet.h>
 #include <wallet/test/util.h>
-#include <validation.h>
+#include <wallet/wallet.h>
 
 namespace wallet {
 namespace {
 const TestingSetup* g_setup;
-static std::unique_ptr<CWallet> g_wallet_ptr;
 
 void initialize_setup()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
-    const auto& node{g_setup->m_node};
-    g_wallet_ptr = std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase());
 }
 
 FUZZ_TARGET(wallet_fees, .init = initialize_setup)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
     const auto& node{g_setup->m_node};
     Chainstate* chainstate = &node.chainman->ActiveChainstate();
-    CWallet& wallet = *g_wallet_ptr;
+    std::unique_ptr<CWallet> wallet_ptr{std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase())};
+    CWallet& wallet{*wallet_ptr};
     {
         LOCK(wallet.cs_wallet);
         wallet.SetLastBlockProcessed(chainstate->m_chain.Height(), chainstate->m_chain.Tip()->GetBlockHash());


### PR DESCRIPTION
`g_wallet_ptr` is destructed after the `testing_setup`. This is not supported and will lead to issues such as https://github.com/bitcoin/bitcoin/pull/30221#issuecomment-2863875857 or https://github.com/bitcoin/bitcoin/pull/32409#issuecomment-2855259932.

This could be fixed by fixing the initialization order.

However, the global wallet is also modified in the fuzz target, which is bad fuzzing practise.

So instead fix it by constructing a fresh wallet for each fuzz iteration.