### PR TITLE
checkqueue: set MAX_SCRIPTCHECK_THREADS to nCores - 1

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -34,6 +34,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <versionbits.h>
+#include <common/system.h>
 
 #include <atomic>
 #include <cstdint>
@@ -80,7 +81,7 @@ static constexpr int DEFAULT_CHECKLEVEL{3};
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
 /** Maximum number of dedicated script-checking threads allowed */
-static constexpr int MAX_SCRIPTCHECK_THREADS{15};
+static int MAX_SCRIPTCHECK_THREADS = GetNumCores();
 
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {


### PR DESCRIPTION
A fixed MAX_SCRIPTCHECK_THREADS value is not flexible for users to leverage their cpu resources, and a value large than nCores - 1 doesn't make sense since it only adds some context switch overhead. Set it to nCores - 1. Assumption: A user who sets the number of script verification workers is aware of how this affects the system performance, otherwise he/she leaves it as default (which is 0)