### PR TITLE
cmake: Use `HINTS` instead of `PATHS` in `find_*` commands

### DIFF
--- a/cmake/module/FindQRencode.cmake
+++ b/cmake/module/FindQRencode.cmake
@@ -21,16 +21,16 @@ endif()
 
 find_path(QRencode_INCLUDE_DIR
   NAMES qrencode.h
-  PATHS ${PC_QRencode_INCLUDE_DIRS}
+  HINTS ${PC_QRencode_INCLUDE_DIRS}
 )
 
 find_library(QRencode_LIBRARY_RELEASE
   NAMES qrencode
-  PATHS ${PC_QRencode_LIBRARY_DIRS}
+  HINTS ${PC_QRencode_LIBRARY_DIRS}
 )
 find_library(QRencode_LIBRARY_DEBUG
   NAMES qrencoded qrencode
-  PATHS ${PC_QRencode_LIBRARY_DIRS}
+  HINTS ${PC_QRencode_LIBRARY_DIRS}
 )
 include(SelectLibraryConfigurations)
 select_library_configurations(QRencode)


### PR DESCRIPTION
According to the CMake documentation, `HINTS` "should be paths computed by system introspection, such as a hint provided by the location of another item already found", which is precisely the case in the `FindQRencode` module.

Entries in `HINTS` are searched before those in `PATHS`. On macOS, Homebrew’s `libqrencode` will therefore be located at its real path rather than via the symlink in the default prefix.

A backport to 29.x is required for https://github.com/bitcoin/bitcoin/pull/32804, as this change prevents contamination of include directories by broad locations such as `/usr/local/include` or `/opt/homebrew/include`, which take precedence over Qt’s `-iframework` flags.

Below is the relevant change in the configuration logs on my macOS 15.5 `x64`:
- master branch @ ead44687483e9c936ba970de890c01d5e7ad3485:
```
% cmake -B build -DBUILD_GUI=ON
<snip>
-- Found QRencode: /usr/local/lib/libqrencode.dylib (found version "4.1.1")
<snip>
```
- this PR:
```
% cmake -B build -DBUILD_GUI=ON
<snip>
-- Found QRencode: /usr/local/Cellar/qrencode/4.1.1/lib/libqrencode.dylib (found version "4.1.1")
<snip>
```