### PR TITLE
build: Revert "Temporarily disable compiling `fuzz/utxo_snapshot.cpp` with MSVC

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -10,7 +10,7 @@ For cross-compiling options, please see [`build-windows.md`](./build-windows.md)
 
 This guide relies on using CMake and vcpkg package manager provided with the Visual Studio installation.
 Here are requirements for the Visual Studio installation:
-1. Minimum required version: Visual Studio 2022 version 17.6.
+1. Minimum required version: Visual Studio 2022 version 17.13.
 2. Installed components:
 - The "Desktop development with C++" workload.
 

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -127,10 +127,7 @@ add_executable(fuzz
   txgraph.cpp
   txorphan.cpp
   txrequest.cpp
-  # Visual Studio 2022 version 17.12 introduced a bug
-  # that causes an internal compiler error.
-  # See: https://github.com/bitcoin/bitcoin/issues/31303
-  $<$<VERSION_LESS:${MSVC_VERSION},1942>:utxo_snapshot.cpp>
+  utxo_snapshot.cpp
   utxo_total_supply.cpp
   validation_load_mempool.cpp
   vecdeque.cpp


### PR DESCRIPTION
Now that GitHub Actions has a fixed version and the Windows developers have updated their compiler, the workaround is no longer needed.