### PR TITLE
refactor: Drop unused `#include <boost/operators.hpp>`

### DIFF
--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -5,7 +5,6 @@
 #include <node/mini_miner.h>
 
 #include <boost/multi_index/detail/hash_index_iterator.hpp>
-#include <boost/operators.hpp>
 #include <consensus/amount.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -29,7 +29,6 @@ EXPECTED_BOOST_INCLUDES = [
                            "boost/multi_index/sequenced_index.hpp",
                            "boost/multi_index/tag.hpp",
                            "boost/multi_index_container.hpp",
-                           "boost/operators.hpp",
                            "boost/signals2/connection.hpp",
                            "boost/signals2/optional_last_value.hpp",
                            "boost/signals2/signal.hpp",


### PR DESCRIPTION
From https://api.cirrus-ci.com/v1/task/5082537556443136/logs/ci.log:
```
[10:04:20.418] /ci_container_base/src/node/mini_miner.cpp should remove these lines:
[10:04:20.418] - #include <boost/operators.hpp>  // lines 8-8
```