### PR TITLE
fuzz: wallet: remove `FundTx` from `FuzzedWallet`

### DIFF
--- a/src/test/fuzz/util/wallet.h
+++ b/src/test/fuzz/util/wallet.h
@@ -74,59 +74,6 @@ struct FuzzedWallet {
         }
     }
     CScript GetScriptPubKey(FuzzedDataProvider& fuzzed_data_provider) { return GetScriptForDestination(GetDestination(fuzzed_data_provider)); }
-    void FundTx(FuzzedDataProvider& fuzzed_data_provider, CMutableTransaction tx)
-    {
-        // The fee of "tx" is 0, so this is the total input and output amount
-        const CAmount total_amt{
-            std::accumulate(tx.vout.begin(), tx.vout.end(), CAmount{}, [](CAmount t, const CTxOut& out) { return t + out.nValue; })};
-        const uint32_t tx_size(GetVirtualTransactionSize(CTransaction{tx}));
-        std::set<int> subtract_fee_from_outputs;
-        if (fuzzed_data_provider.ConsumeBool()) {
-            for (size_t i{}; i < tx.vout.size(); ++i) {
-                if (fuzzed_data_provider.ConsumeBool()) {
-                    subtract_fee_from_outputs.insert(i);
-                }
-            }
-        }
-        std::vector<CRecipient> recipients;
-        for (size_t idx = 0; idx < tx.vout.size(); idx++) {
-            const CTxOut& tx_out = tx.vout[idx];
-            CTxDestination dest;
-            ExtractDestination(tx_out.scriptPubKey, dest);
-            CRecipient recipient = {dest, tx_out.nValue, subtract_fee_from_outputs.count(idx) == 1};
-            recipients.push_back(recipient);
-        }
-        CCoinControl coin_control;
-        coin_control.m_allow_other_inputs = fuzzed_data_provider.ConsumeBool();
-        CallOneOf(
-            fuzzed_data_provider, [&] { coin_control.destChange = GetDestination(fuzzed_data_provider); },
-            [&] { coin_control.m_change_type.emplace(fuzzed_data_provider.PickValueInArray(OUTPUT_TYPES)); },
-            [&] { /* no op (leave uninitialized) */ });
-        coin_control.fAllowWatchOnly = fuzzed_data_provider.ConsumeBool();
-        coin_control.m_include_unsafe_inputs = fuzzed_data_provider.ConsumeBool();
-        {
-            auto& r{coin_control.m_signal_bip125_rbf};
-            CallOneOf(
-                fuzzed_data_provider, [&] { r = true; }, [&] { r = false; }, [&] { r = std::nullopt; });
-        }
-        coin_control.m_feerate = CFeeRate{
-            // A fee of this range should cover all cases
-            fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, 2 * total_amt),
-            tx_size,
-        };
-        if (fuzzed_data_provider.ConsumeBool()) {
-            *coin_control.m_feerate += GetMinimumFeeRate(*wallet, coin_control, nullptr);
-        }
-        coin_control.fOverrideFeeRate = fuzzed_data_provider.ConsumeBool();
-        // Add solving data (m_external_provider and SelectExternal)?
-
-        int change_position{fuzzed_data_provider.ConsumeIntegralInRange<int>(-1, tx.vout.size() - 1)};
-        bilingual_str error;
-        // Clear tx.vout since it is not meant to be used now that we are passing outputs directly.
-        // This sets us up for a future PR to completely remove tx from the function signature in favor of passing inputs directly
-        tx.vout.clear();
-        (void)FundTransaction(*wallet, tx, recipients, change_position, /*lockUnspents=*/false, coin_control);
-    }
 };
 }
 


### PR DESCRIPTION
`FundTx` was used by the `wallet_notifications` target which we recently removed. So it's now unused and can be removed.