### PR TITLE
mempool: use `FeeFrac` for ancestor/descendant score comparators

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -126,9 +126,9 @@ class CompareTxMemPoolEntryByScore
 public:
     bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
-        double f1 = (double)a.GetFee() * b.GetTxSize();
-        double f2 = (double)b.GetFee() * a.GetTxSize();
-        if (f1 == f2) {
+        FeeFrac f1(a.GetFee(), a.GetTxSize());
+        FeeFrac f2(b.GetFee(), b.GetTxSize());
+        if (FeeRateCompare(f1, f2) == 0) {
             return b.GetTx().GetHash() < a.GetTx().GetHash();
         }
         return f1 > f2;


### PR DESCRIPTION
Rather than determining fee-rates for the mempool index scores and comparators manually in a rather tedious way (even involving floating-points), use the `FeeFrac` class [1] to simplify and deduplicate the code. Note that though this is intended to be a refactoring PR, there might be subtle differences in behaviour due to floating-point arithmetic involved in the original code (to avoid overflows at the cost of precision loss), but these shouldn't matter.

[1] introduced in PR #29242, commit ce8e22542ed0b4fa5794d3203207146418d59473