### PR TITLE
ci: update pwsh to use custom shell that fails-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
           }
 
       - name: Get tool information
-        shell: pwsh
+        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
         run: |
           cmake -version | Tee-Object -FilePath "cmake_version"
           Write-Output "---"
@@ -487,7 +487,7 @@ jobs:
           ./src/univalue/unitester.exe
 
       - name: Adjust paths in test/config.ini
-        shell: pwsh
+        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
         run: |
           (Get-Content "test/config.ini") -replace '(?<=^SRCDIR=).*', '${{ github.workspace }}' -replace '(?<=^BUILDDIR=).*', '${{ github.workspace }}' -replace '(?<=^RPCAUTH=).*', '${{ github.workspace }}/share/rpcauth/rpcauth.py' | Set-Content "test/config.ini"
           Get-Content "test/config.ini"


### PR DESCRIPTION
Github by default sets [fail fast](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference) behaviour on pswh shell which means that if any powershell cmdlet fails the script will stop and exit. The problem is that this behaviour doesn't apply when calling native executables, it only applies to powershell cmdlets.

I think the safest thing is to whenever we use pwsh to enable `$PSNativeCommandUseErrorActionPreference = $true` which will also fail calling any exe that returns a non-zero exit code.

Technically the step `Adjust paths in test/config.ini` only uses cmdlets so this step will not benefit from this change but I feel like it's good practice to still enable this feature in case this script gets modified in the future to call an exe.

Here is a CI run that has a script that fails silently (look at Windows Native, VS 2022 -> Get tool information): https://github.com/m3dwards/bitcoin/actions/runs/15415032095/job/43375709475
And with this change applied, the script correctly fails: https://github.com/m3dwards/bitcoin/actions/runs/15416585565/job/43380685364