### PR TITLE
wallet: Store transactions in a separate sqlite table

### DIFF
--- a/src/primitives/transaction_identifier.h
+++ b/src/primitives/transaction_identifier.h
@@ -6,12 +6,14 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_IDENTIFIER_H
 
 #include <attributes.h>
+#include <span.h>
 #include <uint256.h>
 #include <util/types.h>
 
 #include <compare>
 #include <cstddef>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -39,6 +41,7 @@ class transaction_identifier
 public:
     transaction_identifier() : m_wrapped{} {}
     consteval explicit transaction_identifier(std::string_view hex_str) : m_wrapped{uint256{hex_str}} {}
+    explicit transaction_identifier(std::span<const std::byte> sp) : m_wrapped(UCharSpanCast(sp)) {}
 
     template <typename Other>
     bool operator==(const Other& other) const { return Compare(other) == 0; }

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -118,6 +118,7 @@ public:
 
     virtual std::unique_ptr<DatabaseCursor> GetNewCursor() = 0;
     virtual std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(std::span<const std::byte> prefix) = 0;
+    virtual std::unique_ptr<DatabaseCursor> GetNewTransactionsCursor() = 0;
     virtual bool TxnBegin() = 0;
     virtual bool TxnCommit() = 0;
     virtual bool TxnAbort() = 0;

--- a/src/wallet/migrate.h
+++ b/src/wallet/migrate.h
@@ -97,6 +97,7 @@ public:
 
     std::unique_ptr<DatabaseCursor> GetNewCursor() override { return std::make_unique<BerkeleyROCursor>(m_database); }
     std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(std::span<const std::byte> prefix) override;
+    std::unique_ptr<DatabaseCursor> GetNewTransactionsCursor() override { return nullptr; }
     bool TxnBegin() override { return false; }
     bool TxnCommit() override { return false; }
     bool TxnAbort() override { return false; }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -131,6 +131,14 @@ public:
             return sqlite3_column_int(m_stmt, col);
         } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
             return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            const char* text = (const char*)sqlite3_column_text(m_stmt, col);
+            if (!text) {
+                return "";
+            }
+            size_t size = sqlite3_column_bytes(m_stmt, col);
+            std::string str_text(text, size);
+            return str_text;
         } else if constexpr (ColumnBlob<T>) {
             return T(SpanFromBlob(m_stmt, col));
         } else {
@@ -269,37 +277,29 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
         return false;
     }
 
-    sqlite3_stmt* stmt{nullptr};
-    int ret = sqlite3_prepare_v2(m_db, "PRAGMA integrity_check", -1, &stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        sqlite3_finalize(stmt);
-        error = strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret));
-        return false;
+    try {
+        SQLiteStatement integrity_check_stmt(*m_db, "PRAGMA integrity_check");
+        while (true) {
+            int ret = integrity_check_stmt.Step();
+            if (ret == SQLITE_DONE) {
+                break;
+            }
+            if (ret != SQLITE_ROW) {
+                error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
+                break;
+            }
+            std::string str_msg(integrity_check_stmt.Column<std::string>(0));
+            if (str_msg == "ok") {
+                continue;
+            }
+            if (error.empty()) {
+                error = _("Failed to verify database") + Untranslated("\n");
+            }
+            error += Untranslated(strprintf("%s\n", str_msg));
+        }
+    } catch (std::runtime_error& e) {
+        error = Untranslated(e.what());
     }
-    while (true) {
-        ret = sqlite3_step(stmt);
-        if (ret == SQLITE_DONE) {
-            break;
-        }
-        if (ret != SQLITE_ROW) {
-            error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        const char* msg = (const char*)sqlite3_column_text(stmt, 0);
-        if (!msg) {
-            error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
-            break;
-        }
-        std::string str_msg(msg);
-        if (str_msg == "ok") {
-            continue;
-        }
-        if (error.empty()) {
-            error = _("Failed to verify database") + Untranslated("\n");
-        }
-        error += Untranslated(strprintf("%s\n", str_msg));
-    }
-    sqlite3_finalize(stmt);
     return error.empty();
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,6 +78,51 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+/** RAII class that encapsulates a sqlite3_stmt */
+class SQLiteStatement
+{
+private:
+    sqlite3& m_db;
+    sqlite3_stmt* m_stmt{nullptr};
+
+public:
+    explicit SQLiteStatement(sqlite3& db, const std::string& stmt_text)
+        : m_db(db)
+    {
+        int res = sqlite3_prepare_v2(&m_db, stmt_text.c_str(), -1, &m_stmt, nullptr);
+        if (res != SQLITE_OK) {
+            throw std::runtime_error(strprintf(
+                "SQLiteStatement: Failed to prepare SQL statement '%s': %s\n", stmt_text, sqlite3_errstr(res)));
+        }
+    }
+
+    ~SQLiteStatement()
+    {
+        sqlite3_finalize(m_stmt);
+    }
+
+    int Step()
+    {
+        return sqlite3_step(m_stmt);
+    }
+
+    void Reset()
+    {
+        sqlite3_clear_bindings(m_stmt);
+        sqlite3_reset(m_stmt);
+    }
+
+    bool Bind(int index, std::span<const std::byte> data, const std::string& description)
+    {
+        return BindBlobToStatement(m_stmt, index, data, description);
+    }
+
+    std::span<const std::byte> Column(int col)
+    {
+        return SpanFromBlob(m_stmt, col);
+    }
+};
+
 static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,6 +78,12 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
+template <typename T>
+concept ColumnBlob = requires(T a, T::element_type* data, size_t size)
+{
+    T(data, size);
+};
+
 /** RAII class that encapsulates a sqlite3_stmt */
 class SQLiteStatement
 {
@@ -117,9 +123,19 @@ public:
         return BindBlobToStatement(m_stmt, index, data, description);
     }
 
-    std::span<const std::byte> Column(int col)
+    template<typename T>
+    T Column(int col)
     {
-        return SpanFromBlob(m_stmt, col);
+        Assert(col < sqlite3_column_count(m_stmt));
+        if constexpr (std::integral<T> && sizeof(T) <= 4) {
+            return sqlite3_column_int(m_stmt, col);
+        } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
+            return static_cast<int64_t>(sqlite3_column_int64(m_stmt, col));
+        } else if constexpr (ColumnBlob<T>) {
+            return T(SpanFromBlob(m_stmt, col));
+        } else {
+            static_assert(ALWAYS_FALSE<T>);
+        }
     }
 };
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -26,12 +26,6 @@
 namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
 
-static std::span<const std::byte> SpanFromBlob(sqlite3_stmt* stmt, int col)
-{
-    return {reinterpret_cast<const std::byte*>(sqlite3_column_blob(stmt, col)),
-            static_cast<size_t>(sqlite3_column_bytes(stmt, col))};
-}
-
 static void ErrorLogCallback(void* arg, int code, const char* msg)
 {
     // From sqlite3_config() documentation for the SQLITE_CONFIG_LOG option:
@@ -56,26 +50,6 @@ static int TraceSqlCallback(unsigned code, void* context, void* param1, void* pa
         if (expanded) sqlite3_free(expanded);
     }
     return SQLITE_OK;
-}
-
-static bool BindBlobToStatement(sqlite3_stmt* stmt,
-                                int index,
-                                std::span<const std::byte> blob,
-                                const std::string& description)
-{
-    // Pass a pointer to the empty string "" below instead of passing the
-    // blob.data() pointer if the blob.data() pointer is null. Passing a null
-    // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
-    // instead of the empty blob value X'', which would mess up SQL comparisons.
-    int res = sqlite3_bind_blob(stmt, index, blob.data() ? static_cast<const void*>(blob.data()) : "", blob.size(), SQLITE_STATIC);
-    if (res != SQLITE_OK) {
-        LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
-        sqlite3_clear_bindings(stmt);
-        sqlite3_reset(stmt);
-        return false;
-    }
-
-    return true;
 }
 
 template <typename T>
@@ -120,7 +94,18 @@ public:
 
     bool Bind(int index, std::span<const std::byte> data, const std::string& description)
     {
-        return BindBlobToStatement(m_stmt, index, data, description);
+        // Pass a pointer to the empty string "" below instead of passing the
+        // blob.data() pointer if the blob.data() pointer is null. Passing a null
+        // data pointer to bind_blob would cause sqlite to bind the SQL NULL value
+        // instead of the empty blob value X'', which would mess up SQL comparisons.
+        int res = sqlite3_bind_blob(m_stmt, index, data.data() ? static_cast<const void*>(data.data()) : "", data.size(), SQLITE_STATIC);
+        if (res != SQLITE_OK) {
+            LogWarning("Unable to bind %s to statement: %s", description, sqlite3_errstr(res));
+            Reset();
+            return false;
+        }
+
+        return true;
     }
 
     template<typename T>
@@ -140,7 +125,10 @@ public:
             std::string str_text(text, size);
             return str_text;
         } else if constexpr (ColumnBlob<T>) {
-            return T(SpanFromBlob(m_stmt, col));
+            return T(
+                reinterpret_cast<T::element_type*>(sqlite3_column_blob(m_stmt, col)),
+                static_cast<size_t>(sqlite3_column_bytes(m_stmt, col))
+            );
         } else {
             static_assert(ALWAYS_FALSE<T>);
         }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -258,6 +258,26 @@ void SQLiteBatch::MaybeSetupSQLStatement(SQLiteStatementType type)
     case SQLiteStatementType::ERASE_PREFIX:
         if (!m_delete_prefix_stmt) m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
         break;
+    case SQLiteStatementType::INSERT_TX:
+        if (m_database.HasTxsTable() && !m_insert_tx_stmt) {
+            m_insert_tx_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE INTO transactions (txid, tx, comment, comment_to, replaces, replaced_by, timesmart, timereceived, order_pos, messages, payment_requests, state_type, state_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+        }
+        break;
+    case SQLiteStatementType::UPDATE_FULL_TX:
+        if (m_database.HasTxsTable() && !m_update_full_tx_stmt) {
+            m_update_full_tx_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "UPDATE transactions SET comment = ?, comment_to = ?, replaces = ?, replaced_by = ? , timesmart = ?, timereceived = ?, order_pos = ?, messages= ?, payment_requests = ?, state_type =?, state_data = ? WHERE txid = ?");
+        }
+        break;
+    case SQLiteStatementType::UPDATE_TX_REPLACED_BY:
+        if (m_database.HasTxsTable() && !m_update_tx_replaced_by_stmt) {
+            m_update_tx_replaced_by_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "UPDATE transactions SET replaced_by = ? WHERE txid = ?");
+        }
+        break;
+    case SQLiteStatementType::UPDATE_TX_STATE:
+        if (m_database.HasTxsTable() && !m_update_tx_state_stmt) {
+            m_update_tx_state_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "UPDATE transactions SET state_type = ?, state_data = ? WHERE txid = ?");
+        }
+        break;
     }
 }
 
@@ -551,6 +571,10 @@ void SQLiteBatch::Close()
     m_overwrite_stmt.reset();
     m_delete_stmt.reset();
     m_delete_prefix_stmt.reset();
+    m_insert_tx_stmt.reset();
+    m_update_full_tx_stmt.reset();
+    m_update_tx_replaced_by_stmt.reset();
+    m_update_tx_state_stmt.reset();
 
     if (force_conn_refresh) {
         if (m_database.m_additional_flags & SQLITE_OPEN_MEMORY) {
@@ -670,6 +694,113 @@ bool SQLiteBatch::CreateTxsTable()
     if (m_database.HasTxsTable()) return true;
     if (!m_database.CreateTxsTable()) return false;
     return true;
+}
+
+bool SQLiteBatch::WriteTx(
+    const Txid& txid,
+    const std::span<std::byte>& serialized_tx,
+    const std::optional<std::string>& comment,
+    const std::optional<std::string>& comment_to,
+    const std::optional<Txid>& replaces,
+    const std::optional<Txid>& replaced_by,
+    uint32_t timesmart,
+    uint32_t timereceived,
+    int64_t order_pos,
+    const std::vector<std::string>& messages,
+    const std::vector<std::string>& payment_requests,
+    int32_t state_type,
+    const std::vector<unsigned char>& state_data
+)
+{
+    if (!m_database.HasTxsTable()) return true;
+    MaybeSetupSQLStatement(SQLiteStatementType::INSERT_TX);
+
+    // Lifetime of DataStream needs to be until the statement is executed.
+    DataStream ser_messages, ser_payment_reqs;
+
+    if (!m_insert_tx_stmt->Bind(1, txid, "txid")) return false;
+    if (!m_insert_tx_stmt->Bind(2, serialized_tx, "tx")) return false;
+    if (comment && !m_insert_tx_stmt->Bind(3, *comment, "comment")) return false;
+    if (comment_to && !m_insert_tx_stmt->Bind(4, *comment_to, "comment_to")) return false;
+    if (replaces && !m_insert_tx_stmt->Bind(5, *replaces, "replaces")) return false;
+    if (replaced_by && !m_insert_tx_stmt->Bind(6, *replaced_by, "replaced_by")) return false;
+    if (!m_insert_tx_stmt->Bind(7, timesmart, "timesmart")) return false;
+    if (!m_insert_tx_stmt->Bind(8, timereceived, "timereceived")) return false;
+    if (!m_insert_tx_stmt->Bind(9, order_pos, "order_pos")) return false;
+    if (!messages.empty()) {
+        ser_messages << messages;
+        if (!m_insert_tx_stmt->Bind(10, ser_messages, "messages")) return false;
+    }
+    if (!payment_requests.empty()) {
+        ser_payment_reqs << payment_requests;
+        if (!m_insert_tx_stmt->Bind(11, ser_payment_reqs, "payment_requests")) return false;
+    }
+    if (!m_insert_tx_stmt->Bind(12, state_type, "state_type")) return false;
+    if (!m_insert_tx_stmt->Bind(13, state_data, "state_data")) return false;
+    return ExecStatement(m_insert_tx_stmt.get());
+}
+
+bool SQLiteBatch::UpdateFullTx(
+    const Txid& txid,
+    const std::optional<std::string>& comment,
+    const std::optional<std::string>& comment_to,
+    const std::optional<Txid>& replaces,
+    const std::optional<Txid>& replaced_by,
+    uint32_t timesmart,
+    uint32_t timereceived,
+    int64_t order_pos,
+    const std::vector<std::string>& messages,
+    const std::vector<std::string>& payment_requests,
+    int32_t state_type,
+    const std::vector<unsigned char>& state_data
+)
+{
+    if (!m_database.HasTxsTable()) return true;
+    MaybeSetupSQLStatement(SQLiteStatementType::UPDATE_FULL_TX);
+
+    // Lifetime of DataStream needs to be until the statement is executed.
+    DataStream ser_messages, ser_payment_reqs;
+
+    if (comment && !m_update_full_tx_stmt->Bind(1, *comment, "comment")) return false;
+    if (comment_to && !m_update_full_tx_stmt->Bind(2, *comment_to, "comment_to")) return false;
+    if (replaces && !m_update_full_tx_stmt->Bind(3, *replaces, "replaces")) return false;
+    if (replaced_by && !m_update_full_tx_stmt->Bind(4, *replaced_by, "replaced_by")) return false;
+    if (!m_update_full_tx_stmt->Bind(5, timesmart, "timesmart")) return false;
+    if (!m_update_full_tx_stmt->Bind(6, timereceived, "timereceived")) return false;
+    if (!m_update_full_tx_stmt->Bind(7, order_pos, "order_pos")) return false;
+    if (!messages.empty()) {
+        ser_messages << messages;
+        if (!m_update_full_tx_stmt->Bind(8, ser_messages, "messages")) return false;
+    }
+    if (!payment_requests.empty()) {
+        ser_payment_reqs << payment_requests;
+        if (!m_update_full_tx_stmt->Bind(9, ser_payment_reqs, "payment_requests")) return false;
+    }
+    if (!m_update_full_tx_stmt->Bind(10, state_type, "state_type")) return false;
+    if (!m_update_full_tx_stmt->Bind(11, state_data, "state_data")) return false;
+    if (!m_update_full_tx_stmt->Bind(12, txid, "txid")) return false;
+    return ExecStatement(m_update_full_tx_stmt.get());
+}
+
+bool SQLiteBatch::UpdateTxReplacedBy(const Txid& txid, const Txid& replaced_by)
+{
+    if (!m_database.HasTxsTable()) return true;
+    MaybeSetupSQLStatement(SQLiteStatementType::UPDATE_TX_REPLACED_BY);
+
+    if (!m_update_tx_replaced_by_stmt->Bind(1, replaced_by, "replaced_by")) return false;
+    if (!m_update_tx_replaced_by_stmt->Bind(2, txid, "txid")) return false;
+    return ExecStatement(m_update_tx_replaced_by_stmt.get());
+}
+
+bool SQLiteBatch::UpdateTxState(const Txid& txid, int32_t state_type, const std::vector<unsigned char>& state_data)
+{
+    if (!m_database.HasTxsTable()) return true;
+    MaybeSetupSQLStatement(SQLiteStatementType::UPDATE_TX_STATE);
+
+    if (!m_update_tx_state_stmt->Bind(1, state_type, "state_type")) return false;
+    if (!m_update_tx_state_stmt->Bind(2, state_data, "state_data")) return false;
+    if (!m_update_tx_state_stmt->Bind(3, txid, "txid")) return false;
+    return ExecStatement(m_update_tx_state_stmt.get());
 }
 
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -201,13 +201,25 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
     }
 }
 
-void SQLiteBatch::SetupSQLStatements()
+void SQLiteBatch::MaybeSetupSQLStatement(SQLiteStatementType type)
 {
-    m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
-    m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
-    m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
-    m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
-    m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
+    switch (type) {
+    case SQLiteStatementType::READ:
+        if (!m_read_stmt) m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
+        break;
+    case SQLiteStatementType::INSERT:
+        if (!m_insert_stmt) m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
+        break;
+    case SQLiteStatementType::OVERWRITE:
+        if (!m_overwrite_stmt) m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
+        break;
+    case SQLiteStatementType::ERASE:
+        if (!m_delete_stmt) m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
+        break;
+    case SQLiteStatementType::ERASE_PREFIX:
+        if (!m_delete_prefix_stmt) m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
+        break;
+    }
 }
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -438,8 +450,6 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
 {
     // Make sure we have a db handle
     assert(m_database.m_db);
-
-    SetupSQLStatements();
 }
 
 SQLiteBatch::~SQLiteBatch()
@@ -491,7 +501,7 @@ void SQLiteBatch::Close()
 bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
 {
     if (!m_database.m_db) return false;
-    assert(m_read_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::READ);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_read_stmt->Bind(1, key, "key")) return false;
@@ -535,12 +545,13 @@ bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt)
 bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     if (!m_database.m_db) return false;
-    assert(m_insert_stmt && m_overwrite_stmt);
 
     SQLiteStatement* stmt;
     if (overwrite) {
+        MaybeSetupSQLStatement(SQLiteStatementType::OVERWRITE);
         stmt = m_overwrite_stmt.get();
     } else {
+        MaybeSetupSQLStatement(SQLiteStatementType::INSERT);
         stmt = m_insert_stmt.get();
     }
 
@@ -554,7 +565,7 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
     if (!m_database.m_db) return false;
-    assert(m_delete_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::ERASE);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_delete_stmt->Bind(1, key, "key")) return false;
@@ -564,7 +575,7 @@ bool SQLiteBatch::EraseKey(DataStream&& key)
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
     if (!m_database.m_db) return false;
-    assert(m_delete_prefix_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::ERASE_PREFIX);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_delete_prefix_stmt->Bind(1, prefix, "key")) return false;
@@ -574,7 +585,7 @@ bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 bool SQLiteBatch::HasKey(DataStream&& key)
 {
     if (!m_database.m_db) return false;
-    assert(m_read_stmt);
+    MaybeSetupSQLStatement(SQLiteStatementType::READ);
 
     // Bind: leftmost parameter in statement is index 1
     if (!m_read_stmt->Bind(1, key, "key")) return false;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -823,9 +823,60 @@ DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
     return Status::MORE;
 }
 
+DatabaseCursor::Status SQLiteCursor::NextTx(
+    Txid& txid,
+    DataStream& ser_tx,
+    std::optional<std::string>& comment,
+    std::optional<std::string>& comment_to,
+    std::optional<Txid>& replaces,
+    std::optional<Txid>& replaced_by,
+    uint32_t& timesmart,
+    uint32_t& timereceived,
+    int64_t& order_pos,
+    std::vector<std::string>& messages,
+    std::vector<std::string>& payment_requests,
+    int32_t& state_type,
+    std::vector<unsigned char>& state_data
+)
+{
+    int res = m_cursor_stmt->Step();
+    if (res == SQLITE_DONE) {
+        return Status::DONE;
+    }
+    if (res != SQLITE_ROW) {
+        LogWarning("Unable to execute cursor step: %s", sqlite3_errstr(res));
+        return Status::FAIL;
+    }
+
+    // Leftmost column in result is index 0
+    txid = *m_cursor_stmt->Column<Txid>(0);
+    ser_tx.write(*m_cursor_stmt->Column<std::span<const std::byte>>(1));
+    comment = m_cursor_stmt->Column<std::string>(2);
+    comment_to = m_cursor_stmt->Column<std::string>(3);
+    replaces = m_cursor_stmt->Column<Txid>(4);
+    replaced_by = m_cursor_stmt->Column<Txid>(5);
+    timesmart = *m_cursor_stmt->Column<uint32_t>(6);
+    timereceived = *m_cursor_stmt->Column<uint32_t>(7);
+    order_pos = *m_cursor_stmt->Column<int64_t>(8);
+
+    std::optional<DataStream> messages_data = m_cursor_stmt->Column<DataStream>(9);
+    if (messages_data) {
+        *messages_data >> messages;
+    }
+    std::optional<DataStream> pay_reqs_data = m_cursor_stmt->Column<DataStream>(10);
+    if (pay_reqs_data) {
+        *pay_reqs_data >> payment_requests;
+    }
+
+    state_type = *m_cursor_stmt->Column<int32_t>(11);
+    state_data = *m_cursor_stmt->Column<std::vector<unsigned char>>(12);
+    return Status::MORE;
+}
+
 SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text)
-    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)}
-{}
+{
+    m_cursor_stmt = std::make_unique<SQLiteStatement>(db, stmt_text);
+}
 
 SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range)
     : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)},
@@ -874,6 +925,13 @@ std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const 
     const char* stmt_text = end_range.empty() ? "SELECT key, value FROM main WHERE key >= ?" :
                             "SELECT key, value FROM main WHERE key >= ? AND key < ?";
     return std::make_unique<SQLiteCursor>(*m_database.m_db, stmt_text, start_range, end_range);
+}
+
+std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewTransactionsCursor()
+{
+    if (!m_database.m_db) return nullptr;
+    const char* stmt_text = "SELECT txid, tx, comment, comment_to, replaces, replaced_by, timesmart, timereceived, order_pos, messages, payment_requests, state_type, state_data FROM transactions ORDER BY order_pos";
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, stmt_text);
 }
 
 bool SQLiteBatch::TxnBegin()

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -524,6 +524,26 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     return true;
 }
 
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt)
+{
+    if (!m_database.m_db) return false;
+    assert(stmt);
+
+    // Acquire semaphore if not previously acquired when creating a transaction.
+    if (!m_txn) m_database.m_write_semaphore.acquire();
+
+    // Execute
+    int res = stmt->Step();
+    stmt->Reset();
+    if (res != SQLITE_DONE) {
+        LogError("Unable to execute statement: %s\n", sqlite3_errstr(res));
+    }
+
+    if (!m_txn) m_database.m_write_semaphore.release();
+
+    return res == SQLITE_DONE;
+}
+
 bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     if (!m_database.m_db) return false;
@@ -540,53 +560,27 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     // Insert index 1 is key, 2 is value
     if (!stmt->Bind(1, key, "key")) return false;
     if (!stmt->Bind(2, value, "value")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
-}
-
-bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
-{
-    if (!m_database.m_db) return false;
-    assert(stmt);
-
-    // Bind: leftmost parameter in statement is index 1
-    if (!stmt->Bind(1, blob, "key")) return false;
-
-    // Acquire semaphore if not previously acquired when creating a transaction.
-    if (!m_txn) m_database.m_write_semaphore.acquire();
-
-    // Execute
-    int res = stmt->Step();
-    stmt->Reset();
-    if (res != SQLITE_DONE) {
-        LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
-    }
-
-    if (!m_txn) m_database.m_write_semaphore.release();
-
-    return res == SQLITE_DONE;
+    return ExecStatement(stmt);
 }
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt.get(), key);
+    if (!m_database.m_db) return false;
+    assert(m_delete_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_stmt->Bind(1, key, "key")) return false;
+    return ExecStatement(m_delete_stmt.get());
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
+    if (!m_database.m_db) return false;
+    assert(m_delete_prefix_stmt);
+
+    // Bind: leftmost parameter in statement is index 1
+    if (!m_delete_prefix_stmt->Bind(1, prefix, "key")) return false;
+    return ExecStatement(m_delete_prefix_stmt.get());
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -368,22 +368,15 @@ void SQLiteDatabase::Open(int additional_flags)
 
     // Make the table for our key-value pairs
     // First check that the main table exists
-    sqlite3_stmt* check_main_stmt{nullptr};
-    ret = sqlite3_prepare_v2(m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'", -1, &check_main_stmt, nullptr);
-    if (ret != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to prepare statement to check table existence: %s\n", sqlite3_errstr(ret)));
-    }
-    ret = sqlite3_step(check_main_stmt);
-    if (sqlite3_finalize(check_main_stmt) != SQLITE_OK) {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to finalize statement checking table existence: %s\n", sqlite3_errstr(ret)));
-    }
+    SQLiteStatement check_main_stmt(*m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='main'");
+    ret = check_main_stmt.Step();
     bool table_exists;
     if (ret == SQLITE_DONE) {
         table_exists = false;
     } else if (ret == SQLITE_ROW) {
         table_exists = true;
     } else {
-        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check table existence: %s\n", sqlite3_errstr(ret)));
+        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check main table existence: %s\n", sqlite3_errstr(ret)));
     }
 
     // Do the db setup things because the table doesn't exist only when we are creating a new wallet

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -406,6 +406,17 @@ void SQLiteDatabase::Open(int additional_flags)
         throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check main table existence: %s\n", sqlite3_errstr(ret)));
     }
 
+    // Then check that the transactions table exists
+    SQLiteStatement check_txs_stmt(*m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='transactions'");
+    ret = check_txs_stmt.Step();
+    if (ret == SQLITE_DONE) {
+        m_has_txs_table = false;
+    } else if (ret == SQLITE_ROW) {
+        m_has_txs_table = true;
+    } else {
+        throw std::runtime_error(strprintf("SQLiteDatabase: Failed to execute statement to check transactions table existence: %s\n", sqlite3_errstr(ret)));
+    }
+
     // Do the db setup things because the table doesn't exist only when we are creating a new wallet
     if (!table_exists) {
         ret = sqlite3_exec(m_db, "CREATE TABLE main(key BLOB PRIMARY KEY NOT NULL, value BLOB NOT NULL)", nullptr, nullptr, nullptr);
@@ -421,6 +432,12 @@ void SQLiteDatabase::Open(int additional_flags)
         // Set the user version
         SetPragma(m_db, "user_version", strprintf("%d", WALLET_SCHEMA_VERSION),
                   "Failed to set the wallet schema version");
+    }
+
+    if (!m_has_txs_table) {
+        if (!CreateTxsTable()) {
+            throw std::runtime_error(strprintf("SQLiteDatabase: Failed to create new transactions database: %s\n", sqlite3_errstr(ret)));
+        }
     }
 }
 
@@ -482,6 +499,21 @@ std::unique_ptr<DatabaseBatch> SQLiteDatabase::MakeBatch()
 {
     // We ignore flush_on_close because we don't do manual flushing for SQLite
     return std::make_unique<SQLiteBatch>(*this);
+}
+
+bool SQLiteDatabase::HasTxsTable() const
+{
+    return m_has_txs_table;
+}
+
+bool SQLiteDatabase::CreateTxsTable()
+{
+    int ret = sqlite3_exec(m_db, "CREATE TABLE transactions(txid BLOB PRIMARY KEY NOT NULL, tx BLOB NOT NULL, comment STRING, comment_to STRING, replaces BLOB, replaced_by BLOB, timesmart INTEGER, timereceived INTEGER, order_pos INTEGER, messages BLOB, payment_requests BLOB, state_type INTEGER, state_data BLOB)", nullptr, nullptr, nullptr);
+    if (ret != SQLITE_OK) {
+        return false;
+    }
+    m_has_txs_table = true;
+    return true;
 }
 
 SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
@@ -631,6 +663,13 @@ bool SQLiteBatch::HasKey(DataStream&& key)
     int res = m_read_stmt->Step();
     m_read_stmt->Reset();
     return res == SQLITE_ROW;
+}
+
+bool SQLiteBatch::CreateTxsTable()
+{
+    if (m_database.HasTxsTable()) return true;
+    if (!m_database.CreateTxsTable()) return false;
+    return true;
 }
 
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -127,9 +127,14 @@ public:
     }
 
     template<typename T>
-    T Column(int col)
+    std::optional<T> Column(int col)
     {
         Assert(col < sqlite3_column_count(m_stmt));
+        int column_type = sqlite3_column_type(m_stmt, col);
+        if (column_type == SQLITE_NULL) {
+            return std::nullopt;
+        }
+
         if constexpr (std::integral<T> && sizeof(T) <= 4) {
             return sqlite3_column_int(m_stmt, col);
         } else if constexpr (std::integral<T> && std::is_signed_v<T> && sizeof(T) <= 8) {
@@ -163,7 +168,7 @@ static std::optional<int> ReadPragmaInteger(sqlite3& db, const std::string& key,
             error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
             return std::nullopt;
         }
-        int result = pragma_read_stmt.Column<int>(0);
+        int result = *pragma_read_stmt.Column<int>(0);
         return result;
     } catch (std::runtime_error& e) {
         error = Untranslated(e.what());
@@ -294,7 +299,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
                 error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
                 break;
             }
-            std::string str_msg(integrity_check_stmt.Column<std::string>(0));
+            std::string str_msg(*integrity_check_stmt.Column<std::string>(0));
             if (str_msg == "ok") {
                 continue;
             }
@@ -534,7 +539,7 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     }
     // Leftmost column in result is index 0
     value.clear();
-    value.write(m_read_stmt->Column<std::span<const std::byte>>(0));
+    value.write(*m_read_stmt->Column<std::span<const std::byte>>(0));
 
     m_read_stmt->Reset();
     return true;
@@ -627,8 +632,8 @@ DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
     value.clear();
 
     // Leftmost column in result is index 0
-    key.write(m_cursor_stmt->Column<std::span<const std::byte>>(0));
-    value.write(m_cursor_stmt->Column<std::span<const std::byte>>(1));
+    key.write(*m_cursor_stmt->Column<std::span<const std::byte>>(0));
+    value.write(*m_cursor_stmt->Column<std::span<const std::byte>>(1));
     return Status::MORE;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -803,6 +803,11 @@ bool SQLiteBatch::UpdateTxState(const Txid& txid, int32_t state_type, const std:
     return ExecStatement(m_update_tx_state_stmt.get());
 }
 
+bool SQLiteBatch::HasTxsTable() const
+{
+    return m_database.HasTxsTable();
+}
+
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
 {
     int res = m_cursor_stmt->Step();

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -215,23 +215,11 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
 
 void SQLiteBatch::SetupSQLStatements()
 {
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "SELECT value FROM main WHERE key = ?"},
-        {&m_insert_stmt, "INSERT INTO main VALUES(?, ?)"},
-        {&m_overwrite_stmt, "INSERT or REPLACE into main values(?, ?)"},
-        {&m_delete_stmt, "DELETE FROM main WHERE key = ?"},
-        {&m_delete_prefix_stmt, "DELETE FROM main WHERE instr(key, ?) = 1"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_text] : statements) {
-        if (*stmt_prepared == nullptr) {
-            int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, stmt_prepared, nullptr);
-            if (res != SQLITE_OK) {
-                throw std::runtime_error(strprintf(
-                    "SQLiteDatabase: Failed to setup SQL statements: %s\n", sqlite3_errstr(res)));
-            }
-        }
-    }
+    m_read_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "SELECT value FROM main WHERE key = ?");
+    m_insert_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT INTO main VALUES(?, ?)");
+    m_overwrite_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "INSERT or REPLACE into main values(?, ?)");
+    m_delete_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE key = ?");
+    m_delete_prefix_stmt = std::make_unique<SQLiteStatement>(*m_database.m_db, "DELETE FROM main WHERE instr(key, ?) = 1");
 }
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -466,6 +454,11 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
     SetupSQLStatements();
 }
 
+SQLiteBatch::~SQLiteBatch()
+{
+    Close();
+}
+
 void SQLiteBatch::Close()
 {
     bool force_conn_refresh = false;
@@ -484,22 +477,11 @@ void SQLiteBatch::Close()
     }
 
     // Free all of the prepared statements
-    const std::vector<std::pair<sqlite3_stmt**, const char*>> statements{
-        {&m_read_stmt, "read"},
-        {&m_insert_stmt, "insert"},
-        {&m_overwrite_stmt, "overwrite"},
-        {&m_delete_stmt, "delete"},
-        {&m_delete_prefix_stmt, "delete prefix"},
-    };
-
-    for (const auto& [stmt_prepared, stmt_description] : statements) {
-        int res = sqlite3_finalize(*stmt_prepared);
-        if (res != SQLITE_OK) {
-            LogWarning("SQLiteBatch: Batch closed but could not finalize %s statement: %s",
-                      stmt_description, sqlite3_errstr(res));
-        }
-        *stmt_prepared = nullptr;
-    }
+    m_read_stmt.reset();
+    m_insert_stmt.reset();
+    m_overwrite_stmt.reset();
+    m_delete_stmt.reset();
+    m_delete_prefix_stmt.reset();
 
     if (force_conn_refresh) {
         if (m_database.m_additional_flags & SQLITE_OPEN_MEMORY) {
@@ -524,23 +506,21 @@ bool SQLiteBatch::ReadKey(DataStream&& key, DataStream& value)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
     if (res != SQLITE_ROW) {
         if (res != SQLITE_DONE) {
             // SQLITE_DONE means "not found", don't log an error in that case.
             LogWarning("Unable to execute read statement: %s", sqlite3_errstr(res));
         }
-        sqlite3_clear_bindings(m_read_stmt);
-        sqlite3_reset(m_read_stmt);
+        m_read_stmt->Reset();
         return false;
     }
     // Leftmost column in result is index 0
     value.clear();
-    value.write(SpanFromBlob(m_read_stmt, 0));
+    value.write(m_read_stmt->Column<std::span<const std::byte>>(0));
 
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    m_read_stmt->Reset();
     return true;
 }
 
@@ -549,25 +529,24 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     if (!m_database.m_db) return false;
     assert(m_insert_stmt && m_overwrite_stmt);
 
-    sqlite3_stmt* stmt;
+    SQLiteStatement* stmt;
     if (overwrite) {
-        stmt = m_overwrite_stmt;
+        stmt = m_overwrite_stmt.get();
     } else {
-        stmt = m_insert_stmt;
+        stmt = m_insert_stmt.get();
     }
 
     // Bind: leftmost parameter in statement is index 1
     // Insert index 1 is key, 2 is value
-    if (!BindBlobToStatement(stmt, 1, key, "key")) return false;
-    if (!BindBlobToStatement(stmt, 2, value, "value")) return false;
+    if (!stmt->Bind(1, key, "key")) return false;
+    if (!stmt->Bind(2, value, "value")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute write statement: %s", sqlite3_errstr(res));
     }
@@ -577,21 +556,20 @@ bool SQLiteBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
     return res == SQLITE_DONE;
 }
 
-bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob)
+bool SQLiteBatch::ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob)
 {
     if (!m_database.m_db) return false;
     assert(stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(stmt, 1, blob, "key")) return false;
+    if (!stmt->Bind(1, blob, "key")) return false;
 
     // Acquire semaphore if not previously acquired when creating a transaction.
     if (!m_txn) m_database.m_write_semaphore.acquire();
 
     // Execute
-    int res = sqlite3_step(stmt);
-    sqlite3_clear_bindings(stmt);
-    sqlite3_reset(stmt);
+    int res = stmt->Step();
+    stmt->Reset();
     if (res != SQLITE_DONE) {
         LogWarning("Unable to execute exec statement: %s", sqlite3_errstr(res));
     }
@@ -603,12 +581,12 @@ bool SQLiteBatch::ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> b
 
 bool SQLiteBatch::EraseKey(DataStream&& key)
 {
-    return ExecStatement(m_delete_stmt, key);
+    return ExecStatement(m_delete_stmt.get(), key);
 }
 
 bool SQLiteBatch::ErasePrefix(std::span<const std::byte> prefix)
 {
-    return ExecStatement(m_delete_prefix_stmt, prefix);
+    return ExecStatement(m_delete_prefix_stmt.get(), prefix);
 }
 
 bool SQLiteBatch::HasKey(DataStream&& key)
@@ -617,10 +595,9 @@ bool SQLiteBatch::HasKey(DataStream&& key)
     assert(m_read_stmt);
 
     // Bind: leftmost parameter in statement is index 1
-    if (!BindBlobToStatement(m_read_stmt, 1, key, "key")) return false;
-    int res = sqlite3_step(m_read_stmt);
-    sqlite3_clear_bindings(m_read_stmt);
-    sqlite3_reset(m_read_stmt);
+    if (!m_read_stmt->Bind(1, key, "key")) return false;
+    int res = m_read_stmt->Step();
+    m_read_stmt->Reset();
     return res == SQLITE_ROW;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -626,7 +626,7 @@ bool SQLiteBatch::HasKey(DataStream&& key)
 
 DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
 {
-    int res = sqlite3_step(m_cursor_stmt);
+    int res = m_cursor_stmt->Step();
     if (res == SQLITE_DONE) {
         return Status::DONE;
     }
@@ -639,35 +639,34 @@ DatabaseCursor::Status SQLiteCursor::Next(DataStream& key, DataStream& value)
     value.clear();
 
     // Leftmost column in result is index 0
-    key.write(SpanFromBlob(m_cursor_stmt, 0));
-    value.write(SpanFromBlob(m_cursor_stmt, 1));
+    key.write(m_cursor_stmt->Column<std::span<const std::byte>>(0));
+    value.write(m_cursor_stmt->Column<std::span<const std::byte>>(1));
     return Status::MORE;
 }
 
-SQLiteCursor::~SQLiteCursor()
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)}
+{}
+
+SQLiteCursor::SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range)
+    : m_cursor_stmt{std::make_unique<SQLiteStatement>(db, stmt_text)},
+    m_prefix_range_start(std::move(start_range)),
+    m_prefix_range_end(std::move(end_range))
 {
-    sqlite3_clear_bindings(m_cursor_stmt);
-    sqlite3_reset(m_cursor_stmt);
-    int res = sqlite3_finalize(m_cursor_stmt);
-    if (res != SQLITE_OK) {
-        LogWarning("Cursor closed but could not finalize cursor statement: %s",
-                   sqlite3_errstr(res));
+    if (!m_cursor_stmt->Bind(1, m_prefix_range_start, "prefix_start")) {
+        throw std::runtime_error("Unable to bind prefix start to prefix cursor");
+    }
+    if (!m_prefix_range_end.empty() && !m_cursor_stmt->Bind(2, m_prefix_range_end, "prefix_end")) {
+        throw std::runtime_error("Unable to bind prefix end to prefix cursor");
     }
 }
+
+SQLiteCursor::~SQLiteCursor() = default;
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewCursor()
 {
     if (!m_database.m_db) return nullptr;
-    auto cursor = std::make_unique<SQLiteCursor>();
-
-    const char* stmt_text = "SELECT key, value FROM main";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "%s: Failed to setup cursor SQL statement: %s\n", __func__, sqlite3_errstr(res)));
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, "SELECT key, value FROM main");
 }
 
 std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const std::byte> prefix)
@@ -693,23 +692,9 @@ std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewPrefixCursor(std::span<const 
         end_range.clear();
     }
 
-    auto cursor = std::make_unique<SQLiteCursor>(start_range, end_range);
-    if (!cursor) return nullptr;
-
     const char* stmt_text = end_range.empty() ? "SELECT key, value FROM main WHERE key >= ?" :
                             "SELECT key, value FROM main WHERE key >= ? AND key < ?";
-    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
-    if (res != SQLITE_OK) {
-        throw std::runtime_error(strprintf(
-            "SQLiteDatabase: Failed to setup cursor SQL statement: %s\n", sqlite3_errstr(res)));
-    }
-
-    if (!BindBlobToStatement(cursor->m_cursor_stmt, 1, cursor->m_prefix_range_start, "prefix_start")) return nullptr;
-    if (!end_range.empty()) {
-        if (!BindBlobToStatement(cursor->m_cursor_stmt, 2, cursor->m_prefix_range_end, "prefix_end")) return nullptr;
-    }
-
-    return cursor;
+    return std::make_unique<SQLiteCursor>(*m_database.m_db, stmt_text, start_range, end_range);
 }
 
 bool SQLiteBatch::TxnBegin()

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -12,7 +12,6 @@
 
 struct bilingual_str;
 
-struct sqlite3_stmt;
 struct sqlite3;
 
 namespace wallet {
@@ -54,11 +53,11 @@ private:
     SQLiteDatabase& m_database;
     std::unique_ptr<SQliteExecHandler> m_exec_handler{std::make_unique<SQliteExecHandler>()};
 
-    sqlite3_stmt* m_read_stmt{nullptr};
-    sqlite3_stmt* m_insert_stmt{nullptr};
-    sqlite3_stmt* m_overwrite_stmt{nullptr};
-    sqlite3_stmt* m_delete_stmt{nullptr};
-    sqlite3_stmt* m_delete_prefix_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_read_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_insert_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_overwrite_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_delete_prefix_stmt{nullptr};
 
     /** Whether this batch has started a database transaction and whether it owns SQLiteDatabase::m_write_semaphore.
      * If the batch starts a db tx, it acquires the semaphore and sets this to true, keeping the semaphore
@@ -73,7 +72,7 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(sqlite3_stmt* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
 protected:
     bool ReadKey(DataStream&& key, DataStream& value) override;
@@ -84,7 +83,7 @@ protected:
 
 public:
     explicit SQLiteBatch(SQLiteDatabase& database);
-    ~SQLiteBatch() override { Close(); }
+    ~SQLiteBatch() override;
 
     void SetExecHandler(std::unique_ptr<SQliteExecHandler>&& handler) { m_exec_handler = std::move(handler); }
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -72,7 +72,8 @@ private:
     bool m_txn{false};
 
     void SetupSQLStatements();
-    bool ExecStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
+    bool ExecStatement(SQLiteStatement* stmt);
+    bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 
 protected:
     bool ReadKey(DataStream&& key, DataStream& value) override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -17,22 +17,22 @@ struct sqlite3;
 
 namespace wallet {
 class SQLiteDatabase;
+class SQLiteStatement;
 
 /** RAII class that provides a database cursor */
 class SQLiteCursor : public DatabaseCursor
 {
+private:
+    std::unique_ptr<SQLiteStatement> m_cursor_stmt{nullptr};
 public:
-    sqlite3_stmt* m_cursor_stmt{nullptr};
     // Copies of the prefix things for the prefix cursor.
     // Prevents SQLite from accessing temp variables for the prefix things.
     std::vector<std::byte> m_prefix_range_start;
     std::vector<std::byte> m_prefix_range_end;
 
-    explicit SQLiteCursor() = default;
-    explicit SQLiteCursor(std::vector<std::byte> start_range, std::vector<std::byte> end_range)
-        : m_prefix_range_start(std::move(start_range)),
-        m_prefix_range_end(std::move(end_range))
-    {}
+    explicit SQLiteCursor(sqlite3& db, const std::string& stmt_text);
+    explicit SQLiteCursor(sqlite3& db, const std::string& stmt_text, std::vector<std::byte> start_range, std::vector<std::byte> end_range);
+
     ~SQLiteCursor() override;
 
     Status Next(DataStream& key, DataStream& value) override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -71,7 +71,16 @@ private:
      */
     bool m_txn{false};
 
-    void SetupSQLStatements();
+    enum SQLiteStatementType
+    {
+        READ,
+        INSERT,
+        OVERWRITE,
+        ERASE,
+        ERASE_PREFIX,
+    };
+
+    void MaybeSetupSQLStatement(SQLiteStatementType type);
     bool ExecStatement(SQLiteStatement* stmt);
     bool ExecEraseStatement(SQLiteStatement* stmt, std::span<const std::byte> blob);
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -160,6 +160,7 @@ public:
     bool TxnAbort() override;
     bool HasActiveTxn() override { return m_txn; }
 
+    bool HasTxsTable() const;
     bool CreateTxsTable();
 };
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -6,8 +6,10 @@
 #define BITCOIN_WALLET_SQLITE_H
 
 #include <sync.h>
+#include <primitives/transaction_identifier.h>
 #include <wallet/db.h>
 
+#include <optional>
 #include <semaphore>
 
 struct bilingual_str;
@@ -58,6 +60,10 @@ private:
     std::unique_ptr<SQLiteStatement> m_overwrite_stmt{nullptr};
     std::unique_ptr<SQLiteStatement> m_delete_stmt{nullptr};
     std::unique_ptr<SQLiteStatement> m_delete_prefix_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_insert_tx_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_update_full_tx_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_update_tx_replaced_by_stmt{nullptr};
+    std::unique_ptr<SQLiteStatement> m_update_tx_state_stmt{nullptr};
 
     /** Whether this batch has started a database transaction and whether it owns SQLiteDatabase::m_write_semaphore.
      * If the batch starts a db tx, it acquires the semaphore and sets this to true, keeping the semaphore
@@ -78,6 +84,10 @@ private:
         OVERWRITE,
         ERASE,
         ERASE_PREFIX,
+        INSERT_TX,
+        UPDATE_FULL_TX,
+        UPDATE_TX_REPLACED_BY,
+        UPDATE_TX_STATE,
     };
 
     void MaybeSetupSQLStatement(SQLiteStatementType type);
@@ -96,6 +106,34 @@ public:
     ~SQLiteBatch() override;
 
     void SetExecHandler(std::unique_ptr<SQliteExecHandler>&& handler) { m_exec_handler = std::move(handler); }
+
+    bool WriteTx(const Txid& txid,
+                 const std::span<std::byte>& serialized_tx,
+                 const std::optional<std::string>& comment,
+                 const std::optional<std::string>& comment_to,
+                 const std::optional<Txid>& replaces,
+                 const std::optional<Txid>& replaced_by,
+                 uint32_t timesmart,
+                 uint32_t timereceived,
+                 int64_t order_pos,
+                 const std::vector<std::string>& messages,
+                 const std::vector<std::string>& payment_requests,
+                 int32_t state_type,
+                 const std::vector<unsigned char>& state_data);
+    bool UpdateFullTx(const Txid& txid,
+                      const std::optional<std::string>& comment,
+                      const std::optional<std::string>& comment_to,
+                      const std::optional<Txid>& replaces,
+                      const std::optional<Txid>& replaced_by,
+                      uint32_t timesmart,
+                      uint32_t timereceived,
+                      int64_t order_pos,
+                      const std::vector<std::string>& messages,
+                      const std::vector<std::string>& payment_requests,
+                      int32_t state_type,
+                      const std::vector<unsigned char>& state_data);
+    bool UpdateTxReplacedBy(const Txid& txid, const Txid& replaced_by);
+    bool UpdateTxState(const Txid& txid, int32_t state_type, const std::vector<unsigned char>& state_data);
 
     void Close() override;
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -37,6 +37,21 @@ public:
     ~SQLiteCursor() override;
 
     Status Next(DataStream& key, DataStream& value) override;
+    Status NextTx(
+        Txid& txid,
+        DataStream& ser_tx,
+        std::optional<std::string>& comment,
+        std::optional<std::string>& comment_to,
+        std::optional<Txid>& replaces,
+        std::optional<Txid>& replaced_by,
+        uint32_t& timesmart,
+        uint32_t& timereceived,
+        int64_t& order_pos,
+        std::vector<std::string>& messages,
+        std::vector<std::string>& payment_requests,
+        int32_t& state_type,
+        std::vector<unsigned char>& state_data
+    );
 };
 
 /** Class responsible for executing SQL statements in SQLite databases.
@@ -139,6 +154,7 @@ public:
 
     std::unique_ptr<DatabaseCursor> GetNewCursor() override;
     std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(std::span<const std::byte> prefix) override;
+    std::unique_ptr<DatabaseCursor> GetNewTransactionsCursor() override;
     bool TxnBegin() override;
     bool TxnCommit() override;
     bool TxnAbort() override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -105,6 +105,8 @@ public:
     bool TxnCommit() override;
     bool TxnAbort() override;
     bool HasActiveTxn() override { return m_txn; }
+
+    bool CreateTxsTable();
 };
 
 /** An instance of this class represents one SQLite3 database.
@@ -113,6 +115,8 @@ class SQLiteDatabase : public WalletDatabase
 {
 private:
     friend class SQLiteBatch;
+
+    bool m_has_txs_table{false};
 
     const fs::path m_dir_path;
 
@@ -182,6 +186,9 @@ public:
 
     sqlite3* m_db{nullptr};
     bool m_use_unsafe_sync;
+
+    bool HasTxsTable() const;
+    bool CreateTxsTable();
 };
 
 /** An in-memory SQLiteDatabase. Used as a temporary build artifact where no

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3128,7 +3128,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     }
 
     // Initialize version key.
-    if(!WalletBatch(walletInstance->GetDatabase()).WriteVersion(CLIENT_VERSION)) {
+    if(!WalletBatch(walletInstance->GetDatabase()).WriteLastOpenedVersion()) {
         error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
         return nullptr;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4016,6 +4016,13 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         }
     }
 
+    // Set the client features
+    local_wallet_batch.WriteLastOpenedVersion();
+    local_wallet_batch.WriteLastOpenedFeatures();
+    if (HasEncryptionKeys()) {
+        local_wallet_batch.WriteLastDecryptedFeatures();
+    }
+
     // Get best block locator so that we can copy it to the watchonly and solvables
     // Note: The best block locator was introduced in #152 so ancient wallets do not have it
     CBlockLocator best_block_locator;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -626,6 +626,16 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
             if (Unlock(plain_master_key)) {
                 // Now that we've unlocked, upgrade the descriptor cache
                 UpgradeDescriptorCache();
+
+                if (!m_last_decrypted_features || *m_last_decrypted_features != WALLET_CLIENT_FEATURES) {
+                    // Write the current wallet client features to LAST_DECRYPTED_FEATURES.
+                    // This must be done after all automatic upgrades so that those upgrades can be
+                    // performed in an upgrade-downgrade-upgrade scenario.
+                    WalletBatch batch(GetDatabase());
+                    batch.WriteLastDecryptedFeatures();
+                    SetLastDecryptedFeatures(WALLET_CLIENT_FEATURES);
+                }
+
                 return true;
             }
         }
@@ -4647,4 +4657,8 @@ void CWallet::DisconnectChainNotifications()
     }
 }
 
+void CWallet::SetLastDecryptedFeatures(uint64_t features)
+{
+    m_last_decrypted_features = features;
+}
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -946,6 +946,7 @@ DBErrors CWallet::ReorderTransactions()
 
             if (!batch.WriteTx(*pwtx))
                 return DBErrors::LOAD_FAIL;
+            if (!batch.SQLUpdateFullTx(*pwtx)) return DBErrors::LOAD_FAIL;
         }
         else
         {
@@ -964,6 +965,7 @@ DBErrors CWallet::ReorderTransactions()
             // Since we're changing the order, write it back
             if (!batch.WriteTx(*pwtx))
                 return DBErrors::LOAD_FAIL;
+            if (!batch.SQLUpdateFullTx(*pwtx)) return DBErrors::LOAD_FAIL;
         }
     }
     batch.WriteOrderPosNext(nOrderPosNext);
@@ -1015,6 +1017,10 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
 
     bool success = true;
     if (!batch.WriteTx(wtx)) {
+        WalletLogPrintf("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
+        success = false;
+    }
+    if (!batch.SQLUpdateTxReplacedBy(wtx)) {
         WalletLogPrintf("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
         success = false;
     }
@@ -1125,6 +1131,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             // Break caches since we have changed the state
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
+            batch.SQLUpdateTxState(*desc_tx);
             MarkInputsDirty(desc_tx->tx);
             for (unsigned int i = 0; i < desc_tx->tx->vout.size(); ++i) {
                 COutPoint outpoint(desc_tx->GetHash(), i);
@@ -1147,9 +1154,14 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     WalletLogPrintf("AddToWallet %s %s %s", hash.ToString(), status, TxStateString(state));
 
     // Write to disk
-    if (fInsertedNew || fUpdated)
-        if (!batch.WriteTx(wtx))
-            return nullptr;
+    if (fInsertedNew) {
+        if (!batch.WriteTx(wtx)) return nullptr;
+        if (!batch.SQLWriteTx(wtx)) return nullptr;
+    }
+    if (fUpdated) {
+        if (!batch.WriteTx(wtx)) return nullptr;
+        if (!batch.SQLUpdateTxState(wtx)) return nullptr;
+    }
 
     // Break debit/credit balance caches:
     wtx.MarkDirty();
@@ -1414,7 +1426,10 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
         TxUpdate update_state = try_updating_state(wtx);
         if (update_state != TxUpdate::UNCHANGED) {
             wtx.MarkDirty();
-            if (batch) batch->WriteTx(wtx);
+            if (batch) {
+                batch->WriteTx(wtx);
+                batch->SQLUpdateTxState(wtx);
+            }
             // Iterate over all its outputs, and update those tx states as well (if applicable)
             for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
@@ -4076,6 +4091,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
                     return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex())};
                 }
                 watchonly_batch->WriteTx(data.watchonly_wallet->mapWallet.at(hash));
+                watchonly_batch->SQLWriteTx(data.watchonly_wallet->mapWallet.at(hash));
                 // Mark as to remove from the migrated wallet only if it does not also belong to it
                 if (!is_mine) {
                     txids_to_delete.push_back(hash);
@@ -4089,6 +4105,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         }
         // Rewrite the transaction so that anything that may have changed about it in memory also persists to disk
         local_wallet_batch.WriteTx(*wtx);
+        local_wallet_batch.SQLWriteTx(*wtx);
     }
 
     // Do the removes

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -436,6 +436,9 @@ private:
     //! Set of both spent and unspent transaction outputs owned by this wallet
     std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
 
+    //! Features of the last client to decrypt this wallet
+    std::optional<uint64_t> m_last_decrypted_features;
+
     /**
      * Catch wallet up to current chain, scanning new blocks, updating the best
      * block locator and m_last_block_processed, and registering for
@@ -1087,6 +1090,9 @@ public:
 
     //! Disconnect chain notifications and wait for all notifications to be processed
     void DisconnectChainNotifications();
+
+    //! Set the features of the last client to decrypt this wallet
+    void SetLastDecryptedFeatures(uint64_t features);
 };
 
 /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -107,6 +107,13 @@ bool WalletBatch::EraseTx(Txid hash)
     return EraseIC(std::make_pair(DBKeys::TX, hash.ToUint256()));
 }
 
+bool WalletBatch::CreateTxsTable()
+{
+    SQLiteBatch* batch = dynamic_cast<SQLiteBatch*>(m_batch.get());
+    if (!batch) return true;
+    return batch->CreateTxsTable();
+}
+
 bool WalletBatch::WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite)
 {
     return WriteIC(std::make_pair(DBKeys::KEYMETA, pubkey), meta, overwrite);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string LAST_OPENED_FEATURES{"lastopenedfeatures"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MINVERSION{"minversion"};
@@ -1111,6 +1112,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
+    std::optional<uint64_t> last_client_features;
+    if (last_client >= VERSION_LAST_CLIENT_FEATURES) {
+        // Features of last client to open this wallet
+        if (uint64_t features; m_batch->Read(DBKeys::LAST_OPENED_FEATURES, features)) {
+            last_client_features = features;
+        }
+    }
+
     try {
         // Load wallet flags, so they are known when processing other records.
         // The FLAGS key is absent during wallet creation.
@@ -1194,6 +1203,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (!has_last_client || last_client != VERSION_LATEST) {
         WriteLastOpenedVersion();
     }
+    // Record the current client features as the features of the last client to successfully open this wallet file.
+    if (!last_client_features || *last_client_features != WALLET_CLIENT_FEATURES) {
+        WriteLastOpenedFeatures();
+    }
 
     return result;
 }
@@ -1258,6 +1271,11 @@ bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 bool WalletBatch::WriteLastOpenedVersion()
 {
     return WriteIC(DBKeys::VERSION, VERSION_LATEST);
+}
+
+bool WalletBatch::WriteLastOpenedFeatures()
+{
+    return WriteIC(DBKeys::LAST_OPENED_FEATURES, WALLET_CLIENT_FEATURES);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -764,7 +764,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
             value >> desc;
         } catch (const std::ios_base::failure& e) {
             strErr = strprintf("Error: Unrecognized descriptor found in wallet %s. ", pwallet->GetName());
-            strErr += (last_client > CLIENT_VERSION) ? "The wallet might have been created on a newer version. " :
+            strErr += (last_client > VERSION_LATEST) ? "The wallet might have been created on a newer version. " :
                     "The database might be corrupted or the software version is not compatible with one of your wallet descriptors. ";
             strErr += "Please try running the latest software version";
             // Also include error details
@@ -1107,7 +1107,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     LOCK(pwallet->cs_wallet);
 
     // Last client version to open this wallet
-    int last_client = CLIENT_VERSION;
+    int last_client = VERSION_LATEST;
     bool has_last_client = m_batch->Read(DBKeys::VERSION, last_client);
     if (has_last_client) pwallet->WalletLogPrintf("Last client version = %d\n", last_client);
 
@@ -1161,9 +1161,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     if (result != DBErrors::LOAD_OK)
         return result;
 
-    if (!has_last_client || last_client != CLIENT_VERSION) // Update
-        this->WriteVersion(CLIENT_VERSION);
-
     if (any_unordered)
         result = pwallet->ReorderTransactions();
 
@@ -1188,6 +1185,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             }
         }
         pwallet->mapMasterKeys.clear();
+    }
+
+
+    // Record the current client version as the last version to successfully open this wallet file
+    // This must always be done after all automatic upgrades so that those upgrades can be performed
+    // in an upgrade-downgrade-upgrade scenario.
+    if (!has_last_client || last_client != VERSION_LATEST) {
+        WriteLastOpenedVersion();
     }
 
     return result;
@@ -1248,6 +1253,11 @@ bool WalletBatch::EraseAddressData(const CTxDestination& dest)
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 {
     return WriteIC(DBKeys::FLAGS, flags);
+}
+
+bool WalletBatch::WriteLastOpenedVersion()
+{
+    return WriteIC(DBKeys::VERSION, VERSION_LATEST);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string LAST_DECRYPTED_FEATURES{"lastdecryptedfeatures"};
 const std::string LAST_OPENED_FEATURES{"lastopenedfeatures"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
@@ -1118,6 +1119,11 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         if (uint64_t features; m_batch->Read(DBKeys::LAST_OPENED_FEATURES, features)) {
             last_client_features = features;
         }
+
+        // Features of last client to decrypt this wallet
+        if (uint64_t last_decrypted; m_batch->Read(DBKeys::LAST_DECRYPTED_FEATURES, last_decrypted)) {
+            pwallet->SetLastDecryptedFeatures(last_decrypted);
+        }
     }
 
     try {
@@ -1276,6 +1282,11 @@ bool WalletBatch::WriteLastOpenedVersion()
 bool WalletBatch::WriteLastOpenedFeatures()
 {
     return WriteIC(DBKeys::LAST_OPENED_FEATURES, WALLET_CLIENT_FEATURES);
+}
+
+bool WalletBatch::WriteLastDecryptedFeatures()
+{
+    return WriteIC(DBKeys::LAST_DECRYPTED_FEATURES, WALLET_CLIENT_FEATURES);
 }
 
 bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1054,6 +1054,85 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
     return result;
 }
 
+static LoadResult LoadTxsTable(CWallet* pwallet, WalletBatch& wbatch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+{
+    LoadResult result;
+
+    if (!wbatch.HasTxsTable()) {
+        return result;
+    }
+
+    DatabaseBatch& batch = wbatch.GetDatabaseBatch();
+
+    std::unique_ptr<DatabaseCursor> dbcursor = batch.GetNewTransactionsCursor();
+    SQLiteCursor* cursor = dynamic_cast<SQLiteCursor*>(dbcursor.get());
+    if (!cursor) {
+        pwallet->WalletLogPrintf("Error getting database cursor for 'transactions' table\n");
+        result.m_result = DBErrors::CORRUPT;
+        return result;
+    }
+
+    while (true) {
+        Txid txid;
+        DataStream ser_tx;
+        std::optional<std::string> comment;
+        std::optional<std::string> comment_to;
+        std::optional<Txid> replaces;
+        std::optional<Txid> replaced_by;
+        uint32_t timesmart;
+        uint32_t timereceived;
+        int64_t order_pos;
+        std::vector<std::string> messages;
+        std::vector<std::string> payment_requests;
+        int32_t state_type;
+        std::vector<unsigned char> state_data;
+
+        DatabaseCursor::Status status = cursor->NextTx(txid, ser_tx, comment, comment_to, replaces, replaced_by, timesmart, timereceived, order_pos, messages, payment_requests, state_type, state_data);
+        if (status == DatabaseCursor::Status::DONE) {
+            break;
+        } else if (status == DatabaseCursor::Status::FAIL) {
+            pwallet->WalletLogPrintf("Error reading next 'transactions' table record for wallet database\n");
+            result.m_result = DBErrors::CORRUPT;
+            return result;
+        }
+
+        // LoadToWallet call below creates a new CWalletTx that fill_wtx
+        // callback fills with transaction metadata.
+        auto fill_wtx = [&](CWalletTx& wtx, bool new_tx) {
+            if(!new_tx) {
+                // There's some corruption here since the tx we just tried to load was already in the wallet.
+                pwallet->WalletLogPrintf("Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.");
+                result.m_result = DBErrors::CORRUPT;
+                return false;
+            }
+
+            ser_tx >> TX_WITH_WITNESS(wtx.tx);
+            wtx.m_comment = comment;
+            wtx.m_comment_to = comment_to;
+            wtx.m_replaces_txid = replaces;
+            wtx.m_replaced_by_txid = replaced_by;
+            wtx.nTimeSmart = timesmart;
+            wtx.nTimeReceived = timereceived;
+            wtx.nOrderPos = order_pos;
+            wtx.m_messages = messages;
+            wtx.m_payment_requests = payment_requests;
+            wtx.m_state = ConstructTxState(state_type, state_data);
+
+            if (wtx.GetHash() != txid) {
+                return false;
+            }
+
+            return true;
+        };
+        if (!pwallet->LoadToWallet(txid, fill_wtx)) {
+            // Use std::max as fill_wtx may have already set result to CORRUPT
+            result.m_result = std::max(result.m_result, DBErrors::NEED_RESCAN);
+        }
+        ++result.m_records;
+    }
+    return result;
+}
+
 static DBErrors LoadTxRecords(CWallet* pwallet, WalletBatch& wbatch, bool& any_unordered, std::optional<uint64_t> last_client_features) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
@@ -1061,47 +1140,67 @@ static DBErrors LoadTxRecords(CWallet* pwallet, WalletBatch& wbatch, bool& any_u
 
     DatabaseBatch& batch = wbatch.GetDatabaseBatch();
 
-    // Load tx record
-    any_unordered = false;
-    LoadResult tx_res = LoadRecords(pwallet, batch, DBKeys::TX,
-        [&any_unordered] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
-        DBErrors result = DBErrors::LOAD_OK;
-        Txid hash;
-        key >> hash;
-        // LoadToWallet call below creates a new CWalletTx that fill_wtx
-        // callback fills with transaction metadata.
-        auto fill_wtx = [&](CWalletTx& wtx, bool new_tx) {
-            if(!new_tx) {
-                // There's some corruption here since the tx we just tried to load was already in the wallet.
-                err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
-                result = DBErrors::CORRUPT;
-                return false;
-            }
-            value >> wtx;
-            if (wtx.GetHash() != hash)
-                return false;
-
-            if (wtx.nOrderPos == -1)
-                any_unordered = true;
-
-            return true;
-        };
-        if (!pwallet->LoadToWallet(hash, fill_wtx)) {
-            // Use std::max as fill_wtx may have already set result to CORRUPT
-            result = std::max(result, DBErrors::NEED_RESCAN);
-        }
-        return result;
-    });
-    result = std::max(result, tx_res.m_result);
-
     if (!last_client_features || !(*last_client_features & WALLET_CLIENT_TRANSACTIONS_TABLE)) {
-        // Upgrade the wallet to use the database as a SQL database by rewriting all txs into the transactions table
-        pwallet->WalletLogPrintf("Performing automatic upgrade to using transactions table\n");
-        wbatch.CreateTxsTable();
-        for (const auto& [_, tx] : pwallet->mapWallet) {
-            wbatch.SQLWriteTx(tx);
+        // Read tx records
+        std::unordered_map<Txid, CWalletTx, SaltedTxidHasher> txs;
+        LoadResult tx_res = LoadRecords(pwallet, batch, DBKeys::TX,
+            [&txs, &any_unordered] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+            Txid hash;
+            key >> hash;
+            // For descriptor wallets, do not load the transactions into the wallet
+            // Instead place them into txs so that they can be upgraded to the transactions table
+            if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+                const auto& [hash_wtx, _] = txs.emplace(std::piecewise_construct, std::forward_as_tuple(hash), std::forward_as_tuple(nullptr, TxStateInactive{}));
+                CWalletTx& wtx = hash_wtx->second;
+                value >> wtx;
+                if (wtx.GetHash() != hash) {
+                    return DBErrors::CORRUPT;
+                }
+
+                return DBErrors::LOAD_OK;
+            } else {
+                DBErrors result = DBErrors::LOAD_OK;
+                // LoadToWallet call below creates a new CWalletTx that fill_wtx
+                // callback fills with transaction metadata.
+                auto fill_wtx = [&](CWalletTx& wtx, bool new_tx) {
+                    if(!new_tx) {
+                        // There's some corruption here since the tx we just tried to load was already in the wallet.
+                        err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
+                        result = DBErrors::CORRUPT;
+                        return false;
+                    }
+                    value >> wtx;
+                    if (wtx.GetHash() != hash)
+                        return false;
+
+                    if (wtx.nOrderPos == -1)
+                        any_unordered = true;
+
+                    return true;
+                };
+                if (!pwallet->LoadToWallet(hash, fill_wtx)) {
+                    // Use std::max as fill_wtx may have already set result to CORRUPT
+                    result = std::max(result, DBErrors::NEED_RESCAN);
+                }
+                return result;
+            }
+        });
+        result = std::max(result, tx_res.m_result);
+
+        if (result != DBErrors::CORRUPT && pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+            // Upgrade the wallet to use the database as a SQL database by rewriting all txs into the transactions table
+            pwallet->WalletLogPrintf("Performing automatic upgrade to using transactions table\n");
+            wbatch.CreateTxsTable();
+            for (const auto& [_, tx] : txs) {
+                wbatch.SQLWriteTx(tx);
+            }
         }
     }
+
+    // Load the transactions table
+    // Note that we do not need to handle or set any_unordered for this upgrade. All descriptor wallets will have tx records which have nOrderPos set.
+    LoadResult tx_table_res = LoadTxsTable(pwallet, wbatch);
+    result = std::max(result, tx_table_res.m_result);
 
     // Load locked utxo record
     LoadResult locked_utxo_res = LoadRecords(pwallet, batch, DBKeys::LOCKED_UTXO,

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1054,10 +1054,12 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
     return result;
 }
 
-static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_unordered) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+static DBErrors LoadTxRecords(CWallet* pwallet, WalletBatch& wbatch, bool& any_unordered, std::optional<uint64_t> last_client_features) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
+
+    DatabaseBatch& batch = wbatch.GetDatabaseBatch();
 
     // Load tx record
     any_unordered = false;
@@ -1091,6 +1093,15 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         return result;
     });
     result = std::max(result, tx_res.m_result);
+
+    if (!last_client_features || !(*last_client_features & WALLET_CLIENT_TRANSACTIONS_TABLE)) {
+        // Upgrade the wallet to use the database as a SQL database by rewriting all txs into the transactions table
+        pwallet->WalletLogPrintf("Performing automatic upgrade to using transactions table\n");
+        wbatch.CreateTxsTable();
+        for (const auto& [_, tx] : pwallet->mapWallet) {
+            wbatch.SQLWriteTx(tx);
+        }
+    }
 
     // Load locked utxo record
     LoadResult locked_utxo_res = LoadRecords(pwallet, batch, DBKeys::LOCKED_UTXO,
@@ -1230,7 +1241,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         result = std::max(LoadDecryptionKeys(pwallet, *m_batch), result);
 
         // Load tx records
-        result = std::max(LoadTxRecords(pwallet, *m_batch, any_unordered), result);
+        result = std::max(LoadTxRecords(pwallet, *this, any_unordered, last_client_features), result);
     } catch (std::runtime_error& e) {
         // Exceptions that can be ignored or treated as non-critical are handled by the individual loading functions.
         // Any uncaught exceptions will be caught here and treated as critical.

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -301,6 +301,8 @@ public:
     //! Registers db txn callback functions
     void RegisterTxnListener(const DbTxnListener& l);
 
+    DatabaseBatch& GetDatabaseBatch() { return *m_batch; }
+
 private:
     std::unique_ptr<DatabaseBatch> m_batch;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -233,6 +233,8 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(Txid hash);
 
+    bool CreateTxsTable();
+
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, bool overwrite);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -233,6 +233,11 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(Txid hash);
 
+    bool SQLWriteTx(const CWalletTx& wtx);
+    bool SQLUpdateFullTx(const CWalletTx& wtx);
+    bool SQLUpdateTxReplacedBy(const CWalletTx& wtx);
+    bool SQLUpdateTxState(const CWalletTx& wtx);
+    bool HasTxsTable() const;
     bool CreateTxsTable();
 
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, bool overwrite);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -69,6 +69,7 @@ extern const std::string FLAGS;
 extern const std::string HDCHAIN;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string LAST_OPENED_FEATURES;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MINVERSION;
@@ -271,11 +272,14 @@ public:
 
     //! Write the current client version in the VERSION record
     bool WriteLastOpenedVersion();
+    //! Write the current client features in the LAST_OPENED_FEATURES record
+    bool WriteLastOpenedFeatures();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);
 
     bool WriteWalletFlags(uint64_t flags);
+
     //! Begin a new transaction
     bool TxnBegin();
     //! Commit current transaction

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -69,6 +69,7 @@ extern const std::string FLAGS;
 extern const std::string HDCHAIN;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string LAST_DECRYPTED_FEATURES;
 extern const std::string LAST_OPENED_FEATURES;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
@@ -274,6 +275,8 @@ public:
     bool WriteLastOpenedVersion();
     //! Write the current client features in the LAST_OPENED_FEATURES record
     bool WriteLastOpenedFeatures();
+    //! Write the current wallet client features to the LAST_DECRYPTED_FEATURES record
+    bool WriteLastDecryptedFeatures();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -269,8 +269,8 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
 
-    //! Write the given client_version.
-    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, CLIENT_VERSION); }
+    //! Write the current client version in the VERSION record
+    bool WriteLastOpenedVersion();
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -65,7 +65,18 @@ enum WalletClientVersion : int32_t {
     // OR with all versions to set bit 30
     VERSION_MASK = (1ULL << 30),
 
-    VERSION_LATEST = VERSION_MASK
+    // The wallet client supports the records for LastClientFeatures
+    VERSION_LAST_CLIENT_FEATURES = (1ULL << 0) | VERSION_MASK,
+
+    VERSION_LATEST = VERSION_LAST_CLIENT_FEATURES
+};
+
+enum LastClientFeatures : uint64_t {
+    // Flags indicating the automatic upgrade features supported by the wallet client that last opened a wallet file
+    // New automatic upgrades must define a flag here so that upgrade-downgrade-upgrade can be detected to determine whether
+    // an automatic upgrade should be performed.
+
+    WALLET_CLIENT_FEATURES = 0
 };
 
 //! Get the path of the wallet directory.

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -56,6 +56,18 @@ enum WalletFlags : uint64_t {
     WALLET_FLAG_EXTERNAL_SIGNER = (1ULL << 35),
 };
 
+// Version numbers for the wallet client that opens a wallet
+// These numbers will be written as the last client version in the "version" record and can be used to detect
+// when an upgrade-downgrade-upgrade was performed. However, we should prefer to use LastClientFeatures rather
+// than new version numbers.
+// New version numbers must be greater than 299900 which is guaranteed by setting bit 30
+enum WalletClientVersion : int32_t {
+    // OR with all versions to set bit 30
+    VERSION_MASK = (1ULL << 30),
+
+    VERSION_LATEST = VERSION_MASK
+};
+
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -75,8 +75,9 @@ enum LastClientFeatures : uint64_t {
     // Flags indicating the automatic upgrade features supported by the wallet client that last opened a wallet file
     // New automatic upgrades must define a flag here so that upgrade-downgrade-upgrade can be detected to determine whether
     // an automatic upgrade should be performed.
+    WALLET_CLIENT_TRANSACTIONS_TABLE = 1 << 0,
 
-    WALLET_CLIENT_FEATURES = 0
+    WALLET_CLIENT_FEATURES = WALLET_CLIENT_TRANSACTIONS_TABLE
 };
 
 //! Get the path of the wallet directory.

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -275,7 +275,11 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                     continue
                 # Also try to reopen on master after opening on old
                 for n in [node, node_master]:
-                    n.loadwallet(wallet_name)
+                    if self.major_version_at_least(node, 24) and n == node_master:
+                        with n.assert_debug_log(expected_msgs=["Performing automatic upgrade to using transactions table"], unexpected_msgs=["CREATE TABLE transactions"]):
+                            n.loadwallet(wallet_name)
+                    else:
+                        n.loadwallet(wallet_name)
                     wallet = n.get_wallet_rpc(wallet_name)
                     info = wallet.getwalletinfo()
                     if wallet_name == "w1":
@@ -348,7 +352,9 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             old_flags = self.inspect_sqlite_db(backup_path, get_flags)
 
             # Restore the wallet to master
-            load_res = node_master.restorewallet(wallet_name, backup_path)
+            with node_master.assert_debug_log(expected_msgs=["CREATE TABLE transactions", "Performing automatic upgrade to using transactions table"]):
+                load_res = node_master.restorewallet(wallet_name, backup_path)
+
             # There should be no warnings
             assert "warnings" not in load_res
 

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -20,6 +20,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
+WALLET_CLIENT_VERSION = 0x40000000
 
 
 class CreateWalletTest(BitcoinTestFramework):
@@ -192,8 +193,7 @@ class CreateWalletTest(BitcoinTestFramework):
         self.log.info("Check that the version number is being logged correctly")
 
         # Craft the expected version message.
-        client_version = node.getnetworkinfo()["version"]
-        version_message = f"Last client version = {client_version}"
+        version_message = f"Last client version = {WALLET_CLIENT_VERSION}"
 
         # Should not be logged when creating.
         with node.assert_debug_log(expected_msgs=[], unexpected_msgs=[version_message]):

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -20,7 +20,7 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
-WALLET_CLIENT_VERSION = 0x40000000
+WALLET_CLIENT_VERSION = 0x40000001
 
 
 class CreateWalletTest(BitcoinTestFramework):


### PR DESCRIPTION
The wallet uses SQLite as a key-value store even though SQLite is a powerful relational database engine. This causes us numerous headaches due to the need to serialize multiple fields together, and since record read from the database during loading can come in any order.

Notably, for transactions, if we were able to load them in the transaction order assigned by the wallet, PRs like #27865 would be a bit simpler and easier to reason about.

This PR makes it possible for us to do that by storing transactions in a separate table. This table has a column for each field in `CWalletTx`, which lets us use a SQL statement like `SELECT * FROM transactions ORDER BY pos` which guarantees us the order in which the transactions are loaded into the wallet.

The eventual goal is to use SQLite as a relational database with tables that store our keys and other metadata that can reference each other so that the wallet doesn't just use the database as a storage mechanism. But that is still a work in progress.

This PR makes use of the last client opened features introduced in #32895 to determine when the old record style needs to be upgraded to the new transactions table. This should give us sufficient upgrade-downgrade-upgrade handling to not lose any funds.

Depends on #32895, #33033