### PR TITLE
doc: invalid block handling followups

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -615,11 +615,13 @@ public:
     const CBlockIndex* SnapshotBase() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
-     * The set of all CBlockIndex entries that have as much work as our current
-     * tip or more, and transaction data needed to be validated (with
+     * The set of all CBlockIndex entries that score at least as well as the
+     * tip under CBlockIndexWorkComparator (more work or same work with a tiebreak
+     * at least as good) and have transaction data that can be validated (with
      * BLOCK_VALID_TRANSACTIONS for each block and its parents back to the
-     * genesis block or an assumeutxo snapshot block). Entries may be failed,
-     * though, and pruning nodes may be missing the data for the block.
+     * genesis block or an assumeutxo snapshot block).
+     * The tip is always a member of setBlockIndexCandidates.
+     * Entries may be failed though, and pruning nodes may be missing the data for the block.
      */
     std::set<CBlockIndex*, node::CBlockIndexWorkComparator> setBlockIndexCandidates;
 


### PR DESCRIPTION
Some follow-ups from #31405:

- make it clearer that all block indexes with a `CBlockIndexWorkComparator` score at least as good as the tip (and no others) are expected in `setBlockIndexCandidates`.
People think of `nChainWork` when the term `work` is used and not of the (slightly arbitrary) `CBlockIndexWorkComparator` tiebreaker rules, which makes the current documentation imprecise  ( https://github.com/bitcoin/bitcoin/pull/31405#discussion_r2075937910 )
- add a comment that `nChainWork`, not `CBlockIndexWorkComparator` is used for `m_best_header` (https://github.com/bitcoin/bitcoin/pull/31405#discussion_r2138368441)