### PR TITLE
test: fix `ReadTopologicalSet` unsigned integer overflow

### DIFF
--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -304,7 +304,7 @@ SetType ReadTopologicalSet(const DepGraph<SetType>& depgraph, const SetType& tod
     try {
         reader >> VARINT(mask);
     } catch(const std::ios_base::failure&) {}
-    mask += non_empty;
+    if (mask != uint64_t(-1)) mask += non_empty;
 
     SetType ret;
     for (auto i : todo) {


### PR DESCRIPTION
This PR is a simple fix for a potential unsigned integer overflow in ReadTopologicalSet. 
We obtain the value of `mask` from fuzz input, which can be the maximum representable value.
Adding 1 to it would then cause an overflow.

The fix skips the addition when the read value is already the maximum.

See https://github.com/bitcoin/bitcoin/pull/30605#discussion_r2215338569 for more context