### PR TITLE
restrict std::cerr to errors; use std::cout for warnings and info

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -29,7 +29,8 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
     case CClientUIInterface::MSG_ERROR:
         strCaption = "Error: ";
         if (!fSecure) LogError("%s\n", message.original);
-        break;
+        tfm::format(std::cerr, "%s%s\n", strCaption, message.original);
+        return false;
     case CClientUIInterface::MSG_WARNING:
         strCaption = "Warning: ";
         if (!fSecure) LogWarning("%s\n", message.original);
@@ -43,7 +44,8 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
         if (!fSecure) LogInfo("%s%s\n", strCaption, message.original);
     }
 
-    tfm::format(std::cerr, "%s%s\n", strCaption, message.original);
+    tfm::format(std::cout, "%s%s\n", strCaption, message.original);
+    std::cout.flush(); // Unlike std::cerr, std::cout requires flushing the buffer.
     return false;
 }
 

--- a/test/functional/feature_port.py
+++ b/test/functional/feature_port.py
@@ -55,6 +55,11 @@ class PortTest(BitcoinTestFramework):
         node.extra_args = ["-listen", "-port=0"]
         node.assert_start_raises_init_error(expected_msg="Error: Invalid port specified in -port: '0'")
 
+        # Start node in a bad-port (see doc/p2p-bad-ports.md), expect warning
+        node.extra_args = ["-bind=127.0.0.1:6665"]
+        warning_msg = 'Warning: -bind request to listen on port 6665. This port is considered "bad" and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.'
+        node.assert_start_raises_init_warning(node.extra_args, expected_msg=warning_msg)
+
 
 if __name__ == '__main__':
     PortTest(__file__).main()


### PR DESCRIPTION
Warning messages were previously sent to `stderr`, which could cause them to
be misinterpreted as actual errors. This change redirects warning and informational
messages to `stdout` instead, making it explicit that they are not errors and
preventing unintended `stderr` handling.

To verify this behavior, added a test case triggering the simplest init warning I could find
(one that was actually not previously covered by tests): the `-bind` "bad-port" message.
So, running the test commit on master (without the fix) causes the test framework to fail
during shutdown due to a non-empty `stderr` buffer (treated as an error). With the fix
applied, the warning is correctly handled via `stdout`, and the test passes as expected.