### PR TITLE
test, refactor: Embedded ASMap [1/3]: Selected minor preparatory work

### DIFF
--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -57,6 +57,20 @@ int64_t AutoFile::tell()
     return *m_position;
 }
 
+int64_t AutoFile::size()
+{
+    if (IsNull()) {
+        throw std::ios_base::failure("AutoFile::size: file handle is nullptr");
+    }
+    // Temporarily save the current position
+    int64_t current_pos = tell();
+    seek(0, SEEK_END);
+    int64_t file_size = tell();
+    // Restore the original position
+    seek(current_pos, SEEK_SET);
+    return file_size;
+}
+
 void AutoFile::read(std::span<std::byte> dst)
 {
     if (detail_fread(dst) != dst.size()) {

--- a/src/streams.h
+++ b/src/streams.h
@@ -435,6 +435,9 @@ public:
     /** Find position within the file. Will throw if unknown. */
     int64_t tell();
 
+    /** Return the size of the file. Will throw if unknown. */
+    int64_t size();
+
     /** Wrapper around FileCommit(). */
     bool Commit();
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -122,6 +122,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
         BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
+        BOOST_CHECK_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
     }
     {
 #ifdef __MINGW64__
@@ -132,6 +133,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
 #endif
         AutoFile xor_file{raw_file(mode), obfuscation};
         xor_file << test1 << test2;
+        BOOST_CHECK_EQUAL(xor_file.size(), 7);
         BOOST_REQUIRE_EQUAL(xor_file.fclose(), 0);
     }
     {
@@ -142,6 +144,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EQUAL(HexStr(raw), "fc01fd03fd04fa");
         // Check that no padding exists
         BOOST_CHECK_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
+        BOOST_CHECK_EQUAL(non_xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
@@ -151,6 +154,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EQUAL(HexStr(read2), HexStr(test2));
         // Check that eof was reached
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        BOOST_CHECK_EQUAL(xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
@@ -162,6 +166,7 @@ BOOST_AUTO_TEST_CASE(xor_file)
         // Check that ignore and read fail now
         BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        BOOST_CHECK_EQUAL(xor_file.size(), 7);
     }
 }
 

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -203,10 +203,8 @@ std::vector<bool> DecodeAsmap(fs::path path)
         LogWarning("Failed to open asmap file from disk");
         return bits;
     }
-    file.seek(0, SEEK_END);
-    int length = file.tell();
+    int64_t length{file.size()};
     LogInfo("Opened asmap file %s (%d bytes) from disk", fs::quoted(fs::PathToString(path)), length);
-    file.seek(0, SEEK_SET);
     uint8_t cur_byte;
     for (int i = 0; i < length; ++i) {
         file >> cur_byte;
@@ -220,4 +218,3 @@ std::vector<bool> DecodeAsmap(fs::path path)
     }
     return bits;
 }
-

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -200,7 +200,7 @@ std::vector<bool> DecodeAsmap(fs::path path)
     FILE *filestr = fsbridge::fopen(path, "rb");
     AutoFile file{filestr};
     if (file.IsNull()) {
-        LogPrintf("Failed to open asmap file from disk\n");
+        LogWarning("Failed to open asmap file from disk");
         return bits;
     }
     file.seek(0, SEEK_END);
@@ -215,7 +215,7 @@ std::vector<bool> DecodeAsmap(fs::path path)
         }
     }
     if (!SanityCheckASMap(bits, 128)) {
-        LogPrintf("Sanity check of asmap file %s failed\n", fs::quoted(fs::PathToString(path)));
+        LogWarning("Sanity check of asmap file %s failed", fs::quoted(fs::PathToString(path)));
         return {};
     }
     return bits;

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -544,8 +544,7 @@ void BerkeleyRODatabase::Open()
     page_size = outer_meta.pagesize;
 
     // Verify the size of the file is a multiple of the page size
-    db_file.seek(0, SEEK_END);
-    int64_t size = db_file.tell();
+    const int64_t size{db_file.size()};
 
     // Since BDB stores everything in a page, the file size should be a multiple of the page size;
     // However, BDB doesn't actually check that this is the case, and enforcing this check results


### PR DESCRIPTION
This contains some commits from #28792 that can be easily reviewed and merged independently. I hope splitting this change off can make this part move a bit faster and reduce frequency of needed rebases for #28792.

The commits in order:
- Add additional unit test vectors to the asmap interpreter (written by sipa). This helps to ensure that the further refactors in #28792 don't change behavior. 
- Modernizes the logging in `util/asmap.cpp`, I added this while touching the rest of the file all over anyway.
- Adds an `AutoFile::size` helper function with some additional test coverage in a separate commit