### PR TITLE
docs: add guidance on initialism capitalisation in PascalCase identifiers.

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -100,6 +100,12 @@ code.
     naming style](#internal-interface-naming-style) for an exception to this
     convention.
 
+  - When using `PascalCase`, acronyms must be treated as words, i.e capitalize only the first letter. Hence:
+
+    - `JSONRPCRequest` -> `JsonRpcRequest`.
+    - `BIP9Stats` -> `Bip9Stats`.
+  > Note: Legacy code that violates this rule remains unchanged until the surrounding code is updated. This helps minimize code churn while gradually improving consistency.
+
   - Test suite naming convention: The Boost test suite in file
     `src/test/foo_tests.cpp` should be named `foo_tests`. Test suite names
     must be unique.


### PR DESCRIPTION
Fixes #32698

**Problem**
Inconsistent initialization of class,function, method identifiers and structs. Spread throughout the codebase is [screaming / acronym caps](https://gist.github.com/adashrod/66564c690906c9b774e77ddacbd06e1b).

**Solution**
* Add a rule in the developer notes to use consistent camelcase naming convention.
* A class names like `JSONRPCRequest` should be `JsonRpcRequest`.