### PR TITLE
functional test: correctly detect nonstd TRUC tx vsize in feature_taproot

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -644,6 +644,7 @@ MIN_FEE = 50000
 
 TX_MAX_STANDARD_VERSION = 3
 TX_STANDARD_VERSIONS = [1, 2, TX_MAX_STANDARD_VERSION]
+TRUC_MAX_VSIZE = 10000 # test doesn't cover in-mempool spends, so only this limit is hit
 
 # === Actual test cases ===
 
@@ -1538,7 +1539,9 @@ class TaprootTest(BitcoinTestFramework):
                 is_standard_tx = (
                     fail_input is None  # Must be valid to be standard
                     and (all(utxo.spender.is_standard for utxo in input_utxos))  # All inputs must be standard
-                    and tx.version in TX_STANDARD_VERSIONS)  # The tx version must be standard
+                    and tx.version in TX_STANDARD_VERSIONS # The tx version must be standard
+                    and not (tx.version == 3 and tx.get_vsize() > TRUC_MAX_VSIZE)  # Topological standardness rules must be followed
+                )
                 msg = ','.join(utxo.spender.comment + ("*" if n == fail_input else "") for n, utxo in enumerate(input_utxos))
                 if is_standard_tx:
                     node.sendrawtransaction(tx.serialize().hex(), 0)


### PR DESCRIPTION
Resolves https://github.com/bitcoin/bitcoin/pull/32841#discussion_r2180240391