### PR TITLE
mempool: Avoid needless vtx iteration during IBD

### DIFF
--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -567,6 +567,8 @@ bool TxOrphanageImpl::HaveTxToReconsider(NodeId peer)
 }
 void TxOrphanageImpl::EraseForBlock(const CBlock& block)
 {
+    if (m_orphans.empty()) return;
+
     std::set<Wtxid> wtxids_to_erase;
     for (const CTransactionRef& ptx : block.vtx) {
         const CTransaction& block_tx = *ptx;


### PR DESCRIPTION
During Initial Block Download, the mempool is usually empty, but `CTxMemPool::removeForBlock` is still called for every connected block where we:
* iterate over every transaction in the block even though none will be found in the empty `mapTx`, always leaving `txs_removed_for_block` empty...
* which is pre-allocated regardless with `40 bytes * vtx.size()`, even though it will always remain empty.

Similarly to https://github.com/bitcoin/bitcoin/pull/32730#discussion_r2140691354, this change introduces a minor performance & memory optimization by only executing the loop if any of the affected mempool maps have any contents. The second commit is cherry-picked from there since it's related to this change as well.
