### PR TITLE
rpc,net: Add getpeerbyid and listpeersbyids RPCs

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -45,6 +45,7 @@
 #include <queue>
 #include <thread>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 class AddrMan;
@@ -1228,6 +1229,8 @@ public:
     std::map<CNetAddr, LocalServiceInfo> getNetLocalAddresses() const;
     uint32_t GetMappedAS(const CNetAddr& addr) const;
     void GetNodeStats(std::vector<CNodeStats>& vstats) const;
+    bool GetNodeStatsById(NodeId nodeid, CNodeStats& stats) const;
+    bool GetNodeStatsByIds(const std::vector<NodeId>& ids, std::vector<CNodeStats>& out_stats)  const;
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(const CSubNet& subnet);
     bool DisconnectNode(const CNetAddr& addr);
@@ -1444,6 +1447,7 @@ private:
 
     mutable Mutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
+    std::unordered_map<NodeId, CNode*> m_node_id_map GUARDED_BY(m_nodes_mutex);
     std::list<CNode*> m_nodes_disconnected;
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -310,6 +310,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "stop", 0, "wait" },
     { "addnode", 2, "v2transport" },
     { "addconnection", 2, "v2transport" },
+    { "getpeerbyid", 0, "peer_id" },
+    { "listpeersbyids", 0, "peer_ids" },
+    { "listpeersbyids", 1, "strict" },
 };
 // clang-format on
 

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -185,6 +185,8 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "waitforblock",
     "waitforblockheight",
     "waitfornewblock",
+    "getpeerbyid",
+    "listpeersbyids",
 };
 
 std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)


### PR DESCRIPTION
Add fast peer lookup by NodeId using `m_node_id_map` in CConnman.

Adds `GetNodeStatsById` and `GetNodeStatsByIds` in `net.{cpp,h}` for efficient internal access.

Introduces two new RPCs:
- `getpeerbyid(id)`: returns info for a single connected peer
- `listpeersbyids([ids], strict=false)`: batch query with optional strict mode

Includes functional tests covering expected behavior and edge cases.

Useful for tools that track peers by ID without scanning the full list, or for quickly looking up peer IDs seen in debug logs.
