### PR TITLE
depends: drop `ltcg` for Windows Qt

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -150,9 +150,6 @@ endif
 $(package)_config_opts_mingw32 := -no-dbus
 $(package)_config_opts_mingw32 += -no-freetype
 $(package)_config_opts_mingw32 += -no-pkg-config
-ifneq ($(LTO),)
-$(package)_config_opts_mingw32 += -ltcg
-endif
 
 # CMake build options.
 $(package)_config_env := CC="$$($(package)_cc)"


### PR DESCRIPTION
The related Windows patches were dropped in 5e794e62024eef612e1fbb71c76ea54d17435c14, and "Cross-compiling does not support LTO." (from #30997).