### PR TITLE
log: unify `UpdateTip` values

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2976,7 +2976,7 @@ static void UpdateTipLog(
     AssertLockHeld(::cs_main);
 
     // Disable rate limiting in LogPrintLevel_ so this source location may log during IBD.
-    LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/false, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/false, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date=%s progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,


### PR DESCRIPTION
The most frequently seen log line prints tip-update data after each successful block connection. During IBD this produces ~900k lines (~250 characters per line), totaling ~220 MB so far.

Most `key=value` pairs are written directly, but block time is emitted as `date='ISO8601DateTime'`, adding unnecessary single quotes because the value contains no spaces.

Removing those quotes shortens every line and reduces a full-IBD debug log by ~1% (about ~2MB).

Before:
> 2025-07-16T04:50:47Z UpdateTip: new best=00000000000000000001f49fb5fb37753c06d78f1a811d707aebf6194bb147e5 height=890000 version=0x25e9a000 log2_work=95.523053 tx=1172414692 date='2025-03-29T17:29:01Z' progress=0.964378 cache=1578.9MiB(11964898txo)

After:
> 2025-07-16T04:50:47Z UpdateTip: new best=00000000000000000001f49fb5fb37753c06d78f1a811d707aebf6194bb147e5 height=890000 version=0x25e9a000 log2_work=95.523053 tx=1172414692 date=2025-03-29T17:29:01Z progress=0.964378 cache=1578.9MiB(11964898txo)