### PR TITLE
Add read-only mode to sqlite db and use in `bitcoin-wallet`

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -178,6 +178,7 @@ struct DatabaseOptions {
     bool use_unsafe_sync = false;   //!< Disable file sync for faster performance.
     bool use_shared_memory = false; //!< Let other processes access the database.
     int64_t max_log_mb = 100;       //!< Max log size to allow before consolidating.
+    bool read_only = false;         //!< Open database in read-only mode.
 };
 
 enum class DatabaseStatus {

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -112,7 +112,7 @@ Mutex SQLiteDatabase::g_sqlite_mutex;
 int SQLiteDatabase::g_sqlite_count = 0;
 
 SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_path, const DatabaseOptions& options, bool mock)
-    : WalletDatabase(), m_mock(mock), m_dir_path(fs::PathToString(dir_path)), m_file_path(fs::PathToString(file_path)), m_write_semaphore(1), m_use_unsafe_sync(options.use_unsafe_sync)
+    : WalletDatabase(), m_mock(mock), m_read_only(options.read_only), m_dir_path(fs::PathToString(dir_path)), m_file_path(fs::PathToString(file_path)), m_write_semaphore(1), m_use_unsafe_sync(options.use_unsafe_sync)
 {
     {
         LOCK(g_sqlite_mutex);

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -103,6 +103,7 @@ class SQLiteDatabase : public WalletDatabase
 {
 private:
     const bool m_mock{false};
+    const bool m_read_only{false};
 
     const std::string m_dir_path;
 
@@ -154,6 +155,9 @@ public:
 
     /** Return true if there is an on-going txn in this connection */
     bool HasActiveTxn();
+
+    /** Return true if database is opened in read-only mode */
+    bool IsReadOnly() const { return m_read_only; }
 
     sqlite3* m_db{nullptr};
     bool m_use_unsafe_sync;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -135,6 +135,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         DatabaseOptions options;
         ReadDatabaseArgs(args, options);
         options.require_existing = true;
+        options.read_only = true;
         const std::shared_ptr<CWallet> wallet_instance = MakeWallet(name, path, options);
         if (!wallet_instance) return false;
         WalletShowInfo(wallet_instance.get());
@@ -143,6 +144,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         DatabaseOptions options;
         ReadDatabaseArgs(args, options);
         options.require_existing = true;
+        options.read_only = true;
         DatabaseStatus status;
 
         if (IsBDBFile(BDBDataFile(path))) {

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -136,12 +136,6 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
         self.assert_raises_tool_error('No method provided. Run `bitcoin-wallet -help` for valid methods.')
         self.assert_raises_tool_error('Wallet name must be provided when creating a new wallet.', 'create')
-        error = f"SQLiteDatabase: Unable to obtain an exclusive lock on the database, is it being used by another instance of {self.config['environment']['CLIENT_NAME']}?"
-        self.assert_raises_tool_error(
-            error,
-            '-wallet=' + self.default_wallet_name,
-            'info',
-        )
         path = self.nodes[0].wallets_path / "nonexistent.dat"
         self.assert_raises_tool_error("Failed to load database path '{}'. Path does not exist.".format(path), '-wallet=nonexistent.dat', 'info')
 


### PR DESCRIPTION
Currently our `wallet-tool` performs a few "read-only" operations (`info`, `dump`) on sqlite databases. However, currently this involves opening the wallet in RW mode, with the side-effects of modifying the wallet file, and failing to open a "read-only" wallet file.

See #15608 for more context.

Since we have dropped the BDB wallet, this change got a lot simpler; the BDB parser is now custom and only operates in read-only mode anyway.

This change adds a `read_only` bool to `DatabaseOptions`. This can be used by the sqlite dbwrapper to open the database in readonly mode.

Includes tests to verify indempotence of wallet tool "read only" operations.

Fixes: #15608