### PR TITLE
depends: sqlite 3.50.4; switch to autosetup

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -19,6 +19,7 @@
              ((gnu packages python-crypto) #:select (python-asn1crypto))
              ((gnu packages python-science) #:select (python-scikit-build-core))
              ((gnu packages python-xyz) #:select (python-pydantic-2))
+             (gnu packages tcl)
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system cmake)
@@ -547,6 +548,7 @@ inspecting signatures in Mach-O binaries.")
         cmake-minimal
         gnu-make
         ninja
+        tcl
         ;; Scripting
         python-minimal ;; (3.10)
         ;; Git

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -1,35 +1,29 @@
 package=sqlite
-$(package)_version=3460100
-$(package)_download_path=https://sqlite.org/2024/
+$(package)_version=3500400
+$(package)_download_path=https://sqlite.org/2025/
 $(package)_file_name=sqlite-autoconf-$($(package)_version).tar.gz
-$(package)_sha256_hash=67d3fe6d268e6eaddcae3727fce58fcc8e9c53869bdd07a0c61e38ddf2965071
+$(package)_sha256_hash=a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
-$(package)_config_opts+= --disable-rtree --disable-fts4 --disable-fts5
-# We avoid using `--enable-debug` because it overrides CFLAGS, a behavior we want to prevent.
-$(package)_cppflags_debug += -DSQLITE_DEBUG
-$(package)_cppflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
-$(package)_cppflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
-$(package)_cppflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
+$(package)_config_opts = --disable-shared --disable-readline --disable-rtree
+$(package)_config_opts += --disable-fts4 --disable-fts5
+$(package)_config_opts_debug += --debug
+$(package)_cppflags += -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cppflags += -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
+$(package)_cppflags += -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
+$(package)_cppflags += -DSQLITE_OMIT_LOAD_EXTENSION
 endef
 
-define $(package)_preprocess_cmds
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
-endef
-
+# Remove --with-pic, which is applied globally to configure
+# invocations but is incompatible with Autosetup
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  $$(filter-out --with-pic,$($(package)_autoconf))
 endef
 
 define $(package)_build_cmds
-  $(MAKE) libsqlite3.la
+  $(MAKE) libsqlite3.a
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install-libLTLIBRARIES install-includeHEADERS
-endef
-
-define $(package)_postprocess_cmds
-  rm lib/*.la
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install-headers install-lib
 endef


### PR DESCRIPTION
Migrate to SQLite `3.50.4` in depends; switching to its new [Autosetup](https://msteveb.github.io/autosetup/) build system.