### PR TITLE
net: Fix Discover() not running when using -bind=0.0.0.0:port

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2140,7 +2140,26 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         StartTorControl(onion_service_target);
     }
 
-    if (connOptions.bind_on_any) {
+    bool should_discover = connOptions.bind_on_any;
+    if (!should_discover) {
+        for (const auto& bind : connOptions.vBinds) {
+            if (bind.IsBindAny()) {
+                should_discover = true;
+                break;
+            }
+        }
+    }
+
+    if (!should_discover) {
+        for (const auto& whitebind : connOptions.vWhiteBinds) {
+            if (whitebind.m_service.IsBindAny()) {
+                should_discover = true;
+                break;
+            }
+        }
+    }
+
+    if (should_discover) {
         // Only add all IP addresses of the machine if we would be listening on
         // any address - 0.0.0.0 (IPv4) and :: (IPv6).
         Discover();

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -10,31 +10,46 @@ from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.util import (
     assert_equal,
     assert_not_equal,
+    p2p_port,
+    tor_port,
 )
 
-# We need to bind to a routable address for this test to exercise the relevant code
-# and also must have another routable address on another interface which must not
-# be named "lo" or "lo0".
-# To set these routable addresses on the machine, use:
+# We need to bind to routable addresses for this test. Both addresses must be on an
+# interface that is UP and not a loopback interface (IFF_LOOPBACK). To set these
+# routable addresses on the machine, use:
 # Linux:
-# ifconfig lo:0 1.1.1.1/32 up && ifconfig lo:1 2.2.2.2/32 up  # to set up
-# ifconfig lo:0 down && ifconfig lo:1 down  # to remove it, after the test
+# First find your interfaces: ip addr show
+# Then use your actual interface names (replace INTERFACE_NAME with yours):
+# ip addr add 1.1.1.1/32 dev INTERFACE_NAME && ip addr add 2.2.2.2/32 dev INTERFACE_NAME  # to set up
+# ip addr del 1.1.1.1/32 dev INTERFACE_NAME && ip addr del 2.2.2.2/32 dev INTERFACE_NAME  # to remove it
+#
+# macOS:
+# ifconfig en0 alias 1.1.1.1 && ifconfig en0 alias 2.2.2.2  # to set up
+# ifconfig en0 1.1.1.1 -alias && ifconfig en0 2.2.2.2 -alias  # to remove it, after the test
+#
 # FreeBSD:
 # ifconfig em0 1.1.1.1/32 alias && ifconfig wlan0 2.2.2.2/32 alias  # to set up
 # ifconfig em0 1.1.1.1 -alias && ifconfig wlan0 2.2.2.2 -alias  # to remove it, after the test
 ADDR1 = '1.1.1.1'
 ADDR2 = '2.2.2.2'
 
-BIND_PORT = 31001
-
 class BindPortDiscoverTest(BitcoinTestFramework):
     def set_test_params(self):
         # Avoid any -bind= on the command line. Force the framework to avoid adding -bind=127.0.0.1.
-        self.setup_clean_chain = True
         self.bind_to_localhost_only = False
+        # Get dynamic ports for each node from the test framework
+        self.bind_ports = [
+            p2p_port(0),
+            p2p_port(2), # node0 will use their port + 1 for onion listen, which is the same as p2p_port(1), so avoid collision
+            p2p_port(3),
+            p2p_port(4),
+        ]
         self.extra_args = [
-            ['-discover', f'-port={BIND_PORT}'], # bind on any
-            ['-discover', f'-bind={ADDR1}:{BIND_PORT}'],
+            ['-discover', f'-port={self.bind_ports[0]}', '-listen=1'], # Without any -bind
+            ['-discover', f'-bind=0.0.0.0:{self.bind_ports[1]}'], # Explicit -bind=0.0.0.0
+            # Explicit -whitebind=0.0.0.0, add onion bind to avoid port conflict
+            ['-discover', f'-whitebind=0.0.0.0:{self.bind_ports[2]}', f'-bind=127.0.0.1:{tor_port(3)}=onion'],
+            ['-discover', f'-bind={ADDR1}:{self.bind_ports[3]}'], # Explicit -bind=routable_addr
         ]
         self.num_nodes = len(self.extra_args)
 
@@ -70,28 +85,35 @@ class BindPortDiscoverTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info(
-                "Test that if -bind= is not passed then all addresses are "
+                "Test that if -bind= is not passed or -bind=0.0.0.0 is used then all addresses are "
                 "added to localaddresses")
-        found_addr1 = False
-        found_addr2 = False
-        for local in self.nodes[0].getnetworkinfo()['localaddresses']:
-            if local['address'] == ADDR1:
-                found_addr1 = True
-                assert_equal(local['port'], BIND_PORT)
-            if local['address'] == ADDR2:
-                found_addr2 = True
-                assert_equal(local['port'], BIND_PORT)
-        assert found_addr1
-        assert found_addr2
+        for i in [0, 1, 2]:
+            found_addr1 = False
+            found_addr2 = False
+            localaddresses = self.nodes[i].getnetworkinfo()['localaddresses']
+            for local in localaddresses:
+                if local['address'] == ADDR1:
+                    found_addr1 = True
+                    assert_equal(local['port'], self.bind_ports[i])
+                if local['address'] == ADDR2:
+                    found_addr2 = True
+                    assert_equal(local['port'], self.bind_ports[i])
+            if not found_addr1:
+                self.log.error(f"Address {ADDR1} not found in node{i}'s local addresses: {localaddresses}")
+                assert False
+            if not found_addr2:
+                self.log.error(f"Address {ADDR2} not found in node{i}'s local addresses: {localaddresses}")
+                assert False
 
         self.log.info(
-                "Test that if -bind= is passed then only that address is "
+                "Test that if -bind=routable_addr is passed then only that address is "
                 "added to localaddresses")
         found_addr1 = False
-        for local in self.nodes[1].getnetworkinfo()['localaddresses']:
+        i = 3
+        for local in self.nodes[i].getnetworkinfo()['localaddresses']:
             if local['address'] == ADDR1:
                 found_addr1 = True
-                assert_equal(local['port'], BIND_PORT)
+                assert_equal(local['port'], self.bind_ports[i])
             assert_not_equal(local['address'], ADDR2)
         assert found_addr1
 

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -38,6 +38,24 @@ class BindPortDiscoverTest(BitcoinTestFramework):
         ]
         self.num_nodes = len(self.extra_args)
 
+    def setup_network(self):
+        """
+        Override to avoid connecting nodes together. This test intentionally does not connect nodes
+        because each node is bound to a different address or interface, and connections are not needed.
+        """
+        self.setup_nodes()
+
+    def setup_nodes(self):
+        """
+        Override to set has_explicit_bind=True for nodes with explicit bind arguments.
+        """
+        self.add_nodes(self.num_nodes, self.extra_args)
+        # TestNode.start() will add -bind= to extra_args if has_explicit_bind is
+        # False. We do not want any -bind= thus set has_explicit_bind to True.
+        for node in self.nodes:
+            node.has_explicit_bind = True
+        self.start_nodes()
+
     def add_options(self, parser):
         parser.add_argument(
             "--ihave1111and2222", action='store_true', dest="ihave1111and2222",


### PR DESCRIPTION
  This PR fixes two related issues with address discovery when using explicit bind addresses in Bitcoin Core:

  -  #31293
  -  #31336

When using `-bind=0.0.0.0:port` (or `-bind=::`), the `Discover()` function was not being executed because the code only checked the `bind_on_any` flag. This led to two problems:
- The node would not discover its own local addresses if an explicit "any" bind was used.
- The functional test `feature_bind_port_discover.py` would fail, as it expects local addresses to be discovered in these cases.

This PR:
1. Checks both `bind_on_any` and any bind addresses using `IsBindAny()`
   Ensures `Discover()` runs when binding to 0.0.0.0 or ::, even if specified explicitly.
2. Ensures correct address discovery
   The node will now discover its own addresses when using explicit "any" binds, matching user expectations and fixing the test.
3. Maintains backward compatibility
   The semantic meaning of `bind_on_any` is preserved as defined in `net.h`:  
   > "True if the user did not specify -bind= or -whitebind= and thus we should bind on 0.0.0.0 (IPv4) and :: (IPv6)"
4. Updates the test to use dynamic ports
   The functional test `feature_bind_port_discover.py` is updated to use dynamic ports instead of hardcoded ones, improving reliability.

References

- Implementation follows the approach proposed in my [review comment on #31492](https://github.com/bitcoin/bitcoin/pull/31492#issuecomment-2941773645).

Closes #31293

The #31336 has the overall test failure and requires both this PR and #33362 to be fully resolved.
