### PR TITLE
build, docs: Fix Boost-related issues on NetBSD

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -31,6 +31,15 @@ function(add_boost_if_needed)
 
   find_package(Boost 1.73.0 REQUIRED CONFIG)
   mark_as_advanced(Boost_INCLUDE_DIR boost_headers_DIR)
+  # Workaround for a bug in NetBSD pkgsrc.
+  # See: https://github.com/NetBSD/pkgsrc/issues/167.
+  if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+    get_filename_component(_boost_include_dir "${boost_headers_DIR}/../../../include/" ABSOLUTE)
+    set_target_properties(Boost::headers PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${_boost_include_dir}
+    )
+    unset(_boost_include_dir)
+  endif()
   set_target_properties(Boost::headers PROPERTIES IMPORTED_GLOBAL TRUE)
   target_compile_definitions(Boost::headers INTERFACE
     # We don't use multi_index serialization.

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -12,7 +12,7 @@ Install the required dependencies the usual way you [install software on NetBSD]
 The example commands below use `pkgin`.
 
 ```bash
-pkgin install git cmake pkg-config boost-headers libevent
+pkgin install git cmake pkg-config boost libevent
 ```
 
 NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the configure script.


### PR DESCRIPTION
The recently merged https://github.com/bitcoin/bitcoin/pull/32667 broke builds on NetBSD due to the following issues:

1. The `boost-headers` package does not provide CMake configuration files now required since https://github.com/bitcoin/bitcoin/pull/32667.

   The first commit updates the Build Guide to recommend using the `boost` package instead.

2. The CMake configuration file provided by the `boost` package is [broken](https://github.com/NetBSD/pkgsrc/issues/167).

   The second commit adds a workaround for this issue.

Upstream issues:
- https://github.com/NetBSD/pkgsrc/issues/167
- https://github.com/NetBSD/pkgsrc/issues/168

Successful CI job: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/15958818914/job/45008576879.