### PR TITLE
wallet: Prepare for future upgrades by recording versions of last client to open and decrypt

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3110,7 +3110,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     }
 
     // Initialize version key.
-    if(!WalletBatch(walletInstance->GetDatabase()).WriteVersion(CLIENT_VERSION)) {
+    if(!WalletBatch(walletInstance->GetDatabase()).WriteLastOpenedVersion()) {
         error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
         return nullptr;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4005,6 +4005,13 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         }
     }
 
+    // Set the client features
+    local_wallet_batch.WriteLastOpenedVersion();
+    local_wallet_batch.WriteLastOpenedFeatures();
+    if (HasEncryptionKeys()) {
+        local_wallet_batch.WriteLastDecryptedFeatures();
+    }
+
     // Get best block locator so that we can copy it to the watchonly and solvables
     CBlockLocator best_block_locator;
     if (!local_wallet_batch.ReadBestBlock(best_block_locator)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3110,9 +3110,16 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     }
 
     // Initialize version key.
-    if(!WalletBatch(walletInstance->GetDatabase()).WriteLastOpenedVersion()) {
-        error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
-        return nullptr;
+    {
+        WalletBatch batch(walletInstance->GetDatabase());
+        if(!batch.WriteLastOpenedVersion()) {
+            error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
+            return nullptr;
+        }
+        if(!batch.WriteLastOpenedFeatures()) {
+            error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
+            return nullptr;
+        }
     }
     {
         LOCK(walletInstance->cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -641,6 +641,16 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
             if (Unlock(plain_master_key)) {
                 // Now that we've unlocked, upgrade the descriptor cache
                 UpgradeDescriptorCache();
+
+                if (!m_last_decrypted_features || *m_last_decrypted_features != WALLET_CLIENT_FEATURES) {
+                    // Write the current wallet client features to LAST_DECRYPTED_FEATURES.
+                    // This must be done after all automatic upgrades so that those upgrades can be
+                    // performed in an upgrade-downgrade-upgrade scenario.
+                    WalletBatch batch(GetDatabase());
+                    batch.WriteLastDecryptedFeatures();
+                    SetLastDecryptedFeatures(WALLET_CLIENT_FEATURES);
+                }
+
                 return true;
             }
         }
@@ -4623,4 +4633,9 @@ void CWallet::DisconnectChainNotifications()
     }
 }
 
+void CWallet::SetLastDecryptedFeatures(uint64_t features)
+{
+    AssertLockHeld(cs_wallet);
+    m_last_decrypted_features = features;
+}
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3122,7 +3122,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     }
 
     // Initialize version key.
-    if(!WalletBatch(walletInstance->GetDatabase()).WriteVersion(CLIENT_VERSION)) {
+    if(!WalletBatch(walletInstance->GetDatabase()).WriteLastOpenedVersion()) {
         error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
         return nullptr;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3122,9 +3122,16 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     }
 
     // Initialize version key.
-    if(!WalletBatch(walletInstance->GetDatabase()).WriteLastOpenedVersion()) {
-        error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
-        return nullptr;
+    {
+        WalletBatch batch(walletInstance->GetDatabase());
+        if(!batch.WriteLastOpenedVersion()) {
+            error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
+            return nullptr;
+        }
+        if(!batch.WriteLastOpenedFeatures()) {
+            error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
+            return nullptr;
+        }
     }
     {
         LOCK(walletInstance->cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -436,6 +436,9 @@ private:
     //! Set of both spent and unspent transaction outputs owned by this wallet
     std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
 
+    //! Features of the last client to decrypt this wallet
+    std::optional<uint64_t> m_last_decrypted_features GUARDED_BY(cs_wallet);
+
     /**
      * Catch wallet up to current chain, scanning new blocks, updating the best
      * block locator and m_last_block_processed, and registering for
@@ -1081,6 +1084,9 @@ public:
 
     //! Disconnect chain notifications and wait for all notifications to be processed
     void DisconnectChainNotifications();
+
+    //! Set the features of the last client to decrypt this wallet
+    void SetLastDecryptedFeatures(uint64_t features) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 };
 
 /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string LAST_DECRYPTED_FEATURES{"lastdecryptedfeatures"};
 const std::string LAST_OPENED_FEATURES{"lastopenedfeatures"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
@@ -1113,6 +1114,11 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         if (uint64_t features; m_batch->Read(DBKeys::LAST_OPENED_FEATURES, features)) {
             last_client_features = features;
         }
+
+        // Features of last client to decrypt this wallet
+        if (uint64_t last_decrypted; m_batch->Read(DBKeys::LAST_DECRYPTED_FEATURES, last_decrypted)) {
+            pwallet->SetLastDecryptedFeatures(last_decrypted);
+        }
     }
 
     try {
@@ -1271,6 +1277,11 @@ bool WalletBatch::WriteLastOpenedVersion()
 bool WalletBatch::WriteLastOpenedFeatures()
 {
     return WriteIC(DBKeys::LAST_OPENED_FEATURES, WALLET_CLIENT_FEATURES);
+}
+
+bool WalletBatch::WriteLastDecryptedFeatures()
+{
+    return WriteIC(DBKeys::LAST_DECRYPTED_FEATURES, WALLET_CLIENT_FEATURES);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string LAST_OPENED_FEATURES{"lastopenedfeatures"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MINVERSION{"minversion"};
@@ -1106,6 +1107,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
+    std::optional<uint64_t> last_client_features;
+    if (last_client >= VERSION_LAST_CLIENT_FEATURES) {
+        // Features of last client to open this wallet
+        if (uint64_t features; m_batch->Read(DBKeys::LAST_OPENED_FEATURES, features)) {
+            last_client_features = features;
+        }
+    }
+
     try {
         // Load wallet flags, so they are known when processing other records.
         // The FLAGS key is absent during wallet creation.
@@ -1189,6 +1198,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (!has_last_client || last_client != VERSION_LATEST) {
         WriteLastOpenedVersion();
     }
+    // Record the current client features as the features of the last client to successfully open this wallet file.
+    if (!last_client_features || *last_client_features != WALLET_CLIENT_FEATURES) {
+        WriteLastOpenedFeatures();
+    }
 
     return result;
 }
@@ -1253,6 +1266,11 @@ bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 bool WalletBatch::WriteLastOpenedVersion()
 {
     return WriteIC(DBKeys::VERSION, VERSION_LATEST);
+}
+
+bool WalletBatch::WriteLastOpenedFeatures()
+{
+    return WriteIC(DBKeys::LAST_OPENED_FEATURES, WALLET_CLIENT_FEATURES);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -764,7 +764,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
             value >> desc;
         } catch (const std::ios_base::failure& e) {
             strErr = strprintf("Error: Unrecognized descriptor found in wallet %s. ", pwallet->GetName());
-            strErr += (last_client > CLIENT_VERSION) ? "The wallet might have been created on a newer version. " :
+            strErr += (last_client > VERSION_LATEST) ? "The wallet might have been created on a newer version. " :
                     "The database might be corrupted or the software version is not compatible with one of your wallet descriptors. ";
             strErr += "Please try running the latest software version";
             // Also include error details
@@ -1102,7 +1102,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     LOCK(pwallet->cs_wallet);
 
     // Last client version to open this wallet
-    int last_client = CLIENT_VERSION;
+    int last_client = VERSION_LATEST;
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
@@ -1156,9 +1156,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (result != DBErrors::LOAD_OK)
         return result;
 
-    if (!has_last_client || last_client != CLIENT_VERSION) // Update
-        this->WriteVersion(CLIENT_VERSION);
-
     if (any_unordered)
         result = pwallet->ReorderTransactions();
 
@@ -1183,6 +1180,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             }
         }
         pwallet->mapMasterKeys.clear();
+    }
+
+
+    // Record the current client version as the last version to successfully open this wallet file
+    // This must always be done after all automatic upgrades so that those upgrades can be performed
+    // in an upgrade-downgrade-upgrade scenario.
+    if (!has_last_client || last_client != VERSION_LATEST) {
+        WriteLastOpenedVersion();
     }
 
     return result;
@@ -1243,6 +1248,11 @@ bool WalletBatch::EraseAddressData(const CTxDestination& dest)
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 {
     return WriteIC(DBKeys::FLAGS, flags);
+}
+
+bool WalletBatch::WriteLastOpenedVersion()
+{
+    return WriteIC(DBKeys::VERSION, VERSION_LATEST);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string LAST_OPENED_FEATURES{"lastopenedfeatures"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MINVERSION{"minversion"};
@@ -1143,6 +1144,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
+    std::optional<uint64_t> last_client_features;
+    if (last_client >= VERSION_LAST_CLIENT_FEATURES) {
+        // Features of last client to open this wallet
+        if (uint64_t features; m_batch->Read(DBKeys::LAST_OPENED_FEATURES, features)) {
+            last_client_features = features;
+        }
+    }
+
     try {
         // Load wallet flags, so they are known when processing other records.
         // The FLAGS key is absent during wallet creation.
@@ -1226,6 +1235,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (!has_last_client || last_client != VERSION_LATEST) {
         WriteLastOpenedVersion();
     }
+    // Record the current client features as the features of the last client to successfully open this wallet file.
+    if (!last_client_features || *last_client_features != WALLET_CLIENT_FEATURES) {
+        WriteLastOpenedFeatures();
+    }
 
     return result;
 }
@@ -1290,6 +1303,11 @@ bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 bool WalletBatch::WriteLastOpenedVersion()
 {
     return WriteIC(DBKeys::VERSION, VERSION_LATEST);
+}
+
+bool WalletBatch::WriteLastOpenedFeatures()
+{
+    return WriteIC(DBKeys::LAST_OPENED_FEATURES, WALLET_CLIENT_FEATURES);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -769,7 +769,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
             value >> desc;
         } catch (const std::ios_base::failure& e) {
             strErr = strprintf("Error: Unrecognized descriptor found in wallet %s. ", pwallet->GetName());
-            strErr += (last_client > CLIENT_VERSION) ? "The wallet might have been created on a newer version. " :
+            strErr += (last_client > VERSION_LATEST) ? "The wallet might have been created on a newer version. " :
                     "The database might be corrupted or the software version is not compatible with one of your wallet descriptors. ";
             strErr += "Please try running the latest software version";
             // Also include error details
@@ -1139,7 +1139,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     LOCK(pwallet->cs_wallet);
 
     // Last client version to open this wallet
-    int last_client = CLIENT_VERSION;
+    int last_client = VERSION_LATEST;
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
@@ -1193,9 +1193,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (result != DBErrors::LOAD_OK)
         return result;
 
-    if (!has_last_client || last_client != CLIENT_VERSION) // Update
-        this->WriteVersion(CLIENT_VERSION);
-
     if (any_unordered)
         result = pwallet->ReorderTransactions();
 
@@ -1220,6 +1217,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             }
         }
         pwallet->mapMasterKeys.clear();
+    }
+
+
+    // Record the current client version as the last version to successfully open this wallet file
+    // This must always be done after all automatic upgrades so that those upgrades can be performed
+    // in an upgrade-downgrade-upgrade scenario.
+    if (!has_last_client || last_client != VERSION_LATEST) {
+        WriteLastOpenedVersion();
     }
 
     return result;
@@ -1280,6 +1285,11 @@ bool WalletBatch::EraseAddressData(const CTxDestination& dest)
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 {
     return WriteIC(DBKeys::FLAGS, flags);
+}
+
+bool WalletBatch::WriteLastOpenedVersion()
+{
+    return WriteIC(DBKeys::VERSION, VERSION_LATEST);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -264,8 +264,8 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
 
-    //! Write the given client_version.
-    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, CLIENT_VERSION); }
+    //! Write the current client version in the VERSION record
+    bool WriteLastOpenedVersion();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -68,6 +68,7 @@ extern const std::string FLAGS;
 extern const std::string HDCHAIN;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string LAST_DECRYPTED_FEATURES;
 extern const std::string LAST_OPENED_FEATURES;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
@@ -269,6 +270,8 @@ public:
     bool WriteLastOpenedVersion();
     //! Write the current client features in the LAST_OPENED_FEATURES record
     bool WriteLastOpenedFeatures();
+    //! Write the current wallet client features to the LAST_DECRYPTED_FEATURES record
+    bool WriteLastDecryptedFeatures();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -68,6 +68,7 @@ extern const std::string FLAGS;
 extern const std::string HDCHAIN;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string LAST_OPENED_FEATURES;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MINVERSION;
@@ -266,11 +267,14 @@ public:
 
     //! Write the current client version in the VERSION record
     bool WriteLastOpenedVersion();
+    //! Write the current client features in the LAST_OPENED_FEATURES record
+    bool WriteLastOpenedFeatures();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);
 
     bool WriteWalletFlags(uint64_t flags);
+
     //! Begin a new transaction
     bool TxnBegin();
     //! Commit current transaction

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -271,14 +271,8 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
 
-    /**
-     * Write the given `client_version` to m_batch, indicating the last version
-     * of client software to load this wallet.
-     *
-     * @param[in]   client_version  `CLIENT_VERSION` outside of test code.
-     * @return      A bool indicating whether or not the write succeeded.
-     */
-    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, client_version); }
+    //! Write the current client version in the VERSION record
+    bool WriteLastOpenedVersion();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -70,6 +70,7 @@ extern const std::string FLAGS;
 extern const std::string HDCHAIN;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string LAST_OPENED_FEATURES;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MINVERSION;
@@ -273,11 +274,14 @@ public:
 
     //! Write the current client version in the VERSION record
     bool WriteLastOpenedVersion();
+    //! Write the current client features in the LAST_OPENED_FEATURES record
+    bool WriteLastOpenedFeatures();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);
 
     bool WriteWalletFlags(uint64_t flags);
+
     //! Begin a new transaction
     bool TxnBegin();
     //! Commit current transaction

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -64,7 +64,18 @@ enum WalletFlags : uint64_t {
 enum WalletClientVersion : int32_t {
     MIN_VERSION = (1L << 19),
 
-    VERSION_LATEST = MIN_VERSION
+    // The wallet client supports the records for LastClientFeatures
+    VERSION_LAST_CLIENT_FEATURES = MIN_VERSION + 1,
+
+    VERSION_LATEST = VERSION_LAST_CLIENT_FEATURES
+};
+
+enum LastClientFeatures : uint64_t {
+    // Flags indicating the automatic upgrade features supported by the wallet client that last opened a wallet file
+    // New automatic upgrades must define a flag here so that upgrade-downgrade-upgrade can be detected to determine whether
+    // an automatic upgrade should be performed.
+
+    WALLET_CLIENT_FEATURES = 0
 };
 
 //! Get the path of the wallet directory.

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -56,6 +56,17 @@ enum WalletFlags : uint64_t {
     WALLET_FLAG_EXTERNAL_SIGNER = (1ULL << 35),
 };
 
+// Version numbers for the wallet client that opens a wallet
+// These numbers will be written as the last client version in the "version" record and can be used to detect
+// when an upgrade-downgrade-upgrade was performed. However, we should prefer to use LastClientFeatures rather
+// than new version numbers.
+// New version numbers must be greater than 299900 which is guaranteed by setting bit 19
+enum WalletClientVersion : int32_t {
+    MIN_VERSION = (1L << 19),
+
+    VERSION_LATEST = MIN_VERSION
+};
+
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();
 

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -16,6 +16,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
+WALLET_CLIENT_VERSION = 0x80000
 
 
 class CreateWalletTest(BitcoinTestFramework):
@@ -170,8 +171,7 @@ class CreateWalletTest(BitcoinTestFramework):
         self.log.info("Check that the version number is being logged correctly")
 
         # Craft the expected version message.
-        client_version = node.getnetworkinfo()["version"]
-        version_message = f"Last client version = {client_version}"
+        version_message = f"Last client version = {WALLET_CLIENT_VERSION}"
 
         # Should not be logged when creating.
         with node.assert_debug_log(expected_msgs=[], unexpected_msgs=[version_message]):

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -16,7 +16,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
-WALLET_CLIENT_VERSION = 0x80000
+WALLET_CLIENT_VERSION = 0x80001
 
 
 class CreateWalletTest(BitcoinTestFramework):

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -20,6 +20,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
+WALLET_CLIENT_VERSION = 0x80000
 
 
 class CreateWalletTest(BitcoinTestFramework):
@@ -192,8 +193,7 @@ class CreateWalletTest(BitcoinTestFramework):
         self.log.info("Check that the version number is being logged correctly")
 
         # Craft the expected version message.
-        client_version = node.getnetworkinfo()["version"]
-        version_message = f"Last client version = {client_version}"
+        version_message = f"Last client version = {WALLET_CLIENT_VERSION}"
 
         # Should not be logged when creating.
         with node.assert_debug_log(expected_msgs=[], unexpected_msgs=[version_message]):

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -20,7 +20,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
-WALLET_CLIENT_VERSION = 0x80000
+WALLET_CLIENT_VERSION = 0x80001
 
 
 class CreateWalletTest(BitcoinTestFramework):


### PR DESCRIPTION
When a wallet is automatically upgraded, we always do so in a way that allows the user to load their wallet in an older version. When the user loads their wallet into an upgraded version again, the wallet may not perform the automatic upgrade and end up with upgraded and non-upgraded material in the wallet.

If we write some information about the last client to open the wallet, we would be able to detect these upgrade-downgrade-upgrade situations and perform another upgrade if so. However, in order for this to work, we need to have implemented writing such information into versions prior to the ones which introduce new automatic upgrades.

We are already writing the CLIENT_VERSION into all wallets in a "version" record, although this record is not updated in the same way across all previous versions. Since v24.0, we are always updating the record when the client version differs, but prior to that, the record would only be updated when the client version is newer. Even so, we can use this record to store the last client version.

The first commit decouples the written client version from the node version. This aids in development of new features. The version is entirely decoupled from previous versions by requiring all versions to have bit 19 set, and the initial version being `0 | (1 << 19)`. The versions just need to be at least 299900, and forcing bit 19 to be set was an easy way to achieve this.

However, using version numbers is not as flexible as feature flags, so the second commit introduces the concept of Wallet Client Features. These flags are distinct from the existing Wallet Feature Flags since they are conceptually different. These are written in a separate record, and the wallet client version is incremented to `(1 << 19) + 1`.

Lastly, since some upgrades may need private keys and can only occur after the wallet is decrypted, the third commit also adds a last decrypted features flags record to record the features of the last client to decrypt the wallet.

The result is that we will now be able to detect a downgrade down to v24.0 and be able to implement in parallel multiple features that require automatic upgrades.