### PR TITLE
wallet: Fix wallet interface detection of encrypted wallets

### DIFF
--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -643,6 +643,10 @@ public:
         DatabaseStatus status;
         bilingual_str error;
         auto db = MakeWalletDatabase(wallet_name, options, status, error);
+        if (!db && status == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
+            options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
+            db = MakeWalletDatabase(wallet_name, options, status, error);
+        }
         if (!db) return false;
         return WalletBatch(*db).IsEncrypted();
     }


### PR DESCRIPTION
The GUI uses `WalletLoader::isEncrypted()` to detect whether a wallet file is encrypted so that it knows whether to prompt for a passphrase when migrating a legacy wallet. However, legacy wallets need to be opened with `options.require_format = BERKELEY_RO`. Since this wasn't being provided, following #28710, encrypted legacy wallets could not be migrated.

This fixes the issue by detecting when a wallet file is for a legacy wallet, and re-attempting with `options.require_format = BERKELEY_RO` in that case.

Depends on #32449 for `DatabaseStatus::FAILED_LEGACY_DISABLED`