### PR TITLE
depends: Force `CMAKE_EXPORT_NO_PACKAGE_REGISTRY=TRUE`

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -224,6 +224,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                -DCMAKE_INSTALL_LIBDIR=lib/ \
                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                -DCMAKE_VERBOSE_MAKEFILE:BOOL=$(V) \
+               -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY:BOOL=TRUE \
                $$($(1)_config_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"


### PR DESCRIPTION
When using CMake policies 3.14 and below, the `export(PACKAGE)` command by default populates the user package registry, which is stored outside the build tree. Setting the `CMAKE_EXPORT_NO_PACKAGE_REGISTRY` variable disables this side effect.

In CMake 3.15 and later, this behavior is disabled by default, and the variable has no effect.

This PR forces `CMAKE_EXPORT_NO_PACKAGE_REGISTRY=TRUE` globally, rather than managing it for each dependency package individually rather. It may be reverted once all CMake-based packages have updated to policies 3.15 or newer.

Fixes https://github.com/bitcoin/bitcoin/issues/32938.