### PR TITLE
fix: Python 3 bytes comparison in linearize-data.py

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -209,7 +209,7 @@ class BlockDataCopier:
                     return
 
             inhdr = self.read_xored(self.inF, 8)
-            if (not inhdr or (inhdr[0] == "\0")):
+            if (not inhdr or (inhdr[0] == 0)):
                 self.inF.close()
                 self.inF = None
                 self.inFn = self.inFn + 1


### PR DESCRIPTION
Replace comparison of a bytes element to the string literal "\0" with an integer 0 in linearize-data.py to ensure correct behavior in Python 3. In Python 3, indexing a bytes object returns an integer, not a single-character string, so the previous comparison would always be false. This change improves compatibility and correctness of the script when detecting end-of-file or null bytes.

