### PR TITLE
checkqueue: implement a new scriptcheck worker pool with atomic variables

### DIFF
--- a/doc/release-notes-32540.md
+++ b/doc/release-notes-32540.md
@@ -1,0 +1,5 @@
+New RPCs
+--------
+
+- A new REST API endpoint (`/rest/spenttxouts/BLOCKHASH`) has been introduced for
+  efficiently fetching spent transaction outputs using the block's undo data (#32540).

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -15,6 +15,8 @@
 #include <optional>
 #include <vector>
 
+static constexpr int MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD{14};
+
 /**
  * Queue for verifications that have to be performed.
   * The verifications are represented by a type T, which must provide an
@@ -33,6 +35,11 @@ template <typename T, typename R = std::remove_cvref_t<decltype(std::declval<T>(
 class CCheckQueue
 {
 private:
+    //! fAtomic indicates if the atomic version of worker pool is enabled
+    //! m_worker_threads.size() <= MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD: use the mutex version
+    //! m_worker_threads.size() > MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD: use the atomic version
+    bool fAtomic;
+
     //! Mutex to protect the inner state
     Mutex m_mutex;
 
@@ -44,7 +51,7 @@ private:
 
     //! The queue of elements to be processed.
     //! As the order of booleans doesn't matter, it is used as a LIFO (stack)
-    std::vector<T> queue GUARDED_BY(m_mutex);
+    std::vector<T> queue;
 
     //! The number of workers (including the master) that are idle.
     int nIdle GUARDED_BY(m_mutex){0};
@@ -69,7 +76,7 @@ private:
     bool m_request_stop GUARDED_BY(m_mutex){false};
 
     /** Internal function that does bulk of the verification work. If fMaster, return the final result. */
-    std::optional<R> Loop(bool fMaster) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    std::optional<R> LoopMutex(bool fMaster) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
         std::condition_variable& cond = fMaster ? m_master_cv : m_worker_cv;
         std::vector<T> vChecks;
@@ -136,20 +143,91 @@ private:
         } while (true);
     }
 
+    std::atomic<int> nNext{0};
+    int nWorkDone GUARDED_BY(m_mutex){0};
+    bool fComplete GUARDED_BY(m_mutex){false};
+
+    /** Internal function that does bulk of the verification work. If fMaster, return the final result. */
+    std::optional<R> LoopAtomic(bool fMaster, int nr_workers) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        std::condition_variable& cond = fMaster ? m_master_cv : m_worker_cv;
+        std::optional<R> local_result;
+        unsigned int start_index = 0, end_index = 0;
+        bool work_done = false;
+
+        while (true) {
+            if (!fMaster) {
+                WAIT_LOCK(m_mutex, lock);
+                if (m_request_stop) return std::nullopt;
+                if (!fComplete || work_done) {
+                    if (work_done) {
+                        nWorkDone++;
+                        if (nWorkDone == nr_workers)
+                            m_master_cv.notify_one();
+                    }
+
+                    cond.wait(lock); // wait
+                }
+            }
+
+            work_done = false;
+            start_index = end_index = 0;
+            local_result = std::nullopt;
+            const unsigned int que_sz = queue.size();
+
+            while(end_index != que_sz) {
+                start_index = nNext.fetch_add(nBatchSize);
+                end_index = std::min(start_index + nBatchSize, que_sz);
+                for (unsigned int i = start_index; i < end_index; i++) {
+                    local_result = queue[i]();
+                    if (local_result.has_value()) {
+                        LOCK(m_mutex);
+                        if (!m_result.has_value()) {
+                            std::swap(local_result, m_result);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if (fMaster) {
+                WAIT_LOCK(m_mutex, lock);
+                if (nWorkDone != nr_workers)
+                    cond.wait(lock);
+
+                std::optional<R> to_return = std::move(m_result);
+                m_result = std::nullopt;
+                return to_return;
+            }
+
+            work_done = true;
+        }
+
+        return std::nullopt;
+    }
+
 public:
     //! Mutex to ensure only one concurrent CCheckQueueControl
     Mutex m_control_mutex;
 
     //! Create a new check queue
     explicit CCheckQueue(unsigned int batch_size, int worker_threads_num)
-        : nBatchSize(batch_size)
+        : nBatchSize(worker_threads_num <= MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD ? batch_size : 5)
     {
+        fAtomic = false;
+        if (worker_threads_num > MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD) {
+            fAtomic = true;
+        }
+
         LogInfo("Script verification uses %d additional threads", worker_threads_num);
         m_worker_threads.reserve(worker_threads_num);
         for (int n = 0; n < worker_threads_num; ++n) {
-            m_worker_threads.emplace_back([this, n]() {
+            m_worker_threads.emplace_back([this, n, worker_threads_num]() {
                 util::ThreadRename(strprintf("scriptch.%i", n));
-                Loop(false /* worker thread */);
+                if (!fAtomic)
+                    LoopMutex(false /* worker thread */);
+                else
+                    LoopAtomic(false, worker_threads_num);
             });
         }
     }
@@ -162,10 +240,24 @@ public:
     CCheckQueue& operator=(CCheckQueue&&) = delete;
 
     //! Join the execution until completion. If at least one evaluation wasn't successful, return
-    //! its error.
+    //! its error. This is designed to be called only once, and should be after all the Add operations.
     std::optional<R> Complete() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        return Loop(true /* master thread */);
+        if (!fAtomic)
+            return LoopMutex(true /* master thread */);
+
+        nNext = 0;
+        {
+            LOCK(m_mutex);
+            if (!fComplete) fComplete = true;
+            m_result = std::nullopt;
+            nWorkDone = 0;
+            m_worker_cv.notify_all();
+        }
+        auto ret = LoopAtomic(true /* master thread */, m_worker_threads.size());
+        queue.clear();
+
+        return ret;
     }
 
     //! Add a batch of checks to the queue
@@ -175,16 +267,18 @@ public:
             return;
         }
 
-        {
+        if (!fAtomic) {
             LOCK(m_mutex);
             queue.insert(queue.end(), std::make_move_iterator(vChecks.begin()), std::make_move_iterator(vChecks.end()));
             nTodo += vChecks.size();
-        }
 
-        if (vChecks.size() == 1) {
-            m_worker_cv.notify_one();
+            if (vChecks.size() == 1) {
+                m_worker_cv.notify_one();
+            } else {
+                m_worker_cv.notify_all();
+            }
         } else {
-            m_worker_cv.notify_all();
+            queue.insert(queue.end(), std::make_move_iterator(vChecks.begin()), std::make_move_iterator(vChecks.end()));
         }
     }
 

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -16,7 +16,7 @@
 #include <optional>
 #include <vector>
 
-static constexpr int MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD{14};
+static constexpr int MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD{-1};
 
 /**
  * Queue for verifications that have to be performed.
@@ -219,7 +219,8 @@ public:
     {
         // Some tests skip user interface and call CCheckQueue() directly
         // So this code is necessary
-        worker_threads_num = std::min(worker_threads_num, GetNumCores() - 1);
+        //worker_threads_num = std::min(worker_threads_num, GetNumCores() - 1);
+        worker_threads_num = std::min(worker_threads_num, 15);
         if (worker_threads_num > MAX_SCRIPTCHECK_MUTEX_MODE_THRESHOLD) {
             fAtomic = true;
             nBatchSize = 5;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -494,7 +494,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY_HOURS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
-        MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        GetNumCores(), DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempoolv1",
                    strprintf("Whether a mempool.dat file created by -persistmempool or the savemempool RPC will be written in the legacy format "

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(bitcoinkernel
   ../arith_uint256.cpp
   ../chain.cpp
   ../coins.cpp
+  ../common/system.cpp
   ../compressor.cpp
   ../consensus/merkle.cpp
   ../consensus/tx_check.cpp

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -97,7 +97,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     /* Main elements init */
     ui->databaseCache->setRange(MIN_DB_CACHE >> 20, std::numeric_limits<int>::max());
     ui->threadsScriptVerif->setMinimum(-GetNumCores());
-    ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
+    ui->threadsScriptVerif->setMaximum(GetNumCores());
     ui->pruneWarning->setVisible(false);
     ui->pruneWarning->setStyleSheet("QLabel { color: red; }");
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -63,6 +63,7 @@
 #include <util/trace.h>
 #include <util/translation.h>
 #include <validationinterface.h>
+#include <common/system.h>
 
 #include <algorithm>
 #include <cassert>
@@ -6311,7 +6312,7 @@ static ChainstateManager::Options&& Flatten(ChainstateManager::Options&& opts)
 }
 
 ChainstateManager::ChainstateManager(const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options)
-    : m_script_check_queue{/*batch_size=*/128, std::clamp(options.worker_threads_num, 0, MAX_SCRIPTCHECK_THREADS)},
+    : m_script_check_queue{/*batch_size=*/128, std::clamp(options.worker_threads_num, 0, GetNumCores() - 1)},
       m_interrupt{interrupt},
       m_options{Flatten(std::move(options))},
       m_blockman{interrupt, std::move(blockman_options)},

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2697,8 +2697,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         }
         UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
     }
+
+    std::optional<std::remove_cvref_t<decltype(std::declval<CScriptCheck>()().value())>> parallel_result;
     const auto time_3{SteadyClock::now()};
     m_chainman.time_connect += time_3 - time_2;
+    if (control) parallel_result = control->Complete();
     LogDebug(BCLog::BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
              Ticks<MillisecondsDouble>(time_3 - time_2), Ticks<MillisecondsDouble>(time_3 - time_2) / block.vtx.size(),
              nInputs <= 1 ? 0 : Ticks<MillisecondsDouble>(time_3 - time_2) / (nInputs - 1),
@@ -2711,7 +2714,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                       strprintf("coinbase pays too much (actual=%d vs limit=%d)", block.vtx[0]->GetValueOut(), blockReward));
     }
     if (control) {
-        auto parallel_result = control->Complete();
         if (parallel_result.has_value() && state.IsValid()) {
             state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(parallel_result->first)), parallel_result->second);
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -79,9 +79,6 @@ static constexpr int DEFAULT_CHECKLEVEL{3};
 // Setting the target to >= 550 MiB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** Maximum number of dedicated script-checking threads allowed */
-static constexpr int MAX_SCRIPTCHECK_THREADS{15};
-
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -6,6 +6,7 @@
 
 from decimal import Decimal
 from enum import Enum
+from io import BytesIO
 import http.client
 import json
 import typing
@@ -15,6 +16,7 @@ import urllib.parse
 from test_framework.messages import (
     BLOCK_HEADER_SIZE,
     COIN,
+    deser_block_spent_outputs,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -425,6 +427,34 @@ class RESTTest (BitcoinTestFramework):
         self.log.info("Test compatibility of deprecated and newer endpoints")
         assert_equal(self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": 1}), self.test_rest_request(f"/headers/1/{bb_hash}"))
         assert_equal(self.test_rest_request(f"/blockfilterheaders/basic/{bb_hash}", query_params={"count": 1}), self.test_rest_request(f"/blockfilterheaders/basic/5/{bb_hash}"))
+
+        self.log.info("Test the /spenttxouts URI")
+
+        block_count = self.nodes[0].getblockcount()
+        for height in range(0, block_count + 1):
+            blockhash = self.nodes[0].getblockhash(height)
+            spent_bin = self.test_rest_request(f"/spenttxouts/{blockhash}", req_type=ReqType.BIN, ret_type=RetType.BYTES)
+            spent_hex = self.test_rest_request(f"/spenttxouts/{blockhash}", req_type=ReqType.HEX, ret_type=RetType.BYTES)
+            spent_json = self.test_rest_request(f"/spenttxouts/{blockhash}", req_type=ReqType.JSON, ret_type=RetType.JSON)
+
+            assert_equal(bytes.fromhex(spent_hex.decode()), spent_bin)
+
+            spent = deser_block_spent_outputs(BytesIO(spent_bin))
+            block = self.nodes[0].getblock(blockhash, 3)  # return prevout for each input
+            assert_equal(len(spent), len(block["tx"]))
+            assert_equal(len(spent_json), len(block["tx"]))
+
+            for i, tx in enumerate(block["tx"]):
+                prevouts = [txin["prevout"] for txin in tx["vin"] if "coinbase" not in txin]
+                # compare with `getblock` JSON output (coinbase tx has no prevouts)
+                actual = [(txout.scriptPubKey.hex(), Decimal(txout.nValue) / COIN) for txout in spent[i]]
+                expected = [(p["scriptPubKey"]["hex"], p["value"]) for p in prevouts]
+                assert_equal(expected, actual)
+                # also compare JSON format
+                actual = [(prevout["scriptPubKey"], prevout["value"]) for prevout in spent_json[i]]
+                expected = [(p["scriptPubKey"], p["value"]) for p in prevouts]
+                assert_equal(expected, actual)
+
 
         self.log.info("Test the /deploymentinfo URI")
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -230,6 +230,11 @@ def ser_string_vector(l):
     return r
 
 
+def deser_block_spent_outputs(f):
+    nit = deser_compact_size(f)
+    return [deser_vector(f, CTxOut) for _ in range(nit)]
+
+
 def from_hex(obj, hex_string):
     """Deserialize from a hex string representation (e.g. from RPC)
 


### PR DESCRIPTION
    TL;DR
    This patchset proposes a new design of scriptcheck worker pool with
    atomic variables to leverage more cpu resource on a machine which the
    current mutex version cannot. Achieve about 45% boost in performance.
    
    Main Idea:
    
    The current version of worker pool use mutex to do the synchronization
    between worker threads, which makes the performance downgrade after
    worker_threads_num >= 14. One root cause is the high contention on the
    queue's mutex among worker threads. Workers repeatedly sleep and be woken
    up in short time, leading to heavy context switching.
    The idea is to use atomic variables to protect the queue, workers
    acquire it and increase it with a batch_size(a small number). This
    significantly reduces context switching.
    
    Implementation
    
    To implement it, below changes are made:(enabled in atomic mode)
    - atomic<int> nNext is used to indicate the next available indice in the
      queue
    - atomic<int> nTodo2 is used to indicate the number of tasks left
    - nBatchSize is the batch size of tasks everytime a worker consumes
      it should be small to keep workload balance among workers
    - m_mutex is still used, to protect m_result and conditional vars
    - fAtomic to indicate which mode is enabled
    - about the queue:
    
      - the queue is used as queue, not stacks any more
      - the queue is 'add only', which means only adding tasks to it, don't
        remove used tasks.
    
        the above two are a must to make this idea achievable, and the
        second sacrifices space
    
      - start the workers only after all the tasks have been added to the
        queue
    
        this is a trade-off to make the implementaion simple, a worker can
        compare nNext + nBatchSize to queue.size() to find if there are
        tasks undone in the queue, otherwise another atomic<int> tail is
        needed, and race condition may exist in this way (need more
        investigation). From my test, it's not 100% to say this is a
        'trade-off' since it also brings something good, pros && cons:
        - pros:
            1. no contention among producer and consumers when adding tasks
               to the queue
            2. the adding period is very short compared to the verification
               period
        - cons:
            1. the workers start later
    
    For details, please refer to the worker handler code
    
    Tests:
    
    - Numbers
      - For blocks/s numbers
        `./build/bin/bench_bitcoin --filter=ConnectBlockMixedEcdsaSchnor`
      - For cpu usage numbers
        `NANOBENCH_ENDLESS=ConnectBlockAllEcdsa ./build/bin/bench_bitcoin --filter=ConnectBlockAllEcdsa`
    
      - Some data is missing because the machine was billed by time, and there wasn't
        enough time to complete all measurements.
      - Some cells contain a range instead of a single value due to high fluctuations
      - The numbers represent the average of multiple test runs.
    
               |     mutex verion       |   atomic version
    nr_workers | blocks/s  | cpu usage  | blocks/s  | cpu usage2
    -----------|-----------|------------|-----------|-------------
    0          | 4.22      | 100%       | 4.2       | 100%
    1          | 8.23      | 198%       | 8         | 191.3%
    2          | 12.08     | 293.7%     | 11.6      | 276%
    3          | 16        | 386.7%     | 14.9      | 354.5%
    4          | 19.8      | 476.3%     |           |
    5          | 23.12     | 565.4%     |           |
    6          | 27.3      | 654%       | 23        | 560%
    7          | 28.5      | 738%       |           |
    8          | 33.8      | 809%       |           |
    9          | 33.5      | 868%       | 28.5      | 730%
    10         | 37.4      | 910%       | 30.5      | 777%
    11         | 33~40     | 880%~928%  | 32        | 825%
    12         | 22~39     | 860%~925%  | 32.5      | 830%
    13         | 27.8~37   | 700%~913%  | 34.8      | 928%
    15         | 24.8~38.9 | 640%~719%  | 38        | 1000%
    19         | 18~23     | 370%~510%  | 41        | 1161%
    22         | 7~18      | 270%~400%  |           |
    25         | 6.4       | 260%       | 46        | 1400%
    30         | 5         | 270%       | 49        | 1560%
    60         | 5         | 280%       | 50~58     | 2100%
    
    - Env:
     A virtual machine on cloud
       Architecture:          x86_64
       CPU op-mode(s):        32-bit, 64-bit
       Address sizes:         46 bits physical, 48 bits virtual
       Byte Order:            Little Endian
       CPU(s):                64
       On-line CPU(s) list:   0-63
       Vendor ID:             GenuineIntel
       Model name:            Intel Xeon Processor (Cascadelake)
       CPU family:            6
       Model:                 85
       Thread(s) per core:    2
       Core(s) per socket:    16
       Socket(s):             2
       Stepping:              6
       BogoMIPS:              5985.93
     Virtualization features:
       Hypervisor vendor:     KVM
       Virtualization type:   full
     Caches (sum of all):
       L1d:                   2 MiB (64 instances)
       L1i:                   2 MiB (64 instances)
       L2:                    128 MiB (32 instances)
       L3:                    32 MiB (2 instances)
     NUMA:
       NUMA node(s):          2
       NUMA node0 CPU(s):     0-31
       NUMA node1 CPU(s):     32-63
    
    Signed-off-by: Hao Xu <hao.xu@linux.dev>
