### PR TITLE
wallet, sqlite: Encapsulate SQLite statements in a RAII class

### DIFF
--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -610,7 +610,7 @@ bool SQLiteBatch::HasKey(DataStream&& key)
 
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
 {
-    int res = sqlite3_step(m_cursor_stmt);
+    int res = m_cursor_stmt->Step();
     if (res == SQLITE_DONE) {
         return Status::DONE;
     }
@@ -623,35 +623,34 @@ DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
     value.clear();
 
     // Leftmost column in result is index 0
-    key.write(SpanFromBlob(m_cursor_stmt, 0));
-    value.write(SpanFromBlob(m_cursor_stmt, 1));
+    key.write(m_cursor_stmt->Column<std::span<const std::byte>>(0));
+    value.write(m_cursor_stmt->Column<std::span<const std::byte>>(1));
     return Status::MORE;
 }
 
-SQLiteCursor::~SQLiteCursor()
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)}
+{}
+
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)},
+    m_prefix_range_start(std::move(start_range)),
+    m_prefix_range_end(std::move(end_range))
 {
-    sqlite3_clear_bindings(m_cursor_stmt);
-    sqlite3_reset(m_cursor_stmt);
-    int res = sqlite3_finalize(m_cursor_stmt);
-    if (res != SQLITE_OK) {
-        LogWarning("Cursor closed but could not finalize cursor statement: %s",
-                   sqlite3_errstr(res));
+    if (!m_cursor_stmt->Bind(1, m_prefix_range_start, "prefix_start")) {
+        throw std::runtime_error("Unable to bind prefix start to prefix cursor");
+    }
+    if (!m_prefix_range_end.empty() && !m_cursor_stmt->Bind(2, m_prefix_range_end, "prefix_end")) {
+        throw std::runtime_error("Unable to bind prefix end to prefix cursor");
     }
 }
+
+SQLiteCursor::~SQLiteCursor() = default;
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewCursor()
 {
     if (!m_database.m_db) return nullptr;
-    auto cursor = std::make_unique<SQLiteCursor>();
-
-    const char* stmt_text = "SELECT key, value FROM main";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "%s: Failed to setup cursor SQL statement: %s\n", __func__, sqlite3_errstr(res)));
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, "SELECT key, value FROM main");
 }
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const std::byte> prefix)
@@ -677,23 +676,9 @@ std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const 
         end_range.clear();
     }
 
-    auto cursor = std::make_unique<SQLiteCursor>(start_range, end_range);
-    if (!cursor) return nullptr;
-
     const char* stmt_text = end_range.empty() ? "SELECT key, value FROM main WHERE key >= ?" :
                             "SELECT key, value FROM main WHERE key >= ? AND key < ?";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "SQLiteDatabase: Failed to setup cursor SQL statement: %s\n", sqlite3_errstr(res)));
-    }
-
-    if (!BindBlobToStatement(cursor->m_cursor_stmt, 1, cursor->m_prefix_range_start, "prefix_start")) return nullptr;
-    if (!end_range.empty()) {
-        if (!BindBlobToStatement(cursor->m_cursor_stmt, 2, cursor->m_prefix_range_end, "prefix_end")) return nullptr;
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, stmt_text, start_range, end_range);
 }
 
 bool SQLiteBatch::TxnBegin()

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -131,6 +131,14 @@ public:
             return sqlite3_column_int(m_stmt, col);
         } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
             return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            const char* text = (const char*)sqlite3_column_text(m_stmt, col);
+            if (!text) {
+                return "";
+            }
+            size_t size = sqlite3_column_bytes(m_stmt, col);
+            std::string str_text(text, size);
+            return str_text;
         } else if constexpr (ColumnBlob<T>) {
             return T(SpanFromBlob(m_stmt, col));
         } else {
@@ -265,37 +273,29 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
         return false;
     }
 
-    sqlite3_stmt* stmt{nullptr};
-    int ret = sqlite3_prepare_v2(m_db, "PRAGMA integrity_check", -1, &stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        sqlite3_finalize(stmt);
-        error = strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret));
-        return false;
+    try {
+        SQLiteStatement integrity_check_stmt(*m_db, "PRAGMA integrity_check");
+        while (true) {
+            int ret = integrity_check_stmt.Step();
+            if (ret == SQLITE_DONE) {
+                break;
+            }
+            if (ret != SQLITE_ROW) {
+                error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
+                break;
+            }
+            std::string str_msg(integrity_check_stmt.Column<std::string>(0));
+            if (str_msg == "ok") {
+                continue;
+            }
+            if (error.empty()) {
+                error = _("Failed to verify database") + Untranslated("\n");
+            }
+            error += Untranslated(strprintf("%s\n", str_msg));
+        }
+    } catch (std::runtime_error& e) {
+        error = Untranslated(e.what());
     }
-    while (true) {
-        ret = sqlite3_step(stmt);
-        if (ret == SQLITE_DONE) {
-            break;
-        }
-        if (ret != SQLITE_ROW) {
-            error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        const char* msg = (const char*)sqlite3_column_text(stmt, 0);
-        if (!msg) {
-            error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        std::string str_msg(msg);
-        if (str_msg == "ok") {
-            continue;
-        }
-        if (error.empty()) {
-            error = _("Failed to verify database") + Untranslated("\n");
-        }
-        error += Untranslated(strprintf("%s\n", str_msg));
-    }
-    sqlite3_finalize(stmt);
     return error.empty();
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -355,22 +355,15 @@ void SQLiteDatabase::Open()
 
     // Make the table for our key-value pairs
     // First check that the main table exists
-    sqlite3_stmt* check_main_stmt{nullptr};
-    ret = sqlite3_prepare_v2(m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'", -1, &check_main_stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to prepare statement to check table existence: %s\n", sqlite3_errstr(ret)));
-    }
-    ret = sqlite3_step(check_main_stmt);
-    if (sqlite3_finalize(check_main_stmt) != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to finalize statement checking table existence: %s\n", sqlite3_errstr(ret)));
-    }
+    SQLiteStatement check_main_stmt(*m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'");
+    ret = check_main_stmt.Step();
     bool table_exists;
     if (ret == SQLITE_DONE) {
         table_exists = false;
     } else if (ret == SQLITE_ROW) {
         table_exists = true;
     } else {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check table existence: %s\n", sqlite3_errstr(ret)));
+        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check main table existence: %s\n", sqlite3_errstr(ret)));
     }
 
     // Do the db setup things because the table doesn't exist only when we are creating a new wallet

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,6 +78,51 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+/** RAII class that encapsulates a sqlite3_stmt */
+class SQLiteStatement
+{
+private:
+    sqlite3& m_db;
+    sqlite3_stmt* m_stmt{nullptr};
+
+public:
+    explicit SQLiteStatement(sqlite3& db, const std::string& stmt_text)
+        : m_db(db)
+    {
+        int res = sqlite3_prepare_v2(&m_db, stmt_text.c_str(), -1, &m_stmt, nullptr);
+        if (res != SQLITE_OK) {
+            throw std::runtime_error(strprintf(
+                "SQLiteStatement: Failed to prepare SQL statement '%s': %s\n", stmt_text, sqlite3_errstr(res)));
+        }
+    }
+
+    ~SQLiteStatement()
+    {
+        sqlite3_finalize(m_stmt);
+    }
+
+    int Step()
+    {
+        return sqlite3_step(m_stmt);
+    }
+
+    void Reset()
+    {
+        sqlite3_clear_bindings(m_stmt);
+        sqlite3_reset(m_stmt);
+    }
+
+    bool Bind(int index, std::span<const std::byte> data, const std::string& description)
+    {
+        return BindBlobToStatement(m_stmt, index, data, description);
+    }
+
+    std::span<const std::byte> Column(int col)
+    {
+        return SpanFromBlob(m_stmt, col);
+    }
+};
+
 static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -508,6 +508,26 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     return true;
 }
 
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt)
+{
+    if (!m_database.m_db) return false;
+    assert(stmt);
+
+    // Acquire semaphore if not previously acquired when creating a transaction.
+    if (!m_txn) m_database.m_write_semaphore.acquire();
+
+    // Execute
+    int res = stmt->Step();
+    stmt->Reset();
+    if (res != SQLITE_DONE) {
+        LogError("Unable to execute statement: %s\n", sqlite3_errstr(res));
+    }
+
+    if (!m_txn) m_database.m_write_semaphore.release();
+
+    return res == SQLITE_DONE;
+}
+
 bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     if (!m_database.m_db) return false;
@@ -524,53 +544,27 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     // Insert index 1 is key, 2 is value
     if (!stmt->Bind(1, key, "key")) return false;
     if (!stmt->Bind(2, value, "value")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
-}
-
-bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
-{
-    if (!m_database.m_db) return false;
-    assert(stmt);
-
-    // Bind: leftmost parameter in statement is index 1
-    if (!stmt->Bind(1, blob, "key")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
+    return ExecStatement(stmt);
 }
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt.get(), key);
+    if (!m_database.m_db) return false;
+    assert(m_delete_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_stmt->Bind(1, key, "key")) return false;
+    return ExecStatement(m_delete_stmt.get());
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
+    if (!m_database.m_db) return false;
+    assert(m_delete_prefix_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_prefix_stmt->Bind(1, prefix, "key")) return false;
+    return ExecStatement(m_delete_prefix_stmt.get());
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,6 +78,12 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+template <typename T>
+concept ColumnBlob = requires(T a, T::element_type* data, size_t size)
+{
+    T(data, size);
+};
+
 /** RAII class that encapsulates a sqlite3_stmt */
 class SQLiteStatement
 {
@@ -117,9 +123,19 @@ public:
         return BindBlobToStatement(m_stmt, index, data, description);
     }
 
-    std::span<const std::byte> Column(int col)
+    template<typename T>
+    T Column(int col)
     {
-        return SpanFromBlob(m_stmt, col);
+        Assert(col < sqlite3_column_count(m_stmt));
+        if constexpr (std::integral<T> && sizeof(T) <= 4) {
+            return sqlite3_column_int(m_stmt, col);
+        } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
+            return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (ColumnBlob<T>) {
+            return T(SpanFromBlob(m_stmt, col));
+        } else {
+            static_assert(ALWAYS_FALSE<T>);
+        }
     }
 };
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -139,25 +139,22 @@ public:
     }
 };
 
-static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
+static std::optional<int> ReadPragmaInteger(sqlite3& db, const std::string& key, const std::string& description, bilingual_str& error)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);
-    sqlite3_stmt* pragma_read_stmt{nullptr};
-    int ret = sqlite3_prepare_v2(db, stmt_text.c_str(), -1, &pragma_read_stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to prepare the statement to fetch %s: %s", description, sqlite3_errstr(ret)));
+    try {
+        SQLiteStatement pragma_read_stmt(db, stmt_text);
+        int ret = pragma_read_stmt.Step();
+        if (ret != SQLITE_ROW) {
+            error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
+            return std::nullopt;
+        }
+        int result = pragma_read_stmt.Column<int>(0);
+        return result;
+    } catch (std::runtime_error& e) {
+        error = Untranslated(e.what());
         return std::nullopt;
     }
-    ret = sqlite3_step(pragma_read_stmt);
-    if (ret != SQLITE_ROW) {
-        sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
-        return std::nullopt;
-    }
-    int result = sqlite3_column_int(pragma_read_stmt, 0);
-    sqlite3_finalize(pragma_read_stmt);
-    return result;
 }
 
 static void SetPragma(sqlite3* db, const std::string& key, const std::string& value, const std::string& err_msg)
@@ -250,7 +247,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     assert(m_db);
 
     // Check the application ID matches our network magic
-    auto read_result = ReadPragmaInteger(m_db, "application_id", "the application id", error);
+    auto read_result = ReadPragmaInteger(*m_db, "application_id", "the application id", error);
     if (!read_result.has_value()) return false;
     uint32_t app_id = static_cast<uint32_t>(read_result.value());
     uint32_t net_magic = ReadBE32(Params().MessageStart().data());
@@ -260,7 +257,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     }
 
     // Check our schema version
-    read_result = ReadPragmaInteger(m_db, "user_version", "sqlite wallet schema version", error);
+    read_result = ReadPragmaInteger(*m_db, "user_version", "sqlite wallet schema version", error);
     if (!read_result.has_value()) return false;
     int32_t user_ver = read_result.value();
     if (user_ver != WALLET_SCHEMA_VERSION) {

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -211,23 +211,11 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
 
 void SQLiteBatch::SetupSQLStatements()
 {
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "SELECT value FROM main WHERE key = ?"},
-        {&m_insert_stmt, "INSERT INTO main VALUES(?, ?)"},
-        {&m_overwrite_stmt, "INSERT or REPLACE into main values(?, ?)"},
-        {&m_delete_stmt, "DELETE FROM main WHERE key = ?"},
-        {&m_delete_prefix_stmt, "DELETE FROM main WHERE instr(key, ?) = 1"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_text] : statements) {
-        if (*stmt_prepared == nullptr) {
-            int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, stmt_prepared, nullptr);
-            if (res != SQLITE_OK) {
-                throw std::runtime_error(strprintf(
-                    "SQLiteDatabase: Failed to setup SQL statements: %s\n", sqlite3_errstr(res)));
-            }
-        }
-    }
+    m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
+    m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
+    m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
+    m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
+    m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
 }
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -453,6 +441,11 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
     SetupSQLStatements();
 }
 
+SQLiteBatch::~SQLiteBatch()
+{
+    Close();
+}
+
 void SQLiteBatch::Close()
 {
     bool force_conn_refresh = false;
@@ -471,22 +464,11 @@ void SQLiteBatch::Close()
     }
 
     // Free all of the prepared statements
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "read"},
-        {&m_insert_stmt, "insert"},
-        {&m_overwrite_stmt, "overwrite"},
-        {&m_delete_stmt, "delete"},
-        {&m_delete_prefix_stmt, "delete prefix"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_description] : statements) {
-        int res = sqlite3_finalize(*stmt_prepared);
-        if (res != SQLITE_OK) {
-            LogWarning("SQLiteBatch: Batch closed but could not finalize %s statement: %s",
-                      stmt_description, sqlite3_errstr(res));
-        }
-        *stmt_prepared = nullptr;
-    }
+    m_read_stmt.reset();
+    m_insert_stmt.reset();
+    m_overwrite_stmt.reset();
+    m_delete_stmt.reset();
+    m_delete_prefix_stmt.reset();
 
     if (force_conn_refresh) {
         m_database.Close();
@@ -508,23 +490,21 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
     if (res != SQLITE_ROW) {
         if (res != SQLITE_DONE) {
             // SQLITE_DONE means "not found", don't log an error in that case.
             LogWarning("Unable to execute read statement: %s", sqlite3_errstr(res));
         }
-        sqlite3_clear_bindings(m_read_stmt);
-        sqlite3_reset(m_read_stmt);
+        m_read_stmt->Reset();
         return false;
     }
     // Leftmost column in result is index 0
     value.clear();
-    value.write(SpanFromBlob(m_read_stmt, 0));
+    value.write(m_read_stmt->Column<std::span<const std::byte>>(0));
 
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    m_read_stmt->Reset();
     return true;
 }
 
@@ -533,25 +513,24 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     if (!m_database.m_db) return false;
     assert(m_insert_stmt && m_overwrite_stmt);
 
-    sqlite3_stmt* stmt;
+    SQLiteStatement* stmt;
     if (overwrite) {
-        stmt = m_overwrite_stmt;
+        stmt = m_overwrite_stmt.get();
     } else {
-        stmt = m_insert_stmt;
+        stmt = m_insert_stmt.get();
     }
 
     // Bind: leftmost parameter in statement is index 1
     // Insert index 1 is key, 2 is value
-    if (!BindBlobToStatement(stmt, 1, key, "key")) return false;
-    if (!BindBlobToStatement(stmt, 2, value, "value")) return false;
+    if (!stmt->Bind(1, key, "key")) return false;
+    if (!stmt->Bind(2, value, "value")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
     }
@@ -561,21 +540,20 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     return res == SQLITE_DONE;
 }
 
-bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob)
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
 {
     if (!m_database.m_db) return false;
     assert(stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(stmt, 1, blob, "key")) return false;
+    if (!stmt->Bind(1, blob, "key")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
     }
@@ -587,12 +565,12 @@ bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> b
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt, key);
+    return ExecStatement(m_delete_stmt.get(), key);
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt, prefix);
+    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)
@@ -601,10 +579,9 @@ bool SQLiteBatch::HasKey(DataStream&& key)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
+    m_read_stmt->Reset();
     return res == SQLITE_ROW;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -26,12 +26,6 @@
 namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
 
-static std::span<const std::byte> SpanFromBlob(sqlite3_stmt* stmt, int col)
-{
-    return {reinterpret_cast<const std::byte*>(sqlite3_column_blob(stmt, col)),
-            static_cast<size_t>(sqlite3_column_bytes(stmt, col))};
-}
-
 static void ErrorLogCallback(void* arg, int code, const char* msg)
 {
     // From sqlite3_config() documentation for the SQLITE_CONFIG_LOG option:
@@ -56,26 +50,6 @@ static int TraceSqlCallback(unsigned code, void* context, void* param1, void* pa
         if (expanded) sqlite3_free(expanded);
     }
     return SQLITE_OK;
-}
-
-static bool BindBlobToStatement(sqlite3_stmt* stmt,
-                                int index,
-                                std::span<const std::byte> blob,
-                                const std::string& description)
-{
-    // Pass a pointer to the empty string "" below instead of passing the
-    // blob.data() pointer if the blob.data() pointer is null. Passing a null
-    // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
-    // instead of the empty blob value X'', which would mess up SQL comparisons.
-    int res = sqlite3_bind_blob(stmt, index, blob.data() ? static_cast<const void*>(blob.data()) : "", blob.size(), SQLITE_STATIC);
-    if (res != SQLITE_OK) {
-        LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
-        sqlite3_clear_bindings(stmt);
-        sqlite3_reset(stmt);
-        return false;
-    }
-
-    return true;
 }
 
 template <typename T>
@@ -120,7 +94,18 @@ public:
 
     bool Bind(int index, std::span<const std::byte> data, const std::string& description)
     {
-        return BindBlobToStatement(m_stmt, index, data, description);
+        // Pass a pointer to the empty string "" below instead of passing the
+        // blob.data() pointer if the blob.data() pointer is null. Passing a null
+        // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
+        // instead of the empty blob value X'', which would mess up SQL comparisons.
+        int res = sqlite3_bind_blob(m_stmt, index, data.data() ? static_cast<const void*>(data.data()) : "", data.size(), SQLITE_STATIC);
+        if (res != SQLITE_OK) {
+            LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
+            Reset();
+            return false;
+        }
+
+        return true;
     }
 
     template<typename T>
@@ -140,7 +125,10 @@ public:
             std::string str_text(text, size);
             return str_text;
         } else if constexpr (ColumnBlob<T>) {
-            return T(SpanFromBlob(m_stmt, col));
+            return T(
+                reinterpret_cast<T::element_type*>(sqlite3_column_blob(m_stmt, col)),
+                static_cast<size_t>(sqlite3_column_bytes(m_stmt, col))
+            );
         } else {
             static_assert(ALWAYS_FALSE<T>);
         }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -219,23 +219,11 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
 
 void SQLiteBatch::SetupSQLStatements()
 {
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "SELECT value FROM main WHERE key = ?"},
-        {&m_insert_stmt, "INSERT INTO main VALUES(?, ?)"},
-        {&m_overwrite_stmt, "INSERT or REPLACE into main values(?, ?)"},
-        {&m_delete_stmt, "DELETE FROM main WHERE key = ?"},
-        {&m_delete_prefix_stmt, "DELETE FROM main WHERE instr(key, ?) = 1"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_text] : statements) {
-        if (*stmt_prepared == nullptr) {
-            int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, stmt_prepared, nullptr);
-            if (res != SQLITE_OK) {
-                throw std::runtime_error(strprintf(
-                    "SQLiteDatabase: Failed to setup SQL statements: %s\n", sqlite3_errstr(res)));
-            }
-        }
-    }
+    m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
+    m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
+    m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
+    m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
+    m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
 }
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -470,6 +458,11 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
     SetupSQLStatements();
 }
 
+SQLiteBatch::~SQLiteBatch()
+{
+    Close();
+}
+
 void SQLiteBatch::Close()
 {
     bool force_conn_refresh = false;
@@ -488,22 +481,11 @@ void SQLiteBatch::Close()
     }
 
     // Free all of the prepared statements
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "read"},
-        {&m_insert_stmt, "insert"},
-        {&m_overwrite_stmt, "overwrite"},
-        {&m_delete_stmt, "delete"},
-        {&m_delete_prefix_stmt, "delete prefix"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_description] : statements) {
-        int res = sqlite3_finalize(*stmt_prepared);
-        if (res != SQLITE_OK) {
-            LogWarning("SQLiteBatch: Batch closed but could not finalize %s statement: %s",
-                      stmt_description, sqlite3_errstr(res));
-        }
-        *stmt_prepared = nullptr;
-    }
+    m_read_stmt.reset();
+    m_insert_stmt.reset();
+    m_overwrite_stmt.reset();
+    m_delete_stmt.reset();
+    m_delete_prefix_stmt.reset();
 
     if (force_conn_refresh) {
         if (m_database.m_additional_flags & SQLITE_OPEN_MEMORY) {
@@ -528,23 +510,21 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
     if (res != SQLITE_ROW) {
         if (res != SQLITE_DONE) {
             // SQLITE_DONE means "not found", don't log an error in that case.
             LogWarning("Unable to execute read statement: %s", sqlite3_errstr(res));
         }
-        sqlite3_clear_bindings(m_read_stmt);
-        sqlite3_reset(m_read_stmt);
+        m_read_stmt->Reset();
         return false;
     }
     // Leftmost column in result is index 0
     value.clear();
-    value.write(SpanFromBlob(m_read_stmt, 0));
+    value.write(m_read_stmt->Column<std::span<const std::byte>>(0));
 
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    m_read_stmt->Reset();
     return true;
 }
 
@@ -553,25 +533,24 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     if (!m_database.m_db) return false;
     assert(m_insert_stmt && m_overwrite_stmt);
 
-    sqlite3_stmt* stmt;
+    SQLiteStatement* stmt;
     if (overwrite) {
-        stmt = m_overwrite_stmt;
+        stmt = m_overwrite_stmt.get();
     } else {
-        stmt = m_insert_stmt;
+        stmt = m_insert_stmt.get();
     }
 
     // Bind: leftmost parameter in statement is index 1
     // Insert index 1 is key, 2 is value
-    if (!BindBlobToStatement(stmt, 1, key, "key")) return false;
-    if (!BindBlobToStatement(stmt, 2, value, "value")) return false;
+    if (!stmt->Bind(1, key, "key")) return false;
+    if (!stmt->Bind(2, value, "value")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
     }
@@ -581,21 +560,20 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     return res == SQLITE_DONE;
 }
 
-bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob)
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
 {
     if (!m_database.m_db) return false;
     assert(stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(stmt, 1, blob, "key")) return false;
+    if (!stmt->Bind(1, blob, "key")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
     }
@@ -607,12 +585,12 @@ bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> b
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt, key);
+    return ExecStatement(m_delete_stmt.get(), key);
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt, prefix);
+    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)
@@ -621,10 +599,9 @@ bool SQLiteBatch::HasKey(DataStream&& key)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
+    m_read_stmt->Reset();
     return res == SQLITE_ROW;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -372,22 +372,15 @@ void SQLiteDatabase::Open(int additional_flags)
 
     // Make the table for our key-value pairs
     // First check that the main table exists
-    sqlite3_stmt* check_main_stmt{nullptr};
-    ret = sqlite3_prepare_v2(m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'", -1, &check_main_stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to prepare statement to check table existence: %s\n", sqlite3_errstr(ret)));
-    }
-    ret = sqlite3_step(check_main_stmt);
-    if (sqlite3_finalize(check_main_stmt) != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to finalize statement checking table existence: %s\n", sqlite3_errstr(ret)));
-    }
+    SQLiteStatement check_main_stmt(*m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'");
+    ret = check_main_stmt.Step();
     bool table_exists;
     if (ret == SQLITE_DONE) {
         table_exists = false;
     } else if (ret == SQLITE_ROW) {
         table_exists = true;
     } else {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check table existence: %s\n", sqlite3_errstr(ret)));
+        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check main table existence: %s\n", sqlite3_errstr(ret)));
     }
 
     // Do the db setup things because the table doesn't exist only when we are creating a new wallet

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -630,7 +630,7 @@ bool SQLiteBatch::HasKey(DataStream&& key)
 
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
 {
-    int res = sqlite3_step(m_cursor_stmt);
+    int res = m_cursor_stmt->Step();
     if (res == SQLITE_DONE) {
         return Status::DONE;
     }
@@ -643,35 +643,34 @@ DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
     value.clear();
 
     // Leftmost column in result is index 0
-    key.write(SpanFromBlob(m_cursor_stmt, 0));
-    value.write(SpanFromBlob(m_cursor_stmt, 1));
+    key.write(m_cursor_stmt->Column<std::span<const std::byte>>(0));
+    value.write(m_cursor_stmt->Column<std::span<const std::byte>>(1));
     return Status::MORE;
 }
 
-SQLiteCursor::~SQLiteCursor()
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)}
+{}
+
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)},
+    m_prefix_range_start(std::move(start_range)),
+    m_prefix_range_end(std::move(end_range))
 {
-    sqlite3_clear_bindings(m_cursor_stmt);
-    sqlite3_reset(m_cursor_stmt);
-    int res = sqlite3_finalize(m_cursor_stmt);
-    if (res != SQLITE_OK) {
-        LogWarning("Cursor closed but could not finalize cursor statement: %s",
-                   sqlite3_errstr(res));
+    if (!m_cursor_stmt->Bind(1, m_prefix_range_start, "prefix_start")) {
+        throw std::runtime_error("Unable to bind prefix start to prefix cursor");
+    }
+    if (!m_prefix_range_end.empty() && !m_cursor_stmt->Bind(2, m_prefix_range_end, "prefix_end")) {
+        throw std::runtime_error("Unable to bind prefix end to prefix cursor");
     }
 }
+
+SQLiteCursor::~SQLiteCursor() = default;
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewCursor()
 {
     if (!m_database.m_db) return nullptr;
-    auto cursor = std::make_unique<SQLiteCursor>();
-
-    const char* stmt_text = "SELECT key, value FROM main";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "%s: Failed to setup cursor SQL statement: %s\n", __func__, sqlite3_errstr(res)));
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, "SELECT key, value FROM main");
 }
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const std::byte> prefix)
@@ -697,23 +696,9 @@ std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const 
         end_range.clear();
     }
 
-    auto cursor = std::make_unique<SQLiteCursor>(start_range, end_range);
-    if (!cursor) return nullptr;
-
     const char* stmt_text = end_range.empty() ? "SELECT key, value FROM main WHERE key >= ?" :
                             "SELECT key, value FROM main WHERE key >= ? AND key < ?";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "SQLiteDatabase: Failed to setup cursor SQL statement: %s\n", sqlite3_errstr(res)));
-    }
-
-    if (!BindBlobToStatement(cursor->m_cursor_stmt, 1, cursor->m_prefix_range_start, "prefix_start")) return nullptr;
-    if (!end_range.empty()) {
-        if (!BindBlobToStatement(cursor->m_cursor_stmt, 2, cursor->m_prefix_range_end, "prefix_end")) return nullptr;
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, stmt_text, start_range, end_range);
 }
 
 bool SQLiteBatch::TxnBegin()

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -142,8 +142,7 @@ public:
                 return "";
             }
             size_t size = sqlite3_column_bytes(m_stmt, col);
-            std::string str_text(text, size);
-            return str_text;
+            return std::string(text, size);
         } else if constexpr (ColumnBlob<T>) {
             return T(SpanFromBlob(m_stmt, col));
         } else {
@@ -528,6 +527,26 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     return true;
 }
 
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt)
+{
+    if (!m_database.m_db) return false;
+    assert(stmt);
+
+    // Acquire semaphore if not previously acquired when creating a transaction.
+    if (!m_txn) m_database.m_write_semaphore.acquire();
+
+    // Execute
+    int res = stmt->Step();
+    stmt->Reset();
+    if (res != SQLITE_DONE) {
+        LogError("Unable to execute statement: %s\n", sqlite3_errstr(res));
+    }
+
+    if (!m_txn) m_database.m_write_semaphore.release();
+
+    return res == SQLITE_DONE;
+}
+
 bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     if (!m_database.m_db) return false;
@@ -544,53 +563,27 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     // Insert index 1 is key, 2 is value
     if (!stmt->Bind(1, key, "key")) return false;
     if (!stmt->Bind(2, value, "value")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
-}
-
-bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
-{
-    if (!m_database.m_db) return false;
-    assert(stmt);
-
-    // Bind: leftmost parameter in statement is index 1
-    if (!stmt->Bind(1, blob, "key")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
+    return ExecStatement(stmt);
 }
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt.get(), key);
+    if (!m_database.m_db) return false;
+    assert(m_delete_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_stmt->Bind(1, key, "key")) return false;
+    return ExecStatement(m_delete_stmt.get());
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
+    if (!m_database.m_db) return false;
+    assert(m_delete_prefix_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_prefix_stmt->Bind(1, prefix, "key")) return false;
+    return ExecStatement(m_delete_prefix_stmt.get());
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -14,6 +14,7 @@
 #include <util/log.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
+#include <util/types.h>
 #include <wallet/db.h>
 
 #include <sqlite3.h>
@@ -78,6 +79,12 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+template <typename T>
+concept ColumnBlob = requires(T a, T::element_type* data, size_t size)
+{
+    T(data, size);
+};
+
 /** RAII class that encapsulates a sqlite3_stmt */
 class SQLiteStatement
 {
@@ -121,9 +128,19 @@ public:
         return BindBlobToStatement(m_stmt, index, data, description);
     }
 
-    std::span<const std::byte> Column(int col)
+    template<typename T>
+    T Column(int col)
     {
-        return SpanFromBlob(m_stmt, col);
+        Assert(col < sqlite3_column_count(m_stmt));
+        if constexpr (std::integral<T> && sizeof(T) <= 4) {
+            return sqlite3_column_int(m_stmt, col);
+        } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
+            return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (ColumnBlob<T>) {
+            return T(SpanFromBlob(m_stmt, col));
+        } else {
+            static_assert(ALWAYS_FALSE<T>);
+        }
     }
 };
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -27,12 +27,6 @@
 namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
 
-static std::span<const std::byte> SpanFromBlob(sqlite3_stmt* stmt, int col)
-{
-    return {reinterpret_cast<const std::byte*>(sqlite3_column_blob(stmt, col)),
-            static_cast<size_t>(sqlite3_column_bytes(stmt, col))};
-}
-
 static void ErrorLogCallback(void* arg, int code, const char* msg)
 {
     // From sqlite3_config() documentation for the SQLITE_CONFIG_LOG option:
@@ -57,26 +51,6 @@ static int TraceSqlCallback(unsigned code, void* context, void* param1, void* pa
         if (expanded) sqlite3_free(expanded);
     }
     return SQLITE_OK;
-}
-
-static bool BindBlobToStatement(sqlite3_stmt* stmt,
-                                int index,
-                                std::span<const std::byte> blob,
-                                const std::string& description)
-{
-    // Pass a pointer to the empty string "" below instead of passing the
-    // blob.data() pointer if the blob.data() pointer is null. Passing a null
-    // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
-    // instead of the empty blob value X'', which would mess up SQL comparisons.
-    int res = sqlite3_bind_blob(stmt, index, blob.data() ? static_cast<const void*>(blob.data()) : "", blob.size(), SQLITE_STATIC);
-    if (res != SQLITE_OK) {
-        LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
-        sqlite3_clear_bindings(stmt);
-        sqlite3_reset(stmt);
-        return false;
-    }
-
-    return true;
 }
 
 template <typename T>
@@ -123,9 +97,20 @@ public:
         sqlite3_reset(m_stmt);
     }
 
-    bool Bind(int index, std::span<const std::byte> data, const std::string& description)
+    [[nodiscard]] bool Bind(int index, std::span<const std::byte> data, const std::string& description)
     {
-        return BindBlobToStatement(m_stmt, index, data, description);
+        // Pass a pointer to the empty string "" below instead of passing the
+        // blob.data() pointer if the blob.data() pointer is null. Passing a null
+        // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
+        // instead of the empty blob value X'', which would mess up SQL comparisons.
+        int res = sqlite3_bind_blob(m_stmt, index, data.data() ? static_cast<const void*>(data.data()) : "", data.size(), SQLITE_STATIC);
+        if (res != SQLITE_OK) {
+            LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
+            Reset();
+            return false;
+        }
+
+        return true;
     }
 
     template<typename T>
@@ -144,7 +129,10 @@ public:
             size_t size = sqlite3_column_bytes(m_stmt, col);
             return std::string(text, size);
         } else if constexpr (ColumnBlob<T>) {
-            return T(SpanFromBlob(m_stmt, col));
+            return T(
+                reinterpret_cast<T::element_type*>(sqlite3_column_blob(m_stmt, col)),
+                static_cast<size_t>(sqlite3_column_bytes(m_stmt, col))
+            );
         } else {
             static_assert(ALWAYS_FALSE<T>);
         }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -144,25 +144,21 @@ public:
     }
 };
 
-static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
+static std::optional<int> ReadPragmaInteger(sqlite3& db, const std::string& key, const std::string& description, bilingual_str& error)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);
-    sqlite3_stmt* pragma_read_stmt{nullptr};
-    int ret = sqlite3_prepare_v2(db, stmt_text.c_str(), -1, &pragma_read_stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to prepare the statement to fetch %s: %s", description, sqlite3_errstr(ret)));
+    try {
+        SQLiteStatement pragma_read_stmt(db, stmt_text);
+        int ret = pragma_read_stmt.Step();
+        if (ret != SQLITE_ROW) {
+            error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
+            return std::nullopt;
+        }
+        return pragma_read_stmt.Column<int>(0);
+    } catch (const std::runtime_error& e) {
+        error = Untranslated(e.what());
         return std::nullopt;
     }
-    ret = sqlite3_step(pragma_read_stmt);
-    if (ret != SQLITE_ROW) {
-        sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
-        return std::nullopt;
-    }
-    int result = sqlite3_column_int(pragma_read_stmt, 0);
-    sqlite3_finalize(pragma_read_stmt);
-    return result;
 }
 
 static void SetPragma(sqlite3* db, const std::string& key, const std::string& value, const std::string& err_msg)
@@ -259,7 +255,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     assert(m_db);
 
     // Check the application ID matches our network magic
-    auto read_result = ReadPragmaInteger(m_db, "application_id", "the application id", error);
+    auto read_result = ReadPragmaInteger(*m_db, "application_id", "the application id", error);
     if (!read_result.has_value()) return false;
     uint32_t app_id = static_cast<uint32_t>(read_result.value());
     uint32_t net_magic = ReadBE32(Params().MessageStart().data());
@@ -269,7 +265,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
     }
 
     // Check our schema version
-    read_result = ReadPragmaInteger(m_db, "user_version", "sqlite wallet schema version", error);
+    read_result = ReadPragmaInteger(*m_db, "user_version", "sqlite wallet schema version", error);
     if (!read_result.has_value()) return false;
     int32_t user_ver = read_result.value();
     if (user_ver != WALLET_SCHEMA_VERSION) {

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -204,13 +204,25 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
     }
 }
 
-void SQLiteBatch::SetupSQLStatements()
+void SQLiteBatch::MaybeSetupSQLStatement(SQLiteStatementType type)
 {
-    m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
-    m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
-    m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
-    m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
-    m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
+    switch (type) {
+    case SQLiteStatementType::READ:
+        if (!m_read_stmt) m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
+        break;
+    case SQLiteStatementType::INSERT:
+        if (!m_insert_stmt) m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
+        break;
+    case SQLiteStatementType::OVERWRITE:
+        if (!m_overwrite_stmt) m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
+        break;
+    case SQLiteStatementType::ERASE:
+        if (!m_delete_stmt) m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
+        break;
+    case SQLiteStatementType::ERASE_PREFIX:
+        if (!m_delete_prefix_stmt) m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
+        break;
+    }
 }
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -441,8 +453,6 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
 {
     // Make sure we have a db handle
     assert(m_database.m_db);
-
-    SetupSQLStatements();
 }
 
 SQLiteBatch::~SQLiteBatch()
@@ -494,7 +504,7 @@ void SQLiteBatch::Close()
 bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
 {
     if (!m_database.m_db) return false;
-    assert(m_read_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::READ);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_read_stmt->Bind(1, key, "key")) return false;
@@ -538,12 +548,13 @@ bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt)
 bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     if (!m_database.m_db) return false;
-    assert(m_insert_stmt && m_overwrite_stmt);
 
     SQLiteStatement* stmt;
     if (overwrite) {
+        MaybeSetupSQLStatement(SQLiteStatementType::OVERWRITE);
         stmt = m_overwrite_stmt.get();
     } else {
+        MaybeSetupSQLStatement(SQLiteStatementType::INSERT);
         stmt = m_insert_stmt.get();
     }
 
@@ -557,7 +568,7 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
     if (!m_database.m_db) return false;
-    assert(m_delete_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::ERASE);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_delete_stmt->Bind(1, key, "key")) return false;
@@ -567,7 +578,7 @@ bool SQLiteBatch::EraseKey(DataStream&& key)
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
     if (!m_database.m_db) return false;
-    assert(m_delete_prefix_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::ERASE_PREFIX);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_delete_prefix_stmt->Bind(1, prefix, "key")) return false;
@@ -577,7 +588,7 @@ bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 bool SQLiteBatch::HasKey(DataStream&& key)
 {
     if (!m_database.m_db) return false;
-    assert(m_read_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::READ);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_read_stmt->Bind(1, key, "key")) return false;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,6 +78,55 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+/** RAII class that encapsulates a sqlite3_stmt */
+class SQLiteStatement
+{
+private:
+    sqlite3& m_db;
+    sqlite3_stmt* m_stmt{nullptr};
+
+public:
+    explicit SQLiteStatement(sqlite3& db, const std::string& stmt_text)
+        : m_db(db)
+    {
+        const char *tail{nullptr};
+        const char *text = stmt_text.c_str();
+        int res = sqlite3_prepare_v2(&m_db, text, -1, &m_stmt, &tail);
+        if (res != SQLITE_OK) {
+            throw std::runtime_error(strprintf(
+                "SQLiteStatement: Failed to prepare SQL statement '%s': %s\n", stmt_text, sqlite3_errstr(res)));
+        }
+        // Statements are pre-made and should never have more than one
+        Assert(tail == text + stmt_text.size());
+    }
+
+    ~SQLiteStatement()
+    {
+        sqlite3_finalize(m_stmt);
+    }
+
+    int Step()
+    {
+        return sqlite3_step(m_stmt);
+    }
+
+    void Reset()
+    {
+        sqlite3_clear_bindings(m_stmt);
+        sqlite3_reset(m_stmt);
+    }
+
+    bool Bind(int index, std::span<const std::byte> data, const std::string& description)
+    {
+        return BindBlobToStatement(m_stmt, index, data, description);
+    }
+
+    std::span<const std::byte> Column(int col)
+    {
+        return SpanFromBlob(m_stmt, col);
+    }
+};
+
 static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -136,6 +136,14 @@ public:
             return sqlite3_column_int(m_stmt, col);
         } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
             return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            const char* text = (const char*)sqlite3_column_text(m_stmt, col);
+            if (!text) {
+                return "";
+            }
+            size_t size = sqlite3_column_bytes(m_stmt, col);
+            std::string str_text(text, size);
+            return str_text;
         } else if constexpr (ColumnBlob<T>) {
             return T(SpanFromBlob(m_stmt, col));
         } else {
@@ -273,37 +281,29 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
         return false;
     }
 
-    sqlite3_stmt* stmt{nullptr};
-    int ret = sqlite3_prepare_v2(m_db, "PRAGMA integrity_check", -1, &stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        sqlite3_finalize(stmt);
-        error = strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret));
-        return false;
+    try {
+        SQLiteStatement integrity_check_stmt(*m_db, "PRAGMA integrity_check");
+        while (true) {
+            int ret = integrity_check_stmt.Step();
+            if (ret == SQLITE_DONE) {
+                break;
+            }
+            if (ret != SQLITE_ROW) {
+                error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
+                break;
+            }
+            std::string str_msg(integrity_check_stmt.Column<std::string>(0));
+            if (str_msg == "ok") {
+                continue;
+            }
+            if (error.empty()) {
+                error = _("Failed to verify database") + Untranslated("\n");
+            }
+            error += Untranslated(strprintf("%s\n", str_msg));
+        }
+    } catch (const std::runtime_error& e) {
+        error = Untranslated(e.what());
     }
-    while (true) {
-        ret = sqlite3_step(stmt);
-        if (ret == SQLITE_DONE) {
-            break;
-        }
-        if (ret != SQLITE_ROW) {
-            error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        const char* msg = (const char*)sqlite3_column_text(stmt, 0);
-        if (!msg) {
-            error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        std::string str_msg(msg);
-        if (str_msg == "ok") {
-            continue;
-        }
-        if (error.empty()) {
-            error = _("Failed to verify database") + Untranslated("\n");
-        }
-        error += Untranslated(strprintf("%s\n", str_msg));
-    }
-    sqlite3_finalize(stmt);
     return error.empty();
 }
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -12,7 +12,6 @@
 
 struct bilingual_str;
 
-struct sqlite3_stmt;
 struct sqlite3;
 
 namespace wallet {
@@ -54,11 +53,11 @@ private:
     SQLiteDatabase& m_database;
     std::unique_ptr<SQliteExecHandler> m_exec_handler{std::make_unique<SQliteExecHandler>()};
 
-    sqlite3_stmt* m_read_stmt{nullptr};
-    sqlite3_stmt* m_insert_stmt{nullptr};
-    sqlite3_stmt* m_overwrite_stmt{nullptr};
-    sqlite3_stmt* m_delete_stmt{nullptr};
-    sqlite3_stmt* m_delete_prefix_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_read_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_insert_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_overwrite_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_prefix_stmt{nullptr};
 
     /** Whether this batch has started a database transaction and whether it owns SQLiteDatabase::m_write_semaphore.
      * If the batch starts a db tx, it acquires the semaphore and sets this to true, keeping the semaphore
@@ -73,7 +72,7 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
 protected:
     bool ReadKey(DataStream&& key, DataStream& value) override;
@@ -84,7 +83,7 @@ protected:
 
 public:
     explicit SQLiteBatch(SQLiteDatabase& database);
-    ~SQLiteBatch() override { Close(); }
+    ~SQLiteBatch() override;
 
     void SetExecHandler(std::unique_ptr<SQliteExecHandler>&& handler) { m_exec_handler = std::move(handler); }
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -72,7 +72,8 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt);
+    bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
 protected:
     bool ReadKey(DataStream&& key, DataStream& value) override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -12,7 +12,6 @@
 
 struct bilingual_str;
 
-struct sqlite3_stmt;
 struct sqlite3;
 
 namespace wallet {
@@ -54,11 +53,11 @@ private:
     SQLiteDatabase& m_database;
     std::unique_ptr<SQliteExecHandler> m_exec_handler{std::make_unique<SQliteExecHandler>()};
 
-    sqlite3_stmt* m_read_stmt{nullptr};
-    sqlite3_stmt* m_insert_stmt{nullptr};
-    sqlite3_stmt* m_overwrite_stmt{nullptr};
-    sqlite3_stmt* m_delete_stmt{nullptr};
-    sqlite3_stmt* m_delete_prefix_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_read_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_insert_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_overwrite_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_prefix_stmt{nullptr};
 
     /** Whether this batch has started a database transaction and whether it owns SQLiteDatabase::m_write_semaphore.
      * If the batch starts a db tx, it acquires the semaphore and sets this to true, keeping the semaphore
@@ -73,7 +72,7 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
     bool ReadKey(DataStream&& key, DataStream& value) override;
     bool WriteKey(DataStream&& key, DataStream&& value, bool overwrite = true) override;
@@ -83,7 +82,7 @@ private:
 
 public:
     explicit SQLiteBatch(SQLiteDatabase& database);
-    ~SQLiteBatch() override { Close(); }
+    ~SQLiteBatch() override;
 
     void SetExecHandler(std::unique_ptr<SQliteExecHandler>&& handler) { m_exec_handler = std::move(handler); }
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -17,22 +17,22 @@ struct sqlite3;
 
 namespace wallet {
 class SQLiteDatabase;
+class SQLiteStatement;
 
 /** RAII class that provides a database cursor */
 class SQLiteCursor : public DatabaseCursor
 {
+private:
+    std::unique_ptr<SQLiteStatement> m_cursor_stmt{nullptr};
 public:
-    sqlite3_stmt* m_cursor_stmt{nullptr};
     // Copies of the prefix things for the prefix cursor.
     // Prevents SQLite from accessing temp variables for the prefix things.
     std::vector<std::byte> m_prefix_range_start;
     std::vector<std::byte> m_prefix_range_end;
 
-    explicit SQLiteCursor() = default;
-    explicit SQLiteCursor(std::vector<std::byte> start_range, std::vector<std::byte> end_range)
-        : m_prefix_range_start(std::move(start_range)),
-        m_prefix_range_end(std::move(end_range))
-    {}
+    explicit SQLiteCursor(sqlite3& db, const std::string& stmt_text);
+    explicit SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range);
+
     ~SQLiteCursor() override;
 
     Status Next(DataStream& key, DataStream& value) override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -71,7 +71,16 @@ private:
      */
     bool m_txn{false};
 
-    void SetupSQLStatements();
+    enum SQLiteStatementType
+    {
+        READ,
+        INSERT,
+        OVERWRITE,
+        ERASE,
+        ERASE_PREFIX,
+    };
+
+    void MaybeSetupSQLStatement(SQLiteStatementType type);
     bool ExecStatement(SQLiteStatement* stmt);
     bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -72,7 +72,8 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt);
+    bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
     bool ReadKey(DataStream&& key, DataStream& value) override;
     bool WriteKey(DataStream&& key, DataStream&& value, bool overwrite = true) override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -71,7 +71,16 @@ private:
      */
     bool m_txn{false};
 
-    void SetupSQLStatements();
+    enum class SQLiteStatementType
+    {
+        READ,
+        INSERT,
+        OVERWRITE,
+        ERASE,
+        ERASE_PREFIX,
+    };
+
+    void MaybeSetupSQLStatement(SQLiteStatementType type);
     bool ExecStatement(SQLiteStatement* stmt);
     bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 


### PR DESCRIPTION
SQLite statements are C objects which can be long lived, so having them be initialized in a constructor, and cleanup everything in a destructor, makes the sqlite code cleaner and easier to read. This also lets us have the various functions needed to interact with sqlite statements be member functions.

This will be particularly useful in future work which makes use of more complicated SQL statements.