### PR TITLE
net, rpc, qt: add per-peer blocktxn stats to getpeerinfo and qt debug window

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -63,6 +63,8 @@ struct CNodeStateStats {
     ServiceFlags their_services;
     int64_t presync_height{-1};
     std::chrono::seconds time_offset{0};
+    uint64_t m_last_blocktxn_count = 0;
+    uint64_t m_last_blocktxn_size = 0;
 };
 
 struct PeerManagerInfo {

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1832,6 +1832,52 @@
                 </widget>
                </item>
                <item row="28" column="0">
+                <widget class="QLabel" name="peerLastBlocktxnSizeLabel">
+                 <property name="text">
+                  <string>Last Compact TX Size</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="28" column="1">
+                <widget class="QLabel" name="peerLastBlocktxnSize">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="text">
+                  <string>N/A</string>
+                 </property>
+                 <property name="textFormat">
+                  <enum>Qt::PlainText</enum>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="29" column="0">
+                <widget class="QLabel" name="peerLastBlocktxnCountLabel">
+                 <property name="text">
+                  <string>Last Compact TX Count</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="29" column="1">
+                <widget class="QLabel" name="peerLastBlocktxnCount">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="text">
+                  <string>N/A</string>
+                 </property>
+                 <property name="textFormat">
+                  <enum>Qt::PlainText</enum>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="30" column="0">
                 <spacer name="verticalSpacer_3">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1254,6 +1254,8 @@ void RPCConsole::updateDetailWidget()
             ui->peerCommonHeight->setText(ts.unknown);
         }
         ui->peerHeight->setText(QString::number(stats->nodeStateStats.m_starting_height));
+        ui->peerLastBlocktxnCount->setText(QString::number(stats->nodeStateStats.m_last_blocktxn_count));
+        ui->peerLastBlocktxnSize->setText(GUIUtil::formatBytes(stats->nodeStateStats.m_last_blocktxn_size));
         ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStateStats.m_ping_wait));
         ui->peerAddrRelayEnabled->setText(stats->nodeStateStats.m_addr_relay_enabled ? ts.yes : ts.no);
         ui->peerAddrProcessed->setText(QString::number(stats->nodeStateStats.m_addr_processed));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -192,6 +192,8 @@ static RPCHelpMan getpeerinfo()
                                                               "best capture connection behaviors."},
                     {RPCResult::Type::STR, "transport_protocol_type", "Type of transport protocol: \n" + Join(TRANSPORT_TYPE_DOC, ",\n") + ".\n"},
                     {RPCResult::Type::STR, "session_id", "The session ID for this connection, or \"\" if there is none (\"v2\" transport protocol only).\n"},
+                    {RPCResult::Type::NUM, "last_blocktxn_count", "The number of transactions sent to this peer in the last BLOCKTXN response"},
+                    {RPCResult::Type::NUM, "last_blocktxn_size", "The total byte size of transactions sent to this peer in the last BLOCKTXN response"}
                 }},
             }},
         },
@@ -298,6 +300,8 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("connection_type", ConnectionTypeAsString(stats.m_conn_type));
         obj.pushKV("transport_protocol_type", TransportTypeAsString(stats.m_transport_type));
         obj.pushKV("session_id", stats.m_session_id);
+        obj.pushKV("last_blocktxn_count", statestats.m_last_blocktxn_count);
+        obj.pushKV("last_blocktxn_size", statestats.m_last_blocktxn_size);
 
         ret.push_back(std::move(obj));
     }

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -176,6 +176,8 @@ class NetTest(BitcoinTestFramework):
                 "timeoffset": 0,
                 "transport_protocol_type": "v1" if not self.options.v2transport else "v2",
                 "version": 0,
+                "last_blocktxn_count": 0,
+                "last_blocktxn_size": 0
             },
         )
         no_version_peer.peer_disconnect()


### PR DESCRIPTION
Adds per-peer tracking of the TX count and byte size of the last BLOCKTXN message sent.
These stats are exposed via getpeerinfo and displayed in the Qt debug window.