### PR TITLE
doc: clarify that the "-j N" goes after the "--build build" part

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -95,6 +95,6 @@ cmake -B build -DENABLE_WALLET=OFF
 ### 2. Compile
 
 ```bash
-cmake --build build     # Use "-j N" for N parallel jobs.
-ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build     # Append "-j N" for N parallel jobs.
+ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -110,6 +110,6 @@ Run `cmake -B build -LH` to see the full list of available options.
 Build and run the tests:
 
 ```bash
-cmake --build build     # Use "-j N" for N parallel jobs.
-ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build     # Append "-j N" for N parallel jobs.
+ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -89,8 +89,8 @@ Run `cmake -B build -LH` to see the full list of available options.
 ### 2. Compile
 
 ```bash
-cmake --build build     # Use "-j N" for N parallel jobs.
-ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build     # Append "-j N" for N parallel jobs.
+ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ## Resource limits

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -182,8 +182,8 @@ After configuration, you are ready to compile.
 Run the following in your terminal to compile Bitcoin Core:
 
 ``` bash
-cmake --build build     # Use "-j N" here for N parallel jobs.
-ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build     # Append "-j N" here for N parallel jobs.
+ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ### 3. Deploy (optional)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,8 +9,8 @@ To Build
 
 ```bash
 cmake -B build
-cmake --build build    # use "-j N" for N parallel jobs
-cmake --install build  # optional
+cmake --build build    # Append "-j N" for N parallel jobs
+cmake --install build  # Optional
 ```
 
 See below for instructions on how to [install the dependencies on popular Linux

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -54,8 +54,8 @@ In the following instructions, the "Debug" configuration can be specified instea
 
 ```
 cmake -B build --preset vs2022-static          # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
-cmake --build build --config Release           # Use "-j N" for N parallel jobs.
-ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build --config Release           # Append "-j N" for N parallel jobs.
+ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 cmake --install build --config Release         # Optional.
 ```
 
@@ -74,8 +74,8 @@ cmake -B build --preset vs2022-static -DVCPKG_INSTALL_OPTIONS="--x-buildtrees-ro
 
 ```
 cmake -B build --preset vs2022 -DBUILD_GUI=OFF # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
-cmake --build build --config Release           # Use "-j N" for N parallel jobs.
-ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --build build --config Release           # Append "-j N" for N parallel jobs.
+ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ## Performance Notes

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -47,9 +47,9 @@ This means you cannot use a directory that is located directly on the host Windo
 
 Build using:
 
-    gmake -C depends HOST=x86_64-w64-mingw32  # Use "-j N" for N parallel jobs.
+    gmake -C depends HOST=x86_64-w64-mingw32  # Append "-j N" for N parallel jobs.
     cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
-    cmake --build build     # Use "-j N" for N parallel jobs.
+    cmake --build build     # Append "-j N" for N parallel jobs.
 
 ## Depends system
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -532,7 +532,7 @@ cmake -B build -DCMAKE_C_COMPILER="clang" \
    -DAPPEND_CFLAGS="-fprofile-instr-generate -fcoverage-mapping" \
    -DAPPEND_CXXFLAGS="-fprofile-instr-generate -fcoverage-mapping" \
    -DAPPEND_LDFLAGS="-fprofile-instr-generate -fcoverage-mapping"
-cmake --build build # Use "-j N" here for N parallel jobs.
+cmake --build build # Append "-j N" here for N parallel jobs.
 ```
 
 Generating the raw profile data based on `ctest` and functional tests execution:
@@ -542,8 +542,8 @@ Generating the raw profile data based on `ctest` and functional tests execution:
 mkdir -p build/raw_profile_data
 
 # Run tests to generate profiles
-LLVM_PROFILE_FILE="$(pwd)/build/raw_profile_data/%m_%p.profraw" ctest --test-dir build # Use "-j N" here for N parallel jobs.
-LLVM_PROFILE_FILE="$(pwd)/build/raw_profile_data/%m_%p.profraw" build/test/functional/test_runner.py # Use "-j N" here for N parallel jobs
+LLVM_PROFILE_FILE="$(pwd)/build/raw_profile_data/%m_%p.profraw" ctest --test-dir build # Append "-j N" here for N parallel jobs.
+LLVM_PROFILE_FILE="$(pwd)/build/raw_profile_data/%m_%p.profraw" build/test/functional/test_runner.py # Append "-j N" here for N parallel jobs
 
 # Merge all the raw profile data into a single file
 find build/raw_profile_data -name "*.profraw" | xargs llvm-profdata merge -o build/coverage.profdata
@@ -583,7 +583,7 @@ cmake -B build \
    -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
    -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
    -DBUILD_FOR_FUZZING=ON
-cmake --build build # Use "-j N" here for N parallel jobs.
+cmake --build build # Append "-j N" here for N parallel jobs.
 ```
 
 Running fuzz tests with one or more targets


### PR DESCRIPTION
I was surprised that something like `cmake -j 4 --build build` doesn't work, so this might help others to not make the same mistake.