### PR TITLE
Adds transaction propagation information to mempool transactions

### DIFF
--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -149,6 +149,7 @@ public:
     std::optional<std::chrono::microseconds> GetFirstInvTime() const {
         return nFirstInvTime.has_value() ? std::optional{std::chrono::microseconds{nFirstInvTime.value()}} : std::nullopt;
     }
+    void SetFirstInvTime(int64_t time) {nFirstInvTime = std::optional{time};}
     unsigned int GetHeight() const { return entryHeight; }
     uint64_t GetSequence() const { return entry_sequence; }
     int64_t GetSigOpCost() const { return sigOpCost; }

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -142,7 +142,8 @@ public:
         return GetVirtualTransactionSize(nTxWeight, sigOpCost, ::nBytesPerSigOp);
     }
     int32_t GetTxWeight() const { return nTxWeight; }
-    std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
+    std::chrono::seconds GetTime() const { return duration_cast<std::chrono::seconds>(std::chrono::microseconds{nTime}); }
+    std::chrono::microseconds GetTimeUs() const { return std::chrono::microseconds{nTime}; }
     unsigned int GetHeight() const { return entryHeight; }
     uint64_t GetSequence() const { return entry_sequence; }
     int64_t GetSigOpCost() const { return sigOpCost; }

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -166,6 +166,9 @@ public:
     /** Returns next orphan tx to consider, or nullptr if none exist. */
     CTransactionRef GetTxToReconsider(NodeId nodeid);
 
+    /** Returns the timestamp of the first received announcement of this transaction, or nullopt if it cannot be found. */
+    std::optional<int64_t> GetFirstInvTime(const uint256& txhash);
+
     /** Check that all data structures are empty. */
     void CheckIsEmpty() const;
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -75,6 +75,9 @@ CTransactionRef TxDownloadManager::GetTxToReconsider(NodeId nodeid)
 {
     return m_impl->GetTxToReconsider(nodeid);
 }
+std::optional<int64_t> TxDownloadManager::GetFirstInvTime(const uint256& txhash) {
+    return m_impl->GetFirstInvTime(txhash);
+}
 void TxDownloadManager::CheckIsEmpty() const
 {
     m_impl->CheckIsEmpty();
@@ -567,6 +570,10 @@ bool TxDownloadManagerImpl::HaveMoreWork(NodeId nodeid)
 CTransactionRef TxDownloadManagerImpl::GetTxToReconsider(NodeId nodeid)
 {
     return m_orphanage.GetTxToReconsider(nodeid);
+}
+
+std::optional<int64_t> TxDownloadManagerImpl::GetFirstInvTime(const uint256& txhash) {
+    return m_txrequest.GetFirstInvTime(txhash);
 }
 
 void TxDownloadManagerImpl::CheckIsEmpty(NodeId nodeid)

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -218,7 +218,7 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
     const bool overloaded = !info.m_relay_permissions && m_txrequest.CountInFlight(peer) >= MAX_PEER_TX_REQUEST_IN_FLIGHT;
     if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
 
-    m_txrequest.ReceivedInv(peer, gtxid, info.m_preferred, now + delay);
+    m_txrequest.ReceivedInv(peer, gtxid, info.m_preferred, now, delay);
 
     return false;
 }
@@ -255,7 +255,7 @@ bool TxDownloadManagerImpl::MaybeAddOrphanResolutionCandidate(const std::vector<
     // Treat finding orphan resolution candidate as equivalent to the peer announcing all missing parents.
     // In the future, orphan resolution may include more explicit steps
     for (const auto& parent_txid : unique_parents) {
-        m_txrequest.ReceivedInv(nodeid, parent_txid, info.m_preferred, now + delay);
+        m_txrequest.ReceivedInv(nodeid, parent_txid, info.m_preferred, now, delay);
     }
     LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", nodeid, wtxid.ToString());
     return true;

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -184,6 +184,7 @@ public:
 
     bool HaveMoreWork(NodeId nodeid);
     CTransactionRef GetTxToReconsider(NodeId nodeid);
+    std::optional<int64_t> GetFirstInvTime(const uint256& txhash);
 
     void CheckIsEmpty();
     void CheckIsEmpty(NodeId nodeid);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -264,6 +264,8 @@ static std::vector<RPCResult> MempoolEntryDescription()
         RPCResult{RPCResult::Type::NUM, "vsize", "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."},
         RPCResult{RPCResult::Type::NUM, "weight", "transaction weight as defined in BIP 141."},
         RPCResult{RPCResult::Type::NUM_TIME, "time", "local time transaction entered pool in seconds since 1 Jan 1970 GMT"},
+        RPCResult{RPCResult::Type::NUM_TIME, "time_us", "local time transaction entered pool in microseconds since 1 Jan 1970 GMT"},
+        RPCResult{RPCResult::Type::NUM_TIME, "first_inv_time", /*optional=*/true, "local time transaction was first announced to us in microseconds since 1 Jan 1970 GMT"},
         RPCResult{RPCResult::Type::NUM, "height", "block height when transaction entered pool"},
         RPCResult{RPCResult::Type::NUM, "descendantcount", "number of in-mempool descendant transactions (including this one)"},
         RPCResult{RPCResult::Type::NUM, "descendantsize", "virtual transaction size of in-mempool descendants (including this one)"},
@@ -293,6 +295,10 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
     info.pushKV("vsize", (int)e.GetTxSize());
     info.pushKV("weight", (int)e.GetTxWeight());
     info.pushKV("time", count_seconds(e.GetTime()));
+    info.pushKV("time_us", count_microseconds(e.GetTimeUs()));
+    if (auto first_inv_time = e.GetFirstInvTime(); first_inv_time.has_value()) {
+        info.pushKV("first_inv_time", count_microseconds(first_inv_time.value()));
+    }
     info.pushKV("height", (int)e.GetHeight());
     info.pushKV("descendantcount", e.GetCountWithDescendants());
     info.pushKV("descendantsize", e.GetSizeWithDescendants());

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -37,7 +37,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) co
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
 {
-    return CTxMemPoolEntry{tx, nFee, TicksSinceEpoch<std::chrono::seconds>(time), nHeight, m_sequence, spendsCoinbase, sigOpCost, lp};
+    return CTxMemPoolEntry{tx, nFee, TicksSinceEpoch<std::chrono::microseconds>(time), nHeight, m_sequence, spendsCoinbase, sigOpCost, lp};
 }
 
 std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -194,6 +194,12 @@ struct TxMempoolInfo
     /** Time the transaction entered the mempool. */
     std::chrono::seconds m_time;
 
+    /** Time the transaction entered the mempool, in microseconds. */
+    std::chrono::microseconds m_time_us;
+
+    /** Time of the first announcement receive for this transaction, in microseconds. */
+    std::optional<std::chrono::microseconds> m_first_inv_time;
+
     /** Fee of the transaction. */
     CAmount fee;
 
@@ -409,7 +415,7 @@ private:
 
     static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it)
     {
-        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
+        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetTimeUs(), it->GetFirstInvTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
     }
 
 public:

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -717,10 +717,9 @@ public:
     std::optional<int64_t> GetFirstInvTime(const uint256& txhash)
     {
         auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
-        if (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash) return std::optional{it->m_first_inv_time.count()};
+        if (it != m_index.get<ByTxHash>().end() && it->m_gtxid.ToUint256() == txhash) return std::optional{it->m_first_inv_time.count()};
         return std::nullopt;
     }
-
 };
 
 TxRequestTracker::TxRequestTracker(bool deterministic) :

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -714,6 +714,13 @@ public:
         return uint64_t{m_computer(txhash, peer, preferred)};
     }
 
+    std::optional<int64_t> GetFirstInvTime(const uint256& txhash)
+    {
+        auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
+        if (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash) return std::optional{it->m_first_inv_time.count()};
+        return std::nullopt;
+    }
+
 };
 
 TxRequestTracker::TxRequestTracker(bool deterministic) :
@@ -760,4 +767,9 @@ std::vector<GenTxid> TxRequestTracker::GetRequestable(NodeId peer, std::chrono::
 uint64_t TxRequestTracker::ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const
 {
     return m_impl->ComputePriority(txhash, peer, preferred);
+}
+
+std::optional<int64_t> TxRequestTracker::GetFirstInvTime(const uint256& txhash)
+{
+    return m_impl->GetFirstInvTime(txhash);
 }

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -205,6 +205,9 @@ public:
     /** Access to the internal priority computation (testing only) */
     uint64_t ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const;
 
+     /** Returns the timestamp of the first received announcement for the given transaction, or nullopt if not found. */
+    std::optional<int64_t> GetFirstInvTime(const uint256& txhash);
+
     /** Run internal consistency check (testing only). */
     void SanityCheck() const;
 

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -132,8 +132,8 @@ public:
      * fetched. The new announcement is given the specified preferred and reqtime values, and takes its is_wtxid
      * from the specified gtxid.
      */
-    void ReceivedInv(NodeId peer, const GenTxid& gtxid, bool preferred,
-                     std::chrono::microseconds reqtime);
+    void ReceivedInv(NodeId peer, const GenTxid& gtxid, bool preferred, std::chrono::microseconds recvtime,
+                     std::chrono::microseconds delay);
 
     /** Deletes all announcements for a given peer.
      *

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -315,7 +315,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
             if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
+                AcceptToMemoryPool(*this, *it, GetTime<std::chrono::microseconds>().count(),
                     /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
                         MempoolAcceptResult::ResultType::VALID) {
                 // If the transaction doesn't make it in to the mempool, remove any
@@ -1917,10 +1917,10 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     auto result = [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
         AssertLockHeld(cs_main);
         if (test_accept) {
-            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, GetTime(), coins_to_uncache);
+            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, GetTime<std::chrono::microseconds>().count(), coins_to_uncache);
             return MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactions(package, args);
         } else {
-            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, GetTime(), coins_to_uncache, client_maxfeerate);
+            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, GetTime<std::chrono::microseconds>().count(), coins_to_uncache, client_maxfeerate);
             return MemPoolAccept(pool, active_chainstate).AcceptPackage(package, args);
         }
     }();
@@ -4586,7 +4586,7 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
+    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime<std::chrono::microseconds>().count(), /*bypass_limits=*/ false, test_accept);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }


### PR DESCRIPTION
Currently, we store the time transactions enter the mempool (in `CTXMempoolEntry`) as a timestamp with second precision. 

This patch stores data more precisely (microsecond granularity), as well as optionally storing the timestamp of the first inventory message received about each transaction in the pool, while still maintaining the previous interface for backwards compatibility (`nTime` is unchanged, and `nTimeUs` and `nFirstInvTime` are added with microsecond precision).

This is really useful when measuring transaction propagation (e.g. in simulated networks) since there is no easy way of checking when a transaction was first announced or received by the node.

I've tried to make the change as minimal as possible, hence why the use of an intermediate map in `PeerManager` instead of passing the time down to `ProcessValidTx`, which in turn would require adding it to `ProcessOrphanTx`, `ProcessNewPackage`, ...