### PR TITLE
[POC] ci: Skip compilation when running static code analysis

### DIFF
--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:25.04"
 export CONTAINER_NAME=ci_native_tidy
 export TIDY_LLVM_V="20"
 export APT_LLVM_V="${TIDY_LLVM_V}"
@@ -15,13 +15,12 @@ export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=false
-export RUN_CHECK_DEPS=true
+export RUN_CHECK_DEPS=false
 export RUN_TIDY=true
-export GOAL="install"
 export BITCOIN_CONFIG="\
- -DWITH_ZMQ=ON -DBUILD_GUI=ON -DBUILD_BENCH=ON -DWITH_USDT=ON \
+ --preset dev-mode \
+ -DBUILD_GUI=OFF \
+ -DENABLE_IPC=OFF \
  -DCMAKE_C_COMPILER=clang-${TIDY_LLVM_V} \
  -DCMAKE_CXX_COMPILER=clang++-${TIDY_LLVM_V} \
- -DCMAKE_C_FLAGS_RELWITHDEBINFO='-O0 -g0' \
- -DCMAKE_CXX_FLAGS_RELWITHDEBINFO='-O0 -g0' \
 "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ add_custom_target(generate_build_info
   COMMENT "Generating bitcoin-build-info.h"
   VERBATIM
 )
-add_library(bitcoin_clientversion STATIC EXCLUDE_FROM_ALL
+add_library(bitcoin_clientversion STATIC
   clientversion.cpp
 )
 target_link_libraries(bitcoin_clientversion

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -194,10 +194,10 @@ int main(int argc, char* argv[])
         {
         public:
             uint256 hash;
-            bool found;
+            bool found{false};
             BlockValidationState state;
 
-            explicit submitblock_StateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state() {}
+            explicit submitblock_StateCatcher(const uint256& hashIn) : hash(hashIn), state() {}
 
         protected:
             void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override


### PR DESCRIPTION
This PR is a proof of concept for using a compilation database with static analysis tools such as clang-tidy or IWYU. The idea was suggested in https://github.com/bitcoin/bitcoin/pull/32662#issuecomment-2935293250:
> Shouldn't this be excluded in the tidy CI task as well?

Additionally, this PR makes use of the `codegen` target, following the suggestion in https://github.com/bitcoin/bitcoin/pull/32662#issuecomment-2991861497:
> It does seem nice to be able to run clang-tidy on generated files... Maybe more ideally there could be ...  target like `make --build build -t codegen` that only runs code generation steps and doesn't compile the sources.

A few tasks remain to be addressed. Here's the current TODO list:
- [ ] Implement the `codegen` target for CMake versions older than 3.31.
- [ ] Handle files generated by the `mpgen` tool.
- [ ] Handle files generated by Qt tools.
- [ ] Enable `RUN_CHECK_DEPS=true` elsewhere.

While https://github.com/bitcoin/bitcoin/issues/31965 is still under discussion, it may make sense to move this CI job to GHA to provide quicker feedback.