### PR TITLE
Enable `-natpmp` by default

### DIFF
--- a/doc/release-notes-33004.md
+++ b/doc/release-notes-33004.md
@@ -1,0 +1,6 @@
+Updated settings
+----------------
+
+* The `-natpmp` option is now set to `1` by default. This means nodes with `-listen` enabled (the
+  default) but running behind a firewall, such as a local network router, will be reachable if the
+  firewall/router supports any of the `PCP` or `NAT-PMP` protocols.

--- a/src/mapport.h
+++ b/src/mapport.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_MAPPORT_H
 #define BITCOIN_MAPPORT_H
 
-static constexpr bool DEFAULT_NATPMP = false;
+static constexpr bool DEFAULT_NATPMP = true;
 
 void StartMapPort(bool enable);
 void InterruptMapPort();


### PR DESCRIPTION
This turns the default for NAT hole-punching (with [PCP](https://en.wikipedia.org/wiki/Port_Control_Protocol) or [NAT-PMP](https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol)) to on. Closes #31663.