### PR TITLE
[29.x] backport #32069

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -55,6 +55,7 @@ Notable changes
 
 ### Test
 
+- #32069 test: fix intermittent failure in wallet_reorgsrestore.py
 - #32286 test: Handle empty string returned by CLI as None in RPC tests
 - #32312 test: Fix feature_pruning test after nTime typo fix
 - #32336 test: Suppress upstream -Wduplicate-decl-specifier in bpfcc

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -443,6 +443,11 @@ class TestNode():
             kwargs["expected_ret_code"] = 1 if expect_error else 0  # Whether node shutdown return EXIT_FAILURE or EXIT_SUCCESS
         self.wait_until(lambda: self.is_node_stopped(**kwargs), timeout=timeout)
 
+    def kill_process(self):
+        self.process.kill()
+        self.wait_until_stopped(expected_ret_code=1 if platform.system() == "Windows" else -9)
+        assert self.is_node_stopped()
+
     def replace_in_config(self, replacements):
         """
         Perform replacements in the configuration file.

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -5,7 +5,6 @@
 """Test bitcoin-wallet."""
 
 import os
-import platform
 import random
 import stat
 import string
@@ -537,9 +536,7 @@ class ToolWalletTest(BitcoinTestFramework):
         # Next cause a bunch of writes by filling the keypool
         wallet.keypoolrefill(wallet.getwalletinfo()["keypoolsize"] + 100)
         # Lastly kill bitcoind so that the LSNs don't get reset
-        self.nodes[0].process.kill()
-        self.nodes[0].wait_until_stopped(expected_ret_code=1 if platform.system() == "Windows" else -9)
-        assert self.nodes[0].is_node_stopped()
+        self.nodes[0].kill_process()
 
         wallet_dump = self.nodes[0].datadir_path / "unclean_lsn.dump"
         self.assert_raises_tool_error("LSNs are not reset, this database is not completely flushed. Please reopen then close the database with a version that has BDB support", "-wallet=unclean_lsn", f"-dumpfile={wallet_dump}", "dump")

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -115,7 +115,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         assert_equal(wallet.gettransaction(coinbase_tx_id)['details'][0]['abandoned'], True)
 
         # Abort process abruptly to mimic an unclean shutdown (no chain state flush to disk)
-        node.process.kill()
+        node.kill_process()
 
         # Restart the node and confirm that it has not persisted the last chain state changes to disk
         self.start_node(0)


### PR DESCRIPTION
Backport https://github.com/bitcoin/bitcoin/pull/32069 to 29. This is a test flakiness fix for https://github.com/bitcoin/bitcoin/pull/31757, which was backported to 29 in https://github.com/bitcoin/bitcoin/pull/32589.