### PR TITLE
tests: Remove hardcoded addresstype in `rpc_psbt.py`

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -65,7 +65,7 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            ["-walletrbf=1", "-addresstype=bech32", "-changetype=bech32"], #TODO: Remove address type restrictions once taproot has psbt extensions
+            ["-walletrbf=1"],
             ["-walletrbf=0", "-changetype=legacy"],
             []
         ]


### PR DESCRIPTION
Taproot PSBT support was added in #22558 so I believe hard coding the `-addresstype`'s in the test setup is no longer necessary as the TODO indicates? 