### PR TITLE
doc: fix `BlockConnected` incorrect comment

### DIFF
--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -115,7 +115,6 @@ protected:
     virtual void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int nBlockHeight) {}
     /**
      * Notifies listeners of a block being connected.
-     * Provides a vector of transactions evicted from the mempool as a result.
      *
      * Called on a background thread.
      */


### PR DESCRIPTION
This is a simple PR  that fixes the `BlockConnected` validation interface notification comment, which incorrectly states that a vector of transactions removed from the mempool is as a parameter of the method.

Originally, this was the case when the method was first introduced in https://github.com/bitcoin/bitcoin/pull/9725

However, the method has since changed, and this is no longer accurate. Keeping the outdated comment is now misleading.

This PR removes the information about the method parameters from the docstring, aligning it with the style of other notifications methods. As noticed in this PR, comments listing parameters can become stale and go uncorrected. 

Therefore, this PR simply removes the inaccurate comment without listing the current returned values.