### PR TITLE
cmake: Use newer signature of `qt6_add_lrelease` when available

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -245,10 +245,11 @@ endif()
 
 file(GLOB ts_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} locale/*.ts)
 set_source_files_properties(${ts_files} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/locale)
-qt6_add_lrelease(bitcoinqt
-  TS_FILES ${ts_files}
-  OPTIONS -silent
-)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7)
+  qt6_add_lrelease(TS_FILES ${ts_files} OPTIONS -silent)
+else()
+  qt6_add_lrelease(bitcoinqt TS_FILES ${ts_files} OPTIONS -silent)
+endif()
 
 add_executable(bitcoin-qt
   main.cpp


### PR DESCRIPTION
See Qt docs here: https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-lrelease.html.

Fixes https://github.com/bitcoin/bitcoin/issues/32710.