### PR TITLE
index: handle case where pindex_prev equals chain tip in NextSyncBlock()

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -155,9 +155,13 @@ static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, CChain& 
         return chain.Genesis();
     }
 
-    const CBlockIndex* pindex = chain.Next(pindex_prev);
-    if (pindex) {
+    if (const auto* pindex{chain.Next(pindex_prev)}) {
         return pindex;
+    }
+
+    // If there is no next block, we might be synced
+    if (pindex_prev == chain.Tip()) {
+        return nullptr;
     }
 
     // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.


### PR DESCRIPTION
When `pindex_prev` is the chain tip, `NextSyncBlock()` should return `nullptr` (there's no next block to sync). Currently this works, but relies on the fork/reorg path to produce the result: `chain.Next(tip)` returns `nullptr`, falling through to `FindFork(tip)` which returns `tip` itself, then `chain.Next(tip)` returns `nullptr` again.
Add an explicit early return for this case. This makes `NextSyncBlock()`'s three cases self-documenting:

1. next block exists on the active chain — return it
2. at the chain tip — return `nullptr`
3. on a stale branch — find the fork point and return the block after it

It also makes the existing comment ("Since block is not in the chain") accurate — the tip is in the chain, so it shouldn't reach that path.
