### PR TITLE
fees: fix noisy flushing log

### DIFF
--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -972,7 +972,7 @@ void CBlockPolicyEstimator::FlushFeeEstimates()
         LogWarning("Failed to close fee estimates file %s: %s. Continuing anyway.", fs::PathToString(m_estimation_filepath), SysErrorString(errno));
         return;
     }
-    LogInfo("Flushed fee estimates to %s.", fs::PathToString(m_estimation_filepath.filename()));
+    LogDebug(BCLog::ESTIMATEFEE, "Flushed fee estimates to %s.", fs::PathToString(m_estimation_filepath));
 }
 
 bool CBlockPolicyEstimator::Write(AutoFile& fileout) const

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -332,7 +332,8 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         # Verify if the string "Flushed fee estimates to fee_estimates.dat." is present in the debug log file.
         # If present, it indicates that fee estimates have been successfully flushed to disk.
-        with self.nodes[0].assert_debug_log(expected_msgs=["Flushed fee estimates to fee_estimates.dat."], timeout=1):
+        expected_messages = [f"Flushed fee estimates to {fee_dat}."]
+        with self.nodes[0].assert_debug_log(expected_msgs=expected_messages, timeout=1):
             # Mock the scheduler for an hour to flush fee estimates to fee_estimates.dat
             self.nodes[0].mockscheduler(SECONDS_PER_HOUR)
 
@@ -342,7 +343,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         # Verify that the estimates remain the same if there are no blocks in the flush interval
         block_hash_before = self.nodes[0].getbestblockhash()
         fee_dat_initial_content = open(fee_dat, "rb").read()
-        with self.nodes[0].assert_debug_log(expected_msgs=["Flushed fee estimates to fee_estimates.dat."], timeout=1):
+        with self.nodes[0].assert_debug_log(expected_msgs=expected_messages, timeout=1):
             # Mock the scheduler for an hour to flush fee estimates to fee_estimates.dat
             self.nodes[0].mockscheduler(SECONDS_PER_HOUR)
 
@@ -358,7 +359,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         assert_equal(fee_dat_current_content, fee_dat_initial_content)
 
         # Verify that the estimates are not the same if new blocks were produced in the flush interval
-        with self.nodes[0].assert_debug_log(expected_msgs=["Flushed fee estimates to fee_estimates.dat."], timeout=1):
+        with self.nodes[0].assert_debug_log(expected_msgs=expected_messages, timeout=1):
             # Mock the scheduler for an hour to flush fee estimates to fee_estimates.dat
             self.generate(self.nodes[0], 5, sync_fun=self.no_op)
             self.nodes[0].mockscheduler(SECONDS_PER_HOUR)


### PR DESCRIPTION
This is a simple PR that updates the flushing log to use debug-level logging under the estimatefee category. It also ensures the log consistently includes only the full file path.
The motivation behind this is that the "Flushed fee estimates to fee_estimates.dat." logs can become noisy; it's done after one hour, so hiding it in the debug estimatefee category seems reasonable. 

---
I left the logs when the file is not found as info because that should only occur when you start a fresh node, change datadir, or explicitly delete the file