### PR TITLE
test: Use msg_generic in p2p_ping.py

### DIFF
--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -7,7 +7,10 @@
 
 import time
 
-from test_framework.messages import msg_pong
+from test_framework.messages import (
+    msg_pong,
+    msg_generic,
+)
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -18,11 +21,6 @@ from test_framework.util import (
 
 PING_INTERVAL = 2 * 60
 TIMEOUT_INTERVAL = 20 * 60
-
-
-class msg_pong_corrupt(msg_pong):
-    def serialize(self):
-        return b""
 
 
 class NodeNoPong(P2PInterface):
@@ -60,7 +58,7 @@ class PingPongTest(BitcoinTestFramework):
 
         self.log.info('Reply without nonce cancels ping')
         with self.nodes[0].assert_debug_log(['pong peer=0: Short payload']):
-            no_pong_node.send_and_ping(msg_pong_corrupt())
+            no_pong_node.send_and_ping(msg_generic(b"pong", b""))
         self.check_peer_info(pingtime=None, minping=None, pingwait=None)
 
         self.log.info('Reply without ping')

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1374,8 +1374,8 @@ class msg_block:
         return "msg_block(block=%s)" % (repr(self.block))
 
 
-# for cases where a user needs tighter control over what is sent over the wire
-# note that the user must supply the name of the msgtype, and the data
+# Generic type to control the raw bytes sent over the wire.
+# The msgtype and the data must be provided.
 class msg_generic:
     __slots__ = ("msgtype", "data")
 


### PR DESCRIPTION
It seems odd to derive `msg_pong_corrupt` from `msg_pong`, but then overwrite the serialize method, when one can just directly use `msg_generic` to pass the raw bytes to send over the wire.

Fix that by using `msg_generic`. This also serves as a regression test against the fix in commit 33480573cbd8d03aefbde100e51f827a2f7de7f7.

(Can be tested by reverting that commit to observe a failure)