### PR TITLE
doc: move `cmake -B build -LH` up in Unix build docs

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,6 +9,10 @@ To Build
 
 ```bash
 cmake -B build
+```
+Run `cmake -B build -LH` to see the full list of available options.
+
+```bash
 cmake --build build    # Append "-j N" for N parallel jobs
 cmake --install build  # Optional
 ```
@@ -155,13 +159,6 @@ be compiled in disable-wallet mode with:
 In this case there is no dependency on SQLite.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
-
-Additional Configure Flags
---------------------------
-A list of additional configure flags can be displayed with:
-
-    cmake -B build -LH
-
 
 Setup and Build Example: Arch Linux
 -----------------------------------


### PR DESCRIPTION
#32269 rebased.

> I had trouble building bitcoin core the way I wanted since now more features require a flag while building. IMO it makes sense to make it a bit more prominent in the build docs how to get the needed flags.

> Related issue: https://github.com/bitcoin/bitcoin/issues/32258