### PR TITLE
cmake: Add missed `SSE41_CXXFLAGS`

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -47,7 +47,7 @@ if(HAVE_SSE41 AND HAVE_X86_SHANI)
   target_compile_definitions(bitcoin_crypto PRIVATE ENABLE_SSE41 ENABLE_X86_SHANI)
   target_sources(bitcoin_crypto PRIVATE sha256_x86_shani.cpp)
   set_property(SOURCE sha256_x86_shani.cpp PROPERTY
-    COMPILE_OPTIONS ${X86_SHANI_CXXFLAGS}
+    COMPILE_OPTIONS ${SSE41_CXXFLAGS} ${X86_SHANI_CXXFLAGS}
   )
 endif()
 


### PR DESCRIPTION
The missed flags were noticed when building with clang-cl on Windows.