### PR TITLE
ci: Avoid && dropping errors

### DIFF
--- a/.github/ci-test-each-commit-exec.sh
+++ b/.github/ci-test-each-commit-exec.sh
@@ -14,6 +14,8 @@ echo "Running test-one-commit on $( git log -1 )"
 # Use clang++, because it is a bit faster and uses less memory than g++
 CC=clang CXX=clang++ cmake -B build -DWERROR=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWITH_USDT=ON -DCMAKE_CXX_FLAGS='-Wno-error=unused-member-function'
 
-cmake --build build -j "$( nproc )" && ctest --output-on-failure --stop-on-failure --test-dir build -j "$( nproc )"
+cmake --build build -j "$( nproc )"
+
+ctest --output-on-failure --stop-on-failure --test-dir build -j "$( nproc )"
 
 ./build/test/functional/test_runner.py -j $(( $(nproc) * 2 )) --combinedlogslen=99999999


### PR DESCRIPTION
In bash, `&&` will ignore errexit. This can lead to silently ignoring errors. Compare the output of:

```
$ bash -c 'set -xe;   false && false   ; true; echo $?'
+ false
+ true
+ echo 0
0
```

In theory this could be fixed by using a subshell:

```
$ bash -c 'set -xe; ( false && false ) ; true; echo $?'
+ false
```

However, it is easier to just remove the `&&`.

This was introduced in  commit faa807bdf8c3002a28005b4765604f518a6f2736