### PR TITLE
cmake: Explicitly specify `Boost_ROOT` for Homebrew's package

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -17,6 +17,18 @@ function(add_boost_if_needed)
   directory and other added INTERFACE properties.
   ]=]
 
+  if(CMAKE_HOST_APPLE)
+    find_program(HOMEBREW_EXECUTABLE brew)
+    if(HOMEBREW_EXECUTABLE)
+      execute_process(
+        COMMAND ${HOMEBREW_EXECUTABLE} --prefix boost
+        OUTPUT_VARIABLE Boost_ROOT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    endif()
+  endif()
+
   # We cannot rely on find_package(Boost ...) to work properly without
   # Boost_NO_BOOST_CMAKE set until we require a more recent Boost because
   # upstream did not ship proper CMake files until 1.82.0.


### PR DESCRIPTION
On macOS, this PR ensures that the Boost package is located at its real path rather than via the symlink in the default prefix.

A backport to 29.x is required for https://github.com/bitcoin/bitcoin/pull/32804, as this change prevents contamination of include directories by broad locations such as `/usr/local/include` or `/opt/homebrew/include`, which take precedence over Qt’s `-iframework` flags.

Below is the relevant change in the configuration logs on my macOS 15.5 `x64`:
- master branch @ ead44687483e9c936ba970de890c01d5e7ad3485:
```
% cmake -B build
<snip>
-- Found Boost: /usr/local/include (found suitable version "1.88.0", minimum required is "1.73.0")
<snip>
```
- this PR:
```
% cmake -B build
<snip>
-- Found Boost: /usr/local/opt/boost/include (found suitable version "1.88.0", minimum required is "1.73.0")
<snip>
```

This PR is forward-compatible with the changes proposed in https://github.com/bitcoin/bitcoin/pull/32667.