### PR TITLE
bench: reduces unnecessary big vector definition

### DIFF
--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -14,7 +14,7 @@
 static void RollingBloom(benchmark::Bench& bench)
 {
     CRollingBloomFilter filter(120000, 0.000001);
-    std::vector<unsigned char> data(32);
+    std::vector<unsigned char> data(4);
     uint32_t count = 0;
     bench.run([&] {
         count++;


### PR DESCRIPTION
The data vector used in the benchmark was defined to hold 32 bytes, instead of 4, while the writing functions work with 32-bit values.