### PR TITLE
guix: warn and abort when SOURCE_DATE_EPOCH is set

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -70,6 +70,24 @@ fi
 mkdir -p "$VERSION_BASE"
 
 ################
+# SOURCE_DATE_EPOCH should not unintentionally be set
+################
+
+if [ -n "$SOURCE_DATE_EPOCH" ] && [ -z "$FORCE_SOURCE_DATE_EPOCH" ]; then
+cat << EOF
+ERR: Environment variable SOURCE_DATE_EPOCH is set which may break reproducibility.
+
+     Aborting...
+
+Hint: You may want to:
+      1. Unset this variable: \`unset SOURCE_DATE_EPOCH\` before rebuilding
+      2. Set the 'FORCE_SOURCE_DATE_EPOCH' environment variable if you insist on
+         using your own epoch
+EOF
+exit 1
+fi
+
+################
 # Build directories should not exist
 ################
 


### PR DESCRIPTION
Fixes: #29935

Current behaviour will by-default use SOURCE_DATE_EPOCH from the environment without warning. This breaks the default reproducibility from a guix build.

Warn when and exit when this variable is set, and
FORCE_SOURCE_DATE_EPOCH is unset.
