### PR TITLE
refactor: avoid double hashing in `SourceLocationHasher`

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -42,14 +42,14 @@ struct SourceLocationEqual {
     }
 };
 
-struct SourceLocationHasher {
+struct SourceLocationHasher
+{
     size_t operator()(const std::source_location& s) const noexcept
     {
-        // Use CSipHasher(0, 0) as a simple way to get uniform distribution.
-        return static_cast<size_t>(CSipHasher(0, 0)
-                                       .Write(std::hash<std::string_view>{}(s.file_name()))
-                                       .Write(s.line())
-                                       .Finalize());
+        return size_t(CSipHasher(0, 0)
+                      .Write(MakeUCharSpan(std::string_view{s.file_name()}))
+                      .Write(s.line())
+                      .Finalize());
     }
 };
 


### PR DESCRIPTION
Feeds the file name string directly into the hasher instead of pre-hashing it first. The resulting hash changes of course, but that doesn't affect us since it's only stored in-memory.

Fixes: https://github.com/bitcoin/bitcoin/pull/32604#discussion_r2188644325

A few other related nits were also addressed here:
* Comment was redundant, `CSipHasher` is used in other hashers all over the codebase
* `static_cast<size_t>` skewed the whole method, changed to shorter functional-style cast
* `struct` formatting is aligned with `class` formatting - see https://github.com/bitcoin/bitcoin/pull/32813