### PR TITLE
doc: gen-manpages.py should check build options

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -29,6 +29,11 @@ parser.add_argument(
     default=False,
     help="skip generation for binaries that are not found in the build path",
 )
+parser.add_argument(
+    '--skip-build-options-check',
+     action='store_true',
+     help='Skip checking required build options'
+)
 args = parser.parse_args()
 
 # Paths to external utilities.
@@ -85,7 +90,7 @@ def check_build_options():
     return disabled
 
 disabled_options = check_build_options()
-if disabled_options:
+if disabled_options and not args.skip_build_options_check:
     error_msg = (
         "Aborting generating manpages...\n"
         "Missing build components for comprehensive man pages:\n"


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/17506. Second attempt after PR: https://github.com/bitcoin/bitcoin/pull/29457 (closed)

This PR fixes the `gen-manpages.py` script to check the build options and exit when there are missing components. It also adds an option to `--skip-build-options-check`

The PR also addresses the issues raised on PR: https://github.com/bitcoin/bitcoin/pull/29457:
    - https://github.com/bitcoin/bitcoin/pull/29457#discussion_r1836669430 - the default behaviors is fail
    - https://github.com/bitcoin/bitcoin/pull/29457#issuecomment-1955225976 - by adding  `--skip-build-options-check`
    - https://github.com/bitcoin/bitcoin/pull/29457#pullrequestreview-2433974717 - The PR uses `builddir/src/bitcoin-build-config.h` to check for `HAVE_SYSTEM` option and `builddir/test/config.ini` for the rest as they are only available there respectively