### PR TITLE
doc: clarify note about backup after migratewallet

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -164,3 +164,4 @@ original wallet can be found in the wallet directory with the name `<name>-<time
 
 The backup can be restored using the methods discussed in the
 [Restoring the Wallet From a Backup](#16-restoring-the-wallet-from-a-backup) section.
+> **Note:** After migration, the original legacy wallet file itself remains unchanged on disk as a backup.


### PR DESCRIPTION
Added a clarifying note that after migration, the original legacy wallet file remains unchanged on disk as a backup. This helps users understand that migration is non-destructive.