### PR TITLE
depends: Bump boost to 1.88.0 and use new CMake buildsystem

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,10 +1,29 @@
 package=boost
-$(package)_version=1.81.0
-$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
-$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.gz
-$(package)_sha256_hash=205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6
+$(package)_version = 1.88.0
+$(package)_download_path = https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
+$(package)_file_name = boost-$($(package)_version)-cmake.tar.gz
+$(package)_sha256_hash = dcea50f40ba1ecfc448fdf886c0165cf3e525fef2c9e3e080b9804e8117b9694
+$(package)_patches = skip_compiled_targets.patch
+$(package)_build_subdir = build
+
+define $(package)_set_vars
+  $(package)_config_opts = -DBOOST_INCLUDE_LIBRARIES="multi_index;signals2;test"
+  $(package)_config_opts += -DBOOST_TEST_HEADERS_ONLY=ON
+  $(package)_config_opts += -DBOOST_ENABLE_MPI=OFF
+  $(package)_config_opts += -DBOOST_ENABLE_PYTHON=OFF
+  $(package)_config_opts += -DBOOST_INSTALL_LAYOUT=system
+  $(package)_config_opts += -DBUILD_TESTING=OFF
+  $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ICU=ON
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/skip_compiled_targets.patch
+endef
+
+define $(package)_config_cmds
+  $($(package)_cmake) -S .. -B .
+endef
 
 define $(package)_stage_cmds
-  mkdir -p $($(package)_staging_prefix_dir)/include && \
-  cp -r boost $($(package)_staging_prefix_dir)/include
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef

--- a/depends/patches/boost/skip_compiled_targets.patch
+++ b/depends/patches/boost/skip_compiled_targets.patch
@@ -1,0 +1,136 @@
+cmake: Add `BOOST_TEST_HEADERS_ONLY` configuration variable
+
+This change allows the build to be configured to install only the
+Boost.Test headers required for using the headers-only variant of the
+Unit Test Framework.
+
+Upstream commit: 097e97820e654ead9c477b47443a545cef5d3b12
+
+
+--- a/libs/test/CMakeLists.txt
++++ b/libs/test/CMakeLists.txt
+@@ -30,60 +30,70 @@ set(_boost_test_dependencies
+   Boost::utility
+ )
+ 
+-# Compiled targets
++option(BOOST_TEST_HEADERS_ONLY "Boost.Test: Only install headers" OFF)
+ 
+-function(boost_test_add_library name)
++set(_boost_test_libraries "")
+ 
+-  add_library(boost_${name} ${ARGN})
+-  add_library(Boost::${name} ALIAS boost_${name})
++if (NOT BOOST_TEST_HEADERS_ONLY)
+ 
+-  target_include_directories(boost_${name} PUBLIC include)
+-  target_link_libraries(boost_${name} PUBLIC ${_boost_test_dependencies})
++  # Compiled targets
+ 
+-  target_compile_definitions(boost_${name}
+-    PUBLIC BOOST_TEST_NO_LIB
+-    # Source files already define BOOST_TEST_SOURCE
+-    # PRIVATE BOOST_TEST_SOURCE
+-  )
++  function(boost_test_add_library name)
+ 
+-  if(BUILD_SHARED_LIBS)
+-    target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_DYN_LINK)
+-  else()
+-    target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_STATIC_LINK)
+-  endif()
++    add_library(boost_${name} ${ARGN})
++    add_library(Boost::${name} ALIAS boost_${name})
+ 
+-endfunction()
++    target_include_directories(boost_${name} PUBLIC include)
++    target_link_libraries(boost_${name} PUBLIC ${_boost_test_dependencies})
+ 
+-boost_test_add_library(prg_exec_monitor
+-  src/cpp_main.cpp
+-  src/debug.cpp
+-  src/execution_monitor.cpp
+-)
++    target_compile_definitions(boost_${name}
++      PUBLIC BOOST_TEST_NO_LIB
++      # Source files already define BOOST_TEST_SOURCE
++      # PRIVATE BOOST_TEST_SOURCE
++    )
+ 
+-set(SOURCES
+-  src/compiler_log_formatter.cpp
+-  src/debug.cpp
+-  src/decorator.cpp
+-  src/execution_monitor.cpp
+-  src/framework.cpp
+-  src/junit_log_formatter.cpp
+-  src/plain_report_formatter.cpp
+-  src/progress_monitor.cpp
+-  src/results_collector.cpp
+-  src/results_reporter.cpp
+-  src/test_framework_init_observer.cpp
+-  src/test_tools.cpp
+-  src/test_tree.cpp
+-  src/unit_test_log.cpp
+-  src/unit_test_main.cpp
+-  src/unit_test_monitor.cpp
+-  src/unit_test_parameters.cpp
+-  src/xml_log_formatter.cpp
+-  src/xml_report_formatter.cpp
+-)
++    if(BUILD_SHARED_LIBS)
++      target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_DYN_LINK)
++    else()
++      target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_STATIC_LINK)
++    endif()
++
++  endfunction()
+ 
+-boost_test_add_library(test_exec_monitor STATIC ${SOURCES} src/test_main.cpp)
+-boost_test_add_library(unit_test_framework ${SOURCES})
++  boost_test_add_library(prg_exec_monitor
++    src/cpp_main.cpp
++    src/debug.cpp
++    src/execution_monitor.cpp
++  )
++
++  set(SOURCES
++    src/compiler_log_formatter.cpp
++    src/debug.cpp
++    src/decorator.cpp
++    src/execution_monitor.cpp
++    src/framework.cpp
++    src/junit_log_formatter.cpp
++    src/plain_report_formatter.cpp
++    src/progress_monitor.cpp
++    src/results_collector.cpp
++    src/results_reporter.cpp
++    src/test_framework_init_observer.cpp
++    src/test_tools.cpp
++    src/test_tree.cpp
++    src/unit_test_log.cpp
++    src/unit_test_main.cpp
++    src/unit_test_monitor.cpp
++    src/unit_test_parameters.cpp
++    src/xml_log_formatter.cpp
++    src/xml_report_formatter.cpp
++  )
++
++  boost_test_add_library(test_exec_monitor STATIC ${SOURCES} src/test_main.cpp)
++  boost_test_add_library(unit_test_framework ${SOURCES})
++
++  set(_boost_test_libraries boost_prg_exec_monitor boost_test_exec_monitor boost_unit_test_framework)
++
++endif()
+ 
+ # Header-only targets
+ 
+@@ -107,7 +117,7 @@ if(BOOST_SUPERPROJECT_VERSION AND NOT CMAKE_VERSION VERSION_LESS 3.13)
+ 
+   boost_install(
+     TARGETS
+-      boost_prg_exec_monitor boost_test_exec_monitor boost_unit_test_framework
++      ${_boost_test_libraries}
+       boost_included_prg_exec_monitor boost_included_test_exec_monitor boost_included_unit_test_framework
+     VERSION ${BOOST_SUPERPROJECT_VERSION}
+     HEADER_DIRECTORY include


### PR DESCRIPTION
Originally #30434.

This has a few advantages over the old method of simply copying headers:
- Installs proper CMake files which can be picked up by our buildsystem
- Only installs necessary headers, not all of Boost

Pulls in upstreamed https://github.com/boostorg/test/pull/445.