### PR TITLE
rfc: only put replaced txs in extra pool

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3019,11 +3019,8 @@ std::optional<node::PackageToValidate> PeerManagerImpl::ProcessInvalidTx(NodeId 
         nodeid,
         state.ToString());
 
-    const auto& [add_extra_compact_tx, unique_parents, package_to_validate] = m_txdownloadman.MempoolRejectedTx(ptx, state, nodeid, first_time_failure);
+    const auto& [unique_parents, package_to_validate] = m_txdownloadman.MempoolRejectedTx(ptx, state, nodeid, first_time_failure);
 
-    if (add_extra_compact_tx && RecursiveDynamicUsage(*ptx) < 100000) {
-        AddToCompactExtraTransactions(ptx);
-    }
     for (const Txid& parent_txid : unique_parents) {
         if (peer) AddKnownTx(*peer, parent_txid);
     }

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -91,7 +91,6 @@ struct PackageToValidate {
 };
 struct RejectedTxTodo
 {
-    bool m_should_add_extra_compact_tx;
     std::vector<Txid> m_unique_parents;
     std::optional<PackageToValidate> m_package_to_validate;
 };

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -224,7 +224,6 @@ FUZZ_TARGET(txdownloadman, .init = initialize)
                 bool first_time_failure{fuzzed_data_provider.ConsumeBool()};
 
                 node::RejectedTxTodo todo = txdownloadman.MempoolRejectedTx(rand_tx, state, rand_peer, first_time_failure);
-                Assert(first_time_failure || !todo.m_should_add_extra_compact_tx);
             },
             [&] {
                 GenTxid gtxid = fuzzed_data_provider.ConsumeBool() ?
@@ -369,7 +368,6 @@ FUZZ_TARGET(txdownloadman_impl, .init = initialize)
                 bool reject_contains_wtxid{txdownload_impl.RecentRejectsFilter().contains(rand_tx->GetWitnessHash().ToUint256())};
 
                 node::RejectedTxTodo todo = txdownload_impl.MempoolRejectedTx(rand_tx, state, rand_peer, first_time_failure);
-                Assert(first_time_failure || !todo.m_should_add_extra_compact_tx);
                 if (!reject_contains_wtxid) Assert(todo.m_unique_parents.size() <= rand_tx->vin.size());
             },
             [&] {


### PR DESCRIPTION
We currently store rejected mempool transactions in the extra pool. This includes (some) policy and consensus rejected transactions.

It seems trivial to attack this pool for free with consensus invalid transactions, or almost free with policy violating transactions that are extremely unlikely to ever get mined. This was known at the time it was introduced: https://github.com/bitcoin/bitcoin/pull/9499#discussion_r96489548

At the same time the orphanage already handles some cases that were initially dealt with here.

This commit simplifies things by only putting replaced transactions in the extra pool, as these represent things that at least previously passed our mempool DoS protections.

Later on we could introduce similar DoS protection as #31829 does for the orphan pool, and then expand the list of things we store again. Or even revert to the present behavior.

This extra pool was introduced by #9499. It started with just adding replaced transactions in commit 93380c5247526e2248248a7d539233ec48d11bdd, added orphans in 7f8c8cab1e537809848088d3bfaa13ecca7ac8cc and then all the other rejected things in 863edb45b9841c3058e883015c7576e6f69e3cc6.

TODO:
- restore some lost test coverage
- consider bringing some reject reasons back to this pool