### PR TITLE
kernel: Remove dependency on clientversion

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -79,7 +79,6 @@ add_library(bitcoinkernel
   ../validation.cpp
   ../validationinterface.cpp
   ../versionbits.cpp
-  $<TARGET_OBJECTS:bitcoin_clientversion>
   $<TARGET_OBJECTS:bitcoin_crypto>
   $<TARGET_OBJECTS:leveldb>
   $<TARGET_OBJECTS:crc32c>

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -6,7 +6,6 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <clientversion.h>
 #include <tinyformat.h>
 
 #include <cstdio>
@@ -18,10 +17,8 @@
 std::string StrFormatInternalBug(std::string_view msg, const std::source_location& loc)
 {
     return strprintf("Internal bug detected: %s\n%s:%d (%s)\n"
-                     "%s %s\n"
                      "Please report this issue here: %s\n",
-                     msg, loc.file_name(), loc.line(), loc.function_name(),
-                     CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
+                     msg, loc.file_name(), loc.line(), loc.function_name(), CLIENT_BUGREPORT);
 }
 
 NonFatalCheckError::NonFatalCheckError(std::string_view msg, const std::source_location& loc)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -10,7 +10,6 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <checkqueue.h>
-#include <clientversion.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
@@ -3881,8 +3880,8 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     auto prev_tx_sum = [](CBlockIndex& block) { return block.nTx + (block.pprev ? block.pprev->m_chain_tx_count : 0); };
     if (!Assume(pindexNew->m_chain_tx_count == 0 || pindexNew->m_chain_tx_count == prev_tx_sum(*pindexNew) ||
                 pindexNew == GetSnapshotBaseBlock())) {
-        LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
-            pindexNew->nHeight, pindexNew->m_chain_tx_count, prev_tx_sum(*pindexNew), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
+        LogWarning("%s", STR_INTERNAL_BUG(strprintf("block %d has unexpected m_chain_tx_count %i that should be %i",
+            pindexNew->nHeight, pindexNew->m_chain_tx_count, prev_tx_sum(*pindexNew))));
         pindexNew->m_chain_tx_count = 0;
     }
     pindexNew->nFile = pos.nFile;
@@ -3909,8 +3908,8 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             // assumeutxo snapshot block if assumeutxo snapshot metadata has an
             // incorrect hardcoded AssumeutxoData::m_chain_tx_count value.
             if (!Assume(pindex->m_chain_tx_count == 0 || pindex->m_chain_tx_count == prev_tx_sum(*pindex))) {
-                LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
-                   pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
+                LogWarning("%s", STR_INTERNAL_BUG(strprintf("block %d has unexpected m_chain_tx_count %i that should be %i",
+                   pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex))));
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
             pindex->nSequenceId = nBlockSequenceId++;


### PR DESCRIPTION
Including a Bitcoin-Core specific version does not make sense if used by external applications.
