### PR TITLE
test: fix sync function in rpc_psbt.py

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -83,7 +83,7 @@ class PSBTTest(BitcoinTestFramework):
         wallet = node.get_wallet_rpc(self.default_wallet_name)
         address = wallet.getnewaddress()
         wallet.sendtoaddress(address=address, amount=1.0)
-        self.generate(node, nblocks=1, sync_fun=lambda: self.sync_all(self.nodes[:2]))
+        self.generate(node, nblocks=1)
 
         utxos = wallet.listunspent(addresses=[address])
         psbt = wallet.createpsbt([{"txid": utxos[0]["txid"], "vout": utxos[0]["vout"]}], [{wallet.getnewaddress(): 0.9999}])


### PR DESCRIPTION
Even though the block is created on `node2`, the sync is only between `node1` and `node0`. Accordingly the test fails if I put a sleep in `msg_type == NetMsgType::HEADERS` processing: In this case, `node1` and `node0` do not hear about the new  block, the sync still passes because they are in sync with each other, and later on in the `test_input_confs_control` subtest, `node1` would generate a forked block instead of building on the previous one, leading to test failure.

Haven't seen this in the CI, but I ran into it on an experimental branch.