### PR TITLE
Cache m_cached_finished_ibd where SetTip is called.

### DIFF
--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -21,6 +21,7 @@ void TestChainstateManager::DisableNextWrite()
 void TestChainstateManager::ResetIbd()
 {
     m_cached_finished_ibd = false;
+    m_cached_chaintip_recent = false;
     assert(IsInitialBlockDownload());
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2040,6 +2040,17 @@ bool ChainstateManager::IsInitialBlockDownload() const
     return false;
 }
 
+void ChainstateManager::UpdateCachedChaintipRecent()
+{
+    AssertLockHeld(cs_main);
+    CChain& chain{ActiveChain()};
+    if (chain.Tip() == nullptr) return;
+    if (chain.Tip()->nChainWork < MinimumChainWork()) return;
+    if (chain.Tip()->Time() < Now<NodeSeconds>() - m_options.max_tip_age) return;
+
+    m_cached_chaintip_recent = true;
+}
+
 void Chainstate::CheckForkWarningConditions()
 {
     AssertLockHeld(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3100,6 +3100,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     }
 
     m_chain.SetTip(*pindexDelete->pprev);
+    m_chainman.UpdateCachedChaintipRecent();
 
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
@@ -3228,6 +3229,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     }
     // Update m_chain & related variables.
     m_chain.SetTip(*pindexNew);
+    m_chainman.UpdateCachedChaintipRecent();
     UpdateTip(pindexNew);
 
     const auto time_6{SteadyClock::now()};
@@ -4703,6 +4705,7 @@ bool Chainstate::LoadChainTip()
         return false;
     }
     m_chain.SetTip(*pindex);
+    m_chainman.UpdateCachedChaintipRecent();
     PruneBlockIndexCandidates();
 
     tip = m_chain.Tip();

--- a/src/validation.h
+++ b/src/validation.h
@@ -1029,6 +1029,7 @@ public:
      * const, which latches this for caching purposes.
      */
     mutable std::atomic<bool> m_cached_finished_ibd{false};
+    mutable std::atomic<bool> m_cached_chaintip_recent{false};
 
     /**
      * Every received block is assigned a unique and increasing identifier, so we
@@ -1142,6 +1143,7 @@ public:
 
     /** Check whether we are doing an initial block download (synchronizing from disk or network) */
     bool IsInitialBlockDownload() const;
+    void UpdateCachedChaintipRecent() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
     double GuessVerificationProgress(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(GetMutex());


### PR DESCRIPTION
As IsInitialBlockDownload latches to false only once the Tip is sufficiently
advanced there is no need to check the Tip everytime IsIBD is called.

By caching this in advance we can avoid extra work and more importantly a lock.

