### PR TITLE
test: refactor ValidWitnessMalleatedTx class to helper function

### DIFF
--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -22,14 +22,11 @@ from test_framework.util import (
 class MempoolWtxidTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
 
     def run_test(self):
         node = self.nodes[0]
-
-        self.log.info('Start with empty mempool and 101 blocks')
-        # The last 100 coinbase transactions are premature
-        blockhash = self.generate(node, 101)[0]
+        self.log.info('Start with pre-generated blocks')
+        blockhash = self.nodes[0].getblockhash(1)
         txid = node.getblock(blockhash=blockhash, verbosity=2)["tx"][0]["txid"]
         assert_equal(node.getmempoolinfo()['size'], 0)
 
@@ -56,7 +53,6 @@ class MempoolWtxidTest(BitcoinTestFramework):
         self.log.info("Submit child_one to the mempool")
         txid_submitted = node.sendrawtransaction(child_one.serialize().hex())
         assert_equal(node.getmempoolentry(txid_submitted)['wtxid'], child_one_wtxid)
-
         peer_wtxid_relay.wait_for_broadcast([child_one_wtxid])
         assert_equal(node.getmempoolinfo()["unbroadcastcount"], 0)
 

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -45,31 +45,27 @@ class MempoolWtxidTest(BitcoinTestFramework):
         self.generate(node, 1)
 
         peer_wtxid_relay = node.add_p2p_connection(P2PTxInvStore())
-        child_one_wtxid = child_one.wtxid_hex
-        child_one_txid = child_one.txid_hex
-        child_two_wtxid = child_two.wtxid_hex
-        child_two_txid = child_two.txid_hex
 
-        assert_equal(child_one_txid, child_two_txid)
-        assert_not_equal(child_one_wtxid, child_two_wtxid)
+        assert_equal(child_one.txid_hex, child_two.txid_hex)
+        assert_not_equal(child_one.wtxid_hex, child_two.wtxid_hex)
 
         self.log.info("Submit child_one to the mempool")
         txid_submitted = node.sendrawtransaction(child_one.serialize().hex())
-        assert_equal(node.getmempoolentry(txid_submitted)['wtxid'], child_one_wtxid)
-        peer_wtxid_relay.wait_for_broadcast([child_one_wtxid])
+        assert_equal(node.getmempoolentry(txid_submitted)['wtxid'], child_one.wtxid_hex)
+        peer_wtxid_relay.wait_for_broadcast([child_one.wtxid_hex])
         assert_equal(node.getmempoolinfo()["unbroadcastcount"], 0)
 
         # testmempoolaccept reports the "already in mempool" error
         assert_equal(node.testmempoolaccept([child_one.serialize().hex()]), [{
-            "txid": child_one_txid,
-            "wtxid": child_one_wtxid,
+            "txid": child_one.txid_hex,
+            "wtxid": child_one.wtxid_hex,
             "allowed": False,
             "reject-reason": "txn-already-in-mempool",
             "reject-details": "txn-already-in-mempool"
         }])
         assert_equal(node.testmempoolaccept([child_two.serialize().hex()])[0], {
-            "txid": child_two_txid,
-            "wtxid": child_two_wtxid,
+            "txid": child_two.txid_hex,
+            "wtxid": child_two.wtxid_hex,
             "allowed": False,
             "reject-reason": "txn-same-nonwitness-data-in-mempool",
             "reject-details": "txn-same-nonwitness-data-in-mempool"
@@ -87,7 +83,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
 
         # The node should rebroadcast the transaction using the wtxid of the correct transaction
         # (child_one, which is in its mempool).
-        peer_wtxid_relay_2.wait_for_broadcast([child_one_wtxid])
+        peer_wtxid_relay_2.wait_for_broadcast([child_one.wtxid_hex])
         assert_equal(node.getmempoolinfo()["unbroadcastcount"], 0)
 
 if __name__ == '__main__':

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -18,7 +18,6 @@ from test_framework.p2p import (
 from test_framework.messages import (
     CAddress,
     CInv,
-    COIN,
     MSG_WTX,
     malleate_tx_to_invalid_witness,
     msg_inv,
@@ -27,7 +26,7 @@ from test_framework.messages import (
 from test_framework.netutil import (
     format_addr_port
 )
-from test_framework.script_util import ValidWitnessMalleatedTx
+from test_framework.script_util import build_malleated_tx_package
 from test_framework.socks5 import (
     Socks5Configuration,
     Socks5Server,
@@ -400,16 +399,17 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         tx_originator.setmocktime(0) # Let the clock tick again (it will go backwards due to this).
 
         self.log.info("Sending a pair of transactions with the same txid but different valid wtxids via RPC")
-        txgen = ValidWitnessMalleatedTx()
-        funding = wallet.get_utxo()
-        fee_sat = 1000
-        siblings_parent = txgen.build_parent_tx(funding["txid"], amount=funding["value"] * COIN - fee_sat)
-        sibling1, sibling2 = txgen.build_malleated_children(siblings_parent.txid_hex, amount=siblings_parent.vout[0].nValue - fee_sat)
+        parent = wallet.create_self_transfer()["tx"]
+        parent_amount = parent.vout[0].nValue - 10000
+        child_amount = parent_amount - 10000
+        siblings_parent, sibling1, sibling2 = build_malleated_tx_package(
+            parent=parent,
+            rebalance_parent_output_amount=parent_amount,
+            child_amount=child_amount)
         self.log.info(f"  - sibling1: txid={sibling1.txid_hex}, wtxid={sibling1.wtxid_hex}")
         self.log.info(f"  - sibling2: txid={sibling2.txid_hex}, wtxid={sibling2.wtxid_hex}")
         assert_equal(sibling1.txid_hex, sibling2.txid_hex)
         assert_not_equal(sibling1.wtxid_hex, sibling2.wtxid_hex)
-        wallet.sign_tx(siblings_parent)
         assert_equal(len(tx_originator.getrawmempool()), 1)
         tx_returner.send_without_ping(msg_tx(siblings_parent))
         self.wait_until(lambda: len(tx_originator.getrawmempool()) > 1)


### PR DESCRIPTION
This PR refactors ` ValidWitnessMalleatedTx` class into a `build_malleated_tx_package` function. As a result, two tests are updated:  `mempool_accept_wtxid` and `p2p_p2p_private_broadcast`. Also included are a  few small refactors in mempool_accept_wtxid , (switching to MiniWallet, using a pre-mined chain, using txid directly.)

Together, these changes reduce complexity and improve test runtime.


