### PR TITLE
cmake: Use `AUTHOR_WARNING` for warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,10 +185,8 @@ string(APPEND CMAKE_CXX_COMPILE_OBJECT " ${APPEND_CPPFLAGS} ${APPEND_CXXFLAGS}")
 string(APPEND CMAKE_CXX_CREATE_SHARED_LIBRARY " ${APPEND_LDFLAGS}")
 string(APPEND CMAKE_CXX_LINK_EXECUTABLE " ${APPEND_LDFLAGS}")
 
-set(configure_warnings)
-
 include(CheckLinkerSupportsPIE)
-check_linker_supports_pie(configure_warnings)
+check_linker_supports_pie()
 
 # The core_interface library aims to encapsulate common build flags.
 # It is a usage requirement for all targets except for secp256k1, which
@@ -591,9 +589,7 @@ set(Python3_FIND_UNVERSIONED_NAMES FIRST CACHE STRING "")
 mark_as_advanced(Python3_FIND_FRAMEWORK Python3_FIND_UNVERSIONED_NAMES)
 find_package(Python3 3.10 COMPONENTS Interpreter)
 if(NOT TARGET Python3::Interpreter)
-  list(APPEND configure_warnings
-    "Minimum required Python not found."
-  )
+  message(AUTHOR_WARNING "Minimum required Python not found.")
 endif()
 
 target_compile_definitions(core_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS})
@@ -702,13 +698,6 @@ flags_summary()
 message("Treat compiler warnings as errors ..... ${WERROR}")
 message("Use ccache for compiling .............. ${WITH_CCACHE}")
 message("\n")
-if(configure_warnings)
-    message("  ******\n")
-    foreach(warning IN LISTS configure_warnings)
-      message(WARNING "${warning}")
-    endforeach()
-    message("  ******\n")
-endif()
 
 # We want all build properties to be encapsulated properly.
 include(WarnAboutGlobalProperties)

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -12,9 +12,7 @@ if(NOT MSVC)
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     if(CCACHE_EXECUTABLE STREQUAL compiler_resolved_link AND NOT WITH_CCACHE)
-      list(APPEND configure_warnings
-        "Disabling ccache was attempted using -DWITH_CCACHE=${WITH_CCACHE}, but ccache masquerades as the compiler."
-      )
+      message(AUTHOR_WARNING "Disabling ccache was attempted using -DWITH_CCACHE=${WITH_CCACHE}, but ccache masquerades as the compiler.")
       set(WITH_CCACHE ON)
     elseif(WITH_CCACHE)
       list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})

--- a/cmake/module/CheckLinkerSupportsPIE.cmake
+++ b/cmake/module/CheckLinkerSupportsPIE.cmake
@@ -4,7 +4,7 @@
 
 include_guard(GLOBAL)
 
-function(check_linker_supports_pie warnings)
+function(check_linker_supports_pie)
   # Workaround for a bug in the check_pie_supported() function.
   # See:
   # - https://gitlab.kitware.com/cmake/cmake/-/issues/26463
@@ -21,7 +21,7 @@ function(check_linker_supports_pie warnings)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON PARENT_SCOPE)
   elseif(NOT WIN32)
     # The warning is superfluous for Windows.
-    message(WARNING "PIE is not supported at link time. See the configure log for details.")
-    set(${warnings} ${${warnings}} "Position independent code disabled." PARENT_SCOPE)
+    message(AUTHOR_WARNING "PIE is not supported at link time. See the configure log for details.")
+    message(AUTHOR_WARNING "Position independent code disabled.")
   endif()
 endfunction()


### PR DESCRIPTION
Rather than create our own warning logging/handling, which isn't ideal (#31476), use CMakes [`AUTHOR_WARNING`](https://cmake.org/cmake/help/latest/command/message.html) (also pointed out by purpleKarrot here: https://github.com/bitcoin/bitcoin/pull/31665#issuecomment-2667723356).

Would result in failures like:
```bash
-- Performing Test LINKER_SUPPORTS__WL__Z_SEPARATE_CODE - Success
-- Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter) (Required is at least version "3.10")
CMake Error (dev) at CMakeLists.txt:592 (message):
  Minimum required Python not found.  Rpcauth tests are disabled.
This error is for project developers. Use -Wno-error=dev to suppress it.

-- Configuring incomplete, errors occurred!
```

Alternative to #31665 & #31669.
Would close #31476.