### PR TITLE
ci: Allow running CI in worktrees

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C
 
+set -o errexit -o pipefail -o xtrace
+
 export CI_RETRY_EXE="/ci_retry --"
 
 pushd "/"

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -12,7 +12,7 @@ ENV LC_ALL=C.UTF-8
 COPY ./ci/retry/retry /ci_retry
 COPY ./.python-version /.python-version
 COPY ./ci/lint/container-entrypoint.sh /entrypoint.sh
-COPY ./ci/lint/04_install.sh /install.sh
+COPY ./ci/lint/01_install.sh /install.sh
 
 RUN /install.sh && \
   echo 'alias lint="./ci/lint/06_script.sh"' >> ~/.bashrc && \

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -13,6 +13,6 @@ cp "./ci/retry/retry" "/ci_retry"
 cp "./.python-version" "/.python-version"
 mkdir --parents "/test/lint"
 cp --recursive "./test/lint/test_runner" "/test/lint/"
-set -o errexit; source ./ci/lint/04_install.sh
+set -o errexit; source ./ci/lint/01_install.sh
 set -o errexit
 ./ci/lint/06_script.sh

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -6,11 +6,11 @@
 
 export LC_ALL=C.UTF-8
 
-set -ex
+set -o errexit -o pipefail -o xtrace
 
-CFG_DONE="ci.base-install-done"  # Use a global git setting to remember whether this script ran to avoid running it twice
+CFG_DONE="${BASE_ROOT_DIR}/ci.base-install-done"  # Use a global setting to remember whether this script ran to avoid running it twice
 
-if [ "$(git config --global ${CFG_DONE})" == "true" ]; then
+if [ "$( cat "${CFG_DONE}" || true )" == "done" ]; then
   echo "Skip base install"
   exit 0
 fi
@@ -105,4 +105,4 @@ if [ -n "$XCODE_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OSX_SDK_BASENAME}" ]
   tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 
-git config --global ${CFG_DONE} "true"
+echo -n "done" > "${CFG_DONE}"

--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -153,12 +153,8 @@ CI_EXEC () {
 export -f CI_EXEC
 
 # Normalize all folders to BASE_ROOT_DIR
-CI_EXEC rsync --archive --stats --human-readable "${BASE_READ_ONLY_DIR}/" "${BASE_ROOT_DIR}" || echo "Nothing to copy from ${BASE_READ_ONLY_DIR}/"
+CI_EXEC rsync --recursive --perms --stats --human-readable "${BASE_READ_ONLY_DIR}/" "${BASE_ROOT_DIR}" || echo "Nothing to copy from ${BASE_READ_ONLY_DIR}/"
 CI_EXEC "${BASE_ROOT_DIR}/ci/test/01_base_install.sh"
-
-# Fixes permission issues when there is a container UID/GID mismatch with the owner
-# of the git source code directory.
-CI_EXEC git config --global --add safe.directory \"*\"
 
 CI_EXEC mkdir -p "${BINS_SCRATCH_DIR}"
 

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -54,7 +54,7 @@ or `--help`:
 | `py_lint` | [ruff](https://github.com/astral-sh/ruff)
 | markdown link check | [mlc](https://github.com/becheran/mlc)
 
-In use versions and install instructions are available in the [CI setup](../../ci/lint/04_install.sh).
+In use versions and install instructions are available in the [CI setup](../../ci/lint/01_install.sh).
 
 Please be aware that on Linux distributions all dependencies are usually available as packages, but could be outdated.
 


### PR DESCRIPTION
Fixes #30028 (modulo lint and tidy CI).

The error on current master in a worktree is:

```
$ git worktree add ./main origin/master && cd ./main
$ MAKEJOBS="-j$(nproc)" FILE_ENV="./ci/test/00_setup_env_mac_cross.sh" ./ci/test_run_all.sh
...
+ git config --global ci.base-install-done true
fatal: not a git repository: /root/b-c-ci/.git/worktrees/main
```

So just use a plain file, instead of git. Also, enable pipefail while touching this bash script.