### PR TITLE
build: Explicitly set Qt's `AUTO{MOC,RCC,UIC}` property per target

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -47,11 +47,7 @@ endfunction()
 # For Qt-specific commands and variables, please consult:
 #  - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html
 #  - https://doc.qt.io/qt-5/cmake-manual.html
-
-set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOMOC_MOC_OPTIONS "-p${CMAKE_CURRENT_SOURCE_DIR}")
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS forms)
 
 configure_file(bitcoin_locale.qrc bitcoin_locale.qrc USE_SOURCE_PERMISSIONS COPYONLY)
@@ -119,6 +115,11 @@ add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
   $<$<PLATFORM_ID:Windows>:winshutdownmonitor.h>
   bitcoin.qrc
   ${CMAKE_CURRENT_BINARY_DIR}/bitcoin_locale.qrc
+)
+set_target_properties(bitcoinqt PROPERTIES
+  AUTOMOC ON
+  AUTORCC ON
+  AUTOUIC ON
 )
 target_compile_definitions(bitcoinqt
   PUBLIC

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -4,35 +4,55 @@
 
 set(CMAKE_AUTOMOC_MOC_OPTIONS "-p${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_executable(test_bitcoin-qt
+add_library(test_bitcoinqt STATIC EXCLUDE_FROM_ALL
   apptests.cpp
   optiontests.cpp
   rpcnestedtests.cpp
-  test_main.cpp
   uritests.cpp
   util.cpp
-  ../../init/bitcoin-qt.cpp
 )
 
-target_link_libraries(test_bitcoin-qt
+target_compile_definitions(test_bitcoinqt
+  PUBLIC
+    QT_NO_KEYWORDS
+    QT_USE_QSTRINGBUILDER
+)
+
+target_link_libraries(test_bitcoinqt
   core_interface
-  bitcoinqt
-  test_util
-  bitcoin_node
-  Boost::headers
   Qt6::Test
+  Qt6::Widgets
+  bitcoin_common
+  univalue
 )
-
-import_plugins(test_bitcoin-qt)
 
 if(ENABLE_WALLET)
-  target_sources(test_bitcoin-qt
+  target_sources(test_bitcoinqt
     PRIVATE
       addressbooktests.cpp
       wallettests.cpp
       ../../wallet/test/wallet_test_fixture.cpp
   )
+  target_link_libraries(test_bitcoinqt
+    Boost::headers
+  )
 endif()
+
+add_executable(test_bitcoin-qt
+  test_main.cpp
+  ../../init/bitcoin-qt.cpp
+)
+
+target_link_libraries(test_bitcoin-qt
+  core_interface
+  test_bitcoinqt
+  bitcoinqt
+  test_util
+  bitcoin_node
+  Qt6::Test
+)
+
+import_plugins(test_bitcoin-qt)
 
 add_test(NAME test_bitcoin-qt
   COMMAND test_bitcoin-qt

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -12,6 +12,12 @@ add_library(test_bitcoinqt STATIC EXCLUDE_FROM_ALL
   util.cpp
 )
 
+set_target_properties(test_bitcoinqt PROPERTIES
+  AUTOMOC ON
+  AUTORCC ON
+  AUTOUIC ON
+)
+
 target_compile_definitions(test_bitcoinqt
   PUBLIC
     QT_NO_KEYWORDS


### PR DESCRIPTION
The codebase, which is compiled, consists of both files in the source tree and additional files generated during the build process.  These generated files include headers such as `bitcoin-build-config.h`, headers generated for tests and benchmarks from data files, and files produced by Qt's tools, such as `moc`, `rcc` and `uic`.

When using Makefile or Ninja generators, CMake 3.31 and later provides a [convenient](https://github.com/bitcoin/bitcoin/pull/32662#issuecomment-2991861497) builtin build target `codegen`, which builds ~all~ generated files. For example:
```
$ cmake -B build -DCMAKE_GENERATOR="Ninja"
$ cmake --build build --target codegen
```
or
```
$ cmake -B build -DCMAKE_GENERATOR="Unix Makefiles"
$ cmake --build build --target codegen
```

However, when building with `-DBUILD_GUI=ON`, setting the `CMAKE_{AUTOMOC,RCC,UIC}` variables globally introduces undesired dependencies for Makefiles generators, resulting in building dependencies directly unrelated to the generated files.

This PR resolves that issue. The first commit refactors the build system by factoring out the main library from the `test_bitcoin-qt` executable, just as is already done for `bitcoinqt` and `bitcoin-qt`, and prepares the ground for the second commit.