### PR TITLE
rpc: use anti-fee-sniping in send, sendall and walletcreatefundedpsbt

### DIFF
--- a/doc/release-notes-32892.md
+++ b/doc/release-notes-32892.md
@@ -1,0 +1,6 @@
+RPC changes:
+------------
+
+- The `send`, `sendall` and `walletcreatefundedpsbt` will set nLockTime to
+  approximately the current height to avoid fee sniping, unless transaction
+  `locktime` or an input `sequence` is specified. (#32892).

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -111,6 +111,8 @@ public:
     int m_max_depth = DEFAULT_MAX_DEPTH;
     //! SigningProvider that has pubkeys and scripts to do spend size estimation for external inputs
     FlatSigningProvider m_external_provider;
+    //! Avoid fee sniping (m_locktime must be unset)
+    bool m_use_anti_fee_sniping{true};
     //! Locktime
     std::optional<uint32_t> m_locktime;
     //! Version

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1432,8 +1432,9 @@ util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CM
     assert(tx.vout.empty());
 
     // Set the user desired locktime
-    coinControl.m_locktime = tx.nLockTime;
-
+    if (!coinControl.m_use_anti_fee_sniping) {
+        coinControl.m_locktime = tx.nLockTime;
+    }
     // Set the user desired version
     coinControl.m_version = tx.version;
 

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -109,6 +109,10 @@ const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const COutPoint& 
  */
 std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
+void MaybeDiscourageFeeSniping(const CWallet &wallet,
+                               CMutableTransaction& tx,
+                               const CCoinControl coin_control) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
 struct SelectionFilter {
     CoinEligibilityFilter filter;
     bool allow_mixed_output_types{true};

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -709,7 +709,8 @@ class PSBTTest(BitcoinTestFramework):
         for tx_in, psbt_in in zip(decoded_psbt["tx"]["vin"], decoded_psbt["inputs"]):
             assert_equal(tx_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
             assert "bip32_derivs" in psbt_in
-        assert_equal(decoded_psbt["tx"]["locktime"], 0)
+        # Anti fee sniping
+        assert_equal(decoded_psbt["tx"]["locktime"], block_height)
 
         # Same construction without optional arguments, for a node with -walletrbf=0
         unspent1 = self.nodes[1].listunspent()[0]

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -38,15 +38,31 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
     def test_anti_fee_sniping(self):
         self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
+
+        # sendtoaddress RPC
         assert_equal(self.nodes[0].getblockchaininfo()['blocks'], 200)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
+        assert_equal(tx['locktime'], 0)
+
+        # send RPC
+        outputs = [{self.nodes[0].getnewaddress(): 1}]
+        res = self.nodes[0].send(outputs=outputs)
+        assert(res["complete"])
+        tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
         assert_equal(tx['locktime'], 0)
 
         self.log.info('Check that anti-fee-sniping is enabled when we mine a recent block')
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
+        assert 0 < tx['locktime'] <= 201
+
+        # send RPC
+        outputs = [{self.nodes[0].getnewaddress(): 1}]
+        res = self.nodes[0].send(outputs=outputs)
+        assert(res["complete"])
+        tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
         assert 0 < tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -52,6 +52,12 @@ class CreateTxWalletTest(BitcoinTestFramework):
         tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
         assert_equal(tx['locktime'], 0)
 
+        # sendall RPC (don't actually empty the wallet)
+        res = self.nodes[0].sendall(recipients=[self.nodes[0].getnewaddress()], add_to_wallet=False)
+        assert(res["complete"])
+        tx = self.nodes[0].decoderawtransaction(res['hex'])
+        assert_equal(tx['locktime'], 0)
+
         self.log.info('Check that anti-fee-sniping is enabled when we mine a recent block')
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
@@ -63,6 +69,12 @@ class CreateTxWalletTest(BitcoinTestFramework):
         res = self.nodes[0].send(outputs=outputs)
         assert(res["complete"])
         tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
+        assert 0 < tx['locktime'] <= 201
+
+        # sendall RPC
+        res = self.nodes[0].sendall(recipients=[self.nodes[0].getnewaddress()], add_to_wallet=False)
+        assert(res["complete"])
+        tx = self.nodes[0].decoderawtransaction(res['hex'])
         assert 0 < tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -53,7 +53,7 @@ class WalletRescanUnconfirmed(BitcoinTestFramework):
         # The only UTXO available to spend is tx_parent_to_reorg.
         assert_equal(len(w0_utxos), 1)
         assert_equal(w0_utxos[0]["txid"], tx_parent_to_reorg["txid"])
-        tx_child_unconfirmed_sweep = w0.sendall([ADDRESS_BCRT1_UNSPENDABLE])
+        tx_child_unconfirmed_sweep = w0.sendall([ADDRESS_BCRT1_UNSPENDABLE], locktime=0)
         assert tx_child_unconfirmed_sweep["txid"] in node.getrawmempool()
         node.syncwithvalidationinterfacequeue()
 


### PR DESCRIPTION
If the user does not specify `locktime` for `send`, `sendall` and `walletcreatefundedpsbt`, enable anti-fee-sniping. Previously we would set `nLockTime` to 0.

This behavior matches the `sendtoaddress` RPC and the GUI wallet.

Because `sendall` doesn't use `CreateTransactionInternal` this PR refactors (and renames) `DiscourageFeeSniping` so that it checks input `nSequence` values and nLockTime by itself, and brings its own `FastRandomContext`. A subsequent commit then calls this from the `sendall` RPC.