### PR TITLE
tests: speed up coins_tests by parallelizing

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -183,21 +183,20 @@ function(add_boost_test source_file)
 
   file(READ "${source_file}" source_file_content)
   string(REGEX
-    MATCH "(BOOST_FIXTURE_TEST_SUITE|BOOST_AUTO_TEST_SUITE)\\(([A-Za-z0-9_]+)"
+    MATCHALL "(BOOST_FIXTURE_TEST_SUITE|BOOST_AUTO_TEST_SUITE)\\(([A-Za-z0-9_]+)"
     test_suite_macro "${source_file_content}"
   )
-  string(REGEX
+  list(TRANSFORM test_suite_macro
     REPLACE "(BOOST_FIXTURE_TEST_SUITE|BOOST_AUTO_TEST_SUITE)\\(" ""
-    test_suite_name "${test_suite_macro}"
   )
-  if(test_suite_name)
+  foreach(test_suite_name IN LISTS test_suite_macro)
     add_test(NAME ${test_suite_name}
       COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT
     )
     set_property(TEST ${test_suite_name} PROPERTY
       SKIP_REGULAR_EXPRESSION "no test cases matching filter"
     )
-  endif()
+  endforeach()
 endfunction()
 
 function(add_all_test_targets)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -104,8 +104,6 @@ public:
 
 } // namespace
 
-BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
-
 static const unsigned int NUM_SIMULATION_ITERATIONS = 40000;
 
 struct CacheTest : BasicTestingSetup {
@@ -283,15 +281,28 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
 }
 }; // struct CacheTest
 
+BOOST_FIXTURE_TEST_SUITE(coins_tests_base, BasicTestingSetup)
+
 // Run the above simulation for multiple base types.
-BOOST_FIXTURE_TEST_CASE(coins_cache_simulation_test, CacheTest)
+BOOST_FIXTURE_TEST_CASE(coins_cache_base_simulation_test, CacheTest)
 {
     CCoinsViewTest base{m_rng};
     SimulationTest(&base, false);
+}
 
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(coins_tests_dbbase, BasicTestingSetup)
+
+BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
+{
     CCoinsViewDB db_base{{.path = "test", .cache_bytes = 1 << 23, .memory_only = true}, {}};
     SimulationTest(&db_base, true);
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
 struct UpdateTest : BasicTestingSetup {
 // Store of all necessary tx and undo data for next test

--- a/test/lint/lint-tests.py
+++ b/test/lint/lint-tests.py
@@ -30,14 +30,14 @@ def check_matching_test_names(test_suite_list):
     not_matching = [
         x
         for x in test_suite_list
-        if re.search(r"/(.*?)\.cpp:BOOST_FIXTURE_TEST_SUITE\(\1, .*\)", x) is None
+        if re.search(r"/(.*?)\.cpp:BOOST_FIXTURE_TEST_SUITE\(\1(_[a-z0-9]+)?, .*\)", x) is None
     ]
     if len(not_matching) > 0:
         not_matching = "\n".join(not_matching)
         error_msg = (
             "The test suite in file src/test/foo_tests.cpp should be named\n"
-            '"foo_tests". Please make sure the following test suites follow\n'
-            "that convention:\n\n"
+            '`foo_tests`, or if there are multiple test suites, `foo_tests_bar`.\n'
+            'Please make sure the following test suites follow that convention:\n\n'
             f"{not_matching}\n"
         )
         print(error_msg)


### PR DESCRIPTION
Updates the cmake logic to generate a separate test for each BOOST_FIXTURE_TEST_SUITE declaration in a file, and splits coins_tests.cpp into three separate suites so that they can be run in parallel. Also updates the convention enforced by test/lint/lint-tests.py.