### PR TITLE
Update libmultiprocess subtree to fix clang-tidy errors

### DIFF
--- a/include/mp/type-interface.h
+++ b/include/mp/type-interface.h
@@ -44,7 +44,7 @@ void CustomBuildField(TypeList<std::shared_ptr<Impl>>,
 {
     if (value) {
         using Interface = typename decltype(output.get())::Calls;
-        output.set(CustomMakeProxyServer<Interface, Impl>(invoke_context, std::move(value)));
+        output.set(CustomMakeProxyServer<Interface, Impl>(invoke_context, std::forward<Value>(value)));
     }
 }
 

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -183,7 +183,7 @@ struct AsyncCallable
 template <typename Callable>
 AsyncCallable<std::remove_reference_t<Callable>> MakeAsyncCallable(Callable&& callable)
 {
-    return std::move(callable);
+    return std::forward<Callable>(callable);
 }
 
 //! Format current thread name as "{exe_name}-{$pid}/{thread_name}-{$tid}".

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -215,7 +215,7 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_types << "namespace mp {\n";
 
     std::string guard = output_path;
-    std::transform(guard.begin(), guard.end(), guard.begin(), [](unsigned char c) -> unsigned char {
+    std::ranges::transform(guard, guard.begin(), [](unsigned char c) -> unsigned char {
         if ('0' <= c && c <= '9') return c;
         if ('A' <= c && c <= 'Z') return c;
         if ('a' <= c && c <= 'z') return c - 'a' + 'A';
@@ -512,10 +512,20 @@ static void Generate(kj::StringPtr src_prefix,
 
                     add_accessor(field_name);
 
+                    std::ostringstream fwd_args;
                     for (int i = 0; i < field.args; ++i) {
                         if (argc > 0) client_args << ",";
+
+                        // Add to client method parameter list.
                         client_args << "M" << method_ordinal << "::Param<" << argc << "> " << field_name;
                         if (field.args > 1) client_args << i;
+
+                        // Add to MakeClientParam argument list using Fwd helper for perfect forwarding.
+                        if (i > 0) fwd_args << ", ";
+                        fwd_args << "M" << method_ordinal << "::Fwd<" << argc << ">(" << field_name;
+                        if (field.args > 1) fwd_args << i;
+                        fwd_args << ")";
+
                         ++argc;
                     }
                     client_invoke << ", ";
@@ -529,13 +539,10 @@ static void Generate(kj::StringPtr src_prefix,
                     client_invoke << "Accessor<" << base_name << "_fields::" << Cap(field_name) << ", "
                                   << field_flags.str() << ">>(";
 
-                    if (field.retval || field.args == 1) {
+                    if (field.retval) {
                         client_invoke << field_name;
                     } else {
-                        for (int i = 0; i < field.args; ++i) {
-                            if (i > 0) client_invoke << ", ";
-                            client_invoke << field_name << i;
-                        }
+                        client_invoke << fwd_args.str();
                     }
                     client_invoke << ")";
 

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -277,7 +277,7 @@ void EventLoop::startAsyncThread(std::unique_lock<std::mutex>& lock)
     }
 }
 
-bool EventLoop::done(std::unique_lock<std::mutex>& lock)
+bool EventLoop::done(std::unique_lock<std::mutex>& lock) const
 {
     assert(m_num_clients >= 0);
     assert(lock.owns_lock());

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -137,7 +137,7 @@ void ExecProcess(const std::vector<std::string>& args)
     }
     argv.push_back(nullptr);
     if (execvp(argv[0], argv.data()) != 0) {
-        perror("execlp failed");
+        perror("execvp failed");
         _exit(1);
     }
 }


### PR DESCRIPTION
Includes:

- https://github.com/bitcoin-core/libmultiprocess/pull/165
- https://github.com/bitcoin-core/libmultiprocess/pull/173
- https://github.com/bitcoin-core/libmultiprocess/pull/172

These changes are needed to fix CI errors in #31802.

The changes can be verified by running `test/lint/git-subtree-check.sh src/ipc/libmultiprocess` as described in [developer notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#subtrees) and [lint instructions](https://github.com/bitcoin/bitcoin/tree/master/test/lint#git-subtree-checksh)