### PR TITLE
Short-circuit `GetLegacySigOpCount` for known scripts

### DIFF
--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -33,12 +33,11 @@ static bool IsToScriptID(const CScript& script, CScriptID &hash)
 
 static bool IsToPubKey(const CScript& script, CPubKey &pubkey)
 {
-    if (script.IsCompressedPayToPubKey() && (script[1] == 0x02 || script[1] == 0x03)) {
+    if (script.IsCompressedPayToPubKey() && (script[1] == SECP256K1_TAG_PUBKEY_EVEN || script[1] == SECP256K1_TAG_PUBKEY_ODD)) {
         pubkey.Set(&script[1], &script[34]);
         return true;
     }
-    if (script.size() == 67 && script[0] == 65 && script[66] == OP_CHECKSIG
-                            && script[1] == 0x04) {
+    if (script.IsUncompressedPayToPubKey() && (script[1] == SECP256K1_TAG_PUBKEY_UNCOMPRESSED)) {
         pubkey.Set(&script[1], &script[66]);
         return pubkey.IsFullyValid(); // if not fully valid, a case that would not be compressible
     }

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -4,9 +4,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
-
 #include <pubkey.h>
 #include <script/script.h>
+
+#include <secp256k1.h>
 
 /*
  * These check for scripts for which a special case with a shorter encoding is defined.
@@ -32,8 +33,7 @@ static bool IsToScriptID(const CScript& script, CScriptID &hash)
 
 static bool IsToPubKey(const CScript& script, CPubKey &pubkey)
 {
-    if (script.size() == 35 && script[0] == 33 && script[34] == OP_CHECKSIG
-                            && (script[1] == 0x02 || script[1] == 0x03)) {
+    if (script.IsCompressedPayToPubKey() && (script[1] == 0x02 || script[1] == 0x03)) {
         pubkey.Set(&script[1], &script[34]);
         return true;
     }

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -29,12 +29,9 @@ static bool IsToKeyID(const CScript& script, CKeyID &hash)
 
 static bool IsToScriptID(const CScript& script, CScriptID &hash)
 {
-    if (script.size() == 23 && script[0] == OP_HASH160 && script[1] == 20
-                            && script[22] == OP_EQUAL) {
-        memcpy(&hash, &script[2], 20);
-        return true;
-    }
-    return false;
+    if (!script.IsPayToScriptHash()) return false;
+    memcpy(&hash, &script[2], 20);
+    return true;
 }
 
 static bool IsToPubKey(const CScript& script, CPubKey &pubkey)

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -18,13 +18,9 @@
 
 static bool IsToKeyID(const CScript& script, CKeyID &hash)
 {
-    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160
-                            && script[2] == 20 && script[23] == OP_EQUALVERIFY
-                            && script[24] == OP_CHECKSIG) {
-        memcpy(&hash, &script[3], 20);
-        return true;
-    }
-    return false;
+    if (!script.IsPayToPubKeyHash()) return false;
+    memcpy(&hash, &script[3], 20);
+    return true;
 }
 
 static bool IsToScriptID(const CScript& script, CScriptID &hash)

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -17,21 +17,21 @@
  * form).
  */
 
-static bool IsToKeyID(const CScript& script, CKeyID &hash)
+static bool IsToKeyID(const CScript& script, CKeyID& hash)
 {
     if (!script.IsPayToPubKeyHash()) return false;
     memcpy(&hash, &script[3], 20);
     return true;
 }
 
-static bool IsToScriptID(const CScript& script, CScriptID &hash)
+static bool IsToScriptID(const CScript& script, CScriptID& hash)
 {
     if (!script.IsPayToScriptHash()) return false;
     memcpy(&hash, &script[2], 20);
     return true;
 }
 
-static bool IsToPubKey(const CScript& script, CPubKey &pubkey)
+static bool IsToPubKey(const CScript& script, CPubKey& pubkey)
 {
     if (script.IsCompressedPayToPubKey() && (script[1] == SECP256K1_TAG_PUBKEY_EVEN || script[1] == SECP256K1_TAG_PUBKEY_ODD)) {
         pubkey.Set(&script[1], &script[34]);

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -112,13 +112,11 @@ bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeig
 unsigned int GetLegacySigOpCount(const CTransaction& tx)
 {
     unsigned int nSigOps = 0;
-    for (const auto& txin : tx.vin)
-    {
-        nSigOps += txin.scriptSig.GetSigOpCount(false);
+    for (const auto& txin : tx.vin) {
+        nSigOps += txin.scriptSig.GetLegacySigOpCount(/*fAccurate=*/false);
     }
-    for (const auto& txout : tx.vout)
-    {
-        nSigOps += txout.scriptPubKey.GetSigOpCount(false);
+    for (const auto& txout : tx.vout) {
+        nSigOps += txout.scriptPubKey.GetLegacySigOpCount(/*fAccurate=*/false);
     }
     return nSigOps;
 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -209,7 +209,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             if (stack.empty())
                 return false;
             CScript subscript(stack.back().begin(), stack.back().end());
-            if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
+            if (subscript.GetLegacySigOpCount(/*fAccurate=*/true) > MAX_P2SH_SIGOPS) {
                 return false;
             }
         }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -96,6 +96,11 @@ public:
     {
         CBlockHeader::SetNull();
         vtx.clear();
+        ResetChecked();
+    }
+
+    void ResetChecked()
+    {
         fChecked = false;
         m_checked_witness_commitment = false;
         m_checked_merkle_root = false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2084,7 +2084,7 @@ size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& wi
 
         if (witprogram.size() == WITNESS_V0_SCRIPTHASH_SIZE && witness.stack.size() > 0) {
             CScript subscript(witness.stack.back().begin(), witness.stack.back().end());
-            return subscript.GetSigOpCount(true);
+            return subscript.GetLegacySigOpCount(/*fAccurate=*/true);
         }
     }
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -223,11 +223,6 @@ struct ScriptExecutionData
     std::optional<uint256> m_output_hash;
 };
 
-/** Signature hash sizes */
-static constexpr size_t WITNESS_V0_SCRIPTHASH_SIZE = 32;
-static constexpr size_t WITNESS_V0_KEYHASH_SIZE = 20;
-static constexpr size_t WITNESS_V1_TAPROOT_SIZE = 32;
-
 static constexpr uint8_t TAPROOT_LEAF_MASK = 0xfe;
 static constexpr uint8_t TAPROOT_LEAF_TAPSCRIPT = 0xc0;
 static constexpr size_t TAPROOT_CONTROL_BASE_SIZE = 33;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -212,13 +212,6 @@ bool CScript::IsPayToAnchor(int version, const std::vector<unsigned char>& progr
         program[1] == 0x73;
 }
 
-bool CScript::IsPayToTaproot() const
-{
-    return (this->size() == 34 &&
-            (*this)[0] == OP_1 &&
-            (*this)[1] == 0x20);
-}
-
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
 bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -221,14 +221,6 @@ bool CScript::IsPayToAnchor(int version, const std::vector<unsigned char>& progr
         program[1] == 0x73;
 }
 
-bool CScript::IsPayToWitnessScriptHash() const
-{
-    // Extra-fast test for pay-to-witness-script-hash CScripts:
-    return (this->size() == 34 &&
-            (*this)[0] == OP_0 &&
-            (*this)[1] == 0x20);
-}
-
 bool CScript::IsPayToTaproot() const
 {
     return (this->size() == 34 &&

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -221,15 +221,6 @@ bool CScript::IsPayToAnchor(int version, const std::vector<unsigned char>& progr
         program[1] == 0x73;
 }
 
-bool CScript::IsPayToScriptHash() const
-{
-    // Extra-fast test for pay-to-script-hash CScripts:
-    return (this->size() == 23 &&
-            (*this)[0] == OP_HASH160 &&
-            (*this)[1] == 0x14 &&
-            (*this)[22] == OP_EQUAL);
-}
-
 bool CScript::IsPayToWitnessScriptHash() const
 {
     // Extra-fast test for pay-to-witness-script-hash CScripts:

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -186,6 +186,17 @@ static constexpr std::pair<unsigned int, unsigned int> DecodePushData(
 
 unsigned int CScript::GetLegacySigOpCount(bool fAccurate) const
 {
+    switch (size()) {
+    case 0: return 0;
+    case 4: if (IsPayToAnchor()) return 0; else break;
+    case 22: if (IsPayToWitnessPubKeyHash()) return 0; else break;
+    case 23: if (IsPayToScriptHash()) return 0; else break;
+    case 25: if (IsPayToPubKeyHash()) return 1; else break;
+    case 34: if (IsPayToTaproot() || IsPayToWitnessScriptHash()) return 0; else break;
+    case 35: if (IsCompressedPayToPubKey()) return 1; else break;
+    case 67: if (IsUncompressedPayToPubKey()) return 1; else break;
+    }
+
     unsigned int n{0};
     opcodetype prev{OP_INVALIDOPCODE};
     for (const_iterator pc{begin()}, pc_end{end()}; pc < pc_end;) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -156,7 +156,7 @@ std::string GetOpName(opcodetype opcode)
     }
 }
 
-unsigned int CScript::GetSigOpCount(bool fAccurate) const
+unsigned int CScript::GetLegacySigOpCount(bool fAccurate) const
 {
     unsigned int n = 0;
     const_iterator pc = begin();
@@ -183,7 +183,7 @@ unsigned int CScript::GetSigOpCount(bool fAccurate) const
 unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
 {
     if (!IsPayToScriptHash())
-        return GetSigOpCount(true);
+        return GetLegacySigOpCount(/*fAccurate=*/true);
 
     // This is a pay-to-script-hash scriptPubKey;
     // get the last item that the scriptSig
@@ -201,7 +201,7 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
 
     /// ... and return its opcount:
     CScript subscript(vData.begin(), vData.end());
-    return subscript.GetSigOpCount(true);
+    return subscript.GetLegacySigOpCount(/*fAccurate=*/true);
 }
 
 bool CScript::IsPayToAnchor() const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -204,15 +204,6 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     return subscript.GetLegacySigOpCount(/*fAccurate=*/true);
 }
 
-bool CScript::IsPayToAnchor() const
-{
-    return (this->size() == 4 &&
-        (*this)[0] == OP_1 &&
-        (*this)[1] == 0x02 &&
-        (*this)[2] == 0x4e &&
-        (*this)[3] == 0x73);
-}
-
 bool CScript::IsPayToAnchor(int version, const std::vector<unsigned char>& program)
 {
     return version == 1 &&

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -564,7 +564,14 @@ public:
                (*this)[1] == WITNESS_V0_KEYHASH_SIZE &&
                back() == OP_EQUAL;
     }
-    bool IsPayToWitnessScriptHash() const;
+
+    bool IsPayToWitnessScriptHash() const noexcept
+    {
+        return size() == 34 &&
+               front() == OP_0 &&
+               (*this)[1] == WITNESS_V0_SCRIPTHASH_SIZE;
+    }
+
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     bool IsPayToTaproot() const;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -536,7 +536,7 @@ public:
      * counted more accurately, assuming they are of the form
      *  ... OP_N CHECKMULTISIG ...
      */
-    unsigned int GetSigOpCount(bool fAccurate) const;
+    unsigned int GetLegacySigOpCount(bool fAccurate) const;
 
     /**
      * Accurately count sigOps, including sigOps in

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -535,6 +535,12 @@ public:
         return (opcodetype)(OP_1+n-1);
     }
 
+    /** Test for "small positive integer" script opcodes - OP_1 through OP_16. */
+    static constexpr bool IsSmallInteger(opcodetype opcode)
+    {
+        return opcode >= OP_1 && opcode <= OP_16;
+    }
+
     /**
      * Pre-version-0.6, Bitcoin always counted CHECKMULTISIGs
      * as 20 sigops. With pay-to-script-hash, that changed:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -577,9 +577,14 @@ public:
                (*this)[1] == WITNESS_V0_SCRIPTHASH_SIZE;
     }
 
-    bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
+    bool IsPayToTaproot() const noexcept
+    {
+        return size() == 34 &&
+               front() == OP_1 &&
+               (*this)[1] == WITNESS_V1_TAPROOT_SIZE;
+    }
 
-    bool IsPayToTaproot() const;
+    bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -562,6 +562,16 @@ public:
                back() == 0x73;
     }
 
+    bool IsPayToPubKeyHash() const noexcept
+    {
+        return size() == 25 &&
+               front() == OP_DUP &&
+               (*this)[1] == OP_HASH160 &&
+               (*this)[2] == WITNESS_V0_KEYHASH_SIZE &&
+               (*this)[23] == OP_EQUALVERIFY &&
+               back() == OP_CHECKSIG;
+    }
+
     bool IsPayToScriptHash() const noexcept
     {
         return size() == 23 &&

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -24,6 +24,11 @@
 #include <utility>
 #include <vector>
 
+// Signature hash sizes
+static constexpr size_t WITNESS_V0_KEYHASH_SIZE = 20;
+static constexpr size_t WITNESS_V0_SCRIPTHASH_SIZE = 32;
+static constexpr size_t WITNESS_V1_TAPROOT_SIZE = 32;
+
 // Maximum number of bytes pushable to the stack
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520;
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -581,6 +581,14 @@ public:
                back() == OP_EQUAL;
     }
 
+    bool IsPayToWitnessPubKeyHash() const noexcept
+    {
+        return size() == 22 &&
+               front() == OP_0 &&
+               (*this)[1] == WITNESS_V0_KEYHASH_SIZE;
+    }
+
+
     bool IsPayToWitnessScriptHash() const noexcept
     {
         return size() == 34 &&
@@ -608,6 +616,7 @@ public:
                front() == CPubKey::SIZE &&
                back() == OP_CHECKSIG;
     }
+
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -549,13 +549,18 @@ public:
      */
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
-    /*
-     * OP_1 <0x4e73>
-     */
-    bool IsPayToAnchor() const;
     /** Checks if output of IsWitnessProgram comes from a P2A output script
      */
     static bool IsPayToAnchor(int version, const std::vector<unsigned char>& program);
+
+    bool IsPayToAnchor() const noexcept
+    {
+        return size() == 4 &&
+               front() == OP_1 &&
+               (*this)[1] == 0x02 &&
+               (*this)[2] == 0x4e &&
+               back() == 0x73;
+    }
 
     bool IsPayToScriptHash() const noexcept
     {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -9,6 +9,7 @@
 #include <attributes.h>
 #include <crypto/common.h>
 #include <prevector.h> // IWYU pragma: export
+#include <pubkey.h>
 #include <serialize.h>
 #include <uint256.h>
 #include <util/hash_type.h>
@@ -592,6 +593,13 @@ public:
         return size() == 34 &&
                front() == OP_1 &&
                (*this)[1] == WITNESS_V1_TAPROOT_SIZE;
+    }
+
+    bool IsCompressedPayToPubKey() const noexcept
+    {
+        return size() == 35 &&
+               front() == CPubKey::COMPRESSED_SIZE &&
+               back() == OP_CHECKSIG;
     }
 
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -557,7 +557,13 @@ public:
      */
     static bool IsPayToAnchor(int version, const std::vector<unsigned char>& program);
 
-    bool IsPayToScriptHash() const;
+    bool IsPayToScriptHash() const noexcept
+    {
+        return size() == 23 &&
+               front() == OP_HASH160 &&
+               (*this)[1] == WITNESS_V0_KEYHASH_SIZE &&
+               back() == OP_EQUAL;
+    }
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -602,6 +602,12 @@ public:
                back() == OP_CHECKSIG;
     }
 
+    bool IsUncompressedPayToPubKey() const noexcept
+    {
+        return size() == 67 &&
+               front() == CPubKey::SIZE &&
+               back() == OP_CHECKSIG;
+    }
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -35,7 +35,7 @@ std::string GetTxnOutputType(TxoutType t)
 
 static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
 {
-    if (script.size() == CPubKey::SIZE + 2 && script[0] == CPubKey::SIZE && script.back() == OP_CHECKSIG) {
+    if (script.IsUncompressedPayToPubKey()) {
         pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::SIZE + 1);
         return CPubKey::ValidSize(pubkey);
     }

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -53,18 +53,12 @@ static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
     return true;
 }
 
-/** Test for "small positive integer" script opcodes - OP_1 through OP_16. */
-static constexpr bool IsSmallInteger(opcodetype opcode)
-{
-    return opcode >= OP_1 && opcode <= OP_16;
-}
-
 /** Retrieve a minimally-encoded number in range [min,max] from an (opcode, data) pair,
  *  whether it's OP_n or through a push. */
 static std::optional<int> GetScriptNumber(opcodetype opcode, valtype data, int min, int max)
 {
     int count;
-    if (IsSmallInteger(opcode)) {
+    if (CScript::IsSmallInteger(opcode)) {
         count = CScript::DecodeOP_N(opcode);
     } else if (IsPushdataOp(opcode)) {
         if (!CheckMinimalPush(data, opcode)) return {};

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -39,7 +39,7 @@ static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
         pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::SIZE + 1);
         return CPubKey::ValidSize(pubkey);
     }
-    if (script.size() == CPubKey::COMPRESSED_SIZE + 2 && script[0] == CPubKey::COMPRESSED_SIZE && script.back() == OP_CHECKSIG) {
+    if (script.IsCompressedPayToPubKey()) {
         pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::COMPRESSED_SIZE + 1);
         return CPubKey::ValidSize(pubkey);
     }

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -48,11 +48,9 @@ static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
 
 static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
 {
-    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) {
-        pubkeyhash = valtype(script.begin () + 3, script.begin() + 23);
-        return true;
-    }
-    return false;
+    if (!script.IsPayToPubKeyHash()) return false;
+    pubkeyhash = valtype(script.begin () + 3, script.begin() + 23);
+    return true;
 }
 
 /** Test for "small positive integer" script opcodes - OP_1 through OP_16. */

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -7,7 +7,8 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 
-#include <stdint.h>
+#include <cstdint>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -161,6 +162,33 @@ BOOST_AUTO_TEST_CASE(compress_p2pk_scripts_not_on_curve)
         CScript uncompressed_script;
         bool success = DecompressScript(uncompressed_script, compression_id, compressed_script);
         BOOST_CHECK_EQUAL(success, false);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(compressed_p2pk)
+{
+    // Valid Compressed P2PK
+    {
+        auto key{ToByteVector(GenerateRandomKey(/*compressed=*/true).GetPubKey())};
+        const auto script{CScript() << key << OP_CHECKSIG};
+        BOOST_CHECK(script.IsCompressedPayToPubKey());
+
+        CompressedScript compressed_script;
+        BOOST_CHECK(CompressScript(script, compressed_script));
+        BOOST_CHECK_EQUAL(compressed_script.size(), 33U); // should be 33 bytes
+    }
+
+    // Compressed P2PK with an invalid prefix
+    {
+        auto key{ToByteVector(GenerateRandomKey(/*compressed=*/true).GetPubKey())};
+        key[0] = 0x06; // 0x02/0x03 would be valid prefixes
+
+        const auto script{CScript() << key << OP_CHECKSIG};
+        BOOST_CHECK(script.IsCompressedPayToPubKey());
+
+        CompressedScript compressed_script;
+        BOOST_CHECK(!CompressScript(script, compressed_script));
+        BOOST_CHECK(compressed_script.empty());
     }
 }
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -192,4 +192,30 @@ BOOST_AUTO_TEST_CASE(compressed_p2pk)
     }
 }
 
+BOOST_AUTO_TEST_CASE(uncompressed_p2pk)
+{
+    // Valid Uncompressed P2PK
+    {
+        auto key{ToByteVector(GenerateRandomKey(/*compressed=*/false).GetPubKey())};
+        const auto script{CScript() << key << OP_CHECKSIG};
+
+        BOOST_CHECK(script.IsUncompressedPayToPubKey());
+        CompressedScript compressed_script;
+        BOOST_CHECK(CompressScript(script, compressed_script));
+        BOOST_CHECK_EQUAL(compressed_script.size(), 33U);   // compressed form is 33 bytes
+    }
+
+    // Uncompressed P2PK with an invalid prefix
+    {
+        auto key{ToByteVector(GenerateRandomKey(/*compressed=*/false).GetPubKey())};
+        key[0] = 0x06; // 0x04 is the only valid prefix (but GetLen() recognizes 6)
+        const auto script{CScript() << key << OP_CHECKSIG};
+
+        BOOST_CHECK(script.IsUncompressedPayToPubKey());
+        CompressedScript compressed_script;
+        BOOST_CHECK(!CompressScript(script, compressed_script));
+        BOOST_CHECK(compressed_script.empty());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -98,7 +98,7 @@ FUZZ_TARGET(script, .init = initialize_script)
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();
-    (void)script.GetSigOpCount(/* fAccurate= */ false);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/false);
 
     {
         const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -98,7 +98,10 @@ FUZZ_TARGET(script, .init = initialize_script)
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();
-    (void)script.GetLegacySigOpCount(/*fAccurate=*/false);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/fuzzed_data_provider.ConsumeBool());
+
+    auto script_sig{ConsumeScript(fuzzed_data_provider)};
+    (void)script.GetSigOpCount(script_sig);
 
     {
         const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -43,8 +43,8 @@ FUZZ_TARGET(script_ops)
             });
     }
     const CScript& script = script_mut;
-    (void)script.GetSigOpCount(false);
-    (void)script.GetSigOpCount(true);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/false);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/true);
     (void)script.GetSigOpCount(script);
     (void)script.HasValidOps();
     (void)script.IsPayToScriptHash();

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -30,17 +30,16 @@ BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {
-    // Test CScript::GetSigOpCount()
     CScript s1;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
+    BOOST_CHECK_EQUAL(s1.GetLegacySigOpCount(/*fAccurate=*/false), 0U);
+    BOOST_CHECK_EQUAL(s1.GetLegacySigOpCount(/*fAccurate=*/true), 0U);
 
     uint160 dummy;
     s1 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
+    BOOST_CHECK_EQUAL(s1.GetLegacySigOpCount(/*fAccurate=*/true), 2U);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 3U);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 21U);
+    BOOST_CHECK_EQUAL(s1.GetLegacySigOpCount(/*fAccurate=*/true), 3U);
+    BOOST_CHECK_EQUAL(s1.GetLegacySigOpCount(/*fAccurate=*/false), 21U);
 
     CScript p2sh = GetScriptForDestination(ScriptHash(s1));
     CScript scriptSig;
@@ -54,12 +53,12 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
         keys.push_back(k.GetPubKey());
     }
     CScript s2 = GetScriptForMultisig(1, keys);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), 3U);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), 20U);
+    BOOST_CHECK_EQUAL(s2.GetLegacySigOpCount(/*fAccurate=*/true), 3U);
+    BOOST_CHECK_EQUAL(s2.GetLegacySigOpCount(/*fAccurate=*/false), 20U);
 
     p2sh = GetScriptForDestination(ScriptHash(s2));
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0U);
+    BOOST_CHECK_EQUAL(p2sh.GetLegacySigOpCount(/*fAccurate=*/true), 0U);
+    BOOST_CHECK_EQUAL(p2sh.GetLegacySigOpCount(/*fAccurate=*/false), 0U);
     CScript scriptSig2;
     scriptSig2 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << Serialize(s2);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), 3U);

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
 
         auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_many_sigops), m_limits)};
         // legacy uses fAccurate = false, and the maximum number of multisig keys is used
-        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetSigOpCount(/*fAccurate=*/false))};
+        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetLegacySigOpCount(/*fAccurate=*/false))};
         BOOST_CHECK_EQUAL(total_sigops, tx_many_sigops->vin.size() * MAX_PUBKEYS_PER_MULTISIG);
         const int64_t bip141_vsize{GetVirtualTransactionSize(*tx_many_sigops)};
         // Weight limit is not reached...

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -156,9 +156,7 @@ BOOST_AUTO_TEST_CASE(block_malleation)
     // cache flags on `CBlock`.
     auto is_mutated = [](CBlock& block, bool check_witness_root) {
         bool mutated{IsBlockMutated(block, check_witness_root)};
-        block.fChecked = false;
-        block.m_checked_witness_commitment = false;
-        block.m_checked_merkle_root = false;
+        block.ResetChecked();
         return mutated;
     };
     auto is_not_mutated = [&is_mutated](CBlock& block, bool check_witness_root) {

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1501,7 +1501,7 @@ class TaprootTest(BitcoinTestFramework):
                     tx.vout[-1].nValue = random.randint(DUST_LIMIT, in_value)
                 in_value -= tx.vout[-1].nValue
                 tx.vout[-1].scriptPubKey = random.choice(host_spks)
-                sigops_weight += CScript(tx.vout[-1].scriptPubKey).GetSigOpCount(False) * WITNESS_SCALE_FACTOR
+                sigops_weight += CScript(tx.vout[-1].scriptPubKey).GetLegacySigOpCount(fAccurate=False) * WITNESS_SCALE_FACTOR
             fee += in_value
             assert fee >= 0
 

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -199,10 +199,10 @@ def get_legacy_sigopcount_block(block, accurate=True):
 def get_legacy_sigopcount_tx(tx, accurate=True):
     count = 0
     for i in tx.vout:
-        count += i.scriptPubKey.GetSigOpCount(accurate)
+        count += i.scriptPubKey.GetLegacySigOpCount(accurate)
     for j in tx.vin:
         # scriptSig might be of type bytes, so convert to CScript for the moment
-        count += CScript(j.scriptSig).GetSigOpCount(accurate)
+        count += CScript(j.scriptSig).GetLegacySigOpCount(accurate)
     return count
 
 def witness_script(use_p2wsh, pubkey):

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -573,7 +573,7 @@ class CScript(bytes):
 
         return "CScript([%s])" % ', '.join(ops)
 
-    def GetSigOpCount(self, fAccurate):
+    def GetLegacySigOpCount(self, fAccurate):
         """Get the SigOp count.
 
         fAccurate - Accurately count CHECKMULTISIG, see BIP16 for details.
@@ -785,14 +785,14 @@ class TestFrameworkScript(unittest.TestCase):
         for n_ops in range(1, 100, 10):
             for singlesig_op in (OP_CHECKSIG, OP_CHECKSIGVERIFY):
                 singlesigs_script = CScript([singlesig_op]*n_ops)
-                self.assertEqual(singlesigs_script.GetSigOpCount(fAccurate=False), n_ops)
-                self.assertEqual(singlesigs_script.GetSigOpCount(fAccurate=True), n_ops)
+                self.assertEqual(singlesigs_script.GetLegacySigOpCount(fAccurate=False), n_ops)
+                self.assertEqual(singlesigs_script.GetLegacySigOpCount(fAccurate=True), n_ops)
         # test multisig op (including accurate counting, i.e. BIP16)
         for n in range(1, 16+1):
             for multisig_op in (OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY):
                 multisig_script = CScript([CScriptOp.encode_op_n(n), multisig_op])
-                self.assertEqual(multisig_script.GetSigOpCount(fAccurate=False), 20)
-                self.assertEqual(multisig_script.GetSigOpCount(fAccurate=True), n)
+                self.assertEqual(multisig_script.GetLegacySigOpCount(fAccurate=False), 20)
+                self.assertEqual(multisig_script.GetLegacySigOpCount(fAccurate=True), n)
 
 def BIP341_sha_prevouts(txTo):
     return sha256(b"".join(i.prevout.serialize() for i in txTo.vin))


### PR DESCRIPTION
It is an optimization PR for `GetSigOpCount`, covered heavily with new tests, benchmarks and small refactorings.

The changes were split out to https://github.com/bitcoin/bitcoin/pull/32729 (refactors only for now).

-------

### Context

Test coverage was thin for this code path that suddenly became popular for different reasons (https://github.com/bitcoin/bitcoin/pull/31624 and https://github.com/bitcoin/bitcoin/pull/32521 and https://github.com/bitcoin/bitcoin/pull/32533) highlighting the need for better code coverage.

The PR now splits out the common `PUSHDATA` length/bounds reads and error checks and covers its corner cases with unit tests and benchmarks.

### Testing

* added unit tests covering every standard script type (and a historical `OP_RETURN … OP_CHECKSIG` oddity);
* added fuzz-style test that compares the refactored implementation against the *exact* legacy algorithm on random scripts - also ran it continuously for 25 hours without divergence;
* reindexed to height 897,000 [comparing the outputs of the old and the new implementation](https://gist.github.com/l0rinc/ff6347164b3c502a9643ba7be171860e) without incidents.