### PR TITLE
ci: Use optimized Debug build type in test-each-commit

### DIFF
--- a/.github/ci-test-each-commit-exec.py
+++ b/.github/ci-test-each-commit-exec.py
@@ -22,14 +22,20 @@ def main():
 
     num_procs = int(run(["nproc"], stdout=subprocess.PIPE).stdout)
 
-    # Use clang++, because it is a bit faster and uses less memory than g++
     run([
         "cmake",
         "-B",
         "build",
         "-Werror=dev",
+        # Use clang++, because it is a bit faster and uses less memory than g++
         "-DCMAKE_C_COMPILER=clang",
         "-DCMAKE_CXX_COMPILER=clang++",
+        # Use mold, because it is faster than the default linker
+        "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold",
+        # Use Debug build type for more debug checks, but enable optimizations
+        "-DAPPEND_CXXFLAGS='-O3 -g2'",
+        "-DAPPEND_CFLAGS='-O3 -g2'",
+        "-DCMAKE_BUILD_TYPE=Debug",
         "-DWERROR=ON",
         "-DWITH_ZMQ=ON",
         "-DBUILD_GUI=ON",

--- a/.github/ci-test-each-commit-exec.py
+++ b/.github/ci-test-each-commit-exec.py
@@ -17,7 +17,7 @@ def run(cmd, **kwargs):
 
 
 def main():
-    print("Running test-one-commit on ...")
+    print("Running tests on commit ...")
     run(["git", "log", "-1"])
 
     num_procs = int(run(["nproc"], stdout=subprocess.PIPE).stdout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           git config user.name "CI"
       - run: |
           sudo apt-get update
-          sudo apt-get install clang ccache build-essential cmake ninja-build pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev systemtap-sdt-dev libzmq3-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev -y
+          sudo apt-get install clang mold ccache build-essential cmake ninja-build pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev systemtap-sdt-dev libzmq3-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev -y
       - name: Compile and run tests
         run: |
           # Run tests on commits after the last merge commit and before the PR head commit


### PR DESCRIPTION
An optimized debug build is mostly as fast as a release build, because hot loops of heavy debug-only code are rare. So use that setting in the test-each-commit CI, to enable more checks almost "for free".