### PR TITLE
init: [gui] Avoid UB/crash in InitAndLoadChainstate

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -709,6 +709,7 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
 
 const std::vector<std::string> TEST_OPTIONS_DOC{
     "addrman (use deterministic addrman)",
+    "reindex_after_failure_noninteractive_yes (When asked for a reindex after failure interactively, simulate as-if answered with 'yes')",
     "bip94 (enforce BIP94 consensus rules)",
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1737,10 +1737,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         args);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
         // suggest a reindex
-        bool do_retry = uiInterface.ThreadSafeQuestion(
+        bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
+            uiInterface.ThreadSafeQuestion(
             error + Untranslated(".\n\n") + _("Do you want to rebuild the databases now?"),
             error.original + ".\nPlease restart with -reindex or -reindex-chainstate to recover.",
-            "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
+            "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT)};
         if (!do_retry) {
             return false;
         }

--- a/test/functional/feature_reindex_init.py
+++ b/test/functional/feature_reindex_init.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test reindex works on init after a db load failure"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+import os
+import shutil
+
+
+class ReindexInitTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.stop_nodes()
+
+        self.log.info("Removing the block index leads to init error")
+        shutil.rmtree(node.blocks_path / "index")
+        node.assert_start_raises_init_error(
+            expected_msg=f": Error initializing block database.{os.linesep}"
+            "Please restart with -reindex or -reindex-chainstate to recover.",
+        )
+
+        self.log.info("Allowing the reindex should work fine")
+        self.start_node(0, extra_args=["-test=reindex_after_failure_noninteractive_yes"])
+        assert_equal(node.getblockcount(), 200)
+
+
+if __name__ == "__main__":
+    ReindexInitTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -289,6 +289,7 @@ BASE_SCRIPTS = [
     'p2p_leak.py',
     'wallet_encryption.py',
     'feature_dersig.py',
+    'feature_reindex_init.py',
     'feature_cltv.py',
     'rpc_uptime.py',
     'feature_discover.py',


### PR DESCRIPTION
`InitAndLoadChainstate` is problematic, when called twice in the GUI. This can happen when it returns a failure and the user selects an interactive reindex.

There are several bugs that have been introduced since the last time this was working correctly:

* The first one is a crash (assertion failure), which happens due to a cached tip block in the notifiications from the previous run. See https://github.com/bitcoin/bitcoin/pull/31346#discussion_r2207914726
* The second one is UB (use-after-free), which happens because the block index db in the blockmanager is not reset. See https://github.com/bitcoin/bitcoin/pull/30965#discussion_r2207822121

Fix both bugs by resetting any dirty state in `InitAndLoadChainstate`.

Also, add a test, because I don't really want to keep testing this manually every time. (A failing test run can be seen in https://github.com/bitcoin/bitcoin/pull/32979/checks)