### PR TITLE
p2p: Drop unsolicited CMPCTBLOCK from non-HB peer and when blocksonly

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4476,6 +4476,15 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             return;
         }
 
+        {
+            LOCK(cs_main);
+            const CNodeState *nodestate = State(pfrom.GetId());
+            if (!nodestate->m_provides_cmpctblocks) {
+                LogDebug(BCLog::CMPCTBLOCK, "%s sent us a compact block despite never having sent us a SENDCMPCT!", pfrom.LogPeer());
+                return;
+            }
+        }
+
         CBlockHeaderAndShortTxIDs cmpctblock;
         vRecv >> cmpctblock;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4469,7 +4469,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     {
         // Ignore cmpctblock received while importing
         if (m_chainman.m_blockman.LoadingBlocks()) {
-            LogDebug(BCLog::NET, "Unexpected cmpctblock message received from peer %d\n", pfrom.GetId());
+            LogDebug(BCLog::CMPCTBLOCK, "%s sent us a compact block even though we are still loading blocks!", pfrom.LogPeer());
+            return;
+        } else if (m_opts.ignore_incoming_txs) {
+            LogDebug(BCLog::CMPCTBLOCK, "%s sent us a compact block even though we are blocksonly!", pfrom.LogPeer());
             return;
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2610,7 +2610,7 @@ void PeerManagerImpl::SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlo
     if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         uint32_t tx_requested_size{0};
         for (const auto& tx : resp.txn) tx_requested_size += tx->ComputeTotalSize();
-        LogDebug(BCLog::CMPCTBLOCK, "Peer %d sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)\n", pfrom.GetId(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);
+        LogDebug(BCLog::CMPCTBLOCK, "%s sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)", pfrom.LogPeer(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);
     }
     MakeAndPushMessage(pfrom, NetMsgType::BLOCKTXN, resp);
 }
@@ -4554,6 +4554,11 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 break;
             }
             range_flight.first++;
+        }
+
+        if (!requested_block_from_this_peer && !pfrom.m_bip152_highbandwidth_to) {
+            LogDebug(BCLog::CMPCTBLOCK, "%s, not marked as high-bandwidth, sent us an unsolicited compact block!", pfrom.LogPeer());
+            return;
         }
 
         if (pindex->nChainWork <= m_chainman.ActiveChain().Tip()->nChainWork || // We know something better

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -1002,6 +1002,17 @@ class CompactBlocksTest(BitcoinTestFramework):
         unsolicited_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
         self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
 
+        self.log.info("Test that a node ignores unsolicited CMPCTBLOCK messages from peers that have not sent SENDCMPCT.")
+        assert ignores_compact_block(unsolicited_peer, solicited=False)
+
+        self.log.info("Test that a node ignores solicited CMPCTBLOCK messages from peers that have not sent SENDCMPCT.")
+        assert ignores_compact_block(unsolicited_peer, solicited=True)
+
+        # Unsolicited peer announces CMPCTBLOCK support with SENDCMPCT message,
+        # but still non-HB.
+        unsolicited_peer.send_and_ping(msg_sendcmpct())
+        self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
+
         self.log.info("Test that a node ignores unsolicited CMPCTBLOCK messages from non-HB peers.")
         assert ignores_compact_block(unsolicited_peer, solicited=False)
         self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
@@ -1081,12 +1092,14 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # The previous test will lead to a disconnection. Reconnect before continuing.
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.segwit_node.send_and_ping(msg_sendcmpct())
 
         self.log.info("Testing handling of multiple blocktxn responses...")
         self.test_multiple_blocktxn_response(self.segwit_node)
 
         # The previous test will lead to a disconnection. Reconnect before continuing.
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.segwit_node.send_and_ping(msg_sendcmpct())
 
         self.log.info("Testing invalid index in cmpctblock message...")
         self.test_invalid_cmpctblock_message()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -291,20 +291,37 @@ class CompactBlocksTest(BitcoinTestFramework):
         check_announcement_of_new_block(node, test_node, lambda p: "cmpctblock" not in p.last_message and "headers" in p.last_message)
 
     # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
+    # Note, these are not consensus-invalid blocks, but improperly constructed cmpctblock messages.
     def test_invalid_cmpctblock_message(self):
+        # Make a high-bandwidth peer
+        hb_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.request_cb_announcements(hb_peer)
+        self.make_peer_hb_to_candidate(self.nodes[0], hb_peer)
+        self.assert_highbandwidth_states(self.nodes[0], idx=-1, hb_to=True, hb_from=True)
+
+        # Make a low-bandwidth peer
+        lb_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.request_cb_announcements(lb_peer)
+        self.assert_highbandwidth_states(self.nodes[0], idx=-1, hb_to=False, hb_from=True)
+
+        # Construct an invalid cmpctblock message
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         block = self.build_block_on_tip(self.nodes[0])
-
-        self.segwit_node.send_header_for_blocks([block])
-        self.segwit_node.wait_for_getdata([block.hash_int], timeout=30)
-
         cmpct_block = P2PHeaderAndShortIDs()
         cmpct_block.header = CBlockHeader(block)
         cmpct_block.prefilled_txn_length = 1
-        # This index will be too high
-        prefilled_txn = PrefilledTransaction(1, block.vtx[0])
+        too_high_prefill_idx = 1
+        prefilled_txn = PrefilledTransaction(too_high_prefill_idx, block.vtx[0])
         cmpct_block.prefilled_txn = [prefilled_txn]
-        self.segwit_node.send_await_disconnect(msg_cmpctblock(cmpct_block))
+
+        # Test an unsolicited invalid cmpctblock from an HB peer.
+        hb_peer.send_await_disconnect(msg_cmpctblock(cmpct_block))
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
+
+        # Test a solicited invalid cmpctblock from a non-HB peer.
+        lb_peer.send_header_for_blocks([block])
+        lb_peer.wait_for_getdata([block.hash_int], timeout=30)
+        lb_peer.send_await_disconnect(msg_cmpctblock(cmpct_block))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
 
     # Compare the generated shortids to what we expect based on BIP 152, given

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -852,33 +852,34 @@ class CompactBlocksTest(BitcoinTestFramework):
         stalling_peer.send_and_ping(msg)
         assert_equal(node.getbestblockhash(), block.hash_hex)
 
+    # assert the RPC getpeerinfo boolean fields `bip152_hb_{to, from}`
+    # match the given parameters for the last peer of a given node
+    @staticmethod
+    def assert_highbandwidth_states(node, hb_to, hb_from):
+        peerinfo = node.getpeerinfo()[-1]
+        assert_equal(peerinfo['bip152_hb_to'], hb_to)
+        assert_equal(peerinfo['bip152_hb_from'], hb_from)
+
     def test_highbandwidth_mode_states_via_getpeerinfo(self):
         # create new p2p connection for a fresh state w/o any prior sendcmpct messages sent
         hb_test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
 
-        # assert the RPC getpeerinfo boolean fields `bip152_hb_{to, from}`
-        # match the given parameters for the last peer of a given node
-        def assert_highbandwidth_states(node, hb_to, hb_from):
-            peerinfo = node.getpeerinfo()[-1]
-            assert_equal(peerinfo['bip152_hb_to'], hb_to)
-            assert_equal(peerinfo['bip152_hb_from'], hb_from)
-
         # initially, neither node has selected the other peer as high-bandwidth yet
-        assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=False)
+        self.assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=False)
 
         # peer requests high-bandwidth mode by sending sendcmpct(1)
         hb_test_node.send_and_ping(msg_sendcmpct(announce=True, version=2))
-        assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=True)
+        self.assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=True)
 
         # peer generates a block and sends it to node, which should
         # select the peer as high-bandwidth (up to 3 peers according to BIP 152)
         block = self.build_block_on_tip(self.nodes[0])
         hb_test_node.send_and_ping(msg_block(block))
-        assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=True)
+        self.assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=True)
 
         # peer requests low-bandwidth mode by sending sendcmpct(0)
         hb_test_node.send_and_ping(msg_sendcmpct(announce=False, version=2))
-        assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=False)
+        self.assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=False)
 
     def test_compactblock_reconstruction_parallel_reconstruction(self, stalling_peer, delivery_peer, inbound_peer, outbound_peer):
         """ All p2p connections are inbound except outbound_peer. We test that ultimate parallel slot

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -167,18 +167,19 @@ class CompactBlocksTest(BitcoinTestFramework):
         block.solve()
         return block
 
-    # Create 10 more anyone-can-spend utxo's for testing.
+    # Create 12 more anyone-can-spend utxo's for testing.
     def make_utxos(self):
+        COUNT = 12
         block = self.build_block_on_tip(self.nodes[0])
         self.segwit_node.send_and_ping(msg_no_witness_block(block))
         assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
         self.generate(self.wallet, COINBASE_MATURITY)
 
         total_value = block.vtx[0].vout[0].nValue
-        out_value = total_value // 10
+        out_value = total_value // COUNT
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(block.vtx[0].txid_int, 0), b''))
-        for _ in range(10):
+        for _ in range(COUNT):
             tx.vout.append(CTxOut(out_value, CScript([OP_TRUE])))
 
         block2 = self.build_block_on_tip(self.nodes[0])
@@ -187,7 +188,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block2.solve()
         self.segwit_node.send_and_ping(msg_no_witness_block(block2))
         assert_equal(self.nodes[0].getbestblockhash(), block2.hash_hex)
-        self.utxos.extend([[tx.txid_int, i, out_value] for i in range(10)])
+        self.utxos.extend([[tx.txid_int, i, out_value] for i in range(COUNT)])
 
     def announce_cmpct_block(self, node, peer, txn_count=5, solicit=False):
         utxo = self.utxos.pop(0)
@@ -600,7 +601,7 @@ class CompactBlocksTest(BitcoinTestFramework):
     # Multiple blocktxn responses will cause a node to get disconnected.
     def test_multiple_blocktxn_response(self, test_node):
         node = self.nodes[0]
-        utxo = self.utxos[0]
+        utxo = self.utxos.pop(0)
 
         block = self.build_block_with_transactions(node, utxo, 2)
 
@@ -781,8 +782,7 @@ class CompactBlocksTest(BitcoinTestFramework):
     # but invalid transactions.
     def test_invalid_tx_in_compactblock(self, test_node):
         node = self.nodes[0]
-        assert len(self.utxos)
-        utxo = self.utxos[0]
+        utxo = self.utxos.pop(0)
 
         block = self.build_block_with_transactions(node, utxo, 5)
         block.hashMerkleRoot = block.calc_merkle_root()
@@ -849,7 +849,6 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def test_compactblock_reconstruction_stalling_peer(self, stalling_peer, delivery_peer):
         node = self.nodes[0]
-        assert len(self.utxos)
 
         self.make_peer_hb_to_candidate(node, delivery_peer)
         block, cmpct_block = self.announce_cmpct_block(node, stalling_peer)
@@ -923,7 +922,6 @@ class CompactBlocksTest(BitcoinTestFramework):
             can only be taken by an outbound node unless prior attempts were done by an outbound
         """
         node = self.nodes[0]
-        assert len(self.utxos)
 
         for name, peer in [("delivery", delivery_peer), ("inbound", inbound_peer), ("outbound", outbound_peer)]:
             self.log.info(f"Setting {name} as high bandwidth peer")

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -57,6 +57,7 @@ from test_framework.script import (
     OP_RETURN,
 )
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import TestNode
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
@@ -150,6 +151,17 @@ class CompactBlocksTest(BitcoinTestFramework):
         ]]
         self.utxos = []
 
+    def getblocktxn_expected(self, peer, blockhash, indices=None):
+        with p2p_lock:
+            assert "getblocktxn" in peer.last_message
+            gbt = peer.last_message["getblocktxn"].block_txn_request
+
+        assert_equal(gbt.blockhash, blockhash)
+        if indices is not None:
+            assert_equal(gbt.to_absolute(), indices)
+        if isinstance(peer, TestNode):
+            assert_not_equal(peer.getbestblockhash(), blockhash)
+
     def build_block_on_tip(self, node):
         block = create_block(tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
         block.solve()
@@ -184,9 +196,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         cmpct_block = HeaderAndShortIDs()
         cmpct_block.initialize_from_block(block)
         msg = msg_cmpctblock(cmpct_block.to_p2p())
+
+        peer.clear_getblocktxn()
         peer.send_and_ping(msg)
-        with p2p_lock:
-            assert "getblocktxn" in peer.last_message
+        self.getblocktxn_expected(peer, block.hash_int)
         return block, cmpct_block
 
     # Test "sendcmpct" (between peers preferring the same version):
@@ -405,13 +418,11 @@ class CompactBlocksTest(BitcoinTestFramework):
             [k0, k1] = comp_block.get_siphash_keys()
             coinbase_hash = block.vtx[0].wtxid_int
             comp_block.shortids = [calculate_shortid(k0, k1, coinbase_hash)]
+            test_node.clear_getblocktxn()
             test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
             assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
-            # Expect a getblocktxn message.
-            with p2p_lock:
-                assert "getblocktxn" in test_node.last_message
-                absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
-            assert_equal(absolute_indexes, [0])  # should be a coinbase request
+            # Expect a getblocktxn message that requests the coinbase.
+            self.getblocktxn_expected(test_node, block.hash_int, indices=[0])
 
             # Send the coinbase, and verify that the tip advances.
             msg = msg_blocktxn()
@@ -443,11 +454,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         def test_getblocktxn_response(compact_block, peer, expected_result):
             msg = msg_cmpctblock(compact_block.to_p2p())
+            peer.clear_getblocktxn()
             peer.send_and_ping(msg)
-            with p2p_lock:
-                assert "getblocktxn" in peer.last_message
-                absolute_indexes = peer.last_message["getblocktxn"].block_txn_request.to_absolute()
-            assert_equal(absolute_indexes, expected_result)
+            self.getblocktxn_expected(peer, compact_block.header.hash_int, expected_result)
 
         def test_tip_after_message(node, peer, msg, tip):
             peer.send_and_ping(msg)
@@ -508,8 +517,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             assert tx.txid_hex in mempool
 
         # Clear out last request.
-        with p2p_lock:
-            test_node.last_message.pop("getblocktxn", None)
+        test_node.clear_getblocktxn()
 
         # Send compact block
         comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
@@ -538,12 +546,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Send compact block
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
+        test_node.clear_getblocktxn()
         test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-        absolute_indexes = []
-        with p2p_lock:
-            assert "getblocktxn" in test_node.last_message
-            absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [6, 7, 8, 9, 10])
+        expected_indices = [6, 7, 8, 9, 10]
+        self.getblocktxn_expected(test_node, block.hash_int, expected_indices)
 
         # Now give an incorrect response.
         # Note that it's possible for bitcoind to be smart enough to know we're
@@ -578,12 +584,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Send compact block
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
+        test_node.clear_getblocktxn()
         test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-        absolute_indexes = []
-        with p2p_lock:
-            assert "getblocktxn" in test_node.last_message
-            absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [1, 2])
+        self.getblocktxn_expected(test_node, block.hash_int, indices=[1,2])
 
         # Send a blocktxn that does not succeed in reconstruction, triggering
         # getdata fallback.
@@ -896,6 +899,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Test the simple parallel download case...
         for num_missing in [1, 5, 20]:
+            delivery_peer.clear_getblocktxn()
+            inbound_peer.clear_getblocktxn()
+            outbound_peer.clear_getblocktxn()
 
             # Remaining low-bandwidth peer is stalling_peer, who announces first
             assert_equal([peer['bip152_hb_to'] for peer in node.getpeerinfo()], [False, True, True, True])
@@ -903,10 +909,8 @@ class CompactBlocksTest(BitcoinTestFramework):
             block, cmpct_block = self.announce_cmpct_block(node, stalling_peer, num_missing)
 
             delivery_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
-            with p2p_lock:
-                # The second peer to announce should still get a getblocktxn
-                assert "getblocktxn" in delivery_peer.last_message
-            assert_not_equal(node.getbestblockhash(), block.hash_hex)
+            # The second peer to announce should still get a getblocktxn
+            self.getblocktxn_expected(delivery_peer, block.hash_int)
 
             inbound_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
             with p2p_lock:
@@ -915,10 +919,8 @@ class CompactBlocksTest(BitcoinTestFramework):
             assert_not_equal(node.getbestblockhash(), block.hash_hex)
 
             outbound_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
-            with p2p_lock:
-                # The third peer to announce should get a getblocktxn if outbound
-                assert "getblocktxn" in outbound_peer.last_message
-            assert_not_equal(node.getbestblockhash(), block.hash_hex)
+            # The third peer to announce should get a getblocktxn if outbound
+            self.getblocktxn_expected(outbound_peer, block.hash_int)
 
             # Second peer completes the compact block first
             msg = msg_blocktxn()
@@ -930,10 +932,6 @@ class CompactBlocksTest(BitcoinTestFramework):
             # Nothing bad should happen if we get a late fill from the first peer...
             stalling_peer.send_and_ping(msg)
             self.utxos.append([block.vtx[-1].txid_int, 0, block.vtx[-1].vout[0].nValue])
-
-            delivery_peer.clear_getblocktxn()
-            inbound_peer.clear_getblocktxn()
-            outbound_peer.clear_getblocktxn()
 
 
     def run_test(self):

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -189,13 +189,16 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), block2.hash_hex)
         self.utxos.extend([[tx.txid_int, i, out_value] for i in range(10)])
 
-    def announce_cmpct_block(self, node, peer, txn_count=5):
+    def announce_cmpct_block(self, node, peer, txn_count=5, solicit=False):
         utxo = self.utxos.pop(0)
         block = self.build_block_with_transactions(node, utxo, txn_count)
 
         cmpct_block = HeaderAndShortIDs()
         cmpct_block.initialize_from_block(block)
         msg = msg_cmpctblock(cmpct_block.to_p2p())
+        if solicit:
+            peer.send_without_ping(msg_headers([block]))
+            peer.wait_for_getdata([block.hash_int], timeout=30)
 
         peer.clear_getblocktxn()
         peer.send_and_ping(msg)
@@ -291,6 +294,9 @@ class CompactBlocksTest(BitcoinTestFramework):
     def test_invalid_cmpctblock_message(self):
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         block = self.build_block_on_tip(self.nodes[0])
+
+        self.segwit_node.send_header_for_blocks([block])
+        self.segwit_node.wait_for_getdata([block.hash_int], timeout=30)
 
         cmpct_block = P2PHeaderAndShortIDs()
         cmpct_block.header = CBlockHeader(block)
@@ -581,6 +587,10 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         block = self.build_block_with_transactions(node, utxo, 2)
 
+        # The attacker sends the block header so that we request it.
+        test_node.send_without_ping(msg_headers([block]))
+        test_node.wait_for_getdata([block.hash_int], timeout=30)
+
         # Send compact block
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
@@ -806,6 +816,12 @@ class CompactBlocksTest(BitcoinTestFramework):
         msg = msg_cmpctblock(comp_block.to_p2p())
         test_node.send_await_disconnect(msg)
 
+    # peer generates a block and sends it to node, which makes the peer a
+    # candidate for high-bandwidth 'to' (up to 3 peers according to BIP 152)
+    def make_peer_hb_to_candidate(self, node, peer):
+        block = self.build_block_on_tip(node)
+        peer.send_and_ping(msg_block(block))
+
     # Helper for enabling cb announcements
     # Send the sendcmpct request and sync headers
     def request_cb_announcements(self, peer):
@@ -818,6 +834,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         node = self.nodes[0]
         assert len(self.utxos)
 
+        self.make_peer_hb_to_candidate(node, delivery_peer)
         block, cmpct_block = self.announce_cmpct_block(node, stalling_peer)
 
         for tx in block.vtx[1:]:
@@ -890,6 +907,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         for name, peer in [("delivery", delivery_peer), ("inbound", inbound_peer), ("outbound", outbound_peer)]:
             self.log.info(f"Setting {name} as high bandwidth peer")
+            self.make_peer_hb_to_candidate(node, peer)
             block, cmpct_block = self.announce_cmpct_block(node, peer, 1)
             msg = msg_blocktxn()
             msg.block_transactions.blockhash = block.hash_int
@@ -907,7 +925,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             # Remaining low-bandwidth peer is stalling_peer, who announces first
             assert_equal([peer['bip152_hb_to'] for peer in node.getpeerinfo()], [False, True, True, True])
 
-            block, cmpct_block = self.announce_cmpct_block(node, stalling_peer, num_missing)
+            block, cmpct_block = self.announce_cmpct_block(node, stalling_peer, num_missing, solicit=True)
 
             delivery_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
             # The second peer to announce should still get a getblocktxn

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -177,6 +177,17 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), block2.hash_hex)
         self.utxos.extend([[tx.txid_int, i, out_value] for i in range(10)])
 
+    def announce_cmpct_block(self, node, peer, txn_count=5):
+        utxo = self.utxos.pop(0)
+        block = self.build_block_with_transactions(node, utxo, txn_count)
+
+        cmpct_block = HeaderAndShortIDs()
+        cmpct_block.initialize_from_block(block)
+        msg = msg_cmpctblock(cmpct_block.to_p2p())
+        peer.send_and_ping(msg)
+        with p2p_lock:
+            assert "getblocktxn" in peer.last_message
+        return block, cmpct_block
 
     # Test "sendcmpct" (between peers preferring the same version):
     # - No compact block announcements unless sendcmpct is sent.
@@ -804,19 +815,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         node = self.nodes[0]
         assert len(self.utxos)
 
-        def announce_cmpct_block(node, peer):
-            utxo = self.utxos.pop(0)
-            block = self.build_block_with_transactions(node, utxo, 5)
-
-            cmpct_block = HeaderAndShortIDs()
-            cmpct_block.initialize_from_block(block)
-            msg = msg_cmpctblock(cmpct_block.to_p2p())
-            peer.send_and_ping(msg)
-            with p2p_lock:
-                assert "getblocktxn" in peer.last_message
-            return block, cmpct_block
-
-        block, cmpct_block = announce_cmpct_block(node, stalling_peer)
+        block, cmpct_block = self.announce_cmpct_block(node, stalling_peer)
 
         for tx in block.vtx[1:]:
             delivery_peer.send_without_ping(msg_tx(tx))
@@ -832,7 +831,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Now test that delivering an invalid compact block won't break relay
 
-        block, cmpct_block = announce_cmpct_block(node, stalling_peer)
+        block, cmpct_block = self.announce_cmpct_block(node, stalling_peer)
         for tx in block.vtx[1:]:
             delivery_peer.send_without_ping(msg_tx(tx))
         delivery_peer.sync_with_ping()
@@ -885,21 +884,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         node = self.nodes[0]
         assert len(self.utxos)
 
-        def announce_cmpct_block(node, peer, txn_count):
-            utxo = self.utxos.pop(0)
-            block = self.build_block_with_transactions(node, utxo, txn_count)
-
-            cmpct_block = HeaderAndShortIDs()
-            cmpct_block.initialize_from_block(block)
-            msg = msg_cmpctblock(cmpct_block.to_p2p())
-            peer.send_and_ping(msg)
-            with p2p_lock:
-                assert "getblocktxn" in peer.last_message
-            return block, cmpct_block
-
         for name, peer in [("delivery", delivery_peer), ("inbound", inbound_peer), ("outbound", outbound_peer)]:
             self.log.info(f"Setting {name} as high bandwidth peer")
-            block, cmpct_block = announce_cmpct_block(node, peer, 1)
+            block, cmpct_block = self.announce_cmpct_block(node, peer, 1)
             msg = msg_blocktxn()
             msg.block_transactions.blockhash = block.hash_int
             msg.block_transactions.transactions = block.vtx[1:]
@@ -913,7 +900,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             # Remaining low-bandwidth peer is stalling_peer, who announces first
             assert_equal([peer['bip152_hb_to'] for peer in node.getpeerinfo()], [False, True, True, True])
 
-            block, cmpct_block = announce_cmpct_block(node, stalling_peer, num_missing)
+            block, cmpct_block = self.announce_cmpct_block(node, stalling_peer, num_missing)
 
             delivery_peer.send_and_ping(msg_cmpctblock(cmpct_block.to_p2p()))
             with p2p_lock:

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -870,10 +870,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(node.getbestblockhash(), block.hash_hex)
 
     # assert the RPC getpeerinfo boolean fields `bip152_hb_{to, from}`
-    # match the given parameters for the last peer of a given node
+    # match the given parameters for the peer at idx of a given node
     @staticmethod
-    def assert_highbandwidth_states(node, hb_to, hb_from):
-        peerinfo = node.getpeerinfo()[-1]
+    def assert_highbandwidth_states(node, idx, hb_to, hb_from):
+        peerinfo = node.getpeerinfo()[idx]
         assert_equal(peerinfo['bip152_hb_to'], hb_to)
         assert_equal(peerinfo['bip152_hb_from'], hb_from)
 
@@ -881,22 +881,25 @@ class CompactBlocksTest(BitcoinTestFramework):
         # create new p2p connection for a fresh state w/o any prior sendcmpct messages sent
         hb_test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
 
+        # Newly created hb_test_node is the last connection.
+        hb_test_node_idx = -1
+
         # initially, neither node has selected the other peer as high-bandwidth yet
-        self.assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=False)
+        self.assert_highbandwidth_states(self.nodes[0], hb_test_node_idx, hb_to=False, hb_from=False)
 
         # peer requests high-bandwidth mode by sending sendcmpct(1)
         hb_test_node.send_and_ping(msg_sendcmpct(announce=True, version=2))
-        self.assert_highbandwidth_states(self.nodes[0], hb_to=False, hb_from=True)
+        self.assert_highbandwidth_states(self.nodes[0], hb_test_node_idx, hb_to=False, hb_from=True)
 
         # peer generates a block and sends it to node, which should
         # select the peer as high-bandwidth (up to 3 peers according to BIP 152)
         block = self.build_block_on_tip(self.nodes[0])
         hb_test_node.send_and_ping(msg_block(block))
-        self.assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=True)
+        self.assert_highbandwidth_states(self.nodes[0], hb_test_node_idx, hb_to=True, hb_from=True)
 
         # peer requests low-bandwidth mode by sending sendcmpct(0)
         hb_test_node.send_and_ping(msg_sendcmpct(announce=False, version=2))
-        self.assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=False)
+        self.assert_highbandwidth_states(self.nodes[0], hb_test_node_idx, hb_to=True, hb_from=False)
 
     def test_compactblock_reconstruction_parallel_reconstruction(self, stalling_peer, delivery_peer, inbound_peer, outbound_peer):
         """ All p2p connections are inbound except outbound_peer. We test that ultimate parallel slot
@@ -952,6 +955,53 @@ class CompactBlocksTest(BitcoinTestFramework):
             stalling_peer.send_and_ping(msg)
             self.utxos.append([block.vtx[-1].txid_int, 0, block.vtx[-1].vout[0].nValue])
 
+    def test_compact_blocks_ignored(self):
+        node = self.nodes[0]
+
+        def build_compact_block():
+            # generate a compact block to send that will force a GETBLOCKTXN
+            utxo = self.utxos.pop(0)
+            block = self.build_block_with_transactions(node, utxo, 10)
+            cmpct_block = HeaderAndShortIDs()
+            cmpct_block.initialize_from_block(block)
+            msg = msg_cmpctblock(cmpct_block.to_p2p())
+            return block, msg
+
+        # Sends a compact block, uses presence of GETBLOCKTXN as a heuristic
+        # for whether or not the node processed the CMPCTBLOCK.
+        # Note: since we never fulfill the GETBLOCKTXN, this will never change
+        # the HB status of a connection.
+        def ignores_compact_block(conn, solicited=False):
+            block, msg = build_compact_block()
+            conn.clear_getblocktxn()
+            if solicited:
+                conn.send_without_ping(msg_headers([block]))
+                conn.wait_for_getdata([block.hash_int], timeout=30)
+            conn.send_and_ping(msg)
+            with p2p_lock:
+                return "getblocktxn" not in conn.last_message
+
+        # create new p2p connection for a fresh state w/o any prior sendcmpct messages sent
+        unsolicited_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
+
+        self.log.info("Test that a node ignores unsolicited CMPCTBLOCK messages from non-HB peers.")
+        assert ignores_compact_block(unsolicited_peer, solicited=False)
+        self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
+
+        self.log.info("Test that a node does not ignore solicited CMPCTBLOCK messages from non-HB peers.")
+        assert not ignores_compact_block(unsolicited_peer, solicited=True)
+        self.assert_highbandwidth_states(node, idx=-1, hb_to=False, hb_from=False)
+
+        # The node will ask for transactions from an unsolicited compact block
+        # it receives from a high bandwidth peer, we need to use one set up earlier,
+        # since all the slots are full.
+        self.log.info("Test that a node does not ignore unsolicited CMPCTBLOCK messages from HB peers.")
+
+        hb_peer_idx = -2
+        self.assert_highbandwidth_states(node, idx=hb_peer_idx, hb_to=True, hb_from=False)
+        hb_peer = self.nodes[0].p2ps[hb_peer_idx]
+        assert not ignores_compact_block(hb_peer, solicited=False)
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
@@ -1026,6 +1076,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         self.log.info("Testing high-bandwidth mode states via getpeerinfo...")
         self.test_highbandwidth_mode_states_via_getpeerinfo()
+
+        self.log.info("Testing CMPCTBLOCK messages are ignored when expected...")
+        self.test_compact_blocks_ignored()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -12,7 +12,9 @@ from test_framework.messages import (
     CBlockHeader,
     CInv,
     from_hex,
+    HeaderAndShortIDs,
     msg_block,
+    msg_cmpctblock,
     msg_getdata,
     msg_headers,
     msg_sendcmpct,
@@ -37,6 +39,30 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         block_hex = self.nodes[2].getblock(blockhash=blockhash, verbosity=0)
         block = from_hex(CBlock(), block_hex)
         return block
+
+    def ignores_cmpctblock(self, node_id, conn, solicited=False):
+        # Briefly connect to mining node, sync, and disconnect, just to make
+        # sure the node is on the same tip as the miner so that compact block
+        # reconstruction works.
+        self.connect_nodes(2, node_id)
+        self.sync_blocks([self.nodes[2], self.nodes[node_id]], timeout=10)
+        self.disconnect_nodes(2, node_id)
+
+        block = self.build_block_on_tip()
+        if solicited:
+            conn.send_without_ping(msg_headers([block]))
+            conn.wait_for_getdata([block.hash_int], timeout=10)
+        cmpct_block = HeaderAndShortIDs()
+        cmpct_block.initialize_from_block(block, use_witness=True)
+        msg = msg_cmpctblock(cmpct_block.to_p2p())
+        conn.send_and_ping(msg)
+
+        cmpct_block_received = self.nodes[node_id].getbestblockhash() == cmpct_block.header.hash_hex
+        if not cmpct_block_received:
+            # Compact block was ignored, send the full block to keep in sync.
+            conn.send_and_ping(msg_block(block))
+
+        return not cmpct_block_received
 
     def run_test(self):
         # Nodes will only request hb compact blocks mode when they're out of IBD
@@ -98,11 +124,19 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         p2p_conn_high_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
         assert_equal(p2p_conn_high_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.hash_int)])
 
+        # Send the block to avoid stalling the peer later in the test.
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block1, use_witness=True)
+        block1_cb_msg = msg_cmpctblock(comp_block.to_p2p())
+        p2p_conn_high_bw.send_and_ping(block1_cb_msg)
+
         self.log.info("Test that getdata(CMPCT) is still sent on BIP152 low bandwidth connections"
                       " when no -blocksonly nodes are involved")
 
         p2p_conn_low_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
         assert_equal(p2p_conn_low_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.hash_int)])
+        # Send the block to avoid stalling the peer later in the test.
+        p2p_conn_low_bw.send_and_ping(block1_cb_msg)
 
         self.log.info("Test that -blocksonly nodes still serve compact blocks")
 
@@ -121,6 +155,19 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         self.nodes[0].submitblock(block1.serialize().hex())
         self.nodes[0].submitblock(block2.serialize().hex())
         p2p_conn_blocksonly.wait_until(lambda: test_for_cmpctblock(block2))
+
+        # This is redundant with other tests, and is here as a test-of-the-test
+        self.log.info("Test that normal nodes don't ignore CMPCTBLOCK messages from HB peers")
+        assert not self.ignores_cmpctblock(1, p2p_conn_high_bw, solicited=False)
+
+        self.log.info("Test that -blocksonly nodes ignore CMPCTBLOCK messages")
+        assert self.ignores_cmpctblock(0, p2p_conn_blocksonly, solicited=False)
+
+        self.log.info("Test that low bandwidth nodes listen to CMPCTBLOCK messages when the block is requested")
+        assert not self.ignores_cmpctblock(3, p2p_conn_low_bw, solicited=True)
+
+        self.log.info("Test that -blocksonly nodes ignore CMPCTBLOCK messages even when the block is requested")
+        assert self.ignores_cmpctblock(0, p2p_conn_blocksonly, solicited=True)
 
 if __name__ == '__main__':
     P2PCompactBlocksBlocksOnly(__file__).main()

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -14,6 +14,7 @@ from test_framework.messages import (
     msg_cmpctblock,
     msg_block,
     msg_blocktxn,
+    msg_headers,
     HeaderAndShortIDs,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -56,6 +57,10 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # version on the self-transfer.
         mutated_block = copy.deepcopy(block)
         mutated_block.vtx[1].version = 4
+
+        # Send block header through the honest relayer
+        honest_relayer.send_without_ping(msg_headers([block]))
+        honest_relayer.wait_for_getdata([block.hash_int], timeout=30)
 
         # Announce the new block via a compact block through the honest relayer
         cmpctblock = HeaderAndShortIDs()

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -16,6 +16,7 @@ from test_framework.messages import (
     msg_blocktxn,
     msg_headers,
     HeaderAndShortIDs,
+    msg_sendcmpct,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.blocktools import (
@@ -43,6 +44,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         self.generate(self.wallet, COINBASE_MATURITY)
 
         honest_relayer = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="outbound-full-relay")
+        honest_relayer.send_and_ping(msg_sendcmpct())
         attacker = self.nodes[0].add_p2p_connection(P2PInterface())
 
         # Create new block with two transactions (coinbase + 1 self-transfer).

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1672,7 +1672,7 @@ class msg_sendcmpct:
     __slots__ = ("announce", "version")
     msgtype = b"sendcmpct"
 
-    def __init__(self, announce=False, version=1):
+    def __init__(self, announce=False, version=2):
         self.announce = announce
         self.version = version
 


### PR DESCRIPTION
Processing unsolicited `CMPCTBLOCK`'s from a peer that has not been marked high bandwidth is not well-specified behavior in BIP-0152, in fact the BIP seems to imply that it is not permitted:

> "[...] method is not useful for compact blocks because `cmpctblock` blocks can be sent unsolicitedly in high-bandwidth mode"

See https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki#separate-version-for-segregated-witness

This PR disables processing of CMPCTBLOCK messages in three cases:
$1$. When the block is unsolicited and from a non-HB peer.
$2$. When this node is running in `-blocksonly` mode.
$3$. When the peer has not advertised `CMPCTBLOCK` support with a `SENDCMPCT` message.

Not processing unsolicited blocks slightly raises the cost of discovering a peer's mempool via `CMPCTBLOCK` as described in #28272. As pointed out there, getting an HB slot is relatively easy, so this does not prevent an attacker from doing this, it just slightly raises the bar.

Probably more important is not processing `CMPCTBLOCK` messages as a `-blocksonly` node. A blocksonly node has a lot less surface area for leaking its mempool since it does no transaction relay, and leaking a blocksonly node's mempool is pretty dangerous since it is very likely to be the origin for all of the transactions in its mempool.