### PR TITLE
doc: remove // for ... comments

### DIFF
--- a/src/banman.h
+++ b/src/banman.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_BANMAN_H
@@ -7,7 +7,7 @@
 
 #include <addrdb.h>
 #include <common/bloom.h>
-#include <net_types.h> // For banmap_t
+#include <net_types.h>
 #include <sync.h>
 #include <util/fs.h>
 

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,9 +19,9 @@
 #include <util/string.h>
 
 #ifdef WIN32
-#include <codecvt>    /* for codecvt_utf8_utf16 */
-#include <shellapi.h> /* for CommandLineToArgvW */
-#include <shlobj.h>   /* for CSIDL_APPDATA */
+#include <codecvt>
+#include <shellapi.h>
+#include <shlobj.h>
 #endif
 
 #include <algorithm>

--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -7,13 +7,12 @@
 
 #include <crypto/sha3.h>
 #include <crypto/common.h>
-#include <span.h>
 
 #include <algorithm>
-#include <array> // For std::begin and std::end.
+#include <array>
 #include <bit>
-
-#include <stdint.h>
+#include <cstdint>
+#include <span>
 
 void KeccakF(uint64_t (&st)[25])
 {

--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -7,7 +7,7 @@
 
 #include <util/fastrange.h>
 
-#include <algorithm> // std::find
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cmath>

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,7 +8,7 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <consensus/params.h>
-#include <net.h> // For NodeId
+#include <net.h>
 #include <primitives/block.h>
 #include <uint256.h>
 #include <util/bitdeque.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,7 +11,7 @@
 #include <logging.h>
 #include <netbase.h>
 #include <node/interface_ui.h>
-#include <rpc/protocol.h> // For HTTP status codes
+#include <rpc/protocol.h>
 #include <sync.h>
 #include <util/check.h>
 #include <util/signalinterrupt.h>
@@ -27,7 +27,9 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -17,9 +17,14 @@
 #include <util/string.h>
 #include <util/thread.h>
 #include <util/translation.h>
-#include <validation.h> // For g_chainman
+#include <validation.h>
 
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 
 constexpr uint8_t DB_BEST_BLOCK{'B'};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -93,6 +93,7 @@
 #include <walletinitinterface.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
@@ -104,7 +105,6 @@
 #include <vector>
 
 #ifndef WIN32
-#include <cerrno>
 #include <signal.h>
 #include <sys/stat.h>
 #endif

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,14 +7,15 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
-#include <primitives/transaction.h> // For CTransactionRef
+#include <primitives/transaction.h>
 #include <util/result.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
-#include <stddef.h>
-#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -1,22 +1,22 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_INTERFACES_MINING_H
 #define BITCOIN_INTERFACES_MINING_H
 
-#include <consensus/amount.h>       // for CAmount
-#include <interfaces/types.h>       // for BlockRef
-#include <node/types.h>             // for BlockCreateOptions, BlockWaitOptions
-#include <primitives/block.h>       // for CBlock, CBlockHeader
-#include <primitives/transaction.h> // for CTransactionRef
-#include <stdint.h>                 // for int64_t
-#include <uint256.h>                // for uint256
-#include <util/time.h>              // for MillisecondsDouble
+#include <consensus/amount.h>
+#include <interfaces/types.h>
+#include <node/types.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+#include <util/time.h>
 
-#include <memory>   // for unique_ptr, shared_ptr
-#include <optional> // for optional
-#include <vector>   // for vector
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
 
 namespace node {
 struct NodeContext;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,13 +6,13 @@
 #define BITCOIN_INTERFACES_NODE_H
 
 #include <common/settings.h>
-#include <consensus/amount.h>          // For CAmount
-#include <logging.h>                   // For BCLog::CategoryMask
-#include <net.h>                       // For NodeId
-#include <net_types.h>                 // For banmap_t
-#include <netaddress.h>                // For Network
-#include <netbase.h>                   // For ConnectionDirection
-#include <support/allocators/secure.h> // For SecureString
+#include <consensus/amount.h>
+#include <logging.h>
+#include <net.h>
+#include <net_types.h>
+#include <netaddress.h>
+#include <netbase.h>
+#include <support/allocators/secure.h>
 #include <util/translation.h>
 
 #include <functional>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -37,12 +37,9 @@
 #include <util/translation.h>
 #include <util/vector.h>
 
-#ifdef WIN32
-#include <string.h>
-#endif
-
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -1,11 +1,11 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/bantablemodel.h>
 
 #include <interfaces/node.h>
-#include <net_types.h> // For banmap_t
+#include <net_types.h>
 
 #include <utility>
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -64,7 +64,7 @@
 #include <QSize>
 #include <QStandardPaths>
 #include <QString>
-#include <QTextDocument> // for Qt::mightBeRichText
+#include <QTextDocument>
 #include <QThread>
 #include <QUrlQuery>
 #include <QtGlobal>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,17 +17,16 @@
 #include <netbase.h>
 #include <node/caches.h>
 #include <node/chainstatemanager_args.h>
+#include <univalue.h>
 #include <util/string.h>
-#include <validation.h>    // For DEFAULT_SCRIPTCHECK_THREADS
-#include <wallet/wallet.h> // For DEFAULT_SPEND_ZEROCONF_CHANGE
+#include <validation.h>
+#include <wallet/wallet.h>
 
 #include <QDebug>
 #include <QLatin1Char>
 #include <QSettings>
 #include <QStringList>
 #include <QVariant>
-
-#include <univalue.h>
 
 const char *DEFAULT_GUI_PROXY_HOST = "127.0.0.1";
 

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -1,11 +1,11 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_QT_PEERTABLEMODEL_H
 #define BITCOIN_QT_PEERTABLEMODEL_H
 
-#include <net_processing.h> // For CNodeStateStats
+#include <net_processing.h>
 #include <net.h>
 
 #include <QAbstractTableModel>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,11 +10,13 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
-#include <common/signmessage.h> // For MessageSign(), MessageVerify()
+#include <common/signmessage.h>
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 #include <key_io.h>
 #include <wallet/wallet.h>
 
+#include <string>
+#include <variant>
 #include <vector>
 
 #include <QClipboard>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,7 +14,7 @@
 #include <qt/sendcoinsdialog.h>
 #include <qt/transactiontablemodel.h>
 
-#include <common/args.h> // for GetBoolArg
+#include <common/args.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
@@ -23,10 +23,12 @@
 #include <psbt.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
-#include <wallet/wallet.h> // for CRecipient
+#include <wallet/wallet.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
+#include <memory>
+#include <vector>
 
 #include <QDebug>
 #include <QMessageBox>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,7 +12,7 @@
 #include <core_io.h>
 #include <net_permissions.h>
 #include <net_processing.h>
-#include <net_types.h> // For banmap_t
+#include <net_types.h>
 #include <netbase.h>
 #include <node/context.h>
 #include <node/protocol_version.h>
@@ -24,6 +24,7 @@
 #include <rpc/server_util.h>
 #include <rpc/util.h>
 #include <sync.h>
+#include <univalue.h>
 #include <util/chaintype.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -31,9 +32,11 @@
 #include <util/translation.h>
 #include <validation.h>
 
+#include <chrono>
 #include <optional>
-
-#include <univalue.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 using node::NodeContext;
 using util::Join;

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2022 The Bitcoin Core developers
+// Copyright (c) 2016-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,10 +8,9 @@
 #ifdef WIN32
 #include <windows.h>
 #else
-#include <sys/mman.h> // for mmap
-#include <sys/resource.h> // for getrlimit
-#include <limits.h> // for PAGESIZE
-#include <unistd.h> // for sysconf
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <unistd.h>
 #endif
 
 #include <algorithm>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -3,9 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
-#include <common/signmessage.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
-#include <hash.h> // For Hash()
-#include <key.h>  // For CKey
+#include <common/signmessage.h>
+#include <hash.h>
+#include <key.h>
 #include <script/parsing.h>
 #include <span.h>
 #include <sync.h>
@@ -26,12 +26,13 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <limits>
 #include <map>
 #include <optional>
-#include <stdint.h>
-#include <string.h>
+#include <string>
 #include <thread>
 #include <univalue.h>
 #include <utility>

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,13 +6,13 @@
 #define BITCOIN_TXREQUEST_H
 
 #include <primitives/transaction.h>
-#include <net.h> // For NodeId
+#include <net.h>
 #include <uint256.h>
 
 #include <chrono>
+#include <cstdint>
+#include <memory>
 #include <vector>
-
-#include <stdint.h>
 
 /** Data structure to keep track of, and schedule, transaction downloads from peers.
  *

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -37,8 +37,8 @@
 #include <sys/resource.h>
 #include <unistd.h>
 #else
-#include <io.h> /* For _get_osfhandle, _chsize */
-#include <shlobj.h> /* For SHGetSpecialFolderPathW */
+#include <io.h>
+#include <shlobj.h>
 #endif // WIN32
 
 /** Mutex to protect dir_locks. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -25,7 +25,7 @@
 #include <script/sigcache.h>
 #include <sync.h>
 #include <txdb.h>
-#include <txmempool.h> // For CTxMemPool::cs
+#include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/fs.h>

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,7 +8,7 @@
 
 #include <kernel/chain.h>
 #include <kernel/cs_main.h>
-#include <primitives/transaction.h> // CTransaction(Ref)
+#include <primitives/transaction.h>
 #include <sync.h>
 
 #include <cstddef>

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -1,15 +1,20 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compat/byteswap.h>
-#include <crypto/common.h> // For ReadBE32
+#include <crypto/common.h>
 #include <logging.h>
 #include <streams.h>
 #include <util/translation.h>
 #include <wallet/migrate.h>
 
+#include <array>
+#include <cstddef>
 #include <optional>
+#include <stdexcept>
 #include <variant>
+#include <vector>
 
 namespace wallet {
 // Magic bytes in both endianness's

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,13 +6,18 @@
 #define BITCOIN_WALLET_SPEND_H
 
 #include <consensus/amount.h>
-#include <policy/fees.h> // for FeeCalculation
+#include <policy/fees.h>
 #include <util/result.h>
 #include <wallet/coinselection.h>
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+#include <map>
+#include <memory>
 #include <optional>
+#include <set>
+#include <unordered_set>
+#include <vector>
 
 namespace wallet {
 /** Get the marginal bytes if spending the specified output from this transaction.

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -11,11 +11,16 @@
 #include <wallet/sqlite.h>
 #include <wallet/migrate.h>
 #include <wallet/test/util.h>
-#include <wallet/walletutil.h> // for WALLET_FLAG_DESCRIPTORS
+#include <wallet/walletutil.h>
 
+#include <cstddef>
 #include <fstream>
 #include <memory>
+#include <span>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 inline std::ostream& operator<<(std::ostream& os, const std::pair<const SerializeData, SerializeData>& kv)
 {


### PR DESCRIPTION
We don't add or maintain these, and they are of little value, as
well as having the effect of polluting diffs, if changed.

They are also wrong, i.e `DEFAULT_SCRIPTCHECK_THREADS` is not in
`validation.h`.