### PR TITLE
scripted-diff: test: remove 'descriptors=True' argument for `createwallet` calls

### DIFF
--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -60,7 +60,6 @@ class MempoolPersistTest(BitcoinTestFramework):
         if self.is_wallet_compiled():
             self.nodes[2].createwallet(
                 wallet_name="watch",
-                descriptors=True,
                 disable_private_keys=True,
                 load_on_startup=False,
             )

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -606,7 +606,7 @@ class WalletTest(BitcoinTestFramework):
         # Prevent race of listunspent with outstanding TxAddedToMempool notifications
         self.nodes[0].syncwithvalidationinterfacequeue()
         # Now import the descriptors, make sure we can identify on which descriptor each coin was received.
-        self.nodes[0].createwallet(wallet_name="wo", descriptors=True, disable_private_keys=True)
+        self.nodes[0].createwallet(wallet_name="wo", disable_private_keys=True)
         wo_wallet = self.nodes[0].get_wallet_rpc("wo")
         wo_wallet.importdescriptors([
             {

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -71,7 +71,7 @@ class WalletDescriptorTest(BitcoinTestFramework):
     def run_test(self):
         # Make a descriptor wallet
         self.log.info("Making a descriptor wallet")
-        self.nodes[0].createwallet(wallet_name="desc1", descriptors=True)
+        self.nodes[0].createwallet(wallet_name="desc1")
 
         # A descriptor wallet should have 100 addresses * 4 types = 400 keys
         self.log.info("Checking wallet info")
@@ -125,7 +125,7 @@ class WalletDescriptorTest(BitcoinTestFramework):
         assert_equal(addr_info['hdkeypath'], 'm/86h/1h/0h/1/0')
 
         # Make a wallet to receive coins at
-        self.nodes[0].createwallet(wallet_name="desc2", descriptors=True)
+        self.nodes[0].createwallet(wallet_name="desc2")
         recv_wrpc = self.nodes[0].get_wallet_rpc("desc2")
         send_wrpc = self.nodes[0].get_wallet_rpc("desc1")
 
@@ -175,19 +175,19 @@ class WalletDescriptorTest(BitcoinTestFramework):
         enc_rpc.getnewaddress() # Makes sure that we can get a new address from a born encrypted wallet
 
         self.log.info("Test blank descriptor wallets")
-        self.nodes[0].createwallet(wallet_name='desc_blank', blank=True, descriptors=True)
+        self.nodes[0].createwallet(wallet_name='desc_blank', blank=True)
         blank_rpc = self.nodes[0].get_wallet_rpc('desc_blank')
         assert_raises_rpc_error(-4, 'This wallet has no available keys', blank_rpc.getnewaddress)
 
         self.log.info("Test descriptor wallet with disabled private keys")
-        self.nodes[0].createwallet(wallet_name='desc_no_priv', disable_private_keys=True, descriptors=True)
+        self.nodes[0].createwallet(wallet_name='desc_no_priv', disable_private_keys=True)
         nopriv_rpc = self.nodes[0].get_wallet_rpc('desc_no_priv')
         assert_raises_rpc_error(-4, 'This wallet has no available keys', nopriv_rpc.getnewaddress)
 
         self.log.info("Test descriptor exports")
-        self.nodes[0].createwallet(wallet_name='desc_export', descriptors=True)
+        self.nodes[0].createwallet(wallet_name='desc_export')
         exp_rpc = self.nodes[0].get_wallet_rpc('desc_export')
-        self.nodes[0].createwallet(wallet_name='desc_import', disable_private_keys=True, descriptors=True)
+        self.nodes[0].createwallet(wallet_name='desc_import', disable_private_keys=True)
         imp_rpc = self.nodes[0].get_wallet_rpc('desc_import')
 
         addr_types = [('legacy', False, 'pkh(', '44h/1h/0h', -13),
@@ -244,7 +244,7 @@ class WalletDescriptorTest(BitcoinTestFramework):
                 assert_equal(exp_addr, imp_addr)
 
         self.log.info("Test that loading descriptor wallet containing legacy key types throws error")
-        self.nodes[0].createwallet(wallet_name="crashme", descriptors=True)
+        self.nodes[0].createwallet(wallet_name="crashme")
         self.nodes[0].unloadwallet("crashme")
         wallet_db = self.nodes[0].wallets_path / "crashme" / self.wallet_data_filename
         conn = sqlite3.connect(wallet_db)

--- a/test/functional/wallet_fast_rescan.py
+++ b/test/functional/wallet_fast_rescan.py
@@ -37,7 +37,7 @@ class WalletFastRescanTest(BitcoinTestFramework):
 
         self.log.info("Create descriptor wallet with backup")
         WALLET_BACKUP_FILENAME = node.datadir_path / 'wallet.bak'
-        node.createwallet(wallet_name='topup_test', descriptors=True)
+        node.createwallet(wallet_name='topup_test')
         w = node.get_wallet_rpc('topup_test')
         fixed_key = get_generate_key()
         print(w.importdescriptors([{"desc": descsum_create(f"wpkh({fixed_key.privkey})"), "timestamp": "now"}]))
@@ -66,7 +66,7 @@ class WalletFastRescanTest(BitcoinTestFramework):
         txids_fast = self.get_wallet_txids(node, 'rescan_fast')
 
         self.log.info("Import non-active descriptors with block filter index")
-        node.createwallet(wallet_name='rescan_fast_nonactive', descriptors=True, disable_private_keys=True, blank=True)
+        node.createwallet(wallet_name='rescan_fast_nonactive', disable_private_keys=True, blank=True)
         with node.assert_debug_log(['fast variant using block filters']):
             w = node.get_wallet_rpc('rescan_fast_nonactive')
             w.importdescriptors([{"desc": descriptor['desc'], "timestamp": 0} for descriptor in descriptors])
@@ -79,7 +79,7 @@ class WalletFastRescanTest(BitcoinTestFramework):
         txids_slow = self.get_wallet_txids(node, 'rescan_slow')
 
         self.log.info("Import non-active descriptors w/o block filter index")
-        node.createwallet(wallet_name='rescan_slow_nonactive', descriptors=True, disable_private_keys=True, blank=True)
+        node.createwallet(wallet_name='rescan_slow_nonactive', disable_private_keys=True, blank=True)
         with node.assert_debug_log(['slow variant inspecting all blocks']):
             w = node.get_wallet_rpc('rescan_slow_nonactive')
             w.importdescriptors([{"desc": descriptor['desc'], "timestamp": 0} for descriptor in descriptors])

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -65,14 +65,14 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info('Setting up wallets')
-        self.nodes[0].createwallet(wallet_name='w0', disable_private_keys=False, descriptors=True)
+        self.nodes[0].createwallet(wallet_name='w0', disable_private_keys=False)
         w0 = self.nodes[0].get_wallet_rpc('w0')
 
-        self.nodes[1].createwallet(wallet_name='w1', disable_private_keys=True, blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name='w1', disable_private_keys=True, blank=True)
         w1 = self.nodes[1].get_wallet_rpc('w1')
         assert_equal(w1.getwalletinfo()['keypoolsize'], 0)
 
-        self.nodes[1].createwallet(wallet_name="wpriv", disable_private_keys=False, blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name="wpriv", disable_private_keys=False, blank=True)
         wpriv = self.nodes[1].get_wallet_rpc("wpriv")
         assert_equal(wpriv.getwalletinfo()['keypoolsize'], 0)
 
@@ -428,7 +428,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
         # Make sure that we can use import and use multisig as addresses
         self.log.info('Test that multisigs can be imported, signed for, and getnewaddress\'d')
-        self.nodes[1].createwallet(wallet_name="wmulti_priv", disable_private_keys=False, blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name="wmulti_priv", disable_private_keys=False, blank=True)
         wmulti_priv = self.nodes[1].get_wallet_rpc("wmulti_priv")
         assert_equal(wmulti_priv.getwalletinfo()['keypoolsize'], 0)
 
@@ -472,7 +472,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(len(decoded['vin'][0]['txinwitness']), 4)
         self.sync_all()
 
-        self.nodes[1].createwallet(wallet_name="wmulti_pub", disable_private_keys=True, blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name="wmulti_pub", disable_private_keys=True, blank=True)
         wmulti_pub = self.nodes[1].get_wallet_rpc("wmulti_pub")
         assert_equal(wmulti_pub.getwalletinfo()['keypoolsize'], 0)
 
@@ -515,7 +515,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.nodes[1].loadwallet('wmulti_pub')
 
         self.log.info("Multisig with distributed keys")
-        self.nodes[1].createwallet(wallet_name="wmulti_priv1", descriptors=True)
+        self.nodes[1].createwallet(wallet_name="wmulti_priv1")
         wmulti_priv1 = self.nodes[1].get_wallet_rpc("wmulti_priv1")
         res = wmulti_priv1.importdescriptors([
         {
@@ -538,7 +538,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(res[1]['success'], True)
         assert_equal(res[1]['warnings'][0], 'Not all private keys provided. Some wallet functionality may return unexpected errors')
 
-        self.nodes[1].createwallet(wallet_name='wmulti_priv2', blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name='wmulti_priv2', blank=True)
         wmulti_priv2 = self.nodes[1].get_wallet_rpc('wmulti_priv2')
         res = wmulti_priv2.importdescriptors([
         {
@@ -569,7 +569,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.nodes[1].sendrawtransaction(tx_signed_2['hex'])
 
         self.log.info("We can create and use a huge multisig under P2WSH")
-        self.nodes[1].createwallet(wallet_name='wmulti_priv_big', blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name='wmulti_priv_big', blank=True)
         wmulti_priv_big = self.nodes[1].get_wallet_rpc('wmulti_priv_big')
         xkey = "tprv8ZgxMBicQKsPeZSeYx7VXDDTs3XrTcmZQpRLbAeSQFCQGgKwR4gKpcxHaKdoTNHniv4EPDJNdzA3KxRrrBHcAgth8fU5X4oCndkkxk39iAt/*"
         xkey_int = "tprv8ZgxMBicQKsPeZSeYx7VXDDTs3XrTcmZQpRLbAeSQFCQGgKwR4gKpcxHaKdoTNHniv4EPDJNdzA3KxRrrBHcAgth8fU5X4oCndkkxk39iAt/1/*"
@@ -605,7 +605,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.log.info("Under P2SH, multisig are standard with up to 15 "
                       "compressed keys")
         self.nodes[1].createwallet(wallet_name='multi_priv_big_legacy',
-                                   blank=True, descriptors=True)
+                                   blank=True)
         multi_priv_big = self.nodes[1].get_wallet_rpc('multi_priv_big_legacy')
         res = multi_priv_big.importdescriptors([
         {
@@ -634,7 +634,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         decoded = multi_priv_big.gettransaction(txid=txid, verbose=True)['decoded']
 
         self.log.info("Amending multisig with new private keys")
-        self.nodes[1].createwallet(wallet_name="wmulti_priv3", descriptors=True)
+        self.nodes[1].createwallet(wallet_name="wmulti_priv3")
         wmulti_priv3 = self.nodes[1].get_wallet_rpc("wmulti_priv3")
         res = wmulti_priv3.importdescriptors([
             {
@@ -685,13 +685,13 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                               "range": [0,4000],
                               "next_index": 4000}
 
-        self.nodes[0].createwallet("temp_wallet", blank=True, descriptors=True)
+        self.nodes[0].createwallet("temp_wallet", blank=True)
         temp_wallet = self.nodes[0].get_wallet_rpc("temp_wallet")
         temp_wallet.importdescriptors([descriptor])
         self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 1, temp_wallet.getnewaddress())
         self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 1, temp_wallet.getnewaddress())
 
-        self.nodes[0].createwallet("encrypted_wallet", blank=True, descriptors=True, passphrase="passphrase")
+        self.nodes[0].createwallet("encrypted_wallet", blank=True, passphrase="passphrase")
         encrypted_wallet = self.nodes[0].get_wallet_rpc("encrypted_wallet")
 
         descriptor["timestamp"] = 0
@@ -720,9 +720,9 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(temp_wallet.getbalance(), encrypted_wallet.getbalance())
 
         self.log.info("Multipath descriptors")
-        self.nodes[1].createwallet(wallet_name="multipath", descriptors=True, blank=True)
+        self.nodes[1].createwallet(wallet_name="multipath", blank=True)
         w_multipath = self.nodes[1].get_wallet_rpc("multipath")
-        self.nodes[1].createwallet(wallet_name="multipath_split", descriptors=True, blank=True)
+        self.nodes[1].createwallet(wallet_name="multipath_split", blank=True)
         w_multisplit = self.nodes[1].get_wallet_rpc("multipath_split")
         timestamp = int(time.time())
 

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -34,11 +34,11 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-18, 'No wallet is loaded.', node.listdescriptors)
 
         self.log.info('Test the command for empty descriptors wallet.')
-        node.createwallet(wallet_name='w2', blank=True, descriptors=True)
+        node.createwallet(wallet_name='w2', blank=True)
         assert_equal(0, len(node.get_wallet_rpc('w2').listdescriptors()['descriptors']))
 
         self.log.info('Test the command for a default descriptors wallet.')
-        node.createwallet(wallet_name='w3', descriptors=True)
+        node.createwallet(wallet_name='w3')
         result = node.get_wallet_rpc('w3').listdescriptors()
         assert_equal("w3", result['wallet_name'])
         assert_equal(8, len(result['descriptors']))
@@ -101,7 +101,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_equal(expected_private, wallet.listdescriptors(True))
 
         self.log.info('Test list private descriptors with watch-only wallet')
-        node.createwallet(wallet_name='watch-only', descriptors=True, disable_private_keys=True)
+        node.createwallet(wallet_name='watch-only', disable_private_keys=True)
         watch_only_wallet = node.get_wallet_rpc('watch-only')
         watch_only_wallet.importdescriptors([{
             'desc': descsum_create('wpkh(' + xpub_acc + ')'),
@@ -110,7 +110,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, 'Can\'t get descriptor string', watch_only_wallet.listdescriptors, True)
 
         self.log.info('Test non-active non-range combo descriptor')
-        node.createwallet(wallet_name='w4', blank=True, descriptors=True)
+        node.createwallet(wallet_name='w4', blank=True)
         wallet = node.get_wallet_rpc('w4')
         wallet.importdescriptors([{
             'desc': descsum_create('combo(' + node.get_deterministic_priv_key().key + ')'),

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -421,7 +421,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         # Create a watchonly wallet tracking two multisig descriptors.
         multi_a = descsum_create("wsh(multi(1,tpubD6NzVbkrYhZ4YBNjUo96Jxd1u4XKWgnoc7LsA1jz3Yc2NiDbhtfBhaBtemB73n9V5vtJHwU6FVXwggTbeoJWQ1rzdz8ysDuQkpnaHyvnvzR/*,tpubD6NzVbkrYhZ4YHdDGMAYGaWxMSC1B6tPRTHuU5t3BcfcS3nrF523iFm5waFd1pP3ZvJt4Jr8XmCmsTBNx5suhcSgtzpGjGMASR3tau1hJz4/*))")
         multi_b = descsum_create("wsh(multi(1,tpubD6NzVbkrYhZ4YHdDGMAYGaWxMSC1B6tPRTHuU5t3BcfcS3nrF523iFm5waFd1pP3ZvJt4Jr8XmCmsTBNx5suhcSgtzpGjGMASR3tau1hJz4/*,tpubD6NzVbkrYhZ4Y2RLiuEzNQkntjmsLpPYDm3LTRBYynUQtDtpzeUKAcb9sYthSFL3YR74cdFgF5mW8yKxv2W2CWuZDFR2dUpE5PF9kbrVXNZ/*))")
-        self.nodes[0].createwallet(wallet_name="wo", descriptors=True, disable_private_keys=True)
+        self.nodes[0].createwallet(wallet_name="wo", disable_private_keys=True)
         wo_wallet = self.nodes[0].get_wallet_rpc("wo")
         wo_wallet.importdescriptors([
             {

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -322,10 +322,10 @@ class WalletMiniscriptTest(BitcoinTestFramework):
         self.log.info("Making a descriptor wallet")
         self.funder = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
         self.nodes[0].createwallet(
-            wallet_name="ms_wo", descriptors=True, disable_private_keys=True
+            wallet_name="ms_wo", disable_private_keys=True
         )
         self.ms_wo_wallet = self.nodes[0].get_wallet_rpc("ms_wo")
-        self.nodes[0].createwallet(wallet_name="ms_sig", descriptors=True)
+        self.nodes[0].createwallet(wallet_name="ms_sig")
         self.ms_sig_wallet = self.nodes[0].get_wallet_rpc("ms_sig")
 
         # Sanity check we wouldn't let an insane Miniscript descriptor in

--- a/test/functional/wallet_miniscript_decaying_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_miniscript_decaying_multisig_descriptor_psbt.py
@@ -37,7 +37,7 @@ class WalletMiniscriptDecayingMultisigDescriptorPSBTTest(BitcoinTestFramework):
 
     def create_multisig(self, external_xpubs, internal_xpubs):
         """The multisig is created by importing the following descriptors. The resulting wallet is watch-only and every signer can do this."""
-        self.node.createwallet(wallet_name=f"{self.name}", blank=True, descriptors=True, disable_private_keys=True)
+        self.node.createwallet(wallet_name=f"{self.name}", blank=True, disable_private_keys=True)
         multisig = self.node.get_wallet_rpc(f"{self.name}")
         # spending policy: `thresh(4,pk(key_1),pk(key_2),pk(key_3),pk(key_4),after(t1),after(t2),after(t3))`
         # IMPORTANT: when backing up your descriptor, the order of key_1...key_4 must be correct!
@@ -72,14 +72,14 @@ class WalletMiniscriptDecayingMultisigDescriptorPSBTTest(BitcoinTestFramework):
         self.log.info(f"Testing a miniscript multisig which starts as 4-of-4 and 'decays' to 3-of-4 at block height {self.locktimes[0]}, 2-of-4 at {self.locktimes[1]}, and finally 1-of-4 at {self.locktimes[2]}...")
 
         self.log.info("Create the signer wallets and get their xpubs...")
-        signers = [self.node.get_wallet_rpc(self.node.createwallet(wallet_name=f"signer_{i}", descriptors=True)["name"]) for i in range(self.N)]
+        signers = [self.node.get_wallet_rpc(self.node.createwallet(wallet_name=f"signer_{i}")["name"]) for i in range(self.N)]
         external_xpubs, internal_xpubs = [[self._get_xpub(signer, internal) for signer in signers] for internal in [False, True]]
 
         self.log.info("Create the watch-only decaying multisig using signers' xpubs...")
         multisig = self.create_multisig(external_xpubs, internal_xpubs)
 
         self.log.info("Get a mature utxo to send to the multisig...")
-        coordinator_wallet = self.node.get_wallet_rpc(self.node.createwallet(wallet_name="coordinator", descriptors=True)["name"])
+        coordinator_wallet = self.node.get_wallet_rpc(self.node.createwallet(wallet_name="coordinator")["name"])
         self.generatetoaddress(self.node, 101, coordinator_wallet.getnewaddress())
 
         self.log.info("Send funds to the multisig's receiving address...")

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -47,7 +47,7 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
     def participants_create_multisigs(self, external_xpubs, internal_xpubs):
         """The multisig is created by importing the following descriptors. The resulting wallet is watch-only and every participant can do this."""
         for i, node in enumerate(self.nodes):
-            node.createwallet(wallet_name=f"{self.name}_{i}", blank=True, descriptors=True, disable_private_keys=True)
+            node.createwallet(wallet_name=f"{self.name}_{i}", blank=True, disable_private_keys=True)
             multisig = node.get_wallet_rpc(f"{self.name}_{i}")
             external = multisig.getdescriptorinfo(f"wsh(sortedmulti({self.M},{','.join(external_xpubs)}))")
             internal = multisig.getdescriptorinfo(f"wsh(sortedmulti({self.M},{','.join(internal_xpubs)}))")
@@ -77,7 +77,7 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
         participants = {
             # Every participant generates an xpub. The most straightforward way is to create a new descriptor wallet.
             # This wallet will be the participant's `signer` for the resulting multisig. Avoid reusing this wallet for any other purpose (for privacy reasons).
-            "signers": [node.get_wallet_rpc(node.createwallet(wallet_name=f"participant_{self.nodes.index(node)}", descriptors=True)["name"]) for node in self.nodes],
+            "signers": [node.get_wallet_rpc(node.createwallet(wallet_name=f"participant_{self.nodes.index(node)}")["name"]) for node in self.nodes],
             # After participants generate and exchange their xpubs they will each create their own watch-only multisig.
             # Note: these multisigs are all the same, this just highlights that each participant can independently verify everything on their own node.
             "multisigs": []

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -62,23 +62,23 @@ class WalletSignerTest(BitcoinTestFramework):
 
         # Create new wallets for an external signer.
         # disable_private_keys and descriptors must be true:
-        assert_raises_rpc_error(-4, "Private keys must be disabled when using an external signer", self.nodes[1].createwallet, wallet_name='not_hww', disable_private_keys=False, descriptors=True, external_signer=True)
-        self.nodes[1].createwallet(wallet_name='hww', disable_private_keys=True, descriptors=True, external_signer=True)
+        assert_raises_rpc_error(-4, "Private keys must be disabled when using an external signer", self.nodes[1].createwallet, wallet_name='not_hww', disable_private_keys=False, external_signer=True)
+        self.nodes[1].createwallet(wallet_name='hww', disable_private_keys=True, external_signer=True)
         hww = self.nodes[1].get_wallet_rpc('hww')
         assert_equal(hww.getwalletinfo()["external_signer"], True)
 
         # Flag can't be set afterwards (could be added later for non-blank descriptor based watch-only wallets)
-        self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=False)
+        self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, external_signer=False)
         not_hww = self.nodes[1].get_wallet_rpc('not_hww')
         assert_equal(not_hww.getwalletinfo()["external_signer"], False)
         assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
 
-        # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=True)
+        # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, external_signer=True)
 
         # TODO: Handle error thrown by script
         # self.set_mock_result(self.nodes[1], "2")
         # assert_raises_rpc_error(-1, 'Unable to parse JSON',
-        #     self.nodes[1].createwallet, wallet_name='not_hww2', disable_private_keys=True, descriptors=True, external_signer=False
+        #     self.nodes[1].createwallet, wallet_name='not_hww2', disable_private_keys=True, external_signer=False
         # )
         # self.clear_mock_result(self.nodes[1])
 
@@ -136,7 +136,7 @@ class WalletSignerTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
 
         # Load private key into wallet to generate a signed PSBT for the mock
-        self.nodes[1].createwallet(wallet_name="mock", disable_private_keys=False, blank=True, descriptors=True)
+        self.nodes[1].createwallet(wallet_name="mock", disable_private_keys=False, blank=True)
         mock_wallet = self.nodes[1].get_wallet_rpc("mock")
         assert mock_wallet.getwalletinfo()['private_keys_enabled']
 
@@ -165,7 +165,7 @@ class WalletSignerTest(BitcoinTestFramework):
 
         # # Create a new wallet and populate with specific public keys, in order
         # # to work with the mock signed PSBT.
-        # self.nodes[1].createwallet(wallet_name="hww4", disable_private_keys=True, descriptors=True, external_signer=True)
+        # self.nodes[1].createwallet(wallet_name="hww4", disable_private_keys=True, external_signer=True)
         # hww4 = self.nodes[1].get_wallet_rpc("hww4")
         #
         # descriptors = [{
@@ -237,13 +237,13 @@ class WalletSignerTest(BitcoinTestFramework):
     def test_invalid_signer(self):
         self.log.debug(f"-signer={self.mock_invalid_signer_path()}")
         self.log.info('Test invalid external signer')
-        assert_raises_rpc_error(-1, "Invalid descriptor", self.nodes[1].createwallet, wallet_name='hww_invalid', disable_private_keys=True, descriptors=True, external_signer=True)
+        assert_raises_rpc_error(-1, "Invalid descriptor", self.nodes[1].createwallet, wallet_name='hww_invalid', disable_private_keys=True, external_signer=True)
 
     def test_multiple_signers(self):
         self.log.debug(f"-signer={self.mock_multi_signers_path()}")
         self.log.info('Test multiple external signers')
 
-        assert_raises_rpc_error(-1, "GetExternalSigner: More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, descriptors=True, external_signer=True)
+        assert_raises_rpc_error(-1, "GetExternalSigner: More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, external_signer=True)
 
 if __name__ == '__main__':
     WalletSignerTest(__file__).main()

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -229,9 +229,9 @@ class WalletTaprootTest(BitcoinTestFramework):
 
         # Create wallets
         wallet_uuid = uuid.uuid4().hex
-        self.nodes[0].createwallet(wallet_name=f"privs_tr_enabled_{wallet_uuid}", descriptors=True, blank=True)
-        self.nodes[0].createwallet(wallet_name=f"pubs_tr_enabled_{wallet_uuid}", descriptors=True, blank=True, disable_private_keys=True)
-        self.nodes[0].createwallet(wallet_name=f"addr_gen_{wallet_uuid}", descriptors=True, disable_private_keys=True, blank=True)
+        self.nodes[0].createwallet(wallet_name=f"privs_tr_enabled_{wallet_uuid}", blank=True)
+        self.nodes[0].createwallet(wallet_name=f"pubs_tr_enabled_{wallet_uuid}", blank=True, disable_private_keys=True)
+        self.nodes[0].createwallet(wallet_name=f"addr_gen_{wallet_uuid}", disable_private_keys=True, blank=True)
         privs_tr_enabled = self.nodes[0].get_wallet_rpc(f"privs_tr_enabled_{wallet_uuid}")
         pubs_tr_enabled = self.nodes[0].get_wallet_rpc(f"pubs_tr_enabled_{wallet_uuid}")
         addr_gen = self.nodes[0].get_wallet_rpc(f"addr_gen_{wallet_uuid}")
@@ -270,7 +270,7 @@ class WalletTaprootTest(BitcoinTestFramework):
 
         # Create wallets
         wallet_uuid = uuid.uuid4().hex
-        self.nodes[0].createwallet(wallet_name=f"rpc_online_{wallet_uuid}", descriptors=True, blank=True)
+        self.nodes[0].createwallet(wallet_name=f"rpc_online_{wallet_uuid}", blank=True)
         rpc_online = self.nodes[0].get_wallet_rpc(f"rpc_online_{wallet_uuid}")
 
         desc_pay = self.make_desc(pattern, privmap, keys_pay)
@@ -311,9 +311,9 @@ class WalletTaprootTest(BitcoinTestFramework):
 
         # Create wallets
         wallet_uuid = uuid.uuid4().hex
-        self.nodes[0].createwallet(wallet_name=f"psbt_online_{wallet_uuid}", descriptors=True, disable_private_keys=True, blank=True)
-        self.nodes[1].createwallet(wallet_name=f"psbt_offline_{wallet_uuid}", descriptors=True, blank=True)
-        self.nodes[1].createwallet(f"key_only_wallet_{wallet_uuid}", descriptors=True, blank=True)
+        self.nodes[0].createwallet(wallet_name=f"psbt_online_{wallet_uuid}", disable_private_keys=True, blank=True)
+        self.nodes[1].createwallet(wallet_name=f"psbt_offline_{wallet_uuid}", blank=True)
+        self.nodes[1].createwallet(f"key_only_wallet_{wallet_uuid}", blank=True)
         psbt_online = self.nodes[0].get_wallet_rpc(f"psbt_online_{wallet_uuid}")
         psbt_offline = self.nodes[1].get_wallet_rpc(f"psbt_offline_{wallet_uuid}")
         key_only_wallet = self.nodes[1].get_wallet_rpc(f"key_only_wallet_{wallet_uuid}")


### PR DESCRIPTION
Descriptor wallets are already created by default [since v23.0](https://github.com/bitcoin/bitcoin/blob/7710a31f0cb69a04529f39840196826d0b9770ab/doc/release-notes/release-notes-23.0.md?plain=1#L171), but since the recent legacy wallet removal the `descriptors` parameter *must* be True for the `createwallet` RPC (see commit 9f04e02ffaee0fe64027dc56c7bea3885254321a), i.e. still passing it wouldn't contain any information for test readers anymore. So simply drop them in the functional tests in order to reduce code bloat. The only exception is calls to older versions, which happens in `wallet_backwards_compatibility.py` and is explicitly excluded in the scripted diff.