### PR TITLE
doc: add missing packages for BSDs (cmake, gmake, curl) to depends/README.md

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -31,7 +31,7 @@ To build dependencies for the current arch+OS:
 
 ### FreeBSD
 
-    pkg install bash
+    pkg install bash cmake curl gmake
 
 To build dependencies for the current arch+OS:
 
@@ -39,7 +39,7 @@ To build dependencies for the current arch+OS:
 
 ### NetBSD
 
-    pkgin install bash gmake
+    pkgin install bash cmake curl gmake perl
 
 To build dependencies for the current arch+OS:
 
@@ -47,7 +47,7 @@ To build dependencies for the current arch+OS:
 
 ### OpenBSD
 
-    pkg_add bash gmake gtar
+    pkg_add bash cmake curl gmake gtar
 
 To build dependencies for the current arch+OS:
 


### PR DESCRIPTION
Suggested initially only for OpenBSD and cmake (see https://github.com/bitcoin/bitcoin/pull/32690#issuecomment-2949660658, https://github.com/bitcoin/bitcoin/pull/32690#issuecomment-2949729126), this PR adds missing package recommendations for other BSDs as well in order to build depends. I tested this only on OpenBSD, but found the package names for the other BSDs on the ports search engines:
* FreeBSD: https://ports.freebsd.org/cgi/ports.cgi
* NetBSD: https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/index-all.html

At least on OpenBSD, curl is a [dependency of git](https://github.com/openbsd/ports/blob/879e73073bb74a964d64f0d76ecc8e2405f80d3d/devel/git/Makefile#L49-L50), so most users will not need to install it explicitly. But as git is not the only way to obtain the source code, I think it doesn't hurt to list it, and we also do it already for Ubuntu & Debian:
https://github.com/bitcoin/bitcoin/blob/f3bbc746647d1fd23bf5cfe357e32f38c5f6319c/depends/README.md?plain=1#L9-L11