### PR TITLE
bench: Avoid tmp files in pwd

### DIFF
--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -3,8 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <util/fs.h>
 
 #include <cstddef>
@@ -13,11 +13,11 @@
 
 static void FindByte(benchmark::Bench& bench)
 {
-    // Setup
-    AutoFile file{fsbridge::fopen("streams_tmp", "w+b")};
+    const auto testing_setup{MakeNoLogFileContext<const BasicTestingSetup>(ChainType::REGTEST)};
+    AutoFile file{fsbridge::fopen(testing_setup->m_path_root / "streams_tmp", "w+b")};
     const size_t file_size = 200;
     uint8_t data[file_size] = {0};
-    data[file_size-1] = 1;
+    data[file_size - 1] = 1;
     file << data;
     file.seek(0, SEEK_SET);
     BufferedFile bf{file, /*nBufSize=*/file_size + 1, /*nRewindIn=*/file_size};
@@ -27,9 +27,7 @@ static void FindByte(benchmark::Bench& bench)
         bf.FindByte(std::byte(1));
     });
 
-    // Cleanup
     assert(file.fclose() == 0);
-    fs::remove("streams_tmp");
 }
 
 BENCHMARK(FindByte, benchmark::PriorityLevel::HIGH);


### PR DESCRIPTION
It is a bit confusing that one bench run, when aborted, could leave behind temp files in the current working directory. It is similarly confusing to delete those files in the next run of bench.

Fix all issues by using `BasicTestingSetup`, which provides a proper temp folder to use and also cleans up after itself.

Can be tested via:

```
( echo 'my file content' > streams_tmp ) && ls streams_tmp && ./bld-cmake/bin/bench_bitcoin --filter=FindByte && ls streams_tmp
```

Previously the file would be deleted, now it is kept.