### PR TITLE
p2p: never check tx rejections by txid

### DIFF
--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -151,8 +151,8 @@ public:
     /** Check whether we already have this gtxid in:
      *  - mempool
      *  - orphanage
-     *  - m_recent_rejects
-     *  - m_recent_rejects_reconsiderable (if include_reconsiderable = true)
+     *  - m_recent_rejects (if wtxid)
+     *  - m_recent_rejects_reconsiderable (if wtxid and include_reconsiderable = true)
      *  - m_recent_confirmed_transactions
      *  */
     bool AlreadyHaveTx(const GenTxid& gtxid, bool include_reconsiderable);

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -152,13 +152,6 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         node.p2ps[0].send_txs_and_test(orphan_tx_pool, node, success=False)
         self.wait_until(lambda: len(node.getorphantxs()) >= 101)
 
-        self.log.info('Test orphan with rejected parents')
-        rejected_parent = CTransaction()
-        rejected_parent.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_2_invalid.txid_int, 0)))
-        rejected_parent.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
-        with node.assert_debug_log(['not keeping orphan with rejected parents {}'.format(rejected_parent.txid_hex)]):
-            node.p2ps[0].send_txs_and_test([rejected_parent], node, success=False)
-
         self.log.info('Test that a peer disconnection causes erase its transactions from the orphan pool')
         self.reconnect_p2p(num_connections=1)
         self.wait_until(lambda: len(node.getorphantxs()) == 0)

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -203,29 +203,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         peer1 = node.add_p2p_connection(PeerTxRelayer())
         peer2 = node.add_p2p_connection(PeerTxRelayer())
 
-        self.log.info("Test orphan handling when a nonsegwit parent is known to be invalid")
-        parent_low_fee_nonsegwit = self.wallet_nonsegwit.create_self_transfer(fee_rate=0)
-        assert_equal(parent_low_fee_nonsegwit["txid"], parent_low_fee_nonsegwit["tx"].wtxid_hex)
-        parent_other = self.wallet_nonsegwit.create_self_transfer()
-        child_nonsegwit = self.wallet_nonsegwit.create_self_transfer_multi(
-            utxos_to_spend=[parent_other["new_utxo"], parent_low_fee_nonsegwit["new_utxo"]])
-
-        # Relay the parent. It should be rejected because it pays 0 fees.
-        self.relay_transaction(peer1, parent_low_fee_nonsegwit["tx"])
-        assert parent_low_fee_nonsegwit["txid"] not in node.getrawmempool()
-
-        # Relay the child. It should not be accepted because it has missing inputs.
-        # Its parent should not be requested because its hash (txid == wtxid) has been added to the rejection filter.
-        self.relay_transaction(peer2, child_nonsegwit["tx"])
-        assert child_nonsegwit["txid"] not in node.getrawmempool()
-        assert not tx_in_orphanage(node, child_nonsegwit["tx"])
-
-        # No parents are requested.
-        self.nodes[0].bumpmocktime(GETDATA_TX_INTERVAL)
-        peer1.assert_never_requested(int(parent_other["txid"], 16))
-        peer2.assert_never_requested(int(parent_other["txid"], 16))
-        peer2.assert_never_requested(int(parent_low_fee_nonsegwit["txid"], 16))
-
         self.log.info("Test orphan handling when a segwit parent was invalid but may be retried with another witness")
         parent_low_fee = self.wallet.create_self_transfer(fee_rate=0)
         child_low_fee = self.wallet.create_self_transfer(utxo_to_spend=parent_low_fee["new_utxo"])
@@ -398,45 +375,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.nodes[0].bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY)
         assert tx_in_orphanage(node, orphan["tx"])
         peer.wait_for_parent_requests([int(missing_parent["txid"], 16)])
-
-    @cleanup
-    def test_orphan_inherit_rejection(self):
-        node = self.nodes[0]
-        peer1 = node.add_p2p_connection(PeerTxRelayer())
-        peer2 = node.add_p2p_connection(PeerTxRelayer())
-        peer3 = node.add_p2p_connection(PeerTxRelayer(wtxidrelay=False))
-
-        self.log.info("Test that an orphan with rejected parents, along with any descendants, cannot be retried with an alternate witness")
-        parent_low_fee_nonsegwit = self.wallet_nonsegwit.create_self_transfer(fee_rate=0)
-        assert_equal(parent_low_fee_nonsegwit["txid"], parent_low_fee_nonsegwit["tx"].wtxid_hex)
-        child = self.wallet.create_self_transfer(utxo_to_spend=parent_low_fee_nonsegwit["new_utxo"])
-        grandchild = self.wallet.create_self_transfer(utxo_to_spend=child["new_utxo"])
-        assert_not_equal(child["txid"], child["tx"].wtxid_hex)
-        assert_not_equal(grandchild["txid"], grandchild["tx"].wtxid_hex)
-
-        # Relay the parent. It should be rejected because it pays 0 fees.
-        self.relay_transaction(peer1, parent_low_fee_nonsegwit["tx"])
-        assert parent_low_fee_nonsegwit["txid"] not in node.getrawmempool()
-
-        # Relay the child. It should be rejected for having missing parents, and this rejection is
-        # cached by txid and wtxid.
-        self.relay_transaction(peer1, child["tx"])
-        assert_equal(0, len(node.getrawmempool()))
-        assert not tx_in_orphanage(node, child["tx"])
-        peer1.assert_never_requested(parent_low_fee_nonsegwit["txid"])
-
-        # Grandchild should also not be kept in orphanage because its parent has been rejected.
-        self.relay_transaction(peer2, grandchild["tx"])
-        assert_equal(0, len(node.getrawmempool()))
-        assert not tx_in_orphanage(node, grandchild["tx"])
-        peer2.assert_never_requested(child["txid"])
-        peer2.assert_never_requested(child["tx"].wtxid_hex)
-
-        # The child should never be requested, even if announced again with potentially different witness.
-        # Sync with ping to ensure orphans are reconsidered
-        peer3.send_and_ping(msg_inv([CInv(t=MSG_TX, h=int(child["txid"], 16))]))
-        self.nodes[0].bumpmocktime(TXREQUEST_TIME_SKIP)
-        peer3.assert_never_requested(child["txid"])
 
     @cleanup
     def test_same_txid_orphan(self):
@@ -852,7 +790,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.test_orphan_multiple_parents()
         self.test_orphans_overlapping_parents()
         self.test_orphan_of_orphan()
-        self.test_orphan_inherit_rejection()
         self.test_same_txid_orphan()
         self.test_same_txid_orphan_of_orphan()
         self.test_orphan_txid_inv()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -1342,11 +1342,11 @@ class SegWitTest(BitcoinTestFramework):
         tx3.vout.append(CTxOut(total_value - 1000, script_pubkey))
 
         # First we test this transaction against std_node
-        # making sure the txid is added to the reject filter
+        # making sure it is added to the reject filter
         self.std_node.announce_tx_and_wait_for_getdata(tx3)
         test_transaction_acceptance(self.nodes[1], self.std_node, tx3, with_witness=True, accepted=False, reason="bad-txns-nonstandard-inputs")
-        # Now the node will no longer ask for getdata of this transaction when advertised by same txid
-        self.std_node.announce_tx_and_wait_for_getdata(tx3, success=False)
+        # The node will still ask for this transaction when advertised by same txid, because it doesn't check rejections by txid.
+        self.std_node.announce_tx_and_wait_for_getdata(tx3, success=True)
 
         # Spending a higher version witness output is not allowed by policy,
         # even with the node that accepts non-standard txs.


### PR DESCRIPTION
This PR removes the rejection cache filtering part of all txid-based tx requests. In practice, this seems to only be used for orphan resolution because everybody supports wtxidrelay. And so in essence, this PR removes the logic that stops us from attempting orphan resolution when parents are found in the rejection filter.

Background:
We have 2 bloom filters for remembering transactions that we've rejected so we don't redownload them, `RecentRejectsFilter` and `RecentRejectsReconsiderableFilter`. This lets us save a little bit of bandwidth on rejected transactions, particularly if we have policy differences. It's not designed to stop attackers from wasting our download bandwidth, as they can create as many policy-invalid transactions with different witnesses as they want. We generally only put wtxids and not txids in them (see #18044), except for these cases:
(A) When we specifically know that the rejection reason is not due to the witness (however, this is only done for `!AreInputsStandard`, even though there are other cases we could apply)
(B) When the transaction has no witness, so its txid == wtxid
(C) (With #32379) When the transaction's witness has been stripped, so txid == wtxid
We check the filters to decide whether to send a getdata for an inv, whether we should validate a tx we just downloaded, and whether we should keep an orphan: we look the missing parents up by (prevout) txid and throw the orphan away if its parents were already rejected. That means there are very few cases where we save bandwidth by finding a txid in the filter.

Rationale: mainly that the additional complexity is not worth the bandwidth savings. TLDR: this case does not seem to ever hit in practice. Even if that is circumstantial, the number of transactions this filter could apply to is extremely small.

I collected some stats over a couple of weeks, setting mempoolexpiry to 1 hour to try to artificially increase orphan rates (though I don't know whether the effect is significant):
- I'm seeing 100% of peers support wtxidrelay. Bitcoin Core has been doing this since ~5 years ago. I'm sure there are some nodes that don't do it, but it'll probably be rare that we are surrounded by txidrelay peers and that we have a policy difference causing us to reject the transaction that they all send us.
- Orphan parent fetching was 3.64% of my transaction requests.
- 93.77% of all transactions I receive have witnesses (includes accepted and rejected ones). 96.20% of orphan parents I fetched had witnesses.
- I found no cases of already-rejected parent txids in the past week. This could be because all my peers have the same policy as me (which might not always be true), but the number of nonsegwit orphan parents in general is just so tiny - a few dozen requests per day.