### PR TITLE
p2p: avoid traversing blocks (twice) during IBD

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1909,6 +1909,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 12: start node
 
     int64_t best_block_time{};
+    bool initial_sync_finished{false};
     {
         LOCK(chainman.GetMutex());
         const auto& tip{*Assert(chainman.ActiveTip())};
@@ -1924,9 +1925,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             tip_info->header_height = chainman.m_best_header->nHeight;
             tip_info->header_time = chainman.m_best_header->GetBlockTime();
         }
+        initial_sync_finished = !chainman.IsInitialBlockDownload();
     }
     LogPrintf("nBestHeight = %d\n", chain_active_height);
-    if (node.peerman) node.peerman->SetBestBlock(chain_active_height, std::chrono::seconds{best_block_time});
+    if (node.peerman) node.peerman->SetBestBlock(chain_active_height, std::chrono::seconds{best_block_time}, initial_sync_finished);
 
     // Map ports with NAT-PMP
     StartMapPort(args.GetBoolArg("-natpmp", DEFAULT_NATPMP));

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -124,8 +124,8 @@ public:
     /** Send ping message to all peers */
     virtual void SendPings() = 0;
 
-    /** Set the height of the best block and its time (seconds since epoch). */
-    virtual void SetBestBlock(int height, std::chrono::seconds time) = 0;
+    /** Set the height of the best block and its time (seconds since epoch), and indicate whether historical block sync has completed. */
+    virtual void SetBestBlock(int height, std::chrono::seconds time, bool initial_sync_finished) = 0;
 
     /* Public for unit testing. */
     virtual void UnitTestMisbehaving(NodeId peer_id) = 0;

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
     auto tip = WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
     uint64_t tip_block_time = tip->GetBlockTime();
     int tip_block_height = tip->nHeight;
-    peerman->SetBestBlock(tip_block_height, std::chrono::seconds{tip_block_time});
+    peerman->SetBestBlock(tip_block_height, std::chrono::seconds{tip_block_time}, /*initial_sync_finished=*/true);
 
     SetMockTime(tip_block_time + 1); // Set node time to tip time
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -246,6 +246,9 @@ bool TxOrphanage::HaveTxToReconsider(NodeId peer)
 
 void TxOrphanage::EraseForBlock(const CBlock& block)
 {
+    // No orphans, nothing to do
+    if (m_orphans.empty()) return;
+
     std::vector<Wtxid> vOrphanErase;
 
     for (const CTransactionRef& ptx : block.vtx) {


### PR DESCRIPTION
Context:
Every time a block is connected, a `BlockConnected()` event is appended to the validation interface queue. This queue is consumed sequentially by a single worker thread. To avoid excessive memory usage, the queue is limited to 10 events at a time, and we stop processing new blocks until the queued events are handled.

Issue:
Within the `PeerManager::BlockConnected()` listener, we traverse the block twice inside the transaction download manager — despite not needing to handle orphans or transaction requests during IBD.

Extra info about the changes:
The new arg added to `BlockConnected()` in the first commit is primarily meant to avoid locking `cs_main` on the
listener side (to avoid calling `IsInitialBlockDownload()` there).
Another way of implementing this could be to add a bool field `enabled` to the `TxDownloadManager` class that is only
set to true when we are out of IBD, so that we don't have to include a new arg inside the block connection event.
This is open for discussion. Could try implementing this second approach too.