### PR TITLE
build: Find Boost in config mode

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -29,17 +29,8 @@ function(add_boost_if_needed)
     endif()
   endif()
 
-  # We cannot rely on find_package(Boost ...) to work properly without
-  # Boost_NO_BOOST_CMAKE set until we require a more recent Boost because
-  # upstream did not ship proper CMake files until 1.82.0.
-  # Until then, we rely on CMake's FindBoost module.
-  # See: https://cmake.org/cmake/help/latest/policy/CMP0167.html
-  if(POLICY CMP0167)
-    cmake_policy(SET CMP0167 OLD)
-  endif()
-  set(Boost_NO_BOOST_CMAKE ON)
-  find_package(Boost 1.73.0 REQUIRED)
-  mark_as_advanced(Boost_INCLUDE_DIR)
+  find_package(Boost 1.73.0 REQUIRED CONFIG)
+  mark_as_advanced(Boost_INCLUDE_DIR boost_headers_DIR)
   set_target_properties(Boost::headers PROPERTIES IMPORTED_GLOBAL TRUE)
   target_compile_definitions(Boost::headers INTERFACE
     # We don't use multi_index serialization.
@@ -57,34 +48,24 @@ function(add_boost_if_needed)
   # older than 1.80.
   # See: https://github.com/boostorg/config/pull/430.
   set(CMAKE_REQUIRED_DEFINITIONS -DBOOST_NO_CXX98_FUNCTION_BASE)
-  set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIR})
-  include(CMakePushCheckState)
-  cmake_push_check_state()
-  include(TryAppendCXXFlags)
+  get_target_property(CMAKE_REQUIRED_INCLUDES Boost::headers INTERFACE_INCLUDE_DIRECTORIES)
   set(CMAKE_REQUIRED_FLAGS ${working_compiler_werror_flag})
   set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+  include(CheckCXXSourceCompiles)
   check_cxx_source_compiles("
     #include <boost/config.hpp>
     " NO_DIAGNOSTICS_BOOST_NO_CXX98_FUNCTION_BASE
   )
-  cmake_pop_check_state()
   if(NO_DIAGNOSTICS_BOOST_NO_CXX98_FUNCTION_BASE)
     target_compile_definitions(Boost::headers INTERFACE
       BOOST_NO_CXX98_FUNCTION_BASE
     )
-  else()
-    set(CMAKE_REQUIRED_DEFINITIONS)
   endif()
 
   # Some package managers, such as vcpkg, vendor Boost.Test separately
   # from the rest of the headers, so we have to check for it individually.
   if(BUILD_TESTS AND DEFINED VCPKG_TARGET_TRIPLET)
-    list(APPEND CMAKE_REQUIRED_DEFINITIONS -DBOOST_TEST_NO_MAIN)
-    include(CheckIncludeFileCXX)
-    check_include_file_cxx(boost/test/included/unit_test.hpp HAVE_BOOST_INCLUDED_UNIT_TEST_H)
-    if(NOT HAVE_BOOST_INCLUDED_UNIT_TEST_H)
-      message(FATAL_ERROR "Building test_bitcoin executable requested but boost/test/included/unit_test.hpp header not available.")
-    endif()
+    find_package(boost_included_unit_test_framework ${Boost_VERSION} EXACT REQUIRED CONFIG)
   endif()
 
 endfunction()


### PR DESCRIPTION
The `FindBoost` module has been removed by policy [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html).