### PR TITLE
rpc: Add optional peer_ids param to filter getpeerinfo

### DIFF
--- a/doc/release-notes-32741.md
+++ b/doc/release-notes-32741.md
@@ -1,0 +1,6 @@
+RPC
+---
+
+- `getpeerinfo` now accepts an optional parameter to filter by peer ID(s).
+  This can be a single ID or a list of IDs. When provided, only the specified
+  peers are returned instead of all connected peers.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -386,6 +386,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signmessagewithprivkey", 1, "message", ParamFormat::STRING },
     { "walletpassphrasechange", 0, "oldpassphrase", ParamFormat::STRING },
     { "walletpassphrasechange", 1, "newpassphrase", ParamFormat::STRING },
+    { "getpeerinfo", 0, "peer_ids", ParamFormat::JSON_OR_STRING },
 };
 // clang-format on
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -121,8 +121,18 @@ static RPCHelpMan getpeerinfo()
 {
     return RPCHelpMan{
         "getpeerinfo",
-        "Returns data about each connected network peer as a json array of objects.",
-        {},
+        "Returns data about each connected network peer as a json array of objects.\n"
+        "Optionally filter by peer ids.\n",
+        {
+            {"peer_ids", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "A JSON array of peer IDs, or a single peer ID as a number.\n"
+                "If omitted, returns all peers.\n",
+                {
+                    {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Peer ID"},
+                },
+                {RPCArgOptions{.skip_type_check = true, .type_str = {"", "numeric or array"}}}
+            }
+        },
         RPCResult{
             RPCResult::Type::ARR, "", "",
             {
@@ -199,10 +209,27 @@ static RPCHelpMan getpeerinfo()
         },
         RPCExamples{
             HelpExampleCli("getpeerinfo", "")
+            + HelpExampleCli("getpeerinfo", "2")
+            + HelpExampleCli("getpeerinfo", "\"[2, 3, 7]\"")
             + HelpExampleRpc("getpeerinfo", "")
+            + HelpExampleRpc("getpeerinfo", "2")
+            + HelpExampleRpc("getpeerinfo", "[2, 3, 7]")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    std::unordered_set<NodeId> peer_ids;
+    if (const UniValue* arg = self.MaybeArg<UniValue>("peer_ids")) {
+        if (arg->isNum()) {
+            peer_ids.insert(arg->getInt<NodeId>());
+        } else if (arg->isArray()) {
+            peer_ids.reserve(arg->size());
+            for (const UniValue& v : arg->getValues()) peer_ids.insert(v.getInt<NodeId>());
+        } else {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "peer_ids must be a number or an array of numbers");
+        }
+    }
+    const bool fFilter = !peer_ids.empty();
+
     NodeContext& node = EnsureAnyNodeContext(request.context);
     const CConnman& connman = EnsureConnman(node);
     const PeerManager& peerman = EnsurePeerman(node);
@@ -213,6 +240,7 @@ static RPCHelpMan getpeerinfo()
     UniValue ret(UniValue::VARR);
 
     for (const CNodeStats& stats : vstats) {
+        if (fFilter && !peer_ids.contains(stats.nodeid)) continue;
         UniValue obj(UniValue::VOBJ);
         CNodeStateStats statestats;
         bool fStateStats = peerman.GetNodeStateStats(stats.nodeid, statestats);
@@ -304,6 +332,7 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("session_id", stats.m_session_id);
 
         ret.push_back(std::move(obj));
+        if (fFilter && ret.size() >= peer_ids.size()) break; // All requested peer_ids found
     }
 
     return ret;

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -180,6 +180,28 @@ class NetTest(BitcoinTestFramework):
                 "version": 0,
             },
         )
+
+        self.log.info("Check getpeerinfo filtering: all, single, multiple")
+        node = self.nodes[0]
+        all_peers = node.getpeerinfo()
+        assert_equal(len(all_peers), node.getconnectioncount())
+
+        for peer in all_peers:
+            filtered = node.getpeerinfo(peer["id"])
+            assert_equal(len(filtered), 1)
+            assert_equal(filtered[0]["id"], peer["id"])
+
+        ids = [p["id"] for p in all_peers[:2]]
+        filtered = node.getpeerinfo(ids)
+        assert_equal(len(filtered), len(ids))
+        assert_equal(sorted(p["id"] for p in filtered), sorted(ids))
+
+        self.log.info("Check getpeerinfo with nonexistent peer_id")
+        nonexistent_id = max(p["id"] for p in all_peers) + 1000
+        assert_equal(node.getpeerinfo(nonexistent_id), [])
+        assert_raises_rpc_error(-8, "must be a number or an array of numbers", node.getpeerinfo, {})
+        assert_equal(len(node.getpeerinfo([ids[0], nonexistent_id])), 1)
+
         no_version_peer.peer_disconnect()
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 2)
 


### PR DESCRIPTION
Adds an optional `peer_ids` parameter to `getpeerinfo` to filter results by peer IDs.

This is useful when using bitcoin-cli or the console to inspect specific peers referenced in debug.log.