### PR TITLE
contrib: drop use of `PermissionsStartOnly` & `Group=`

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -25,8 +25,7 @@ ExecStart=/usr/bin/bitcoind -pid=/run/bitcoind/bitcoind.pid \
                             -shutdownnotify='systemd-notify --stopping'
 
 # Make sure the config directory is readable by the service user
-PermissionsStartOnly=true
-ExecStartPre=/bin/chgrp bitcoin /etc/bitcoin
+ExecStartPre=!/bin/chgrp bitcoin /etc/bitcoin
 
 # Process management
 ####################

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -44,7 +44,6 @@ TimeoutStopSec=600
 
 # Run as bitcoin:bitcoin
 User=bitcoin
-Group=bitcoin
 
 # /run/bitcoind
 RuntimeDirectory=bitcoind


### PR DESCRIPTION
> This removes the redundant 'Group=' directive and replaces the deprecated 'PermissionsStartOnly' directive.

Picks up #16994 / #19513. The concern in both of these PRs was changing this too early, while systemd v240 was still prelevant on supported systems. That was ~5 years ago, and from what I can see, no modern/supported OS is still using an older systemd.

Separately , I am wondering if we should move these files out to https://github.com/bitcoin-core/packaging/.