### PR TITLE
ci: Move DEBUG=1 to centos task

### DIFF
--- a/ci/test/00_setup_env_native_centos.sh
+++ b/ci/test/00_setup_env_native_centos.sh
@@ -10,6 +10,6 @@ export CONTAINER_NAME=ci_native_centos
 export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
 export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make ninja-build git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake"
 export PIP_PACKAGES="pyzmq"
-export DEP_OPTS="DEBUG=1"  # Temporarily enable a DEBUG=1 build to check for GCC-bug-117966 regressions. This can be removed once the minimum GCC version is bumped to 12 in the previous releases task, see https://github.com/bitcoin/bitcoin/issues/31436#issuecomment-2530717875
+export DEP_OPTS="DEBUG=1"
 export GOAL="install"
 export BITCOIN_CONFIG="-DWITH_ZMQ=ON -DBUILD_GUI=ON -DREDUCE_EXPORTS=ON -DCMAKE_BUILD_TYPE=Debug"

--- a/ci/test/00_setup_env_native_previous_releases.sh
+++ b/ci/test/00_setup_env_native_previous_releases.sh
@@ -10,7 +10,7 @@ export CONTAINER_NAME=ci_native_previous_releases
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:22.04"
 # Use minimum supported python3.10 and gcc-11, see doc/dependencies.md
 export PACKAGES="gcc-11 g++-11 python3-zmq"
-export DEP_OPTS="DEBUG=1 CC=gcc-11 CXX=g++-11"
+export DEP_OPTS="CC=gcc-11 CXX=g++-11"
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
@@ -20,8 +20,8 @@ export BITCOIN_CONFIG="\
  -DWITH_ZMQ=ON -DBUILD_GUI=ON -DREDUCE_EXPORTS=ON \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_FLAGS='-funsigned-char' \
- -DCMAKE_C_FLAGS_DEBUG='-g0 -O2' \
+ -DCMAKE_C_FLAGS_DEBUG='-g2 -O2' \
  -DCMAKE_CXX_FLAGS='-funsigned-char' \
- -DCMAKE_CXX_FLAGS_DEBUG='-g0 -O2' \
+ -DCMAKE_CXX_FLAGS_DEBUG='-g2 -O2' \
  -DAPPEND_CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE' \
 "


### PR DESCRIPTION
The glibcxx debug mode has many bugs in prior gcc releases:

* https://github.com/bitcoin/bitcoin/issues/32524#issuecomment-2890411766
* https://github.com/bitcoin/bitcoin/issues/31436#issuecomment-2530717875
* ...

Instead of working around all of them, just use the existing `ci_native_centos` task with gcc-14 to have it enabled. This also follows the logic of other sanitizers (tsan, asan, ubsan, msan, valgrind, ...) to generally prefer the latest version of the sanitizer for the latests features and bugfixes.

Fixes #32524.

Also, while touching the `ci_native_previous_releases`, increase g0 to g2, so that it is easier for developers to use gdb inside the CI without having to re-compile