### PR TITLE
p2p: TxOrphanage revamp cleanups

### DIFF
--- a/doc/release-notes-31829.md
+++ b/doc/release-notes-31829.md
@@ -1,0 +1,11 @@
+P2P
+
+- The transaction orphanage, which holds transactions with missing inputs temporarily while the node attempts to fetch
+its parents, now has improved Denial of Service protections. Previously, it enforced a maximum number of unique
+transactions (default 100, configurable using `-maxorphantx`). Now, its limits are as follows: the number of entries
+(unique by wtxid and peer), plus each unique transaction's input count divided by 10, must not exceed 3,000. The total
+weight of unique transactions must not exceed 404,000 Wu multiplied by the number of peers.
+
+- The `-maxorphantx` option no longer has any effect, since the orphanage no longer limits the number of unique
+transactions. Users should remove this configuration option if they were using it, as the setting will cause an
+error in future versions when it is no longer recognized.

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -97,7 +97,6 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
         // Lastly, add the large transaction.
         const auto num_announcements_before_trim{orphanage->CountAnnouncements()};
         assert(orphanage->AddTx(large_tx, peer));
-        orphanage->LimitOrphans();
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
         const auto num_announcements_after_trim{orphanage->CountAnnouncements()};
@@ -178,7 +177,6 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
         const auto num_announcements_before_trim{orphanage->CountAnnouncements()};
         // There is a small gap between the total usage and the max usage. Add a transaction to fill it.
         assert(orphanage->AddTx(last_tx, 0));
-        orphanage->LimitOrphans();
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
         const auto num_evicted{num_announcements_before_trim - orphanage->CountAnnouncements() + 1};

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -68,7 +68,7 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     auto large_tx = MakeTransactionBulkedTo(1, MAX_STANDARD_TX_WEIGHT, det_rand);
     assert(GetTransactionWeight(*large_tx) <= MAX_STANDARD_TX_WEIGHT);
 
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_ann=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
 
     // Populate the orphanage. To maximize the number of evictions, first fill up with tiny transactions, then add a huge one.
     NodeId peer{0};
@@ -131,7 +131,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     indexes.resize(NUM_UNIQUE_TXNS);
     std::iota(indexes.begin(), indexes.end(), 0);
 
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_ann=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
     // Every peer sends the same transactions, all from shared_txs.
     // Each peer has 1 or 2 assigned transactions, which they must place as the last and second-to-last positions.
     // The assignments ensure that every transaction is in some peer's last 2 transactions, and is thus remains in the orphanage until the end of LimitOrphans.
@@ -189,7 +189,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
 static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
 {
     FastRandomContext det_rand{true};
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_ann=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
     // This is an unrealistically large number of inputs for a block, as there is almost no room given to witness data,
     // outputs, and overhead for individual transactions. The entire block is 1 transaction with 20,000 inputs.
     constexpr unsigned int NUM_BLOCK_INPUTS{MAX_BLOCK_WEIGHT / APPROX_WEIGHT_PER_INPUT};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -490,6 +490,8 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-allowignoredconf", strprintf("For backwards compatibility, treat an unused %s file in the datadir as a warning, not an error.", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE_MB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    // TODO: remove in v31.0
+    argsman.AddArg("-maxorphantx=<n>", strprintf("(Removed option, see release notes)"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY_HOURS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
@@ -891,6 +893,11 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     if (args.IsArgSet("-datacarriersize") || args.IsArgSet("-datacarrier")) {
         InitWarning(_("Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated. They will be removed in a future version."));
+    }
+
+    // We no longer limit the orphanage based on number of transactions but keep the option to warn users who still have it in their config.
+    if (args.IsArgSet("-maxorphantx")) {
+        InitWarning(_("Option '-maxorphantx' is set but no longer has any effect (see release notes). Please remove it from your configuration."));
     }
 
     // Error if network-specific options (-addnode, -connect, etc) are

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -533,7 +533,7 @@ public:
     std::optional<std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    std::vector<node::TxOrphanage::OrphanTxBase> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
+    std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
     PeerManagerInfo GetInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void SendPings() override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void RelayTransaction(const Txid& txid, const Wtxid& wtxid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -1754,7 +1754,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
     return true;
 }
 
-std::vector<node::TxOrphanage::OrphanTxBase> PeerManagerImpl::GetOrphanTransactions()
+std::vector<node::TxOrphanage::OrphanInfo> PeerManagerImpl::GetOrphanTransactions()
 {
     LOCK(m_tx_download_mutex);
     return m_txdownloadman.GetOrphanTransactions();

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -109,7 +109,7 @@ public:
     /** Get statistics from node state */
     virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
 
-    virtual std::vector<node::TxOrphanage::OrphanTxBase> GetOrphanTransactions() = 0;
+    virtual std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() = 0;
 
     /** Get peer manager info. */
     virtual PeerManagerInfo GetInfo() const = 0;

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -170,7 +170,7 @@ public:
     void CheckIsEmpty(NodeId nodeid) const;
 
     /** Wrapper for TxOrphanage::GetOrphanTransactions */
-    std::vector<TxOrphanage::OrphanTxBase> GetOrphanTransactions() const;
+    std::vector<TxOrphanage::OrphanInfo> GetOrphanTransactions() const;
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_H

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -83,7 +83,7 @@ void TxDownloadManager::CheckIsEmpty(NodeId nodeid) const
 {
     m_impl->CheckIsEmpty(nodeid);
 }
-std::vector<TxOrphanage::OrphanTxBase> TxDownloadManager::GetOrphanTransactions() const
+std::vector<TxOrphanage::OrphanInfo> TxDownloadManager::GetOrphanTransactions() const
 {
     return m_impl->GetOrphanTransactions();
 }
@@ -576,7 +576,7 @@ void TxDownloadManagerImpl::CheckIsEmpty()
     assert(m_txrequest.Size() == 0);
     assert(m_num_wtxid_peers == 0);
 }
-std::vector<TxOrphanage::OrphanTxBase> TxDownloadManagerImpl::GetOrphanTransactions() const
+std::vector<TxOrphanage::OrphanInfo> TxDownloadManagerImpl::GetOrphanTransactions() const
 {
     return m_orphanage->GetOrphanTransactions();
 }

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -572,7 +572,7 @@ void TxDownloadManagerImpl::CheckIsEmpty(NodeId nodeid)
 void TxDownloadManagerImpl::CheckIsEmpty()
 {
     assert(m_orphanage->TotalOrphanUsage() == 0);
-    assert(m_orphanage->Size() == 0);
+    assert(m_orphanage->CountUniqueOrphans() == 0);
     assert(m_txrequest.Size() == 0);
     assert(m_num_wtxid_peers == 0);
 }

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -188,7 +188,6 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
 
             if (MaybeAddOrphanResolutionCandidate(unique_parents, *wtxid, peer, now)) {
                 m_orphanage->AddAnnouncer(orphan_tx->GetWitnessHash(), peer);
-                m_orphanage->LimitOrphans();
             }
 
             // Return even if the peer isn't an orphan resolution candidate. This would be caught by AlreadyHaveTx.
@@ -419,9 +418,6 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 // Once added to the orphan pool, a tx is considered AlreadyHave, and we shouldn't request it anymore.
                 m_txrequest.ForgetTxHash(tx.GetHash());
                 m_txrequest.ForgetTxHash(tx.GetWitnessHash());
-
-                // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
-                m_orphanage->LimitOrphans();
             } else {
                 unique_parents.clear();
                 LogDebug(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s (wtxid=%s)\n",

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -188,7 +188,7 @@ public:
     void CheckIsEmpty();
     void CheckIsEmpty(NodeId nodeid);
 
-    std::vector<TxOrphanage::OrphanTxBase> GetOrphanTransactions() const;
+    std::vector<TxOrphanage::OrphanInfo> GetOrphanTransactions() const;
 
 protected:
     /** Helper for getting deduplicated vector of Txids in vin. */

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -229,7 +229,7 @@ public:
     std::vector<std::pair<Wtxid, NodeId>> AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng) override;
     bool HaveTxToReconsider(NodeId peer) override;
     std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const override;
-    std::vector<OrphanTxBase> GetOrphanTransactions() const override;
+    std::vector<OrphanInfo> GetOrphanTransactions() const override;
     TxOrphanage::Usage TotalOrphanUsage() const override;
     void SanityCheck() const override;
 };
@@ -665,9 +665,9 @@ std::vector<CTransactionRef> TxOrphanageImpl::GetChildrenFromSamePeer(const CTra
     return children_found;
 }
 
-std::vector<TxOrphanage::OrphanTxBase> TxOrphanageImpl::GetOrphanTransactions() const
+std::vector<TxOrphanage::OrphanInfo> TxOrphanageImpl::GetOrphanTransactions() const
 {
-    std::vector<TxOrphanage::OrphanTxBase> result;
+    std::vector<TxOrphanage::OrphanInfo> result;
     result.reserve(m_unique_orphans);
 
     auto& index_by_wtxid = m_orphans.get<ByWtxid>();
@@ -675,7 +675,7 @@ std::vector<TxOrphanage::OrphanTxBase> TxOrphanageImpl::GetOrphanTransactions() 
     std::set<NodeId> this_orphan_announcers;
     while (it != index_by_wtxid.end()) {
         this_orphan_announcers.insert(it->m_announcer);
-        // If this is the last entry, or the next entry has a different wtxid, build a OrphanTxBase.
+        // If this is the last entry, or the next entry has a different wtxid, build a OrphanInfo.
         if (std::next(it) == index_by_wtxid.end() || std::next(it)->m_tx->GetWitnessHash() != it->m_tx->GetWitnessHash()) {
             result.emplace_back(it->m_tx, std::move(this_orphan_announcers));
             this_orphan_announcers.clear();

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -229,7 +229,6 @@ public:
     std::vector<std::pair<Wtxid, NodeId>> AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng) override;
     bool HaveTxToReconsider(NodeId peer) override;
     std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const override;
-    size_t Size() const override { return m_unique_orphans; }
     std::vector<OrphanTxBase> GetOrphanTransactions() const override;
     TxOrphanage::Usage TotalOrphanUsage() const override;
     void SanityCheck() const override;

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -497,8 +497,8 @@ void TxOrphanageImpl::LimitOrphans()
         unsigned int num_erased_this_round{0};
         unsigned int starting_num_ann{it_worst_peer->second.m_count_announcements};
         while (NeedsTrim()) {
-            if (!Assume(it_ann->m_announcer == worst_peer)) break;
             if (!Assume(it_ann != m_orphans.get<ByPeer>().end())) break;
+            if (!Assume(it_ann->m_announcer == worst_peer)) break;
 
             Erase<ByPeer>(it_ann++);
             num_erased += 1;
@@ -537,7 +537,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
 
                 // Belt and suspenders, each entry in m_outpoint_to_orphan_wtxids should always have at least 1 announcement.
                 auto it = index_by_wtxid.lower_bound(ByWtxidView{wtxid, MIN_PEER});
-                if (!Assume(it != index_by_wtxid.end())) continue;
+                if (!Assume(it != index_by_wtxid.end() && it->m_tx->GetWitnessHash() == wtxid)) continue;
 
                 // Select a random peer to assign orphan processing, reducing wasted work if the orphan is still missing
                 // inputs. However, we don't want to create an issue in which the assigned peer can purposefully stop us

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -98,9 +98,6 @@ public:
      * recent to least recent. */
     virtual std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const = 0;
 
-    /** Return how many entries exist in the orphange */
-    virtual size_t Size() const = 0;
-
     /** Get all orphan transactions */
     virtual std::vector<OrphanTxBase> GetOrphanTransactions() const = 0;
 

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -94,8 +94,8 @@ public:
     /** Does this peer have any work to do? */
     virtual bool HaveTxToReconsider(NodeId peer) = 0;
 
-    /** Get all children that spend from this tx and were received from nodeid. Sorted from most
-     * recent to least recent. */
+    /** Get all children that spend from this tx and were received from nodeid. Sorted
+     * reconsiderable before non-reconsiderable, then from most recent to least recent. */
     virtual std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const = 0;
 
     /** Get all orphan transactions */

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -88,9 +88,6 @@ public:
     /** Erase all orphans included in or invalidated by a new block */
     virtual void EraseForBlock(const CBlock& block) = 0;
 
-    /** Limit the orphanage to MaxGlobalLatencyScore and MaxGlobalUsage. */
-    virtual void LimitOrphans() = 0;
-
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
     virtual std::vector<std::pair<Wtxid, NodeId>> AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng) = 0;
 

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -41,13 +41,13 @@ public:
     using Count = unsigned int;
 
     /** Allows providing orphan information externally */
-    struct OrphanTxBase {
+    struct OrphanInfo {
         CTransactionRef tx;
         /** Peers added with AddTx or AddAnnouncer. */
         std::set<NodeId> announcers;
 
         // Constructor with moved announcers
-        OrphanTxBase(CTransactionRef tx, std::set<NodeId>&& announcers) :
+        OrphanInfo(CTransactionRef tx, std::set<NodeId>&& announcers) :
             tx(std::move(tx)),
             announcers(std::move(announcers))
         {}
@@ -99,7 +99,7 @@ public:
     virtual std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const = 0;
 
     /** Get all orphan transactions */
-    virtual std::vector<OrphanTxBase> GetOrphanTransactions() const = 0;
+    virtual std::vector<OrphanInfo> GetOrphanTransactions() const = 0;
 
     /** Get the total usage (weight) of all orphans. If an orphan has multiple announcers, its usage is
      * only counted once within this total. */

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -146,6 +146,6 @@ public:
 
 /** Create a new TxOrphanage instance */
 std::unique_ptr<TxOrphanage> MakeTxOrphanage() noexcept;
-std::unique_ptr<TxOrphanage> MakeTxOrphanage(TxOrphanage::Count max_global_ann, TxOrphanage::Usage reserved_peer_usage) noexcept;
+std::unique_ptr<TxOrphanage> MakeTxOrphanage(TxOrphanage::Count max_global_latency_score, TxOrphanage::Usage reserved_peer_usage) noexcept;
 } // namespace node
 #endif // BITCOIN_NODE_TXORPHANAGE_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -839,7 +839,7 @@ static std::vector<RPCResult> OrphanDescription()
     };
 }
 
-static UniValue OrphanToJSON(const node::TxOrphanage::OrphanTxBase& orphan)
+static UniValue OrphanToJSON(const node::TxOrphanage::OrphanInfo& orphan)
 {
     UniValue o(UniValue::VOBJ);
     o.pushKV("txid", orphan.tx->GetHash().ToString());
@@ -895,7 +895,7 @@ static RPCHelpMan getorphantxs()
         {
             const NodeContext& node = EnsureAnyNodeContext(request.context);
             PeerManager& peerman = EnsurePeerman(node);
-            std::vector<node::TxOrphanage::OrphanTxBase> orphanage = peerman.GetOrphanTransactions();
+            std::vector<node::TxOrphanage::OrphanInfo> orphanage = peerman.GetOrphanTransactions();
 
             int verbosity{ParseVerbosity(request.params[0], /*default_verbosity=*/0, /*allow_bool*/false)};
 

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -470,9 +470,9 @@ FUZZ_TARGET(txorphanage_sim)
     // 3. Initialize real orphanage
     //
 
-    auto max_global_ann = provider.ConsumeIntegralInRange<node::TxOrphanage::Count>(NUM_PEERS, MAX_ANN);
+    auto max_global_latency_score = provider.ConsumeIntegralInRange<node::TxOrphanage::Count>(NUM_PEERS, MAX_ANN);
     auto reserved_peer_usage = provider.ConsumeIntegralInRange<node::TxOrphanage::Usage>(1, total_usage);
-    auto real = node::MakeTxOrphanage(max_global_ann, reserved_peer_usage);
+    auto real = node::MakeTxOrphanage(max_global_latency_score, reserved_peer_usage);
 
     //
     // 4. Functions and data structures for the simulation.
@@ -683,7 +683,7 @@ FUZZ_TARGET(txorphanage_sim)
             }
         }
         // Always trim after each command if needed.
-        const auto max_ann = max_global_ann / std::max<unsigned>(1, count_peers_fn());
+        const auto max_ann = max_global_latency_score / std::max<unsigned>(1, count_peers_fn());
         const auto max_mem = reserved_peer_usage;
         while (true) {
             // Count global usage and number of peers.
@@ -813,12 +813,12 @@ FUZZ_TARGET(txorphanage_sim)
     // CountUniqueOrphans
     assert(unique_orphans == real->CountUniqueOrphans());
     // MaxGlobalLatencyScore
-    assert(max_global_ann == real->MaxGlobalLatencyScore());
+    assert(max_global_latency_score == real->MaxGlobalLatencyScore());
     // ReservedPeerUsage
     assert(reserved_peer_usage == real->ReservedPeerUsage());
     // MaxPeerLatencyScore
     auto present_peers = count_peers_fn();
-    assert(max_global_ann / std::max<unsigned>(1, present_peers) == real->MaxPeerLatencyScore());
+    assert(max_global_latency_score / std::max<unsigned>(1, present_peers) == real->MaxPeerLatencyScore());
     // MaxGlobalUsage
     assert(reserved_peer_usage * std::max<unsigned>(1, present_peers) == real->MaxGlobalUsage());
     // TotalLatencyScore.

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -328,7 +328,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     {
                         if (peer_is_protected && !have_tx_and_peer &&
                             (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
-                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size()) + 1 > honest_latency_limit)) {
+                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
                             // We never want our protected peer oversized
                         } else {
                             orphanage->AddAnnouncer(tx->GetWitnessHash(), peer_id);

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -367,7 +367,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
 FUZZ_TARGET(txorphanage_sim)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
-    // This is a comphehensive simulation fuzz test, which runs through a scenario involving up to
+    // This is a comprehensive simulation fuzz test, which runs through a scenario involving up to
     // 16 transactions (which may have simple or complex topology, and may have duplicate txids
     // with distinct wtxids, and up to 16 peers. The scenario is performed both on a real
     // TxOrphanage object and the behavior is compared with a naive reimplementation (just a vector
@@ -726,7 +726,7 @@ FUZZ_TARGET(txorphanage_sim)
             }
             assert(done);
         }
-        // We must now be within limits, otherwise LimitOrphans should have continued further).
+        // We must now be within limits, otherwise LimitOrphans should have continued further.
         // We don't check the contents of the orphanage until the end to make fuzz runs faster.
         assert(real->TotalLatencyScore() <= real->MaxGlobalLatencyScore());
         assert(real->TotalOrphanUsage() <= real->MaxGlobalUsage());

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -94,8 +94,8 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
     {
         // Test announcement limits
         NodeId peer{8};
-        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_ann=*/1, /*reserved_peer_usage=*/TX_SIZE * 10);
-        auto orphanage_low_mem = node::MakeTxOrphanage(/*max_global_ann=*/10, /*reserved_peer_usage=*/TX_SIZE);
+        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/1, /*reserved_peer_usage=*/TX_SIZE * 10);
+        auto orphanage_low_mem = node::MakeTxOrphanage(/*max_global_latency_score=*/10, /*reserved_peer_usage=*/TX_SIZE);
 
         // Add the first transaction
         orphanage_low_ann->AddTx(txns.at(0), peer);
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
     {
         // Test latency score limits
         NodeId peer{10};
-        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_ann=*/5, /*reserved_peer_usage=*/TX_SIZE * 1000);
+        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/5, /*reserved_peer_usage=*/TX_SIZE * 1000);
 
         // Add the first transaction
         orphanage_low_ann->AddTx(txns.at(0), peer);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
         // Test announcement limits
         NodeId peer{9};
-        auto orphanage = node::MakeTxOrphanage(/*max_global_ann=*/3, /*reserved_peer_usage=*/TX_SIZE * 10);
+        auto orphanage = node::MakeTxOrphanage(/*max_global_latency_score=*/3, /*reserved_peer_usage=*/TX_SIZE * 10);
 
         // First add a tx which will be made reconsiderable.
         orphanage->AddTx(children.at(0), peer);

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -830,6 +830,16 @@ class OrphanHandlingTest(BitcoinTestFramework):
         assert orphan["txid"] in final_mempool
         assert tx_replacer_C["txid"] in final_mempool
 
+    @cleanup
+    def test_maxorphantx_option(self):
+        # This test should be removed when -maxorphantx is removed.
+        self.log.info("Test that setting the -maxorphantx option does not error")
+        warning = "Warning: Option '-maxorphantx' is set but no longer has any effect (see release notes). Please remove it from your configuration."
+        self.restart_node(0, extra_args=["-maxorphantx=5"])
+        assert_equal(self.nodes[0].getorphantxs(), [])
+        self.stop_node(0, expected_stderr=warning)
+        self.restart_node(0)
+
     def run_test(self):
         self.nodes[0].setmocktime(int(time.time()))
         self.wallet_nonsegwit = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_P2PK)
@@ -850,6 +860,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.test_announcers_before_and_after()
         self.test_parents_change()
         self.test_maximal_package_protected()
+        self.test_maxorphantx_option()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Followup to #31829:
- Release notes
- Have the orphanage auto-trim itself whenever necessary (and test changes) https://github.com/bitcoin/bitcoin/pull/31829#discussion_r2169508690
- Reduce duplicate reconsiderations by keeping track of which txns are already reconsiderable so we only mark it for reconsideration for 1 peer at a time https://github.com/bitcoin/bitcoin/pull/31829#issuecomment-3001627814
- Rename `OrphanTxBase` to `OrphanInfo`
- Get rid of `Size()` method by replacing all calls with `CountUniqueOrphans`
- Rename outpoints index since they point to wtxids, not iterators https://github.com/bitcoin/bitcoin/pull/31829#discussion_r2205557613
- Add more logging in the `LimitOrphans` inner loop to make it easy to see which peers are being trimmed https://github.com/bitcoin/bitcoin/pull/31829#issuecomment-3074385460