### PR TITLE
Mining: Avoid copying template CBlocks

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -33,25 +33,25 @@ class BlockTemplate
 public:
     virtual ~BlockTemplate() = default;
 
-    virtual CBlockHeader getBlockHeader() = 0;
+    virtual const CBlockHeader& getBlockHeader() const = 0;
     // Block contains a dummy coinbase transaction that should not be used.
-    virtual CBlock getBlock() = 0;
+    virtual const CBlock& getBlock() const = 0;
 
     // Fees per transaction, not including coinbase transaction.
-    virtual std::vector<CAmount> getTxFees() = 0;
+    virtual const std::vector<CAmount>& getTxFees() const = 0;
     // Sigop cost per transaction, not including coinbase transaction.
-    virtual std::vector<int64_t> getTxSigops() = 0;
+    virtual const std::vector<int64_t>& getTxSigops() const = 0;
 
-    virtual CTransactionRef getCoinbaseTx() = 0;
-    virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
-    virtual int getWitnessCommitmentIndex() = 0;
+    virtual CTransactionRef getCoinbaseTx() const = 0;
+    virtual const std::vector<unsigned char>& getCoinbaseCommitment() const = 0;
+    virtual int getWitnessCommitmentIndex() const = 0;
 
     /**
      * Compute merkle path to the coinbase transaction
      *
      * @return merkle path ordered from the deepest
      */
-    virtual std::vector<uint256> getCoinbaseMerklePath() = 0;
+    virtual std::vector<uint256> getCoinbaseMerklePath() const = 0;
 
     /**
      * Construct and broadcast the block.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -887,42 +887,42 @@ public:
         assert(m_block_template);
     }
 
-    CBlockHeader getBlockHeader() override
+    const CBlockHeader& getBlockHeader() const override
     {
         return m_block_template->block;
     }
 
-    CBlock getBlock() override
+    const CBlock& getBlock() const override
     {
         return m_block_template->block;
     }
 
-    std::vector<CAmount> getTxFees() override
+    const std::vector<CAmount>& getTxFees() const override
     {
         return m_block_template->vTxFees;
     }
 
-    std::vector<int64_t> getTxSigops() override
+    const std::vector<int64_t>& getTxSigops() const override
     {
         return m_block_template->vTxSigOpsCost;
     }
 
-    CTransactionRef getCoinbaseTx() override
+    CTransactionRef getCoinbaseTx() const override
     {
         return m_block_template->block.vtx[0];
     }
 
-    std::vector<unsigned char> getCoinbaseCommitment() override
+    const std::vector<unsigned char>& getCoinbaseCommitment() const override
     {
         return m_block_template->vchCoinbaseCommitment;
     }
 
-    int getWitnessCommitmentIndex() override
+    int getWitnessCommitmentIndex() const override
     {
         return GetWitnessCommitmentIndex(m_block_template->block);
     }
 
-    std::vector<uint256> getCoinbaseMerklePath() override
+    std::vector<uint256> getCoinbaseMerklePath() const override
     {
         return TransactionMerklePath(m_block_template->block, 0);
     }

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -75,7 +75,7 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)
     block.hashMerkleRoot = BlockMerkleRoot(block);
 }
 
-static BlockAssembler::Options ClampOptions(BlockAssembler::Options options)
+static BlockCreateOptions ClampOptions(BlockCreateOptions options)
 {
     Assert(options.block_reserved_weight <= MAX_BLOCK_WEIGHT);
     Assert(options.block_reserved_weight >= MINIMUM_BLOCK_RESERVED_WEIGHT);

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -37,8 +37,6 @@ using interfaces::BlockRef;
 namespace node {
 class KernelNotifications;
 
-static const bool DEFAULT_PRINT_MODIFIED_FEE = false;
-
 struct CBlockTemplate
 {
     CBlock block;
@@ -169,14 +167,7 @@ private:
     Chainstate& m_chainstate;
 
 public:
-    struct Options : BlockCreateOptions {
-        // Configuration parameters for the block size
-        size_t nBlockMaxWeight{DEFAULT_BLOCK_MAX_WEIGHT};
-        CFeeRate blockMinFeeRate{DEFAULT_BLOCK_MIN_TX_FEE};
-        // Whether to call TestBlockValidity() at the end of CreateNewBlock().
-        bool test_block_validity{true};
-        bool print_modified_fee{DEFAULT_PRINT_MODIFIED_FEE};
-    };
+    using Options = BlockCreateOptions;
 
     explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options);
 

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -14,10 +14,12 @@
 #define BITCOIN_NODE_TYPES_H
 
 #include <consensus/amount.h>
-#include <cstddef>
+#include <policy/feerate.h>
 #include <policy/policy.h>
 #include <script/script.h>
 #include <util/time.h>
+
+#include <cstddef>
 
 namespace node {
 enum class TransactionError {
@@ -30,6 +32,8 @@ enum class TransactionError {
     MAX_BURN_EXCEEDED,
     INVALID_PACKAGE,
 };
+
+static const bool DEFAULT_PRINT_MODIFIED_FEE = false;
 
 struct BlockCreateOptions {
     /**
@@ -62,6 +66,13 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+
+    // Configuration parameters for the block size
+    size_t nBlockMaxWeight{DEFAULT_BLOCK_MAX_WEIGHT};
+    CFeeRate blockMinFeeRate{DEFAULT_BLOCK_MIN_TX_FEE};
+    // Whether to call TestBlockValidity() at the end of CreateNewBlock().
+    bool test_block_validity{true};
+    bool print_modified_fee{DEFAULT_PRINT_MODIFIED_FEE};
 };
 
 struct BlockWaitOptions {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -901,8 +901,8 @@ static UniValue TemplateToJSON(const Consensus::Params& consensusParams, const C
 
     UniValue transactions(UniValue::VARR);
     std::map<uint256, int64_t> setTxIndex;
-    std::vector<CAmount> tx_fees{block_template->getTxFees()};
-    std::vector<CAmount> tx_sigops{block_template->getTxSigops()};
+    const std::vector<CAmount>& tx_fees{block_template->getTxFees()};
+    const std::vector<CAmount>& tx_sigops{block_template->getTxSigops()};
 
     int i = 0;
     for (const auto& it : block.vtx) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -169,7 +169,7 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
         CHECK_NONFATAL(block_template);
 
         std::shared_ptr<const CBlock> block_out;
-        if (!GenerateBlock(chainman, block_template->getBlock(), nMaxTries, block_out, /*process_new_block=*/true)) {
+        if (!GenerateBlock(chainman, CBlock{block_template->getBlock()}, nMaxTries, block_out, /*process_new_block=*/true)) {
             break;
         }
 


### PR DESCRIPTION
Refactoring to avoid unnecessary copies/complexity, at least in the mainnet paths.

Also abstracts out a new `TemplateToJSON` function to keep track of variable scoping better.