### PR TITLE
test: delete commented-out tests and add a test case in wallet_signer

### DIFF
--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -80,12 +80,11 @@ class WalletSignerTest(BitcoinTestFramework):
 
         # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, external_signer=True)
 
-        # TODO: Handle error thrown by script
-        # self.set_mock_result(self.nodes[1], "2")
-        # assert_raises_rpc_error(-1, 'Unable to parse JSON',
-        #     self.nodes[1].createwallet, wallet_name='not_hww2', disable_private_keys=True, external_signer=False
-        # )
-        # self.clear_mock_result(self.nodes[1])
+        self.set_mock_result(self.nodes[1], '0 {"invalid json"}')
+        assert_raises_rpc_error(-1, 'Unable to parse JSON',
+            self.nodes[1].createwallet, wallet_name='hww2', disable_private_keys=True, external_signer=True
+        )
+        self.clear_mock_result(self.nodes[1])
 
         assert_equal(hww.getwalletinfo()["keypoolsize"], 40)
 

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -78,7 +78,6 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_equal(not_hww.getwalletinfo()["external_signer"], False)
         assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
 
-        # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, external_signer=True)
 
         self.set_mock_result(self.nodes[1], '0 {"invalid json"}')
         assert_raises_rpc_error(-1, 'Unable to parse JSON',
@@ -167,31 +166,6 @@ class WalletSignerTest(BitcoinTestFramework):
         mock_tx = mock_psbt_signed["hex"]
         assert mock_wallet.testmempoolaccept([mock_tx])[0]["allowed"]
 
-        # # Create a new wallet and populate with specific public keys, in order
-        # # to work with the mock signed PSBT.
-        # self.nodes[1].createwallet(wallet_name="hww4", disable_private_keys=True, external_signer=True)
-        # hww4 = self.nodes[1].get_wallet_rpc("hww4")
-        #
-        # descriptors = [{
-        #     "desc": "wpkh([00000001/84h/1h/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*)#x30uthjs",
-        #     "timestamp": "now",
-        #     "range": [0, 1],
-        #     "internal": False,
-        #     "watchonly": True,
-        #     "active": True
-        # },
-        # {
-        #     "desc": "wpkh([00000001/84h/1h/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)#h92akzzg",
-        #     "timestamp": "now",
-        #     "range": [0, 0],
-        #     "internal": True,
-        #     "watchonly": True,
-        #     "active": True
-        # }]
-
-        # result = hww4.importdescriptors(descriptors)
-        # assert_equal(result[0], {'success': True})
-        # assert_equal(result[1], {'success': True})
         assert_equal(hww.getwalletinfo()["txcount"], 1)
 
         assert hww.testmempoolaccept([mock_tx])[0]["allowed"]
@@ -231,12 +205,6 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_greater_than(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
 
-        # # Handle error thrown by script
-        # self.set_mock_result(self.nodes[4], "2")
-        # assert_raises_rpc_error(-1, 'Unable to parse JSON',
-        #     hww4.signerprocesspsbt, psbt_orig, "00000001"
-        # )
-        # self.clear_mock_result(self.nodes[4])
 
     def test_disconnected_signer(self):
         self.log.info('Test disconnected external signer')


### PR DESCRIPTION

I noticed that some test cases had been commented out in wallet_signer.py.
This PR uncomments and modifies some of those test cases so that they can pass.

https://github.com/bitcoin/bitcoin/commit/dac74c69491c3787c63b7bf09a3818ea79f9b8a8 -> deleting this assertion since multiple signers is being tested here https://github.com/bitcoin/bitcoin/blob/master/test/functional/wallet_signer.py#L273

https://github.com/bitcoin/bitcoin/commit/1707c905661ef43935eaaeff06e8141f1be5ea07 test when  an external signer returns malformed or invalid JSON, which would trigger this error:
→ https://github.com/bitcoin/bitcoin/blob/master/src/common/run_command.cpp#L42

https://github.com/bitcoin/bitcoin/commit/b96156821efda510c262e80d38b9063fb9ab762f test  importdescriptors with external signer
