### PR TITLE
cmake: Fix `FindQt` module

### DIFF
--- a/cmake/module/FindQt.cmake
+++ b/cmake/module/FindQt.cmake
@@ -40,6 +40,15 @@ find_package_handle_standard_args(Qt
   VERSION_VAR Qt${Qt_FIND_VERSION_MAJOR}_VERSION
 )
 
-foreach(component IN LISTS Qt_FIND_COMPONENTS ITEMS "")
-  mark_as_advanced(Qt${Qt_FIND_VERSION_MAJOR}${component}_DIR)
+foreach(component IN LISTS Qt_FIND_COMPONENTS)
+  mark_as_advanced(
+    Qt${Qt_FIND_VERSION_MAJOR}${component}_DIR
+    Qt${Qt_FIND_VERSION_MAJOR}${component}Tools_DIR
+  )
 endforeach()
+mark_as_advanced(
+  QT_ADDITIONAL_HOST_PACKAGES_PREFIX_PATH
+  QT_ADDITIONAL_PACKAGES_PREFIX_PATH
+  XKB_INCLUDE_DIR
+  XKB_LIBRARY
+)

--- a/cmake/module/FindQt.cmake
+++ b/cmake/module/FindQt.cmake
@@ -36,7 +36,7 @@ unset(_qt_homebrew_prefix)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Qt
-  REQUIRED_VARS Qt${Qt_FIND_VERSION_MAJOR}_DIR
+  REQUIRED_VARS Qt${Qt_FIND_VERSION_MAJOR}_FOUND
   VERSION_VAR Qt${Qt_FIND_VERSION_MAJOR}_VERSION
 )
 


### PR DESCRIPTION
This PR improves the `FindQt` module in two ways:

1. Ensures that the `find_package(Qt .. MODULE REQUIRED COMPONENTS ...)` call treats any missing component as a fatal error. In the master branch, only a warning is currently issued.

2. Cleans up the user-facing part of the CMake cache following the migration to Qt 6. An exception (`Qt6_DIR`) is documented.