### PR TITLE
wallet: remove outdated `pszSkip` arg of database `Rewrite` func

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -139,9 +139,9 @@ public:
     //! Counts the number of active database users to be sure that the database is not closed while someone is using it
     std::atomic<int> m_refcount{0};
 
-    /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
+    /** Rewrite the entire database on disk
      */
-    virtual bool Rewrite(const char* pszSkip=nullptr) = 0;
+    virtual bool Rewrite() = 0;
 
     /** Back up the entire database to a file.
      */

--- a/src/wallet/migrate.h
+++ b/src/wallet/migrate.h
@@ -35,9 +35,9 @@ public:
     /** Open the database if it is not already opened. */
     void Open() override;
 
-    /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
+    /** Rewrite the entire database on disk
      */
-    bool Rewrite(const char* pszSkip = nullptr) override { return false; }
+    bool Rewrite() override { return false; }
 
     /** Back up the entire database to a file.
      */

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -336,7 +336,7 @@ void SQLiteDatabase::Open()
     }
 }
 
-bool SQLiteDatabase::Rewrite(const char* skip)
+bool SQLiteDatabase::Rewrite()
 {
     // Rewrite the database using the VACUUM command: https://sqlite.org/lang_vacuum.html
     int ret = sqlite3_exec(m_db, "VACUUM", nullptr, nullptr, nullptr);

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -140,7 +140,7 @@ public:
     void Close() override;
 
     /** Rewrite the entire database on disk */
-    bool Rewrite(const char* skip = nullptr) override;
+    bool Rewrite() override;
 
     /** Back up the entire database to a file.
      */

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -104,7 +104,7 @@ public:
 
     void Open() override {}
 
-    bool Rewrite(const char* pszSkip=nullptr) override { return m_pass; }
+    bool Rewrite() override { return m_pass; }
     bool Backup(const std::string& strDest) const override { return m_pass; }
     void Close() override {}
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2266,7 +2266,7 @@ DBErrors CWallet::LoadWallet()
     DBErrors nLoadWalletRet = WalletBatch(GetDatabase()).LoadWallet(this);
     if (nLoadWalletRet == DBErrors::NEED_REWRITE)
     {
-        if (GetDatabase().Rewrite("\x04pool"))
+        if (GetDatabase().Rewrite())
         {
             for (const auto& spk_man_pair : m_spk_managers) {
                 spk_man_pair.second->RewriteDB();


### PR DESCRIPTION
This argument might have been used in the legacy wallets, but I don't see any implementation using this argument in the SQLite wallets. Removing it cleans up the code a bit.