### PR TITLE
[POC] wallet: Add Support for BIP-353 DNS-Based Bitcoin Address via External Resolver

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -33,6 +33,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-consolidatefeerate=<amt>",
         "-disablewallet",
         "-discardfee=<amt>",
+        "-dnsresolver=<cmd>",
         "-fallbackfee=<amt>",
         "-keypool=<n>",
         "-maxapsfee=<n>",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -82,6 +82,8 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-walletcrosschain", strprintf("Allow reusing wallet files across chains (default: %u)", DEFAULT_WALLETCROSSCHAIN), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
+    argsman.AddArg("-dnsresolver=<cmd>", "DNSSEC-validating resolver for BIP-353 Bitcoin addresses", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+
 }
 
 bool WalletInit::ParameterInteraction() const


### PR DESCRIPTION
This PR implements [BIP-353](https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki) support in Bitcoin Core's wallet, enabling users to send Bitcoin to human-readable usernames instead of traditional addresses.

### What is BIP-353?
BIP-353 specifies a method for resolving human-friendly payment instructions via DNS. Instead of sharing long Bitcoin addresses, users can share memorable usernames like `alice._bitcoin-payment.example.com`.

### Key Features

* New `-dnsresolver` option: Specify a DNSSEC-validating DNS resolver command to handle BIP-353 lookups
* Seamless integration: The `sendtoaddress` RPC now accepts both traditional Bitcoin addresses and BIP-353 usernames
* Automatic resolution: When a BIP-353 username is provided, it's automatically resolved to a Bitcoin address before processing the transaction

### How it works

1. Users provide a username in the format: `username._bitcoin-payment.domain.com`
2. The wallet validates the username format
3. If valid and a DNS resolver is configured, it queries the DNS TXT record
4. The resolver returns a `bitcoin:` URI containing the destination address
5. The transaction proceeds with the resolved address

### Example Usage
```bash
# Configure DNS resolver
bitcoind -dnsresolver="/home/user/dns-bitcoin-resolver"

# Send to a BIP-353 username
bitcoin-cli sendtoaddress "alice.user._bitcoin-payment.alice.com" 0.01
```

###  Implementation Details

* Validates usernames according to DNS naming rules and BIP-353 format
* Handles FQDN format (with or without trailing dot)
* Provides error messages for resolution failures
* Falls back to traditional address validation if the input isn't a valid BIP-353 username

P.S.: There is an example `-dnsresolver` application here: https://github.com/w0xlt/dns-bitcoin-resolver for testing

The idea of this PR is to gather feedback on whether this direction makes sense and how we might best implement BIP-353 support if there's interest. 
This would be even better if combined with Silent Payment and DNS resolver with DNSSEC validation could also solve some issues related to Payjoin V2 implementation in Core.