### PR TITLE
clang-tidy: Apply modernize-deprecated-headers

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -9,6 +9,7 @@ bugprone-lambda-function-name,
 bugprone-unhandled-self-assignment,
 misc-unused-using-decls,
 misc-no-recursion,
+modernize-deprecated-headers,
 modernize-use-default-member-init,
 modernize-use-emplace,
 modernize-use-equals-default,
@@ -29,6 +30,8 @@ readability-redundant-string-init,
 HeaderFilterRegex: '.'
 WarningsAsErrors: '*'
 CheckOptions:
+ - key: modernize-deprecated-headers.CheckHeaderFile
+   value: false
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
    value: false
  - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -9,8 +9,8 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include <limits>
 

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -7,7 +7,7 @@
 #include <util/vector.h>
 
 #include <array>
-#include <assert.h>
+#include <cassert>
 #include <numeric>
 #include <optional>
 

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2017, 2021 Pieter Wuille
-// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -14,7 +14,7 @@
 #ifndef BITCOIN_BECH32_H
 #define BITCOIN_BECH32_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2017, 2021 Pieter Wuille
-// Copyright (c) 2021 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bench/examples.cpp
+++ b/src/bench/examples.cpp
@@ -5,7 +5,7 @@
 #include <bench/bench.h>
 
 // Extremely fast-running benchmark:
-#include <math.h>
+#include <cmath>
 
 volatile double sum = 0.0; // volatile, global so not optimized away
 

--- a/src/bench/examples.cpp
+++ b/src/bench/examples.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bench/parse_hex.cpp
+++ b/src/bench/parse_hex.cpp
@@ -1,12 +1,13 @@
-// Copyright (c) 2024- The Bitcoin Core developers
+// Copyright (c) 2024-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
 #include <random.h>
-#include <cstddef>
 #include <util/strencodings.h>
+
 #include <cassert>
+#include <cstddef>
 #include <optional>
 #include <vector>
 

--- a/src/bench/parse_hex.cpp
+++ b/src/bench/parse_hex.cpp
@@ -4,7 +4,7 @@
 
 #include <bench/bench.h>
 #include <random.h>
-#include <stddef.h>
+#include <cstddef>
 #include <util/strencodings.h>
 #include <cassert>
 #include <optional>

--- a/src/bip324.cpp
+++ b/src/bip324.cpp
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <string>
 

--- a/src/bip324.cpp
+++ b/src/bip324.cpp
@@ -16,7 +16,7 @@
 #include <uint256.h>
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <cstdint>
 #include <cstddef>
 #include <iterator>

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,7 +9,7 @@
 #include <tinyformat.h>
 #include <util/chaintype.h>
 
-#include <assert.h>
+#include <cassert>
 
 void SetupChainParamsBaseOptions(ArgsManager& argsman)
 {

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -6,11 +6,11 @@
 #define BITCOIN_CLUSTER_LINEARIZE_H
 
 #include <algorithm>
+#include <cstdint>
 #include <numeric>
 #include <optional>
-#include <cstdint>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include <random.h>
 #include <span.h>

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <numeric>
 #include <optional>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <utility>
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -16,8 +16,8 @@
 #include <util/check.h>
 #include <util/hasher.h>
 
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 
 #include <functional>
 #include <unordered_map>

--- a/src/coins.h
+++ b/src/coins.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -16,7 +16,7 @@
 #include <map>
 #include <optional>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -11,12 +11,12 @@
 #include <util/chaintype.h>
 #include <util/fs.h>
 
+#include <cstdint>
 #include <iosfwd>
 #include <list>
 #include <map>
 #include <optional>
 #include <set>
-#include <cstdint>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -7,7 +7,7 @@
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -7,7 +7,7 @@
 
 #include <consensus/amount.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 class CBlockIndex;

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 The Bitcoin Core developers
+// Copyright (c) 2016-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/aes.h>
 
-#include <string.h>
+#include <cstring>
 
 extern "C" {
 #include <crypto/ctaes/ctaes.c>

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 #include <bit>
-#include <string.h>
+#include <cstring>
 
 #define QUARTERROUND(a,b,c,d) \
   a += b; d = std::rotl(d ^ a, 16); \

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -9,8 +9,8 @@
 
 #include <array>
 #include <cstddef>
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 
 // classes for ChaCha20 256-bit stream cipher developed by Daniel J. Bernstein

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -10,7 +10,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 
 // classes for ChaCha20 256-bit stream cipher developed by Daniel J. Bernstein

--- a/src/crypto/chacha20poly1305.cpp
+++ b/src/crypto/chacha20poly1305.cpp
@@ -10,7 +10,7 @@
 #include <span.h>
 #include <support/cleanse.h>
 
-#include <assert.h>
+#include <cassert>
 #include <cstddef>
 
 AEADChaCha20Poly1305::AEADChaCha20Poly1305(std::span<const std::byte> key) noexcept : m_chacha20(key)

--- a/src/crypto/chacha20poly1305.cpp
+++ b/src/crypto/chacha20poly1305.cpp
@@ -4,8 +4,8 @@
 
 #include <crypto/chacha20poly1305.h>
 
-#include <crypto/common.h>
 #include <crypto/chacha20.h>
+#include <crypto/common.h>
 #include <crypto/poly1305.h>
 #include <span.h>
 #include <support/cleanse.h>

--- a/src/crypto/chacha20poly1305.h
+++ b/src/crypto/chacha20poly1305.h
@@ -6,7 +6,7 @@
 #define BITCOIN_CRYPTO_CHACHA20POLY1305_H
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 #include <crypto/chacha20.h>
 #include <crypto/poly1305.h>

--- a/src/crypto/hkdf_sha256_32.cpp
+++ b/src/crypto/hkdf_sha256_32.cpp
@@ -4,8 +4,8 @@
 
 #include <crypto/hkdf_sha256_32.h>
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 CHKDF_HMAC_SHA256_L32::CHKDF_HMAC_SHA256_L32(const unsigned char* ikm, size_t ikmlen, const std::string& salt)
 {

--- a/src/crypto/hkdf_sha256_32.cpp
+++ b/src/crypto/hkdf_sha256_32.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -8,7 +8,7 @@
 #include <crypto/hmac_sha256.h>
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A rfc5869 HKDF implementation with HMAC_SHA256 and fixed key output length of 32 bytes (L=32) */
 class CHKDF_HMAC_SHA256_L32

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -7,8 +7,8 @@
 
 #include <crypto/hmac_sha256.h>
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A rfc5869 HKDF implementation with HMAC_SHA256 and fixed key output length of 32 bytes (L=32) */
 class CHKDF_HMAC_SHA256_L32

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/hmac_sha256.h>
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -8,7 +8,7 @@
 #include <crypto/sha256.h>
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha256.h>
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/hmac_sha512.h>
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha512.h>
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -8,7 +8,7 @@
 #include <crypto/sha512.h>
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -8,7 +8,7 @@
 #include <serialize.h>
 #include <uint256.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 class Num3072
 {

--- a/src/crypto/poly1305.cpp
+++ b/src/crypto/poly1305.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2019-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/poly1305.cpp
+++ b/src/crypto/poly1305.cpp
@@ -5,7 +5,7 @@
 #include <crypto/common.h>
 #include <crypto/poly1305.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace poly1305_donna {
 

--- a/src/crypto/poly1305.h
+++ b/src/crypto/poly1305.h
@@ -8,8 +8,8 @@
 #include <span.h>
 
 #include <cassert>
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 #define POLY1305_BLOCK_SIZE 16
 

--- a/src/crypto/poly1305.h
+++ b/src/crypto/poly1305.h
@@ -9,7 +9,7 @@
 
 #include <cassert>
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 #define POLY1305_BLOCK_SIZE 16
 

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -6,7 +6,7 @@
 #define BITCOIN_CRYPTO_RIPEMD160_H
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_RIPEMD160_H
 #define BITCOIN_CRYPTO_RIPEMD160_H
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA1_H
 #define BITCOIN_CRYPTO_SHA1_H
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for SHA1. */
 class CSHA1

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -6,7 +6,7 @@
 #define BITCOIN_CRYPTO_SHA1_H
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A hasher class for SHA1. */
 class CSHA1

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -6,7 +6,7 @@
 #define BITCOIN_CRYPTO_SHA256_H
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 /** A hasher class for SHA-256. */

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA256_H
 #define BITCOIN_CRYPTO_SHA256_H
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 
 /** A hasher class for SHA-256. */

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -4,7 +4,7 @@
 
 #ifdef ENABLE_AVX2
 
-#include <stdint.h>
+#include <cstdint>
 #include <immintrin.h>
 
 #include <attributes.h>

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -5,8 +5,8 @@
 // This is a translation to GCC extended asm syntax from YASM code by Intel
 // (available at the bottom of this file).
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 #if defined(__x86_64__) || defined(__amd64__)
 

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -6,7 +6,7 @@
 // (available at the bottom of this file).
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(__x86_64__) || defined(__amd64__)
 

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -4,7 +4,7 @@
 
 #ifdef ENABLE_SSE41
 
-#include <stdint.h>
+#include <cstdint>
 #include <immintrin.h>
 
 #include <attributes.h>

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Copyright (c) 2018-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -8,7 +8,7 @@
 
 #if defined(ENABLE_SSE41) && defined(ENABLE_X86_SHANI)
 
-#include <stdint.h>
+#include <cstdint>
 #include <immintrin.h>
 
 #include <attributes.h>

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -7,8 +7,8 @@
 
 #include <span.h>
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 //! The Keccak-f[1600] transform.
 void KeccakF(uint64_t (&st)[25]);

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -8,7 +8,7 @@
 #include <span.h>
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 //! The Keccak-f[1600] transform.
 void KeccakF(uint64_t (&st)[25]);

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA512_H
 #define BITCOIN_CRYPTO_SHA512_H
 
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for SHA-512. */
 class CSHA512

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -6,7 +6,7 @@
 #define BITCOIN_CRYPTO_SHA512_H
 
 #include <cstdlib>
-#include <stdint.h>
+#include <cstdint>
 
 /** A hasher class for SHA-512. */
 class CSHA512

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_CRYPTO_SIPHASH_H
 #define BITCOIN_CRYPTO_SIPHASH_H
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <span.h>
 #include <uint256.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -105,7 +105,7 @@
 #include <vector>
 
 #ifndef WIN32
-#include <signal.h>
+#include <csignal>
 #include <sys/stat.h>
 #endif
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -15,10 +15,10 @@
 #include <support/allocators/secure.h>
 #include <util/translation.h>
 
-#include <functional>
-#include <memory>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -17,8 +17,8 @@
 
 #include <functional>
 #include <memory>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/src/kernel/disconnected_transactions.cpp
+++ b/src/kernel/disconnected_transactions.cpp
@@ -4,7 +4,7 @@
 
 #include <kernel/disconnected_transactions.h>
 
-#include <assert.h>
+#include <cassert>
 #include <core_memusage.h>
 #include <memusage.h>
 #include <primitives/transaction.h>

--- a/src/kernel/disconnected_transactions.cpp
+++ b/src/kernel/disconnected_transactions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -15,11 +15,11 @@
 #include <util/overflow.h>
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <set>
-#include <cstddef>
-#include <cstdint>
 
 class CBlockIndex;
 

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -18,8 +18,8 @@
 #include <functional>
 #include <memory>
 #include <set>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 class CBlockIndex;
 

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -12,8 +12,8 @@
 #include <util/strencodings.h>
 
 #include <algorithm>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 /// Maximum witness length for Bech32 addresses.
 static constexpr std::size_t BECH32_WITNESS_PROG_MAX_LEN = 40;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Copyright (c) 2014-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,9 +11,9 @@
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
-#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <unordered_set>

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -13,7 +13,7 @@
 
 #include <functional>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <unordered_set>

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -6,7 +6,7 @@
 #define BITCOIN_NODE_CONNECTION_TYPES_H
 
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /** Different types of connections to a peer. This enum encapsulates the
  * information we have available at the time of opening or accepting the

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_NODE_CONNECTION_TYPES_H
 #define BITCOIN_NODE_CONNECTION_TYPES_H
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 /** Different types of connections to a peer. This enum encapsulates the
  * information we have available at the time of opening or accepting the

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -13,9 +13,9 @@
 #include <txmempool.h>
 #include <util/feefrac.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
-#include <cstdint>
 
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/indexed_by.hpp>

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -15,7 +15,7 @@
 
 #include <memory>
 #include <optional>
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/indexed_by.hpp>

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -9,11 +9,11 @@
 #include <primitives/transaction.h>
 #include <uint256.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
-#include <cstdint>
 #include <vector>
 
 class CFeeRate;

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -13,7 +13,7 @@
 #include <memory>
 #include <optional>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 class CFeeRate;

--- a/src/pow.h
+++ b/src/pow.h
@@ -8,7 +8,7 @@
 
 #include <consensus/params.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 class CBlockHeader;
 class CBlockIndex;

--- a/src/pow.h
+++ b/src/pow.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -10,7 +10,7 @@
 #include <interfaces/node.h>
 #include <qt/initexecutor.h>
 
-#include <assert.h>
+#include <cassert>
 #include <memory>
 #include <optional>
 

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -23,7 +23,7 @@
 #include <util/time.h>
 #include <validation.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <QDebug>
 #include <QMetaObject>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -18,7 +18,7 @@
 #ifdef USE_DBUS
 #include <QDBusMetaType>
 #include <QtDBus>
-#include <stdint.h>
+#include <cstdint>
 #endif
 #ifdef Q_OS_MACOS
 #include <qt/macnotificationhandler.h>

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -12,7 +12,7 @@
 #include <QAbstractListModel>
 #include <QFont>
 
-#include <assert.h>
+#include <cassert>
 #include <variant>
 
 struct bilingual_str;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -19,7 +19,7 @@
 #include <validation.h>
 #include <wallet/types.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <QLatin1String>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -9,7 +9,7 @@
 #include <key_io.h>
 #include <wallet/types.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <QDateTime>
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -52,7 +52,7 @@
 #include <validationinterface.h>
 #include <versionbits.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <condition_variable>
 #include <iterator>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -13,7 +13,7 @@
 #include <validation.h>
 
 #include <any>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 class CBlock;

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -8,7 +8,7 @@
 #include <tinyformat.h>
 
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <string_view>
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -7,8 +7,8 @@
 #include <rpc/client.h>
 #include <tinyformat.h>
 
-#include <set>
 #include <cstdint>
+#include <set>
 #include <string>
 #include <string_view>
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -43,8 +43,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <memory>
 #include <cstdint>
+#include <memory>
 
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -44,7 +44,7 @@
 #include <validationinterface.h>
 
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -26,7 +26,7 @@
 #include <util/check.h>
 #include <util/time.h>
 
-#include <stdint.h>
+#include <cstdint>
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>
 #endif

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -42,8 +42,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <numeric>
 #include <cstdint>
+#include <numeric>
 
 #include <univalue.h>
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -43,7 +43,7 @@
 #include <validationinterface.h>
 
 #include <numeric>
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -9,9 +9,9 @@
 #include <rpc/request.h>
 #include <rpc/util.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
-#include <cstdint>
 #include <string>
 
 #include <univalue.h>

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -11,7 +11,7 @@
 
 #include <functional>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <univalue.h>

--- a/src/streams.h
+++ b/src/streams.h
@@ -14,12 +14,12 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <ios>
 #include <limits>
 #include <optional>
-#include <cstdint>
-#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/streams.h
+++ b/src/streams.h
@@ -12,14 +12,14 @@
 #include <util/overflow.h>
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <cstddef>
 #include <cstdio>
 #include <ios>
 #include <limits>
 #include <optional>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2021 The Bitcoin Core developers
+// Copyright (c) 2012-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -7,7 +7,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -21,7 +21,7 @@
 #include <validation.h>
 
 #include <array>
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -14,7 +14,7 @@
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
-#include <time.h>
+#include <ctime>
 #include <util/asmap.h>
 #include <util/chaintype.h>
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -14,12 +14,12 @@
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
-#include <ctime>
 #include <util/asmap.h>
 #include <util/chaintype.h>
 
 #include <cassert>
 #include <cstdint>
+#include <ctime>
 #include <optional>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -10,7 +10,7 @@
 #include <optional>
 #include <vector>
 
-#include <assert.h>
+#include <cassert>
 
 FUZZ_TARGET(asmap_direct)
 {

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -13,7 +13,7 @@
 #include <util/feefrac.h>
 
 #include <algorithm>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <utility>
 

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -6,16 +6,16 @@
 #include <random.h>
 #include <serialize.h>
 #include <streams.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/util/cluster_linearize.h>
 #include <util/bitset.h>
 #include <util/feefrac.h>
 
 #include <algorithm>
 #include <cstdint>
-#include <vector>
 #include <utility>
+#include <vector>
 
 using namespace cluster_linearize;
 

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -5,14 +5,14 @@
 #include <coins.h>
 #include <crypto/sha256.h>
 #include <primitives/transaction.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <optional>
-#include <memory>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <vector>
 
 namespace {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -9,10 +9,10 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
 
-#include <assert.h>
+#include <cassert>
 #include <optional>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -29,10 +29,10 @@
 #include <test/util/setup_common.h>
 #include <undo.h>
 
+#include <cstdint>
 #include <exception>
 #include <optional>
 #include <stdexcept>
-#include <cstdint>
 
 using node::SnapshotMetadata;
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -32,7 +32,7 @@
 #include <exception>
 #include <optional>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 
 using node::SnapshotMetadata;
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/fuzz/feeratediagram.cpp
+++ b/src/test/fuzz/feeratediagram.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <vector>
 
@@ -12,7 +12,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <assert.h>
+#include <cassert>
 
 namespace {
 

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -2,20 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <txgraph.h>
 #include <cluster_linearize.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/util/random.h>
+#include <txgraph.h>
 #include <util/bitset.h>
 #include <util/feefrac.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <set>
-#include <cstdint>
 #include <utility>
 
 using namespace cluster_linearize;

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -15,7 +15,7 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 
 using namespace cluster_linearize;

--- a/src/test/fuzz/vecdeque.cpp
+++ b/src/test/fuzz/vecdeque.cpp
@@ -7,8 +7,8 @@
 #include <test/fuzz/util.h>
 #include <util/vecdeque.h>
 
-#include <deque>
 #include <cstdint>
+#include <deque>
 
 namespace {
 

--- a/src/test/fuzz/vecdeque.cpp
+++ b/src/test/fuzz/vecdeque.cpp
@@ -8,7 +8,7 @@
 #include <util/vecdeque.h>
 
 #include <deque>
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -7,9 +7,9 @@
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
 #include <cassert>
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -6,10 +6,10 @@
 #ifndef BITCOIN_TEST_SCRIPTNUM10_H
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
-#include <assert.h>
+#include <cassert>
 #include <limits>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Bitcoin Core developers
+// Copyright (c) 2012-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -7,8 +7,8 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <limits.h>
-#include <stdint.h>
+#include <climits>
+#include <cstdint>
 
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -8,7 +8,7 @@
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -12,7 +12,7 @@
 #include <util/bitset.h>
 #include <util/feefrac.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <numeric>
 #include <vector>
 #include <utility>

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -14,8 +14,8 @@
 
 #include <cstdint>
 #include <numeric>
-#include <vector>
 #include <utility>
+#include <vector>
 
 namespace {
 

--- a/src/test/util/coins.cpp
+++ b/src/test/util/coins.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/util/coins.cpp
+++ b/src/test/util/coins.cpp
@@ -10,7 +10,7 @@
 #include <test/util/random.h>
 #include <uint256.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 
 COutPoint AddTestCoin(FastRandomContext& rng, CCoinsViewCache& coins_view)

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -3,11 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compare>
+#include <cstdint>
 #include <memory>
 #include <optional>
-#include <cstdint>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include <util/feefrac.h>
 

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -5,7 +5,7 @@
 #include <compare>
 #include <memory>
 #include <optional>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <utility>
 

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include <assert.h>
+#include <cassert>
 
 namespace {
 

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_UTIL_FEEFRAC_H
 #define BITCOIN_UTIL_FEEFRAC_H
 
-#include <cstdint>
-#include <compare>
-#include <vector>
 #include <span.h>
 #include <util/check.h>
+
+#include <compare>
+#include <cstdint>
+#include <vector>
 
 /** Data structure storing a fee and size, ordered by increasing fee/size.
  *

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_FEEFRAC_H
 #define BITCOIN_UTIL_FEEFRAC_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <compare>
 #include <vector>
 #include <span.h>

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <util/tokenpipe.h>

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -7,7 +7,7 @@
 
 #ifndef WIN32
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <optional>
 #include <unistd.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -41,7 +41,7 @@
 #include <optional>
 #include <set>
 #include <span>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/src/validation.h
+++ b/src/validation.h
@@ -36,12 +36,12 @@
 #include <versionbits.h>
 
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <span>
-#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -10,15 +10,15 @@
 #include <crypto/common.h>
 #include <logging.h>
 #include <sync.h>
-#include <util/fs_helpers.h>
 #include <util/check.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 #include <wallet/db.h>
 
 #include <sqlite3.h>
-#include <cstdint>
 
+#include <cstdint>
 #include <optional>
 #include <utility>
 #include <vector>

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -17,7 +17,7 @@
 #include <wallet/db.h>
 
 #include <sqlite3.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include <optional>
 #include <utility>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -6,7 +6,7 @@
 
 #include <future>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include <addresstype.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/wallet.h>
 
+#include <cstdint>
 #include <future>
 #include <memory>
-#include <cstdint>
 #include <vector>
 
 #include <addresstype.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Copyright (c) 2012-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -6,11 +6,11 @@
 #ifndef BITCOIN_WALLET_WALLETDB_H
 #define BITCOIN_WALLET_WALLETDB_H
 
+#include <key.h>
 #include <script/sign.h>
 #include <util/transaction_identifier.h>
 #include <wallet/db.h>
 #include <wallet/walletutil.h>
-#include <key.h>
 
 #include <cstdint>
 #include <string>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -12,7 +12,7 @@
 #include <wallet/walletutil.h>
 #include <key.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Bitcoin Core is written in C++, so it is confusing to sometimes use the deprecated C headers (with the `.h` extension). For example, it is less clear whether `string.h` refers to the file in this repo or the cstring stdlib header (https://github.com/bitcoin/bitcoin/pull/31308#discussion_r2121492797).

The check is currently disabled for headers, to exclude subtree headers.