### PR TITLE
subprocess: Let shell parse command on non-Windows systems

### DIFF
--- a/src/common/run_command.cpp
+++ b/src/common/run_command.cpp
@@ -24,7 +24,12 @@ UniValue RunCommandParseJSON(const std::string& str_command, const std::string& 
 
     if (str_command.empty()) return UniValue::VNULL;
 
+#ifdef WIN32
     auto c = sp::Popen(str_command, sp::input{sp::PIPE}, sp::output{sp::PIPE}, sp::error{sp::PIPE}, sp::close_fds{true});
+#else
+    auto c = sp::Popen({str_command}, sp::input{sp::PIPE}, sp::output{sp::PIPE}, sp::error{sp::PIPE}, sp::close_fds{true}, sp::shell{true});
+#endif // WIN32
+
     if (!str_std_in.empty()) {
         c.send(str_std_in);
     }

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -62,12 +62,12 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
 
 UniValue ExternalSigner::DisplayAddress(const std::string& descriptor) const
 {
-    return RunCommandParseJSON(m_command + " --fingerprint " + m_fingerprint + NetworkArg() + " displayaddress --desc " + descriptor);
+    return RunCommandParseJSON(m_command + " --fingerprint \"" + m_fingerprint + "\"" + NetworkArg() + " displayaddress --desc \"" + descriptor + "\"");
 }
 
 UniValue ExternalSigner::GetDescriptors(const int account)
 {
-    return RunCommandParseJSON(m_command + " --fingerprint " + m_fingerprint + NetworkArg() + " getdescriptors --account " + strprintf("%d", account));
+    return RunCommandParseJSON(m_command + " --fingerprint \"" + m_fingerprint + "\"" + NetworkArg() + " getdescriptors --account \"" + strprintf("%d", account) + "\"");
 }
 
 bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::string& error)
@@ -93,8 +93,8 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
         return false;
     }
 
-    const std::string command = m_command + " --stdin --fingerprint " + m_fingerprint + NetworkArg();
-    const std::string stdinStr = "signtx " + EncodeBase64(ssTx.str());
+    const std::string command = m_command + " --stdin --fingerprint \"" + m_fingerprint + "\"" + NetworkArg();
+    const std::string stdinStr = "signtx \"" + EncodeBase64(ssTx.str()) + "\"";
 
     const UniValue signer_result = RunCommandParseJSON(command, stdinStr);
 

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -28,22 +28,20 @@ BOOST_AUTO_TEST_CASE(run_command)
 #ifdef WIN32
         const UniValue result = RunCommandParseJSON("cmd.exe /c echo {\"success\": true}");
 #else
-        const UniValue result = RunCommandParseJSON("echo {\"success\": true}");
+        const UniValue result = RunCommandParseJSON("echo '{\"success\": true}'");
 #endif
         BOOST_CHECK(result.isObject());
         const UniValue& success = result.find_value("success");
         BOOST_CHECK(!success.isNull());
         BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
+#ifdef WIN32
     {
         // An invalid command is handled by cpp-subprocess
-#ifdef WIN32
         const std::string expected{"CreateProcess failed: "};
-#else
-        const std::string expected{"execve failed: "};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON("invalid_command"), subprocess::CalledProcessError, HasReason(expected));
     }
+#endif
     {
         // Return non-zero exit code, no output to stderr
 #ifdef WIN32
@@ -62,7 +60,7 @@ BOOST_AUTO_TEST_CASE(run_command)
 #ifdef WIN32
         const std::string command{"cmd.exe /c \"echo err 1>&2 && exit 1\""};
 #else
-        const std::string command{"sh -c 'echo err 1>&2 && false'"};
+        const std::string command{"echo err 1>&2 && false"};
 #endif
         const std::string expected{"err"};
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -55,7 +55,7 @@ class RPCSignerTest(BitcoinTestFramework):
             -1,
             "CreateProcess failed: The system cannot find the file specified."
             if platform.system() == "Windows"
-            else "execve failed: No such file or directory",
+            else "not found",
             self.nodes[3].enumeratesigners,
         )
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/32574.

The `subprocess::Popen` constructor has two overloads: https://github.com/bitcoin/bitcoin/blob/7763e86afa045910a14ac9b2cd644927a447370b/src/util/subprocess.h#L938-L941

During the migration from Boost.Process in https://github.com/bitcoin/bitcoin/pull/28981, the second was chosen for two reasons: (1) it minimized changes at the call sites, and (2) it [addressed](https://github.com/bitcoin/bitcoin/pull/28981#issuecomment-1837238921) quoting issues on Windows. This approach internally uses the `subprocess::util::split()` function, which currently fails to handle quoted tokens, such as in subshell invocations like `sh -c 'ls; echo'`.

This issue was not caught by our tests as they are broken. The last commit fixes the `system_tests/run_command` test. This commit can be applied on top of the master branch to reproduce the existing failure in `subprocess`.

The second commit is intended to be upstreamed. However, I'm seeking code review feedback first (please note that the `src/util/subprocess.h` code is C++11 compatible).