### PR TITLE
doc: Remove build instruction for running `clang-tidy`

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -221,7 +221,6 @@ Configure with clang as the compiler:
 
 ```sh
 cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-cmake --build build -j $(nproc)
 ```
 
 The output is denoised of errors from external dependencies.


### PR DESCRIPTION
One of the benefits of using a compilation database, which is available after the CMake build system generation step, is that it is not necessary to actually build the code in order to run `clang-tidy`.