### PR TITLE
test: add assertions to SRD max weight test

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -1223,7 +1223,7 @@ BOOST_AUTO_TEST_CASE(srd_tests)
 
     {
         // ################################################################################################################
-        // 3) Test selection when some coins surpass the max allowed weight while others not. --> must find a good solution
+        // 3) Test that SRD result does not exceed the max weight
         // ################################################################################################################
         CAmount target = 25.33L * COIN;
         int max_selection_weight = 10000; // WU
@@ -1238,6 +1238,7 @@ BOOST_AUTO_TEST_CASE(srd_tests)
             return available_coins;
         });
         BOOST_CHECK(res);
+        BOOST_CHECK(res->GetWeight() <= max_selection_weight);
     }
 }
 


### PR DESCRIPTION
Replace generic assertion with a result specific assertion showing the correctness of the solution found.  If the max weight parameter is exceeded, the least valuable `UTXOs` are removed from the result. Therefore, only the most valued _encountered_ `UTXO's` are selected. While the smallest set would include all the most valued `UTXO's`, in the case of the test there is one high value `UTXO` that is never found before the target value is reached.

Correct the test comment to be more specific about why the assertion is a good result.