### PR TITLE
test: refactor: overhaul block hash determination for `CBlock{,Header}` objects

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -481,15 +481,15 @@ def do_generate(args):
         # report
         bstr = "block" if gen.is_mine else "backup block"
 
-        next_delta = gen.next_block_delta(block.nBits, block.hash)
+        next_delta = gen.next_block_delta(block.nBits, block.hash_hex)
         next_delta += block.nTime - time.time()
-        next_is_mine = gen.next_block_is_mine(block.hash)
+        next_is_mine = gen.next_block_is_mine(block.hash_hex)
 
-        logging.debug("Block hash %s payout to %s", block.hash, reward_addr)
+        logging.debug("Block hash %s payout to %s", block.hash_hex, reward_addr)
         logging.info("Mined %s at height %d; next in %s (%s)", bstr, tmpl["height"], seconds_to_hms(next_delta), ("mine" if next_is_mine else "backup"))
         if r != "":
-            logging.warning("submitblock returned %s for height %d hash %s", r, tmpl["height"], block.hash)
-        lastheader = block.hash
+            logging.warning("submitblock returned %s for height %d hash %s", r, tmpl["height"], block.hash_hex)
+        lastheader = block.hash_hex
 
 def do_calibrate(args):
     if args.nbits is not None and args.seconds is not None:

--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -95,7 +95,6 @@ def finish_block(block, signet_solution, grind_cmd):
         newheadhex = subprocess.run(cmd, stdout=subprocess.PIPE, input=b"", check=True).stdout.strip()
         newhead = from_hex(CBlockHeader(), newheadhex.decode('utf8'))
         block.nNonce = newhead.nNonce
-        block.rehash()
     return block
 
 def new_block(tmpl, reward_spk, *, blocktime=None, poolid=None):

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -57,7 +57,6 @@ class BaseNode(P2PInterface):
         """Override the standard on_block callback
 
         Store the hash of a received block in the dictionary."""
-        message.block.calc_sha256()
         self.block_receive_map[message.block.sha256] += 1
 
     def on_inv(self, message):

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -57,7 +57,7 @@ class BaseNode(P2PInterface):
         """Override the standard on_block callback
 
         Store the hash of a received block in the dictionary."""
-        self.block_receive_map[message.block.sha256] += 1
+        self.block_receive_map[message.block.hash_int] += 1
 
     def on_inv(self, message):
         """Override the standard on_inv callback"""
@@ -181,7 +181,7 @@ class ExampleTest(BitcoinTestFramework):
             block_message = msg_block(block)
             # Send message is used to send a P2P message to the node over our P2PInterface
             peer_messaging.send_without_ping(block_message)
-            self.tip = block.sha256
+            self.tip = block.hash_int
             blocks.append(self.tip)
             self.block_time += 1
             height += 1

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -272,7 +272,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         block_time = node0.getblock(node0.getbestblockhash())['time'] + 1
         fork_block1 = create_block(int(parent_block_hash, 16), create_coinbase(SNAPSHOT_BASE_HEIGHT), block_time)
         fork_block1.solve()
-        fork_block2 = create_block(fork_block1.sha256, create_coinbase(SNAPSHOT_BASE_HEIGHT + 1), block_time + 1)
+        fork_block2 = create_block(fork_block1.hash_int, create_coinbase(SNAPSHOT_BASE_HEIGHT + 1), block_time + 1)
         fork_block2.solve()
         node1.submitheader(fork_block1.serialize().hex())
         node1.submitheader(fork_block2.serialize().hex())

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -103,7 +103,7 @@ class AssumeValidTest(BitcoinTestFramework):
         block.solve()
         # Save the coinbase for later
         self.block1 = block
-        self.tip = block.sha256
+        self.tip = block.hash_int
         height += 1
 
         # Bury the block 100 deep so the coinbase output is spendable
@@ -111,7 +111,7 @@ class AssumeValidTest(BitcoinTestFramework):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.blocks.append(block)
-            self.tip = block.sha256
+            self.tip = block.hash_int
             self.block_time += 1
             height += 1
 
@@ -124,7 +124,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.block_time += 1
         block102.solve()
         self.blocks.append(block102)
-        self.tip = block102.sha256
+        self.tip = block102.hash_int
         self.block_time += 1
         height += 1
 
@@ -133,7 +133,7 @@ class AssumeValidTest(BitcoinTestFramework):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.blocks.append(block)
-            self.tip = block.sha256
+            self.tip = block.hash_int
             self.block_time += 1
             height += 1
 

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -138,8 +138,8 @@ class AssumeValidTest(BitcoinTestFramework):
             height += 1
 
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
-        self.start_node(1, extra_args=["-assumevalid=" + block102.hash])
-        self.start_node(2, extra_args=["-assumevalid=" + block102.hash])
+        self.start_node(1, extra_args=["-assumevalid=" + block102.hash_hex])
+        self.start_node(2, extra_args=["-assumevalid=" + block102.hash_hex])
 
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
         p2p0.send_header_for_blocks(self.blocks[0:2000])

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -327,7 +327,7 @@ class BIP68Test(BitcoinTestFramework):
         for i in range(2):
             block = create_block(tmpl=tmpl, ntime=cur_time)
             block.solve()
-            tip = block.sha256
+            tip = block.hash_int
             assert_equal(None if i == 1 else 'inconclusive', self.nodes[0].submitblock(block.serialize().hex()))
             tmpl = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
             tmpl['previousblockhash'] = '%x' % tip

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -383,7 +383,7 @@ class BIP68Test(BitcoinTestFramework):
         block.solve()
 
         assert_equal(None, self.nodes[0].submitblock(block.serialize().hex()))
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
     def activateCSV(self):
         # activation should happen at block height 432 (3 periods)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -609,11 +609,11 @@ class FullBlockTest(BitcoinTestFramework):
         # The next few blocks are going to be created "by hand" since they'll do funky things, such as having
         # the first transaction be non-coinbase, etc.  The purpose of b44 is to make sure this works.
         self.log.info("Build block 44 manually")
-        height = self.block_heights[self.tip.sha256] + 1
+        height = self.block_heights[self.tip.hash_int] + 1
         coinbase = create_coinbase(height, self.coinbase_pubkey)
         b44 = CBlock()
         b44.nTime = self.tip.nTime + 1
-        b44.hashPrevBlock = self.tip.sha256
+        b44.hashPrevBlock = self.tip.hash_int
         b44.nBits = REGTEST_N_BITS
         b44.vtx.append(coinbase)
         tx = self.create_and_sign_transaction(out[14], 1)
@@ -621,7 +621,7 @@ class FullBlockTest(BitcoinTestFramework):
         b44.hashMerkleRoot = b44.calc_merkle_root()
         b44.solve()
         self.tip = b44
-        self.block_heights[b44.sha256] = height
+        self.block_heights[b44.hash_int] = height
         self.blocks[44] = b44
         self.send_blocks([b44], True)
 
@@ -629,12 +629,12 @@ class FullBlockTest(BitcoinTestFramework):
         non_coinbase = self.create_tx(out[15], 0, 1)
         b45 = CBlock()
         b45.nTime = self.tip.nTime + 1
-        b45.hashPrevBlock = self.tip.sha256
+        b45.hashPrevBlock = self.tip.hash_int
         b45.nBits = REGTEST_N_BITS
         b45.vtx.append(non_coinbase)
         b45.hashMerkleRoot = b45.calc_merkle_root()
         b45.solve()
-        self.block_heights[b45.sha256] = self.block_heights[self.tip.sha256] + 1
+        self.block_heights[b45.hash_int] = self.block_heights[self.tip.hash_int] + 1
         self.tip = b45
         self.blocks[45] = b45
         self.send_blocks([b45], success=False, reject_reason='bad-cb-missing', reconnect=True)
@@ -643,12 +643,12 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(44)
         b46 = CBlock()
         b46.nTime = b44.nTime + 1
-        b46.hashPrevBlock = b44.sha256
+        b46.hashPrevBlock = b44.hash_int
         b46.nBits = REGTEST_N_BITS
         b46.vtx = []
         b46.hashMerkleRoot = 0
         b46.solve()
-        self.block_heights[b46.sha256] = self.block_heights[b44.sha256] + 1
+        self.block_heights[b46.hash_int] = self.block_heights[b44.hash_int] + 1
         self.tip = b46
         assert 46 not in self.blocks
         self.blocks[46] = b46
@@ -658,7 +658,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(44)
         b47 = self.next_block(47)
         target = uint256_from_compact(b47.nBits)
-        while b47.sha256 <= target:
+        while b47.hash_int <= target:
             # Rehash nonces until an invalid too-high-hash block is found.
             b47.nNonce += 1
         self.send_blocks([b47], False, force_send=True, reject_reason='high-hash', reconnect=True)
@@ -731,7 +731,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.log.info("Accept a previously rejected future block at a later time")
         node.setmocktime(int(time.time()) + 2*60*60)
         self.move_tip(48)
-        self.block_heights[b48.sha256] = self.block_heights[b44.sha256] + 1 # b48 is a parent of b44
+        self.block_heights[b48.hash_int] = self.block_heights[b44.hash_int] + 1 # b48 is a parent of b44
         b48p = self.next_block("48p")
         self.send_blocks([b48, b48p], success=True) # Reorg to the longer chain
         node.invalidateblock(b48p.hash) # mark b48p as invalid
@@ -1058,12 +1058,12 @@ class FullBlockTest(BitcoinTestFramework):
         b72 = self.update_block(72, [tx1, tx2])  # now tip is 72
         b71 = copy.deepcopy(b72)
         b71.vtx.append(tx2)   # add duplicate tx2
-        self.block_heights[b71.sha256] = self.block_heights[b69.sha256] + 1  # b71 builds off b69
+        self.block_heights[b71.hash_int] = self.block_heights[b69.hash_int] + 1  # b71 builds off b69
         self.blocks[71] = b71
 
         assert_equal(len(b71.vtx), 4)
         assert_equal(len(b72.vtx), 3)
-        assert_equal(b72.sha256, b71.sha256)
+        assert_equal(b72.hash_int, b71.hash_int)
 
         self.move_tip(71)
         self.send_blocks([b71], success=False, reject_reason='bad-txns-duplicate', reconnect=True)
@@ -1368,7 +1368,7 @@ class FullBlockTest(BitcoinTestFramework):
             base_block_hash = self.genesis_hash
             block_time = int(time.time()) + 1
         else:
-            base_block_hash = self.tip.sha256
+            base_block_hash = self.tip.hash_int
             block_time = self.tip.nTime + 1
         # First create the coinbase
         height = self.block_heights[base_block_hash] + 1
@@ -1386,7 +1386,7 @@ class FullBlockTest(BitcoinTestFramework):
         # Block is created. Find a valid nonce.
         block.solve()
         self.tip = block
-        self.block_heights[block.sha256] = height
+        self.block_heights[block.hash_int] = height
         assert number not in self.blocks
         self.blocks[number] = block
         return block
@@ -1409,16 +1409,16 @@ class FullBlockTest(BitcoinTestFramework):
     def update_block(self, block_number, new_transactions, *, nTime=None):
         block = self.blocks[block_number]
         self.add_transactions_to_block(block, new_transactions)
-        old_sha256 = block.sha256
+        old_hash_int = block.hash_int
         if nTime is not None:
             block.nTime = nTime
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
         # Update the internal state just like in next_block
         self.tip = block
-        if block.sha256 != old_sha256:
-            self.block_heights[block.sha256] = self.block_heights[old_sha256]
-            del self.block_heights[old_sha256]
+        if block.hash_int != old_hash_int:
+            self.block_heights[block.hash_int] = self.block_heights[old_hash_int]
+            del self.block_heights[old_hash_int]
         self.blocks[block_number] = block
         return block
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -280,7 +280,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.send_blocks([b12, b13, b14], success=False, reject_reason='bad-cb-amount', reconnect=True)
 
         # New tip should be b13.
-        assert_equal(node.getbestblockhash(), b13.hash)
+        assert_equal(node.getbestblockhash(), b13.hash_hex)
 
         # Add a block with MAX_BLOCK_SIGOPS and one with one more sigop
         #     genesis -> b1 (0) -> b2 (1) -> b5 (2) -> b6  (3)
@@ -734,7 +734,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.block_heights[b48.hash_int] = self.block_heights[b44.hash_int] + 1 # b48 is a parent of b44
         b48p = self.next_block("48p")
         self.send_blocks([b48, b48p], success=True) # Reorg to the longer chain
-        node.invalidateblock(b48p.hash) # mark b48p as invalid
+        node.invalidateblock(b48p.hash_hex) # mark b48p as invalid
         node.setmocktime(0)
 
         # Test Merkle tree malleability
@@ -778,7 +778,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.blocks[56] = b56
         assert_equal(len(b56.vtx), 3)
         b56 = self.update_block(56, [tx1])
-        assert_equal(b56.hash, b57.hash)
+        assert_equal(b56.hash_hex, b57.hash_hex)
         self.send_blocks([b56], success=False, reject_reason='bad-txns-duplicate', reconnect=True)
 
         # b57p2 - a good block with 6 tx'es, don't submit until end
@@ -796,7 +796,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(55)
         b56p2 = copy.deepcopy(b57p2)
         self.blocks["b56p2"] = b56p2
-        assert_equal(b56p2.hash, b57p2.hash)
+        assert_equal(b56p2.hash_hex, b57p2.hash_hex)
         assert_equal(len(b56p2.vtx), 6)
         b56p2 = self.update_block("b56p2", [tx3, tx4])
         self.send_blocks([b56p2], success=False, reject_reason='bad-txns-duplicate', reconnect=True)
@@ -954,7 +954,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip('dup_2')
         b64 = CBlock(b64a)
         b64.vtx = copy.deepcopy(b64a.vtx)
-        assert_equal(b64.hash, b64a.hash)
+        assert_equal(b64.hash_hex, b64a.hash_hex)
         assert_equal(b64.get_weight(), MAX_BLOCK_WEIGHT)
         self.blocks[64] = b64
         b64 = self.update_block(64, [])

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -719,8 +719,7 @@ class FullBlockTest(BitcoinTestFramework):
         # valid timestamp
         self.move_tip(53)
         b55 = self.next_block(55, spend=out[15])
-        b55.nTime = b35.nTime
-        self.update_block(55, [])
+        self.update_block(55, [], nTime=b35.nTime)
         self.send_blocks([b55], True)
         self.save_spendable_output()
 
@@ -1408,10 +1407,12 @@ class FullBlockTest(BitcoinTestFramework):
         self.tip = self.blocks[number]
 
     # adds transactions to the block and updates state
-    def update_block(self, block_number, new_transactions):
+    def update_block(self, block_number, new_transactions, *, nTime=None):
         block = self.blocks[block_number]
         self.add_transactions_to_block(block, new_transactions)
         old_sha256 = block.sha256
+        if nTime is not None:
+            block.nTime = nTime
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
         # Update the internal state just like in next_block

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -661,7 +661,6 @@ class FullBlockTest(BitcoinTestFramework):
         while b47.sha256 <= target:
             # Rehash nonces until an invalid too-high-hash block is found.
             b47.nNonce += 1
-            b47.rehash()
         self.send_blocks([b47], False, force_send=True, reject_reason='high-hash', reconnect=True)
 
         self.log.info("Reject a block with a timestamp >2 hours in the future")

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -196,7 +196,7 @@ class BIP65Test(BitcoinTestFramework):
         self.test_cltv_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         peer.send_and_ping(msg_block(block))
         self.test_cltv_info(is_active=True)  # Active as of current tip
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hash_int)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -130,7 +130,7 @@ class BIP65Test(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         self.log.info("Test that blocks must now be at least version 4")
-        tip = block.sha256
+        tip = block.hash_int
         block_time += 1
         block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time, version=3)
         block.solve()
@@ -196,7 +196,7 @@ class BIP65Test(BitcoinTestFramework):
         self.test_cltv_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         peer.send_and_ping(msg_block(block))
         self.test_cltv_info(is_active=True)  # Active as of current tip
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hash_int)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -127,7 +127,7 @@ class BIP65Test(BitcoinTestFramework):
         self.test_cltv_info(is_active=False)  # Not active as of current tip and next block does not need to obey rules
         peer.send_and_ping(msg_block(block))
         self.test_cltv_info(is_active=True)  # Not active as of current tip, but next block must obey rules
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         self.log.info("Test that blocks must now be at least version 4")
         tip = block.hash_int
@@ -135,7 +135,7 @@ class BIP65Test(BitcoinTestFramework):
         block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time, version=3)
         block.solve()
 
-        with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash}, bad-version(0x00000003)']):
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash_hex}, bad-version(0x00000003)']):
             peer.send_and_ping(msg_block(block))
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
             peer.sync_with_ping()

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -165,7 +165,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
             block = self.create_test_block([])
             test_blocks.append(block)
             self.last_block_time += 600
-            self.tip = block.sha256
+            self.tip = block.hash_int
             self.tipheight += 1
         return test_blocks
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -146,7 +146,7 @@ class BIP66Test(BitcoinTestFramework):
         self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         peer.send_and_ping(msg_block(block))
         self.test_dersig_info(is_active=True)  # Active as of current tip
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hash_int)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -95,7 +95,7 @@ class BIP66Test(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         self.log.info("Test that blocks must now be at least version 3")
-        tip = block.sha256
+        tip = block.hash_int
         block_time += 1
         block = create_block(tip, create_coinbase(DERSIG_HEIGHT), block_time, version=2)
         block.solve()
@@ -146,7 +146,7 @@ class BIP66Test(BitcoinTestFramework):
         self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         peer.send_and_ping(msg_block(block))
         self.test_dersig_info(is_active=True)  # Active as of current tip
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hash_int)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -92,7 +92,7 @@ class BIP66Test(BitcoinTestFramework):
         peer.send_and_ping(msg_block(block))
         assert_equal(self.nodes[0].getblockcount(), DERSIG_HEIGHT - 1)
         self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         self.log.info("Test that blocks must now be at least version 3")
         tip = block.hash_int
@@ -100,7 +100,7 @@ class BIP66Test(BitcoinTestFramework):
         block = create_block(tip, create_coinbase(DERSIG_HEIGHT), block_time, version=2)
         block.solve()
 
-        with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash}, bad-version(0x00000002)']):
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash_hex}, bad-version(0x00000002)']):
             peer.send_and_ping(msg_block(block))
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
             peer.sync_with_ping()

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -41,7 +41,6 @@ class TestP2PConn(P2PInterface):
         pass
 
     def on_block(self, message):
-        message.block.calc_sha256()
         self.block_receive_map[message.block.sha256] += 1
 
 class MaxUploadTest(BitcoinTestFramework):

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -41,7 +41,7 @@ class TestP2PConn(P2PInterface):
         pass
 
     def on_block(self, message):
-        self.block_receive_map[message.block.sha256] += 1
+        self.block_receive_map[message.block.hash_int] += 1
 
 class MaxUploadTest(BitcoinTestFramework):
 

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -143,8 +143,8 @@ class NULLDUMMYTest(BitcoinTestFramework):
         block.solve()
         assert_equal(None if accept else NULLDUMMY_ERROR, node.submitblock(block.serialize().hex()))
         if accept:
-            assert_equal(node.getbestblockhash(), block.hash)
-            self.lastblockhash = block.hash
+            assert_equal(node.getbestblockhash(), block.hash_hex)
+            self.lastblockhash = block.hash_hex
             self.lastblocktime += 1
             self.lastblockheight += 1
         else:

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -58,7 +58,7 @@ def mine_large_blocks(node, n):
         # Submit to the node
         node.submitblock(block.serialize().hex())
 
-        previousblockhash = block.sha256
+        previousblockhash = block.hash_int
         height += 1
         mine_large_blocks.nTime += 1
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1342,7 +1342,7 @@ class TaprootTest(BitcoinTestFramework):
             assert block_response is not None and err_msg in block_response, "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg)
         if accept:
             assert node.getbestblockhash() == block.hash, "Failed to accept: %s (response: %s)" % (msg, block_response)
-            self.tip = block.sha256
+            self.tip = block.hash_int
             self.lastblockhash = block.hash
             self.lastblocktime += 1
             self.lastblockheight += 1

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1574,7 +1574,6 @@ class TaprootTest(BitcoinTestFramework):
         assert coinbase.txid_hex == "f60c73405d499a956d3162e3483c395526ef78286458a4cb17b125aa92e49b20"
         # Mine it
         block = create_block(hashprev=int(self.nodes[0].getbestblockhash(), 16), coinbase=coinbase)
-        block.rehash()
         block.solve()
         self.nodes[0].submitblock(block.serialize().hex())
         assert_equal(self.nodes[0].getblockcount(), 1)

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1341,9 +1341,9 @@ class TaprootTest(BitcoinTestFramework):
         if err_msg is not None:
             assert block_response is not None and err_msg in block_response, "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg)
         if accept:
-            assert node.getbestblockhash() == block.hash, "Failed to accept: %s (response: %s)" % (msg, block_response)
+            assert node.getbestblockhash() == block.hash_hex, "Failed to accept: %s (response: %s)" % (msg, block_response)
             self.tip = block.hash_int
-            self.lastblockhash = block.hash
+            self.lastblockhash = block.hash_hex
             self.lastblocktime += 1
             self.lastblockheight += 1
         else:

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -50,7 +50,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
             peer.send_without_ping(msg_block(block))
             block_time += 1
             height += 1
-            tip = block.sha256
+            tip = block.hash_int
         peer.sync_with_ping()
 
     def versionbits_in_alert_file(self):

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -424,7 +424,7 @@ class ZMQTest (BitcoinTestFramework):
         block.solve()
         assert_equal(self.nodes[0].submitblock(block.serialize().hex()), None)
         tip = self.nodes[0].getbestblockhash()
-        assert_equal(int(tip, 16), block.sha256)
+        assert_equal(int(tip, 16), block.hash_int)
         orig_txid_2 = self.wallet.send_self_transfer(from_node=self.nodes[0])['txid']
 
         # Flush old notifications until evicted tx original entry

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -44,7 +44,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
             block = create_block(tip, create_coinbase(height + 1), block_time)
             block.solve()
             blocks.append(block)
-            tip = block.sha256
+            tip = block.hash_int
             block_time += 1
             height += 1
 

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -473,7 +473,7 @@ class MiningTest(BitcoinTestFramework):
         assert_equal(node.submitblock(hexdata=bad_block_lock.serialize().hex()), 'duplicate-invalid')
         # Build a "good" block on top of the submitted bad block
         bad_block2 = copy.deepcopy(block)
-        bad_block2.hashPrevBlock = bad_block_lock.sha256
+        bad_block2.hashPrevBlock = bad_block_lock.hash_int
         bad_block2.solve()
         assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(hexdata=CBlockHeader(bad_block2).serialize().hex()))
 

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -445,25 +445,25 @@ class MiningTest(BitcoinTestFramework):
         def chain_tip(b_hash, *, status='headers-only', branchlen=1):
             return {'hash': b_hash, 'height': 202, 'branchlen': branchlen, 'status': status}
 
-        assert chain_tip(block.hash) not in node.getchaintips()
+        assert chain_tip(block.hash_hex) not in node.getchaintips()
         node.submitheader(hexdata=block.serialize().hex())
-        assert chain_tip(block.hash) in node.getchaintips()
+        assert chain_tip(block.hash_hex) in node.getchaintips()
         node.submitheader(hexdata=CBlockHeader(block).serialize().hex())  # Noop
-        assert chain_tip(block.hash) in node.getchaintips()
+        assert chain_tip(block.hash_hex) in node.getchaintips()
 
         bad_block_root = copy.deepcopy(block)
         bad_block_root.hashMerkleRoot += 2
         bad_block_root.solve()
-        assert chain_tip(bad_block_root.hash) not in node.getchaintips()
+        assert chain_tip(bad_block_root.hash_hex) not in node.getchaintips()
         node.submitheader(hexdata=CBlockHeader(bad_block_root).serialize().hex())
-        assert chain_tip(bad_block_root.hash) in node.getchaintips()
+        assert chain_tip(bad_block_root.hash_hex) in node.getchaintips()
         # Should still reject invalid blocks, even if we have the header:
         assert_equal(node.submitblock(hexdata=bad_block_root.serialize().hex()), 'bad-txnmrklroot')
         assert_equal(node.submitblock(hexdata=bad_block_root.serialize().hex()), 'bad-txnmrklroot')
-        assert chain_tip(bad_block_root.hash) in node.getchaintips()
+        assert chain_tip(bad_block_root.hash_hex) in node.getchaintips()
         # We know the header for this invalid block, so should just return early without error:
         node.submitheader(hexdata=CBlockHeader(bad_block_root).serialize().hex())
-        assert chain_tip(bad_block_root.hash) in node.getchaintips()
+        assert chain_tip(bad_block_root.hash_hex) in node.getchaintips()
 
         bad_block_lock = copy.deepcopy(block)
         bad_block_lock.vtx[0].nLockTime = 2**32 - 1
@@ -488,7 +488,7 @@ class MiningTest(BitcoinTestFramework):
         peer.wait_for_getheaders(timeout=5, block_hash=block.hashPrevBlock)
         peer.send_blocks_and_test(blocks=[block], node=node)
         # Must be active now:
-        assert chain_tip(block.hash, status='active', branchlen=0) in node.getchaintips()
+        assert chain_tip(block.hash_hex, status='active', branchlen=0) in node.getchaintips()
 
         # Building a few blocks should give the same results
         self.generatetoaddress(node, 10, node.get_deterministic_priv_key().address)

--- a/test/functional/mining_mainnet.py
+++ b/test/functional/mining_mainnet.py
@@ -66,7 +66,6 @@ class MiningMainnetTest(BitcoinTestFramework):
         block.vtx[0].nLockTime = 0
         block.vtx[0].vin[0].nSequence = SEQUENCE_FINAL
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         block_hex = block.serialize(with_witness=False).hex()
         self.log.debug(block_hex)
         assert_equal(node.submitblock(block_hex), None)

--- a/test/functional/mining_mainnet.py
+++ b/test/functional/mining_mainnet.py
@@ -70,7 +70,7 @@ class MiningMainnetTest(BitcoinTestFramework):
         self.log.debug(block_hex)
         assert_equal(node.submitblock(block_hex), None)
         prev_hash = node.getbestblockhash()
-        assert_equal(prev_hash, block.hash)
+        assert_equal(prev_hash, block.hash_hex)
         return prev_hash
 
 

--- a/test/functional/mining_template_verification.py
+++ b/test/functional/mining_template_verification.py
@@ -158,7 +158,6 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         # Ensure that it doesn't meet the target by coincidence
         while block.sha256 <= target:
             block.nNonce += 1
-            block.rehash()
         self.log.debug("Found a nonce")
 
         self.log.info("A block template doesn't need PoW")

--- a/test/functional/mining_template_verification.py
+++ b/test/functional/mining_template_verification.py
@@ -156,7 +156,7 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         self.log.info("Generate a block")
         target = uint256_from_compact(block.nBits)
         # Ensure that it doesn't meet the target by coincidence
-        while block.sha256 <= target:
+        while block.hash_int <= target:
             block.nNonce += 1
         self.log.debug("Found a nonce")
 

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -623,7 +623,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tips = node.getchaintips()
         found = False
         for x in tips:
-            if x["hash"] == block.hash:
+            if x["hash"] == block.hash_hex:
                 found = True
                 break
         assert not found
@@ -667,7 +667,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tips = node.getchaintips()
         found = False
         for x in tips:
-            if x["hash"] == block.hash:
+            if x["hash"] == block.hash_hex:
                 assert_equal(x["status"], "headers-only")
                 found = True
                 break

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -80,13 +80,11 @@ class TestP2PConn(P2PInterface):
 
     def on_cmpctblock(self, message):
         self.block_announced = True
-        self.last_message["cmpctblock"].header_and_shortids.header.calc_sha256()
         self.announced_blockhashes.add(self.last_message["cmpctblock"].header_and_shortids.header.sha256)
 
     def on_headers(self, message):
         self.block_announced = True
         for x in self.last_message["headers"].headers:
-            x.calc_sha256()
             self.announced_blockhashes.add(x.sha256)
 
     def on_inv(self, message):
@@ -308,7 +306,6 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Store the raw block in our internal format.
         block = from_hex(CBlock(), node.getblock("%064x" % block_hash, False))
-        block.rehash()
 
         # Wait until the block was announced (via compact blocks)
         test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
@@ -336,7 +333,6 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def check_compactblock_construction_from_block(self, header_and_shortids, block_hash, block):
         # Check that we got the right block!
-        header_and_shortids.header.calc_sha256()
         assert_equal(header_and_shortids.header.sha256, block_hash)
 
         # Make sure the prefilled_txn appears to have included the coinbase
@@ -599,7 +595,6 @@ class CompactBlocksTest(BitcoinTestFramework):
             test_node.last_message.pop("blocktxn", None)
         test_node.send_and_ping(msg)
         with p2p_lock:
-            test_node.last_message["block"].block.calc_sha256()
             assert_equal(test_node.last_message["block"].block.sha256, int(block_hash, 16))
             assert "blocktxn" not in test_node.last_message
 
@@ -656,7 +651,6 @@ class CompactBlocksTest(BitcoinTestFramework):
         test_node.send_without_ping(msg_getdata([CInv(MSG_CMPCT_BLOCK, int(new_blocks[0], 16))]))
         test_node.wait_until(lambda: "block" in test_node.last_message, timeout=30)
         with p2p_lock:
-            test_node.last_message["block"].block.calc_sha256()
             assert_equal(test_node.last_message["block"].block.sha256, int(new_blocks[0], 16))
 
         # Generate an old compactblock, and verify that it's not accepted.
@@ -705,7 +699,6 @@ class CompactBlocksTest(BitcoinTestFramework):
             l.wait_until(lambda: "cmpctblock" in l.last_message, timeout=30)
         with p2p_lock:
             for l in listeners:
-                l.last_message["cmpctblock"].header_and_shortids.header.calc_sha256()
                 assert_equal(l.last_message["cmpctblock"].header_and_shortids.header.sha256, block.sha256)
 
     # Test that we don't get disconnected if we relay a compact block with valid header,

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -36,7 +36,6 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         blockhash = self.generate(self.nodes[2], 1, sync_fun=self.no_op)[0]
         block_hex = self.nodes[2].getblock(blockhash=blockhash, verbosity=0)
         block = from_hex(CBlock(), block_hex)
-        block.rehash()
         return block
 
     def run_test(self):

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -72,14 +72,14 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         # A -blocksonly node should not request BIP152 high bandwidth mode upon
         # receiving a new valid block at the tip.
         p2p_conn_blocksonly.send_and_ping(msg_block(block0))
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block0.sha256)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block0.hash_int)
         assert_equal(p2p_conn_blocksonly.message_count['sendcmpct'], 1)
         assert_equal(p2p_conn_blocksonly.last_message['sendcmpct'].announce, False)
 
         # A normal node participating in transaction relay should request BIP152
         # high bandwidth mode upon receiving a new valid block at the tip.
         p2p_conn_high_bw.send_and_ping(msg_block(block0))
-        assert_equal(int(self.nodes[1].getbestblockhash(), 16), block0.sha256)
+        assert_equal(int(self.nodes[1].getbestblockhash(), 16), block0.hash_int)
         p2p_conn_high_bw.wait_until(lambda: p2p_conn_high_bw.message_count['sendcmpct'] == 2)
         assert_equal(p2p_conn_high_bw.last_message['sendcmpct'].announce, True)
 
@@ -93,25 +93,25 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         block1 = self.build_block_on_tip()
 
         p2p_conn_blocksonly.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
-        assert_equal(p2p_conn_blocksonly.last_message['getdata'].inv, [CInv(MSG_BLOCK | MSG_WITNESS_FLAG, block1.sha256)])
+        assert_equal(p2p_conn_blocksonly.last_message['getdata'].inv, [CInv(MSG_BLOCK | MSG_WITNESS_FLAG, block1.hash_int)])
 
         p2p_conn_high_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
-        assert_equal(p2p_conn_high_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.sha256)])
+        assert_equal(p2p_conn_high_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.hash_int)])
 
         self.log.info("Test that getdata(CMPCT) is still sent on BIP152 low bandwidth connections"
                       " when no -blocksonly nodes are involved")
 
         p2p_conn_low_bw.send_and_ping(msg_headers(headers=[CBlockHeader(block1)]))
-        assert_equal(p2p_conn_low_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.sha256)])
+        assert_equal(p2p_conn_low_bw.last_message['getdata'].inv, [CInv(MSG_CMPCT_BLOCK, block1.hash_int)])
 
         self.log.info("Test that -blocksonly nodes still serve compact blocks")
 
         def test_for_cmpctblock(block):
             if 'cmpctblock' not in p2p_conn_blocksonly.last_message:
                 return False
-            return p2p_conn_blocksonly.last_message['cmpctblock'].header_and_shortids.header.rehash() == block.sha256
+            return p2p_conn_blocksonly.last_message['cmpctblock'].header_and_shortids.header.hash_int == block.hash_int
 
-        p2p_conn_blocksonly.send_without_ping(msg_getdata([CInv(MSG_CMPCT_BLOCK, block0.sha256)]))
+        p2p_conn_blocksonly.send_without_ping(msg_getdata([CInv(MSG_CMPCT_BLOCK, block0.hash_int)]))
         p2p_conn_blocksonly.wait_until(lambda: test_for_cmpctblock(block0))
 
         # Request BIP152 high bandwidth mode from the -blocksonly node.

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -72,14 +72,14 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         # A -blocksonly node should not request BIP152 high bandwidth mode upon
         # receiving a new valid block at the tip.
         p2p_conn_blocksonly.send_and_ping(msg_block(block0))
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block0.hash_int)
+        assert_equal(self.nodes[0].getbestblockhash(), block0.hash_hex)
         assert_equal(p2p_conn_blocksonly.message_count['sendcmpct'], 1)
         assert_equal(p2p_conn_blocksonly.last_message['sendcmpct'].announce, False)
 
         # A normal node participating in transaction relay should request BIP152
         # high bandwidth mode upon receiving a new valid block at the tip.
         p2p_conn_high_bw.send_and_ping(msg_block(block0))
-        assert_equal(int(self.nodes[1].getbestblockhash(), 16), block0.hash_int)
+        assert_equal(self.nodes[1].getbestblockhash(), block0.hash_hex)
         p2p_conn_high_bw.wait_until(lambda: p2p_conn_high_bw.message_count['sendcmpct'] == 2)
         assert_equal(p2p_conn_high_bw.last_message['sendcmpct'].announce, True)
 

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -41,7 +41,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
             block.solve()
 
             blocks.append(block)
-            prev_hash = block.hash
+            prev_hash = block.hash_hex
             prev_height += 1
             prev_median_time = block_time
         return blocks

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -79,7 +79,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         # Force reorg to a longer chain
         node0.send_without_ping(msg_headers(new_blocks))
-        node0.wait_for_getdata([x.sha256 for x in new_blocks])
+        node0.wait_for_getdata([x.hash_int for x in new_blocks])
         for block in new_blocks:
             node0.send_and_ping(msg_block(block))
 

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -19,7 +19,6 @@ class P2PStoreBlock(P2PInterface):
         self.blocks = defaultdict(int)
 
     def on_block(self, message):
-        message.block.calc_sha256()
         self.blocks[message.block.sha256] += 1
 
 

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -19,7 +19,7 @@ class P2PStoreBlock(P2PInterface):
         self.blocks = defaultdict(int)
 
     def on_block(self, message):
-        self.blocks[message.block.sha256] += 1
+        self.blocks[message.block.hash_int] += 1
 
 
 class GetdataTest(BitcoinTestFramework):

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -129,7 +129,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
             block = create_block(hashprev = hashPrevBlock, tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
             block.solve()
             new_blocks.append(block)
-            hashPrevBlock = block.sha256
+            hashPrevBlock = block.hash_int
 
         headers_message = msg_headers(headers=new_blocks)
         p2p.send_and_ping(headers_message)

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -62,11 +62,11 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         for _ in range(NUM_BLOCKS):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
-            tip = blocks[-1].sha256
+            tip = blocks[-1].hash_int
             block_time += 1
             height += 1
-            block_dict[blocks[-1].sha256] = blocks[-1]
-        stall_block = blocks[0].sha256
+            block_dict[blocks[-1].hash_int] = blocks[-1]
+        stall_block = blocks[0].hash_int
 
         headers_message = msg_headers()
         headers_message.headers = [CBlockHeader(b) for b in blocks[:NUM_BLOCKS-1]]

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -115,7 +115,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         # Update tip info
         height += 1
         block_time += 1
-        tip = int(block2_orig.hash_hex, 16)
+        tip = block2_orig.hash_int
 
         # Complete testing of CVE-2018-17144, by checking for the inflation bug.
         # Create a block that spends the output of a tx in a previous block.

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -115,7 +115,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         # Update tip info
         height += 1
         block_time += 1
-        tip = int(block2_orig.hash, 16)
+        tip = int(block2_orig.hash_hex, 16)
 
         # Complete testing of CVE-2018-17144, by checking for the inflation bug.
         # Create a block that spends the output of a tx in a previous block.

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -77,13 +77,13 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         block2 = create_block(tip, create_coinbase(height), block_time, txlist=[tx1, tx2])
         block_time += 1
         block2.solve()
-        orig_hash = block2.sha256
+        orig_hash = block2.hash_int
         block2_orig = copy.deepcopy(block2)
 
         # Mutate block 2
         block2.vtx.append(tx2)
         assert_equal(block2.hashMerkleRoot, block2.calc_merkle_root())
-        assert_equal(orig_hash, block2.rehash())
+        assert_equal(orig_hash, block2.hash_int)
         assert_not_equal(block2_orig.vtx, block2.vtx)
 
         peer.send_blocks_and_test([block2], node, success=False, reject_reason='bad-txns-duplicate')

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -288,10 +288,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
         blockheader.hashPrevBlock = int(blockheader_tip_hash, 16)
         blockheader.nTime = int(time.time())
         blockheader.nBits = blockheader_tip.nBits
-        blockheader.rehash()
         while not blockheader.hash.startswith('0'):
             blockheader.nNonce += 1
-            blockheader.rehash()
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_headers([blockheader]))
         assert_equal(self.nodes[0].getblockchaininfo()['headers'], 1)
@@ -302,7 +300,6 @@ class InvalidMessagesTest(BitcoinTestFramework):
         # invalidate PoW
         while not blockheader.hash.startswith('f'):
             blockheader.nNonce += 1
-            blockheader.rehash()
         with self.nodes[0].assert_debug_log(['Misbehaving', 'header with invalid proof of work']):
             peer.send_without_ping(msg_headers([blockheader]))
             peer.wait_for_disconnect()

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -288,17 +288,17 @@ class InvalidMessagesTest(BitcoinTestFramework):
         blockheader.hashPrevBlock = int(blockheader_tip_hash, 16)
         blockheader.nTime = int(time.time())
         blockheader.nBits = blockheader_tip.nBits
-        while not blockheader.hash.startswith('0'):
+        while not blockheader.hash_hex.startswith('0'):
             blockheader.nNonce += 1
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_headers([blockheader]))
         assert_equal(self.nodes[0].getblockchaininfo()['headers'], 1)
         chaintips = self.nodes[0].getchaintips()
         assert_equal(chaintips[0]['status'], 'headers-only')
-        assert_equal(chaintips[0]['hash'], blockheader.hash)
+        assert_equal(chaintips[0]['hash'], blockheader.hash_hex)
 
         # invalidate PoW
-        while not blockheader.hash.startswith('f'):
+        while not blockheader.hash_hex.startswith('f'):
             blockheader.nNonce += 1
         with self.nodes[0].assert_debug_log(['Misbehaving', 'header with invalid proof of work']):
             peer.send_without_ping(msg_headers([blockheader]))

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -68,7 +68,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
                 return False
 
             get_block_txn = honest_relayer.last_message['getblocktxn']
-            return get_block_txn.block_txn_request.blockhash == block.sha256 and \
+            return get_block_txn.block_txn_request.blockhash == block.hash_int and \
                    get_block_txn.block_txn_request.indexes == [1]
         honest_relayer.wait_until(self_transfer_requested, timeout=5)
 
@@ -93,7 +93,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # The honest relayer should be able to complete relaying the block by
         # sending the blocktxn that was requested.
         block_txn = msg_blocktxn()
-        block_txn.block_transactions = BlockTransactions(blockhash=block.sha256, transactions=[tx])
+        block_txn.block_transactions = BlockTransactions(blockhash=block.hash_int, transactions=[tx])
         honest_relayer.send_and_ping(block_txn)
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -95,7 +95,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
         block_txn = msg_blocktxn()
         block_txn.block_transactions = BlockTransactions(blockhash=block.hash_int, transactions=[tx])
         honest_relayer.send_and_ping(block_txn)
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         # Check that unexpected-witness mutation check doesn't trigger on a header that doesn't connect to anything
         assert_equal(len(self.nodes[0].getpeerinfo()), 1)

--- a/test/functional/p2p_outbound_eviction.py
+++ b/test/functional/p2p_outbound_eviction.py
@@ -190,7 +190,7 @@ class P2POutEvict(BitcoinTestFramework):
 
         self.log.info("Mine a new block and keep the unprotected honest peer on sync, all the rest off-sync")
         # Mine a block so all peers become outdated
-        target_hash = prev_header.rehash()
+        target_hash = prev_header.hash_int
         tip_hash = self.generateblock(node, output="raw(42)", transactions=[])["hash"]
         tip_header = from_hex(CBlockHeader(), node.getblockheader(tip_hash, False))
         tip_headers_message = msg_headers([tip_header])
@@ -235,7 +235,7 @@ class P2POutEvict(BitcoinTestFramework):
         cur_mock_time += (CHAIN_SYNC_TIMEOUT + 1)
         node.setmocktime(cur_mock_time)
         peer.sync_with_ping()
-        peer.wait_for_getheaders(block_hash=tip_header.rehash())
+        peer.wait_for_getheaders(block_hash=tip_header.hash_int)
         cur_mock_time += (HEADERS_RESPONSE_TIME + 1)
         node.setmocktime(cur_mock_time)
         self.log.info("Test that the peer gets evicted")

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -230,7 +230,6 @@ class SegWitTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount() + 1
         block_time = self.nodes[0].getblockheader(tip)["mediantime"] + 1
         block = create_block(int(tip, 16), create_coinbase(height), block_time)
-        block.rehash()
         return block
 
     def update_witness_block_with_transactions(self, block, tx_list, nonce=0):

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -195,10 +195,10 @@ class TestP2PConn(P2PInterface):
         if use_header:
             self.send_without_ping(msg)
         else:
-            self.send_without_ping(msg_inv(inv=[CInv(MSG_BLOCK, block.sha256)]))
+            self.send_without_ping(msg_inv(inv=[CInv(MSG_BLOCK, block.hash_int)]))
             self.wait_for_getheaders(block_hash=block.hashPrevBlock, timeout=timeout)
             self.send_without_ping(msg)
-        self.wait_for_getdata([block.sha256], timeout=timeout)
+        self.wait_for_getdata([block.hash_int], timeout=timeout)
 
     def request_block(self, blockhash, inv_type, timeout=60):
         with p2p_lock:
@@ -414,8 +414,8 @@ class SegWitTest(BitcoinTestFramework):
             test_witness_block(self.nodes[0], self.test_node, block, accepted=True)
             # Now try to retrieve it...
             rpc_block = self.nodes[0].getblock(block.hash, False)
-            non_wit_block = self.test_node.request_block(block.sha256, 2)
-            wit_block = self.test_node.request_block(block.sha256, 2 | MSG_WITNESS_FLAG)
+            non_wit_block = self.test_node.request_block(block.hash_int, 2)
+            wit_block = self.test_node.request_block(block.hash_int, 2 | MSG_WITNESS_FLAG)
             assert_equal(wit_block.serialize(), bytes.fromhex(rpc_block))
             assert_equal(wit_block.serialize(False), non_wit_block.serialize())
             assert_equal(wit_block.serialize(), block.serialize())
@@ -443,7 +443,7 @@ class SegWitTest(BitcoinTestFramework):
             msg.headers = [CBlockHeader(block4)]
             self.old_node.send_without_ping(msg)
             self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
-            assert block4.sha256 not in self.old_node.getdataset
+            assert block4.hash_int not in self.old_node.getdataset
 
     @subtest
     def test_v0_outputs_arent_spendable(self):

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -143,7 +143,7 @@ def test_witness_block(node, p2p, block, accepted, with_witness=True, reason=Non
     reason = [reason] if reason else []
     with node.assert_debug_log(expected_msgs=reason):
         p2p.send_and_ping(msg_block(block) if with_witness else msg_no_witness_block(block))
-        assert_equal(node.getbestblockhash() == block.hash, accepted)
+        assert_equal(node.getbestblockhash() == block.hash_hex, accepted)
 
 
 class TestP2PConn(P2PInterface):
@@ -346,7 +346,7 @@ class SegWitTest(BitcoinTestFramework):
         # But it should not be permanently marked bad...
         # Resend without witness information.
         self.test_node.send_and_ping(msg_no_witness_block(block))  # make sure the block was processed
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         # Update our utxo list; we spent the first entry.
         self.utxo.pop(0)
@@ -413,7 +413,7 @@ class SegWitTest(BitcoinTestFramework):
             assert len(block.vtx[0].wit.vtxinwit[0].scriptWitness.stack) == 1
             test_witness_block(self.nodes[0], self.test_node, block, accepted=True)
             # Now try to retrieve it...
-            rpc_block = self.nodes[0].getblock(block.hash, False)
+            rpc_block = self.nodes[0].getblock(block.hash_hex, False)
             non_wit_block = self.test_node.request_block(block.hash_int, 2)
             wit_block = self.test_node.request_block(block.hash_int, 2 | MSG_WITNESS_FLAG)
             assert_equal(wit_block.serialize(), bytes.fromhex(rpc_block))
@@ -421,7 +421,7 @@ class SegWitTest(BitcoinTestFramework):
             assert_equal(wit_block.serialize(), block.serialize())
 
             # Test size, vsize, weight
-            rpc_details = self.nodes[0].getblock(block.hash, True)
+            rpc_details = self.nodes[0].getblock(block.hash_hex, True)
             assert_equal(rpc_details["size"], len(block.serialize()))
             assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
             assert_equal(rpc_details["weight"], block.get_weight())
@@ -819,13 +819,13 @@ class SegWitTest(BitcoinTestFramework):
         # TODO: repeat this test with a block that can be relayed
         assert_equal('bad-witness-nonce-size', self.nodes[0].submitblock(block.serialize().hex()))
 
-        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.pop()
         assert block.get_weight() < MAX_BLOCK_WEIGHT
         assert_equal(None, self.nodes[0].submitblock(block.serialize().hex()))
 
-        assert self.nodes[0].getbestblockhash() == block.hash
+        assert self.nodes[0].getbestblockhash() == block.hash_hex
 
         # Now make sure that malleating the witness reserved value doesn't
         # result in a block permanently marked bad.
@@ -926,14 +926,14 @@ class SegWitTest(BitcoinTestFramework):
         block.vtx[0].wit = CTxWitness()  # drop the nonce
         block.solve()
         assert_equal('bad-witness-merkle-match', self.nodes[0].submitblock(block.serialize().hex()))
-        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_not_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         # Now redo commitment with the standard nonce, but let bitcoind fill it in.
         add_witness_commitment(block, nonce=0)
         block.vtx[0].wit = CTxWitness()
         block.solve()
         assert_equal(None, self.nodes[0].submitblock(block.serialize().hex()))
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash_hex)
 
         # This time, add a tx with non-empty witness, but don't supply
         # the commitment.
@@ -949,7 +949,7 @@ class SegWitTest(BitcoinTestFramework):
 
         assert_equal('bad-txnmrklroot', self.nodes[0].submitblock(block_2.serialize().hex()))
         # Tip should not advance!
-        assert_not_equal(self.nodes[0].getbestblockhash(), block_2.hash)
+        assert_not_equal(self.nodes[0].getbestblockhash(), block_2.hash_hex)
 
     @subtest
     def test_extra_witness_data(self):
@@ -1891,7 +1891,7 @@ class SegWitTest(BitcoinTestFramework):
         # Reset the tip back down for the next test
         self.sync_blocks()
         for x in self.nodes:
-            x.invalidateblock(block_4.hash)
+            x.invalidateblock(block_4.hash_hex)
 
         # Try replacing the last input of tx2 to be spending the last
         # output of tx

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -247,12 +247,12 @@ class SendHeadersTest(BitcoinTestFramework):
         block.solve()
         test_node.send_header_for_blocks([block])
         test_node.clear_block_announcements()
-        test_node.send_get_headers(locator=[], hashstop=int(block.hash_hex, 16))
+        test_node.send_get_headers(locator=[], hashstop=block.hash_int)
         test_node.sync_with_ping()
         assert_equal(test_node.block_announced, False)
         inv_node.clear_block_announcements()
         test_node.send_without_ping(msg_block(block))
-        inv_node.check_last_inv_announcement(inv=[int(block.hash_hex, 16)])
+        inv_node.check_last_inv_announcement(inv=[block.hash_int])
 
     def test_nonnull_locators(self, test_node, inv_node):
         tip = int(self.nodes[0].getbestblockhash(), 16)
@@ -538,7 +538,7 @@ class SendHeadersTest(BitcoinTestFramework):
             test_node.wait_for_getdata([x.hash_int for x in blocks])
             [test_node.send_without_ping(msg_block(x)) for x in blocks]
             test_node.sync_with_ping()
-            assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].hash_int)
+            assert_equal(self.nodes[0].getbestblockhash(), blocks[1].hash_hex)
             expected_hash = blocks[1].hash_int
 
         blocks = []

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -150,7 +150,6 @@ class BaseNode(P2PInterface):
         if len(message.headers):
             self.block_announced = True
             for x in message.headers:
-                x.calc_sha256()
                 # append because headers may be announced over multiple messages.
                 self.recent_headers_announced.append(x.sha256)
             self.last_blockhash_announced = message.headers[-1].sha256

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -247,12 +247,12 @@ class SendHeadersTest(BitcoinTestFramework):
         block.solve()
         test_node.send_header_for_blocks([block])
         test_node.clear_block_announcements()
-        test_node.send_get_headers(locator=[], hashstop=int(block.hash, 16))
+        test_node.send_get_headers(locator=[], hashstop=int(block.hash_hex, 16))
         test_node.sync_with_ping()
         assert_equal(test_node.block_announced, False)
         inv_node.clear_block_announcements()
         test_node.send_without_ping(msg_block(block))
-        inv_node.check_last_inv_announcement(inv=[int(block.hash, 16)])
+        inv_node.check_last_inv_announcement(inv=[int(block.hash_hex, 16)])
 
     def test_nonnull_locators(self, test_node, inv_node):
         tip = int(self.nodes[0].getbestblockhash(), 16)

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -151,8 +151,8 @@ class BaseNode(P2PInterface):
             self.block_announced = True
             for x in message.headers:
                 # append because headers may be announced over multiple messages.
-                self.recent_headers_announced.append(x.sha256)
-            self.last_blockhash_announced = message.headers[-1].sha256
+                self.recent_headers_announced.append(x.hash_int)
+            self.last_blockhash_announced = message.headers[-1].hash_int
 
     def clear_block_announcements(self):
         with p2p_lock:
@@ -286,7 +286,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 new_block = create_block(tip, create_coinbase(height + 1), block_time)
                 new_block.solve()
                 test_node.send_header_for_blocks([new_block])
-                test_node.wait_for_getdata([new_block.sha256])
+                test_node.wait_for_getdata([new_block.hash_int])
                 test_node.send_and_ping(msg_block(new_block))  # make sure this block is processed
                 inv_node.wait_until(lambda: inv_node.block_announced)
                 inv_node.clear_block_announcements()
@@ -322,7 +322,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 for _ in range(i + 1):
                     blocks.append(create_block(tip, create_coinbase(height), block_time))
                     blocks[-1].solve()
-                    tip = blocks[-1].sha256
+                    tip = blocks[-1].hash_int
                     block_time += 1
                     height += 1
                 if j == 0:
@@ -336,13 +336,13 @@ class SendHeadersTest(BitcoinTestFramework):
                     test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
                     # getdata requests, or duplicate headers announcements
-                    [inv_node.send_block_inv(x.sha256) for x in blocks]
-                    test_node.wait_for_getdata([x.sha256 for x in blocks])
+                    [inv_node.send_block_inv(x.hash_int) for x in blocks]
+                    test_node.wait_for_getdata([x.hash_int for x in blocks])
                     inv_node.sync_with_ping()
                 else:
                     # Announce via headers
                     test_node.send_header_for_blocks(blocks)
-                    test_node.wait_for_getdata([x.sha256 for x in blocks])
+                    test_node.wait_for_getdata([x.hash_int for x in blocks])
                     # Test that duplicate headers won't result in duplicate
                     # getdata requests (the check is further down)
                     inv_node.send_header_for_blocks(blocks)
@@ -440,7 +440,7 @@ class SendHeadersTest(BitcoinTestFramework):
         for _ in range(2):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
-            tip = blocks[-1].sha256
+            tip = blocks[-1].hash_int
             block_time += 1
             height += 1
             inv_node.send_without_ping(msg_block(blocks[-1]))
@@ -458,20 +458,20 @@ class SendHeadersTest(BitcoinTestFramework):
         for _ in range(3):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
-            tip = blocks[-1].sha256
+            tip = blocks[-1].hash_int
             block_time += 1
             height += 1
 
         test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=DIRECT_FETCH_RESPONSE_TIME)
+        test_node.wait_for_getdata([x.hash_int for x in blocks], timeout=DIRECT_FETCH_RESPONSE_TIME)
 
         [test_node.send_without_ping(msg_block(x)) for x in blocks]
 
         test_node.sync_with_ping()
 
         # Now announce a header that forks the last two blocks
-        tip = blocks[0].sha256
+        tip = blocks[0].hash_int
         height -= 2
         blocks = []
 
@@ -479,7 +479,7 @@ class SendHeadersTest(BitcoinTestFramework):
         for _ in range(20):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
-            tip = blocks[-1].sha256
+            tip = blocks[-1].hash_int
             block_time += 1
             height += 1
 
@@ -495,13 +495,13 @@ class SendHeadersTest(BitcoinTestFramework):
         # both blocks (same work as tip)
         test_node.send_header_for_blocks(blocks[1:2])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=DIRECT_FETCH_RESPONSE_TIME)
+        test_node.wait_for_getdata([x.hash_int for x in blocks[0:2]], timeout=DIRECT_FETCH_RESPONSE_TIME)
 
         # Announcing 16 more headers should trigger direct fetch for 14 more
         # blocks
         test_node.send_header_for_blocks(blocks[2:18])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[2:16]], timeout=DIRECT_FETCH_RESPONSE_TIME)
+        test_node.wait_for_getdata([x.hash_int for x in blocks[2:16]], timeout=DIRECT_FETCH_RESPONSE_TIME)
 
         # Announcing 1 more header should not trigger any response
         test_node.last_message.pop("getdata", None)
@@ -528,18 +528,18 @@ class SendHeadersTest(BitcoinTestFramework):
             for _ in range(2):
                 blocks.append(create_block(tip, create_coinbase(height), block_time))
                 blocks[-1].solve()
-                tip = blocks[-1].sha256
+                tip = blocks[-1].hash_int
                 block_time += 1
                 height += 1
             # Send the header of the second block -> this won't connect.
             test_node.send_header_for_blocks([blocks[1]])
             test_node.wait_for_getheaders(block_hash=expected_hash)
             test_node.send_header_for_blocks(blocks)
-            test_node.wait_for_getdata([x.sha256 for x in blocks])
+            test_node.wait_for_getdata([x.hash_int for x in blocks])
             [test_node.send_without_ping(msg_block(x)) for x in blocks]
             test_node.sync_with_ping()
-            assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].sha256)
-            expected_hash = blocks[1].sha256
+            assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].hash_int)
+            expected_hash = blocks[1].hash_int
 
         blocks = []
         # Now we test that if we repeatedly don't send connecting headers, we
@@ -547,7 +547,7 @@ class SendHeadersTest(BitcoinTestFramework):
         for _ in range(NUM_HEADERS + 1):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
-            tip = blocks[-1].sha256
+            tip = blocks[-1].hash_int
             block_time += 1
             height += 1
 

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -97,14 +97,14 @@ class AcceptBlockTest(BitcoinTestFramework):
             block_time += 1
         test_node.send_and_ping(msg_block(blocks_h2[0]))
 
-        with self.nodes[1].assert_debug_log(expected_msgs=[f"AcceptBlockHeader: not adding new block header {blocks_h2[1].hash}, missing anti-dos proof-of-work validation"]):
+        with self.nodes[1].assert_debug_log(expected_msgs=[f"AcceptBlockHeader: not adding new block header {blocks_h2[1].hash_hex}, missing anti-dos proof-of-work validation"]):
             min_work_node.send_and_ping(msg_block(blocks_h2[1]))
 
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 1)
 
         # Ensure that the header of the second block was also not accepted by node1
-        assert_equal(self.check_hash_in_chaintips(self.nodes[1], blocks_h2[1].hash), False)
+        assert_equal(self.check_hash_in_chaintips(self.nodes[1], blocks_h2[1].hash_hex), False)
         self.log.info("First height 2 block accepted by node0; correctly rejected by node1")
 
         # 3. Send another block that builds on genesis.
@@ -115,11 +115,11 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         tip_entry_found = False
         for x in self.nodes[0].getchaintips():
-            if x['hash'] == block_h1f.hash:
+            if x['hash'] == block_h1f.hash_hex:
                 assert_equal(x['status'], "headers-only")
                 tip_entry_found = True
         assert tip_entry_found
-        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_h1f.hash)
+        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_h1f.hash_hex)
 
         # 4. Send another two block that build on the fork.
         block_h2f = create_block(block_h1f.hash_int, create_coinbase(2), block_time)
@@ -131,13 +131,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # can't be fully validated.
         tip_entry_found = False
         for x in self.nodes[0].getchaintips():
-            if x['hash'] == block_h2f.hash:
+            if x['hash'] == block_h2f.hash_hex:
                 assert_equal(x['status'], "headers-only")
                 tip_entry_found = True
         assert tip_entry_found
 
         # But this block should be accepted by node since it has equal work.
-        self.nodes[0].getblock(block_h2f.hash)
+        self.nodes[0].getblock(block_h2f.hash_hex)
         self.log.info("Second height 2 block accepted, but not reorg'ed to")
 
         # 4b. Now send another block that builds on the forking chain.
@@ -149,14 +149,14 @@ class AcceptBlockTest(BitcoinTestFramework):
         # can't be fully validated.
         tip_entry_found = False
         for x in self.nodes[0].getchaintips():
-            if x['hash'] == block_h3.hash:
+            if x['hash'] == block_h3.hash_hex:
                 assert_equal(x['status'], "headers-only")
                 tip_entry_found = True
         assert tip_entry_found
-        self.nodes[0].getblock(block_h3.hash)
+        self.nodes[0].getblock(block_h3.hash_hex)
 
         # But this block should be accepted by node since it has more work.
-        self.nodes[0].getblock(block_h3.hash)
+        self.nodes[0].getblock(block_h3.hash_hex)
         self.log.info("Unrequested more-work block accepted")
 
         # 4c. Now mine 288 more blocks and deliver; all should be processed but
@@ -172,8 +172,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         # Now send the block at height 5 and check that it wasn't accepted (missing header)
         test_node.send_without_ping(msg_block(all_blocks[1]))
         test_node.wait_for_disconnect()
-        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblock, all_blocks[1].hash)
-        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, all_blocks[1].hash)
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblock, all_blocks[1].hash_hex)
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, all_blocks[1].hash_hex)
         test_node = self.nodes[0].add_p2p_connection(P2PInterface())
 
         # The block at height 5 should be accepted if we provide the missing header, though
@@ -181,7 +181,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         headers_message.headers.append(CBlockHeader(all_blocks[0]))
         test_node.send_without_ping(headers_message)
         test_node.send_and_ping(msg_block(all_blocks[1]))
-        self.nodes[0].getblock(all_blocks[1].hash)
+        self.nodes[0].getblock(all_blocks[1].hash_hex)
 
         # Now send the blocks in all_blocks
         for i in range(288):
@@ -190,8 +190,8 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # Blocks 1-287 should be accepted, block 288 should be ignored because it's too far ahead
         for x in all_blocks[:-1]:
-            self.nodes[0].getblock(x.hash)
-        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, all_blocks[-1].hash)
+            self.nodes[0].getblock(x.hash_hex)
+        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, all_blocks[-1].hash_hex)
 
         # 5. Test handling of unrequested block on the node that didn't process
         # Should still not be processed (even though it has a child that has more
@@ -228,9 +228,9 @@ class AcceptBlockTest(BitcoinTestFramework):
         # 7. Send the missing block for the third time (now it is requested)
         test_node.send_and_ping(msg_block(block_h1f))
         assert_equal(self.nodes[0].getblockcount(), 290)
-        self.nodes[0].getblock(all_blocks[286].hash)
-        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash)
-        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, all_blocks[287].hash)
+        self.nodes[0].getblock(all_blocks[286].hash_hex)
+        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash_hex)
+        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, all_blocks[287].hash_hex)
         self.log.info("Successfully reorged to longer chain")
 
         # 8. Create a chain which is invalid at a height longer than the
@@ -256,17 +256,17 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         tip_entry_found = False
         for x in self.nodes[0].getchaintips():
-            if x['hash'] == block_292.hash:
+            if x['hash'] == block_292.hash_hex:
                 assert_equal(x['status'], "headers-only")
                 tip_entry_found = True
         assert tip_entry_found
-        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_292.hash)
+        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_292.hash_hex)
 
         test_node.send_without_ping(msg_block(block_289f))
         test_node.send_and_ping(msg_block(block_290f))
 
-        self.nodes[0].getblock(block_289f.hash)
-        self.nodes[0].getblock(block_290f.hash)
+        self.nodes[0].getblock(block_289f.hash_hex)
+        self.nodes[0].getblock(block_290f.hash_hex)
 
         test_node.send_without_ping(msg_block(block_291))
 
@@ -279,8 +279,8 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # We should have failed reorg and switched back to 290 (but have block 291)
         assert_equal(self.nodes[0].getblockcount(), 290)
-        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash)
-        assert_equal(self.nodes[0].getblock(block_291.hash)["confirmations"], -1)
+        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash_hex)
+        assert_equal(self.nodes[0].getblock(block_291.hash_hex)["confirmations"], -1)
 
         # Now send a new header on the invalid chain, indicating we're forked off, and expect to get disconnected
         block_293 = create_block(block_292.hash_int, create_coinbase(293), block_292.nTime+1)

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -41,7 +41,7 @@ class P2PEncrypted(BitcoinTestFramework):
             block = create_block(tip, create_coinbase(tipheight + 1), last_block_time + 1)
             block.solve()
             test_blocks.append(block)
-            tip = block.sha256
+            tip = block.hash_int
             tipheight += 1
             last_block_time += 1
         return test_blocks

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -621,7 +621,7 @@ class BlockchainTest(BitcoinTestFramework):
             return b
 
         b1 = solve_and_send_block(int(fork_hash, 16), fork_height+1, fork_block['time'] + 1)
-        b2 = solve_and_send_block(b1.sha256, fork_height+2, b1.nTime + 1)
+        b2 = solve_and_send_block(b1.hash_int, fork_height+2, b1.nTime + 1)
 
         node.invalidateblock(b2.hash)
 
@@ -734,7 +734,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Test getblock when block data is available but undo data isn't")
         # Submits a block building on the header-only block, so it can't be connected and has no undo data
         tx = create_tx_with_script(block.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
-        block_noundo = create_block(block.sha256, create_coinbase(current_height + 2, nValue=100), block_time + 1, txlist=[tx])
+        block_noundo = create_block(block.hash_int, create_coinbase(current_height + 2, nValue=100), block_time + 1, txlist=[tx])
         block_noundo.solve()
         node.submitblock(block_noundo.serialize().hex())
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -480,7 +480,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_is_hex_string(header_hex)
 
         header = from_hex(CBlockHeader(), header_hex)
-        assert_equal(header.hash, besthash)
+        assert_equal(header.hash_hex, besthash)
 
         assert 'previousblockhash' not in node.getblockheader(node.getblockhash(0))
         assert 'nextblockhash' not in node.getblockheader(node.getbestblockhash())
@@ -623,7 +623,7 @@ class BlockchainTest(BitcoinTestFramework):
         b1 = solve_and_send_block(int(fork_hash, 16), fork_height+1, fork_block['time'] + 1)
         b2 = solve_and_send_block(b1.hash_int, fork_height+2, b1.nTime + 1)
 
-        node.invalidateblock(b2.hash)
+        node.invalidateblock(b2.hash_hex)
 
         def assert_waitforheight(height, timeout=2):
             assert_equal(
@@ -729,7 +729,7 @@ class BlockchainTest(BitcoinTestFramework):
         block = create_block(int(blockhash, 16), create_coinbase(current_height + 1, nValue=100), block_time)
         block.solve()
         node.submitheader(block.serialize().hex())
-        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", lambda: node.getblock(block.hash))
+        assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", lambda: node.getblock(block.hash_hex))
 
         self.log.info("Test getblock when block data is available but undo data isn't")
         # Submits a block building on the header-only block, so it can't be connected and has no undo data
@@ -738,10 +738,10 @@ class BlockchainTest(BitcoinTestFramework):
         block_noundo.solve()
         node.submitblock(block_noundo.serialize().hex())
 
-        assert_fee_not_in_block(block_noundo.hash, 2)
-        assert_fee_not_in_block(block_noundo.hash, 3)
-        assert_vin_does_not_contain_prevout(block_noundo.hash, 2)
-        assert_vin_does_not_contain_prevout(block_noundo.hash, 3)
+        assert_fee_not_in_block(block_noundo.hash_hex, 2)
+        assert_fee_not_in_block(block_noundo.hash_hex, 3)
+        assert_vin_does_not_contain_prevout(block_noundo.hash_hex, 2)
+        assert_vin_does_not_contain_prevout(block_noundo.hash_hex, 3)
 
         self.log.info("Test getblock when block is missing")
         move_block_file('blk00000.dat', 'blk00000.dat.bak')

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -480,7 +480,6 @@ class BlockchainTest(BitcoinTestFramework):
         assert_is_hex_string(header_hex)
 
         header = from_hex(CBlockHeader(), header_hex)
-        header.calc_sha256()
         assert_equal(header.hash, besthash)
 
         assert 'previousblockhash' not in node.getblockheader(node.getblockhash(0))

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -73,7 +73,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         invalid_block.solve()
 
         block_time += 1
-        block2 = create_block(invalid_block.sha256, create_coinbase(2), block_time, version=4)
+        block2 = create_block(invalid_block.hash_int, create_coinbase(2), block_time, version=4)
         block2.solve()
 
         self.log.info("Submit headers-only chain")

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -103,7 +103,7 @@ class InvalidateTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getblockchaininfo()['headers'], 3)
 
         # Reconsider the header
-        self.nodes[0].reconsiderblock(block.hash)
+        self.nodes[0].reconsiderblock(block.hash_hex)
         # Since header doesn't have block data, it can't be chain tip
         # Check if it's possible for an ancestor (with block data) to be the chain tip
         assert_equal(self.nodes[0].getbestblockhash(), blockhash_6)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -111,7 +111,6 @@ def create_block(hashprev=None, coinbase=None, ntime=None, *, version=None, tmpl
                 tx = tx_from_hex(tx)
             block.vtx.append(tx)
     block.hashMerkleRoot = block.calc_merkle_root()
-    block.calc_sha256()
     return block
 
 def get_witness_script(witness_root, witness_nonce):
@@ -135,7 +134,6 @@ def add_witness_commitment(block, nonce=0):
     # witness commitment is the last OP_RETURN output in coinbase
     block.vtx[0].vout.append(CTxOut(0, get_witness_script(witness_root, witness_nonce)))
     block.hashMerkleRoot = block.calc_merkle_root()
-    block.rehash()
 
 
 def script_BIP34_coinbase_height(height):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -748,7 +748,7 @@ class CBlockHeader:
         return r
 
     @property
-    def hash(self):
+    def hash_hex(self):
         """Return block header hash as hex string."""
         return hash256(self._serialize_header())[::-1].hex()
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -717,7 +717,6 @@ class CBlockHeader:
             self.nTime = header.nTime
             self.nBits = header.nBits
             self.nNonce = header.nNonce
-            self.calc_sha256()
 
     def set_null(self):
         self.nVersion = 4
@@ -757,10 +756,6 @@ class CBlockHeader:
     def sha256(self):
         """Return block header hash as integer."""
         return uint256_from_str(hash256(self._serialize_header()))
-
-    # TODO: get rid of this method, remove call-sites
-    def calc_sha256(self):
-        pass
 
     # TODO: get rid of this method, replace call-sites by .sha256 access (if return value is used)
     def rehash(self):
@@ -823,7 +818,6 @@ class CBlock(CBlockHeader):
         return self.get_merkle_root(hashes)
 
     def is_valid(self):
-        self.calc_sha256()
         target = uint256_from_compact(self.nBits)
         if self.sha256 > target:
             return False
@@ -835,11 +829,9 @@ class CBlock(CBlockHeader):
         return True
 
     def solve(self):
-        self.rehash()
         target = uint256_from_compact(self.nBits)
         while self.sha256 > target:
             self.nNonce += 1
-            self.rehash()
 
     # Calculate the block weight using witness and non-witness
     # serialization size (does NOT use sigops).

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -742,6 +742,9 @@ class CBlockHeader:
         self.hash = None
 
     def serialize(self):
+        return self._serialize_header()
+
+    def _serialize_header(self):
         r = b""
         r += self.nVersion.to_bytes(4, "little", signed=True)
         r += ser_uint256(self.hashPrevBlock)
@@ -753,13 +756,7 @@ class CBlockHeader:
 
     def calc_sha256(self):
         if self.sha256 is None:
-            r = b""
-            r += self.nVersion.to_bytes(4, "little", signed=True)
-            r += ser_uint256(self.hashPrevBlock)
-            r += ser_uint256(self.hashMerkleRoot)
-            r += self.nTime.to_bytes(4, "little")
-            r += self.nBits.to_bytes(4, "little")
-            r += self.nNonce.to_bytes(4, "little")
+            r = self._serialize_header()
             self.sha256 = uint256_from_str(hash256(r))
             self.hash = hash256(r)[::-1].hex()
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -704,8 +704,8 @@ class CTransaction:
 
 
 class CBlockHeader:
-    __slots__ = ("hash", "hashMerkleRoot", "hashPrevBlock", "nBits", "nNonce",
-                 "nTime", "nVersion", "sha256")
+    __slots__ = ("hashMerkleRoot", "hashPrevBlock", "nBits", "nNonce",
+                 "nTime", "nVersion")
 
     def __init__(self, header=None):
         if header is None:
@@ -717,8 +717,6 @@ class CBlockHeader:
             self.nTime = header.nTime
             self.nBits = header.nBits
             self.nNonce = header.nNonce
-            self.sha256 = header.sha256
-            self.hash = header.hash
             self.calc_sha256()
 
     def set_null(self):
@@ -728,8 +726,6 @@ class CBlockHeader:
         self.nTime = 0
         self.nBits = 0
         self.nNonce = 0
-        self.sha256 = None
-        self.hash = None
 
     def deserialize(self, f):
         self.nVersion = int.from_bytes(f.read(4), "little", signed=True)
@@ -738,8 +734,6 @@ class CBlockHeader:
         self.nTime = int.from_bytes(f.read(4), "little")
         self.nBits = int.from_bytes(f.read(4), "little")
         self.nNonce = int.from_bytes(f.read(4), "little")
-        self.sha256 = None
-        self.hash = None
 
     def serialize(self):
         return self._serialize_header()
@@ -754,15 +748,22 @@ class CBlockHeader:
         r += self.nNonce.to_bytes(4, "little")
         return r
 
-    def calc_sha256(self):
-        if self.sha256 is None:
-            r = self._serialize_header()
-            self.sha256 = uint256_from_str(hash256(r))
-            self.hash = hash256(r)[::-1].hex()
+    @property
+    def hash(self):
+        """Return block header hash as hex string."""
+        return hash256(self._serialize_header())[::-1].hex()
 
+    @property
+    def sha256(self):
+        """Return block header hash as integer."""
+        return uint256_from_str(hash256(self._serialize_header()))
+
+    # TODO: get rid of this method, remove call-sites
+    def calc_sha256(self):
+        pass
+
+    # TODO: get rid of this method, replace call-sites by .sha256 access (if return value is used)
     def rehash(self):
-        self.sha256 = None
-        self.calc_sha256()
         return self.sha256
 
     def __repr__(self):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -753,13 +753,9 @@ class CBlockHeader:
         return hash256(self._serialize_header())[::-1].hex()
 
     @property
-    def sha256(self):
+    def hash_int(self):
         """Return block header hash as integer."""
         return uint256_from_str(hash256(self._serialize_header()))
-
-    # TODO: get rid of this method, replace call-sites by .sha256 access (if return value is used)
-    def rehash(self):
-        return self.sha256
 
     def __repr__(self):
         return "CBlockHeader(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x)" \
@@ -819,7 +815,7 @@ class CBlock(CBlockHeader):
 
     def is_valid(self):
         target = uint256_from_compact(self.nBits)
-        if self.sha256 > target:
+        if self.hash_int > target:
             return False
         for tx in self.vtx:
             if not tx.is_valid():
@@ -830,7 +826,7 @@ class CBlock(CBlockHeader):
 
     def solve(self):
         target = uint256_from_compact(self.nBits)
-        while self.sha256 > target:
+        while self.hash_int > target:
             self.nNonce += 1
 
     # Calculate the block weight using witness and non-witness

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -896,9 +896,9 @@ class P2PDataStore(P2PInterface):
                 self.sync_with_ping(timeout=timeout)
 
             if success:
-                self.wait_until(lambda: node.getbestblockhash() == blocks[-1].hash, timeout=timeout)
+                self.wait_until(lambda: node.getbestblockhash() == blocks[-1].hash_hex, timeout=timeout)
             else:
-                assert_not_equal(node.getbestblockhash(), blocks[-1].hash)
+                assert_not_equal(node.getbestblockhash(), blocks[-1].hash_hex)
 
     def send_txs_and_test(self, txs, node, *, success=True, expect_disconnect=False, reject_reason=None):
         """Send txs to test node and test whether they're accepted to the mempool.

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -625,7 +625,7 @@ class P2PInterface(P2PConnection):
 
     def wait_for_block(self, blockhash, *, timeout=60):
         def test_function():
-            return self.last_message.get("block") and self.last_message["block"].block.rehash() == blockhash
+            return self.last_message.get("block") and self.last_message["block"].block.hash_int == blockhash
 
         self.wait_until(test_function, timeout=timeout)
 
@@ -634,7 +634,7 @@ class P2PInterface(P2PConnection):
             last_headers = self.last_message.get('headers')
             if not last_headers:
                 return False
-            return last_headers.headers[0].rehash() == int(blockhash, 16)
+            return last_headers.headers[0].hash_int == int(blockhash, 16)
 
         self.wait_until(test_function, timeout=timeout)
 
@@ -643,7 +643,7 @@ class P2PInterface(P2PConnection):
             last_filtered_block = self.last_message.get('merkleblock')
             if not last_filtered_block:
                 return False
-            return last_filtered_block.merkleblock.header.rehash() == int(blockhash, 16)
+            return last_filtered_block.merkleblock.header.hash_int == int(blockhash, 16)
 
         self.wait_until(test_function, timeout=timeout)
 
@@ -837,14 +837,14 @@ class P2PDataStore(P2PInterface):
             return
 
         headers_list = [self.block_store[self.last_block_hash]]
-        while headers_list[-1].sha256 not in locator.vHave:
+        while headers_list[-1].hash_int not in locator.vHave:
             # Walk back through the block store, adding headers to headers_list
             # as we go.
             prev_block_hash = headers_list[-1].hashPrevBlock
             if prev_block_hash in self.block_store:
                 prev_block_header = CBlockHeader(self.block_store[prev_block_hash])
                 headers_list.append(prev_block_header)
-                if prev_block_header.sha256 == hash_stop:
+                if prev_block_header.hash_int == hash_stop:
                     # if this is the hashstop header, stop here
                     break
             else:
@@ -872,8 +872,8 @@ class P2PDataStore(P2PInterface):
 
         with p2p_lock:
             for block in blocks:
-                self.block_store[block.sha256] = block
-                self.last_block_hash = block.sha256
+                self.block_store[block.hash_int] = block
+                self.last_block_hash = block.hash_int
 
         reject_reason = [reject_reason] if reject_reason else []
         with node.assert_debug_log(expected_msgs=reject_reason):
@@ -885,7 +885,7 @@ class P2PDataStore(P2PInterface):
             else:
                 self.send_without_ping(msg_headers([CBlockHeader(block) for block in blocks]))
                 self.wait_until(
-                    lambda: blocks[-1].sha256 in self.getdata_requests,
+                    lambda: blocks[-1].hash_int in self.getdata_requests,
                     timeout=timeout,
                     check_connected=success,
                 )


### PR DESCRIPTION
Similar to what #32421 did for `CTransaction` instances, this PR aims to improve the block hash determination of `CBlockHeader`/`CBlock` (the latter is a subclass of the former) instances by removing the block header caching mechanism and introducing consistent naming. Without the statefulness, sneaky testing bugs like #32742 and #32823 are less likely to happen in the future. Note that performance is even less of an issue here compared to `CTransaction`, as we only need to hash 80 bytes, which is less than typical standard transaction sizes [2].
The only instance where the testing logic was relying on caching (i.e. we want to return an outdated value) is tackled in the second commit, the rest should be straight-forward to review, especially for contributors who already reviewed #32421.

Summary table showing block hash determaination before/after this PR:
| Task                               | master                   | PR           |
|:-----------------------------------|:-------------------------|:-------------|
| get block header hash (hex string) | `.hash`[1]               | `.hash_hex`  |
| get block header hash (integer)    | `rehash()`, `.sha256`[1] | `.hash_int`  |

[1] = returned value might be `None` or out-of-date, if rehashing function wasn't called after modification
[2] = the only exception I could think of are transaction with pay-to-anchor (P2A) outputs