### PR TITLE
wallet: Replace CWalletTx::mapValue and vOrderForm with explicit class members

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -149,8 +149,7 @@ public:
         std::optional<unsigned int> change_pos) = 0;
 
     //! Commit transaction.
-    virtual void commitTransaction(CTransactionRef tx,
-        WalletOrderForm order_form) = 0;
+    virtual void commitTransaction(CTransactionRef tx, const std::vector<std::string>& messages) = 0;
 
     //! Return whether transaction can be abandoned.
     virtual bool transactionCanBeAbandoned(const Txid& txid) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -391,6 +391,8 @@ struct WalletTx
     CAmount debit;
     CAmount change;
     int64_t time;
+    std::optional<std::string> from; // Deprecated
+    std::optional<std::string> message; // Deprecated
     std::map<std::string, std::string> value_map;
     bool is_coinbase;
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -60,7 +60,6 @@ struct WalletTxStatus;
 struct WalletMigrationResult;
 
 using WalletOrderForm = std::vector<std::pair<std::string, std::string>>;
-using WalletValueMap = std::map<std::string, std::string>;
 
 //! Interface for accessing a wallet.
 class Wallet
@@ -395,7 +394,6 @@ struct WalletTx
     std::optional<std::string> message; // Deprecated
     std::optional<std::string> comment;
     std::optional<std::string> comment_to;
-    std::map<std::string, std::string> value_map;
     bool is_coinbase;
 
     bool operator<(const WalletTx& a) const { return tx->GetHash() < a.tx->GetHash(); }

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -393,6 +393,8 @@ struct WalletTx
     int64_t time;
     std::optional<std::string> from; // Deprecated
     std::optional<std::string> message; // Deprecated
+    std::optional<std::string> comment;
+    std::optional<std::string> comment_to;
     std::map<std::string, std::string> value_map;
     bool is_coinbase;
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -151,7 +151,6 @@ public:
 
     //! Commit transaction.
     virtual void commitTransaction(CTransactionRef tx,
-        WalletValueMap value_map,
         WalletOrderForm order_form) = 0;
 
     //! Return whether transaction can be abandoned.

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -59,8 +59,6 @@ struct WalletTxOut;
 struct WalletTxStatus;
 struct WalletMigrationResult;
 
-using WalletOrderForm = std::vector<std::pair<std::string, std::string>>;
-
 //! Interface for accessing a wallet.
 class Wallet
 {
@@ -195,7 +193,8 @@ public:
     //! Get transaction details.
     virtual WalletTx getWalletTxDetails(const Txid& txid,
         WalletTxStatus& tx_status,
-        WalletOrderForm& order_form,
+        std::vector<std::string>& messages,
+        std::vector<std::string>& payment_requests,
         bool& in_mempool,
         int& num_blocks) = 0;
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -123,11 +123,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     if (wtx.is_coinbase)
     {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated") + "<br>";
-    }
-    else if (wtx.value_map.contains("from") && !wtx.value_map["from"].empty())
-    {
+    } else if (wtx.from) {
         // Online transaction
-        strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx.value_map["from"]) + "<br>";
+        strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(*wtx.from) + "<br>";
     }
     else
     {
@@ -273,9 +271,10 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Message
     //
-    if (wtx.value_map.contains("message") && !wtx.value_map["message"].empty())
-        strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["message"], true) + "<br>";
-    if (wtx.value_map.contains("comment") && !wtx.value_map["comment"].empty())
+    if (wtx.message) {
+        strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(*wtx.message, true) + "<br>";
+    }
+    if (wtx.value_map.count("comment") && !wtx.value_map["comment"].empty())
         strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["comment"], true) + "<br>";
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -98,9 +98,10 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
 {
     int numBlocks;
     interfaces::WalletTxStatus status;
-    interfaces::WalletOrderForm orderForm;
     bool inMempool;
-    interfaces::WalletTx wtx = wallet.getWalletTxDetails(rec->hash, status, orderForm, inMempool, numBlocks);
+    std::vector<std::string> messages;
+    std::vector<std::string> payment_requests;
+    interfaces::WalletTx wtx = wallet.getWalletTxDetails(rec->hash, status, messages, payment_requests, inMempool, numBlocks);
 
     QString strHTML;
 
@@ -282,24 +283,19 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal bitcoin:URI (bitcoin:123...?message=example)
-    for (const std::pair<std::string, std::string>& r : orderForm) {
-        if (r.first == "Message")
-            strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
-
-        //
-        // PaymentRequest info:
-        //
-        if (r.first == "PaymentRequest")
-        {
-            QString merchant;
-            if (!GetPaymentRequestMerchant(r.second, merchant)) {
-                merchant.clear();
-            } else {
-                merchant = tr("%1 (Certificate was not verified)").arg(merchant);
-            }
-            if (!merchant.isNull()) {
-                strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
-            }
+    for (const std::string& msg : messages) {
+        strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(msg, true) + "<br>";
+    }
+    // BIP 70 Payment Requests
+    for (const std::string& req : payment_requests) {
+        QString merchant;
+        if (!GetPaymentRequestMerchant(req, merchant)) {
+            merchant.clear();
+        } else {
+            merchant = tr("%1 (Certificate was not verified)").arg(merchant);
+        }
+        if (!merchant.isNull()) {
+            strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
         }
     }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -155,10 +155,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // To
     //
-    if (wtx.value_map.contains("to") && !wtx.value_map["to"].empty())
-    {
+    if (wtx.comment_to) {
         // Online transaction
-        std::string strAddress = wtx.value_map["to"];
+        std::string strAddress = *wtx.comment_to;
         strHTML += "<b>" + tr("To") + ":</b> ";
         CTxDestination dest = DecodeDestination(strAddress);
         std::string name;
@@ -210,8 +209,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
                 if (toSelf && all_from_me)
                     continue;
 
-                if (!wtx.value_map.contains("to") || wtx.value_map["to"].empty())
-                {
+                if (!wtx.comment_to) {
                     // Offline transaction
                     CTxDestination address;
                     if (ExtractDestination(txout.scriptPubKey, address))
@@ -274,8 +272,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     if (wtx.message) {
         strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(*wtx.message, true) + "<br>";
     }
-    if (wtx.value_map.count("comment") && !wtx.value_map["comment"].empty())
-        strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["comment"], true) + "<br>";
+    if (wtx.comment) {
+        strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(*wtx.comment, true) + "<br>";
+    }
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->ComputeTotalSize()) + " bytes<br>";

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -32,7 +32,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     CAmount nDebit = wtx.debit;
     CAmount nNet = nCredit - nDebit;
     Txid hash = wtx.tx->GetHash();
-    std::map<std::string, std::string> mapValue = wtx.value_map;
 
     bool all_from_me = true;
     bool any_from_me = false;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -112,7 +112,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 {
                     // Received by IP connection (deprecated features), or a multisignature or other non-simple transaction
                     sub.type = TransactionRecord::RecvFromOther;
-                    sub.address = mapValue["from"];
+                    sub.address = wtx.from.value_or("");
                 }
                 if (wtx.is_coinbase)
                 {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -77,7 +77,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 {
                     // Sent to IP, or other non-address transaction like OP_EVAL
                     sub.type = TransactionRecord::SendToOther;
-                    sub.address = mapValue["to"];
+                    sub.address = wtx.comment_to.value_or("");
                 }
 
                 CAmount nValue = txout.nValue;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -246,7 +246,7 @@ void WalletModel::sendCoins(WalletModelTransaction& transaction)
         }
 
         auto& newTx = transaction.getWtx();
-        wallet().commitTransaction(newTx, /*value_map=*/{}, std::move(vOrderForm));
+        wallet().commitTransaction(newTx, std::move(vOrderForm));
 
         DataStream ssTx;
         ssTx << TX_WITH_WITNESS(*newTx);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -238,15 +238,16 @@ void WalletModel::sendCoins(WalletModelTransaction& transaction)
     QByteArray transaction_array; /* store serialized transaction */
 
     {
-        std::vector<std::pair<std::string, std::string>> vOrderForm;
+        std::vector<std::string> messages;
         for (const SendCoinsRecipient &rcp : transaction.getRecipients())
         {
-            if (!rcp.message.isEmpty()) // Message from normal bitcoin:URI (bitcoin:123...?message=example)
-                vOrderForm.emplace_back("Message", rcp.message.toStdString());
+            if (!rcp.message.isEmpty()) { // Message from normal bitcoin:URI (bitcoin:123...?message=example)
+                messages.emplace_back(rcp.message.toStdString());
+            }
         }
 
         auto& newTx = transaction.getWtx();
-        wallet().commitTransaction(newTx, std::move(vOrderForm));
+        wallet().commitTransaction(newTx, messages);
 
         DataStream ssTx;
         ssTx << TX_WITH_WITNESS(*newTx);

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -370,9 +370,7 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // commit/broadcast the tx
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
-    std::optional<std::string> comment = oldWtx.mapValue.contains("comment") ? std::optional(oldWtx.mapValue.at("comment")) : std::nullopt;
-    std::optional<std::string> comment_to = oldWtx.mapValue.contains("to") ? std::optional(oldWtx.mapValue.at("to")) : std::nullopt;
-    wallet.CommitTransaction(tx, oldWtx.vOrderForm, oldWtx.GetHash(), comment, comment_to);
+    wallet.CommitTransaction(tx, oldWtx.vOrderForm, oldWtx.GetHash(), oldWtx.m_comment, oldWtx.m_comment_to);
 
     // mark the original tx as bumped
     bumped_txid = tx->GetHash();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -41,8 +41,8 @@ static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWallet
         return feebumper::Result::WALLET_ERROR;
     }
 
-    if (wtx.mapValue.contains("replaced_by_txid")) {
-        errors.push_back(Untranslated(strprintf("Cannot bump transaction %s which was already bumped by transaction %s", wtx.GetHash().ToString(), wtx.mapValue.at("replaced_by_txid"))));
+    if (wtx.m_replaced_by_txid) {
+        errors.push_back(Untranslated(strprintf("Cannot bump transaction %s which was already bumped by transaction %s", wtx.GetHash().ToString(), wtx.m_replaced_by_txid->ToString())));
         return feebumper::Result::WALLET_ERROR;
     }
 

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -370,7 +370,9 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // commit/broadcast the tx
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
-    wallet.CommitTransaction(tx, oldWtx.mapValue, oldWtx.vOrderForm, oldWtx.GetHash());
+    std::optional<std::string> comment = oldWtx.mapValue.contains("comment") ? std::optional(oldWtx.mapValue.at("comment")) : std::nullopt;
+    std::optional<std::string> comment_to = oldWtx.mapValue.contains("to") ? std::optional(oldWtx.mapValue.at("to")) : std::nullopt;
+    wallet.CommitTransaction(tx, oldWtx.vOrderForm, oldWtx.GetHash(), comment, comment_to);
 
     // mark the original tx as bumped
     bumped_txid = tx->GetHash();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -370,7 +370,13 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // commit/broadcast the tx
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
-    wallet.CommitTransaction(tx, oldWtx.vOrderForm, oldWtx.GetHash(), oldWtx.m_comment, oldWtx.m_comment_to);
+    std::vector<std::string> messages;
+    std::vector<std::string> payment_requests;
+    for (const auto& [type, data] : oldWtx.vOrderForm) {
+        if (type == "Message") messages.emplace_back(data);
+        else if (type == "PaymentRequest") payment_requests.emplace_back(data);
+    }
+    wallet.CommitTransaction(tx, oldWtx.GetHash(), oldWtx.m_comment, oldWtx.m_comment_to, messages, payment_requests);
 
     // mark the original tx as bumped
     bumped_txid = tx->GetHash();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -370,13 +370,7 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // commit/broadcast the tx
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
-    std::vector<std::string> messages;
-    std::vector<std::string> payment_requests;
-    for (const auto& [type, data] : oldWtx.vOrderForm) {
-        if (type == "Message") messages.emplace_back(data);
-        else if (type == "PaymentRequest") payment_requests.emplace_back(data);
-    }
-    wallet.CommitTransaction(tx, oldWtx.GetHash(), oldWtx.m_comment, oldWtx.m_comment_to, messages, payment_requests);
+    wallet.CommitTransaction(tx, oldWtx.GetHash(), oldWtx.m_comment, oldWtx.m_comment_to, oldWtx.m_messages, oldWtx.m_payment_requests);
 
     // mark the original tx as bumped
     bumped_txid = tx->GetHash();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -370,10 +370,7 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // commit/broadcast the tx
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
-    mapValue_t mapValue = oldWtx.mapValue;
-    mapValue["replaces_txid"] = oldWtx.GetHash().ToString();
-
-    wallet.CommitTransaction(tx, std::move(mapValue), oldWtx.vOrderForm);
+    wallet.CommitTransaction(tx, oldWtx.mapValue, oldWtx.vOrderForm, oldWtx.GetHash());
 
     // mark the original tx as bumped
     bumped_txid = tx->GetHash();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -79,6 +79,8 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     result.debit = CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/true);
     result.change = CachedTxGetChange(wallet, wtx);
     result.time = wtx.GetTxTime();
+    result.from = wtx.m_from;
+    result.message = wtx.m_message;
     result.value_map = wtx.mapValue;
     result.is_coinbase = wtx.IsCoinBase();
     return result;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -48,7 +48,6 @@ using interfaces::WalletOrderForm;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
 using interfaces::WalletTxStatus;
-using interfaces::WalletValueMap;
 
 namespace wallet {
 // All members of the classes in this namespace are intentionally public, as the
@@ -83,7 +82,6 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     result.message = wtx.m_message;
     result.comment = wtx.m_comment;
     result.comment_to = wtx.m_comment_to;
-    result.value_map = wtx.mapValue;
     result.is_coinbase = wtx.IsCoinBase();
     return result;
 }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -81,6 +81,8 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     result.time = wtx.GetTxTime();
     result.from = wtx.m_from;
     result.message = wtx.m_message;
+    result.comment = wtx.m_comment;
+    result.comment_to = wtx.m_comment_to;
     result.value_map = wtx.mapValue;
     result.is_coinbase = wtx.IsCoinBase();
     return result;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -44,7 +44,6 @@ using interfaces::WalletAddress;
 using interfaces::WalletBalances;
 using interfaces::WalletLoader;
 using interfaces::WalletMigrationResult;
-using interfaces::WalletOrderForm;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
 using interfaces::WalletTxStatus;
@@ -349,7 +348,8 @@ public:
     }
     WalletTx getWalletTxDetails(const Txid& txid,
         WalletTxStatus& tx_status,
-        WalletOrderForm& order_form,
+        std::vector<std::string>& messages,
+        std::vector<std::string>& payment_requests,
         bool& in_mempool,
         int& num_blocks) override
     {
@@ -358,7 +358,8 @@ public:
         if (mi != m_wallet->mapWallet.end()) {
             num_blocks = m_wallet->GetLastBlockHeight();
             in_mempool = mi->second.InMempool();
-            order_form = mi->second.vOrderForm;
+            messages = mi->second.m_messages;
+            payment_requests = mi->second.m_payment_requests;
             tx_status = MakeWalletTxStatus(*m_wallet, mi->second);
             return MakeWalletTx(*m_wallet, mi->second);
         }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -267,11 +267,10 @@ public:
         LOCK(m_wallet->cs_wallet);
         return CreateTransaction(*m_wallet, recipients, change_pos, coin_control, sign);
     }
-    void commitTransaction(CTransactionRef tx,
-        WalletOrderForm order_form) override
+    void commitTransaction(CTransactionRef tx, const std::vector<std::string>& messages) override
     {
         LOCK(m_wallet->cs_wallet);
-        m_wallet->CommitTransaction(std::move(tx), std::move(order_form));
+        m_wallet->CommitTransaction(std::move(tx), /*replaces_txid=*/std::nullopt, /*comment=*/std::nullopt, /*comment_to=*/std::nullopt, messages);
     }
     bool transactionCanBeAbandoned(const Txid& txid) override { return m_wallet->TransactionCanBeAbandoned(txid); }
     bool abandonTransaction(const Txid& txid) override

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -266,11 +266,10 @@ public:
         return CreateTransaction(*m_wallet, recipients, change_pos, coin_control, sign);
     }
     void commitTransaction(CTransactionRef tx,
-        WalletValueMap value_map,
         WalletOrderForm order_form) override
     {
         LOCK(m_wallet->cs_wallet);
-        m_wallet->CommitTransaction(std::move(tx), std::move(value_map), std::move(order_form));
+        m_wallet->CommitTransaction(std::move(tx), std::move(order_form));
     }
     bool transactionCanBeAbandoned(const Txid& txid) override { return m_wallet->TransactionCanBeAbandoned(txid); }
     bool abandonTransaction(const Txid& txid) override

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -168,7 +168,7 @@ static void PreventOutdatedOptions(const UniValue& options)
     }
 }
 
-UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vector<CRecipient> &recipients, mapValue_t map_value, bool verbose)
+UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vector<CRecipient> &recipients, std::optional<std::string> comment, std::optional<std::string> comment_to, bool verbose)
 {
     EnsureWalletIsUnlocked(wallet);
 
@@ -191,7 +191,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, util::ErrorString(res).original);
     }
     const CTransactionRef& tx = res->tx;
-    wallet.CommitTransaction(tx, std::move(map_value), /*orderForm=*/{});
+    wallet.CommitTransaction(tx, /*mapValue=*/{}, /*orderForm=*/{}, /*replaces_txid=*/std::nullopt, comment, comment_to);
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("txid", tx->GetHash().GetHex());
@@ -301,11 +301,12 @@ RPCMethod sendtoaddress()
     LOCK(pwallet->cs_wallet);
 
     // Wallet comments
-    mapValue_t mapValue;
+    std::optional<std::string> comment;
+    std::optional<std::string> comment_to;
     if (!request.params[2].isNull() && !request.params[2].get_str().empty())
-        mapValue["comment"] = request.params[2].get_str();
+        comment = request.params[2].get_str();
     if (!request.params[3].isNull() && !request.params[3].get_str().empty())
-        mapValue["to"] = request.params[3].get_str();
+        comment_to = request.params[3].get_str();
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
@@ -332,7 +333,7 @@ RPCMethod sendtoaddress()
     std::vector<CRecipient> recipients{CreateRecipients(ParseOutputs(address_amounts), sffo_set)};
     const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
 
-    return SendMoney(*pwallet, coin_control, recipients, mapValue, verbose);
+    return SendMoney(*pwallet, coin_control, recipients, comment, comment_to, verbose);
 },
     };
 }
@@ -409,9 +410,9 @@ RPCMethod sendmany()
     }
     UniValue sendTo = request.params[1].get_obj();
 
-    mapValue_t mapValue;
+    std::optional<std::string> comment;
     if (!request.params[3].isNull() && !request.params[3].get_str().empty())
-        mapValue["comment"] = request.params[3].get_str();
+        comment = request.params[3].get_str();
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
@@ -426,7 +427,7 @@ RPCMethod sendmany()
     );
     const bool verbose{request.params[9].isNull() ? false : request.params[9].get_bool()};
 
-    return SendMoney(*pwallet, coin_control, recipients, std::move(mapValue), verbose);
+    return SendMoney(*pwallet, coin_control, recipients, comment, /*comment_to=*/std::nullopt, verbose);
 },
     };
 }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -139,7 +139,7 @@ static UniValue FinishTransaction(const std::shared_ptr<CWallet> pwallet, const 
         CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
         result.pushKV("txid", tx->GetHash().GetHex());
         if (add_to_wallet && !psbt_opt_in) {
-            pwallet->CommitTransaction(tx, {}, /*orderForm=*/{});
+            pwallet->CommitTransaction(tx, /*orderForm=*/{});
         } else {
             result.pushKV("hex", hex);
         }
@@ -191,7 +191,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, util::ErrorString(res).original);
     }
     const CTransactionRef& tx = res->tx;
-    wallet.CommitTransaction(tx, /*mapValue=*/{}, /*orderForm=*/{}, /*replaces_txid=*/std::nullopt, comment, comment_to);
+    wallet.CommitTransaction(tx, /*orderForm=*/{}, /*replaces_txid=*/std::nullopt, comment, comment_to);
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("txid", tx->GetHash().GetHex());

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -139,7 +139,7 @@ static UniValue FinishTransaction(const std::shared_ptr<CWallet> pwallet, const 
         CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
         result.pushKV("txid", tx->GetHash().GetHex());
         if (add_to_wallet && !psbt_opt_in) {
-            pwallet->CommitTransaction(tx, /*orderForm=*/{});
+            pwallet->CommitTransaction(tx);
         } else {
             result.pushKV("hex", hex);
         }
@@ -191,7 +191,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, util::ErrorString(res).original);
     }
     const CTransactionRef& tx = res->tx;
-    wallet.CommitTransaction(tx, /*orderForm=*/{}, /*replaces_txid=*/std::nullopt, comment, comment_to);
+    wallet.CommitTransaction(tx, /*replaces_txid=*/std::nullopt, comment, comment_to);
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("txid", tx->GetHash().GetHex());

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -64,6 +64,8 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
 
     if (wtx.m_comment) entry.pushKV("comment", *wtx.m_comment);
     if (wtx.m_comment_to) entry.pushKV("to", *wtx.m_comment_to);
+    if (wtx.m_replaces_txid) entry.pushKV("replaces_txid", wtx.m_replaces_txid->ToString());
+    if (wtx.m_replaced_by_txid) entry.pushKV("replaced_by_txid", wtx.m_replaced_by_txid->ToString());
 
     for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -62,6 +62,9 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
         entry.pushKV("bip125-replaceable", rbfStatus);
     }
 
+    if (wtx.m_comment) entry.pushKV("comment", *wtx.m_comment);
+    if (wtx.m_comment_to) entry.pushKV("to", *wtx.m_comment_to);
+
     for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
 }

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -66,9 +66,6 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
     if (wtx.m_comment_to) entry.pushKV("to", *wtx.m_comment_to);
     if (wtx.m_replaces_txid) entry.pushKV("replaces_txid", wtx.m_replaces_txid->ToString());
     if (wtx.m_replaced_by_txid) entry.pushKV("replaced_by_txid", wtx.m_replaced_by_txid->ToString());
-
-    for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
-        entry.pushKV(item.first, item.second);
 }
 
 struct tallyitem

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -378,7 +378,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             // be a 1-block reorg away from the chain where transactions A and C
             // were accepted to another chain where B, B', and C were all
             // accepted.
-            if (nDepth == 0 && wtx.mapValue.contains("replaces_txid")) {
+            if (nDepth == 0 && wtx.m_replaces_txid) {
                 safeTx = false;
             }
 
@@ -390,7 +390,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             // intending to replace A', but potentially resulting in a scenario
             // where A, A', and D could all be accepted (instead of just B and
             // D, or just A and A' like the user would want).
-            if (nDepth == 0 && wtx.mapValue.contains("replaced_by_txid")) {
+            if (nDepth == 0 && wtx.m_replaced_by_txid) {
                 safeTx = false;
             }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -402,7 +402,7 @@ public:
             BOOST_CHECK(res);
             tx = res->tx;
         }
-        wallet->CommitTransaction(tx, {});
+        wallet->CommitTransaction(tx);
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -402,7 +402,7 @@ public:
             BOOST_CHECK(res);
             tx = res->tx;
         }
-        wallet->CommitTransaction(tx, {}, {});
+        wallet->CommitTransaction(tx, {});
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -199,14 +199,15 @@ public:
     // These fields are kept to avoid losing metadata.
     std::optional<std::string> m_from;
     std::optional<std::string> m_message;
+    // Comment strings provided by the user
+    std::optional<std::string> m_comment;
+    std::optional<std::string> m_comment_to;
     /**
      * Key/value map with information about the transaction.
      *
      * The following keys can be read and written through the map and are
      * serialized in the wallet database:
      *
-     *     "comment", "to"   - comment strings provided to sendtoaddress,
-     *                         and sendmany wallet RPCs
      *     "replaces_txid"   - txid (as HexStr) of transaction replaced by
      *                         bumpfee on transaction created by bumpfee
      *     "replaced_by_txid" - txid (as HexStr) of transaction created by
@@ -223,6 +224,8 @@ public:
      *                         2014 (removed in commit 93a18a3)
      *     "from", "message" - obsolete fields that could be set in UI prior to
      *                         2011 (removed in commit 4d9b223)
+     *     "comment", "to"   - comment strings provided to sendtoaddress,
+     *                         and sendmany wallet RPCs
      */
     mapValue_t mapValue;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
@@ -292,6 +295,8 @@ public:
         mapValue_t mapValueCopy = mapValue;
         if (m_from) mapValueCopy["from"] = *m_from;
         if (m_message) mapValueCopy["message"] = *m_message;
+        if (m_comment) mapValueCopy["comment"] = *m_comment;
+        if (m_comment_to) mapValueCopy["to"] = *m_comment_to;
 
         mapValueCopy["fromaccount"] = "";
         if (nOrderPos != -1) {
@@ -330,6 +335,8 @@ public:
             else if (key == "timesmart") nTimeSmart = LocaleIndependentAtoi<int64_t>(value);
             else if (key == "from") m_from = value;
             else if (key == "message") m_message = value;
+            else if (key == "comment") m_comment = value;
+            else if (key == "to") m_comment_to = value;
         }
 
         mapValue.erase("fromaccount");
@@ -338,6 +345,8 @@ public:
         mapValue.erase("timesmart");
         mapValue.erase("from");
         mapValue.erase("message");
+        mapValue.erase("comment");
+        mapValue.erase("to");
     }
 
     void SetTx(CTransactionRef arg)

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -202,16 +202,10 @@ public:
     // Comment strings provided by the user
     std::optional<std::string> m_comment;
     std::optional<std::string> m_comment_to;
+    std::optional<Txid> m_replaces_txid;
+    std::optional<Txid> m_replaced_by_txid;
     /**
      * Key/value map with information about the transaction.
-     *
-     * The following keys can be read and written through the map and are
-     * serialized in the wallet database:
-     *
-     *     "replaces_txid"   - txid (as HexStr) of transaction replaced by
-     *                         bumpfee on transaction created by bumpfee
-     *     "replaced_by_txid" - txid (as HexStr) of transaction created by
-     *                         bumpfee on transaction replaced by bumpfee
      *
      * The following keys are serialized in the wallet database, but shouldn't
      * be read or written through the map (they will be temporarily added and
@@ -226,6 +220,10 @@ public:
      *                         2011 (removed in commit 4d9b223)
      *     "comment", "to"   - comment strings provided to sendtoaddress,
      *                         and sendmany wallet RPCs
+     *     "replaces_txid"   - txid (as HexStr) of transaction replaced by
+     *                         bumpfee on transaction created by bumpfee
+     *     "replaced_by_txid" - txid (as HexStr) of transaction created by
+     *                         bumpfee on transaction replaced by bumpfee
      */
     mapValue_t mapValue;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
@@ -297,6 +295,8 @@ public:
         if (m_message) mapValueCopy["message"] = *m_message;
         if (m_comment) mapValueCopy["comment"] = *m_comment;
         if (m_comment_to) mapValueCopy["to"] = *m_comment_to;
+        if (m_replaces_txid) mapValueCopy["replaces_txid"] = m_replaces_txid->ToString();
+        if (m_replaced_by_txid) mapValueCopy["replaced_by_txid"] = m_replaced_by_txid->ToString();
 
         mapValueCopy["fromaccount"] = "";
         if (nOrderPos != -1) {
@@ -337,6 +337,8 @@ public:
             else if (key == "message") m_message = value;
             else if (key == "comment") m_comment = value;
             else if (key == "to") m_comment_to = value;
+            else if (key == "replaces_txid") m_replaces_txid = Txid::FromHex(value);
+            else if (key == "replaced_by_txid") m_replaced_by_txid = Txid::FromHex(value);
         }
 
         mapValue.erase("fromaccount");
@@ -347,6 +349,8 @@ public:
         mapValue.erase("message");
         mapValue.erase("comment");
         mapValue.erase("to");
+        mapValue.erase("replaces_txid");
+        mapValue.erase("replaced_by_txid");
     }
 
     void SetTx(CTransactionRef arg)

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -201,7 +201,10 @@ public:
     std::optional<std::string> m_comment_to;
     std::optional<Txid> m_replaces_txid;
     std::optional<Txid> m_replaced_by_txid;
-    std::vector<std::pair<std::string, std::string> > vOrderForm;
+    // BIP 21 URI Messages
+    std::vector<std::string> m_messages;
+    // BIP 70 Payment Request (deprecated, field kept to preserve metadata from old wallets)
+    std::vector<std::string> m_payment_requests;
     unsigned int nTimeReceived; //!< time received by this node
     /**
      * Stable timestamp that never changes, and reflects the order a transaction
@@ -238,7 +241,6 @@ public:
 
     void Init()
     {
-        vOrderForm.clear();
         nTimeReceived = 0;
         nTimeSmart = 0;
         fChangeCached = false;
@@ -275,13 +277,22 @@ public:
         if (nOrderPos != -1) string_values["n"] = util::ToString(nOrderPos);
         if (nTimeSmart) string_values["timesmart"] = strprintf("%u", nTimeSmart);
 
+        std::vector<std::pair<std::string, std::string>> msgs_reqs;
+        msgs_reqs.reserve(m_messages.size() + m_payment_requests.size());
+        for (const std::string& msg : m_messages) {
+            msgs_reqs.emplace_back("Message", msg);
+        }
+        for (const std::string& req : m_payment_requests) {
+            msgs_reqs.emplace_back("PaymentRequest", req);
+        }
+
         std::vector<uint8_t> dummy_vector1; // Used to be vMerkleBranch
         std::vector<uint8_t> dummy_vector2; // Used to be vtxPrev
         bool dummy_bool = false; // Used to be fFromMe, and fSpent
         uint32_t dummy_int = 0; // Used to be fTimeReceivedIsTxTime
         uint256 serializedHash = TxStateSerializedBlockHash(m_state);
         int serializedIndex = TxStateSerializedIndex(m_state);
-        s << TX_WITH_WITNESS(tx) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << vOrderForm << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
+        s << TX_WITH_WITNESS(tx) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << msgs_reqs << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
     }
 
     template<typename Stream>
@@ -296,7 +307,8 @@ public:
         uint256 serialized_block_hash;
         int serializedIndex;
         std::map<std::string, std::string> string_values;
-        s >> TX_WITH_WITNESS(tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> vOrderForm >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
+        std::vector<std::pair<std::string, std::string>> msgs_reqs;
+        s >> TX_WITH_WITNESS(tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> msgs_reqs >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
@@ -313,6 +325,14 @@ public:
             else if (key == "replaced_by_txid") m_replaced_by_txid = Txid::FromHex(value);
             else {
                 throw std::runtime_error("Unexpected value in CWalletTx strings value map");
+            }
+        }
+
+        for (const auto& [type, data] : msgs_reqs) {
+            if (type == "Message") m_messages.emplace_back(data);
+            else if (type == "PaymentRequest") m_payment_requests.emplace_back(data);
+            else {
+                throw std::runtime_error("Unknown type in CWalletTx messages and requests vector");
             }
         }
     }

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -164,9 +164,6 @@ struct CachableAmount
 };
 
 
-typedef std::map<std::string, std::string> mapValue_t;
-
-
 /** Legacy class used for deserializing vtxPrev for backwards compatibility.
  * vtxPrev was removed in commit 93a18a3650292afbb441a47d1fa1b94aeb0164e3,
  * but old wallet.dat files may still contain vtxPrev vectors of CMerkleTxs.
@@ -204,28 +201,6 @@ public:
     std::optional<std::string> m_comment_to;
     std::optional<Txid> m_replaces_txid;
     std::optional<Txid> m_replaced_by_txid;
-    /**
-     * Key/value map with information about the transaction.
-     *
-     * The following keys are serialized in the wallet database, but shouldn't
-     * be read or written through the map (they will be temporarily added and
-     * removed from the map during serialization):
-     *
-     *     "fromaccount"     - serialized strFromAccount value
-     *     "n"               - serialized nOrderPos value
-     *     "timesmart"       - serialized nTimeSmart value
-     *     "spent"           - serialized vfSpent value that existed prior to
-     *                         2014 (removed in commit 93a18a3)
-     *     "from", "message" - obsolete fields that could be set in UI prior to
-     *                         2011 (removed in commit 4d9b223)
-     *     "comment", "to"   - comment strings provided to sendtoaddress,
-     *                         and sendmany wallet RPCs
-     *     "replaces_txid"   - txid (as HexStr) of transaction replaced by
-     *                         bumpfee on transaction created by bumpfee
-     *     "replaced_by_txid" - txid (as HexStr) of transaction created by
-     *                         bumpfee on transaction replaced by bumpfee
-     */
-    mapValue_t mapValue;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int nTimeReceived; //!< time received by this node
     /**
@@ -263,7 +238,6 @@ public:
 
     void Init()
     {
-        mapValue.clear();
         vOrderForm.clear();
         nTimeReceived = 0;
         nTimeSmart = 0;
@@ -290,21 +264,16 @@ public:
     template<typename Stream>
     void Serialize(Stream& s) const
     {
-        mapValue_t mapValueCopy = mapValue;
-        if (m_from) mapValueCopy["from"] = *m_from;
-        if (m_message) mapValueCopy["message"] = *m_message;
-        if (m_comment) mapValueCopy["comment"] = *m_comment;
-        if (m_comment_to) mapValueCopy["to"] = *m_comment_to;
-        if (m_replaces_txid) mapValueCopy["replaces_txid"] = m_replaces_txid->ToString();
-        if (m_replaced_by_txid) mapValueCopy["replaced_by_txid"] = m_replaced_by_txid->ToString();
-
-        mapValueCopy["fromaccount"] = "";
-        if (nOrderPos != -1) {
-            mapValueCopy["n"] = util::ToString(nOrderPos);
-        }
-        if (nTimeSmart) {
-            mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
-        }
+        std::map<std::string, std::string> string_values;
+        if (m_from) string_values["from"] = *m_from;
+        if (m_message) string_values["message"] = *m_message;
+        if (m_comment) string_values["comment"] = *m_comment;
+        if (m_comment_to) string_values["to"] = *m_comment_to;
+        if (m_replaces_txid) string_values["replaces_txid"] = m_replaces_txid->ToString();
+        if (m_replaced_by_txid) string_values["replaced_by_txid"] = m_replaced_by_txid->ToString();
+        string_values["fromaccount"] = "";
+        if (nOrderPos != -1) string_values["n"] = util::ToString(nOrderPos);
+        if (nTimeSmart) string_values["timesmart"] = strprintf("%u", nTimeSmart);
 
         std::vector<uint8_t> dummy_vector1; // Used to be vMerkleBranch
         std::vector<uint8_t> dummy_vector2; // Used to be vtxPrev
@@ -312,7 +281,7 @@ public:
         uint32_t dummy_int = 0; // Used to be fTimeReceivedIsTxTime
         uint256 serializedHash = TxStateSerializedBlockHash(m_state);
         int serializedIndex = TxStateSerializedIndex(m_state);
-        s << TX_WITH_WITNESS(tx) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << mapValueCopy << vOrderForm << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
+        s << TX_WITH_WITNESS(tx) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << vOrderForm << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
     }
 
     template<typename Stream>
@@ -326,13 +295,14 @@ public:
         uint32_t dummy_int; // Used to be fTimeReceivedIsTxTime
         uint256 serialized_block_hash;
         int serializedIndex;
-        s >> TX_WITH_WITNESS(tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> mapValue >> vOrderForm >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
+        std::map<std::string, std::string> string_values;
+        s >> TX_WITH_WITNESS(tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> vOrderForm >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
-        mapValue.erase("fromaccount");
-        mapValue.erase("spent");
-        for (const auto& [key, value] : mapValue) {
+        string_values.erase("fromaccount");
+        string_values.erase("spent");
+        for (const auto& [key, value] : string_values) {
             if (key == "n") nOrderPos = LocaleIndependentAtoi<int64_t>(value);
             else if (key == "timesmart") nTimeSmart = LocaleIndependentAtoi<int64_t>(value);
             else if (key == "from") m_from = value;
@@ -345,15 +315,6 @@ public:
                 throw std::runtime_error("Unexpected value in CWalletTx strings value map");
             }
         }
-
-        mapValue.erase("n");
-        mapValue.erase("timesmart");
-        mapValue.erase("from");
-        mapValue.erase("message");
-        mapValue.erase("comment");
-        mapValue.erase("to");
-        mapValue.erase("replaces_txid");
-        mapValue.erase("replaced_by_txid");
     }
 
     void SetTx(CTransactionRef arg)

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -194,6 +194,11 @@ public:
 class CWalletTx
 {
 public:
+    // "from" and "message" are obsolete fields that could be set in
+    // the UI prior to 2011 (removed in commit 4d9b223)
+    // These fields are kept to avoid losing metadata.
+    std::optional<std::string> m_from;
+    std::optional<std::string> m_message;
     /**
      * Key/value map with information about the transaction.
      *
@@ -206,8 +211,6 @@ public:
      *                         bumpfee on transaction created by bumpfee
      *     "replaced_by_txid" - txid (as HexStr) of transaction created by
      *                         bumpfee on transaction replaced by bumpfee
-     *     "from", "message" - obsolete fields that could be set in UI prior to
-     *                         2011 (removed in commit 4d9b223)
      *
      * The following keys are serialized in the wallet database, but shouldn't
      * be read or written through the map (they will be temporarily added and
@@ -218,6 +221,8 @@ public:
      *     "timesmart"       - serialized nTimeSmart value
      *     "spent"           - serialized vfSpent value that existed prior to
      *                         2014 (removed in commit 93a18a3)
+     *     "from", "message" - obsolete fields that could be set in UI prior to
+     *                         2011 (removed in commit 4d9b223)
      */
     mapValue_t mapValue;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
@@ -285,6 +290,8 @@ public:
     void Serialize(Stream& s) const
     {
         mapValue_t mapValueCopy = mapValue;
+        if (m_from) mapValueCopy["from"] = *m_from;
+        if (m_message) mapValueCopy["message"] = *m_message;
 
         mapValueCopy["fromaccount"] = "";
         if (nOrderPos != -1) {
@@ -318,15 +325,19 @@ public:
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
-        const auto it_op = mapValue.find("n");
-        nOrderPos = (it_op != mapValue.end()) ? LocaleIndependentAtoi<int64_t>(it_op->second) : -1;
-        const auto it_ts = mapValue.find("timesmart");
-        nTimeSmart = (it_ts != mapValue.end()) ? static_cast<unsigned int>(LocaleIndependentAtoi<int64_t>(it_ts->second)) : 0;
+        for (const auto& [key, value] : mapValue) {
+            if (key == "n") nOrderPos = LocaleIndependentAtoi<int64_t>(value);
+            else if (key == "timesmart") nTimeSmart = LocaleIndependentAtoi<int64_t>(value);
+            else if (key == "from") m_from = value;
+            else if (key == "message") m_message = value;
+        }
 
         mapValue.erase("fromaccount");
         mapValue.erase("spent");
         mapValue.erase("n");
         mapValue.erase("timesmart");
+        mapValue.erase("from");
+        mapValue.erase("message");
     }
 
     void SetTx(CTransactionRef arg)

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -330,6 +330,8 @@ public:
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
+        mapValue.erase("fromaccount");
+        mapValue.erase("spent");
         for (const auto& [key, value] : mapValue) {
             if (key == "n") nOrderPos = LocaleIndependentAtoi<int64_t>(value);
             else if (key == "timesmart") nTimeSmart = LocaleIndependentAtoi<int64_t>(value);
@@ -339,10 +341,11 @@ public:
             else if (key == "to") m_comment_to = value;
             else if (key == "replaces_txid") m_replaces_txid = Txid::FromHex(value);
             else if (key == "replaced_by_txid") m_replaced_by_txid = Txid::FromHex(value);
+            else {
+                throw std::runtime_error("Unexpected value in CWalletTx strings value map");
+            }
         }
 
-        mapValue.erase("fromaccount");
-        mapValue.erase("spent");
         mapValue.erase("n");
         mapValue.erase("timesmart");
         mapValue.erase("from");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -744,6 +744,8 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         if (!copyFrom->IsEquivalentTo(*copyTo)) continue;
         copyTo->m_from = copyFrom->m_from;
         copyTo->m_message = copyFrom->m_message;
+        copyTo->m_comment = copyFrom->m_comment;
+        copyTo->m_comment_to = copyFrom->m_comment_to;
         copyTo->mapValue = copyFrom->mapValue;
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // nTimeReceived not copied on purpose
@@ -2343,8 +2345,8 @@ void CWallet::CommitTransaction(
         CHECK_NONFATAL(wtx.mapValue.empty());
         CHECK_NONFATAL(wtx.vOrderForm.empty());
         if (replaces_txid) wtx.mapValue["replaces_txid"] = replaces_txid->ToString();
-        if (comment) wtx.mapValue["comment"] = *comment;
-        if (comment_to) wtx.mapValue["to"] = *comment_to;
+        if (comment) wtx.m_comment = comment;
+        if (comment_to) wtx.m_comment_to = comment_to;
         wtx.vOrderForm = std::move(orderForm);
         return true;
     });

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2324,7 +2324,12 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
     return m_default_address_type;
 }
 
-void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
+void CWallet::CommitTransaction(
+    CTransactionRef tx,
+    mapValue_t mapValue,
+    std::vector<std::pair<std::string, std::string>> orderForm,
+    std::optional<Txid> replaces_txid
+)
 {
     LOCK(cs_wallet);
     WalletLogPrintf("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
@@ -2335,6 +2340,7 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
         CHECK_NONFATAL(wtx.mapValue.empty());
         CHECK_NONFATAL(wtx.vOrderForm.empty());
         wtx.mapValue = std::move(mapValue);
+        if (replaces_txid) wtx.mapValue["replaces_txid"] = replaces_txid->ToString();
         wtx.vOrderForm = std::move(orderForm);
         return true;
     });

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -748,7 +748,8 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         copyTo->m_comment_to = copyFrom->m_comment_to;
         copyTo->m_replaces_txid = copyFrom->m_replaces_txid;
         copyTo->m_replaced_by_txid = copyFrom->m_replaced_by_txid;
-        copyTo->vOrderForm = copyFrom->vOrderForm;
+        copyTo->m_messages = copyFrom->m_messages;
+        copyTo->m_payment_requests = copyFrom->m_payment_requests;
         // nTimeReceived not copied on purpose
         copyTo->nTimeSmart = copyFrom->nTimeSmart;
         // nOrderPos not copied on purpose
@@ -2344,20 +2345,11 @@ void CWallet::CommitTransaction(
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
     CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
-        CHECK_NONFATAL(wtx.vOrderForm.empty());
         if (replaces_txid) wtx.m_replaces_txid = replaces_txid;
         if (comment) wtx.m_comment = comment;
         if (comment_to) wtx.m_comment_to = comment_to;
-        if (!messages.empty()) {
-            for (const std::string& msg : messages) {
-                wtx.vOrderForm.emplace_back("Message", msg);
-            }
-        }
-        if (!payment_requests.empty()) {
-            for (const std::string& msg : payment_requests) {
-                wtx.vOrderForm.emplace_back("PaymentRequest", msg);
-            }
-        }
+        if (!messages.empty()) wtx.m_messages = messages;
+        if (!payment_requests.empty()) wtx.m_payment_requests = payment_requests;
         return true;
     });
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2331,10 +2331,11 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 
 void CWallet::CommitTransaction(
     CTransactionRef tx,
-    std::vector<std::pair<std::string, std::string>> orderForm,
     std::optional<Txid> replaces_txid,
     std::optional<std::string> comment,
-    std::optional<std::string> comment_to
+    std::optional<std::string> comment_to,
+    const std::vector<std::string>& messages,
+    const std::vector<std::string>& payment_requests
 )
 {
     LOCK(cs_wallet);
@@ -2347,7 +2348,16 @@ void CWallet::CommitTransaction(
         if (replaces_txid) wtx.m_replaces_txid = replaces_txid;
         if (comment) wtx.m_comment = comment;
         if (comment_to) wtx.m_comment_to = comment_to;
-        wtx.vOrderForm = std::move(orderForm);
+        if (!messages.empty()) {
+            for (const std::string& msg : messages) {
+                wtx.vOrderForm.emplace_back("Message", msg);
+            }
+        }
+        if (!payment_requests.empty()) {
+            for (const std::string& msg : payment_requests) {
+                wtx.vOrderForm.emplace_back("PaymentRequest", msg);
+            }
+        }
         return true;
     });
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -742,6 +742,8 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         if (copyFrom == copyTo) continue;
         assert(copyFrom && "Oldest wallet transaction in range assumed to have been found.");
         if (!copyFrom->IsEquivalentTo(*copyTo)) continue;
+        copyTo->m_from = copyFrom->m_from;
+        copyTo->m_message = copyFrom->m_message;
         copyTo->mapValue = copyFrom->mapValue;
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // nTimeReceived not copied on purpose

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2328,7 +2328,9 @@ void CWallet::CommitTransaction(
     CTransactionRef tx,
     mapValue_t mapValue,
     std::vector<std::pair<std::string, std::string>> orderForm,
-    std::optional<Txid> replaces_txid
+    std::optional<Txid> replaces_txid,
+    std::optional<std::string> comment,
+    std::optional<std::string> comment_to
 )
 {
     LOCK(cs_wallet);
@@ -2341,6 +2343,8 @@ void CWallet::CommitTransaction(
         CHECK_NONFATAL(wtx.vOrderForm.empty());
         wtx.mapValue = std::move(mapValue);
         if (replaces_txid) wtx.mapValue["replaces_txid"] = replaces_txid->ToString();
+        if (comment) wtx.mapValue["comment"] = *comment;
+        if (comment_to) wtx.mapValue["to"] = *comment_to;
         wtx.vOrderForm = std::move(orderForm);
         return true;
     });

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -746,6 +746,8 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         copyTo->m_message = copyFrom->m_message;
         copyTo->m_comment = copyFrom->m_comment;
         copyTo->m_comment_to = copyFrom->m_comment_to;
+        copyTo->m_replaces_txid = copyFrom->m_replaces_txid;
+        copyTo->m_replaced_by_txid = copyFrom->m_replaced_by_txid;
         copyTo->mapValue = copyFrom->mapValue;
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // nTimeReceived not copied on purpose
@@ -985,9 +987,9 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
     CWalletTx& wtx = (*mi).second;
 
     // Ensure for now that we're not overwriting data
-    assert(!wtx.mapValue.contains("replaced_by_txid"));
+    Assert(!wtx.m_replaced_by_txid);
 
-    wtx.mapValue["replaced_by_txid"] = newHash.ToString();
+    wtx.m_replaced_by_txid = newHash;
 
     // Refresh mempool status without waiting for transactionRemovedFromMempool or transactionAddedToMempool
     RefreshMempoolStatus(wtx, chain());
@@ -2344,7 +2346,7 @@ void CWallet::CommitTransaction(
     CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
         CHECK_NONFATAL(wtx.mapValue.empty());
         CHECK_NONFATAL(wtx.vOrderForm.empty());
-        if (replaces_txid) wtx.mapValue["replaces_txid"] = replaces_txid->ToString();
+        if (replaces_txid) wtx.m_replaces_txid = replaces_txid;
         if (comment) wtx.m_comment = comment;
         if (comment_to) wtx.m_comment_to = comment_to;
         wtx.vOrderForm = std::move(orderForm);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2326,7 +2326,6 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 
 void CWallet::CommitTransaction(
     CTransactionRef tx,
-    mapValue_t mapValue,
     std::vector<std::pair<std::string, std::string>> orderForm,
     std::optional<Txid> replaces_txid,
     std::optional<std::string> comment,
@@ -2341,7 +2340,6 @@ void CWallet::CommitTransaction(
     CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
         CHECK_NONFATAL(wtx.mapValue.empty());
         CHECK_NONFATAL(wtx.vOrderForm.empty());
-        wtx.mapValue = std::move(mapValue);
         if (replaces_txid) wtx.mapValue["replaces_txid"] = replaces_txid->ToString();
         if (comment) wtx.mapValue["comment"] = *comment;
         if (comment_to) wtx.mapValue["to"] = *comment_to;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -748,7 +748,6 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         copyTo->m_comment_to = copyFrom->m_comment_to;
         copyTo->m_replaces_txid = copyFrom->m_replaces_txid;
         copyTo->m_replaced_by_txid = copyFrom->m_replaced_by_txid;
-        copyTo->mapValue = copyFrom->mapValue;
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // nTimeReceived not copied on purpose
         copyTo->nTimeSmart = copyFrom->nTimeSmart;
@@ -2344,7 +2343,6 @@ void CWallet::CommitTransaction(
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
     CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
-        CHECK_NONFATAL(wtx.mapValue.empty());
         CHECK_NONFATAL(wtx.vOrderForm.empty());
         if (replaces_txid) wtx.m_replaces_txid = replaces_txid;
         if (comment) wtx.m_comment = comment;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -693,12 +693,16 @@ public:
      * @param[in] mapValue key-values to be set on the transaction.
      * @param[in] orderForm BIP 70 / BIP 21 order form details to be set on the transaction.
      * @param[in] replaces_txid The txid of the transaction that this transaction replaces
+     * @param[in] comment The user's comment for this transaction
+     * @param[in] comment_to The comment for this transaction indicating where coins are sent to
      */
     void CommitTransaction(
         CTransactionRef tx,
         mapValue_t mapValue,
         std::vector<std::pair<std::string, std::string>> orderForm,
-        std::optional<Txid> replaces_txid = std::nullopt
+        std::optional<Txid> replaces_txid = std::nullopt,
+        std::optional<std::string> comment = std::nullopt,
+        std::optional<std::string> comment_to = std::nullopt
     );
 
     /** Pass this transaction to node for optional mempool insertion and relay to peers. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -690,7 +690,6 @@ public:
      * broadcasting the transaction.
      *
      * @param[in] tx The transaction to be broadcast.
-     * @param[in] mapValue key-values to be set on the transaction.
      * @param[in] orderForm BIP 70 / BIP 21 order form details to be set on the transaction.
      * @param[in] replaces_txid The txid of the transaction that this transaction replaces
      * @param[in] comment The user's comment for this transaction
@@ -698,7 +697,6 @@ public:
      */
     void CommitTransaction(
         CTransactionRef tx,
-        mapValue_t mapValue,
         std::vector<std::pair<std::string, std::string>> orderForm,
         std::optional<Txid> replaces_txid = std::nullopt,
         std::optional<std::string> comment = std::nullopt,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -690,17 +690,18 @@ public:
      * broadcasting the transaction.
      *
      * @param[in] tx The transaction to be broadcast.
-     * @param[in] orderForm BIP 70 / BIP 21 order form details to be set on the transaction.
      * @param[in] replaces_txid The txid of the transaction that this transaction replaces
      * @param[in] comment The user's comment for this transaction
      * @param[in] comment_to The comment for this transaction indicating where coins are sent to
+     * @param[in] messages The BIP 21 URI messages to attach to this transaction
      */
     void CommitTransaction(
         CTransactionRef tx,
-        std::vector<std::pair<std::string, std::string>> orderForm,
         std::optional<Txid> replaces_txid = std::nullopt,
         std::optional<std::string> comment = std::nullopt,
-        std::optional<std::string> comment_to = std::nullopt
+        std::optional<std::string> comment_to = std::nullopt,
+        const std::vector<std::string>& messages = {},
+        const std::vector<std::string>& payment_requests = {}
     );
 
     /** Pass this transaction to node for optional mempool insertion and relay to peers. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -692,8 +692,14 @@ public:
      * @param[in] tx The transaction to be broadcast.
      * @param[in] mapValue key-values to be set on the transaction.
      * @param[in] orderForm BIP 70 / BIP 21 order form details to be set on the transaction.
+     * @param[in] replaces_txid The txid of the transaction that this transaction replaces
      */
-    void CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm);
+    void CommitTransaction(
+        CTransactionRef tx,
+        mapValue_t mapValue,
+        std::vector<std::pair<std::string, std::string>> orderForm,
+        std::optional<Txid> replaces_txid = std::nullopt
+    );
 
     /** Pass this transaction to node for optional mempool insertion and relay to peers. */
     bool SubmitTxMemoryPoolAndRelay(CWalletTx& wtx, std::string& err_string, node::TxBroadcast broadcast_method) const


### PR DESCRIPTION
`mapValue` and `vOrderForm` are opaque data structures that contain transaction metadata. It is hard to determine what actual data each field contains, and they can ostensibly be misused where metadata is added in the future without developers realizing that such metadata exists.

It's much clearer to have all of that metadata live in their own explicit member variables within `CWalletTx`. This PR implements that change.

Since the serialization format of `CWalletTx` depends on `mapValue` and `vOrderForm`, the serialization remains unchanged, so when serializing these new members, they need to be shoved/extracted from a temporary `mapValue` or `vOrderForm`.

This does end up breaking forwards compatibility as unknown fields in `mapValue` and `vOrderForm` are stripped out if the record is rewritten. However, I don't expect that we would continue to use these fields for future metadata, so I think that risk is low.