### PR TITLE
fix typos and improve clarity in documentation

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,7 +71,7 @@ It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin
 
 `sqlite` is required to support for descriptor wallets.
 
-macOS ships with a useable `sqlite` package, meaning you don't need to
+macOS ships with a usable `sqlite` package, meaning you don't need to
 install anything.
 
 ---

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -59,7 +59,7 @@ outgoing connections, but more is possible.
         service provider.
         ------------------------------------------------------------------------
 
-If -proxy or -onion is specified multiple times, later occurences override
+If -proxy or -onion is specified multiple times, later occurrences override
 earlier ones and command line overrides the config file. UNIX domain sockets may
 be used for proxy connections. Set `-onion` or `-proxy` to the local socket path
 with the prefix `unix:` (e.g. `-onion=unix:/home/me/torsocket`).

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -368,7 +368,7 @@ serialization of data structures is probably fine, a `sleep(10s)` not.
 TRACEPOINT_SEMAPHORE(example, gated_expensive_argument);
 …
 if (TRACEPOINT_ACTIVE(example, gated_expensive_argument)) {
-    expensive_argument = expensive_calulation();
+    expensive_argument = expensive_calculation();
     TRACEPOINT(example, gated_expensive_argument, expensive_argument);
 }
 ```


### PR DESCRIPTION


---


**Description:**  
This pull request corrects minor typos and improves clarity in the following documentation files:
- build-osx.md: Fixes `useable` to `usable`
- tor.md: Fixes `occurences` to `occurrences`
- tracing.md: Fixes `calulation` to `calculation`


---