### PR TITLE
refactor: cleanup index logging

### DIFF
--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -126,12 +126,12 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
         uint256 expected_block_hash{*Assert(block.prev_hash)};
         if (read_out.first != expected_block_hash) {
-            LogPrintf("WARNING: previous block header belongs to unexpected block %s; expected %s\n",
+            LogWarning("previous block header belongs to unexpected block %s; expected %s",
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                LogError("%s: previous block header not found; expected %s\n",
-                             __func__, expected_block_hash.ToString());
+                LogError("previous block header not found; expected %s",
+                          expected_block_hash.ToString());
                 return false;
             }
         }
@@ -236,15 +236,15 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
     db_it.Seek(key);
 
     if (!db_it.GetKey(key) || key.height != height) {
-        LogError("%s: unexpected key in %s: expected (%c, %d)\n",
-                 __func__, index_name, DB_BLOCK_HEIGHT, height);
+        LogError("unexpected key in %s: expected (%c, %d)",
+                 index_name, DB_BLOCK_HEIGHT, height);
         return false;
     }
 
     std::pair<uint256, DBVal> value;
     if (!db_it.GetValue(value)) {
-        LogError("%s: unable to read value in %s at key (%c, %d)\n",
-                 __func__, index_name, DB_BLOCK_HEIGHT, height);
+        LogError("unable to read value in %s at key (%c, %d)",
+                 index_name, DB_BLOCK_HEIGHT, height);
         return false;
     }
 
@@ -325,8 +325,8 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockRef>& block
         // exist. Any other errors indicate database corruption or a disk
         // failure, and starting the index would cause further corruption.
         if (m_db->Exists(DB_MUHASH)) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
-                         __func__, GetName());
+            LogError("Cannot read current %s state; index may be corrupted",
+                      GetName());
             return false;
         }
     }
@@ -334,16 +334,16 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockRef>& block
     if (block) {
         DBVal entry;
         if (!LookUpOne(*m_db, *block, entry)) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
-                         __func__, GetName());
+            LogError("Cannot read current %s state; index may be corrupted",
+                      GetName());
             return false;
         }
 
         uint256 out;
         m_muhash.Finalize(out);
         if (entry.muhash != out) {
-            LogError("%s: Cannot read current %s state; index may be corrupted\n",
-                         __func__, GetName());
+            LogError("Cannot read current %s state; index may be corrupted",
+                      GetName());
             return false;
         }
 
@@ -397,12 +397,12 @@ bool CoinStatsIndex::ReverseBlock(const interfaces::BlockInfo& block)
 
         uint256 expected_block_hash{*block.prev_hash};
         if (read_out.first != expected_block_hash) {
-            LogPrintf("WARNING: previous block header belongs to unexpected block %s; expected %s\n",
+            LogWarning("previous block header belongs to unexpected block %s; expected %s",
                       read_out.first.ToString(), expected_block_hash.ToString());
 
             if (!m_db->Read(DBHashKey(expected_block_hash), read_out)) {
-                LogError("%s: previous block header not found; expected %s\n",
-                             __func__, expected_block_hash.ToString());
+                LogError("previous block header not found; expected %s",
+                          expected_block_hash.ToString());
                 return false;
             }
         }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -81,7 +81,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
 
     AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
-        LogError("%s: OpenBlockFile failed\n", __func__);
+        LogError("OpenBlockFile failed");
         return false;
     }
     CBlockHeader header;
@@ -90,11 +90,11 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         file.seek(postx.nTxOffset, SEEK_CUR);
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
-        LogError("%s: Deserialize or I/O error - %s\n", __func__, e.what());
+        LogError("Deserialize or I/O error - %s", e.what());
         return false;
     }
     if (tx->GetHash() != tx_hash) {
-        LogError("%s: txid mismatch\n", __func__);
+        LogError("txid mismatch");
         return false;
     }
     block_hash = header.GetHash();


### PR DESCRIPTION
This PR removes the use of `__func__` from index logging, since we have `-logsourcelocations`.

It also improves readability by putting `GetName()` in a more logical place.

Before

> coinstatsindex: best block of the index not found. Please rebuild the index.

After:

> best block of coinstatsindex not found. Please rebuild the index.

I found myself maintaining this commit as part of https://github.com/Sjors/bitcoin/pull/86, but since that might never land here, it seemed better to split it into its own PR (or get rid of it).