### PR TITLE
depends: fix libevent `_WIN32_WINNT` usage

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -5,6 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 $(package)_patches=cmake_fixups.patch
 $(package)_patches += netbsd_fixup.patch
+$(package)_patches += winver_fixup.patch
 $(package)_build_subdir=build
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
@@ -21,7 +22,8 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch && \
-  patch -p1 < $($(package)_patch_dir)/netbsd_fixup.patch
+  patch -p1 < $($(package)_patch_dir)/netbsd_fixup.patch && \
+  patch -p1 < $($(package)_patch_dir)/winver_fixup.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/winver_fixup.patch
+++ b/depends/patches/libevent/winver_fixup.patch
@@ -1,0 +1,122 @@
+Cherry-picked from a14ff91254f40cf36e0fee199e26fb11260fab49.
+
+move _WIN32_WINNT defintions before first #include
+
+_WIN32_WINNT and WIN32_LEAN_AND_MEAN need to be defined
+before the windows.h is included for the first time.
+Avoid the confusion of indirect #include by defining
+before any.
+
+diff --git a/event_iocp.c b/event_iocp.c
+index 6b2a2e15..4955e426 100644
+--- a/event_iocp.c
++++ b/event_iocp.c
+@@ -23,12 +23,14 @@
+  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+-#include "evconfig-private.h"
+ 
+ #ifndef _WIN32_WINNT
+ /* Minimum required for InitializeCriticalSectionAndSpinCount */
+ #define _WIN32_WINNT 0x0403
+ #endif
++
++#include "evconfig-private.h"
++
+ #include <winsock2.h>
+ #include <windows.h>
+ #include <process.h>
+diff --git a/evthread_win32.c b/evthread_win32.c
+index 2ec80560..8647f72b 100644
+--- a/evthread_win32.c
++++ b/evthread_win32.c
+@@ -23,18 +23,21 @@
+  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+-#include "event2/event-config.h"
+-#include "evconfig-private.h"
+ 
+ #ifdef _WIN32
+ #ifndef _WIN32_WINNT
+ /* Minimum required for InitializeCriticalSectionAndSpinCount */
+ #define _WIN32_WINNT 0x0403
+ #endif
+-#include <winsock2.h>
+ #define WIN32_LEAN_AND_MEAN
++#endif
++
++#include "event2/event-config.h"
++#include "evconfig-private.h"
++
++#ifdef _WIN32
++#include <winsock2.h>
+ #include <windows.h>
+-#undef WIN32_LEAN_AND_MEAN
+ #include <sys/locking.h>
+ #endif
+ 
+diff --git a/evutil.c b/evutil.c
+index 9817f086..8537ffe8 100644
+--- a/evutil.c
++++ b/evutil.c
+@@ -24,6 +24,14 @@
+  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
++#ifdef _WIN32
++#ifndef _WIN32_WINNT
++/* For structs needed by GetAdaptersAddresses */
++#define _WIN32_WINNT 0x0501
++#endif
++#define WIN32_LEAN_AND_MEAN
++#endif
++
+ #include "event2/event-config.h"
+ #include "evconfig-private.h"
+ 
+@@ -31,15 +39,10 @@
+ #include <winsock2.h>
+ #include <winerror.h>
+ #include <ws2tcpip.h>
+-#define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+-#undef WIN32_LEAN_AND_MEAN
+ #include <io.h>
+ #include <tchar.h>
+ #include <process.h>
+-#undef _WIN32_WINNT
+-/* For structs needed by GetAdaptersAddresses */
+-#define _WIN32_WINNT 0x0501
+ #include <iphlpapi.h>
+ #include <netioapi.h>
+ #endif
+diff --git a/listener.c b/listener.c
+index f5c00c9c..d1080e76 100644
+--- a/listener.c
++++ b/listener.c
+@@ -24,16 +24,19 @@
+  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
++#ifdef _WIN32
++#ifndef _WIN32_WINNT
++/* Minimum required for InitializeCriticalSectionAndSpinCount */
++#define _WIN32_WINNT 0x0403
++#endif
++#endif
++
+ #include "event2/event-config.h"
+ #include "evconfig-private.h"
+ 
+ #include <sys/types.h>
+ 
+ #ifdef _WIN32
+-#ifndef _WIN32_WINNT
+-/* Minimum required for InitializeCriticalSectionAndSpinCount */
+-#define _WIN32_WINNT 0x0403
+-#endif
+ #include <winsock2.h>
+ #include <winerror.h>
+ #include <ws2tcpip.h>


### PR DESCRIPTION
Starting with version 13.x, the mingw headers will define the value of
`NTDDI_VERSION`, based on the value of `_WIN32_WINNT`, if that version is <
Windows 10. Given that libevent was undefining our `_WIN32_WINNT`, and
redefining it to a value < Windows 10 (`0x0501`), `NTDDI_VERSION` was also
being defined to that value, leading to functions not being exposed in
the mingw-w64 headers; see here: https://github.com/mingw-w64/mingw-w64/blob/9c2668ef77e75ea4d8a6c7d100b14643269caec3/mingw-w64-headers/include/iphlpapi.h#L36-L41.

Imports a commit from usptream ([a14ff91254f40cf36e0fee199e26fb11260fab49](https://github.com/libevent/libevent/commit/a14ff91254f40cf36e0fee199e26fb11260fab49)).

Fixes #32707.