### PR TITLE
test: Fix list index out of range error in feature_bip68_sequence.py

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -144,8 +144,10 @@ class BIP68Test(BitcoinTestFramework):
         # between height/time locking). Small random chance of making the locks
         # all pass.
         for _ in range(400):
+            available_utxos = len(utxos)
+
             # Randomly choose up to 10 inputs
-            num_inputs = random.randint(1, 10)
+            num_inputs = random.randint(1, min(10, available_utxos))
             random.shuffle(utxos)
 
             # Track whether any sequence locks used should fail


### PR DESCRIPTION
Fixes [#32334](https://github.com/bitcoin/bitcoin/issues/32334)

The test `feature_bip68_sequence.py` fails with `IndexError: list index out of range` error due to a mismatch between the number of inputs requested (at random) and the number of UTXOs available. The error is reproducible with the randomseed: 
``` 
$ ./build/test/functional/feature_bip68_sequence.py --randomseed 6169832640268785903 
```
This PR adds a valid upper bound to randomly select the inputs.
