### PR TITLE
wallet: Remove `upgradewallet` RPC

### DIFF
--- a/doc/release-notes-32944.md
+++ b/doc/release-notes-32944.md
@@ -1,0 +1,3 @@
+# RPC
+
+`upgradewallet` has been removed. It was unused and only applied to unsupported legacy wallets.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -275,7 +275,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
-    { "upgradewallet", 0, "version" },
     { "gethdkeys", 0, "active_only" },
     { "gethdkeys", 0, "options" },
     { "gethdkeys", 0, "private" },

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -118,9 +118,6 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     virtual bool CanGetAddresses(bool internal = false) const { return false; }
 
-    /** Upgrades the wallet to the specified version */
-    virtual bool Upgrade(int prev_version, int new_version, bilingual_str& error) { return true; }
-
     virtual bool HavePrivateKeys() const { return false; }
     virtual bool HaveCryptedKeys() const { return false; }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -942,9 +942,6 @@ public:
         LogInfo("%s %s", GetDisplayName(), tfm::format(wallet_fmt, params...));
     };
 
-    /** Upgrade the wallet */
-    bool UpgradeWallet(int version, bilingual_str& error);
-
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;
     bool IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const;

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -183,9 +183,6 @@ class MultiWalletTest(BitcoinTestFramework):
         open(not_a_dir, 'a', encoding="utf8").close()
         self.nodes[0].assert_start_raises_init_error(['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
 
-        self.log.info("Do not allow -upgradewallet with multiwallet")
-        self.nodes[0].assert_start_raises_init_error(['-upgradewallet'], "Error: Error parsing command line arguments: Invalid parameter -upgradewallet")
-
         # if wallets/ doesn't exist, datadir should be the default wallet dir
         wallet_dir2 = data_dir('walletdir')
         os.rename(wallet_dir(), wallet_dir2)


### PR DESCRIPTION
Based on discussions  in https://github.com/bitcoin/bitcoin/pull/32803, this PR proposes removing the ` upgradewallet`  RPC.