### PR TITLE
guix: warn SOURCE_DATE_EPOCH set in guix-codesign

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -73,19 +73,7 @@ mkdir -p "$VERSION_BASE"
 # SOURCE_DATE_EPOCH should not unintentionally be set
 ################
 
-if [ -n "$SOURCE_DATE_EPOCH" ] && [ -z "$FORCE_SOURCE_DATE_EPOCH" ]; then
-cat << EOF
-ERR: Environment variable SOURCE_DATE_EPOCH is set which may break reproducibility.
-
-     Aborting...
-
-Hint: You may want to:
-      1. Unset this variable: \`unset SOURCE_DATE_EPOCH\` before rebuilding
-      2. Set the 'FORCE_SOURCE_DATE_EPOCH' environment variable if you insist on
-         using your own epoch
-EOF
-exit 1
-fi
+check_source_date_epoch
 
 ################
 # Build directories should not exist

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -68,6 +68,12 @@ exit 1
 fi
 
 ################
+# SOURCE_DATE_EPOCH should not unintentionally be set
+################
+
+check_source_date_epoch
+
+################
 # The codesignature git worktree should not be dirty
 ################
 

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -21,6 +21,26 @@ check_tools() {
     done
 }
 
+################
+# SOURCE_DATE_EPOCH should not unintentionally be set
+################
+
+check_source_date_epoch() {
+    if [ -n "$SOURCE_DATE_EPOCH" ] && [ -z "$FORCE_SOURCE_DATE_EPOCH" ]; then
+        cat << EOF
+ERR: Environment variable SOURCE_DATE_EPOCH is set which may break reproducibility.
+
+     Aborting...
+
+Hint: You may want to:
+      1. Unset this variable: \`unset SOURCE_DATE_EPOCH\` before rebuilding
+      2. Set the 'FORCE_SOURCE_DATE_EPOCH' environment variable if you insist on
+         using your own epoch
+EOF
+        exit 1
+    fi
+}
+
 check_tools cat env readlink dirname basename git
 
 ################


### PR DESCRIPTION
#32678 added a sanity check for this environment variable when running `guix-build` but missed that `guix-codesign` also relies on `SOURCE_DATE_EPOCH`, which can result in non-determinism in the codesigning step: https://github.com/bitcoin-core/guix.sigs/pull/1720#issuecomment-3124332676

To avoid repeating the logic move common functionality into the prelude and call the function in both guix actions.
