### PR TITLE
test: Fix `system_tests/run_command` test

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -125,6 +125,9 @@ add_executable(test_bitcoin
   validationinterface_tests.cpp
   versionbits_tests.cpp
 )
+set_property(SOURCE system_tests.cpp PROPERTY
+  COMPILE_DEFINITIONS PRINT_ERR_AND_FAIL_SCRIPT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/print_err_and_fail.sh"
+)
 
 include(TargetDataSources)
 target_json_data_sources(test_bitcoin

--- a/src/test/print_err_and_fail.sh
+++ b/src/test/print_err_and_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This script is used in system_tests/run_command test.
+echo "$1" >&2
+exit 1


### PR DESCRIPTION
This PR addresses two issues related to the "Return non-zero exit code, with error message for stderr" check in the `system_tests/run_command` test:
1. The test now checks the exact exit code, which must be 1.
2. The process invocation string is removed from the exception message before checking the stderr output, as the latter is a substring of the former.

This is an alternative to https://github.com/bitcoin/bitcoin/pull/32577 without introducing a shell wrapper and altering quotation in `src/external_signer.cpp`.

The main idea is to avoid parsing the problematic `sh -c 'echo err 1>&2 && false'` command with `subprocess::Popen`.

In the past, this check used:https://github.com/bitcoin/bitcoin/blob/5abb9b1af49be9024f95fa2f777285c531785d85/src/test/system_tests.cpp#L56-L58

which was problematic due to its dependence on the system locale.

Fixes https://github.com/bitcoin/bitcoin/issues/32574.