### PR TITLE
depends: fix multiprocess build on OpenBSD (apply capnp patch, correct SHA256SUM command)

### DIFF
--- a/depends/builders/openbsd.mk
+++ b/depends/builders/openbsd.mk
@@ -1,7 +1,7 @@
 build_openbsd_CC = clang
 build_openbsd_CXX = clang++
 
-build_openbsd_SHA256SUM = sha256
+build_openbsd_SHA256SUM = sha256 -r
 build_openbsd_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 build_openbsd_TAR = gtar

--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -5,6 +5,7 @@ $(package)_download_file=$(native_$(package)_download_file)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_patches=abi_placement_new.patch
+$(package)_patches += fix_openbsd_build.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DBUILD_TESTING=OFF
@@ -14,7 +15,8 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
-  patch -p2 < $($(package)_patch_dir)/abi_placement_new.patch
+  patch -p2 < $($(package)_patch_dir)/abi_placement_new.patch && \
+  patch -p2 < $($(package)_patch_dir)/fix_openbsd_build.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/native_capnp.mk
+++ b/depends/packages/native_capnp.mk
@@ -4,11 +4,16 @@ $(package)_download_path=https://capnproto.org/
 $(package)_download_file=capnproto-c++-$($(package)_version).tar.gz
 $(package)_file_name=capnproto-cxx-$($(package)_version).tar.gz
 $(package)_sha256_hash=07167580e563f5e821e3b2af1c238c16ec7181612650c5901330fa9a0da50939
+$(package)_patches=fix_openbsd_build.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DBUILD_TESTING=OFF
   $(package)_config_opts += -DWITH_OPENSSL=OFF
   $(package)_config_opts += -DWITH_ZLIB=OFF
+endef
+
+define $(package)_preprocess_cmds
+  patch -p2 < $($(package)_patch_dir)/fix_openbsd_build.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/capnp/fix_openbsd_build.patch
+++ b/depends/patches/capnp/fix_openbsd_build.patch
@@ -1,0 +1,71 @@
+From 0cd1792332dce6a3afae6e2bc2939da69fea65fa Mon Sep 17 00:00:00 2001
+From: Sebastian Falbesoner <sebastian.falbesoner@gmail.com>
+Date: Sat, 31 May 2025 00:49:44 +0200
+Subject: [PATCH 1/2] In cidr.c++, include <netinet/in.h> on all non-Windows
+ systems
+
+The motivation for this commit is to fix the build for OpenBSD,
+but it may also solves the same potential problem for other systems
+without causing any harm.
+
+Suggested already twice, see
+https://github.com/capnproto/capnproto/pull/1846#discussion_r1399499535
+https://github.com/capnproto/capnproto/pull/1907#discussion_r1452602424
+---
+ c++/src/kj/cidr.c++ | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/c++/src/kj/cidr.c++ b/c++/src/kj/cidr.c++
+index 6a1fa32e..9432b8f4 100644
+--- a/c++/src/kj/cidr.c++
++++ b/c++/src/kj/cidr.c++
+@@ -39,9 +39,6 @@
+ #else
+ #include <sys/socket.h>
+ #include <arpa/inet.h>
+-#endif
+-
+-#if __FreeBSD__
+ #include <netinet/in.h>
+ #endif
+ 
+-- 
+2.49.0
+
+
+From 2e76d17db3fc484061487c0779b16495939d30c3 Mon Sep 17 00:00:00 2001
+From: Sebastian Falbesoner <sebastian.falbesoner@gmail.com>
+Date: Sat, 31 May 2025 01:06:42 +0200
+Subject: [PATCH 2/2] Don't set KJ_USE_KQUEUE on OpenBSD
+
+OpenBSD doesn't support user event filters yet, hence
+the build fails as it misses the symbol EVFILT_USER in
+the kqueue implementation in async-unix.c++. Fix that
+by not setting KJ_USE_KQUEUE on OpenBSD, so the poll()-
+based implementation is used instead.
+
+Suggested in
+https://github.com/capnproto/capnproto/pull/1907/commits/829d3f03735f8f6762a50fc346db56bf02140f02#r1452600300
+---
+ c++/src/kj/async-unix.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/c++/src/kj/async-unix.h b/c++/src/kj/async-unix.h
+index 665305ea..e66ad8e4 100644
+--- a/c++/src/kj/async-unix.h
++++ b/c++/src/kj/async-unix.h
+@@ -37,8 +37,9 @@ KJ_BEGIN_HEADER
+ #if __linux__
+ // Default to epoll on Linux.
+ #define KJ_USE_EPOLL 1
+-#elif __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+-// MacOS and BSDs prefer kqueue() for event notification.
++#elif __APPLE__ || __FreeBSD__ || __NetBSD__ || __DragonFly__
++// MacOS and most BSDs prefer kqueue() for event notification.
++// (Note that OpenBSD's kqueue(2) doesn't support user event filters yet)
+ #define KJ_USE_KQUEUE 1
+ #endif
+ #endif
+-- 
+2.49.0
+

--- a/depends/patches/native_capnp/fix_openbsd_build.patch
+++ b/depends/patches/native_capnp/fix_openbsd_build.patch
@@ -1,0 +1,71 @@
+From 0cd1792332dce6a3afae6e2bc2939da69fea65fa Mon Sep 17 00:00:00 2001
+From: Sebastian Falbesoner <sebastian.falbesoner@gmail.com>
+Date: Sat, 31 May 2025 00:49:44 +0200
+Subject: [PATCH 1/2] In cidr.c++, include <netinet/in.h> on all non-Windows
+ systems
+
+The motivation for this commit is to fix the build for OpenBSD,
+but it may also solves the same potential problem for other systems
+without causing any harm.
+
+Suggested already twice, see
+https://github.com/capnproto/capnproto/pull/1846#discussion_r1399499535
+https://github.com/capnproto/capnproto/pull/1907#discussion_r1452602424
+---
+ c++/src/kj/cidr.c++ | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/c++/src/kj/cidr.c++ b/c++/src/kj/cidr.c++
+index 6a1fa32e..9432b8f4 100644
+--- a/c++/src/kj/cidr.c++
++++ b/c++/src/kj/cidr.c++
+@@ -39,9 +39,6 @@
+ #else
+ #include <sys/socket.h>
+ #include <arpa/inet.h>
+-#endif
+-
+-#if __FreeBSD__
+ #include <netinet/in.h>
+ #endif
+ 
+-- 
+2.49.0
+
+
+From 2e76d17db3fc484061487c0779b16495939d30c3 Mon Sep 17 00:00:00 2001
+From: Sebastian Falbesoner <sebastian.falbesoner@gmail.com>
+Date: Sat, 31 May 2025 01:06:42 +0200
+Subject: [PATCH 2/2] Don't set KJ_USE_KQUEUE on OpenBSD
+
+OpenBSD doesn't support user event filters yet, hence
+the build fails as it misses the symbol EVFILT_USER in
+the kqueue implementation in async-unix.c++. Fix that
+by not setting KJ_USE_KQUEUE on OpenBSD, so the poll()-
+based implementation is used instead.
+
+Suggested in
+https://github.com/capnproto/capnproto/pull/1907/commits/829d3f03735f8f6762a50fc346db56bf02140f02#r1452600300
+---
+ c++/src/kj/async-unix.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/c++/src/kj/async-unix.h b/c++/src/kj/async-unix.h
+index 665305ea..e66ad8e4 100644
+--- a/c++/src/kj/async-unix.h
++++ b/c++/src/kj/async-unix.h
+@@ -37,8 +37,9 @@ KJ_BEGIN_HEADER
+ #if __linux__
+ // Default to epoll on Linux.
+ #define KJ_USE_EPOLL 1
+-#elif __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+-// MacOS and BSDs prefer kqueue() for event notification.
++#elif __APPLE__ || __FreeBSD__ || __NetBSD__ || __DragonFly__
++// MacOS and most BSDs prefer kqueue() for event notification.
++// (Note that OpenBSD's kqueue(2) doesn't support user event filters yet)
+ #define KJ_USE_KQUEUE 1
+ #endif
+ #endif
+-- 
+2.49.0
+


### PR DESCRIPTION
This PR fixes the multiprocess depends build for OpenBSD by applying upstream patch https://github.com/capnproto/capnproto/pull/2308 and switching the SHA256SUM command to output hash sums in the expected format (the default is BSD format [1], but we need GNU format [2], see commit message for details). Note that the hashing issue is only prevailing for packages defining the `$(package)_local_dir` variable (introduced in 5d105fb8c3ffa39c3e716c3147ee74795b129113, part of #31741), where the following line of the `fetch_local_dir_sha256` function leads to the wrong output:
https://github.com/bitcoin/bitcoin/blob/ae024137bda9fe189f4e7ccf26dbaffd44cbbeb6/depends/funcs.mk#L57

The first commit can be replaced with a simple capnp version bump once this is available in a release.

Tested on OpenBSD 7.7 (x86_64) via
```
$ gmake -C depends MULTIPROCESS=1 NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_QR=1 NO_WALLET=1 NO_ZMQ=1 NO_USDT=1
```

[1] example output: `SHA256 (/home/thestack/.vimrc) = 6ba69d100e8c5ca0488ded6293d4e5f740a6a5d5ace96cbcf0599c18d27389e4`
[2] example output: `6ba69d100e8c5ca0488ded6293d4e5f740a6a5d5ace96cbcf0599c18d27389e4 /home/thestack/.vimrc`