### PR TITLE
consensus: Remove special treatment for single threaded script checking

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -196,8 +196,6 @@ public:
             t.join();
         }
     }
-
-    bool HasThreads() const { return !m_worker_threads.empty(); }
 };
 
 /**

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -20,11 +20,16 @@ struct Dersig100Setup : public TestChain100Setup {
         : TestChain100Setup{ChainType::REGTEST, {.extra_args = {"-testactivationheight=dersig@102"}}} {}
 };
 
+// Both CheckInputScripts and GetScriptCacheEntry use the same caching
+// checks internally so they are used here interchangeably across the test.
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify_flags flags,
+                                           bool cacheFullScriptStore, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)
 
@@ -151,15 +156,11 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
         // Test the caching
         if (ret && add_to_cache) {
             // Check that we get a cache hit if the tx was valid
-            std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
-            BOOST_CHECK(scriptchecks.empty());
+            BOOST_CHECK(!GetScriptCacheEntry(tx, test_flags, add_to_cache, validation_cache));
         } else {
             // Check that we get script executions to check, if the transaction
             // was invalid, or we didn't add to cache.
-            std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
-            BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
+            BOOST_CHECK(GetScriptCacheEntry(tx, test_flags, add_to_cache, validation_cache));
         }
     }
 }
@@ -218,12 +219,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
 
         BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
 
-        // If we call again asking for scriptchecks (as happens in
-        // ConnectBlock), we should add a script check object for this -- we're
+        // If we call GetScriptCacheEntry instead (as happens in
+        // ConnectBlock), we should get a signal to script check this tx -- we're
         // not caching invalidity (if that changes, delete this test case).
-        std::vector<CScriptCheck> scriptchecks;
-        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
-        BOOST_CHECK_EQUAL(scriptchecks.size(), 1U);
+        BOOST_CHECK(GetScriptCacheEntry(CTransaction(spend_tx), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, m_node.chainman->m_validation_cache));
 
         // Test that CheckInputScripts returns true iff DERSIG-enforcing flags are
         // not present.  Don't add these checks to the cache, so that we can
@@ -376,12 +375,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         // This transaction is now invalid under segwit, because of the second input.
         BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
 
-        std::vector<CScriptCheck> scriptchecks;
         // Make sure this transaction was not cached (ie because the first
         // input was valid)
-        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
-        // Should get 2 script checks back -- caching is on a whole-transaction basis.
-        BOOST_CHECK_EQUAL(scriptchecks.size(), 2U);
+        BOOST_CHECK(GetScriptCacheEntry(CTransaction(tx), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, m_node.chainman->m_validation_cache));
     }
 }
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -25,8 +25,7 @@ struct Dersig100Setup : public TestChain100Setup {
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                       ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify_flags flags,
                                            bool cacheFullScriptStore, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -147,7 +146,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
             // WITNESS requires P2SH
             test_flags |= SCRIPT_VERIFY_P2SH;
         }
-        bool ret = CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
+        bool ret = CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache);
         // CheckInputScripts should succeed iff test_flags doesn't intersect with
         // failing_flags
         bool expected_return_value = !(test_flags & failing_flags);
@@ -217,7 +216,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData ptd_spend_tx;
 
-        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache));
 
         // If we call GetScriptCacheEntry instead (as happens in
         // ConnectBlock), we should get a signal to script check this tx -- we're
@@ -283,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_cltv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_cltv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache));
     }
 
     // TEST CHECKSEQUENCEVERIFY
@@ -311,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache));
     }
 
     // TODO: add tests for remaining script flags
@@ -373,7 +372,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData txdata;
         // This transaction is now invalid under segwit, because of the second input.
-        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache));
 
         // Make sure this transaction was not cached (ie because the first
         // input was valid)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2048,6 +2048,23 @@ void ValidationCache::CacheScriptValidation(const uint256& entry)
     m_script_execution_cache.insert(entry);
 }
 
+static void EnsureTxData(const CTransaction& tx, const CCoinsViewCache& inputs, PrecomputedTransactionData& txdata)
+{
+    if (!txdata.m_spent_outputs_ready) {
+        std::vector<CTxOut> spent_outputs;
+        spent_outputs.reserve(tx.vin.size());
+
+        for (const auto& txin : tx.vin) {
+            const COutPoint& prevout = txin.prevout;
+            const Coin& coin = inputs.AccessCoin(prevout);
+            assert(!coin.IsSpent());
+            spent_outputs.emplace_back(coin.out);
+        }
+        txdata.Init(tx, std::move(spent_outputs));
+    }
+    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+}
+
 /**
  * Check whether all of this transaction's input scripts succeed.
  *
@@ -2091,19 +2108,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         return true;
     }
 
-    if (!txdata.m_spent_outputs_ready) {
-        std::vector<CTxOut> spent_outputs;
-        spent_outputs.reserve(tx.vin.size());
-
-        for (const auto& txin : tx.vin) {
-            const COutPoint& prevout = txin.prevout;
-            const Coin& coin = inputs.AccessCoin(prevout);
-            assert(!coin.IsSpent());
-            spent_outputs.emplace_back(coin.out);
-        }
-        txdata.Init(tx, std::move(spent_outputs));
-    }
-    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+    EnsureTxData(tx, inputs, txdata);
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2036,6 +2036,18 @@ ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, cons
               approx_size_bytes >> 20, script_execution_cache_bytes >> 20, num_elems);
 }
 
+bool ValidationCache::IsScriptValidated(const uint256& entry, bool erase)
+{
+    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
+    return m_script_execution_cache.contains(entry, erase);
+}
+
+void ValidationCache::CacheScriptValidation(const uint256& entry)
+{
+    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
+    m_script_execution_cache.insert(entry);
+}
+
 /**
  * Check whether all of this transaction's input scripts succeed.
  *
@@ -2075,8 +2087,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     uint256 hashCacheEntry;
     CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
     hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
-    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
-    if (validation_cache.m_script_execution_cache.contains(hashCacheEntry, !cacheFullScriptStore)) {
+    if (validation_cache.IsScriptValidated(hashCacheEntry, !cacheFullScriptStore)) {
         return true;
     }
 
@@ -2124,7 +2135,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (cacheFullScriptStore && !pvChecks) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
-        validation_cache.m_script_execution_cache.insert(hashCacheEntry);
+        validation_cache.CacheScriptValidation(hashCacheEntry);
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2536,8 +2536,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // doesn't invalidate pointers into the vector, and keep txsdata in scope
     // for as long as `control`.
     std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    std::vector<uint256> script_cache_entries;
     std::optional<CCheckQueueControl<CScriptCheck>> control;
-    if (auto& queue = m_chainman.GetCheckQueue(); queue.HasThreads() && fScriptChecks) control.emplace(queue);
+    if (fScriptChecks) control.emplace(m_chainman.GetCheckQueue());
 
     std::vector<int> prevheights;
     CAmount nFees = 0;
@@ -2597,22 +2598,21 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (!tx.IsCoinBase() && fScriptChecks)
         {
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
-            bool tx_ok;
-            TxValidationState tx_state;
-            // If CheckInputScripts is called with a pointer to a checks vector, the resulting checks are appended to it. In that case
-            // they need to be added to control which runs them asynchronously. Otherwise, CheckInputScripts runs the checks before returning.
-            if (control) {
+            ValidationCache& validation_cache{m_chainman.m_validation_cache};
+            if (auto hashCacheEntry = GetScriptCacheEntry(tx, flags, fCacheResults, validation_cache)) {
+                // Collect the cache entry when doing TestBlockValidity (fJustCheck=true), so
+                // the script execution result can be reused when the block is actually connected.
+                if (fCacheResults) script_cache_entries.push_back(*hashCacheEntry);
+                EnsureTxData(tx, view, txsdata[i]);
+                // Turn all of this transaction's input scripts into script checks and add them to the queue
                 std::vector<CScriptCheck> vChecks;
-                tx_ok = CheckInputScripts(tx, tx_state, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache, &vChecks);
-                if (tx_ok) control->Add(std::move(vChecks));
-            } else {
-                tx_ok = CheckInputScripts(tx, tx_state, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache);
-            }
-            if (!tx_ok) {
-                // Any transaction validation failure in ConnectBlock is a block consensus failure
-                state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
-                              tx_state.GetRejectReason(), tx_state.GetDebugMessage());
-                break;
+                vChecks.reserve(tx.vin.size());
+                PrecomputedTransactionData& txdata{txsdata[i]};
+                for (unsigned int j = 0; j < tx.vin.size(); j++) {
+                    CScriptCheck check(txdata.m_spent_outputs[j], tx, validation_cache.m_signature_cache, j, flags, fCacheResults, &txdata);
+                    vChecks.emplace_back(std::move(check));
+                }
+                control->Add(std::move(vChecks));
             }
         }
 
@@ -2644,6 +2644,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (!state.IsValid()) {
         LogInfo("Block validation error: %s", state.ToString());
         return false;
+    }
+    // All script checks have passed and the block is valid, so it is now safe to
+    // write the collected cache entries.
+    for (const auto& entry : script_cache_entries) {
+        m_chainman.m_validation_cache.CacheScriptValidation(entry);
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_verify += time_4 - time_2;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -138,6 +138,9 @@ const CBlockIndex* Chainstate::FindForkInGlobalIndex(const CBlockLocator& locato
     return m_chain.Genesis();
 }
 
+std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify_flags flags,
+                                           bool cacheFullScriptStore, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
@@ -2066,6 +2069,29 @@ static void EnsureTxData(const CTransaction& tx, const CCoinsViewCache& inputs, 
 }
 
 /**
+ * Look up whether this transaction's input scripts are already validated in the script execution
+ * cache. Returns nullopt if no checks are needed, i.e. they are already cached or this is a coinbase
+ * transaction. Otherwise returns the cache entry under which the caller should record success after
+ * running the checks.
+ *
+ * Non-static (and redeclared) in src/test/txvalidationcache_tests.cpp
+ */
+std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify_flags flags,
+                                           bool cacheFullScriptStore, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (tx.IsCoinBase()) return std::nullopt;
+
+    uint256 hashCacheEntry;
+    CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
+    hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
+    if (validation_cache.IsScriptValidated(hashCacheEntry, !cacheFullScriptStore)) {
+        return std::nullopt;
+    }
+
+    return hashCacheEntry;
+}
+
+/**
  * Check whether all of this transaction's input scripts succeed.
  *
  * This involves ECDSA signature checks so can be computationally intensive. This function should
@@ -2090,23 +2116,8 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks)
 {
-    if (tx.IsCoinBase()) return true;
-
-    if (pvChecks) {
-        pvChecks->reserve(tx.vin.size());
-    }
-
-    // First check if script executions have been cached with the same
-    // flags. Note that this assumes that the inputs provided are
-    // correct (ie that the transaction hash which is in tx's prevouts
-    // properly commits to the scriptPubKey in the inputs view of that
-    // transaction).
-    uint256 hashCacheEntry;
-    CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
-    hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
-    if (validation_cache.IsScriptValidated(hashCacheEntry, !cacheFullScriptStore)) {
-        return true;
-    }
+    auto hashCacheEntry = GetScriptCacheEntry(tx, flags, cacheFullScriptStore, validation_cache);
+    if (!hashCacheEntry) return true;
 
     EnsureTxData(tx, inputs, txdata);
 
@@ -2140,7 +2151,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (cacheFullScriptStore && !pvChecks) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
-        validation_cache.CacheScriptValidation(hashCacheEntry);
+        validation_cache.CacheScriptValidation(*hashCacheEntry);
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -144,8 +144,7 @@ std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks = nullptr)
+                       ValidationCache& validation_cache)
                        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& tx)
@@ -2097,10 +2096,6 @@ std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify
  * This involves ECDSA signature checks so can be computationally intensive. This function should
  * only be called after the cheap sanity checks in CheckTxInputs passed.
  *
- * If pvChecks is not nullptr, script checks are pushed onto it instead of being performed inline. Any
- * script checks which are not necessary (eg due to script execution cache hits) are, obviously,
- * not pushed onto pvChecks/run.
- *
  * Setting cacheSigStore/cacheFullScriptStore to false will remove elements from the corresponding cache
  * which are matched. This is useful for checking blocks where we will likely never need the cache
  * entry again.
@@ -2113,8 +2108,7 @@ std::optional<uint256> GetScriptCacheEntry(const CTransaction& tx, script_verify
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks)
+                       ValidationCache& validation_cache)
 {
     auto hashCacheEntry = GetScriptCacheEntry(tx, flags, cacheFullScriptStore, validation_cache);
     if (!hashCacheEntry) return true;
@@ -2131,9 +2125,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
 
         // Verify signature
         CScriptCheck check(txdata.m_spent_outputs[i], tx, validation_cache.m_signature_cache, i, flags, cacheSigStore, &txdata);
-        if (pvChecks) {
-            pvChecks->emplace_back(std::move(check));
-        } else if (auto result = check(); result.has_value()) {
+        if (auto result = check(); result.has_value()) {
             // Tx failures never trigger disconnections/bans.
             // This is so that network splits aren't triggered
             // either due to non-consensus relay policies (such as
@@ -2148,7 +2140,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         }
     }
 
-    if (cacheFullScriptStore && !pvChecks) {
+    if (cacheFullScriptStore) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
         validation_cache.CacheScriptValidation(*hashCacheEntry);

--- a/src/validation.h
+++ b/src/validation.h
@@ -373,8 +373,10 @@ private:
     //! Pre-initialized hasher to avoid having to recreate it for every hash calculation.
     CSHA256 m_script_execution_cache_hasher;
 
-public:
+    //! Cache for script verification results to avoid re-validation.
     CuckooCache::cache<uint256, SignatureCacheHasher> m_script_execution_cache;
+
+public:
     SignatureCache m_signature_cache;
 
     ValidationCache(size_t script_execution_cache_bytes, size_t signature_cache_bytes);
@@ -384,6 +386,9 @@ public:
 
     //! Return a copy of the pre-initialized hasher.
     CSHA256 ScriptExecutionCacheHasher() const { return m_script_execution_cache_hasher; }
+
+    bool IsScriptValidated(const uint256& entry, bool erase) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void CacheScriptValidation(const uint256& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 /** Functions for validating blocks and updating the block tree */


### PR DESCRIPTION
This topic has been motivated by my work on batch validation and a related conversation just happened here: https://github.com/bitcoin/bitcoin/pull/32467#discussion_r2098305199 

`CheckInputScripts` currently only does what its name implies if there is no multithreading usage for validation. If there are worker threads available the function instead only creates the checks and puts them into a vector. Aside from some shared pre-checks the multithreaded code path is much simpler compared to the rest. This dual use makes the function hard to grasp and its naming confusing.

This PR refactors this code to be more readable and improves documentation aside from unifying the single threaded and the multithreaded cases by letting checkqueue handle single threaded script checking as well. The code is already suited for this and there seems to be not noticable performance overhead from this.