### PR TITLE
Set minimum supported Windows version to 1903 (May 2019 Update)

### DIFF
--- a/cmake/windows-app.manifest.in
+++ b/cmake/windows-app.manifest.in
@@ -5,6 +5,12 @@
       name="org.bitcoincore.${target}"
       version="${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}.0"
   />
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+      <application>
+          <!-- Windows 10, version 1903 -->
+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      </application>
+  </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -35,8 +35,8 @@ wallet versions of Bitcoin Core are generally supported.
 Compatibility
 ==============
 
-Bitcoin Core is supported and tested on operating systems using the
-Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Bitcoin Core is supported and tested on the following operating systems or newer:
+Linux Kernel 3.17, macOS 13, and Windows 10 (version 1903). Bitcoin
 Core should also work on most other Unix-like systems but is not as
 frequently tested on them. It is not recommended to use Bitcoin Core on
 unsupported systems.


### PR DESCRIPTION
This PR sets the minimum supported Windows version to 1903 (May 2019 Update).

This version is the minimum [required](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page#set-a-process-code-page-to-utf-8) to support the UTF-8 code page (CP_UTF8), which is necessary for https://github.com/bitcoin/bitcoin/pull/32380.

Additionally, the `symbol-check.py` script has been amended to verify application manifests for supported OS value.