### PR TITLE
doc/zmq: fix unix socket path example

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -84,7 +84,7 @@ For instance:
     $ bitcoind -zmqpubhashtx=tcp://127.0.0.1:28332 \
                -zmqpubhashtx=tcp://192.168.1.2:28332 \
                -zmqpubhashblock="tcp://[::1]:28333" \
-               -zmqpubrawtx=ipc:///tmp/bitcoind.tx.raw \
+               -zmqpubrawtx=unix:/tmp/bitcoind.tx.raw \
                -zmqpubhashtxhwm=10000
 
 `bitcoin node` or `bitcoin gui` can also be substituted for `bitcoind`.


### PR DESCRIPTION
Following https://github.com/bitcoin/bitcoin/blob/75a5c8258ec5309fe506438aa3815608430b53d6/doc/release-notes/release-notes-28.0.md?plain=1#L105
