### PR TITLE
[WIP] tracing: lock contention

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -92,31 +92,18 @@ template <typename PARENT>
 class LOCKABLE AnnotatedMixin : public PARENT
 {
 public:
-    ~AnnotatedMixin() {
-        DeleteLock((void*)this);
-    }
+    AnnotatedMixin();
+    ~AnnotatedMixin();
 
-    void lock() EXCLUSIVE_LOCK_FUNCTION()
-    {
-        PARENT::lock();
-    }
-
-    void unlock() UNLOCK_FUNCTION()
-    {
-        PARENT::unlock();
-    }
-
-    bool try_lock() EXCLUSIVE_TRYLOCK_FUNCTION(true)
-    {
-        return PARENT::try_lock();
-    }
-
+    void lock() EXCLUSIVE_LOCK_FUNCTION();
+    void unlock() UNLOCK_FUNCTION();
+    bool try_lock() EXCLUSIVE_TRYLOCK_FUNCTION(true);
     using unique_lock = std::unique_lock<PARENT>;
 #ifdef __clang__
     //! For negative capabilities in the Clang Thread Safety Analysis.
     //! A negative requirement uses the EXCLUSIVE_LOCKS_REQUIRED attribute, in conjunction
     //! with the ! operator, to indicate that a mutex should not be held.
-    const AnnotatedMixin& operator!() const { return *this; }
+    const AnnotatedMixin& operator!() const;
 #endif // __clang__
 };
 
@@ -153,61 +140,18 @@ class SCOPED_LOCKABLE UniqueLock : public MutexType::unique_lock
 {
 private:
     using Base = typename MutexType::unique_lock;
-
-    void Enter(const char* pszName, const char* pszFile, int nLine)
-    {
-        EnterCritical(pszName, pszFile, nLine, Base::mutex());
-#ifdef DEBUG_LOCKCONTENTION
-        if (Base::try_lock()) return;
-        LOG_TIME_MICROS_WITH_CATEGORY(strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine), BCLog::LOCK);
-#endif
-        Base::lock();
-    }
-
-    bool TryEnter(const char* pszName, const char* pszFile, int nLine)
-    {
-        EnterCritical(pszName, pszFile, nLine, Base::mutex(), true);
-        if (Base::try_lock()) {
-            return true;
-        }
-        LeaveCritical();
-        return false;
-    }
+    void Enter(const char* pszName, const char* pszFile, int nLine);
+    bool TryEnter(const char* pszName, const char* pszFile, int nLine);
 
 public:
-    UniqueLock(MutexType& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn) : Base(mutexIn, std::defer_lock)
-    {
-        if (fTry)
-            TryEnter(pszName, pszFile, nLine);
-        else
-            Enter(pszName, pszFile, nLine);
-    }
-
-    UniqueLock(MutexType* pmutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(pmutexIn)
-    {
-        if (!pmutexIn) return;
-
-        *static_cast<Base*>(this) = Base(*pmutexIn, std::defer_lock);
-        if (fTry)
-            TryEnter(pszName, pszFile, nLine);
-        else
-            Enter(pszName, pszFile, nLine);
-    }
-
-    ~UniqueLock() UNLOCK_FUNCTION()
-    {
-        if (Base::owns_lock())
-            LeaveCritical();
-    }
-
-    operator bool()
-    {
-        return Base::owns_lock();
-    }
+    UniqueLock(MutexType& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn);
+    UniqueLock(MutexType* pmutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(pmutexIn);
+    ~UniqueLock() UNLOCK_FUNCTION();
+    operator bool();
 
 protected:
     // needed for reverse_lock
-    UniqueLock() = default;
+    UniqueLock();
 
 public:
     /**

--- a/src/sync.h
+++ b/src/sync.h
@@ -55,7 +55,7 @@ LEAVE_CRITICAL_SECTION(mutex); // no RAII
 
 #ifdef DEBUG_LOCKORDER
 template <typename MutexType>
-void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexType* cs, bool fTry = false);
+void EnterCritical(const char* m_pszName, const char* m_pszFile, int m_nLine, MutexType* cs, bool fTry = false);
 void LeaveCritical();
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line);
 template <typename MutexType>
@@ -138,10 +138,14 @@ inline void AssertLockNotHeldInline(const char* name, const char* file, int line
 template <typename MutexType>
 class SCOPED_LOCKABLE UniqueLock : public MutexType::unique_lock
 {
+    const char* m_pszName;
+    const char* m_pszFile;
+    int m_nLine;
+
 private:
     using Base = typename MutexType::unique_lock;
-    void Enter(const char* pszName, const char* pszFile, int nLine);
-    bool TryEnter(const char* pszName, const char* pszFile, int nLine);
+    void Enter();
+    bool TryEnter();
 
 public:
     UniqueLock(MutexType& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn);


### PR DESCRIPTION
Currently there is a macro `DEBUG_LOCKCONTENTION` (see developer-notes.md) to enable logging of contention. The disadvantage of this method is that `bitcoind` needs to be especially compiled with that enabled, and when enabled this quickly produces huge log files, and has a relatively large overhead.

This is a rework of PR #25081.

Previously the binary(`bitcoind`) shows multiple [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) notes which is problematic as it can bloat the binary with redundant metadata, and can also confuse tracing tools(bcc, etc) when using binary path. see [comment](https://github.com/bitcoin/bitcoin/pull/25081#issuecomment-1129370599).

I am keeping this as DRAFT for now and research more on the better way to handle the duplication of ELF notes, currently we use a check to omit multiple instantiation of TRACEPOINT. After a suitable workaround is found, I will be updating the commits with  bpftrace scripts for lock analysis.

CC 0xB10C 