### PR TITLE
Replace dead gnome link notificator.cpp

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -141,7 +141,6 @@ QVariant FreedesktopImage::toVariant(const QImage &img)
 
 void Notificator::notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
-    // https://developer.gnome.org/documentation/tutorials/notifications.html
     // Arguments for DBus "Notify" call:
     QList<QVariant> args;
 

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -141,7 +141,7 @@ QVariant FreedesktopImage::toVariant(const QImage &img)
 
 void Notificator::notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
-    // https://developer.gnome.org/notification-spec/
+    // https://developer.gnome.org/documentation/tutorials/notifications.html
     // Arguments for DBus "Notify" call:
     QList<QVariant> args;
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL
https://developer.gnome.org/notification-spec/ - old link
https://developer.gnome.org/documentation/tutorials/notifications.html - new link