### PR TITLE
fs: use `ftruncate` in `AllocateFileRange` on OpenBSD

### DIFF
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -200,10 +200,13 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     }
     ftruncate(fileno(file), static_cast<off_t>(offset) + length);
 #else
+    off_t nEndPos = (off_t)offset + length;
 #if defined(HAVE_POSIX_FALLOCATE)
     // Version using posix_fallocate
-    off_t nEndPos = (off_t)offset + length;
     if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+#elif defined(__OpenBSD__)
+    // OpenBSD doesn't have fallocate or posix_fallocate, use ftruncate
+    if (0 == ftruncate(fileno(file), nEndPos)) return;
 #endif
     // Fallback version
     // TODO: just write one byte per block


### PR DESCRIPTION
Closes #32643.

Tested on OpenBSD 7.7 (amd64) by running a signet IBD, with the following patch on top to ensure the fallback isn't executed anymore:
```diff
diff --git a/src/util/fs_helpers.cpp b/src/util/fs_helpers.cpp
index 84ac3690c9..c6dff2d29d 100644
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -208,6 +208,7 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     // OpenBSD doesn't have fallocate or posix_fallocate, use ftruncate
     if (0 == ftruncate(fileno(file), nEndPos)) return;
 #endif
+    assert(false);
     // Fallback version
     // TODO: just write one byte per block
     static const char buf[65536] = {};
``` 
Didn't run any performance tests, happy to take inputs on how to best measure any potential difference.

For another reference, here's an OpenBSD ports patch for [kitty](https://sw.kovidgoyal.net/kitty/) that replaces `posix_fallocate` with `ftruncate`: https://github.com/openbsd/ports/blob/master/x11/kitty/patches/patch-glfw_backend_utils_c