### PR TITLE
contrib: [tracing] fix pointer argument handling in mempool_monitor.py

### DIFF
--- a/contrib/tracing/mempool_monitor.py
+++ b/contrib/tracing/mempool_monitor.py
@@ -66,7 +66,7 @@ BPF_PERF_OUTPUT(replaced_events);
 int trace_added(struct pt_regs *ctx) {
   struct added_event added = {};
   void *phash = NULL;
-  bpf_usdt_readarg(1, ctx, phash);
+  bpf_usdt_readarg(1, ctx, &phash);
   bpf_probe_read_user(&added.hash, sizeof(added.hash), phash);
   bpf_usdt_readarg(2, ctx, &added.vsize);
   bpf_usdt_readarg(3, ctx, &added.fee);
@@ -78,9 +78,9 @@ int trace_added(struct pt_regs *ctx) {
 int trace_removed(struct pt_regs *ctx) {
   struct removed_event removed = {};
   void *phash = NULL, *preason = NULL;
-  bpf_usdt_readarg(1, ctx, phash);
+  bpf_usdt_readarg(1, ctx, &phash);
   bpf_probe_read_user(&removed.hash, sizeof(removed.hash), phash);
-  bpf_usdt_readarg(2, ctx, preason);
+  bpf_usdt_readarg(2, ctx, &preason);
   bpf_probe_read_user_str(&removed.reason, sizeof(removed.reason), preason);
   bpf_usdt_readarg(3, ctx, &removed.vsize);
   bpf_usdt_readarg(4, ctx, &removed.fee);
@@ -93,9 +93,9 @@ int trace_removed(struct pt_regs *ctx) {
 int trace_rejected(struct pt_regs *ctx) {
   struct rejected_event rejected = {};
   void *phash = NULL, *preason = NULL;
-  bpf_usdt_readarg(1, ctx, phash);
+  bpf_usdt_readarg(1, ctx, &phash);
   bpf_probe_read_user(&rejected.hash, sizeof(rejected.hash), phash);
-  bpf_usdt_readarg(2, ctx, preason);
+  bpf_usdt_readarg(2, ctx, &preason);
   bpf_probe_read_user_str(&rejected.reason, sizeof(rejected.reason), preason);
   rejected_events.perf_submit(ctx, &rejected, sizeof(rejected));
   return 0;
@@ -104,12 +104,12 @@ int trace_rejected(struct pt_regs *ctx) {
 int trace_replaced(struct pt_regs *ctx) {
   struct replaced_event replaced = {};
   void *phash_replaced = NULL, *phash_replacement = NULL;
-  bpf_usdt_readarg(1, ctx, phash_replaced);
+  bpf_usdt_readarg(1, ctx, &phash_replaced);
   bpf_probe_read_user(&replaced.replaced_hash, sizeof(replaced.replaced_hash), phash_replaced);
   bpf_usdt_readarg(2, ctx, &replaced.replaced_vsize);
   bpf_usdt_readarg(3, ctx, &replaced.replaced_fee);
   bpf_usdt_readarg(4, ctx, &replaced.replaced_entry_time);
-  bpf_usdt_readarg(5, ctx, phash_replacement);
+  bpf_usdt_readarg(5, ctx, &phash_replacement);
   bpf_probe_read_user(&replaced.replacement_hash, sizeof(replaced.replacement_hash), phash_replacement);
   bpf_usdt_readarg(6, ctx, &replaced.replacement_vsize);
   bpf_usdt_readarg(7, ctx, &replaced.replacement_fee);


### PR DESCRIPTION
The BPF code was incorrectly passing pointer variables by value to `bpf_usdt_readarg()`, causing the function to fail silently and resulting in transaction hashes showing as zeros and reason strings displaying empty strings.

This fix adds the missing reference operator (&) when passing pointer variables to `bpf_usdt_readarg()`, allowing the function to properly write the pointer values and enabling correct display of transaction hashes and removal/rejection reasons.

Fixes the regression introduced in [ec47ba349d](https://github.com/bitcoin/bitcoin/commit/ec47ba349d0b3cb2d274593ca7b828ae70584e10) where `bpf_usdt_readarg_p` was replaced with `bpf_usdt_readarg` but the calling convention wasn't properly updated for pointer arguments.

**Before: "0000000000000000000000000000000000000000000000000000000000000000" tx hashes, and missing reasons (empty strings) for removal.**

<img width="1683" height="1330" alt="Screenshot 2025-07-29 at 4 30 03 PM" src="https://github.com/user-attachments/assets/71ba88be-dbcc-43a6-bfe7-bd49ae082b13" />

**After: tx hashes show, reasons for removal showing.**

<img width="1682" height="1330" alt="Screenshot 2025-07-29 at 4 29 23 PM" src="https://github.com/user-attachments/assets/03738c75-5526-4c1e-82c2-ba100cdf128a" />
