### PR TITLE
doc, windows: CompanyName "Bitcoin" => "Bitcoin Core project"

### DIFF
--- a/src/bitcoin-cli-res.rc
+++ b/src/bitcoin-cli-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoin-cli (JSON-RPC client for " CLIENT_NAME ")"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoin-cli"

--- a/src/bitcoin-res.rc
+++ b/src/bitcoin-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoin (Bitcoin wrapper executable that can call other executables)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoin"

--- a/src/bitcoin-tx-res.rc
+++ b/src/bitcoin-tx-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoin-tx (CLI Bitcoin transaction editor utility)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoin-tx"

--- a/src/bitcoin-util-res.rc
+++ b/src/bitcoin-util-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoin-util (CLI Bitcoin utility)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoin-util"

--- a/src/bitcoin-wallet-res.rc
+++ b/src/bitcoin-wallet-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoin-wallet (CLI tool for " CLIENT_NAME " wallets)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoin-wallet"

--- a/src/bitcoind-res.rc
+++ b/src/bitcoind-res.rc
@@ -14,7 +14,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    "bitcoind (Bitcoin node with a JSON-RPC server)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
             VALUE "InternalName",       "bitcoind"

--- a/src/qt/res/bitcoin-qt-res.rc
+++ b/src/qt/res/bitcoin-qt-res.rc
@@ -21,7 +21,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
+            VALUE "CompanyName",        CLIENT_NAME " project"
             VALUE "FileDescription",    CLIENT_NAME " (GUI node for Bitcoin)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "bitcoin-qt"


### PR DESCRIPTION
Brings Windows executables in line with */share/setup.nsi.in:14* used by the installer.

Discovered while reviewing tangential PR: https://github.com/bitcoin/bitcoin/pull/32634#discussion_r2112641918