### PR TITLE
build: Add resource file and manifest to `bitcoin.exe`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -335,6 +335,7 @@ target_link_libraries(bitcoin_node
 # Bitcoin wrapper executable that can call other executables.
 if(BUILD_BITCOIN_BIN)
   add_executable(bitcoin bitcoin.cpp)
+  add_windows_resources(bitcoin bitcoin-res.rc)
   target_link_libraries(bitcoin core_interface bitcoin_util)
   install_binary_component(bitcoin)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,6 +336,7 @@ target_link_libraries(bitcoin_node
 if(BUILD_BITCOIN_BIN)
   add_executable(bitcoin bitcoin.cpp)
   add_windows_resources(bitcoin bitcoin-res.rc)
+  add_windows_application_manifest(bitcoin)
   target_link_libraries(bitcoin core_interface bitcoin_util)
   install_binary_component(bitcoin)
 endif()

--- a/src/bitcoin-res.rc
+++ b/src/bitcoin-res.rc
@@ -1,0 +1,33 @@
+#include <windows.h>             // needed for VERSIONINFO
+#include "clientversion.h"       // holds the needed client version information
+
+#define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
+#define VER_FILEVERSION        VER_PRODUCTVERSION
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4" // U.S. English - multilingual (hex)
+        BEGIN
+            VALUE "CompanyName",        "Bitcoin"
+            VALUE "FileDescription",    "bitcoin (Bitcoin wrapper executable that can call other executables)"
+            VALUE "FileVersion",        CLIENT_VERSION_STRING
+            VALUE "InternalName",       "bitcoin"
+            VALUE "LegalCopyright",     COPYRIGHT_STR
+            VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
+            VALUE "OriginalFilename",   "bitcoin.exe"
+            VALUE "ProductName",        "bitcoin"
+            VALUE "ProductVersion",     CLIENT_VERSION_STRING
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0, 1252 // language neutral - multilingual (decimal)
+    END
+END


### PR DESCRIPTION
This PR is a follow up to https://github.com/bitcoin/bitcoin/pull/31375, which:
1. Adds a resource file for `bitcoin.exe` for consistency with other Windows executables.
2. Adds an application manifest to `bitcoin.exe`, which has been required for release binaries since https://github.com/bitcoin/bitcoin/pull/32396.