### PR TITLE
build: add root dir to CMAKE_PREFIX_PATH in toolchain

### DIFF
--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -92,6 +92,22 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(QT_TRANSLATIONS_DIR "${CMAKE_CURRENT_LIST_DIR}/translations")
 
+# The following is only necessary when using cmake from Nix or NixOS, because
+# Nix patches cmake to remove the root directory `/` from
+# CMAKE_SYSTEM_PREFIX_PATH. Adding it back is harmless on other platforms and
+# necessary on Nix because without it cmake find_path, find_package, etc
+# functions do not know where to look in CMAKE_FIND_ROOT_PATH for dependencies
+# (https://github.com/bitcoin/bitcoin/issues/32428).
+#
+# TODO: longer term, it may be possible to use a dependency provider, which
+# would bring the find_package calls completely under our control, making this
+# patch unnecessary.
+#
+# Make sure we only append once, as this file may be called repeatedly.
+if(NOT "/" IN_LIST CMAKE_PREFIX_PATH)
+  list(APPEND CMAKE_PREFIX_PATH "/")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_APPLE)
   # The find_package(Qt ...) function internally uses find_library()
   # calls for all dependencies to ensure their availability.


### PR DESCRIPTION
Fixes: #32428

Nix patches `cmake` to remove the root directory `/` from `CMAKE_PREFIX_PATH`:
https://github.com/NixOS/nixpkgs/blob/428b49b28ebc8938a6d9f6c540d32d7a06713972/pkgs/by-name/cm/cmake/001-search-path.diff#L10

Without this, and when using the toolchain for depends builds, cmake's `find_path()` and `find_package()` do not know where to find dependencies, causing issues like as seen in #32428

Adding this path back is harmless on other systems, and fixes the toolchain for Nix users.

As described in https://github.com/bitcoin/bitcoin/issues/32428#issuecomment-2991258328 I think this can be taken as a temporary fix whilst a longer-term solution is worked on.