### PR TITLE
depends: disable variables, rules and suffixes.

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,4 +1,6 @@
 .NOTPARALLEL :
+# Disable builtin rules and suffixes.
+MAKEFLAGS += --no-builtin-rules
 
 # Pattern rule to print variables, e.g. make print-top_srcdir
 print-%: FORCE

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,6 +1,6 @@
 .NOTPARALLEL :
-# Disable builtin rules and suffixes.
-MAKEFLAGS += --no-builtin-rules
+# Disable builtin variables, rules and suffixes.
+MAKEFLAGS += --no-builtin-rules --no-builtin-variables
 
 # Pattern rule to print variables, e.g. make print-top_srcdir
 print-%: FORCE


### PR DESCRIPTION
This picks up #22126. Previously, this was more complicated to do, as depends packages (upnp, natpmp) used the rules being disabled. Those packages have since been removed.

When there is no rule to build a target in the makefile, make looks for a builtin rule. When `-r` is specified make no longer performs this lookup.

E.g. the following in an excerpt from `make -d` output. Here, make looks for a rule to build `all`.
```bash
Considering target file 'all'.
 File 'all' does not exist.
 Looking for an implicit rule for 'all'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.o'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.c'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.cc'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.C'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.cpp'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.p'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.f'.
...
```
Many more lines like this are omitted.

Because this build system does not use make builtin rules or suffixes, there is no benefit in having builtin rules enabled.

There are 2 benefits in having builtin rules disabled.

1. Improves performance by eliminating redundant lookups.
2. Simplifies troubleshooting by reducing the output of make `-d` or make `-p`.

Also see: https://www.gnu.org/software/make/manual/make.html#index-_002d_002dno_002dbuiltin_002drules.