### PR TITLE
Have createwalletdescriptor auto-detect an unused(KEY)

### DIFF
--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -1380,7 +1380,7 @@ void CheckUnused(const std::string& prv, const std::string& pub)
     // Check both only have one pubkey
     std::set<CPubKey> prv_pubkeys;
     std::set<CExtPubKey> prv_extpubs;
-    parse_pub->GetPubKeys(prv_pubkeys, prv_extpubs);
+    parse_priv->GetPubKeys(prv_pubkeys, prv_extpubs);
     BOOST_CHECK_EQUAL(prv_pubkeys.size() + prv_extpubs.size(), 1);
     std::set<CPubKey> pub_pubkeys;
     std::set<CExtPubKey> pub_extpubs;

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -800,11 +800,37 @@ static RPCMethod createwalletdescriptor()
 
             CExtPubKey xpub;
             if (hdkey.isNull()) {
+                // First consider the HD key from active descriptors
                 std::set<CExtPubKey> active_xpubs = pwallet->GetActiveHDPubKeys();
-                if (active_xpubs.size() != 1) {
+                if (active_xpubs.size() == 1) {
+                    xpub = *active_xpubs.begin();
+                } else if (active_xpubs.size() > 1) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'");
+                } else {
+                    // Look for an unused(KEY) descriptor
+                    std::set<DescriptorScriptPubKeyMan*> spkms{pwallet->GetScriptlessSPKMs()};
+
+                    std::vector<CExtPubKey> wallet_xpubs;
+                    for (auto* spkm : spkms) {
+                        // Retrieve the pubkeys from the descriptor
+                        LOCK(spkm->cs_desc_man);
+                        std::set<CPubKey> pubkeys;
+                        std::set<CExtPubKey> extpubs;
+                        spkm->GetWalletDescriptor().descriptor->GetPubKeys(pubkeys, extpubs);
+
+                        for (const CExtPubKey& xpub : extpubs) {
+                            wallet_xpubs.emplace_back(xpub);
+                        }
+                    }
+
+                    if (wallet_xpubs.empty()) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No HD key found. Please generate one with 'addhdkey' or import an active descriptor.");
+                    } else if (wallet_xpubs.size() > 1) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to determine which HD key to use. Please specify with 'hdkey'");
+                    }
+
+                    xpub = wallet_xpubs[0];
                 }
-                xpub = *active_xpubs.begin();
             } else {
                 xpub = DecodeExtPubKey(hdkey.get_str());
                 if (!xpub.pubkey.IsValid()) {

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -892,6 +892,10 @@ RPCMethod addhdkey()
             }
 
             LOCK(wallet->cs_wallet);
+            if (wallet->GetKey(hdkey.Neuter().pubkey.GetID())) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "HD key already exists");
+            }
+
             std::string desc_str = "unused(" + EncodeExtKey(hdkey) + ")";
             FlatSigningProvider keys;
             std::string error;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3588,6 +3588,20 @@ void CWallet::ConnectScriptPubKeyManNotifiers()
     }
 }
 
+std::set<DescriptorScriptPubKeyMan*> CWallet::GetScriptlessSPKMs() const
+{
+    std::set<DescriptorScriptPubKeyMan*> spk_mans;
+    for (const auto& spkm : GetAllScriptPubKeyMans()) {
+        DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
+        if (!desc_spkm) continue;
+        LOCK(desc_spkm->cs_desc_man);
+        if (!desc_spkm->GetWalletDescriptor().descriptor->HasScripts()) {
+            spk_mans.insert(desc_spkm);
+        }
+    }
+    return spk_mans;
+}
+
 void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc, const KeyMap& keys, const CryptedKeyMap& ckeys)
 {
     std::unique_ptr<DescriptorScriptPubKeyMan> spk_manager;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -961,6 +961,9 @@ public:
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;
     bool IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const;
 
+    //! Returns all unused(key) SPKMs
+    std::set<DescriptorScriptPubKeyMan*> GetScriptlessSPKMs() const;
+
     //! Returns all unique ScriptPubKeyMans
     std::set<ScriptPubKeyMan*> GetAllScriptPubKeyMans() const;
 

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -34,6 +34,8 @@ class WalletHDTest(BitcoinTestFramework):
         wallet = self.nodes[0].get_wallet_rpc("hdkey")
 
         assert_equal(len(wallet.gethdkeys()), 1)
+        existing_wallet_xprv = wallet.gethdkeys(private=True)[0]["xprv"]
+        assert_raises_rpc_error(-4, "HD key already exists", wallet.addhdkey, existing_wallet_xprv)
 
         wallet.addhdkey()
         xpub_info = wallet.gethdkeys()


### PR DESCRIPTION
The `createwalletdescriptor` was introduced in #29130 to let users add a `tr()` descriptor to an existing SegWit wallet. The new `addhdkey` method from #29136 introduces a new potential workflow: start from a blank wallet, generate an HD and then add only the descriptors you need, e.g.:

```sh
bitcoin rpc createwallet TaprootMaxi blank=true
bitcoin rpc addhdkey
bitcoin rpc createwalletdescriptor bech32m
```

Before this PR the last line would fail, requiring the user to call `gethdkeys` and copy-paste the xpub.

This PR makes `createwalletdescriptor` a bit smarter so it just finds the `unused(KEY)` generated by `hdkey` and uses that.

If multiple `unused(KEY)` descriptors are present the user still has to pick one.

A potential followup is to make our [multisig tutorial](https://github.com/bitcoin/bitcoin/blob/master/doc/multisig-tutorial.md) slightly safer to use. Rather than creating a full wallet, the instruction could be changed to start with a blank wallet and only generate the default legacy descriptor. This avoids accidental use of single sig `p2sh-segwit` and `bech32` addresses.

--

The first two commits are quick followups for #29136.