### PR TITLE
build: document why we check for `std::system`

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -19,6 +19,8 @@ endif()
 include(TestAppendRequiredLibraries)
 test_append_atomic_library(core_interface)
 
+# Even though ::system is part of the standard library, we still check
+# for it, to support building targets that don't have it, such as iOS.
 check_cxx_symbol_exists(std::system "cstdlib" HAVE_STD_SYSTEM)
 check_cxx_symbol_exists(::_wsystem "stdlib.h" HAVE__WSYSTEM)
 if(HAVE_STD_SYSTEM OR HAVE__WSYSTEM)


### PR DESCRIPTION
It's probably debatable if we support targets like iOS, but for now, document why we are checking for this standard library feature.

Trying to use `std::system` for a `aarch64-darwin-ios` target results in:
```bash
test.cpp:7:10: error: 'system' is unavailable: not available on iOS
    7 |     std::system("some_command");
      |          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdlib.h:203:6: note: 'system' has been explicitly marked unavailable here
  203 | int      system(const char *) __DARWIN_ALIAS_C(system);
      |          ^
1 error generated.
```