### PR TITLE
RPC: removeprunedfunds should take an array of txids

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -281,6 +281,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "gethdkeys", 0, "private" },
     { "createwalletdescriptor", 1, "options" },
     { "createwalletdescriptor", 1, "internal" },
+    { "removeprunedfunds", 0, "txids" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -78,6 +78,11 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
         proof3 = self.nodes[0].gettxoutproof([txnid3])
 
+        txnid4 = self.nodes[0].sendtoaddress(address2, 0.025)
+        self.generate(self.nodes[0], 1)
+        rawtxn4 = self.nodes[0].gettransaction(txnid4)['hex']
+        proof4 = self.nodes[0].gettxoutproof([txnid4])
+
         self.sync_all()
 
         # Import with no affiliated address
@@ -91,7 +96,8 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         wwatch = self.nodes[1].get_wallet_rpc('wwatch')
         wwatch.importaddress(address=address2, rescan=False)
         wwatch.importprunedfunds(rawtransaction=rawtxn2, txoutproof=proof2)
-        assert [tx for tx in wwatch.listtransactions(include_watchonly=True) if tx['txid'] == txnid2]
+        wwatch.importprunedfunds(rawtransaction=rawtxn4, txoutproof=proof4)
+        assert [tx for tx in wwatch.listtransactions(include_watchonly=True) if tx['txid'] == txnid2 or tx['txid'] == txnid4]
 
         # Import with private key with no rescan
         w1 = self.nodes[1].get_wallet_rpc(self.default_wallet_name)
@@ -113,14 +119,16 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['ismine'], True)
 
         # Remove transactions
-        assert_raises_rpc_error(-4, f'Transaction {txnid1} does not belong to this wallet', w1.removeprunedfunds, txnid1)
+        assert_raises_rpc_error(-4, f'Transaction {txnid1} does not belong to this wallet', w1.removeprunedfunds, [txnid1])
         assert not [tx for tx in w1.listtransactions(include_watchonly=True) if tx['txid'] == txnid1]
 
-        wwatch.removeprunedfunds(txnid2)
-        assert not [tx for tx in wwatch.listtransactions(include_watchonly=True) if tx['txid'] == txnid2]
+        wwatch.removeprunedfunds([txnid2, txnid4])
+        assert not [tx for tx in wwatch.listtransactions(include_watchonly=True) if tx['txid'] == txnid2 or tx['txid'] == txnid4]
 
-        w1.removeprunedfunds(txnid3)
+        w1.removeprunedfunds([txnid3])
         assert not [tx for tx in w1.listtransactions(include_watchonly=True) if tx['txid'] == txnid3]
+
+        assert_raises_rpc_error(-8, "Parameter 'txids' cannot be empty", w1.removeprunedfunds, []) # Test Empty list
 
         # Check various RPC parameter validation errors
         assert_raises_rpc_error(-22, "TX decode failed", w1.importprunedfunds, b'invalid tx'.hex(), proof1)


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/29466

Update `removeprunedfunds` RPC to take an `array of strings of txids` instead of a `single txid string` to allow batch removal of transactions