### PR TITLE
depends: Override host compilers for FreeBSD and OpenBSD

### DIFF
--- a/depends/builders/freebsd.mk
+++ b/depends/builders/freebsd.mk
@@ -3,3 +3,7 @@ build_freebsd_CXX=clang++
 
 build_freebsd_SHA256SUM = sha256sum
 build_freebsd_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
+
+# freebsd host on freebsd builder: override freebsd host preferences.
+freebsd_CC = clang
+freebsd_CXX = clang++

--- a/depends/builders/openbsd.mk
+++ b/depends/builders/openbsd.mk
@@ -7,3 +7,7 @@ build_openbsd_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CON
 build_openbsd_TAR = gtar
 # openBSD touch doesn't understand -h
 build_openbsd_TOUCH = touch -m -t 200001011200
+
+# openbsd host on openbsd builder: override openbsd host preferences.
+openbsd_CC = clang
+openbsd_CXX = clang++


### PR DESCRIPTION
When building depends on FreeBSD/OpenBSD `aarch64`, the host compilers default to `default_host_{CC,CXX}`, which resolves to `gcc`/`g++`. This is incorrect on these systems, where Clang is the default system compiler.

To ensure proper compiler selection, this PR adopts the same approach used for `darwin`:https://github.com/bitcoin/bitcoin/blob/c1d4253d316ea627f46b26e395d7b48842258381/depends/builders/darwin.mk#L12-L14

Fixes https://github.com/bitcoin/bitcoin/issues/32691.