### PR TITLE
wallet: Add address validation in `sendtoaddress` RPC

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -304,6 +304,11 @@ RPCHelpMan sendtoaddress()
 
     UniValue address_amounts(UniValue::VOBJ);
     const std::string address = request.params[0].get_str();
+
+    if (!IsValidDestinationString(address)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid bitcoin address");
+    }
+
     address_amounts.pushKV(address, request.params[1]);
 
     std::set<int> sffo_set;

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -463,6 +463,14 @@ class WalletSendTest(BitcoinTestFramework):
         addr = self.nodes[0].deriveaddresses(desc)[0]
         addr_info = ext_fund.getaddressinfo(addr)
 
+        assert_raises_rpc_error(
+            -8, # RPC_INVALID_PARAMETER
+            "Invalid bitcoin address",
+            self.nodes[0].sendtoaddress,
+            "invalid_address",
+            10
+        )
+
         self.nodes[0].sendtoaddress(addr, 10)
         self.nodes[0].sendtoaddress(ext_wallet.getnewaddress(), 10)
         self.generate(self.nodes[0], 6)


### PR DESCRIPTION
Is there a specific reason not to validate the address in the `sendtoaddress` RPC?
This PR adds that.