### PR TITLE
index: store per-block transaction locations for efficient lookups

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -41,6 +41,10 @@ To query for a confirmed transaction, enable the transaction index via "txindex=
 Given a block hash and transaction offset within it: returns a transaction in binary, hex-encoded binary, or JSON formats.
 Responds with 404 if the transaction doesn't exist.
 
+By default, this endpoint will also deserialize the leading transactions, before reading and returning the requested one
+(which results in wasted deserialization work if the transaction is not in the beginning of the block).
+To read the requested transaction directly, enable the transaction locations' index via "locationsindex=1" command line / configuration option.
+
 #### Blocks
 - `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 - `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -36,6 +36,11 @@ Responds with 404 if the transaction doesn't exist.
 By default, this endpoint will only search the mempool.
 To query for a confirmed transaction, enable the transaction index via "txindex=1" command line / configuration option.
 
+`GET /rest/txfromblock/<BLOCK-HASH>-<TX-OFFSET>.<bin|hex|json>`
+
+Given a block hash and transaction offset within it: returns a transaction in binary, hex-encoded binary, or JSON formats.
+Responds with 404 if the transaction doesn't exist.
+
 #### Blocks
 - `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 - `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`

--- a/doc/files.md
+++ b/doc/files.md
@@ -58,6 +58,7 @@ Subdirectory       | File(s)               | Description
 `indexes/blockfilter/basic/db/` | LevelDB database      | Blockfilter index LevelDB database for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `indexes/blockfilter/basic/`    | `fltrNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Blockfilter index filters for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `indexes/coinstats/db/` | LevelDB database | Coinstats index; *optional*, used if `-coinstatsindex=1`
+`indexes/locations/db/` | LevelDB database | Transaction locations index; *optional*, used if `-locationsindex=1`
 `wallets/`         |                       | [Contains wallets](#multi-wallet-environment); can be specified by `-walletdir` option; if `wallets/` subdirectory does not exist, wallets reside in the [data directory](#data-directory-location)
 `./`               | `anchors.dat`         | Anchor IP address database, created on shutdown and deleted at startup. Anchors are last known outgoing block-relay-only peers that are tried to re-connect to on startup
 `./`               | `banlist.json`        | Stores the addresses/subnets of banned nodes.

--- a/doc/release-notes-32541.md
+++ b/doc/release-notes-32541.md
@@ -1,0 +1,5 @@
+New RPCs
+--------
+
+- A new REST API endpoint (`/rest/txfromblock/BLOCKHASH-OFFSET`) has been introduced for
+  efficiently fetching a specific transaction for a given block and offset (#32541).

--- a/doc/release-notes-32541.md
+++ b/doc/release-notes-32541.md
@@ -3,3 +3,5 @@ New RPCs
 
 - A new REST API endpoint (`/rest/txfromblock/BLOCKHASH-OFFSET`) has been introduced for
   efficiently fetching a specific transaction for a given block and offset (#32541).
+- An optional transaction locations' index (`-locationsindex`)  has been introduced for
+  improving transaction read performance using the new REST API (#32541).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,6 +193,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   index/base.cpp
   index/blockfilterindex.cpp
   index/coinstatsindex.cpp
+  index/locationsindex.cpp
   index/txindex.cpp
   init.cpp
   kernel/chain.cpp

--- a/src/index/locationsindex.cpp
+++ b/src/index/locationsindex.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blockencodings.h>
+#include <common/args.h>
+#include <dbwrapper.h>
+#include <hash.h>
+#include <index/locationsindex.h>
+#include <logging.h>
+#include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <serialize.h>
+#include <util/fs_helpers.h>
+#include <validation.h>
+
+constexpr uint8_t DB_BLOCK_HASH{'s'};
+
+constexpr uint32_t TXS_PER_ROW{128};
+
+namespace {
+
+struct DBKey {
+    uint256 hash;
+    uint32_t row; // allow splitting one block's transactions into multiple DB rows
+
+    explicit DBKey(const uint256& hash_in, uint32_t row_in) : hash(hash_in), row(row_in) {}
+
+    SERIALIZE_METHODS(DBKey, obj)
+    {
+        uint8_t prefix{DB_BLOCK_HASH};
+        READWRITE(prefix);
+        if (prefix != DB_BLOCK_HASH) {
+            throw std::ios_base::failure("Invalid format for location index DB hash key");
+        }
+
+        READWRITE(obj.hash);
+        READWRITE(COMPACTSIZE(obj.row));
+    }
+};
+
+struct DBValue {
+    FlatFilePos block_pos;
+    std::vector<uint32_t> offsets{};
+
+    SERIALIZE_METHODS(DBValue, obj)
+    {
+        READWRITE(obj.block_pos);
+        READWRITE(Using<VectorFormatter<DifferenceFormatter>>(obj.offsets));
+    }
+};
+
+}; // namespace
+
+std::unique_ptr<LocationsIndex> g_locations_index;
+
+LocationsIndex::LocationsIndex(std::unique_ptr<interfaces::Chain> chain,
+                               size_t cache_size, bool memory_only, bool wipe)
+    : BaseIndex{std::move(chain), "locationsindex"}, m_db{std::make_unique<BaseIndex::DB>(gArgs.GetDataDirNet() / "indexes" / "locations" / "db", cache_size, memory_only, wipe)}
+{
+}
+
+bool LocationsIndex::CustomAppend(const interfaces::BlockInfo& block)
+{
+    static const uint32_t HEADER_SIZE = ::GetSerializeSize(CBlockHeader{});
+
+    assert(block.data);
+    assert(block.file_number >= 0);
+
+    Assume(block.data->vtx.size() <= std::numeric_limits<uint32_t>::max());
+    const uint32_t tx_count{static_cast<uint32_t>(block.data->vtx.size())};
+    uint32_t tx_offset{HEADER_SIZE + GetSizeOfCompactSize(tx_count)};
+
+    std::vector<uint32_t> block_offsets{};
+    block_offsets.reserve(tx_count + 1);
+    block_offsets.push_back(tx_offset); // first transaction offset within the block
+
+    for (const auto& tx : block.data->vtx) {
+        tx_offset += ::GetSerializeSize(TX_WITH_WITNESS(*tx));
+        block_offsets.push_back(tx_offset);
+    }
+
+    CDBBatch batch{GetDB()};
+    uint32_t copied = 0;
+    for (uint32_t row = 0; copied < tx_count; ++row) {
+        size_t row_size = std::min(tx_count - copied, TXS_PER_ROW);
+        std::span<uint32_t> row_offsets{&block_offsets[copied], row_size + 1};
+
+        DBKey key{block.hash, row};
+        DBValue value{{block.file_number, block.data_pos}, {row_offsets.begin(), row_offsets.end()}};
+
+        copied += row_size;
+        batch.Write(key, value);
+    }
+    return GetDB().WriteBatch(batch);
+}
+
+std::vector<std::byte> LocationsIndex::ReadRawTransaction(const uint256& block_hash, uint32_t i) const
+{
+    const uint32_t row{i / TXS_PER_ROW};    // used to find the correct DB row
+    const uint32_t column{i % TXS_PER_ROW}; // index within a single DB row
+
+    DBValue value{};
+    if (!m_db->Read(DBKey{block_hash, row}, value)) {
+        return {};
+    }
+
+    if (value.offsets.size() <= 1) {
+        LogError("%s: LocationsIndex entry for %s:%u must have >1 offsets\n", __func__, block_hash.ToString(), row);
+        return {};
+    }
+    const size_t tx_count{value.offsets.size() - 1};
+    if (column >= tx_count) {
+        LogError("%s: LocationsIndex entry for %s:%u has %d transactions\n", __func__, block_hash.ToString(), row, tx_count);
+        return {};
+    }
+
+    FlatFilePos tx_pos{value.block_pos};
+    tx_pos.nPos += value.offsets[column];
+    size_t tx_size = value.offsets[column + 1] - value.offsets[column];
+
+    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(tx_pos, true)};
+    if (file.IsNull()) {
+        LogError("%s: OpenBlockFile failed\n", __func__);
+        return {};
+    }
+
+    std::vector<std::byte> out(tx_size);
+    try {
+        file.read(MakeWritableByteSpan(out));
+        return out;
+    } catch (const std::exception& e) {
+        LogError("%s: Read %d bytes from %s failed: %s\n", __func__, tx_size, tx_pos.ToString(), e.what());
+        return {};
+    }
+}

--- a/src/index/locationsindex.h
+++ b/src/index/locationsindex.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_LOCATIONSINDEX_H
+#define BITCOIN_INDEX_LOCATIONSINDEX_H
+
+#include <attributes.h>
+#include <chain.h>
+#include <index/base.h>
+
+static constexpr bool DEFAULT_LOCATIONSINDEX{false};
+
+/**
+ * LocationsIndex is used to store and retrieve the location of transactions within a block.
+ *
+ * This is done in a compressed manner, allowing the whole index to fit in RAM on decent hardware.
+ * For example, the on-disk size was 2.8 GiB at block height 912371.
+ */
+class LocationsIndex final : public BaseIndex
+{
+private:
+    std::unique_ptr<BaseIndex::DB> m_db;
+
+    bool AllowPrune() const override { return true; }
+
+protected:
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
+
+    BaseIndex::DB& GetDB() const LIFETIMEBOUND override { return *m_db; }
+
+public:
+    // Constructs the index, which becomes available to be queried.
+    explicit LocationsIndex(std::unique_ptr<interfaces::Chain> chain,
+                            size_t cache_size, bool memory_only = false, bool wipe = false);
+
+    // Read transaction #i from a given block.
+    std::vector<std::byte> ReadRawTransaction(const uint256& block_hash, uint32_t i) const;
+};
+
+extern std::unique_ptr<LocationsIndex> g_locations_index;
+
+#endif // BITCOIN_INDEX_LOCATIONSINDEX_H

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -417,6 +417,8 @@ public:
 
     bool ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const;
 
+    CTransactionRef ReadTxFromBlock(const FlatFilePos& block_pos, uint32_t tx_index) const;
+
     void CleanupBlockRevFiles() const;
 };
 

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -9,6 +9,7 @@
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
+#include <index/locationsindex.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
@@ -398,6 +399,10 @@ static RPCHelpMan getindexinfo()
     ForEachBlockFilterIndex([&result, &index_name](const BlockFilterIndex& index) {
         result.pushKVs(SummaryToJSON(index.GetSummary(), index_name));
     });
+
+    if (g_locations_index) {
+        result.pushKVs(SummaryToJSON(g_locations_index->GetSummary(), index_name));
+    }
 
     return result;
 },

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(test_bitcoin
   netbase_tests.cpp
   node_init_tests.cpp
   node_warnings_tests.cpp
+  locationsindex_tests.cpp
   orphanage_tests.cpp
   pcp_tests.cpp
   peerman_tests.cpp

--- a/src/test/locationsindex_tests.cpp
+++ b/src/test/locationsindex_tests.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresstype.h>
+#include <chainparams.h>
+#include <index/locationsindex.h>
+#include <interfaces/chain.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(locationsindex_tests)
+
+struct LocationsIndexSetup : public TestChain100Setup {
+    LocationsIndex index;
+
+    LocationsIndexSetup() : index(interfaces::MakeChain(m_node), 1 << 20, true)
+    {
+        BOOST_REQUIRE(index.Init());
+    }
+
+    CTransactionRef ReadTransaction(const uint256& block_hash, uint32_t i)
+    {
+        const std::vector<std::byte> out{index.ReadRawTransaction(block_hash, i)};
+        if (out.empty()) {
+            return nullptr;
+        }
+        CTransactionRef tx;
+        DataStream ssTx(out);
+        ssTx >> TX_WITH_WITNESS(tx);
+        return tx;
+    }
+
+    CTransactionRef ReadTransactionFallback(FlatFilePos block_pos, uint32_t i)
+    {
+        return m_node.chainman->m_blockman.ReadTxFromBlock(block_pos, i);
+    }
+};
+
+
+BOOST_FIXTURE_TEST_CASE(index_initial_sync, LocationsIndexSetup)
+{
+    // Transaction should not be found in the index before it is started.
+    BOOST_CHECK(!ReadTransaction(Params().GenesisBlock().GetHash(), 0));
+
+    // BlockUntilSyncedToCurrentChain should return false before index is started.
+    BOOST_CHECK(!index.BlockUntilSyncedToCurrentChain());
+
+    index.Sync();
+
+    // Check that index includes all mined transactions.
+    const CBlockIndex* block_index = WITH_LOCK(cs_main, return m_node.chainman->ActiveTip());
+    BOOST_REQUIRE(block_index);
+    while (block_index) {
+        uint256 block_hash = block_index->GetBlockHash();
+        FlatFilePos block_pos{WITH_LOCK(cs_main, return block_index->GetBlockPos())};
+        BOOST_REQUIRE(!block_pos.IsNull());
+        CBlock block;
+        BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlock(block, *block_index));
+        for (size_t i = 0; i < block.vtx.size(); ++i) {
+            CTransactionRef tx = ReadTransaction(block_hash, i);
+            BOOST_CHECK(tx);
+            BOOST_CHECK(*tx == *block.vtx[i]);
+            CTransactionRef tx_fallback = ReadTransactionFallback(block_pos, i);
+            BOOST_CHECK(tx_fallback);
+            BOOST_CHECK(*tx_fallback == *block.vtx[i]);
+        }
+        BOOST_CHECK(!ReadTransaction(block_hash, block.vtx.size()));
+        BOOST_CHECK(!ReadTransaction(block_hash, block.vtx.size() + 1));
+        BOOST_CHECK(!ReadTransactionFallback(block_pos, block.vtx.size()));
+        BOOST_CHECK(!ReadTransactionFallback(block_pos, block.vtx.size() + 1));
+        block_index = block_index->pprev;
+    }
+
+    // Test invalid blockhashes
+    BOOST_CHECK(!ReadTransaction(uint256::ZERO, 0));
+    BOOST_CHECK(!ReadTransaction(uint256::ONE, 0));
+
+    // It is not safe to stop and destroy the index until it finishes handling
+    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
+    // call above is sufficient to ensure this, but the
+    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
+    // TSAN always sees the test thread waiting for the notification thread, and
+    // avoid potential false positive reports.
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    // shutdown sequence (c.f. Shutdown() in init.cpp)
+    index.Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -79,6 +79,7 @@ class InitTest(BitcoinTestFramework):
             b'txindex thread start',
             b'block filter index thread start',
             b'coinstatsindex thread start',
+            b'locationsindex thread start',
             b'msghand thread start',
             b'net thread start',
             b'addcon thread start',
@@ -86,7 +87,7 @@ class InitTest(BitcoinTestFramework):
         if self.is_wallet_compiled():
             lines_to_terminate_after.append(b'Verifying wallet')
 
-        args = ['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1']
+        args = ['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1', '-locationsindex=1']
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will terminate after line {terminate_line}")
             with node.busy_wait_for_debug_log([terminate_line]):
@@ -126,6 +127,11 @@ class InitTest(BitcoinTestFramework):
                 'filepath_glob': 'indexes/txindex/MANIFEST*',
                 'error_message': 'LevelDB error: Corruption: CURRENT points to a non-existent file',
                 'startup_args': ['-txindex=1'],
+            },
+            {
+                'filepath_glob': 'indexes/locations/db/MANIFEST*',
+                'error_message': 'LevelDB error: Corruption: CURRENT points to a non-existent file',
+                'startup_args': ['-locationsindex=1'],
             },
             # Removing these files does not result in a startup error:
             # 'indexes/blockfilter/basic/*.dat', 'indexes/blockfilter/basic/db/*.*', 'indexes/coinstats/db/*.*',
@@ -167,6 +173,16 @@ class InitTest(BitcoinTestFramework):
                 'filepath_glob': 'indexes/txindex/CURRENT',
                 'error_message': 'LevelDB error: Corruption',
                 'startup_args': ['-txindex=1'],
+            },
+            {
+                'filepath_glob': 'indexes/locations/db/*.log',
+                'error_message': 'LevelDB error: Corruption',
+                'startup_args': ['-locationsindex=1'],
+            },
+            {
+                'filepath_glob': 'indexes/locations/db/CURRENT',
+                'error_message': 'LevelDB error: Corruption',
+                'startup_args': ['-locationsindex=1'],
             },
             # Perturbing these files does not result in a startup error:
             # 'indexes/blockfilter/basic/*.dat', 'indexes/txindex/MANIFEST*', 'indexes/txindex/LOCK'


### PR DESCRIPTION
Currently, electrs and other indexers map between an address/scripthash to the list of the relevant transactions.

However, in order to fetch those transactions from bitcoind, electrs relies on reading the whole block and post-filtering for a specific transaction[^1]. Other indexers use a `txindex` to fetch a transaction using its txid [^2][^3][^4].

The above approach has significant storage and CPU overhead, since the `txid` is a pseudo-random 32-byte value.

This PR is adding support for using the transaction's position within its block to be able to fetch it directly using [REST API](https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md), using the following HTTP request (to fetch the `N`-th transaction from `BLOCKHASH`):

```
GET /rest/txfromblock/BLOCKHASH-N.bin
```

If binary response format is used, the transaction data will be read directly from the storage and sent back to the client, without any deserialization overhead.

The resulting index is much smaller (allowing it to be cached in RAM):
```
$ du -sh indexes/locations/ indexes/txindex/
2.5G	indexes/locations/
57G	indexes/txindex/
```

The new index is using the following DB schema:

```c++
struct DBKey {
    uint256 hash;   // blockhash
    uint32_t row;   // allow splitting one block's transactions into multiple DB rows
};

struct DBValue {
    FlatFilePos block_pos;          // file id + offset of the block
    std::vector<uint32_t> offsets;  // a list of transaction offsets within the block
};
```

For example, when fetching the 5000th transaction of [block #90005](https://mempool.space/block/000000000000000000017bfd05b5fa367a424c4a565a4baf7950d9e8605df8ec) using `ab -k -c 1 -n 100000`, enabled `locationsindex` improves the performance [~19x (2.574ms → 0.136ms)](https://github.com/bitcoin/bitcoin/pull/32541#issuecomment-3250323045). 

I am working on a proof-of-concept indexer (https://github.com/romanz/bindex-rs) which is using https://github.com/bitcoin/bitcoin/pull/32540 & https://github.com/bitcoin/bitcoin/pull/32541 - please let me know if there are any questions/comments/concerns :)

[^1]: https://github.com/romanz/electrs/blob/master/doc/schema.md
[^2]: https://github.com/Blockstream/electrs/blob/new-index/doc/schema.md#txstore
[^3]: https://github.com/spesmilo/electrumx/blob/master/docs/HOWTO.rst#prerequisites
[^4]: https://github.com/cculianu/Fulcrum/blob/master/README.md#requirements

