### PR TITLE
tsan: remove note about dropping Qt wildcards

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -11,7 +11,7 @@ deadlock:Chainstate::ConnectTip
 # Intentional deadlock in tests
 deadlock:sync_tests::potential_deadlock_detected
 
-# Wildcard for all of the gui, should be replaced with non-wildcard suppressions
+# Wildcard for all of the gui
 race:bitcoin-qt
 race:src/qt/test/*
 deadlock:src/qt/test/*


### PR DESCRIPTION
Doing so looks unmaintainable.