### PR TITLE
depends: hard-code necessary c(xx)flags rather than setting them per-host

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -8,9 +8,11 @@ $(1)_ar=$$($$($(1)_type)_AR)
 $(1)_ranlib=$$($$($(1)_type)_RANLIB)
 $(1)_nm=$$($$($(1)_type)_NM)
 $(1)_cflags=$$($$($(1)_type)_CFLAGS) \
-            $$($$($(1)_type)_$$(release_type)_CFLAGS)
+            $$($$($(1)_type)_$$(release_type)_CFLAGS) \
+            -pipe -std=$(C_STANDARD)
 $(1)_cxxflags=$$($$($(1)_type)_CXXFLAGS) \
-              $$($$($(1)_type)_$$(release_type)_CXXFLAGS)
+              $$($$($(1)_type)_$$(release_type)_CXXFLAGS) \
+              -pipe -std=$(CXX_STANDARD)
 $(1)_ldflags=$$($$($(1)_type)_LDFLAGS) \
              $$($$($(1)_type)_$$(release_type)_LDFLAGS) \
              -L$$($($(1)_type)_prefix)/lib

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -60,8 +60,8 @@ darwin_CXX=$(clangxx_prog) --target=$(host) \
                -iwithsysroot/usr/include/c++/v1 \
                -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
 
-darwin_CFLAGS=-pipe -std=$(C_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION)
-darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION)
+darwin_CFLAGS=-mmacos-version-min=$(OSX_MIN_VERSION)
+darwin_CXXFLAGS=-mmacos-version-min=$(OSX_MIN_VERSION)
 darwin_LDFLAGS=-Wl,-platform_version,macos,$(OSX_MIN_VERSION),$(OSX_SDK_VERSION)
 
 ifneq ($(build_os),darwin)

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -1,5 +1,5 @@
-freebsd_CFLAGS=-pipe -std=$(C_STANDARD)
-freebsd_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+freebsd_CFLAGS=
+freebsd_CXXFLAGS=
 
 freebsd_release_CFLAGS=-O2
 freebsd_release_CXXFLAGS=$(freebsd_release_CFLAGS)

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -1,5 +1,5 @@
-linux_CFLAGS=-pipe -std=$(C_STANDARD)
-linux_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+linux_CFLAGS=
+linux_CXXFLAGS=
 
 ifneq ($(LTO),)
 linux_AR = $(host_toolchain)gcc-ar

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -5,8 +5,8 @@ ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-g++-posix"),)
 mingw32_CXX := $(host)-g++-posix
 endif
 
-mingw32_CFLAGS=-pipe -std=$(C_STANDARD)
-mingw32_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+mingw32_CFLAGS=
+mingw32_CXXFLAGS=
 
 ifneq ($(LTO),)
 mingw32_AR = $(host_toolchain)gcc-ar

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -1,5 +1,5 @@
-netbsd_CFLAGS=-pipe -std=$(C_STANDARD)
-netbsd_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+netbsd_CFLAGS=
+netbsd_CXXFLAGS=
 
 ifneq ($(LTO),)
 netbsd_AR = $(host_toolchain)gcc-ar

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -1,5 +1,5 @@
-openbsd_CFLAGS=-pipe -std=$(C_STANDARD)
-openbsd_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+openbsd_CFLAGS=
+openbsd_CXXFLAGS=
 
 openbsd_release_CFLAGS=-O2
 openbsd_release_CXXFLAGS=$(openbsd_release_CFLAGS)


### PR DESCRIPTION
The per-host flag variables hold platform-specific defaults that are ignored when flag environment variables are set, so it was wrong for them to contain -std options relied on by package definitions.

Additionally, these flags (-pipe and -std=xx) will no longer be passed into the CMake build, meaning less duplication in the build summary.

Pulled out of #31920.