### PR TITLE
cmake: Drop no longer necessary "cmakeMinimumRequired" object

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,6 +1,5 @@
 {
   "version": 3,
-  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
   "configurePresets": [
     {
       "name": "vs2022",


### PR DESCRIPTION
The minimum required CMake version is 3.22:https://github.com/bitcoin/bitcoin/blob/6a13a6106e3c1ebe95ba6430184d6260a7b942bd/CMakeLists.txt#L10