### PR TITLE
descriptor: don't underestimate the size of a Taproot spend (instead, overestimate it)

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -55,6 +55,11 @@ def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
     if fee > high_fee:
         raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
 
+def assert_fee_enough(fee, tx_size, feerate_BTC_kvB):
+    """Assert the fee meets the feerate"""
+    target_fee = get_fee(tx_size, feerate_BTC_kvB)
+    if fee < target_fee:
+        raise AssertionError("Fee of %s BTC too low! (Should be at least %s BTC)" % (str(fee), str(target_fee)))
 
 def summarise_dict_differences(thing1, thing2):
     if not isinstance(thing1, dict) or not isinstance(thing2, dict):


### PR DESCRIPTION
This PR revives #26573 since it has some ACKs and is labeled "Up for grabs". 
I just added a comment explaining the behavior change.