### PR TITLE
p2p: add more bad ports

### DIFF
--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -87,10 +87,14 @@ incoming connections.
     1720:  h323hostcall
     1723:  pptp
     2049:  nfs
+    3306:  MySQL
+    3389:  RDP / Windows Remote Desktop
     3659:  apple-sasl / PasswordServer
     4045:  lockd
     5060:  sip
     5061:  sips
+    5432:  PostgreSQL
+    5900:  VNC
     6000:  X11
     6566:  sane-port
     6665:  Alternate IRC
@@ -100,6 +104,7 @@ incoming connections.
     6669:  Alternate IRC
     6697:  IRC + TLS
     10080: Amanda
+    27017: MongoDB
 
 For further information see:
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -921,10 +921,14 @@ bool IsBadPort(uint16_t port)
     case 1720:  // h323hostcall
     case 1723:  // pptp
     case 2049:  // nfs
+    case 3306:  // MySQL
+    case 3389:  // RDP / Windows Remote Desktop
     case 3659:  // apple-sasl / PasswordServer
     case 4045:  // lockd
     case 5060:  // sip
     case 5061:  // sips
+    case 5432:  // PostgreSQL
+    case 5900:  // VNC
     case 6000:  // X11
     case 6566:  // sane-port
     case 6665:  // Alternate IRC
@@ -934,6 +938,7 @@ bool IsBadPort(uint16_t port)
     case 6669:  // Alternate IRC
     case 6697:  // IRC + TLS
     case 10080: // Amanda
+    case 27017: // MongoDB
         return true;
     }
     return false;

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -14,6 +14,7 @@
 #include <util/translation.h>
 
 #include <string>
+#include <numeric>
 
 #include <boost/test/unit_test.hpp>
 
@@ -603,14 +604,10 @@ BOOST_AUTO_TEST_CASE(isbadport)
     BOOST_CHECK(!IsBadPort(443));
     BOOST_CHECK(!IsBadPort(8333));
 
-    // Check all ports, there must be 80 bad ports in total.
-    size_t total_bad_ports{0};
-    for (uint16_t port = std::numeric_limits<uint16_t>::max(); port > 0; --port) {
-        if (IsBadPort(port)) {
-            ++total_bad_ports;
-        }
-    }
-    BOOST_CHECK_EQUAL(total_bad_ports, 80);
+    // Check all possible ports and ensure we only flag the expected amount as bad
+    std::list<int> ports(std::numeric_limits<uint16_t>::max());
+    std::iota(ports.begin(), ports.end(), 1);
+    BOOST_CHECK_EQUAL(std::ranges::count_if(ports, IsBadPort), 85);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a few more ports used by extremely well adopted services that require authentication and really ought not be used by bitcoin nodes for p2p traffic.