### PR TITLE
Introduce SockMan ("lite"): low-level socket handling for HTTP

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/run_command.cpp
   common/settings.cpp
   common/signmessage.cpp
+  common/sockman.cpp
   common/system.cpp
   common/url.cpp
   compressor.cpp

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -93,3 +93,27 @@ void SockMan::StopListening()
 {
     m_listen.clear();
 }
+
+std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)
+{
+    // Make sure we only operate on our own listening sockets
+    Assume(std::ranges::any_of(m_listen, [&](const auto& sock) { return sock.get() == &listen_sock; }));
+
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+    auto sock = listen_sock.Accept((struct sockaddr*)&sockaddr, &len);
+
+    if (!sock) {
+        const int nErr = WSAGetLastError();
+        if (nErr != WSAEWOULDBLOCK) {
+            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
+        }
+        return {};
+    }
+
+    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
+    }
+
+    return sock;
+}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -167,6 +167,10 @@ bool SockMan::ShouldTryToSend(Id id) const { return true; }
 
 bool SockMan::ShouldTryToRecv(Id id) const { return true; }
 
+void SockMan::EventIOLoopCompletedForOne(Id id) {}
+
+void SockMan::EventIOLoopCompletedForAll() {}
+
 SockMan::Id SockMan::GetNewId()
 {
     return m_next_id.fetch_add(1, std::memory_order_relaxed);
@@ -233,6 +237,8 @@ void SockMan::ThreadSocketHandler()
     AssertLockNotHeld(m_connected_mutex);
 
     while (!m_interrupt_net) {
+        EventIOLoopCompletedForAll();
+
         // Check for the readiness of the already connected sockets and the
         // listening sockets in one call ("readiness" as in poll(2) or
         // select(2)). If none are ready, wait for a short while and return
@@ -330,6 +336,8 @@ void SockMan::SocketHandlerConnected(const IOReadiness& io_readiness)
                 EventGotData(id, {buf, static_cast<size_t>(nrecv)});
             }
         }
+
+        EventIOLoopCompletedForOne(id);
     }
 }
 

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -121,3 +121,8 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
 
     return sock;
 }
+
+SockMan::Id SockMan::GetNewId()
+{
+    return m_next_id.fetch_add(1, std::memory_order_relaxed);
+}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <common/sockman.h>
+#include <logging.h>
+#include <netbase.h>
+#include <util/sock.h>
+
+bool SockMan::BindListenPort(const CService& addrBind, bilingual_str& strError)
+{
+    int nOne = 1;
+
+    // Create socket for listening for incoming connections
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
+    {
+        strError = Untranslated(strprintf("Bind address family for %s not supported", addrBind.ToStringAddrPort()));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    if (!sock) {
+        strError = Untranslated(strprintf("Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError())));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    // Allow binding if the port is still in TIME_WAIT state after
+    // the program was closed and restarted.
+    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &nOne, sizeof(int)) == SOCKET_ERROR) {
+        strError = Untranslated(strprintf("Error setting SO_REUSEADDR on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+        LogPrintf("%s\n", strError.original);
+    }
+
+    // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
+    // and enable it by default or not. Try to enable it, if possible.
+    if (addrBind.IsIPv6()) {
+#ifdef IPV6_V6ONLY
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &nOne, sizeof(int)) == SOCKET_ERROR) {
+            strError = Untranslated(strprintf("Error setting IPV6_V6ONLY on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+            LogPrintf("%s\n", strError.original);
+        }
+#endif
+#ifdef WIN32
+        int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &nProtLevel, sizeof(int)) == SOCKET_ERROR) {
+            strError = Untranslated(strprintf("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
+            LogPrintf("%s\n", strError.original);
+        }
+#endif
+    }
+
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
+        int nErr = WSAGetLastError();
+        if (nErr == WSAEADDRINUSE)
+            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), CLIENT_NAME);
+        else
+            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+    LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
+
+    // Listen for incoming connections
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
+    {
+        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
+        return false;
+    }
+
+    m_listen.emplace_back(std::move(sock));
+
+    return true;
+}
+
+void SockMan::StopListening()
+{
+    m_listen.clear();
+}

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -9,74 +9,84 @@
 #include <netbase.h>
 #include <util/sock.h>
 
-bool SockMan::BindListenPort(const CService& addrBind, bilingual_str& strError)
+util::Result<void> SockMan::BindAndStartListening(const CService& to)
 {
-    int nOne = 1;
-
     // Create socket for listening for incoming connections
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
-    {
-        strError = Untranslated(strprintf("Bind address family for %s not supported", addrBind.ToStringAddrPort()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
+    sockaddr_storage storage;
+    socklen_t len{sizeof(storage)};
+    if (!to.GetSockAddr(reinterpret_cast<sockaddr*>(&storage), &len)) {
+        return util::Error{Untranslated(strprintf("Bind address family for %s not supported", to.ToStringAddrPort()))};
     }
 
-    std::unique_ptr<Sock> sock = CreateSock(addrBind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    std::unique_ptr<Sock> sock{CreateSock(to.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP)};
     if (!sock) {
-        strError = Untranslated(strprintf("Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError())));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
+        return util::Error{Untranslated(strprintf("Cannot create %s listen socket: %s",
+                                                    to.ToStringAddrPort(),
+                                                    NetworkErrorString(WSAGetLastError())))};
     }
+
+    int socket_option_true{1};
 
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.
-    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &nOne, sizeof(int)) == SOCKET_ERROR) {
-        strError = Untranslated(strprintf("Error setting SO_REUSEADDR on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-        LogPrintf("%s\n", strError.original);
+    if (sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &socket_option_true, sizeof(socket_option_true)) == SOCKET_ERROR) {
+        LogPrintLevel(BCLog::NET,
+                      BCLog::Level::Info,
+                      "Cannot set SO_REUSEADDR on %s listen socket: %s, continuing anyway",
+                      to.ToStringAddrPort(),
+                      NetworkErrorString(WSAGetLastError()));
     }
 
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) {
+    if (to.IsIPv6()) {
 #ifdef IPV6_V6ONLY
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &nOne, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_V6ONLY on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
+        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &socket_option_true, sizeof(socket_option_true)) == SOCKET_ERROR) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Info,
+                          "Cannot set IPV6_V6ONLY on %s listen socket: %s, continuing anyway",
+                          to.ToStringAddrPort(),
+                          NetworkErrorString(WSAGetLastError()));
         }
 #endif
 #ifdef WIN32
-        int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
-        if (sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &nProtLevel, sizeof(int)) == SOCKET_ERROR) {
-            strError = Untranslated(strprintf("Error setting IPV6_PROTECTION_LEVEL on socket: %s, continuing anyway", NetworkErrorString(WSAGetLastError())));
-            LogPrintf("%s\n", strError.original);
+        int prot_level{PROTECTION_LEVEL_UNRESTRICTED};
+        if (sock->SetSockOpt(IPPROTO_IPV6,
+                             IPV6_PROTECTION_LEVEL,
+                             &prot_level,
+                             sizeof(prot_level)) == SOCKET_ERROR) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Info,
+                          "Cannot set IPV6_PROTECTION_LEVEL on %s listen socket: %s, continuing anyway",
+                          to.ToStringAddrPort(),
+                          NetworkErrorString(WSAGetLastError()));
         }
 #endif
     }
 
-    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
-        int nErr = WSAGetLastError();
-        if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToStringAddrPort(), CLIENT_NAME);
-        else
-            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToStringAddrPort(), NetworkErrorString(nErr));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
+    if (sock->Bind(reinterpret_cast<sockaddr*>(&storage), len) == SOCKET_ERROR) {
+        const int err{WSAGetLastError()};
+        if (err == WSAEADDRINUSE) {
+            return util::Error{strprintf(_("Unable to bind to %s on this computer. %s is probably already running."),
+                                            to.ToStringAddrPort(),
+                                            CLIENT_NAME)};
+        } else {
+            return util::Error{strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"),
+                                            to.ToStringAddrPort(),
+                                            NetworkErrorString(err))};
+        }
     }
-    LogPrintf("Bound to %s\n", addrBind.ToStringAddrPort());
 
     // Listen for incoming connections
-    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
-    {
-        strError = strprintf(_("Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", strError.original);
-        return false;
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR) {
+        return util::Error{strprintf(_("Cannot listen on %s: %s"),
+                                        to.ToStringAddrPort(),
+                                        NetworkErrorString(WSAGetLastError()))};
     }
 
     m_listen.emplace_back(std::move(sock));
 
-    return true;
+    return {};
 }
 
 void SockMan::StopListening()

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -8,6 +8,13 @@
 #include <logging.h>
 #include <netbase.h>
 #include <util/sock.h>
+#include <util/thread.h>
+
+// The set of sockets cannot be modified while waiting
+// The sleep time needs to be small to avoid new sockets stalling
+static constexpr auto SELECT_TIMEOUT{50ms};
+
+static constexpr int SOCKET_OPTION_TRUE{1};
 
 util::Result<void> SockMan::BindAndStartListening(const CService& to)
 {
@@ -89,9 +96,65 @@ util::Result<void> SockMan::BindAndStartListening(const CService& to)
     return {};
 }
 
+void SockMan::StartSocketsThreads(const Options& options)
+{
+    m_thread_socket_handler = std::thread(
+        &util::TraceThread, options.socket_handler_thread_name, [this] { ThreadSocketHandler(); });
+}
+
+void SockMan::JoinSocketsThreads()
+{
+    if (m_thread_socket_handler.joinable()) {
+        m_thread_socket_handler.join();
+    }
+}
+
+bool SockMan::CloseConnection(Id id)
+{
+    LOCK(m_connected_mutex);
+    return m_connected.erase(id) > 0;
+}
+
 void SockMan::StopListening()
 {
     m_listen.clear();
+}
+
+bool SockMan::ShouldTryToSend(Id id) const { return true; }
+
+bool SockMan::ShouldTryToRecv(Id id) const { return true; }
+
+SockMan::Id SockMan::GetNewId()
+{
+    return m_next_id.fetch_add(1, std::memory_order_relaxed);
+}
+
+void SockMan::NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    if (!sock->IsSelectable()) {
+        LogPrintf("connection from %s dropped: non-selectable socket\n", them.ToStringAddrPort());
+        return;
+    }
+
+    // According to the internet TCP_NODELAY is not carried into accepted sockets
+    // on all platforms.  Set it again here just to be sure.
+    if (sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &SOCKET_OPTION_TRUE, sizeof(SOCKET_OPTION_TRUE)) == SOCKET_ERROR) {
+        LogDebug(BCLog::NET, "connection from %s: unable to set TCP_NODELAY, continuing anyway\n",
+                 them.ToStringAddrPort());
+    }
+
+    const Id id{GetNewId()};
+
+    {
+        LOCK(m_connected_mutex);
+        m_connected.emplace(id, std::make_shared<ConnectionSocket>(std::move(sock)));
+    }
+
+    if (!EventNewConnectionAccepted(id, me, them)) {
+        CloseConnection(id);
+    }
 }
 
 std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CService& addr)
@@ -122,7 +185,70 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
     return sock;
 }
 
-SockMan::Id SockMan::GetNewId()
+void SockMan::ThreadSocketHandler()
 {
-    return m_next_id.fetch_add(1, std::memory_order_relaxed);
+    AssertLockNotHeld(m_connected_mutex);
+
+    while (!m_interrupt_net) {
+        // Check for the readiness of the already connected sockets and the
+        // listening sockets in one call ("readiness" as in poll(2) or
+        // select(2)). If none are ready, wait for a short while and return
+        // empty sets.
+        auto io_readiness{GenerateWaitSockets()};
+        if (io_readiness.events_per_sock.empty() ||
+            // WaitMany() may as well be a static method, the context of the first Sock in the vector is not relevant.
+            !io_readiness.events_per_sock.begin()->first->WaitMany(SELECT_TIMEOUT,
+                                                                   io_readiness.events_per_sock)) {
+            m_interrupt_net.sleep_for(SELECT_TIMEOUT);
+        }
+
+        // Accept new connections from listening sockets.
+        SocketHandlerListening(io_readiness.events_per_sock);
+    }
+}
+
+SockMan::IOReadiness SockMan::GenerateWaitSockets()
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    IOReadiness io_readiness;
+
+    for (const auto& sock : m_listen) {
+        io_readiness.events_per_sock.emplace(sock, Sock::Events{Sock::RECV});
+    }
+
+    auto connected_snapshot{WITH_LOCK(m_connected_mutex, return m_connected;)};
+
+    for (const auto& [id, sockets] : connected_snapshot) {
+        const bool select_recv{ShouldTryToRecv(id)};
+        const bool select_send{ShouldTryToSend(id)};
+        if (!select_recv && !select_send) continue;
+
+        Sock::Event event = (select_send ? Sock::SEND : 0) | (select_recv ? Sock::RECV : 0);
+        io_readiness.events_per_sock.emplace(sockets->sock, Sock::Events{event});
+        io_readiness.ids_per_sock.emplace(sockets->sock, id);
+    }
+
+    return io_readiness;
+}
+
+void SockMan::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock)
+{
+    AssertLockNotHeld(m_connected_mutex);
+
+    for (const auto& sock : m_listen) {
+        if (m_interrupt_net) {
+            return;
+        }
+        const auto it = events_per_sock.find(sock);
+        if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
+            CService addr_accepted;
+
+            auto sock_accepted{AcceptConnection(*sock, addr_accepted)};
+
+            if (sock_accepted) {
+                NewSockAccepted(std::move(sock_accepted), GetBindAddress(*sock), addr_accepted);
+            }
+        }
+    }
 }

--- a/src/common/sockman.cpp
+++ b/src/common/sockman.cpp
@@ -99,19 +99,23 @@ std::unique_ptr<Sock> SockMan::AcceptConnection(const Sock& listen_sock, CServic
     // Make sure we only operate on our own listening sockets
     Assume(std::ranges::any_of(m_listen, [&](const auto& sock) { return sock.get() == &listen_sock; }));
 
-    struct sockaddr_storage sockaddr;
-    socklen_t len = sizeof(sockaddr);
-    auto sock = listen_sock.Accept((struct sockaddr*)&sockaddr, &len);
+    sockaddr_storage storage;
+    socklen_t len{sizeof(storage)};
+
+    auto sock{listen_sock.Accept(reinterpret_cast<sockaddr*>(&storage), &len)};
 
     if (!sock) {
-        const int nErr = WSAGetLastError();
-        if (nErr != WSAEWOULDBLOCK) {
-            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
+        const int err{WSAGetLastError()};
+        if (err != WSAEWOULDBLOCK) {
+            LogPrintLevel(BCLog::NET,
+                          BCLog::Level::Error,
+                          "Cannot accept new connection: %s\n",
+                          NetworkErrorString(err));
         }
         return {};
     }
 
-    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
+    if (!addr.SetSockAddr(reinterpret_cast<sockaddr*>(&storage), len)) {
         LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "Unknown socket family\n");
     }
 

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -86,6 +86,23 @@ public:
      */
     void StopListening();
 
+    /**
+     * Try to send some data over the given connection.
+     * @param[in] id Identifier of the connection.
+     * @param[in] data The data to send, it might happen that only a prefix of this is sent.
+     * @param[in] will_send_more Used as an optimization if the caller knows that they will
+     * be sending more data soon after this call.
+     * @param[out] errmsg If <0 is returned then this will contain a human readable message
+     * explaining the error.
+     * @retval >=0 The number of bytes actually sent.
+     * @retval <0 A permanent error has occurred.
+     */
+    ssize_t SendBytes(Id id,
+                      std::span<const std::byte> data,
+                      bool will_send_more,
+                      std::string& errmsg) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
 protected:
     //
     // Pure virtual functions must be implemented by children classes.
@@ -103,6 +120,16 @@ protected:
     virtual bool EventNewConnectionAccepted(Id id,
                                             const CService& me,
                                             const CService& them) = 0;
+
+    /**
+     * Called when the socket is ready to send data and `ShouldTryToSend()` has
+     * returned true. This is where the higher level code serializes its messages
+     * and calls `SockMan::SendBytes()`.
+     * @param[in] id Id of the connection whose socket is ready to send.
+     * @param[out] cancel_recv Should always be set upon return and if it is true,
+     * then the next attempt to receive data from that connection will be omitted.
+     */
+    virtual void EventReadyToSend(Id id, bool& cancel_recv) = 0;
 
     /**
      * Called when new data has been received.

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -19,7 +19,10 @@
  * To use this class, inherit from it and implement the pure virtual methods.
  * Handled operations:
  * - binding and listening on sockets
+ * - starting of necessary threads to process socket operations
  * - accepting incoming connections
+ * - closing connections
+ * - waiting for IO readiness on sockets and doing send/recv accordingly
  */
 class SockMan
 {
@@ -29,12 +32,54 @@ public:
      */
     using Id = int64_t;
 
+    virtual ~SockMan()
+    {
+        Assume(!m_thread_socket_handler.joinable()); // Missing call to JoinSocketsThreads()
+        Assume(m_connected.empty()); // Missing call to CloseConnection()
+        Assume(m_listen.empty()); // Missing call to StopListening()
+    }
+
+    //
+    // Non-virtual functions, to be reused by children classes.
+    //
+
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
+     * Should be called before `StartSocketsThreads()`.
      * @param[in] to Where to bind.
      * @returns {} or the reason for failure.
      */
     util::Result<void> BindAndStartListening(const CService& to);
+
+    /**
+     * Options to influence `StartSocketsThreads()`.
+     */
+    struct Options {
+        std::string_view socket_handler_thread_name;
+    };
+
+    /**
+     * Start the necessary threads for sockets IO.
+     */
+    void StartSocketsThreads(const Options& options);
+
+    /**
+     * Join (wait for) the threads started by `StartSocketsThreads()` to exit.
+     */
+    void JoinSocketsThreads();
+
+    /**
+     * Stop network activity
+     */
+    void InterruptNet() { m_interrupt_net(); }
+
+    /**
+     * Destroy a given connection by closing its socket and release resources occupied by it.
+     * @param[in] id Connection to destroy.
+     * @return Whether the connection existed and its socket was closed by this call.
+     */
+    bool CloseConnection(Id id)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
 
     /**
      * Stop listening by closing all listening sockets.
@@ -42,13 +87,43 @@ public:
     void StopListening();
 
 protected:
+    //
+    // Pure virtual functions must be implemented by children classes.
+    //
+
     /**
-     * Accept a connection.
-     * @param[in] listen_sock Socket on which to accept the connection.
-     * @param[out] addr Address of the peer that was accepted.
-     * @return Newly created socket for the accepted connection.
+     * Be notified when a new connection has been accepted.
+     * @param[in] id Id of the newly accepted connection.
+     * @param[in] me The address and port at our side of the connection.
+     * @param[in] them The address and port at the peer's side of the connection.
+     * @retval true The new connection was accepted at the higher level.
+     * @retval false The connection was refused at the higher level, so the
+     * associated socket and id should be discarded by `SockMan`.
      */
-    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
+    virtual bool EventNewConnectionAccepted(Id id,
+                                            const CService& me,
+                                            const CService& them) = 0;
+
+    //
+    // Non-pure virtual functions can be overridden by children classes or left
+    // alone to use the default implementation from SockMan.
+    //
+
+    /**
+     * Can be used to temporarily pause sends on a connection.
+     * SockMan would only call Send() if this returns true.
+     * The implementation in SockMan always returns true.
+     * @param[in] id Connection for which to confirm or omit the next call to EventReadyToSend().
+     */
+    virtual bool ShouldTryToSend(Id id) const;
+
+    /**
+     * SockMan would only call Recv() on a connection's socket if this returns true.
+     * Can be used to temporarily pause receives on a connection.
+     * The implementation in SockMan always returns true.
+     * @param[in] id Connection for which to confirm or omit the next receive.
+     */
+    virtual bool ShouldTryToRecv(Id id) const;
 
     /**
      * List of listening sockets.
@@ -62,9 +137,114 @@ private:
     Id GetNewId();
 
     /**
-     * The id to assign to the next created connection.
+     * The id to assign to the next created connection. Used to generate ids of connections.
      */
     std::atomic<Id> m_next_id{0};
+
+    /**
+     * After a new socket with a peer has been created, configure its flags,
+     * make a new connection id and call `EventNewConnectionAccepted()`.
+     * @param[in] sock The newly created socket.
+     * @param[in] me Address at our end of the connection.
+     * @param[in] them Address of the new peer.
+     */
+    void NewSockAccepted(std::unique_ptr<Sock>&& sock, const CService& me, const CService& them)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Accept a connection.
+     * @param[in] listen_sock Socket on which to accept the connection.
+     * @param[out] addr Address of the peer that was accepted.
+     * @return Newly created socket for the accepted connection.
+     */
+    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
+
+    /**
+     * The sockets used by a connection.
+     */
+    struct ConnectionSocket {
+        explicit ConnectionSocket(std::unique_ptr<Sock>&& s)
+            : sock{std::move(s)}
+        {
+        }
+
+        /**
+         * Mutex that serializes the Send() and Recv() calls on `sock`.
+         */
+        Mutex mutex;
+
+        /**
+         * Underlying socket.
+         * `shared_ptr` (instead of `unique_ptr`) is used to avoid premature close of the
+         * underlying file descriptor by one thread while another thread is poll(2)-ing
+         * it for activity.
+         * @see https://github.com/bitcoin/bitcoin/issues/21744 for details.
+         */
+        std::shared_ptr<Sock> sock;
+    };
+
+    /**
+     * Info about which socket has which event ready and its connection id.
+     */
+    struct IOReadiness {
+        /**
+         * Map of socket -> socket events. For example:
+         * socket1 -> { requested = SEND|RECV, occurred = RECV }
+         * socket2 -> { requested = SEND, occurred = SEND }
+         */
+        Sock::EventsPerSock events_per_sock;
+
+        /**
+         * Map of socket -> connection id (in `m_connected`). For example
+         * socket1 -> id=23
+         * socket2 -> id=56
+         */
+        std::unordered_map<Sock::EventsPerSock::key_type,
+                           SockMan::Id,
+                           Sock::HashSharedPtrSock,
+                           Sock::EqualSharedPtrSock>
+            ids_per_sock;
+    };
+
+    /**
+     * Check connected and listening sockets for IO readiness and process them accordingly.
+     */
+    void ThreadSocketHandler()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Generate a collection of sockets to check for IO readiness.
+     * @return Sockets to check for readiness plus an aux map to find the
+     * corresponding connection id given a socket.
+     */
+    IOReadiness GenerateWaitSockets()
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * Accept incoming connections, one from each read-ready listening socket.
+     * @param[in] events_per_sock Sockets that are ready for IO.
+     */
+    void SocketHandlerListening(const Sock::EventsPerSock& events_per_sock)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_connected_mutex);
+
+    /**
+     * This is signaled when network activity should cease.
+     */
+    CThreadInterrupt m_interrupt_net;
+
+    /**
+     * Thread that sends to and receives from sockets and accepts connections.
+     */
+    std::thread m_thread_socket_handler;
+
+    mutable Mutex m_connected_mutex;
+
+    /**
+     * Sockets for existent connections.
+     * The `shared_ptr` makes it possible to create a snapshot of this by simply copying
+     * it (under `m_connected_mutex`).
+     */
+    std::unordered_map<Id, std::shared_ptr<ConnectionSocket>> m_connected GUARDED_BY(m_connected_mutex);
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -1,0 +1,45 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_COMMON_SOCKMAN_H
+#define BITCOIN_COMMON_SOCKMAN_H
+
+#include <netaddress.h>
+#include <util/sock.h>
+#include <util/translation.h>
+
+#include <memory>
+#include <vector>
+
+/**
+ * A socket manager class which handles socket operations.
+ * To use this class, inherit from it and implement the pure virtual methods.
+ * Handled operations:
+ * - binding and listening on sockets
+ */
+class SockMan
+{
+public:
+    /**
+     * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
+     * @param[in] addrBind Where to bind.
+     * @param[out] strError Error string if an error occurs.
+     * @retval true Success.
+     * @retval false Failure, `strError` will be set.
+     */
+    bool BindListenPort(const CService& addrBind, bilingual_str& strError);
+
+    /**
+     * Stop listening by closing all listening sockets.
+     */
+    void StopListening();
+
+protected:
+    /**
+     * List of listening sockets.
+     */
+    std::vector<std::shared_ptr<Sock>> m_listen;
+};
+
+#endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -10,6 +10,7 @@
 #include <util/sock.h>
 #include <util/translation.h>
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -23,6 +24,11 @@
 class SockMan
 {
 public:
+    /**
+     * Each connection is assigned an unique id of this type.
+     */
+    using Id = int64_t;
+
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
      * @param[in] to Where to bind.
@@ -48,6 +54,17 @@ protected:
      * List of listening sockets.
      */
     std::vector<std::shared_ptr<Sock>> m_listen;
+
+private:
+    /**
+     * Generate an id for a newly created connection.
+     */
+    Id GetNewId();
+
+    /**
+     * The id to assign to the next created connection.
+     */
+    std::atomic<Id> m_next_id{0};
 };
 
 #endif // BITCOIN_COMMON_SOCKMAN_H

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -175,6 +175,23 @@ protected:
     virtual bool ShouldTryToRecv(Id id) const;
 
     /**
+     * SockMan has completed the current send+recv iteration for a given connection.
+     * It will do another send+recv for this connection after processing all other connections.
+     * Can be used to execute periodic tasks for a given connection.
+     * The implementation in SockMan does nothing.
+     * @param[in] id Connection for which send+recv has been done.
+     */
+    virtual void EventIOLoopCompletedForOne(Id id);
+
+    /**
+     * SockMan has completed send+recv for all connections.
+     * Can be used to execute periodic tasks for all connections, like closing
+     * connections due to higher level logic.
+     * The implementation in SockMan does nothing.
+     */
+    virtual void EventIOLoopCompletedForAll();
+
+    /**
      * List of listening sockets.
      */
     std::vector<std::shared_ptr<Sock>> m_listen;

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -18,6 +18,7 @@
  * To use this class, inherit from it and implement the pure virtual methods.
  * Handled operations:
  * - binding and listening on sockets
+ * - accepting incoming connections
  */
 class SockMan
 {
@@ -35,6 +36,14 @@ public:
     void StopListening();
 
 protected:
+    /**
+     * Accept a connection.
+     * @param[in] listen_sock Socket on which to accept the connection.
+     * @param[out] addr Address of the peer that was accepted.
+     * @return Newly created socket for the accepted connection.
+     */
+    std::unique_ptr<Sock> AcceptConnection(const Sock& listen_sock, CService& addr);
+
     /**
      * List of listening sockets.
      */

--- a/src/common/sockman.h
+++ b/src/common/sockman.h
@@ -6,6 +6,7 @@
 #define BITCOIN_COMMON_SOCKMAN_H
 
 #include <netaddress.h>
+#include <util/result.h>
 #include <util/sock.h>
 #include <util/translation.h>
 
@@ -23,12 +24,10 @@ class SockMan
 public:
     /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
-     * @param[in] addrBind Where to bind.
-     * @param[out] strError Error string if an error occurs.
-     * @retval true Success.
-     * @retval false Failure, `strError` will be set.
+     * @param[in] to Where to bind.
+     * @returns {} or the reason for failure.
      */
-    bool BindListenPort(const CService& addrBind, bilingual_str& strError);
+    util::Result<void> BindAndStartListening(const CService& to);
 
     /**
      * Stop listening by closing all listening sockets.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -360,20 +360,6 @@ bool CConnman::CheckIncomingNonce(uint64_t nonce)
     return true;
 }
 
-/** Get the bind address for a socket as CService. */
-static CService GetBindAddress(const Sock& sock)
-{
-    CService addr_bind;
-    struct sockaddr_storage sockaddr_bind;
-    socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
-    if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
-        addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind, sockaddr_bind_len);
-    } else {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
-    }
-    return addr_bind;
-}
-
 CNode* CConnman::ConnectNode(CAddress addrConnect,
                              const char* pszDest,
                              bool fCountFailure,

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -951,3 +951,16 @@ CService MaybeFlipIPv6toCJDNS(const CService& service)
     }
     return ret;
 }
+
+CService GetBindAddress(const Sock& sock)
+{
+    CService addr_bind;
+    struct sockaddr_storage sockaddr_bind;
+    socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
+    if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
+        addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind, sockaddr_bind_len);
+    } else {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
+    }
+    return addr_bind;
+}

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -955,10 +955,10 @@ CService MaybeFlipIPv6toCJDNS(const CService& service)
 CService GetBindAddress(const Sock& sock)
 {
     CService addr_bind;
-    struct sockaddr_storage sockaddr_bind;
-    socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
-    if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
-        addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind, sockaddr_bind_len);
+    sockaddr_storage storage;
+    socklen_t len{sizeof(storage)};
+    if (!sock.GetSockName(reinterpret_cast<sockaddr*>(&storage), &len)) {
+        addr_bind.SetSockAddr(reinterpret_cast<sockaddr*>(&storage), len);
     } else {
         LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
     }

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -362,4 +362,7 @@ bool IsBadPort(uint16_t port);
  */
 CService MaybeFlipIPv6toCJDNS(const CService& service);
 
+/** Get the bind address for a socket as CService. */
+CService GetBindAddress(const Sock& sock);
+
 #endif // BITCOIN_NETBASE_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -99,6 +99,7 @@ add_executable(test_bitcoin
   sigopcount_tests.cpp
   skiplist_tests.cpp
   sock_tests.cpp
+  sockman_tests.cpp
   span_tests.cpp
   streams_tests.cpp
   sync_tests.cpp

--- a/src/test/sockman_tests.cpp
+++ b/src/test/sockman_tests.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sockman.h>
+#include <test/util/setup_common.h>
+#include <util/translation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sockman_tests, SocketTestingSetup)
+
+class TestSockMan : public SockMan
+{
+public:
+    size_t GetListeningSocketCount() { return m_listen.size(); };
+};
+
+BOOST_AUTO_TEST_CASE(test_sockman)
+{
+    TestSockMan sockman;
+
+    {
+        // We can only bind to NET_IPV4 and NET_IPV6
+        CService onion_address{Lookup("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2dqd.onion", 0, false).value()};
+        bilingual_str str_error;
+        auto result{sockman.BindListenPort(onion_address, str_error)};
+        BOOST_REQUIRE(!result);
+        BOOST_CHECK_EQUAL(str_error.original, "Bind address family for aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2dqd.onion:0 not supported");
+    }
+
+    // This VALID address won't actually get used because we stubbed CreateSock()
+    CService addr_bind{Lookup("0.0.0.0", 0, false).value()};
+
+    // Init state
+    BOOST_REQUIRE_EQUAL(sockman.GetListeningSocketCount(), 0);
+    // Bind to mock Listening Socket
+    bilingual_str str_error;
+    BOOST_REQUIRE(sockman.BindListenPort(addr_bind, str_error));
+    // We are bound and listening
+    BOOST_REQUIRE_EQUAL(sockman.GetListeningSocketCount(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sockman_tests.cpp
+++ b/src/test/sockman_tests.cpp
@@ -14,6 +14,11 @@ class TestSockMan : public SockMan
 {
 public:
     size_t GetListeningSocketCount() { return m_listen.size(); };
+
+    std::unique_ptr<Sock> AcceptConnectionFromListeningSocket(CService& addr)
+    {
+        return AcceptConnection(*m_listen.front(), addr);
+    }
 };
 
 BOOST_AUTO_TEST_CASE(test_sockman)
@@ -38,6 +43,16 @@ BOOST_AUTO_TEST_CASE(test_sockman)
     BOOST_REQUIRE(sockman.BindAndStartListening(addr_bind));
     // We are bound and listening
     BOOST_REQUIRE_EQUAL(sockman.GetListeningSocketCount(), 1);
+
+    // Pick up the phone, there's no one there
+    CService addr_connection;
+    BOOST_REQUIRE(!sockman.AcceptConnectionFromListeningSocket(addr_connection));
+
+    // Create a mock client and add it to the local CreateSock queue
+    ConnectClient();
+    // Accept the connection
+    BOOST_REQUIRE(sockman.AcceptConnectionFromListeningSocket(addr_connection));
+    BOOST_CHECK_EQUAL(addr_connection.ToStringAddrPort(), "5.5.5.5:6789");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sockman_tests.cpp
+++ b/src/test/sockman_tests.cpp
@@ -23,10 +23,9 @@ BOOST_AUTO_TEST_CASE(test_sockman)
     {
         // We can only bind to NET_IPV4 and NET_IPV6
         CService onion_address{Lookup("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2dqd.onion", 0, false).value()};
-        bilingual_str str_error;
-        auto result{sockman.BindListenPort(onion_address, str_error)};
+        auto result{sockman.BindAndStartListening(onion_address)};
         BOOST_REQUIRE(!result);
-        BOOST_CHECK_EQUAL(str_error.original, "Bind address family for aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2dqd.onion:0 not supported");
+        BOOST_CHECK_EQUAL(util::ErrorString(result).original, "Bind address family for aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2dqd.onion:0 not supported");
     }
 
     // This VALID address won't actually get used because we stubbed CreateSock()
@@ -36,7 +35,7 @@ BOOST_AUTO_TEST_CASE(test_sockman)
     BOOST_REQUIRE_EQUAL(sockman.GetListeningSocketCount(), 0);
     // Bind to mock Listening Socket
     bilingual_str str_error;
-    BOOST_REQUIRE(sockman.BindListenPort(addr_bind, str_error));
+    BOOST_REQUIRE(sockman.BindAndStartListening(addr_bind));
     // We are bound and listening
     BOOST_REQUIRE_EQUAL(sockman.GetListeningSocketCount(), 1);
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -599,12 +599,13 @@ SocketTestingSetup::~SocketTestingSetup()
     CreateSock = m_create_sock_orig;
 }
 
-void SocketTestingSetup::ConnectClient()
+void SocketTestingSetup::ConnectClient(std::span<const std::byte> data)
 {
     // I/O pipes for a mock Connected Socket we can read and write to.
     std::shared_ptr<DynSock::Pipes> connected_socket_pipes(std::make_shared<DynSock::Pipes>());
 
-    // TODO: Insert a payload
+    // Insert the payload
+    connected_socket_pipes->recv.PushBytes(data.data(), data.size());
 
     // Create the Mock Connected Socket that represents a client.
     // It needs I/O pipes but its queue can remain empty

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -599,6 +599,21 @@ SocketTestingSetup::~SocketTestingSetup()
     CreateSock = m_create_sock_orig;
 }
 
+void SocketTestingSetup::ConnectClient()
+{
+    // I/O pipes for a mock Connected Socket we can read and write to.
+    std::shared_ptr<DynSock::Pipes> connected_socket_pipes(std::make_shared<DynSock::Pipes>());
+
+    // TODO: Insert a payload
+
+    // Create the Mock Connected Socket that represents a client.
+    // It needs I/O pipes but its queue can remain empty
+    std::unique_ptr<DynSock> connected_socket{std::make_unique<DynSock>(connected_socket_pipes, std::make_shared<DynSock::Queue>())};
+
+    // Push into the queue of Accepted Sockets returned by the local CreateSock()
+    m_accepted_sockets->Push(std::move(connected_socket));
+}
+
 /**
  * @returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
  *      with 9 txs.

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -582,6 +582,23 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
     return mempool_transactions;
 }
 
+SocketTestingSetup::SocketTestingSetup()
+    : m_create_sock_orig{CreateSock}
+{
+    CreateSock = [this](int, int, int) {
+        // This is a mock Listening Socket that a server can "bind" to and
+        // listen to for incoming connections. We won't need to access its I/O
+        // pipes because we don't read or write directly to it. It will return
+        // Connected Sockets from the queue via its Accept() method.
+        return std::make_unique<DynSock>(std::make_shared<DynSock::Pipes>(), m_accepted_sockets);
+    };
+};
+
+SocketTestingSetup::~SocketTestingSetup()
+{
+    CreateSock = m_create_sock_orig;
+}
+
 /**
  * @returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
  *      with 9 txs.

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -599,7 +599,7 @@ SocketTestingSetup::~SocketTestingSetup()
     CreateSock = m_create_sock_orig;
 }
 
-void SocketTestingSetup::ConnectClient(std::span<const std::byte> data)
+std::shared_ptr<DynSock::Pipes> SocketTestingSetup::ConnectClient(std::span<const std::byte> data)
 {
     // I/O pipes for a mock Connected Socket we can read and write to.
     std::shared_ptr<DynSock::Pipes> connected_socket_pipes(std::make_shared<DynSock::Pipes>());
@@ -613,6 +613,8 @@ void SocketTestingSetup::ConnectClient(std::span<const std::byte> data)
 
     // Push into the queue of Accepted Sockets returned by the local CreateSock()
     m_accepted_sockets->Push(std::move(connected_socket));
+
+    return connected_socket_pipes;
 }
 
 /**

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <stdexcept>
+#include <test/util/net.h>
 #include <test/util/random.h>
 #include <util/chaintype.h> // IWYU pragma: export
 #include <util/check.h>
@@ -258,6 +259,20 @@ std::unique_ptr<T> MakeNoLogFileContext(const ChainType chain_type = ChainType::
 
     return std::make_unique<T>(chain_type, opts);
 }
+
+class SocketTestingSetup : public BasicTestingSetup
+{
+public:
+    explicit SocketTestingSetup();
+    ~SocketTestingSetup();
+
+private:
+    // Save the original value of CreateSock here and restore it when the test ends.
+    const decltype(CreateSock) m_create_sock_orig;
+
+    // Queue of connected sockets returned by listening socket (represents network interface)
+    std::shared_ptr<DynSock::Queue> m_accepted_sockets{std::make_shared<DynSock::Queue>()};
+};
 
 CBlock getBlock13b8a();
 

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -266,6 +266,9 @@ public:
     explicit SocketTestingSetup();
     ~SocketTestingSetup();
 
+    // Connect to the socket with a mock client (a DynSock)
+    void ConnectClient();
+
 private:
     // Save the original value of CreateSock here and restore it when the test ends.
     const decltype(CreateSock) m_create_sock_orig;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -266,8 +266,8 @@ public:
     explicit SocketTestingSetup();
     ~SocketTestingSetup();
 
-    // Connect to the socket with a mock client (a DynSock)
-    void ConnectClient();
+    // Connect to the socket with a mock client (a DynSock) and send pre-loaded data.
+    void ConnectClient(std::span<const std::byte> data);
 
 private:
     // Save the original value of CreateSock here and restore it when the test ends.

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -267,7 +267,8 @@ public:
     ~SocketTestingSetup();
 
     // Connect to the socket with a mock client (a DynSock) and send pre-loaded data.
-    void ConnectClient(std::span<const std::byte> data);
+    // Returns the I/O pipes from the mock client so we can read response datasent to it.
+    std::shared_ptr<DynSock::Pipes> ConnectClient(std::span<const std::byte> data);
 
 private:
     // Save the original value of CreateSock here and restore it when the test ends.


### PR DESCRIPTION
Introduces a new low-level socket manager `SockMan` as an abstract class with virtual functions for implementing higher-level networking protocols like HTTP. This is the next step in https://github.com/bitcoin/bitcoin/issues/31194

This is a minimal, alternative version of #30988 ("Split CConnman") without any changes to working code (P2P is not affected). It adds a stripped-down version of the `SockMan` introduced in that pull request that implements only what is needed for the HTTP server implemented in #32061 (i.e. no I2P stuff and for now, no outbound connection stuff). Exclusions from the original `SockMan` pull request can be checked with:

```
git diff vasild/sockman \
src/common/sockman.h \
src/common/sockman.cpp
```

The commit order has been flipped quite a bit because the original PR incrementally pulls logic out of `net` wheras this PR builds a new system from the bottom-up. Otherwise I tried to keep all the `SockMan` code in order so reviewers of the original PR would be familiar with it.

It also adds unit tests by introducing a `SocketTestingSetup` which mocks network sockets by returning a queue of `DynSock` from `CreateSock()`. HTTP server tests in #32061 will be rebased on this framework as well.

