### PR TITLE
Allow disabling default consistency checks on regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -44,6 +44,7 @@ void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& option
 void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& options)
 {
     if (auto value = args.GetBoolArg("-fastprune")) options.fastprune = *value;
+    if (auto value = args.GetBoolArg("-disableconsistencychecks")) options.default_consistency_checks = !*value;
     if (HasTestOption(args, "bip94")) options.enforce_bip94 = true;
 
     for (const std::string& arg : args.GetArgs("-testactivationheight")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -476,6 +476,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                              kernel::DEFAULT_XOR_BLOCKSDIR),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-fastprune", "Use smaller block files and lower minimum prune height for testing purposes", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-disableconsistencychecks", "Disables extra block indexes checks done in regtest", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
 #if HAVE_SYSTEM
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -586,7 +586,7 @@ public:
         vSeeds.clear();
         vSeeds.emplace_back("dummySeed.invalid.");
 
-        fDefaultConsistencyChecks = true;
+        fDefaultConsistencyChecks = opts.default_consistency_checks;
         m_is_mockable_chain = true;
 
         m_assumeutxo_data = {

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -143,6 +143,7 @@ public:
         std::unordered_map<Consensus::BuriedDeployment, int> activation_heights{};
         bool fastprune{false};
         bool enforce_bip94{false};
+        bool default_consistency_checks{true};
     };
 
     static std::unique_ptr<const CChainParams> RegTest(const RegTestOptions& options);


### PR DESCRIPTION
This stems from a twitter conversation with @instagibbs and @stickies-v (https://x.com/Stphnvlstk/status/1948352236456714326). Currently trying to sync a 2.5M block regtest chain and its only done 1.3M headers in a few days. This adds the option to disable `fDefaultConsistencyChecks` so it can sync at a normal speed. 

I am running this currently running this and it is infinitely faster and no longer using 100% CPU.