### PR TITLE
assumevalid: log every script validation state change

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2580,6 +2580,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<SecondsDouble>(m_chainman.time_forks),
              Ticks<MillisecondsDouble>(m_chainman.time_forks) / m_chainman.num_blocks_total);
 
+    if (fScriptChecks != m_prev_script_checks_logged && GetRole() == ChainstateRole::NORMAL) {
+        LogInfo("%s signature validations at block #%d (%s).", fScriptChecks ? "Enabling" : "Disabling", pindex->nHeight, block_hash.ToString());
+        m_prev_script_checks_logged = fScriptChecks;
+    }
+
     CBlockUndo blockundo;
 
     // Precomputed transaction data pointers must not be invalidated

--- a/src/validation.h
+++ b/src/validation.h
@@ -550,6 +550,8 @@ protected:
     //! Cached result of LookupBlockIndex(*m_from_snapshot_blockhash)
     mutable const CBlockIndex* m_cached_snapshot_base GUARDED_BY(::cs_main){nullptr};
 
+    std::atomic_bool m_prev_script_checks_logged{true};
+
 public:
     //! Reference to a BlockManager instance which itself is shared across all
     //! Chainstate instances.

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -153,12 +153,12 @@ class AssumeValidTest(BitcoinTestFramework):
         p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
         p2p1.send_header_for_blocks(self.blocks[0:2000])
         p2p1.send_header_for_blocks(self.blocks[2000:])
-
-        # Send all blocks to node1. All blocks will be accepted.
-        for i in range(2202):
-            p2p1.send_without_ping(msg_block(self.blocks[i]))
-        # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
-        p2p1.sync_with_ping(timeout=960)
+        with self.nodes[1].assert_debug_log(expected_msgs=['Disabling signature validations at block #1', 'Enabling signature validations at block #103']):
+            # Send all blocks to node1. All blocks will be accepted.
+            for i in range(2202):
+                p2p1.send_without_ping(msg_block(self.blocks[i]))
+            # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
+            p2p1.sync_with_ping(timeout=960)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)
 
         p2p2 = self.nodes[2].add_p2p_connection(BaseNode())


### PR DESCRIPTION
The `-assumevalid` option skips script verification for a specified block and all its ancestors during Initial Block Download.
Many new [users are surprised](https://github.com/bitcoin/bitcoin/issues/32832) when this suddenly slows their node to a halt.
This commit adds a log message to clearly indicate when this optimization ends and full validation begins (and vice versa).

<details>
<summary>Testing instructions</summary>

The behavior can easily be tested by adding this before the new log:
```C++
    // TODO hack to enable/disable script checks based on block height for testing purposes
         if (pindex->nHeight < 100) fScriptChecks = false;
    else if (pindex->nHeight < 200) fScriptChecks = true;
    else if (pindex->nHeight < 300) fScriptChecks = false;
    else if (pindex->nHeight < 400) fScriptChecks = true;
```
and exercise the new code with:
```bash
cmake -B build && cmake --build build && mkdir -p demo && build/bin/bitcoind -datadir=demo -stopatheight=500 | grep 'signature validation'
```
showing something like:
* Disabling signature validations at block #​1 (00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048).
* Enabling signature validations at block #​100 (000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a).
* Disabling signature validations at block #​200 (000000008f1a7008320c16b8402b7f11e82951f44ca2663caf6860ab2eeef320).
* Enabling signature validations at block #​300 (0000000062b69e4a2c3312a5782d7798b0711e9ebac065cd5d19f946439f8609).

</details>
