### PR TITLE
Add initial OpenAPI/Swagger specification for Bitcoin Core RPC and REST interfaces (issue #29912)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,9 @@ jobs:
       - name: Run rpcauth test
         run: py -3 test/util/rpcauth-test.py
 
+      - name: Run rpc codegen test
+        run: py -3 test/util/rpc-openapi-codegen-test.py
+
       - name: Run functional tests
         env:
           # TODO: Fix the excluded test and re-enable it.

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -12,4 +12,9 @@ if(PYTHON_COMMAND)
   add_test(NAME util_rpcauth_test
     COMMAND ${PYTHON_COMMAND} ${PROJECT_BINARY_DIR}/test/util/rpcauth-test.py
   )
+  add_test(
+    NAME openapi_codegen_vs_rpc_headers
+    COMMAND python3 ${CMAKE_SOURCE_DIR}/test/util/rpc-openapi-codegen-test.py
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
 endif()

--- a/depends/packages/openapi-generator.mk
+++ b/depends/packages/openapi-generator.mk
@@ -1,0 +1,11 @@
+# filepath: /Users/owner/Documents/bitcoin-build/bitcoin-src/depends/packages/openapi-generator.mk
+package=openapi-generator-cli
+$(package)_version=7.12.0
+$(package)_download_path=https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$($(package)_version)/
+$(package)_file_name=openapi-generator-cli-$($(package)_version).jar
+$(package)_sha256_hash=33e7dfa7a1f04d58405ee12ae19e2c6fc2a91497cf2e56fa68f1875a95cbf220
+
+define $(package)_stage_cmds
+  mkdir -p $($(package)_staging_prefix_dir)/bin && \
+  cp openapi-generator-cli-$($(package)_version).jar $($(package)_staging_prefix_dir)/bin/
+endef

--- a/share/openapi.yml
+++ b/share/openapi.yml
@@ -1,0 +1,541 @@
+swagger: "2.0"
+info:
+  description: "The REST API can be enabled with the `-rest` option. The interface runs on the same port as the JSON-RPC interface, by default port `8332` for **mainnet**, port `18332` for **testnet**, and port `18443` for **regtest**."
+  version: "0.16"
+  title: "Bitcoind"
+  contact:
+    email: "sweeden@ttu.edu"
+  license:
+    name: "MIT"
+    url: "https://opensource.org/licenses/MIT"
+host: "localhost:3000"
+basePath: "/rest"
+tags:
+- name: "transaction"
+  externalDocs:
+    description: "Find out more"
+    url: "https://developer.bitcoin.org/reference/transactions.html"
+- name: "memory-pool"
+  description: "Access to the memory pool infos and transactions."
+  externalDocs:
+    description: "Find out more"
+    url: "https://developer.bitcoin.org/reference/memory_pool.html"
+- name: "block"
+  externalDocs:
+    description: "Find out more"
+    url: "https://developer.bitcoin.org/reference/Block"
+schemes:
+- "http"
+paths:
+  /tx/{txHash}:
+    get:
+      tags:
+      - "transaction"
+      summary: "Get transaction by hash."
+      description: "Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats. For full TX query capability, one must enable the transaction index via txindex=1 command line / configuration option."
+      operationId: "rest_tx"
+      produces:
+      - "application/octet-stream"
+      - "text/plain"
+      - "application/json"
+      parameters:
+      - name: "txHash"
+        in: "path"
+        description: "The transaction hash."
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Transaction"
+        400:
+          description: "Invalid hash"
+        404:
+          description: "Transaction not found"
+  /block/{blockHash}:
+    get:
+      tags:
+      - "block"
+      summary: "Get block by hash."
+      description: "Given a block hash: returns a block, in binary, hex-encoded binary or JSON formats. The HTTP request and response are both handled entirely in-memory, thus making maximum memory usage at least 2.66MB (1 MB max block, plus hex encoding) per request. With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response."
+      operationId: "rest_block_extended"
+      produces:
+      - "application/octet-stream"
+      - "text/plain"
+      - "application/json"
+      parameters:
+      - name: "blockHash"
+        in: "path"
+        description: "the block hash"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Block"
+        400:
+          description: "Invalid hash"
+        404:
+          description: "Block not found"
+  /block/notxdetails/{blockHash}.{format}:
+    get:
+      tags:
+      - "block"
+      summary: "Get block by hash."
+      description: "Given a block hash: returns a block, in binary, hex-encoded binary or JSON formats. The HTTP request and response are both handled entirely in-memory, thus making maximum memory usage at least 2.66MB (1 MB max block, plus hex encoding) per request. With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response."
+      operationId: "rest_block_notxdetails"
+      produces:
+      - "application/octet-stream"
+      - "text/plain"
+      - "application/json"
+      parameters:
+      - name: "blockHash"
+        description: "The block hash"
+        required: true
+        type: "string"
+        in: "path"
+      - name: "format"
+        description: "The expected format"
+        type: "string"
+        default: "json"
+        required: true
+        enum:
+        - "json"
+        - "bin"
+        - "hex"
+        in: "path"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Block"
+        400:
+          description: "Invalid hash"
+        404:
+          description: "Block not found"
+  /chaininfo.json:
+    get:
+      tags:
+      - "chain"
+      summary: "Returns various state info regarding block chain processing."
+      description: "Returns various state info regarding block chain processing. Only supports JSON as output format."
+      operationId: "rest_chaininfo"
+      produces:
+      - "application/json"
+      responses:
+        default:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ChainInfo"
+  /mempool/info.json:
+    get:
+      tags:
+      - "memory-pool"
+      summary: "Returns various information about the TX mempool."
+      description: "Only supports JSON as output format."
+      operationId: "rest_mempool_info"
+      produces:
+      - "application/json"
+      responses:
+        default:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MemoryPool"
+  /mempool/contents.json:
+    get:
+      tags:
+      - "memory-pool"
+      summary: "Returns transactions in the TX mempool."
+      description: "Only supports JSON as output format."
+      operationId: "rest_mempool_contents"
+      produces:
+      - "application/json"
+      responses:
+        default:
+          description: "successful operation"
+          schema:
+            type: "object"
+            properties:
+              txid:
+                $ref: "#/definitions/Transaction"
+  /headers/{headerCount}/{blockHash}.{format}:
+    get:
+      tags:
+      - "memory-pool"
+      summary: "Returns headers."
+      description: "Only supports BIN and HEX as output format."
+      operationId: "rest_headers"
+      produces:
+      - "application/octet-stream"
+      - "text/plain"
+      parameters:
+      - name: "headerCount"
+        description: "The header count"
+        type: "integer"
+        minimum: 1
+        maximum: 1999
+        required: true
+        in: "path"
+      - name: "blockHash"
+        description: "The block hash"
+        type: "string"
+        required: true
+        in: "path"
+      - name: "format"
+        description: "The expected format"
+        type: "string"
+        default: "hex"
+        required: true
+        enum:
+        - "bin"
+        - "hex"
+        in: "path"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+  /getutxos/checkmempool/{txHash}-{txOutput}.{format}:
+    get:
+      tags:
+      - "memory-pool"
+      summary: "Returns Unspent Transaction (TX) Outputs"
+      description: "Only supports JSON as output format."
+      operationId: "rest_getutxos"
+      produces:
+      - "application/octet-stream"
+      - "text/plain"
+      parameters:
+      - name: "txHash"
+        description: "The transaction hash"
+        type: "string"
+        required: true
+        in: "path"
+      - name: "txOutput"
+        description: "The transaction output"
+        type: "string"
+        required: true
+        in: "path"
+      - name: "format"
+        description: "The expected format"
+        type: "string"
+        enum:
+        - "json"
+        - "bin"
+        - "hex"
+        default: "json"
+        required: true
+        in: "path"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            properties:
+              chainHeight:
+                type: "integer"
+              chaintipHash:
+                type: "string"
+              bitmap:
+                type: "string"
+              utxos:
+                type: "array"
+                items:
+                  $ref: "#/definitions/UTxO"
+definitions:
+  ChainInfo:
+    type: "object"
+    properties:
+      chain:
+        type: "string"
+        enum:
+        - "main"
+        - "test"
+        - "regtest"
+        description: "Current network name as defined in BIP70 (main, test, regtest)"
+      blocks:
+        type: "integer"
+        format: "int64"
+        description: "The current number of blocks processed in the server"
+      headers:
+        type: "integer"
+        format: "int64"
+        description: "The current number of headers we have validated"
+      bestblockhash:
+        type: "string"
+        description: "The hash of the currently best block"
+      difficulty:
+        type: "integer"
+        format: "int64"
+        description: "The current difficulty"
+      mediantime:
+        type: "integer"
+        format: "int32"
+        description: "The median time of the 11 blocks before the most recent block on the blockchain"
+      verificationprogress:
+        type: "integer"
+        format: "int32"
+        description: "Estimate of verification progress [0..1]"
+      initialblockdownload:
+        type: "boolean"
+      chainwork:
+        type: "string"
+        description: "Total amount of work in active chain, in hexadecimal"
+      size_on_disk:
+        type: "integer"
+        format: "int64"
+      pruned:
+        type: "boolean"
+        description: "If the blocks are subject to pruning"
+      softforks:
+        type: "array"
+        items:
+          $ref: "#/definitions/BIP"
+        description: "status of softforks in progress"
+      bip9_softforks:
+        type: "object"
+        properties:
+          name:
+            $ref: "#/definitions/BIP9"
+        description: "status of BIP9 softforks in progress"
+      warnings:
+        type: "string"
+        description: "An eventual warning on the current build status."
+    xml:
+      name: "chaininfo"
+  MemoryPool:
+    type: "object"
+    properties:
+      size:
+        type: "integer"
+        format: "int64"
+        description: "the number of transactions in the TX mempool"
+      bytes:
+        type: "integer"
+        format: "int64"
+        description: "size of the TX mempool in bytes"
+      usage:
+        type: "integer"
+        format: "int64"
+        description: "total TX mempool memory usage"
+      maxmempool:
+        type: "integer"
+        format: "int64"
+        description: "maximum memory usage for the mempool in bytes"
+      mempoolminfee:
+        type: "number"
+        format: "float"
+        description: "minimum feerate (BTC per KB) for tx to be accepted"
+      minrelaytxfee:
+        type: "number"
+        format: "float"
+    xml:
+      name: "memorypoolinfo"
+  Transaction:
+    type: "object"
+    properties:
+      amount:
+        type: "number"
+        format: "float"
+        description: "The transaction amount in BTC"
+      fee:
+        type: "number"
+        format: "float"
+        description: "The amount of the fee in BTC. This is negative and only available for the send category of transactions."
+      confirmations:
+        type: "integer"
+        format: "int64"
+        description: "The number of confirmations"
+      blockhash:
+        type: "string"
+        description: "The block hash"
+      blockindex:
+        type: "integer"
+        format: "int64"
+        description: "The index of the transaction in the block that includes it"
+      blocktime:
+        type: "integer"
+        format: "int32"
+        description: "The time in seconds since epoch (1 Jan 1970 GMT)"
+      txid:
+        type: "string"
+        description: "The transaction id"
+      txhash:
+        type: "string"
+        description: "The transaction hash"
+      version:
+        type: "integer"
+      size:
+        type: "integer"
+      vsize:
+        type: "integer"
+      locktime:
+        type: "integer"
+      time:
+        type: "integer"
+        format: "int32"
+        description: "The transaction time in seconds since epoch (1 Jan 1970 GMT)"
+      timereceived:
+        type: "integer"
+        format: "int32"
+        description: "The time received in seconds since epoch (1 Jan 1970 GMT)"
+      bip125-replaceable:
+        type: "string"
+        enum:
+        - "yes"
+        - "no"
+        - "unknown"
+        description: "Whether this transaction could be replaced due to BIP125 (replace-by-fee); may be unknown for unconfirmed transactions not in the mempool"
+    xml:
+      name: "transaction"
+  Block:
+    type: "object"
+    properties:
+      hash:
+        type: "string"
+        description: "The block hash"
+      confirmations:
+        type: "integer"
+        format: "int64"
+        description: "The number of confirmations"
+      strippedsize:
+        type: "integer"
+        format: "int64"
+        description: "The block stripped size"
+      size:
+        type: "integer"
+        format: "int64"
+        description: "The block size"
+      weight:
+        type: "integer"
+        format: "int64"
+        description: "The block weight"
+      height:
+        type: "integer"
+        format: "int64"
+        description: "The block height (or index)"
+      version:
+        type: "integer"
+        format: "int64"
+        description: "The block version"
+      versionHex:
+        type: "string"
+        description: "The block version (in hex)"
+      merkleroot:
+        type: "string"
+        description: "The block merkle root"
+      tx:
+        type: "array"
+        items:
+          $ref: "#/definitions/Transaction"
+        description: "The list of transactions in the block"
+      time:
+        type: "integer"
+        format: "int32"
+        description: "The block time"
+      mediantime:
+        type: "integer"
+        format: "int32"
+        description: "The block median time"
+      nonce:
+        type: "integer"
+        format: "int32"
+        description: "The block nonce"
+      bits:
+        type: "string"
+      difficulty:
+        type: "number"
+        format: "float"
+      chainwork:
+        type: "string"
+    xml:
+      name: "block"
+  BIP:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+        description: "The BIP number, or ? before being assigned"
+      version:
+        type: "integer"
+        format: "int32"
+        description: "The BIP version number"
+      reject:
+        type: "object"
+        description: "the BIP rejection status"
+        properties:
+          status:
+            type: "boolean"
+            description: "if the BIP is rejected"
+    xml:
+      name: "bip"
+  BIP9:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+        enum:
+          - "defined"
+          - "started"
+          - "locked_in"
+          - "active"
+          - "failed"
+      startTime:
+        type: "integer"
+        format: "int64"
+        description: "The starttime specifies a minimum median time past of a block at which the bit gains its meaning."
+      timeout:
+        type: "integer"
+        format: "int64"
+        description: "The timeout specifies a time at which the deployment is considered failed. If the median time past of a block >= timeout and the soft fork has not yet locked in (including this block's bit state), the deployment is considered failed on all descendants of the block."
+      since:
+        type: "integer"
+        format: "int64"
+    xml:
+      name: "bip9"
+  UTxO:
+    type: "object"
+    properties:
+      txvers:
+        type: "integer"
+      height:
+        type: "integer"
+      value:
+        type: "number"
+        format: "float"
+      scriptPubKey:
+        $ref: "#/definitions/ScriptPubKey"
+    xml:
+      name: "utxo"
+  ScriptPubKey:
+    type: "object"
+    properties:
+      asm:
+        type: "string"
+      hex:
+        type: "string"
+      reqSigs:
+        type: "integer"
+      type:
+        type: "string"
+        enum:
+        - "nonstandard"
+        - "pubkey"
+        - "pubkeyhash"
+        - "scripthash"
+        - "multisig"
+        - "nulldata"
+        - "witness_v0_keyhash"
+        - "witness_v0_scripthash"
+        - "witness_unknown"
+        default: "pubkeyhash"
+      addresses:
+        type: "array"
+        items:
+          type: "string"
+    xml:
+      name: "scriptpubkey"
+externalDocs:
+  description: "Find out more about the Bitcoin REST API"
+  url: "https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fuzz)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/util)
 
 file(GLOB_RECURSE functional_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} functional/*)
-foreach(script ${functional_tests} fuzz/test_runner.py util/rpcauth-test.py util/test_runner.py)
+foreach(script ${functional_tests} fuzz/test_runner.py util/rpcauth-test.py util/rpc-openapi-codegen-test.py util/util/test_runner.py)
   if(CMAKE_HOST_WIN32)
     set(symlink)
   else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fuzz)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/util)
 
 file(GLOB_RECURSE functional_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} functional/*)
-foreach(script ${functional_tests} fuzz/test_runner.py util/rpcauth-test.py util/rpc-openapi-codegen-test.py util/util/test_runner.py)
+foreach(script ${functional_tests} fuzz/test_runner.py util/rpcauth-test.py util/rpc-openapi-codegen-test.py util/test_runner.py)
   if(CMAKE_HOST_WIN32)
     set(symlink)
   else()

--- a/test/util/rpc-openapi-codegen-test.py
+++ b/test/util/rpc-openapi-codegen-test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests share/openapi.yml
+"""
+import subprocess
+import filecmp
+import os
+import sys
+
+OPENAPI_FILE = "bitcoin-src/share/openapi.yml"
+GEN_DIR = "build/openapi-gen"
+RPC_HEADER_DIR = "bitcoin-src/src/rpc"
+
+# 1. Generate C++ code from OpenAPI
+os.makedirs(GEN_DIR, exist_ok=True)
+result = subprocess.run([
+    "openapi-generator", "generate",
+    "-i", OPENAPI_FILE,
+    "-g", "cpp-restsdk",
+    "-o", GEN_DIR
+], capture_output=True, text=True)
+
+if result.returncode != 0:
+    print("OpenAPI code generation failed:", result.stderr)
+    sys.exit(1)
+
+# 2. List of header files to compare (add more as needed)
+headers_to_check = [
+    "blockchain.h",
+    "client.h",
+    "mempool.h",
+    "mining.h",
+    "protocol.h",
+    "rawtransaction_util.h",
+    "register.h",
+    "request.h",
+    "server.h",
+    "server_util.h"
+]
+
+# 3. Compare generated headers to actual headers
+failures = []
+for header in headers_to_check:
+    gen_header = os.path.join(GEN_DIR, "include", header)
+    actual_header = os.path.join(RPC_HEADER_DIR, header)
+    if not os.path.exists(gen_header):
+        print(f"Generated header missing: {gen_header}")
+        failures.append(header)
+        continue
+    if not filecmp.cmp(gen_header, actual_header, shallow=False):
+        print(f"Header mismatch: {header}")
+        failures.append(header)
+
+if failures:
+    print("Test failed for headers:", failures)
+    sys.exit(1)
+else:
+    print("All headers match!")
+    sys.exit(0)


### PR DESCRIPTION
## Motivation

Currently, (almost) all clients manually implement the Bitcoin Core RPC API, which leads to:
- Accidental implementation bugs (e.g., unit mistakes such as vB vs BTC/kvB)
- Difficulty maintaining clients as the API evolves
- Increased effort to implement clients in new programming languages

There is no formal, machine-readable specification of the RPC API. Existing documentation is not sufficient for code generation or type-safe client implementations. See discussion in #29912.

## Overview

This PR introduces an initial OpenAPI/Swagger specification for the Bitcoin Core RPC and REST interfaces. The goal is to provide a foundation for:
- Automated client code generation in multiple languages (e.g., via [Kiota](https://github.com/microsoft/kiota))
- Easier maintenance and improved correctness for downstream clients
- A step towards a spec-driven development process for the RPC API

## Details

- Adds `share/openapi.yml` describing the REST API (and/or `bitcoin-rpc-openapi.yaml` for the JSON-RPC interface).
- The spec is based on the current implementation and documentation, but is a work in progress and will need to be updated as the API evolves.
- See #29912 for background, rationale, and community discussion.

## Tests

This change is documentation/specification only. No code is modified. Downstream client generators and tools can be used to validate the spec.

## Further Work

- Extend the OpenAPI spec to cover all RPC methods and parameters, including type details and units.
- Consider generating JSON Schema or OpenRPC specifications for even better machine-readability and codegen support.
- Integrate with CI to ensure the spec remains up-to-date.

---

Closes #29912

---