### PR TITLE
doc: add alpine build instructions

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -53,6 +53,18 @@ To build dependencies for the current arch+OS:
 
     gmake
 
+### Alpine
+
+    apk add bash build-base cmake curl make patch
+
+Skip the following packages if you don't intend to use the GUI and will build with [`NO_QT=1`](#dependency-options):
+
+    apk add bison linux-headers samurai pkgconf python3
+
+To build dependencies for the current arch+OS:
+
+    make
+
 ## Configuring Bitcoin Core
 
 **When configuring Bitcoin Core, CMake by default will ignore the depends output.** In

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -161,8 +161,7 @@ ZMQ dependencies (provides ZMQ API):
 
     apk add zeromq-dev
 
-User-Space, Statically Defined Tracing (USDT) is not directly compatible on
-Alpine as it uses libc functionality not available on musl.
+User-Space, Statically Defined Tracing (USDT) is not supported or tested on Alpine Linux at this time.
 
 GUI dependencies:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -139,6 +139,46 @@ The GUI will be able to encode addresses in QR codes unless this feature is expl
 
 Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
 
+### Alpine
+
+#### Dependency Build Instructions
+
+Build requirements:
+
+    apk add build-base cmake linux-headers pkgconf python3
+
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
+
+    apk add libevent-dev boost-dev
+
+SQLite is required for the descriptor wallet:
+
+    apk add sqlite-dev
+
+To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+
+ZMQ dependencies (provides ZMQ API):
+
+    apk add zeromq-dev
+
+User-Space, Statically Defined Tracing (USDT) is not directly compatible on
+Alpine as it uses libc functionality not available on musl.
+
+GUI dependencies:
+
+Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
+
+    apk add qt6-qtbase-dev  qt6-qttools-dev
+
+For Qt 6.5 and later, the `xcb-util-cursor` package must be installed at runtime.
+
+The GUI will be able to encode addresses in QR codes unless this feature is explicitly disabled. To install libqrencode, run:
+
+    apk add libqrencode-dev
+
+Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
+
 ## Dependencies
 
 See [dependencies.md](dependencies.md) for a complete overview, and


### PR DESCRIPTION
Closes: #32512

- Provide Alpine build instructions in build-unix.md.
- Instructions cover building all components except USDT which is marked as unsupported for Alpine.