### PR TITLE
test: fix feature_init.py intermittencies

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -54,11 +54,13 @@ class InitTest(BitcoinTestFramework):
                 match=ErrorMatch.PARTIAL_REGEX,
             )
 
-        def check_clean_start():
+        def check_clean_start(extra_args):
             """Ensure that node restarts successfully after various interrupts."""
-            node.start()
+            node.start(extra_args)
             node.wait_for_rpc_connection()
-            assert_equal(200, node.getblockcount())
+            height = node.getblockcount()
+            assert_equal(200, height)
+            self.wait_until(lambda: all(i["synced"] and i["best_block_height"] == height for i in node.getindexinfo().values()))
 
         lines_to_terminate_after = [
             b'Validating signatures for all blocks',
@@ -97,7 +99,9 @@ class InitTest(BitcoinTestFramework):
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()
 
-        check_clean_start()
+        # Prior to deleting/perturbing index files, start node with all indexes enabled.
+        # 'check_clean_start' will ensure indexes are synchronized (i.e., data exists to modify)
+        check_clean_start(args)
         self.stop_node(0)
 
         self.log.info("Test startup errors after removing certain essential files")
@@ -186,7 +190,7 @@ class InitTest(BitcoinTestFramework):
                 self.log.debug(f"Restoring file from {bak_path} and restarting")
                 Path(bak_path).rename(target_file)
 
-            check_clean_start()
+            check_clean_start(args)
             self.stop_node(0)
 
         self.log.info("Test startup errors after perturbing certain essential files")


### PR DESCRIPTION
Aims to solve #32600. Found it while working on #26966 (this was really annoying there).

This ensures the node is index-synced before perturbing files.
If the index sync gets interrupted before it starts, the database could be empty,
making any following perturbation ineffective (which explains why the node
does not abort during startup in the #32600 logs).

Also, the first commit avoids initializing components not under test.
This reduces log flooding, which helped in understanding the issue.

Patch to reproduce the issue on master using `feature_init.py` (this simulates
a node shutting down before the index starts syncing):
```
diff --git a/src/index/base.cpp b/src/index/base.cpp
--- a/src/index/base.cpp	(revision 1e03052c3fefb188f047e72548f2c6b0cc019e50)
+++ b/src/index/base.cpp	(date 1751293306725)
@@ -185,6 +185,7 @@
 void BaseIndex::Sync()
 {
     const CBlockIndex* pindex = m_best_block_index.load();
+    m_interrupt();
     if (!m_synced) {
         std::chrono::steady_clock::time_point last_log_time{0s};
         std::chrono::steady_clock::time_point last_locator_write_time{0s};
```
