### PR TITLE
contrib: tracing: Fix read of `pmsg_type` in p2p_monitor.py

### DIFF
--- a/contrib/tracing/p2p_monitor.py
+++ b/contrib/tracing/p2p_monitor.py
@@ -54,7 +54,7 @@ int trace_inbound_message(struct pt_regs *ctx) {
     bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
     bpf_usdt_readarg(3, ctx, &pconn_type);
     bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
-    bpf_usdt_readarg(4, ctx, &pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
     bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 
@@ -71,7 +71,7 @@ int trace_outbound_message(struct pt_regs *ctx) {
     bpf_probe_read_user_str(&msg.peer_addr, sizeof(msg.peer_addr), paddr);
     bpf_usdt_readarg(3, ctx, &pconn_type);
     bpf_probe_read_user_str(&msg.peer_conn_type, sizeof(msg.peer_conn_type), pconn_type);
-    bpf_usdt_readarg(4, ctx, &pconn_type);
+    bpf_usdt_readarg(4, ctx, &pmsg_type);
     bpf_probe_read_user_str(&msg.msg_type, sizeof(msg.msg_type), pmsg_type);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 


### PR DESCRIPTION
This fixes a bug in the contrib tracing script `p2p_monitor.py`. currently the script fails to read the `msg_type` of inbound and outbound messages, which is useful in the per-peer message view.

<details>
<summary>Screenshot of p2p_monitor.py on master</summary>

![Screenshot From 2025-06-18 11-37-43](https://github.com/user-attachments/assets/56612088-54d7-465c-b0b6-1b425b919785)
</details>


<details>
<summary>Screenshot of p2p_monitor.py on this branch</summary>

![Screenshot From 2025-06-18 11-41-38](https://github.com/user-attachments/assets/4438a483-938c-450b-a12e-6d6909b2c37e)

</details>

