### PR TITLE
refactor: modernize deprecated ipc headers

### DIFF
--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -16,8 +16,8 @@
 #include <mp/util.h>
 #include <util/threadnames.h>
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include <future>
 #include <memory>
 #include <mutex>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -15,10 +15,10 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <stdexcept>
-#include <string.h>
 #include <string>
 #include <unistd.h>
 #include <utility>

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -13,11 +13,11 @@
 
 #include <cstdint>
 #include <cstdlib>
-#include <errno.h>
+#include <cstring>
+#include <cerrno>
 #include <exception>
 #include <iostream>
 #include <stdexcept>
-#include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>


### PR DESCRIPTION
Split off from #31802.

Pre-empt tidy warning when multiprocess is on by default:

```
[10:33:51.654] /ci_container_base/src/ipc/capnp/protocol.cpp:20:10: error: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead [modernize-deprecated-headers,-warnings-as-errors]
[10:33:51.654]    20 | #include <errno.h>
[10:33:51.654]       |          ^~~~~~~~~
[10:33:51.654]       |          <cerrno>
[10:33:51.654] 919 warnings generated.
```

https://github.com/bitcoin/bitcoin/pull/31802/checks?check_run_id=43968493627