### PR TITLE
util: C++20 `ToIntegral()` Improvement

### DIFF
--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -172,14 +172,15 @@ constexpr inline bool IsSpace(char c) noexcept {
  * trailing character fail the parsing. The required format expressed as regex
  * is `-?[0-9]+`. The minus sign is only permitted for signed integer types.
  *
+ * @tparam T Integral type (excluding bool).
+ * @param str The input view to parse.
  * @returns std::nullopt if the entire string could not be parsed, or if the
  *   parsed value is not in the range representable by the type T.
  */
-template <typename T>
-std::optional<T> ToIntegral(std::string_view str)
+template <std::integral T> requires (!std::same_as<T,bool>)
+[[nodiscard]] constexpr std::optional<T> ToIntegral(std::string_view str) noexcept
 {
-    static_assert(std::is_integral_v<T>);
-    T result;
+    T result{};
     const auto [first_nonmatching, error_condition] = std::from_chars(str.data(), str.data() + str.size(), result);
     if (first_nonmatching != str.data() + str.size() || error_condition != std::errc{}) {
         return std::nullopt;


### PR DESCRIPTION
While reviewing https://github.com/bitcoin/bitcoin/pull/32520, I noticed that the function `ToIntegral()` could be improved:

* Instead of manually asserting `std::is_integral_v<T>`,  the template can be constrained with the standard `std::integral` for clearer intent.

* Annotation with `[[nodiscard]]` and `noexcept`. Compilers will warn if the return value is discarded and since `std::from_chars` is guaranteed to throw nothing, declaring the wrapper `noexcept` makes the exception guarantee explicit.

* With C++23, the integral overloads of `std::from_chars` are `constexpr`, allowing `ToIntegral` to become a `constexpr` function.

https://en.cppreference.com/w/cpp/utility/from_chars