### PR TITLE
rest: replace `rf_names[0].rf` by `RESTResponseFormat::UNDEF`

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -144,7 +144,7 @@ RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq
 
     // No format string is found
     if (pos_format == std::string::npos) {
-        return rf_names[0].rf;
+        return RESTResponseFormat::UNDEF;
     }
 
     // Match format string to available formats
@@ -157,7 +157,7 @@ RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq
     }
 
     // If no suffix is found, return RESTResponseFormat::UNDEF and original string without query string
-    return rf_names[0].rf;
+    return RESTResponseFormat::UNDEF;
 }
 
 static std::string AvailableDataFormatsString()


### PR DESCRIPTION
I'm reviewing the bitcoin's rest.cpp source code.
In the function: `ParseDataFormat`, `rf_names[0].rf` is actualy `RESTResponseFormat::UNDEF`: 
https://github.com/bitcoin/bitcoin/blob/e3f416dbf7633b2fb19c933e5508bd231cc7e9cf/src/rest.cpp#L48-L57
so it would be more clarity and code readability to use `return RESTResponseFormat::UNDEF;` to replace `return rf_names[0].rf;`
