### PR TITLE
doc - fix typos and spellings

### DIFF
--- a/depends/patches/libxcb/remove_pthread_stubs.patch
+++ b/depends/patches/libxcb/remove_pthread_stubs.patch
@@ -1,4 +1,4 @@
-Remove uneeded pthread-stubs dependency
+Remove unneeded pthread-stubs dependency
 --- a/configure
 +++ b/configure
 @@ -19695,7 +19695,7 @@ fi

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -59,7 +59,7 @@ outgoing connections, but more is possible.
         service provider.
         ------------------------------------------------------------------------
 
-If -proxy or -onion is specified multiple times, later occurences override
+If -proxy or -onion is specified multiple times, later occurrences override
 earlier ones and command line overrides the config file. UNIX domain sockets may
 be used for proxy connections. Set `-onion` or `-proxy` to the local socket path
 with the prefix `unix:` (e.g. `-onion=unix:/home/me/torsocket`).

--- a/src/crc32c/src/crc32c_sse42.cc
+++ b/src/crc32c/src/crc32c_sse42.cc
@@ -176,7 +176,7 @@ uint32_t ExtendSse42(uint32_t crc, const uint8_t* data, size_t size) {
     }
   }
 
-  // Proccess the data in predetermined block sizes with tables for quickly
+  // Process the data in predetermined block sizes with tables for quickly
   // combining the checksum. Experimentally it's better to use larger block
   // sizes where possible so use a hierarchy of decreasing block sizes.
   uint64_t l64 = l;

--- a/src/ipc/libmultiprocess/cmake/compat_find.cmake
+++ b/src/ipc/libmultiprocess/cmake/compat_find.cmake
@@ -6,10 +6,10 @@
 # cmake find_package() calls are made
 
 # Set FOUND_LIBATOMIC to work around bug in debian capnproto package that is
-# debian-specific and does not happpen upstream. Debian includes a patch
+# debian-specific and does not happen upstream. Debian includes a patch
 # https://sources.debian.org/patches/capnproto/1.0.1-4/07_libatomic.patch/ which
 # uses check_library_exists(atomic __atomic_load_8 ...) and it fails because the
-# symbol name conflicts with a compiler instrinsic as described
+# symbol name conflicts with a compiler intrinsic as described
 # https://github.com/bitcoin-core/libmultiprocess/issues/68#issuecomment-1135150171.
 # This could be fixed by improving the check_library_exists function as
 # described in the github comment, or by changing the debian patch to check for

--- a/src/ipc/libmultiprocess/include/mp/proxy-types.h
+++ b/src/ipc/libmultiprocess/include/mp/proxy-types.h
@@ -94,7 +94,7 @@ struct ReadDestEmplace
 {
     ReadDestEmplace(TypeList<LocalType>, EmplaceFn&& emplace_fn) : m_emplace_fn(emplace_fn) {}
 
-    //! Simple case. If ReadField impementation calls this construct() method
+    //! Simple case. If ReadField implementation calls this construct() method
     //! with constructor arguments, just pass them on to the emplace function.
     template <typename... Args>
     decltype(auto) construct(Args&&... args)

--- a/src/ipc/libmultiprocess/test/CMakeLists.txt
+++ b/src/ipc/libmultiprocess/test/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_target(mptests)
 add_custom_target(mpcheck COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS mptests)
 
 # Only add more convenient tests and check targets if project is being built
-# standlone, to prevent clashes with external projects.
+# standalone, to prevent clashes with external projects.
 if (MP_STANDALONE)
   add_custom_target(tests DEPENDS mptests)
   add_custom_target(check DEPENDS mpcheck)

--- a/src/leveldb/db/snapshot.h
+++ b/src/leveldb/db/snapshot.h
@@ -25,7 +25,7 @@ class SnapshotImpl : public Snapshot {
   friend class SnapshotList;
 
   // SnapshotImpl is kept in a doubly-linked circular list. The SnapshotList
-  // implementation operates on the next/previous fields direcly.
+  // implementation operates on the next/previous fields directly.
   SnapshotImpl* prev_;
   SnapshotImpl* next_;
 

--- a/src/leveldb/doc/index.md
+++ b/src/leveldb/doc/index.md
@@ -325,7 +325,7 @@ sizes.
 
 Each block is individually compressed before being written to persistent
 storage. Compression is on by default since the default compression method is
-very fast, and is automatically disabled for uncompressible data. In rare cases,
+very fast, and is automatically disabled for incompressible data. In rare cases,
 applications may want to disable compression entirely, but should only do so if
 benchmarks show a performance improvement:
 

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -218,7 +218,7 @@ class PosixMmapReadableFile final : public RandomAccessFile {
   // over the ownership of the region.
   //
   // |mmap_limiter| must outlive this instance. The caller must have already
-  // aquired the right to use one mmap region, which will be released when this
+  // acquired the right to use one mmap region, which will be released when this
   // instance is destroyed.
   PosixMmapReadableFile(std::string filename, char* mmap_base, size_t length,
                         Limiter* mmap_limiter)
@@ -741,7 +741,7 @@ class PosixEnv : public Env {
   // Instances are constructed on the thread calling Schedule() and used on the
   // background thread.
   //
-  // This structure is thread-safe beacuse it is immutable.
+  // This structure is thread-safe because it is immutable.
   struct BackgroundWorkItem {
     explicit BackgroundWorkItem(void (*function)(void* arg), void* arg)
         : function(function), arg(arg) {}

--- a/src/leveldb/util/env_windows.cc
+++ b/src/leveldb/util/env_windows.cc
@@ -689,7 +689,7 @@ class WindowsEnv : public Env {
   // Instances are constructed on the thread calling Schedule() and used on the
   // background thread.
   //
-  // This structure is thread-safe beacuse it is immutable.
+  // This structure is thread-safe because it is immutable.
   struct BackgroundWorkItem {
     explicit BackgroundWorkItem(void (*function)(void* arg), void* arg)
         : function(function), arg(arg) {}


### PR DESCRIPTION
This PR only fixes typos and spelling error. It does not change any functionality.

I'm just trying to do a very simple first PR, while reading and familiarizing with the code.
I hope I'm not wasting anyone's time, sorry if this is the case.