### PR TITLE
POC: IPC tracing interface

### DIFF
--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -41,12 +41,7 @@ ALLOWED_DEPENDENCIES+=(
 
 # Declare list of known errors that should be suppressed.
 declare -A SUPPRESS
-# init/common.cpp file calls InitError and InitWarning from interface_ui which
-# is currently part of the node library. interface_ui should just be part of the
-# common library instead, and is moved in
-# https://github.com/bitcoin/bitcoin/issues/10102
-SUPPRESS["common.cpp.o interface_ui.cpp.o _Z11InitWarningRK13bilingual_str"]=1
-SUPPRESS["common.cpp.o interface_ui.cpp.o _Z9InitErrorRK13bilingual_str"]=1
+#SUPPRESS["caller.cpp.o callee.cpp.o _Z10SymbolName"]=1
 
 usage() {
    echo "Usage: $(basename "${BASH_SOURCE[0]}") [BUILD_DIR]"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,16 @@ if(ENABLE_IPC AND BUILD_DAEMON)
     $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
   install_binary_component(bitcoin-node)
+
+  add_executable(bitcoin-trace
+    bitcoin-trace.cpp
+    init/basic.cpp
+  )
+  target_link_libraries(bitcoin-trace
+    core_interface
+    bitcoin_common
+    bitcoin_ipc
+  )
 endif()
 
 if(ENABLE_IPC AND BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   net_types.cpp
   netaddress.cpp
   netbase.cpp
+  node/interface_ui.cpp
   outputtype.cpp
   policy/feerate.cpp
   policy/policy.cpp
@@ -263,7 +264,6 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/context.cpp
   node/database_args.cpp
   node/eviction.cpp
-  node/interface_ui.cpp
   node/interfaces.cpp
   node/kernel_notifications.cpp
   node/mempool_args.cpp

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -27,7 +27,7 @@ static void CCoinsCaching(benchmark::Bench& bench)
 
     FillableSigningProvider keystore;
     CCoinsView coinsDummy;
-    CCoinsViewCache coins(&coinsDummy);
+    CCoinsViewCache coins(&coinsDummy, /*traces=*/nullptr);
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11 * COIN, 50 * COIN, 21 * COIN, 22 * COIN});
 

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -98,7 +98,7 @@ void BenchmarkConnectBlock(benchmark::Bench& bench, std::vector<CKey>& keys, std
         auto& chainstate{chainman->ActiveChainstate()};
         BlockValidationState test_block_state;
         auto* pindex{chainman->m_blockman.AddToBlockIndex(test_block, chainman->m_best_header)}; // Doing this here doesn't impact the benchmark
-        CCoinsViewCache viewNew{&chainstate.CoinsTip()};
+        CCoinsViewCache viewNew{&chainstate.CoinsTip(), test_setup.m_node.kernel_traces.get()};
 
         assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));
     });

--- a/src/bitcoin-trace.cpp
+++ b/src/bitcoin-trace.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <chainparamsbase.h>
+#include <chainparams.h>
+#include <clientversion.h>
+#include <common/args.h>
+#include <common/system.h>
+#include <compat/compat.h>
+#include <init/common.h>
+#include <interfaces/init.h>
+#include <interfaces/ipc.h>
+#include <logging.h>
+#include <tinyformat.h>
+#include <util/signalinterrupt.h>
+#include <util/translation.h>
+
+#include <csignal>
+
+static const char* const HELP_USAGE{R"(
+bitcoin-trace is a test program for tracing a bitcoin-node process via IPC.
+
+Usage:
+  bitcoin-trace [options]
+)"};
+
+static const char* HELP_EXAMPLES{R"(
+Examples:
+  # Start separate bitcoin-node that bitcoin-trace can connect to.
+  bitcoin-node -regtest -ipcbind=unix
+
+  # Run printing traces.
+  bitcoin-trace -regtest -debug
+
+  # Run with debug output.
+  bitcoin-trace -regtest -debug
+)"};
+
+const TranslateFn G_TRANSLATION_FUN{nullptr};
+
+static std::optional<util::SignalInterrupt> g_shutdown;
+std::string g_shutdown_message;
+
+void HandleCtrlC(int)
+{
+    // (void)! needed to suppress -Wunused-result warning from GCC
+    (void)!write(STDOUT_FILENO, g_shutdown_message.data(), g_shutdown_message.size());
+    // Return value is intentionally ignored because there is not a better way
+    // of handling this failure in a signal handler.
+    (void)(*Assert(g_shutdown))();
+}
+
+static void AddArgs(ArgsManager& args)
+{
+    SetupHelpOptions(args);
+    SetupChainParamsBaseOptions(args);
+    args.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    args.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    args.AddArg("-ipcconnect=<address>", "Connect to bitcoin-node process in the background to perform online operations. Valid <address> values are 'unix' to connect to the default socket, 'unix:<socket path>' to connect to a socket at a nonstandard path. Default value: unix", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+    init::AddLoggingArgs(args);
+}
+
+MAIN_FUNCTION
+{
+    ArgsManager& args = gArgs;
+    AddArgs(args);
+    std::string error_message;
+    if (!args.ParseParameters(argc, argv, error_message)) {
+        tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error_message);
+        return EXIT_FAILURE;
+    }
+    if (!args.ReadConfigFiles(error_message, true)) {
+        tfm::format(std::cerr, "Error reading config files: %s\n", error_message);
+        return EXIT_FAILURE;
+    }
+    if (HelpRequested(args) || args.IsArgSet("-version")) {
+        std::string output{strprintf("%s bitcoin-trace version", CLIENT_NAME) + " " + FormatFullVersion() + "\n"};
+        if (args.IsArgSet("-version")) {
+            output += FormatParagraph(LicenseInfo());
+        } else {
+            output += HELP_USAGE;
+            output += args.GetHelpMessage();
+            output += HELP_EXAMPLES;
+        }
+        tfm::format(std::cout, "%s", output);
+        return EXIT_SUCCESS;
+    }
+    if (!CheckDataDirOption(args)) {
+        tfm::format(std::cerr, "Error: Specified data directory \"%s\" does not exist.\n", args.GetArg("-datadir", ""));
+        return EXIT_FAILURE;
+    }
+    SelectParams(args.GetChainType());
+
+    // Set logging options but override -printtoconsole default to depend on -debug rather than -daemon
+    init::SetLoggingOptions(args);
+    if (auto result{init::SetLoggingCategories(args)}; !result) {
+        tfm::format(std::cerr, "Error: %s\n", util::ErrorString(result).original);
+        return EXIT_FAILURE;
+    }
+    if (auto result{init::SetLoggingLevel(args)}; !result) {
+        tfm::format(std::cerr, "Error: %s\n", util::ErrorString(result).original);
+        return EXIT_FAILURE;
+    }
+    LogInstance().m_print_to_console = args.GetBoolArg("-printtoconsole", LogInstance().GetCategoryMask());
+    if (!init::StartLogging(args)) {
+        tfm::format(std::cerr, "Error: StartLogging failed\n");
+        return EXIT_FAILURE;
+    }
+
+    // Connect to bitcoin-node process, or fail and print an error.
+    std::unique_ptr<interfaces::Init> trace_init{interfaces::MakeBasicInit("bitcoin-trace", argc > 0 ? argv[0] : "")};
+    assert(trace_init);
+    std::unique_ptr<interfaces::Init> node_init;
+    try {
+        std::string address{args.GetArg("-ipcconnect", "unix")};
+        node_init = trace_init->ipc()->connectAddress(address);
+    } catch (const std::exception& exception) {
+        tfm::format(std::cerr, "Error: %s\n", exception.what());
+        tfm::format(std::cerr, "Probably bitcoin-node is not running or not listening on a unix socket. Can be started with:\n\n");
+        tfm::format(std::cerr, "    bitcoin-node -chain=%s -ipcbind=unix\n", args.GetChainTypeString());
+        return EXIT_FAILURE;
+    }
+    assert(node_init);
+    tfm::format(std::cout, "Connected to bitcoin-node\n");
+    std::unique_ptr<interfaces::Tracing> tracing{node_init->makeTracing()};
+    assert(tracing);
+
+    g_shutdown.emplace();
+    g_shutdown_message = "SIGINT received — starting to shut down.\n";
+    struct sigaction sa{};
+    sa.sa_handler = HandleCtrlC;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    sigaction(SIGINT, &sa, nullptr);
+
+    class Callback : public interfaces::UtxoCacheTrace
+    {
+        void add(const interfaces::UtxoInfo& coin) override
+        {
+            tfm::format(std::cout, "-- add utxo: outpoint hash %s index %s height %s value %s is_coinbase %s\n", coin.outpoint_hash.ToString(), coin.outpoint_n, coin.height, coin.value, coin.is_coinbase);
+        }
+        void spend(const interfaces::UtxoInfo& coin) override
+        {
+            tfm::format(std::cout, "-- spend utxo: outpoint hash %s index %s height %s value %s is_coinbase %s\n", coin.outpoint_hash.ToString(), coin.outpoint_n, coin.height, coin.value, coin.is_coinbase);
+        }
+        void uncache(const interfaces::UtxoInfo& coin) override
+        {
+            tfm::format(std::cout, "-- uncache utxo: outpoint hash %s index %s height %s value %s is_coinbase %s\n", coin.outpoint_hash.ToString(), coin.outpoint_n, coin.height, coin.value, coin.is_coinbase);
+        }
+    };
+
+    auto handler{tracing->traceUtxoCache(std::make_unique<Callback>())};
+    if (!g_shutdown->wait()) {
+        tfm::format(std::cerr, "Error waiting for shutdown signal.\n");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -586,7 +586,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     CMutableTransaction mergedTx{tx};
     const CMutableTransaction txv{tx};
     CCoinsView viewDummy;
-    CCoinsViewCache view(&viewDummy);
+    CCoinsViewCache view(&viewDummy, /*traces=*/nullptr);
 
     if (!registers.count("privatekeys"))
         throw std::runtime_error("privatekeys register variable must be set.");

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -15,6 +15,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
 #include <kernel/context.h>
+#include <kernel/traces.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <node/warnings.h>
@@ -190,6 +191,7 @@ static bool AppInit(NodeContext& node)
         }
 
         node.warnings = std::make_unique<node::Warnings>();
+        node.kernel_traces = std::make_unique<kernel::Traces>();
 
         node.kernel = std::make_unique<kernel::Context>();
         node.ecc_context = std::make_unique<ECC_Context>();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -109,6 +109,12 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
            (uint32_t)it->second.coin.nHeight,
            (int64_t)it->second.coin.out.nValue,
            (bool)it->second.coin.IsCoinBase());
+    if (m_traces) {
+        LOCK(m_traces->mutex);
+        for (const auto& trace : m_traces->utxo_cache) {
+            trace->add(interfaces::UtxoInfo{outpoint.hash, outpoint.n, it->second.coin.nHeight, it->second.coin.out.nValue, it->second.coin.IsCoinBase()});
+        }
+    }
 }
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
@@ -138,6 +144,12 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
            (uint32_t)it->second.coin.nHeight,
            (int64_t)it->second.coin.out.nValue,
            (bool)it->second.coin.IsCoinBase());
+    if (m_traces) {
+        LOCK(m_traces->mutex);
+        for (const auto& trace : m_traces->utxo_cache) {
+            trace->spend(interfaces::UtxoInfo{outpoint.hash, outpoint.n, it->second.coin.nHeight, it->second.coin.out.nValue, it->second.coin.IsCoinBase()});
+        }
+    }
     if (moveout) {
         *moveout = std::move(it->second.coin);
     }
@@ -283,6 +295,12 @@ void CCoinsViewCache::Uncache(const COutPoint& hash)
                (uint32_t)it->second.coin.nHeight,
                (int64_t)it->second.coin.out.nValue,
                (bool)it->second.coin.IsCoinBase());
+        if (m_traces) {
+            LOCK(m_traces->mutex);
+            for (const auto& trace : m_traces->utxo_cache) {
+                trace->uncache(interfaces::UtxoInfo{hash.hash, hash.n, it->second.coin.nHeight, it->second.coin.out.nValue, it->second.coin.IsCoinBase()});
+            }
+        }
         cacheCoins.erase(it);
     }
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -34,9 +34,10 @@ bool CCoinsViewBacked::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &h
 std::unique_ptr<CCoinsViewCursor> CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
+CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, kernel::Traces* traces, bool deterministic) :
     CCoinsViewBacked(baseIn), m_deterministic(deterministic),
-    cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
+    cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource),
+    m_traces(traces)
 {
     m_sentinel.second.SelfRef(m_sentinel);
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -8,6 +8,7 @@
 
 #include <compressor.h>
 #include <core_memusage.h>
+#include <kernel/traces.h>
 #include <memusage.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -379,7 +380,9 @@ protected:
     mutable size_t cachedCoinsUsage{0};
 
 public:
-    CCoinsViewCache(CCoinsView *baseIn, bool deterministic = false);
+    kernel::Traces* m_traces;
+
+    CCoinsViewCache(CCoinsView *baseIn, kernel::Traces* traces, bool deterministic = false);
 
     /**
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1239,6 +1239,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
         .datadir = args.GetDataDirNet(),
         .notifications = *node.notifications,
         .signals = node.validation_signals.get(),
+        .traces = node.kernel_traces.get(),
     };
     Assert(ApplyArgsManOptions(args, chainman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/init/basic.cpp
+++ b/src/init/basic.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/init.h>
+#include <interfaces/ipc.h>
+
+namespace init {
+namespace {
+class BitcoinBasicInit : public interfaces::Init
+{
+public:
+    BitcoinBasicInit(const char* exe_name, const char* process_argv0) : m_ipc(interfaces::MakeIpc(exe_name, process_argv0, *this)) {}
+    interfaces::Ipc* ipc() override { return m_ipc.get(); }
+private:
+    std::unique_ptr<interfaces::Ipc> m_ipc;
+};
+} // namespace
+} // namespace init
+
+namespace interfaces {
+std::unique_ptr<Init> MakeBasicInit(const char* exe_name, const char* process_argv0)
+{
+    return std::make_unique<init::BitcoinBasicInit>(exe_name, process_argv0);
+}
+} // namespace interfaces

--- a/src/init/bitcoin-gui.cpp
+++ b/src/init/bitcoin-gui.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <interfaces/node.h>
+#include <interfaces/tracing.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
 #include <util/check.h>
@@ -33,6 +34,7 @@ public:
         return MakeWalletLoader(chain, *Assert(m_node.args));
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
+    std::unique_ptr<interfaces::Tracing> makeTracing() override { return interfaces::MakeTracing(m_node); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
     // bitcoin-gui accepts -ipcbind option even though it does not use it
     // directly. It just returns true here to accept the option because

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <interfaces/node.h>
+#include <interfaces/tracing.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
 #include <util/check.h>
@@ -36,6 +37,7 @@ public:
         return MakeWalletLoader(chain, *Assert(m_node.args));
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
+    std::unique_ptr<interfaces::Tracing> makeTracing() override { return interfaces::MakeTracing(m_node); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
     bool canListenIpc() override { return true; }
     node::NodeContext& m_node;

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -53,6 +53,25 @@ std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status);
 
 //! Return implementation of Init interface for the gui process.
 std::unique_ptr<Init> MakeGuiInit(int argc, char* argv[]);
+
+//! Return implementation of Init interface for a basic IPC client that doesn't
+//! provide any IPC services itself.
+//!
+//! When an IPC client connects to a socket or spawns a process, it gets a pointer
+//! to an Init object allowing it to create objects and threads on the remote
+//! side of the IPC connection. But the client also needs to provide a local Init
+//! object to allow the remote side of the connection to create objects and
+//! threads on this side. This function just returns a basic Init object
+//! allowing remote connections to only create local threads, not other objects
+//! (because its Init::make* methods return null.)
+//!
+//! @param exe_name Current executable name, which is just passed to the IPC
+//!     system and used for logging.
+//!
+//! @param process_argv0 Optional string containing argv[0] value passed to
+//!     main(). This is passed to the IPC system and used to locate binaries by
+//!     relative path if subprocesses are spawned.
+std::unique_ptr<Init> MakeBasicInit(const char* exe_name, const char* process_argv0="");
 } // namespace interfaces
 
 #endif // BITCOIN_INTERFACES_INIT_H

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -9,6 +9,7 @@
 #include <interfaces/echo.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
+#include <interfaces/tracing.h>
 #include <interfaces/wallet.h>
 
 #include <memory>
@@ -36,6 +37,7 @@ public:
     virtual std::unique_ptr<Mining> makeMining() { return nullptr; }
     virtual std::unique_ptr<WalletLoader> makeWalletLoader(Chain& chain) { return nullptr; }
     virtual std::unique_ptr<Echo> makeEcho() { return nullptr; }
+    virtual std::unique_ptr<Tracing> makeTracing() { return nullptr; }
     virtual Ipc* ipc() { return nullptr; }
     virtual bool canListenIpc() { return false; }
 };

--- a/src/interfaces/tracing.h
+++ b/src/interfaces/tracing.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_TRACING_H
+#define BITCOIN_INTERFACES_TRACING_H
+
+#include <interfaces/handler.h>
+#include <util/transaction_identifier.h>
+
+#include <memory>
+
+namespace node {
+struct NodeContext;
+} // namespace node
+
+namespace interfaces {
+struct UtxoInfo {
+    Txid outpoint_hash;
+    uint32_t outpoint_n;
+    uint32_t height;
+    int64_t value;
+    bool is_coinbase;
+};
+
+class UtxoCacheTrace
+{
+public:
+    virtual ~UtxoCacheTrace() = default;
+    virtual void add(const UtxoInfo& coin) {}
+    virtual void spend(const UtxoInfo& coin) {}
+    virtual void uncache(const UtxoInfo& coin) {}
+};
+
+class Tracing
+{
+public:
+    virtual ~Tracing() = default;
+    virtual std::unique_ptr<Handler> traceUtxoCache(std::unique_ptr<UtxoCacheTrace> callback) = 0;
+};
+
+//! Return implementation of Tracing interface.
+std::unique_ptr<Tracing> MakeTracing(node::NodeContext& node);
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_TRACING_H

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -12,8 +12,10 @@ add_library(bitcoin_ipc STATIC EXCLUDE_FROM_ALL
 target_capnp_sources(bitcoin_ipc ${PROJECT_SOURCE_DIR}
   capnp/common.capnp
   capnp/echo.capnp
+  capnp/handler.capnp
   capnp/init.capnp
   capnp/mining.capnp
+  capnp/tracing.capnp
 )
 
 target_link_libraries(bitcoin_ipc

--- a/src/ipc/capnp/handler-types.h
+++ b/src/ipc/capnp/handler-types.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_CAPNP_HANDLER_TYPES_H
+#define BITCOIN_IPC_CAPNP_HANDLER_TYPES_H
+
+#include <mp/type-context.h>
+#include <ipc/capnp/handler.capnp.proxy.h>
+
+#endif // BITCOIN_IPC_CAPNP_HANDLER_TYPES_H

--- a/src/ipc/capnp/handler.capnp
+++ b/src/ipc/capnp/handler.capnp
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xebd8f46e2f369076;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/handler.h");
+$Proxy.includeTypes("ipc/capnp/handler-types.h");
+
+interface Handler $Proxy.wrap("interfaces::Handler") {
+    destroy @0 (context :Proxy.Context) -> ();
+    disconnect @1 (context :Proxy.Context) -> ();
+}

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -7,5 +7,6 @@
 
 #include <ipc/capnp/echo.capnp.proxy-types.h>
 #include <ipc/capnp/mining.capnp.proxy-types.h>
+#include <ipc/capnp/tracing.capnp.proxy-types.h>
 
 #endif // BITCOIN_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -11,13 +11,16 @@ using Proxy = import "/mp/proxy.capnp";
 $Proxy.include("interfaces/echo.h");
 $Proxy.include("interfaces/init.h");
 $Proxy.include("interfaces/mining.h");
+$Proxy.include("interfaces/tracing.h");
 $Proxy.includeTypes("ipc/capnp/init-types.h");
 
 using Echo = import "echo.capnp";
 using Mining = import "mining.capnp";
+using Tracing = import "tracing.capnp";
 
 interface Init $Proxy.wrap("interfaces::Init") {
     construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     makeEcho @1 (context :Proxy.Context) -> (result :Echo.Echo);
     makeMining @2 (context :Proxy.Context) -> (result :Mining.Mining);
+    makeTracing @3 (context :Proxy.Context) -> (result :Tracing.Tracing);
 }

--- a/src/ipc/capnp/tracing-types.h
+++ b/src/ipc/capnp/tracing-types.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_CAPNP_TRACING_TYPES_H
+#define BITCOIN_IPC_CAPNP_TRACING_TYPES_H
+
+#include <interfaces/tracing.h>
+#include <ipc/capnp/common-types.h>
+#include <ipc/capnp/handler-types.h>
+#include <ipc/capnp/tracing.capnp.proxy.h>
+
+namespace mp {
+// Custom serializations
+} // namespace mp
+
+#endif // BITCOIN_IPC_CAPNP_TRACING_TYPES_H

--- a/src/ipc/capnp/tracing.capnp
+++ b/src/ipc/capnp/tracing.capnp
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xfcbbd3f49874128e;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Common = import "common.capnp";
+using Handler = import "handler.capnp";
+using Proxy = import "/mp/proxy.capnp";
+
+$Proxy.include("interfaces/tracing.h");
+$Proxy.includeTypes("ipc/capnp/tracing-types.h");
+
+interface Tracing $Proxy.wrap("interfaces::Tracing") {
+    traceUtxoCache @0 (context :Proxy.Context, callback :UtxoCacheTrace) -> (result :Handler.Handler);
+}
+
+interface UtxoCacheTrace $Proxy.wrap("interfaces::UtxoCacheTrace") {
+    destroy @0 (context :Proxy.Context) -> ();
+    add @1 (utxoInfo :UtxoInfo) -> ();
+    spend @2 (utxoInfo :UtxoInfo) -> ();
+    uncache @3 (utxoInfo :UtxoInfo) -> ();
+}
+
+struct UtxoInfo $Proxy.wrap("interfaces::UtxoInfo") {
+    outpointHash @0 :Data $Proxy.name("outpoint_hash");
+    outpointN @1 :UInt32 $Proxy.name("outpoint_n");
+    height @2 :UInt32 $Proxy.name("height");
+    value @3 :Int64 $Proxy.name("value");
+    isCoinbase @4 :Bool $Proxy.name("is_coinbase");
+}

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -24,6 +24,7 @@ class ValidationSignals;
 static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
 
 namespace kernel {
+struct Traces;
 
 /**
  * An options struct for `ChainstateManager`, more ergonomically referred to as
@@ -44,6 +45,7 @@ struct ChainstateManagerOpts {
     CoinsViewOptions coins_view{};
     Notifications& notifications;
     ValidationSignals* signals{nullptr};
+    Traces* traces{nullptr};
     //! Number of script check worker threads. Zero means no parallel verification.
     int worker_threads_num{0};
     size_t script_execution_cache_bytes{DEFAULT_SCRIPT_EXECUTION_CACHE_BYTES};

--- a/src/kernel/traces.h
+++ b/src/kernel/traces.h
@@ -5,12 +5,19 @@
 #ifndef BITCOIN_KERNEL_TRACES_H
 #define BITCOIN_KERNEL_TRACES_H
 
+#include <interfaces/tracing.h>
+#include <sync.h>
+
+#include <list>
+
 namespace kernel {
 /**
  * Struct used by kernel code which emits traces to track which traces are
  * enabled and which listeners are receiving them.
  */
 struct Traces {
+    Mutex mutex;
+    std::list<std::unique_ptr<interfaces::UtxoCacheTrace>> utxo_cache GUARDED_BY(mutex);
 };
 } // namespace kernel
 

--- a/src/kernel/traces.h
+++ b/src/kernel/traces.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_TRACES_H
+#define BITCOIN_KERNEL_TRACES_H
+
+namespace kernel {
+/**
+ * Struct used by kernel code which emits traces to track which traces are
+ * enabled and which listeners are receiving them.
+ */
+struct Traces {
+};
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_TRACES_H

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -34,6 +34,7 @@ class WalletLoader;
 } // namespace interfaces
 namespace kernel {
 struct Context;
+struct Traces;
 }
 namespace util {
 class SignalInterrupt;
@@ -90,6 +91,7 @@ struct NodeContext {
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;
     std::thread background_init_thread;
+    std::unique_ptr<kernel::Traces> kernel_traces;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -117,7 +117,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
         // Estimate the size
         CMutableTransaction mtx(*psbtx.tx);
         CCoinsView view_dummy;
-        CCoinsViewCache view(&view_dummy);
+        CCoinsViewCache view(&view_dummy, /*traces=*/nullptr);
         bool success = true;
 
         for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2802,7 +2802,7 @@ static RPCHelpMan getdescriptoractivity()
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(::cs_main);
         LOCK(mempool.cs);
-        const CCoinsViewCache& coins_view = &active_chainstate.CoinsTip();
+        const CCoinsViewCache& coins_view{active_chainstate.CoinsTip()};
 
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {
             const auto& tx = e.GetSharedTx();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -662,7 +662,7 @@ static RPCHelpMan combinerawtransaction()
 
     // Fetch previous transactions (inputs):
     CCoinsView viewDummy;
-    CCoinsViewCache view(&viewDummy);
+    CCoinsViewCache view(&viewDummy, /*traces=*/nullptr);
     {
         NodeContext& node = EnsureAnyNodeContext(request.context);
         const CTxMemPool& mempool = EnsureMemPool(node);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -79,7 +79,7 @@ public:
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
-    explicit CCoinsViewCacheTest(CCoinsView* _base) : CCoinsViewCache(_base) {}
+    explicit CCoinsViewCacheTest(CCoinsView* _base) : CCoinsViewCache(_base, /*traces=*/nullptr) {}
 
     void SelfTest(bool sanity_check = true) const
     {

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -95,7 +95,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
-            CCoinsViewCache view(&chainstate.CoinsTip());
+            CCoinsViewCache view(&chainstate.CoinsTip(), m_node.kernel_traces.get());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }
         // Send block connected notification, then stop the index without

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -46,7 +46,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
 {
     bool good_data{true};
 
-    CCoinsViewCache coins_view_cache{&backend_coins_view, /*deterministic=*/true};
+    CCoinsViewCache coins_view_cache{&backend_coins_view, /*traces=*/nullptr, /*deterministic=*/true};
     if (is_db) coins_view_cache.SetBestBlock(uint256::ONE);
     COutPoint random_out_point;
     Coin random_coin;

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -248,7 +248,7 @@ FUZZ_TARGET(coinscache_sim)
         ++current_height;
         // Make sure there is always at least one CCoinsViewCache.
         if (caches.empty()) {
-            caches.emplace_back(new CCoinsViewCache(&bottom, /*deterministic=*/true));
+            caches.emplace_back(new CCoinsViewCache(&bottom, /*traces=*/nullptr, /*deterministic=*/true));
             sim_caches[caches.size()].Wipe();
         }
 
@@ -376,7 +376,7 @@ FUZZ_TARGET(coinscache_sim)
             [&]() { // Add a cache level (if not already at the max).
                 if (caches.size() != MAX_CACHES) {
                     // Apply to real caches.
-                    caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
+                    caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*traces=*/nullptr, /*deterministic=*/true));
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();
                 }

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -88,7 +88,7 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
     (void)SignalsOptInRBF(tx);
 
     CCoinsView coins_view;
-    const CCoinsViewCache coins_view_cache(&coins_view);
+    const CCoinsViewCache coins_view_cache(&coins_view, /*traces=*/nullptr);
     (void)AreInputsStandard(tx, coins_view_cache);
     (void)IsWitnessStandard(tx, coins_view_cache);
 

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(switchover)
 BOOST_AUTO_TEST_CASE(AreInputsStandard)
 {
     CCoinsView coinsDummy;
-    CCoinsViewCache coins(&coinsDummy);
+    CCoinsViewCache coins(&coinsDummy, m_node.kernel_traces.get());
     FillableSigningProvider keystore;
     CKey key[6];
     for (int i = 0; i < 6; i++)

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
 
     // Create utxo set
     CCoinsView coinsDummy;
-    CCoinsViewCache coins(&coinsDummy);
+    CCoinsViewCache coins(&coinsDummy, m_node.kernel_traces.get());
     // Create key
     CKey key = GenerateRandomKey();
     CPubKey pubkey = key.GetPubKey();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(test_Get)
 {
     FillableSigningProvider keystore;
     CCoinsView coinsDummy;
-    CCoinsViewCache coins(&coinsDummy);
+    CCoinsViewCache coins(&coinsDummy, m_node.kernel_traces.get());
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});
 
@@ -783,7 +783,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
     FillableSigningProvider keystore;
     CCoinsView coinsDummy;
-    CCoinsViewCache coins(&coinsDummy);
+    CCoinsViewCache coins(&coinsDummy, m_node.kernel_traces.get());
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -142,7 +142,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t fail
             // WITNESS requires P2SH
             test_flags |= SCRIPT_VERIFY_P2SH;
         }
-        bool ret = CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
+        bool ret = CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
         // CheckInputScripts should succeed iff test_flags doesn't intersect with
         // failing_flags
         bool expected_return_value = !(test_flags & failing_flags);
@@ -152,13 +152,13 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t fail
         if (ret && add_to_cache) {
             // Check that we get a cache hit if the tx was valid
             std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
+            BOOST_CHECK(CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
             BOOST_CHECK(scriptchecks.empty());
         } else {
             // Check that we get script executions to check, if the transaction
             // was invalid, or we didn't add to cache.
             std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
+            BOOST_CHECK(CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
             BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
         }
     }
@@ -216,13 +216,13 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData ptd_spend_tx;
 
-        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
 
         // If we call again asking for scriptchecks (as happens in
         // ConnectBlock), we should add a script check object for this -- we're
         // not caching invalidity (if that changes, delete this test case).
         std::vector<CScriptCheck> scriptchecks;
-        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
+        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
         BOOST_CHECK_EQUAL(scriptchecks.size(), 1U);
 
         // Test that CheckInputScripts returns true iff DERSIG-enforcing flags are
@@ -312,7 +312,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
     }
 
     // TODO: add tests for remaining script flags
@@ -374,12 +374,12 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData txdata;
         // This transaction is now invalid under segwit, because of the second input.
-        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
 
         std::vector<CScriptCheck> scriptchecks;
         // Make sure this transaction was not cached (ie because the first
         // input was valid)
-        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
+        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
         // Should get 2 script checks back -- caching is on a whole-transaction basis.
         BOOST_CHECK_EQUAL(scriptchecks.size(), 2U);
     }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -445,7 +445,7 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
     }
     // - Populate a CoinsViewCache with the unspent output
     CCoinsView coins_view;
-    CCoinsViewCache coins_cache(&coins_view);
+    CCoinsViewCache coins_cache(&coins_view, m_node.kernel_traces.get());
     for (const auto& input_transaction : input_transactions) {
         AddCoins(coins_cache, *input_transaction.get(), input_height);
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -704,7 +704,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
     uint64_t innerUsage = 0;
     uint64_t prev_ancestor_count{0};
 
-    CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(&active_coins_tip));
+    CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(&active_coins_tip), active_coins_tip.m_traces);
 
     for (const auto& it : GetSortedDepthAndScore()) {
         checkTotal += it->GetTxSize();

--- a/src/validation.h
+++ b/src/validation.h
@@ -57,6 +57,7 @@ struct LockPoints;
 struct AssumeutxoData;
 namespace node {
 class SnapshotMetadata;
+struct Traces;
 } // namespace node
 namespace Consensus {
 struct Params;
@@ -491,7 +492,7 @@ public:
     CoinsViews(DBParams db_params, CoinsViewOptions options);
 
     //! Initialize the CCoinsViewCache member.
-    void InitCache() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void InitCache(kernel::Traces* traces) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 
 enum class CoinsCacheSizeState


### PR DESCRIPTION
This a is proof-of-concept adding an IPC interface for tracing as discussed in https://github.com/bitcoin-core/libmultiprocess/issues/185. As mentioned there, this is a naive implementation that would need to be optimized to have good performance, but it does show an end-to-end demo of how tracing could work using IPC.

The can be tested by building with `-DENABLE_IPC=ON` and running:

```bash
build/bin/bitcoin-node -regtest -ipcbind=unix  # Start node listening on IPC socket
build/bin/bitcoin-trace -regtest -debug        # Run bitcoin-trace and connect to socket
build/bin/bitcoin-cli -regtest -generate       # Create a block to generate sample traces
```