### PR TITLE
feature:automatically include the elapsed time in logging

### DIFF
--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -41,11 +41,7 @@ public:
 
     ~Timer()
     {
-        if (m_message_on_completion) {
-            this->Log(strprintf("%s completed", m_title));
-        } else {
-            this->Log("completed");
-        }
+        this->Log(m_message_on_completion ? strprintf("%s completed", m_title) : "completed");
     }
 
     void Log(const std::string& msg)


### PR DESCRIPTION
Simple, minimal change to improve logging by including the elapsed time in the "completed" log message even when `msg_on_completion` is set to true. Motivation is to contribute, and improve Bitcoin Core user experience & Bitcoin Core developer experience with a simple log modification.

Current log outputs:
```
LoadBlockIndex completed
```
--- 

After modification log output:
```
LoadBlockIndex: LoadBlockIndex completed (452.87ms)
```

Current state doesn't include how long the operation took. Which can force developers to either Parse "started" and "completed" lines separately Or add an intermediate log themselves to capture the duration.