### PR TITLE
test: Add `msgtype` to `msg_generic` slots

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1377,7 +1377,7 @@ class msg_block:
 # for cases where a user needs tighter control over what is sent over the wire
 # note that the user must supply the name of the msgtype, and the data
 class msg_generic:
-    __slots__ = ("data")
+    __slots__ = ("msgtype", "data")
 
     def __init__(self, msgtype, data=None):
         self.msgtype = msgtype


### PR DESCRIPTION
`msg_generic` can't be used unless `msgtype` is listed in `__slots__`

Example from a [custom test](https://github.com/dergoegge/bitcoin/blob/6329ce979f63b396aa036a1ad39798bb83fa4ade/test/functional/p2p_bug28676.py):

```
2025-06-30T10:14:55.418000Z TestFramework (INFO): PRNG seed is: 3137163719543762151
2025-06-30T10:14:55.418000Z TestFramework (INFO): Initializing test directory /tmp/nix-shell-110135-0/bitcoin_func_test_7lmiemmp
2025-06-30T10:14:55.675000Z TestFramework (INFO): Setting up connections & mining some blocks...
2025-06-30T10:14:56.511000Z TestFramework (ERROR): Unexpected exception caught during testing
Traceback (most recent call last):
  File "/home/dergoegge/workspace/bitcoin/worktrees/master/test/functional/test_framework/test_framework.py", line 189, in main
    self.run_test()
  File "/home/dergoegge/workspace/bitcoin/worktrees/master/./build/test/functional/p2p_bug28676.py", line 46, in run_test
    self.connections[0].send_without_ping(msg_generic(b"block", bytes.fromhex("0500000006226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f06b816712ffab8c59299a6abb58ccefa1995a1368ca4348782ef268cbc9bacacdbe5494dffff7f200200000001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff075105ffffffff00ffffffff0200f90295000000002200204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc332600000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")))
  File "/home/dergoegge/workspace/bitcoin/worktrees/master/test/functional/test_framework/messages.py", line 1386, in __init__
    self.msgtype = msgtype
AttributeError: 'msg_generic' object has no attribute 'msgtype'
```