### PR TITLE
wallet: support bip388 policy with external signer

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -74,6 +74,16 @@ UniValue ExternalSigner::GetDescriptors(const int account)
     return RunCommandParseJSON(Cat(m_command, Cat(Cat({"--fingerprint", m_fingerprint}, NetworkArg()), {"getdescriptors", "--account", strprintf("%d", account)})), "");
 }
 
+UniValue ExternalSigner::RegisterPolicy(const std::string& name, const std::string& descriptor_template, const std::vector<std::string>& keys_info) const
+{
+    std::vector<std::string> command = Cat(m_command, Cat(Cat({"--fingerprint", m_fingerprint}, NetworkArg()), {"register", "--name", name, "--desc", descriptor_template}));
+    for (const std::string& key_info : keys_info) {
+        command.emplace_back("--key");
+        command.emplace_back(key_info);
+    }
+    return RunCommandParseJSON(command, "");
+}
+
 bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::string& error)
 {
     // Serialize the PSBT

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -57,6 +57,14 @@ public:
     //! @returns see doc/external-signer.md
     UniValue GetDescriptors(int account);
 
+    //! Register BIP388 policy on the device.
+    //! Calls `<command> register` and passes the name, policy and key info
+    //! @param[in] name policy name to display on the signer
+    //! @param[in] descriptor_template BIP388 descriptor template
+    //! @param[in] keys_info key with origin for each participant
+    //! @returns hmac provided by the signer
+    UniValue RegisterPolicy(const std::string& name, const std::string& descriptor_template, const std::vector<std::string>& keys_info) const;
+
     //! Sign PartiallySignedTransaction on the device.
     //! Calls `<command> signtransaction` and passes the PSBT via stdin.
     //! @param[in,out] psbt  PartiallySignedTransaction to be signed

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -130,6 +130,9 @@ public:
     //! Display address on external signer
     virtual util::Result<void> displayAddress(const CTxDestination& dest) = 0;
 
+    //! Register BIP388 policy on external signer, store and return hmac
+    virtual util::Result<std::string> registerPolicy(const std::optional<std::string>& name) = 0;
+
     //! Lock coin.
     virtual bool lockCoin(const COutPoint& output, bool write_to_db) = 0;
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -11,10 +11,18 @@
 #include <string>
 
 namespace util {
-void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute)
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute, bool regex)
 {
     if (search.empty()) return;
-    in_out = std::regex_replace(in_out, std::regex(search), substitute);
+    if (regex) {
+        in_out = std::regex_replace(in_out, std::regex(search), substitute);
+        return;
+    }
+    size_t pos{0};
+    while ((pos = in_out.find(search, pos)) != std::string::npos) {
+        in_out.replace(pos, search.size(), substitute);
+        ++pos;
+    }
 }
 
 LineReader::LineReader(std::span<const std::byte> buffer, size_t max_line_length)

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -96,7 +96,7 @@ struct ConstevalFormatString {
     consteval ConstevalFormatString(const char* str) : fmt{str} { detail::CheckNumFormatSpecifiers<num_params>(fmt); }
 };
 
-void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute);
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute, bool regex = true);
 
 /** Split a string on any char found in separators, returning a vector.
  *

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -7,6 +7,7 @@
 #include <common/system.h>
 #include <external_signer.h>
 #include <node/types.h>
+#include <util/strencodings.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
 
 #include <iostream>
@@ -106,4 +107,23 @@ std::optional<PSBTError> ExternalSignerScriptPubKeyMan::FillPSBT(PartiallySigned
     if (finalize) FinalizePSBT(psbt);
     return {};
 }
+
+util::Result<std::string> ExternalSignerScriptPubKeyMan::RegisterPolicy(const ExternalSigner& signer,
+                                                                        const std::string& name,
+                                                                        const std::string& descriptor_template,
+                                                                        const std::vector<std::string>& keys_info) const
+{
+    const UniValue& result{signer.RegisterPolicy(name, descriptor_template, keys_info)};
+
+    const UniValue& error = result.find_value("error");
+    if (error.isStr()) return util::Error{strprintf(_("Signer returned error: %s"), error.getValStr())};
+
+    const UniValue& ret_hmac = result.find_value("hmac");
+    if (!ret_hmac.isStr()) return util::Error{_("Signer did not return hmac")};
+    const std::string hmac{ret_hmac.getValStr()};
+    if (!IsHex(hmac)) return util::Error{strprintf(_("Signer return invalid hmac: %s"), hmac)};
+
+    return util::Result<std::string>(hmac);
+}
+
 } // namespace wallet

--- a/src/wallet/external_signer_scriptpubkeyman.h
+++ b/src/wallet/external_signer_scriptpubkeyman.h
@@ -37,6 +37,18 @@ class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
  util::Result<void> DisplayAddress(const CTxDestination& dest, const ExternalSigner& signer) const;
 
   std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, std::optional<int> sighash_type = std::nullopt, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
+
+  /**
+   * Register BIP388 wallet policy.
+   * @param[in] name policy name to display on the signer
+   * @param[in] descriptor_template BIP388 descriptor template
+   * @param[in] keys_info key with origin for each participant
+   * @returns hmac or an error message
+   */
+  util::Result<std::string> RegisterPolicy(const ExternalSigner& signer,
+                                           const std::string& name,
+                                           const std::string& descriptor_template,
+                                           const std::vector<std::string>& keys_info) const;
 };
 } // namespace wallet
 #endif // BITCOIN_WALLET_EXTERNAL_SIGNER_SCRIPTPUBKEYMAN_H

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -237,6 +237,11 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->DisplayAddress(dest);
     }
+    util::Result<std::string> registerPolicy(const std::optional<std::string>& name) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->RegisterPolicy(name);
+    }
     bool lockCoin(const COutPoint& output, const bool write_to_db) override
     {
         LOCK(m_wallet->cs_wallet);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -56,6 +56,15 @@ static RPCMethod getwalletinfo()
                         }, {.skip_type_check=true}, },
                         {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for output script management"},
                         {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
+                        {RPCResult::Type::ARR, "bip388", /*optional=*/true, "BIP388 HMACs provided by external signers",
+                        {
+                            {RPCResult::Type::OBJ, "bip388_hmacs", "BIP388 HMACs for the policies registered with the external signer",
+                            {
+                                {RPCResult::Type::STR, "name", "the name of the BIP388 policy"},
+                                {RPCResult::Type::STR, "fingerprint", "the fingerprint of the external signer"},
+                                {RPCResult::Type::STR_HEX, "hmac", "the BIP388 HMAC for the policy and fingerprint"},
+                            },
+                        }}},
                         {RPCResult::Type::BOOL, "blank", "Whether this wallet intentionally does not contain any keys, scripts, or descriptors"},
                         {RPCResult::Type::NUM_TIME, "birthtime", /*optional=*/true, "The start time for blocks scanning. It could be modified by (re)importing any descriptor with an earlier timestamp."},
                         {RPCResult::Type::ARR, "flags", "The flags currently set on the wallet",
@@ -107,6 +116,17 @@ static RPCMethod getwalletinfo()
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+    if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+        UniValue bip388_hmacs(UniValue::VARR);
+        for (const wallet::BIP388& hmac : pwallet->GetHmacs()) {
+            UniValue bip388(UniValue::VOBJ);
+            bip388.pushKV("name", hmac.name);
+            bip388.pushKV("fingerprint", hmac.fingerprint);
+            bip388.pushKV("hmac", hmac.hmac);
+            bip388_hmacs.push_back(std::move(bip388));
+        }
+        obj.pushKV("bip388", bip388_hmacs);
+    }
     obj.pushKV("blank", pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET));
     if (int64_t birthtime = pwallet->GetBirthTime(); birthtime != UNKNOWN_TIME) {
         obj.pushKV("birthtime", birthtime);
@@ -840,6 +860,45 @@ static RPCMethod createwalletdescriptor()
     };
 }
 
+#ifdef ENABLE_EXTERNAL_SIGNER
+RPCMethod registerpolicy()
+{
+    return RPCMethod{
+        "registerpolicy",
+        "Register BIP388 policy on an external signer and store the result.",
+        {
+            {"policy_name", RPCArg::Type::STR, RPCArg::DefaultHint{"wallet name"}, "Policy name to display on the device"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ,"","",
+            {
+                {RPCResult::Type::STR, "hmac", "The hmac (stored in the wallet)"},
+            }
+        },
+        RPCExamples{""},
+        [&](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+            if (!wallet) return UniValue::VNULL;
+            CWallet* const pwallet = wallet.get();
+
+            LOCK(pwallet->cs_wallet);
+
+            std::optional<std::string> policy_name;
+            if (!request.params[0].isNull()) {
+                policy_name = std::string_view{request.params[0].get_str()};
+            }
+            util::Result<std::string> res = pwallet->RegisterPolicy(policy_name);
+            if (!res) throw JSONRPCError(RPC_MISC_ERROR, util::ErrorString(res).original);
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("hmac", *res);
+            return result;
+        }
+    };
+}
+#endif // ENABLE_EXTERNAL_SIGNER
+
 // addresses
 RPCMethod getaddressinfo();
 RPCMethod getnewaddress();
@@ -956,6 +1015,7 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &unloadwallet},
         {"wallet", &walletcreatefundedpsbt},
 #ifdef ENABLE_EXTERNAL_SIGNER
+        {"wallet", &registerpolicy},
         {"wallet", &walletdisplayaddress},
 #endif // ENABLE_EXTERNAL_SIGNER
         {"wallet", &walletlock},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -36,7 +36,9 @@
 #include <psbt.h>
 #include <pubkey.h>
 #include <random.h>
+#include <regex>
 #include <script/descriptor.h>
+#include <script/parsing.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/sign.h>
@@ -1831,8 +1833,9 @@ uint64_t CWallet::GetWalletFlags() const
     return m_wallet_flags;
 }
 
-void CWallet::LoadHmacBIP388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac) {
-    m_bip388.push_back({.name = policy_name, .fingerprint = fingerprint, .hmac = hmac});
+void CWallet::LoadHmacBIP388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac)
+{
+    m_bip388.emplace_back(BIP388{policy_name, fingerprint, hmac});
 }
 
 void CWallet::MaybeUpdateBirthTime(int64_t time)
@@ -2746,7 +2749,7 @@ util::Result<void> CWallet::DisplayAddress(const CTxDestination& dest)
 {
     CScript scriptPubKey = GetScriptForDestination(dest);
     for (const auto& spk_man : GetScriptPubKeyMans(scriptPubKey)) {
-        auto signer_spk_man = dynamic_cast<ExternalSignerScriptPubKeyMan *>(spk_man);
+        auto signer_spk_man = dynamic_cast<ExternalSignerScriptPubKeyMan*>(spk_man);
         if (signer_spk_man == nullptr) {
             continue;
         }
@@ -2755,6 +2758,161 @@ util::Result<void> CWallet::DisplayAddress(const CTxDestination& dest)
         return signer_spk_man->DisplayAddress(dest, *signer);
     }
     return util::Error{_("There is no ScriptPubKeyManager for this address")};
+}
+
+// TODO:
+// - apply furth BIP388 restrictions
+// - avoid string parsing, add properties to Descriptor instead
+bool CWallet::IsCandidateForBIP388Policy(DescriptorScriptPubKeyMan& spkm)
+{
+    std::string desc;
+    if (!Assume(spkm.GetDescriptorString(desc, /*priv=*/false))) return false;
+
+    std::span<const char> sp{desc};
+
+    if (!(script::Const("tr(", sp, /*skip=*/true) || script::Const("wsh(", sp, /*skip=*/true))) return false;
+    // Must be MuSig2, have a leaf script or segwit multisig
+    if (desc.find(',') == std::string::npos) return false;
+
+    return true;
+}
+
+util::Result<std::pair<std::string, std::vector<std::string>>> CWallet::DerivePolicy(const std::optional<std::pair<DescriptorScriptPubKeyMan&, DescriptorScriptPubKeyMan&>>& spk_pair)
+{
+    std::string receive_descriptor;
+    std::string change_descriptor;
+
+    DescriptorScriptPubKeyMan* receive{nullptr};
+    DescriptorScriptPubKeyMan* change{nullptr};
+
+    if (spk_pair) {
+        if (!IsCandidateForBIP388Policy(spk_pair->first) || !IsCandidateForBIP388Policy(spk_pair->second)) {
+            return util::Error{_("Provided descriptors are not compatible with BIP388")};
+        }
+        receive = &spk_pair->first;
+        change = &spk_pair->second;
+    } else {
+        for (bool internal : {false, true}) {
+            // TODO: support P2SH.
+            for (const OutputType type : {OutputType::BECH32M, OutputType::BECH32}) {
+                // Only look for a single candidate
+                if (!internal && !receive_descriptor.empty()) continue;
+                if (internal && !change_descriptor.empty()) continue;
+
+                auto spk_man = GetScriptPubKeyMan(type, internal);
+                if (!Assume(spk_man)) continue;
+                auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+                if (!Assume(desc_spk_man)) continue;
+
+                if (!IsCandidateForBIP388Policy(*desc_spk_man)) continue;
+
+                if (internal) {
+                    change = desc_spk_man;
+                } else {
+                    receive = desc_spk_man;
+                }
+            }
+        }
+    }
+
+    if (!receive || !change) {
+        return util::Error{_("No suitable descriptors found or provided for BIP388 policy")};
+    }
+
+    bool res{receive->GetDescriptorString(receive_descriptor, /*priv=*/false)};
+    res &= change->GetDescriptorString(change_descriptor, /*priv=*/false);
+    if (!Assume(res)) {
+        return util::Error{_("Failed to get descriptor strings")};
+    }
+
+    // TODO: render (candidate) policy directly from Descriptor class and extract
+    //       keys there.
+
+    // Lookup keys in the receive descriptor.
+    std::vector<std::string> keys_info;
+    const std::regex key_regex{R"(((?:\[[a-f\dh'/]{8,}\])?[\w]{10,})[,\)\/])"};
+    auto search_begin = std::sregex_token_iterator(receive_descriptor.begin(), receive_descriptor.end(), key_regex, 1);
+    auto search_end = std::sregex_token_iterator();
+
+    for (std::regex_token_iterator i = search_begin; i != search_end; ++i) {
+        std::string key{i->str()};
+        if (std::find(keys_info.begin(), keys_info.end(), key) != keys_info.end()) continue;
+        keys_info.push_back(key);
+    }
+
+    // Replace keys in descriptor swith @1, etc
+    // - convert /0/* in the receive descriptor to /**
+    // - convert /1/* in the change descriptor to /**
+    // - TODO: support arbitrary /<NUM;NUM>/*
+    // - also drop checksum
+    std::string descriptor_template{receive_descriptor.substr(0, receive_descriptor.size() - 9)};
+    std::string descriptor_template_check{change_descriptor.substr(0, change_descriptor.size() - 9)};
+    uint32_t key_index = 0;
+    for (auto& key_info : keys_info) {
+        util::ReplaceAll(descriptor_template, key_info, strprintf("@%d", key_index), /*regex=*/false);
+        util::ReplaceAll(descriptor_template_check, key_info, strprintf("@%d", key_index), /*regex=*/false);
+        key_index++;
+    }
+
+    // Replace /0/* with /@0/**
+    util::ReplaceAll(descriptor_template, "/0/*", "/**", /*regex=*/false);
+
+    // Replace /1/* with /@0/**
+    util::ReplaceAll(descriptor_template_check, "/1/*", "/**", /*regex=*/false);
+
+    // The receive and change descriptor should now be identical
+    if (descriptor_template != descriptor_template_check) {
+        return util::Error{Untranslated(strprintf(
+            "Receive and change descriptors incompatible for BIP388 policy registration:\n%s\n%s\nKey info:\n%s",
+            descriptor_template.c_str(),
+            descriptor_template_check.c_str(),
+            util::Join(keys_info, "\n")
+        ))};
+    }
+
+    // Replace h with ' in key info:
+    for (std::string& key : keys_info) {
+        util::ReplaceAll(key, "h/", "'/", /*regex=*/false);
+        util::ReplaceAll(key, "h]", "']", /*regex=*/false);
+    }
+
+    return std::pair<std::string, std::vector<std::string>>{descriptor_template, keys_info};
+}
+
+util::Result<std::string> CWallet::RegisterPolicy(const std::optional<std::string>& name)
+{
+    const std::string policy_name{name.has_value() ? *name : m_name};
+
+    // A wallet with multiple descriptors could have multiple BIP388 policies,
+    // but this is currently unsupported. DerivePolicy just picks one.
+    const auto res{DerivePolicy(/*spk_pair=*/std::nullopt)};
+    if (!res) return util::Error{util::ErrorString(res)};
+    const std::string& descriptor_template{res->first};
+    const std::vector<std::string>& keys_info{res->second};
+
+    for (const auto& spk_man : GetActiveScriptPubKeyMans()) {
+        auto signer_spk_man = dynamic_cast<ExternalSignerScriptPubKeyMan *>(spk_man);
+        if (signer_spk_man == nullptr) {
+            continue;
+        }
+        auto signer{ExternalSignerScriptPubKeyMan::GetExternalSigner()};
+        if (!signer) return util::Error{util::ErrorString(signer)};
+
+        util::Result<std::string> res{signer_spk_man->RegisterPolicy(*signer, policy_name, descriptor_template, keys_info)};
+        if (!res) return util::Error{util::ErrorString(res)};
+
+        if (res) {
+            // Store hmac in wallet
+            WalletBatch batch(GetDatabase());
+            if (!batch.WriteHmacBip388(policy_name, signer->m_fingerprint, *res)) {
+                return util::Error{_("Failed to store BIP388 hmac in wallet database.")};
+            }
+            LoadHmacBIP388(policy_name, signer->m_fingerprint, *res);
+        }
+
+        return res;
+    }
+    return util::Error{_("Could not find ExternalSignerScriptPubKeyMananager")};
 }
 
 void CWallet::LoadLockedCoin(const COutPoint& coin, bool persistent)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1831,6 +1831,10 @@ uint64_t CWallet::GetWalletFlags() const
     return m_wallet_flags;
 }
 
+void CWallet::LoadHmacBIP388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac) {
+    m_bip388.push_back({.name = policy_name, .fingerprint = fingerprint, .hmac = hmac});
+}
+
 void CWallet::MaybeUpdateBirthTime(int64_t time)
 {
     int64_t birthtime = m_birth_time.load();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -301,6 +301,13 @@ struct CRecipient
     bool fSubtractFeeFromAmount;
 };
 
+/** BIP388 registered hmac */
+struct BIP388 {
+    std::string name;
+    std::string fingerprint;
+    std::string hmac;
+};
+
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.
@@ -379,6 +386,8 @@ private:
 
     /** WalletFlags set on this wallet. */
     std::atomic<uint64_t> m_wallet_flags{0};
+
+    std::vector<BIP388> m_bip388;
 
     bool SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& address, const std::string& strName, const std::optional<AddressPurpose>& strPurpose);
 
@@ -924,6 +933,11 @@ public:
     bool LoadWalletFlags(uint64_t flags);
     //! Retrieve all of the wallet's flags
     uint64_t GetWalletFlags() const;
+
+    std::vector<BIP388> GetHmacs() const { return m_bip388; }
+
+    //! Load BIP388 registered hmac
+    void LoadHmacBIP388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac);
 
     /** Return wallet name for use in logs, will return "default wallet" if the wallet has no name. */
     std::string LogName() const override

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -578,6 +578,28 @@ public:
     /** Display address on an external signer. */
     util::Result<void> DisplayAddress(const CTxDestination& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /** Determine if the SPKM descriptor is compatible with BIP388 */
+    bool IsCandidateForBIP388Policy(DescriptorScriptPubKeyMan& spkm) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /**
+     * Derive a BIP388 policy from a pair of descriptor scriptpubkey manangers.
+     *
+     * Ignores trivial single sig policies: pkh(KEY), wpkh(KEY), sh(wpkh(KEY))
+     * and tr(KEY)
+     *
+     * If no SKPM pair is provided, look for the first suitable pair.
+     *
+     * @param[in] spk_pair The receive and change SKPM to use.
+     *
+     * @return a string containing the BIP388 policy and array of strings
+     *         containing the key information. An error if no suitable
+     *         descriptors were found.
+     */
+    util::Result<std::pair<std::string, std::vector<std::string>>> DerivePolicy(const std::optional<std::pair<DescriptorScriptPubKeyMan&, DescriptorScriptPubKeyMan&>>& spk_pair) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Register BIP388 on an external signer. Store and return the resulting hmac. */
+    util::Result<std::string> RegisterPolicy(const std::optional<std::string>& name) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     bool IsLockedCoin(const COutPoint& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LoadLockedCoin(const COutPoint& coin, bool persistent) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool LockCoin(const COutPoint& output, bool persist) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -33,6 +33,7 @@ const std::string ACENTRY{"acentry"};
 const std::string ACTIVEEXTERNALSPK{"activeexternalspk"};
 const std::string ACTIVEINTERNALSPK{"activeinternalspk"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
+const std::string BIP388_HMAC{"bip388_hmac"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CSCRIPT{"cscript"};
@@ -914,6 +915,31 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
     return desc_res.m_result;
 }
 
+static DBErrors LoadWalletPolicyRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+{
+    AssertLockHeld(pwallet->cs_wallet);
+
+    LoadResult res = LoadRecords(pwallet, batch, DBKeys::BIP388_HMAC,
+        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        std::pair<std::string, std::string> key_pair;
+        std::string hmac;
+        key >> key_pair;
+        value >> hmac;
+        std::string policy_name = key_pair.first;
+        std::string fingerprint = key_pair.second;
+        pwallet->LoadHmacBIP388(policy_name, fingerprint, hmac);
+        return DBErrors::LOAD_OK;
+    });
+
+    if (res.m_result <= DBErrors::NONCRITICAL_ERROR) {
+        // Only log if there are no critical errors
+        pwallet->WalletLogPrintf("Loaded BIP388 policy");
+    }
+
+    return res.m_result;
+}
+
+
 static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
@@ -1128,6 +1154,9 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         // when in reality the wallet is simply too new.
         if (result == DBErrors::UNKNOWN_DESCRIPTOR) return result;
 
+        // Load BIP388 HMAC record
+        result = std::max(LoadWalletPolicyRecords(pwallet, *m_batch, last_client), result);
+
         // Load address book
         result = std::max(LoadAddressBookRecords(pwallet, *m_batch), result);
 
@@ -1243,6 +1272,11 @@ bool WalletBatch::EraseAddressData(const CTxDestination& dest)
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 {
     return WriteIC(DBKeys::FLAGS, flags);
+}
+
+bool WalletBatch::WriteHmacBip388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac)
+{
+    return WriteIC(std::make_pair(DBKeys::BIP388_HMAC, std::make_pair(policy_name, fingerprint)), hmac);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -60,6 +60,7 @@ extern const std::string ACTIVEEXTERNALSPK;
 extern const std::string ACTIVEINTERNALSPK;
 extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
+extern const std::string BIP388_HMAC;
 extern const std::string CRYPTED_KEY;
 extern const std::string CSCRIPT;
 extern const std::string DEFAULTKEY;
@@ -271,6 +272,10 @@ public:
     bool EraseRecords(const std::unordered_set<std::string>& types);
 
     bool WriteWalletFlags(uint64_t flags);
+
+    // Write a  BIP-388 policy hmac for the signer identified by fingerprint.
+    bool WriteHmacBip388(const std::string& policy_name, const std::string& fingerprint, const std::string& hmac);
+
     //! Begin a new transaction
     bool TxnBegin();
     //! Commit current transaction

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -56,6 +56,12 @@ def displayaddress(args):
 
     return sys.stdout.write(json.dumps({"address": expected_desc[args.desc]}))
 
+def register(args):
+    if args.fingerprint != "00000001":
+        return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
+
+    return sys.stdout.write(json.dumps({"hmac": "0000000000000000000000000000000000000000000000000000000000000000"}))
+
 def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
@@ -89,6 +95,12 @@ parser_getdescriptors.add_argument('--account', metavar='account')
 parser_displayaddress = subparsers.add_parser('displayaddress', help='display address on signer')
 parser_displayaddress.add_argument('--desc', metavar='desc')
 parser_displayaddress.set_defaults(func=displayaddress)
+
+parser_register = subparsers.add_parser('register')
+parser_register.add_argument('--name')
+parser_register.add_argument('--desc')
+parser_register.add_argument('--key', action='append')
+parser_register.set_defaults(func=register)
 
 parser_signtx = subparsers.add_parser('signtx')
 parser_signtx.add_argument('psbt', metavar='psbt')

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -10,6 +10,7 @@ See also rpc_signer.py for tests without wallet context.
 import os
 import sys
 
+from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -61,6 +62,8 @@ class WalletSignerTest(BitcoinTestFramework):
         self.test_invalid_signer()
         self.restart_node(1, [f"-signer={self.mock_multi_signers_path()}", "-keypool=10"])
         self.test_multiple_signers()
+        self.restart_node(1)
+        self.test_bip388_policy()
 
     def test_valid_signer(self):
         self.log.debug(f"-signer={self.mock_signer_path()}")
@@ -238,6 +241,46 @@ class WalletSignerTest(BitcoinTestFramework):
         self.log.info('Test multiple external signers')
 
         assert_raises_rpc_error(-1, "More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, external_signer=True)
+
+    def test_bip388_policy(self):
+        self.log.debug(f"-signer={self.mock_multi_signers_path()}")
+        self.log.info('Register BIP388 wallet policy')\
+
+        # TODO: set blank=True after https://github.com/bitcoin/bitcoin/pull/33112
+        self.nodes[1].createwallet(wallet_name='hww_policy', disable_private_keys=True, external_signer=True)
+        wallet = self.nodes[1].get_wallet_rpc('hww_policy')
+        self.log.debug(wallet.getwalletinfo())
+
+        # e.g. obtained via hwi getxpub
+        device_key = "[00000001/47h/1h/0h]tpubD6NzVbkrYhZ4YNXVQbNhMK1WqguFsUXceaVJKbmno2aZ3B6QfbMeraaYvnBSGpV3vxLyTTK9DYT1yoEck4XUScMzXoQ2U2oSmE2JyMedq3H"
+        # for this test it doesn't matter that we can't actually sign with it
+        our_key = "[00000001/47h/1h/0h]tpubDAXcJ7s7ZwicqjprRaEWdPoHKrCS215qxGYxpusRLLmJuT69ZSicuGdSfyvyKpvUNYBW1s2U3NSrT6vrCYB9e6nZUEvrqnwXPF8ArTCRXMY"
+
+        res = wallet.importdescriptors([{
+            "desc": descsum_create(f"wsh(multi(2,{device_key}/<0;1>/*,{our_key}/<0;1>/*))"),
+            "active": True,
+            "timestamp": "now"
+        }])
+        assert(res[0]["success"] and res[0]["success"])
+
+        self.log.debug(wallet.listdescriptors())
+
+        res = wallet.registerpolicy()
+        hmac = res["hmac"]
+
+        assert_equal(hmac, "0000000000000000000000000000000000000000000000000000000000000000")
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["bip388"][0]["hmac"], hmac)
+
+        # Make sure it's persisted
+        self.nodes[1].unloadwallet("hww_policy")
+        self.nodes[1].loadwallet("hww_policy")
+        wallet = self.nodes[1].get_wallet_rpc('hww_policy')
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["bip388"][0]["hmac"], hmac)
+
 
 if __name__ == '__main__':
     WalletSignerTest(__file__).main()


### PR DESCRIPTION
External signers such as Ledger, BitBox02 and Jade, when used with multisig, use [BIP388](https://github.com/bitcoin/bips/blob/master/bip-0388.mediawiki) to display (and constrain) descriptor policies to their users.

At least in the case of Ledger (no others so far, see https://github.com/bitcoin/bitcoin/pull/33008#issuecomment-3165080503) this requires us to hold on to an hmac, which proves to the device that the user previously reviewed and approved it.

This PR adds a new RPC call `registerpolicy` which converts our descriptor(s) into a BIP388 policy (_partially implemented_), calls a new HWI method `register` (_implemented_) and stores the resulting HMAC (_implemented_).

When signing a transaction using HWI's `signtx` it passes the HMAC along with the PSBT (_TODO_).

For convenience the HMAC can be retrieved via `getwalletinfo` (_implemented_). This is useful for scenario's where we can't (yet) complete a transaction via HWI calls.

Note that the HMAC itself is not specified in BIP388 and may be different for different hardware vendors. So we'll store and echo any hex string the device gives us.

An alternative approach to directly supporting BIP388 policies would be to pass the involved descriptors to HWI and have it figure out how to derive a policy.

Testing:
- make a multisig wallet with a Ledger or other [supported device](https://github.com/bitcoin/bips/blob/master/bip-0388.mediawiki#reference-implementation)
  - try https://github.com/Sjors/bitcoin/pull/91 if you're feeling adventurous, it includes this PR
- install https://github.com/bitcoin-core/HWI/pull/791 HWI branch
- call `bitcoin rpc registerpolicy`
- call `bitcoin rpc getwalletinfo` to see the hmac

TODO:
- [ ] derive policy using `Descriptor` class instead regex madness, implement all constraints
- [ ] pass hmac along when signing

Depends on:
- [ ] HWI `register` command: https://github.com/bitcoin-core/HWI/pull/791
- [ ] HWI optional `--hmac` argument for `signtx` (if set, bypass the current auto-registration workaround)

Potential followups:
- pass hmac along when displaying an address. This provides some extra assurance to the user. See https://github.com/bitcoin-core/HWI/pull/647
