### PR TITLE
test: Add missing ipc subtree to lint

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1268,7 +1268,7 @@ Subtrees
 
 Several parts of the repository are subtrees of software maintained elsewhere.
 
-Some of these are maintained by active developers of Bitcoin Core, in which case
+Normally, these are maintained by active developers of Bitcoin Core, in which case
 changes should go directly upstream without being PRed directly against the project.
 They will be merged back in the next subtree merge.
 
@@ -1280,31 +1280,19 @@ should be taken upstream.
 There is a tool in `test/lint/git-subtree-check.sh` ([instructions](../test/lint#git-subtree-checksh))
 to check a subtree directory for consistency with its upstream repository.
 
-Current subtrees include:
+The tool instructions also include a list of the subtrees managed by Bitcoin Core.
+
+The ultimate upstream of the few externally managed subtrees are:
 
 - src/leveldb
-  - Subtree at https://github.com/bitcoin-core/leveldb-subtree ; maintained by Core contributors.
   - Upstream at https://github.com/google/leveldb ; maintained by Google. Open
-    important PRs to the subtree to avoid delay.
+    important PRs to the Bitcoin Core subtree to avoid delay.
   - **Note**: Follow the instructions in [Upgrading LevelDB](#upgrading-leveldb) when
     merging upstream changes to the LevelDB subtree.
 
 - src/crc32c
   - Used by leveldb for hardware acceleration of CRC32C checksums for data integrity.
-  - Subtree at https://github.com/bitcoin-core/crc32c-subtree ; maintained by Core contributors.
   - Upstream at https://github.com/google/crc32c ; maintained by Google.
-
-- src/secp256k1
-  - Upstream at https://github.com/bitcoin-core/secp256k1/ ; maintained by Core contributors.
-
-- src/crypto/ctaes
-  - Upstream at https://github.com/bitcoin-core/ctaes ; maintained by Core contributors.
-
-- src/minisketch
-  - Upstream at https://github.com/bitcoin-core/minisketch ; maintained by Core contributors.
-
-- src/ipc/libmultiprocess
-  - Upstream at https://github.com/bitcoin-core/libmultiprocess ; maintained by Core contributors.
 
 Upgrading LevelDB
 ---------------------

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -92,11 +92,14 @@ Usage: test/lint/git-subtree-check.sh [-r] DIR [COMMIT]
 
 To do a full check with `-r`, make sure that you have fetched the upstream repository branch in which the subtree is
 maintained:
-* for `src/secp256k1`: https://github.com/bitcoin-core/secp256k1.git (branch master)
-* for `src/leveldb`: https://github.com/bitcoin-core/leveldb-subtree.git (branch bitcoin-fork)
-* for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)
 * for `src/crc32c`: https://github.com/bitcoin-core/crc32c-subtree.git (branch bitcoin-fork)
+* for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)
+* for `src/ipc/libmultiprocess`: https://github.com/bitcoin-core/libmultiprocess (branch master)
+* for `src/leveldb`: https://github.com/bitcoin-core/leveldb-subtree.git (branch bitcoin-fork)
 * for `src/minisketch`: https://github.com/bitcoin-core/minisketch.git (branch master)
+* for `src/secp256k1`: https://github.com/bitcoin-core/secp256k1.git (branch master)
+
+Keep this list in sync with `fn get_subtrees()` in the lint runner.
 
 To do so, add the upstream repository as remote:
 

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -205,9 +205,11 @@ fn commit_range() -> String {
 
 /// Return all subtree paths
 fn get_subtrees() -> Vec<&'static str> {
+    // Keep in sync with [test/lint/README.md#git-subtree-checksh]
     vec![
         "src/crc32c",
         "src/crypto/ctaes",
+        "src/ipc/libmultiprocess",
         "src/leveldb",
         "src/minisketch",
         "src/secp256k1",


### PR DESCRIPTION
The subtree docs and lint checks list the subtrees in three places, making it hard to follow and update and easy to miss one.

Fix all issues by including the missing one and removing the list in one place.