### PR TITLE
index: Deduplicate HashKey / HeightKey handling

### DIFF
--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -11,6 +11,7 @@
 #include <flatfile.h>
 #include <hash.h>
 #include <index/base.h>
+#include <index/db_key.h>
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
 #include <logging.h>
@@ -25,7 +26,6 @@
 
 #include <cerrno>
 #include <exception>
-#include <ios>
 #include <map>
 #include <optional>
 #include <span>
@@ -46,12 +46,8 @@
  * disk location of the next block filter to be written (represented as a FlatFilePos) is stored
  * under the DB_FILTER_POS key.
  *
- * Keys for the height index have the type [DB_BLOCK_HEIGHT, uint32 (BE)]. The height is represented
- * as big-endian so that sequential reads of filters by height are fast.
- * Keys for the hash index have the type [DB_BLOCK_HASH, uint256].
+ * The logic for keys is shared with other indexes, see index/db_key.h.
  */
-constexpr uint8_t DB_BLOCK_HASH{'s'};
-constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
 constexpr uint8_t DB_FILTER_POS{'P'};
 
 constexpr unsigned int MAX_FLTR_FILE_SIZE = 0x1000000; // 16 MiB
@@ -72,45 +68,6 @@ struct DBVal {
     FlatFilePos pos;
 
     SERIALIZE_METHODS(DBVal, obj) { READWRITE(obj.hash, obj.header, obj.pos); }
-};
-
-struct DBHeightKey {
-    int height;
-
-    explicit DBHeightKey(int height_in) : height(height_in) {}
-
-    template<typename Stream>
-    void Serialize(Stream& s) const
-    {
-        ser_writedata8(s, DB_BLOCK_HEIGHT);
-        ser_writedata32be(s, height);
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream& s)
-    {
-        const uint8_t prefix{ser_readdata8(s)};
-        if (prefix != DB_BLOCK_HEIGHT) {
-            throw std::ios_base::failure("Invalid format for block filter index DB height key");
-        }
-        height = ser_readdata32be(s);
-    }
-};
-
-struct DBHashKey {
-    uint256 hash;
-
-    explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
-
-    SERIALIZE_METHODS(DBHashKey, obj) {
-        uint8_t prefix{DB_BLOCK_HASH};
-        READWRITE(prefix);
-        if (prefix != DB_BLOCK_HASH) {
-            throw std::ios_base::failure("Invalid format for block filter index DB hash key");
-        }
-
-        READWRITE(obj.hash);
-    }
 };
 
 }; // namespace
@@ -317,29 +274,6 @@ bool BlockFilterIndex::Write(const BlockFilter& filter, uint32_t block_height, c
     return true;
 }
 
-[[nodiscard]] static bool CopyHeightIndexToHashIndex(CDBIterator& db_it, CDBBatch& batch,
-                                                     const std::string& index_name, int height)
-{
-    DBHeightKey key(height);
-    db_it.Seek(key);
-
-    if (!db_it.GetKey(key) || key.height != height) {
-        LogError("unexpected key in %s: expected (%c, %d)",
-                  index_name, DB_BLOCK_HEIGHT, height);
-        return false;
-    }
-
-    std::pair<uint256, DBVal> value;
-    if (!db_it.GetValue(value)) {
-        LogError("unable to read value in %s at key (%c, %d)",
-                 index_name, DB_BLOCK_HEIGHT, height);
-        return false;
-    }
-
-    batch.Write(DBHashKey(value.first), std::move(value.second));
-    return true;
-}
-
 bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
 {
     CDBBatch batch(*m_db);
@@ -348,7 +282,7 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
     // During a reorg, we need to copy block filter that is getting disconnected from the
     // height index to the hash index so we can still find it when the height index entry
     // is overwritten.
-    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, block.height)) {
+    if (!CopyHeightIndexToHashIndex<DBVal>(*db_it, batch, m_name, block.height)) {
         return false;
     }
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -234,25 +234,6 @@ bool CoinStatsIndex::CustomRemove(const interfaces::BlockInfo& block)
     return true;
 }
 
-static bool LookUpOne(const CDBWrapper& db, const interfaces::BlockRef& block, DBVal& result)
-{
-    // First check if the result is stored under the height index and the value
-    // there matches the block hash. This should be the case if the block is on
-    // the active chain.
-    std::pair<uint256, DBVal> read_out;
-    if (!db.Read(DBHeightKey(block.height), read_out)) {
-        return false;
-    }
-    if (read_out.first == block.hash) {
-        result = std::move(read_out.second);
-        return true;
-    }
-
-    // If value at the height index corresponds to an different block, the
-    // result will be stored in the hash index.
-    return db.Read(DBHashKey(block.hash), result);
-}
-
 std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex& block_index) const
 {
     CCoinsStats stats{block_index.nHeight, block_index.GetBlockHash()};

--- a/src/index/db_key.h
+++ b/src/index/db_key.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_DB_KEY_H
+#define BITCOIN_INDEX_DB_KEY_H
+
+#include <dbwrapper.h>
+#include <interfaces/types.h>
+#include <logging.h>
+#include <serialize.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <ios>
+#include <string>
+#include <utility>
+
+/*
+ * This file includes the logic for the db keys used by blockfilterindex and coinstatsindex.
+ * Index data is usually indexed by height, but in case of a reorg, entries of blocks no
+ * longer in the main chain will be copied to a hash index by which they can still be queried.
+ * Keys for the height index have the type [DB_BLOCK_HEIGHT, uint32 (BE)]. The height is represented
+ * as big-endian so that sequential reads of filters by height are fast.
+ * Keys for the hash index have the type [DB_BLOCK_HASH, uint256].
+ */
+
+static constexpr uint8_t DB_BLOCK_HASH{'s'};
+static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
+
+struct DBHeightKey {
+    int height;
+
+    explicit DBHeightKey(int height_in) : height(height_in) {}
+
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ser_writedata8(s, DB_BLOCK_HEIGHT);
+        ser_writedata32be(s, height);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        const uint8_t prefix{ser_readdata8(s)};
+        if (prefix != DB_BLOCK_HEIGHT) {
+            throw std::ios_base::failure("Invalid format for index DB height key");
+        }
+        height = ser_readdata32be(s);
+    }
+};
+
+struct DBHashKey {
+    uint256 hash;
+
+    explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
+
+    SERIALIZE_METHODS(DBHashKey, obj) {
+        uint8_t prefix{DB_BLOCK_HASH};
+        READWRITE(prefix);
+        if (prefix != DB_BLOCK_HASH) {
+            throw std::ios_base::failure("Invalid format for index DB hash key");
+        }
+
+        READWRITE(obj.hash);
+    }
+};
+
+template <typename DBVal>
+[[nodiscard]] static bool CopyHeightIndexToHashIndex(CDBIterator& db_it, CDBBatch& batch,
+                                                     const std::string& index_name, int height)
+{
+    DBHeightKey key(height);
+    db_it.Seek(key);
+
+    if (!db_it.GetKey(key) || key.height != height) {
+        LogError("unexpected key in %s: expected (%c, %d)",
+                  index_name, DB_BLOCK_HEIGHT, height);
+        return false;
+    }
+
+    std::pair<uint256, DBVal> value;
+    if (!db_it.GetValue(value)) {
+        LogError("unable to read value in %s at key (%c, %d)",
+                 index_name, DB_BLOCK_HEIGHT, height);
+        return false;
+    }
+
+    batch.Write(DBHashKey(value.first), value.second);
+    return true;
+}
+
+#endif // BITCOIN_INDEX_DB_KEY_H

--- a/src/index/db_key.h
+++ b/src/index/db_key.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 
+namespace index_util {
 /*
  * This file includes the logic for the db keys used by blockfilterindex and coinstatsindex.
  * Index data is usually indexed by height, but in case of a reorg, entries of blocks no
@@ -110,5 +111,6 @@ static bool LookUpOne(const CDBWrapper& db, const interfaces::BlockRef& block, D
     // result will be stored in the hash index.
     return db.Read(DBHashKey(block.hash), result);
 }
+} // namespace index_util
 
 #endif // BITCOIN_INDEX_DB_KEY_H

--- a/src/index/db_key.h
+++ b/src/index/db_key.h
@@ -91,4 +91,24 @@ template <typename DBVal>
     return true;
 }
 
+template <typename DBVal>
+static bool LookUpOne(const CDBWrapper& db, const interfaces::BlockRef& block, DBVal& result)
+{
+    // First check if the result is stored under the height index and the value
+    // there matches the block hash. This should be the case if the block is on
+    // the active chain.
+    std::pair<uint256, DBVal> read_out;
+    if (!db.Read(DBHeightKey(block.height), read_out)) {
+        return false;
+    }
+    if (read_out.first == block.hash) {
+        result = std::move(read_out.second);
+        return true;
+    }
+
+    // If value at the height index corresponds to an different block, the
+    // result will be stored in the hash index.
+    return db.Read(DBHashKey(block.hash), result);
+}
+
 #endif // BITCOIN_INDEX_DB_KEY_H


### PR DESCRIPTION
The logic for `DBHashKey` / `DBHeightKey` handling and lookup of entries is shared by `coinstatsindex` and `blockfilterindex`, leading to many lines of duplicated code. De-duplicate this by moving the logic to `index/db_key.h` (using templates for the index-specific `DBVal`).