### PR TITLE
refactor: unify container presence checks

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -457,7 +457,7 @@ void AddrManImpl::Delete(nid_type nId)
 {
     AssertLockHeld(cs);
 
-    assert(mapInfo.count(nId) != 0);
+    assert(mapInfo.contains(nId));
     AddrInfo& info = mapInfo[nId];
     assert(!info.fInTried);
     assert(info.nRefCount == 0);
@@ -1115,7 +1115,7 @@ int AddrManImpl::CheckAddrman() const
     for (int n = 0; n < ADDRMAN_TRIED_BUCKET_COUNT; n++) {
         for (int i = 0; i < ADDRMAN_BUCKET_SIZE; i++) {
             if (vvTried[n][i] != -1) {
-                if (!setTried.count(vvTried[n][i]))
+                if (!setTried.contains(vvTried[n][i]))
                     return -11;
                 const auto it{mapInfo.find(vvTried[n][i])};
                 if (it == mapInfo.end() || it->second.GetTriedBucket(nKey, m_netgroupman) != n) {
@@ -1132,7 +1132,7 @@ int AddrManImpl::CheckAddrman() const
     for (int n = 0; n < ADDRMAN_NEW_BUCKET_COUNT; n++) {
         for (int i = 0; i < ADDRMAN_BUCKET_SIZE; i++) {
             if (vvNew[n][i] != -1) {
-                if (!mapNew.count(vvNew[n][i]))
+                if (!mapNew.contains(vvNew[n][i]))
                     return -12;
                 const auto it{mapInfo.find(vvNew[n][i])};
                 if (it == mapInfo.end() || it->second.GetBucketPosition(nKey, true, n) != i) {

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -516,7 +516,7 @@ void AddrManImpl::MakeTried(AddrInfo& info, nid_type nId)
     if (vvTried[nKBucket][nKBucketPos] != -1) {
         // find an item to evict
         nid_type nIdEvict = vvTried[nKBucket][nKBucketPos];
-        assert(mapInfo.count(nIdEvict) == 1);
+        assert(mapInfo.contains(nIdEvict));
         AddrInfo& infoOld = mapInfo[nIdEvict];
 
         // Remove the to-be-evicted item from the tried set.
@@ -919,7 +919,7 @@ void AddrManImpl::ResolveCollisions_()
         bool erase_collision = false;
 
         // If id_new not found in mapInfo remove it from m_tried_collisions
-        if (mapInfo.count(id_new) != 1) {
+        if (!mapInfo.contains(id_new)) {
             erase_collision = true;
         } else {
             AddrInfo& info_new = mapInfo[id_new];
@@ -985,7 +985,7 @@ std::pair<CAddress, NodeSeconds> AddrManImpl::SelectTriedCollision_()
     nid_type id_new = *it;
 
     // If id_new not found in mapInfo remove it from m_tried_collisions
-    if (mapInfo.count(id_new) != 1) {
+    if (!mapInfo.contains(id_new)) {
         m_tried_collisions.erase(it);
         return {};
     }

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1129,7 +1129,7 @@ static void ParseGetInfoResult(UniValue& result)
         const std::string proxy = network["proxy"].getValStr();
         if (proxy.empty()) continue;
         // Add proxy to ordered_proxy if has not been processed
-        if (proxy_networks.find(proxy) == proxy_networks.end()) ordered_proxies.push_back(proxy);
+        if (!proxy_networks.contains(proxy)) ordered_proxies.push_back(proxy);
 
         proxy_networks[proxy].push_back(network["name"].getValStr());
     }

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -588,7 +588,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     CCoinsView viewDummy;
     CCoinsViewCache view(&viewDummy);
 
-    if (!registers.count("privatekeys"))
+    if (!registers.contains("privatekeys"))
         throw std::runtime_error("privatekeys register variable must be set.");
     FillableSigningProvider tempKeystore;
     UniValue keysObj = registers["privatekeys"];
@@ -604,7 +604,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     }
 
     // Add previous txouts given in the RPC call:
-    if (!registers.count("prevtxs"))
+    if (!registers.contains("prevtxs"))
         throw std::runtime_error("prevtxs register variable must be set.");
     UniValue prevtxsObj = registers["prevtxs"];
     {

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -820,7 +820,7 @@ std::variant<ChainType, std::string> ArgsManager::GetChainArg() const
 
 bool ArgsManager::UseDefaultSection(const std::string& arg) const
 {
-    return m_network == ChainTypeToString(ChainType::MAIN) || m_network_only_args.count(arg) == 0;
+    return m_network == ChainTypeToString(ChainType::MAIN) || !m_network_only_args.contains(arg);
 }
 
 common::SettingsValue ArgsManager::GetSetting(const std::string& arg) const

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -166,7 +166,7 @@ std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
 
     LOCK(cs_args);
     std::list<SectionInfo> unrecognized = m_config_sections;
-    unrecognized.remove_if([](const SectionInfo& appeared){ return available_sections.find(appeared.m_name) != available_sections.end(); });
+    unrecognized.remove_if([](const SectionInfo& appeared){ return available_sections.contains(appeared.m_name); });
     return unrecognized;
 }
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -307,7 +307,7 @@ static bool InitRPCAuthentication()
     for (const std::string& strRPCWhitelist : gArgs.GetArgs("-rpcwhitelist")) {
         auto pos = strRPCWhitelist.find(':');
         std::string strUser = strRPCWhitelist.substr(0, pos);
-        bool intersect = g_rpc_whitelist.count(strUser);
+        bool intersect = g_rpc_whitelist.contains(strUser);
         std::set<std::string>& whitelist = g_rpc_whitelist[strUser];
         if (pos != std::string::npos) {
             std::string strWhitelist = strRPCWhitelist.substr(pos + 1);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -957,7 +957,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     // Signal NODE_COMPACT_FILTERS if peerblockfilters and basic filters index are both enabled.
     if (args.GetBoolArg("-peerblockfilters", DEFAULT_PEERBLOCKFILTERS)) {
-        if (g_enabled_filter_types.count(BlockFilterType::BASIC) != 1) {
+        if (!g_enabled_filter_types.contains(BlockFilterType::BASIC)) {
             return InitError(_("Cannot set -peerblockfilters without -blockfilterindex."));
         }
 

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -40,7 +40,7 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std:
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const Txid& hash{block.vtx[i]->GetHash()};
-        if (txids && txids->count(hash)) {
+        if (txids && txids->contains(hash)) {
             vMatch.push_back(true);
         } else if (filter && filter->IsRelevantAndUpdate(*block.vtx[i])) {
             vMatch.push_back(true);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -322,7 +322,7 @@ bool SeenLocal(const CService& addr)
 bool IsLocal(const CService& addr)
 {
     LOCK(g_maplocalhost_mutex);
-    return mapLocalHost.count(addr) > 0;
+    return mapLocalHost.contains(addr);
 }
 
 CNode* CConnman::FindNode(const CNetAddr& ip)
@@ -2611,7 +2611,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
                 // (e.g. in case of -onlynet changes by the user), fixed seeds will
                 // be loaded only for networks for which we have no addresses.
                 seed_addrs.erase(std::remove_if(seed_addrs.begin(), seed_addrs.end(),
-                                                [&fixed_seed_networks](const CAddress& addr) { return fixed_seed_networks.count(addr.GetNetwork()) == 0; }),
+                                                [&fixed_seed_networks](const CAddress& addr) { return !fixed_seed_networks.contains(addr.GetNetwork()); }),
                                  seed_addrs.end());
                 CNetAddr local;
                 local.SetInternal("fixedseeds");
@@ -2759,7 +2759,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
                 m_anchors.pop_back();
                 if (!addr.IsValid() || IsLocal(addr) || !g_reachable_nets.Contains(addr) ||
                     !m_msgproc->HasAllDesirableServiceFlags(addr.nServices) ||
-                    outbound_ipv46_peer_netgroups.count(m_netgroupman.GetGroup(addr))) continue;
+                    outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(addr))) continue;
                 addrConnect = addr;
                 LogDebug(BCLog::NET, "Trying to make an anchor connection to %s\n", addrConnect.ToStringAddrPort());
                 break;
@@ -2805,7 +2805,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
             }
 
             // Require outbound IPv4/IPv6 connections, other than feelers, to be to distinct network groups
-            if (!fFeeler && outbound_ipv46_peer_netgroups.count(m_netgroupman.GetGroup(addr))) {
+            if (!fFeeler && outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(addr))) {
                 continue;
             }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1156,7 +1156,7 @@ std::chrono::microseconds PeerManagerImpl::NextInvToInbounds(std::chrono::micros
 
 bool PeerManagerImpl::IsBlockRequested(const uint256& hash)
 {
-    return mapBlocksInFlight.count(hash);
+    return mapBlocksInFlight.contains(hash);
 }
 
 bool PeerManagerImpl::IsBlockRequestedFromOutbound(const uint256& hash)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -125,7 +125,7 @@ public:
     {
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
-        return m_reachable.count(net) > 0;
+        return m_reachable.contains(net);
     }
 
     [[nodiscard]] bool Contains(const CNetAddr& addr) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -198,7 +198,7 @@ void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
 {
     for (CTxMemPool::setEntries::iterator iit = testSet.begin(); iit != testSet.end(); ) {
         // Only test txs not already in the block
-        if (inBlock.count((*iit)->GetSharedTx()->GetHash())) {
+        if (inBlock.contains((*iit)->GetSharedTx()->GetHash())) {
             testSet.erase(iit++);
         } else {
             iit++;
@@ -263,7 +263,7 @@ static int UpdatePackagesForAdded(const CTxMemPool& mempool,
         mempool.CalculateDescendants(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
-            if (alreadyAdded.count(desc)) {
+            if (alreadyAdded.contains(desc)) {
                 continue;
             }
             ++nDescendantsUpdated;
@@ -337,7 +337,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
         if (mi != mempool.mapTx.get<ancestor_score>().end()) {
             auto it = mempool.mapTx.project<0>(mi);
             assert(it != mempool.mapTx.end());
-            if (mapModifiedTx.count(it) || inBlock.count(it->GetSharedTx()->GetHash()) || failedTx.count(it->GetSharedTx()->GetHash())) {
+            if (mapModifiedTx.contains(it) || inBlock.contains(it->GetSharedTx()->GetHash()) || failedTx.contains(it->GetSharedTx()->GetHash())) {
                 ++mi;
                 continue;
             }
@@ -371,7 +371,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
 
         // We skip mapTx entries that are inBlock, and mapModifiedTx shouldn't
         // contain anything that is inBlock.
-        assert(!inBlock.count(iter->GetSharedTx()->GetHash()));
+        assert(!inBlock.contains(iter->GetSharedTx()->GetHash()));
 
         uint64_t packageSize = iter->GetSizeWithAncestors();
         CAmount packageFees = iter->GetModFeesWithAncestors();

--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -239,7 +239,7 @@ void MiniMiner::SanityCheck() const
                entry->second.GetModFeesWithAncestors() >= entry->second.GetModifiedFee();}));
     // None of the entries should be to-be-replaced transactions
     Assume(std::all_of(m_to_be_replaced.begin(), m_to_be_replaced.end(),
-        [&](const auto& txid){return m_entries_by_txid.find(txid) == m_entries_by_txid.end();}));
+        [&](const auto& txid){return !m_entries_by_txid.contains(txid);}));
 }
 
 void MiniMiner::BuildMockTemplate(std::optional<CFeeRate> target_feerate)

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -77,7 +77,7 @@ public:
         // Read the version
         uint16_t version;
         s >> version;
-        if (m_supported_versions.find(version) == m_supported_versions.end()) {
+        if (!m_supported_versions.contains(version)) {
             throw std::ios_base::failure(strprintf("Version of snapshot %s does not match any of the supported versions.", version));
         }
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -598,7 +598,7 @@ void CBlockPolicyEstimator::processTransaction(const NewMempoolTransactionInfo& 
     LOCK(m_cs_fee_estimator);
     const unsigned int txHeight = tx.info.txHeight;
     const auto& hash = tx.info.m_tx->GetHash();
-    if (mapMemPoolTxs.count(hash)) {
+    if (mapMemPoolTxs.contains(hash)) {
         LogDebug(BCLog::ESTIMATEFEE, "Blockpolicy error mempool tx %s already being tracked\n",
                  hash.ToString());
         return;

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -130,7 +130,7 @@ bool IsChildWithParents(const Package& package)
 
     // Every transaction must be a parent of the last transaction in the package.
     return std::all_of(package.cbegin(), package.cend() - 1,
-                       [&input_txids](const auto& ptx) { return input_txids.count(ptx->GetHash()) > 0; });
+                       [&input_txids](const auto& ptx) { return input_txids.contains(ptx->GetHash()); });
 }
 
 bool IsChildWithParentsTree(const Package& package)
@@ -142,7 +142,7 @@ bool IsChildWithParentsTree(const Package& package)
     // Each parent must not have an input who is one of the other parents.
     return std::all_of(package.cbegin(), package.cend() - 1, [&](const auto& ptx) {
         for (const auto& input : ptx->vin) {
-            if (parent_txids.count(input.prevout.hash) > 0) return false;
+            if (parent_txids.contains(input.prevout.hash)) return false;
         }
         return true;
     });

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -26,7 +26,7 @@ bool IsTopoSortedPackage(const Package& txns, std::unordered_set<Txid, SaltedTxi
     // than its child.
     for (const auto& tx : txns) {
         for (const auto& input : tx->vin) {
-            if (later_txids.find(input.prevout.hash) != later_txids.end()) {
+            if (later_txids.contains(input.prevout.hash)) {
                 // The parent is a subsequent transaction in the package.
                 return false;
             }
@@ -62,7 +62,7 @@ bool IsConsistentPackage(const Package& txns)
             return false;
         }
         for (const auto& input : tx->vin) {
-            if (inputs_seen.find(input.prevout) != inputs_seen.end()) {
+            if (inputs_seen.contains(input.prevout)) {
                 // This input is also present in another tx in the package.
                 return false;
             }

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -103,7 +103,7 @@ std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx,
         // Note that if you relax this to make RBF a little more useful, this may break the
         // CalculateMempoolAncestors RBF relaxation which subtracts the conflict count/size from the
         // descendant limit.
-        if (!parents_of_conflicts.count(tx.vin[j].prevout.hash)) {
+        if (!parents_of_conflicts.contains(tx.vin[j].prevout.hash)) {
             // Rather than check the UTXO set - potentially expensive - it's cheaper to just check
             // if the new input refers to a tx that's in the mempool.
             if (pool.exists(tx.vin[j].prevout.hash)) {
@@ -121,7 +121,7 @@ std::optional<std::string> EntriesAndTxidsDisjoint(const CTxMemPool::setEntries&
 {
     for (CTxMemPool::txiter ancestorIt : ancestors) {
         const Txid& hashAncestor = ancestorIt->GetTx().GetHash();
-        if (direct_conflicts.count(hashAncestor)) {
+        if (direct_conflicts.contains(hashAncestor)) {
             return strprintf("%s spends conflicting transaction %s",
                              txid.ToString(),
                              hashAncestor.ToString());

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -38,7 +38,7 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
         outputs[i].Merge(psbt.outputs[i]);
     }
     for (auto& xpub_pair : psbt.m_xpubs) {
-        if (m_xpubs.count(xpub_pair.first) == 0) {
+        if (!m_xpubs.contains(xpub_pair.first)) {
             m_xpubs[xpub_pair.first] = xpub_pair.second;
         } else {
             m_xpubs[xpub_pair.first].insert(xpub_pair.second.begin(), xpub_pair.second.end());

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -158,7 +158,7 @@ void DeserializeHDKeypaths(Stream& s, const std::vector<unsigned char>& key, std
     if (!pubkey.IsFullyValid()) {
        throw std::ios_base::failure("Invalid pubkey");
     }
-    if (hd_keypaths.count(pubkey) > 0) {
+    if (hd_keypaths.contains(pubkey)) {
         throw std::ios_base::failure("Duplicate Key, pubkey derivation path already provided");
     }
 
@@ -515,7 +515,7 @@ struct PSBTInput
                     if (!pubkey.IsFullyValid()) {
                        throw std::ios_base::failure("Invalid pubkey");
                     }
-                    if (partial_sigs.count(pubkey.GetID()) > 0) {
+                    if (partial_sigs.contains(pubkey.GetID())) {
                         throw std::ios_base::failure("Duplicate Key, input partial signature for pubkey already provided");
                     }
 
@@ -596,7 +596,7 @@ struct PSBTInput
                     // Read in the hash from key
                     std::vector<unsigned char> hash_vec(key.begin() + 1, key.end());
                     uint160 hash(hash_vec);
-                    if (ripemd160_preimages.count(hash) > 0) {
+                    if (ripemd160_preimages.contains(hash)) {
                         throw std::ios_base::failure("Duplicate Key, input ripemd160 preimage already provided");
                     }
 
@@ -617,7 +617,7 @@ struct PSBTInput
                     // Read in the hash from key
                     std::vector<unsigned char> hash_vec(key.begin() + 1, key.end());
                     uint256 hash(hash_vec);
-                    if (sha256_preimages.count(hash) > 0) {
+                    if (sha256_preimages.contains(hash)) {
                         throw std::ios_base::failure("Duplicate Key, input sha256 preimage already provided");
                     }
 
@@ -638,7 +638,7 @@ struct PSBTInput
                     // Read in the hash from key
                     std::vector<unsigned char> hash_vec(key.begin() + 1, key.end());
                     uint160 hash(hash_vec);
-                    if (hash160_preimages.count(hash) > 0) {
+                    if (hash160_preimages.contains(hash)) {
                         throw std::ios_base::failure("Duplicate Key, input hash160 preimage already provided");
                     }
 
@@ -659,7 +659,7 @@ struct PSBTInput
                     // Read in the hash from key
                     std::vector<unsigned char> hash_vec(key.begin() + 1, key.end());
                     uint256 hash(hash_vec);
-                    if (hash256_preimages.count(hash) > 0) {
+                    if (hash256_preimages.contains(hash)) {
                         throw std::ios_base::failure("Duplicate Key, input hash256 preimage already provided");
                     }
 
@@ -825,7 +825,7 @@ struct PSBTInput
                     this_prop.subtype = ReadCompactSize(skey);
                     this_prop.key = key;
 
-                    if (m_proprietary.count(this_prop) > 0) {
+                    if (m_proprietary.contains(this_prop)) {
                         throw std::ios_base::failure("Duplicate Key, proprietary key already found");
                     }
                     s >> this_prop.value;
@@ -834,7 +834,7 @@ struct PSBTInput
                 }
                 // Unknown stuff
                 default:
-                    if (unknown.count(key) > 0) {
+                    if (unknown.contains(key)) {
                         throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
                     }
                     // Read in the value
@@ -1082,7 +1082,7 @@ struct PSBTOutput
                     this_prop.subtype = ReadCompactSize(skey);
                     this_prop.key = key;
 
-                    if (m_proprietary.count(this_prop) > 0) {
+                    if (m_proprietary.contains(this_prop)) {
                         throw std::ios_base::failure("Duplicate Key, proprietary key already found");
                     }
                     s >> this_prop.value;
@@ -1091,7 +1091,7 @@ struct PSBTOutput
                 }
                 // Unknown stuff
                 default: {
-                    if (unknown.count(key) > 0) {
+                    if (unknown.contains(key)) {
                         throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
                     }
                     // Read in the value
@@ -1267,7 +1267,7 @@ struct PartiallySignedTransaction
                     if (!xpub.pubkey.IsFullyValid()) {
                        throw std::ios_base::failure("Invalid pubkey");
                     }
-                    if (global_xpubs.count(xpub) > 0) {
+                    if (global_xpubs.contains(xpub)) {
                        throw std::ios_base::failure("Duplicate key, global xpub already provided");
                     }
                     global_xpubs.insert(xpub);
@@ -1277,7 +1277,7 @@ struct PartiallySignedTransaction
 
                     // Note that we store these swapped to make searches faster.
                     // Serialization uses xpub -> keypath to enqure key uniqueness
-                    if (m_xpubs.count(keypath) == 0) {
+                    if (!m_xpubs.contains(keypath)) {
                         // Make a new set to put the xpub in
                         m_xpubs[keypath] = {xpub};
                     } else {
@@ -1308,7 +1308,7 @@ struct PartiallySignedTransaction
                     this_prop.subtype = ReadCompactSize(skey);
                     this_prop.key = key;
 
-                    if (m_proprietary.count(this_prop) > 0) {
+                    if (m_proprietary.contains(this_prop)) {
                         throw std::ios_base::failure("Duplicate Key, proprietary key already found");
                     }
                     s >> this_prop.value;
@@ -1317,7 +1317,7 @@ struct PartiallySignedTransaction
                 }
                 // Unknown stuff
                 default: {
-                    if (unknown.count(key) > 0) {
+                    if (unknown.contains(key)) {
                         throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
                     }
                     // Read in the value

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -70,7 +70,7 @@ bool WalletFrame::addView(WalletView* walletView)
 {
     if (!clientModel) return false;
 
-    if (mapWalletViews.count(walletView->getWalletModel()) > 0) return false;
+    if (mapWalletViews.contains(walletView->getWalletModel())) return false;
 
     walletView->setClientModel(clientModel);
     walletView->showOutOfSyncWarning(bOutOfSync);
@@ -90,7 +90,7 @@ bool WalletFrame::addView(WalletView* walletView)
 
 void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
 {
-    if (mapWalletViews.count(wallet_model) == 0) return;
+    if (!mapWalletViews.contains(wallet_model)) return;
 
     // Stop the effect of hidden widgets on the size hint of the shown one in QStackedWidget.
     WalletView* view_about_to_hide = currentWalletView();
@@ -116,7 +116,7 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
 
 void WalletFrame::removeWallet(WalletModel* wallet_model)
 {
-    if (mapWalletViews.count(wallet_model) == 0) return;
+    if (!mapWalletViews.contains(wallet_model)) return;
 
     WalletView *walletView = mapWalletViews.take(wallet_model);
     walletStack->removeWidget(walletView);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1872,7 +1872,7 @@ static inline bool SetHasKeys(const std::set<T>& set) {return false;}
 template<typename T, typename Tk, typename... Args>
 static inline bool SetHasKeys(const std::set<T>& set, const Tk& key, const Args&... args)
 {
-    return (set.count(key) != 0) || SetHasKeys(set, args...);
+    return (set.contains(key)) || SetHasKeys(set, args...);
 }
 
 // outpoint (needed for the utxo index) + nHeight + fCoinBase
@@ -1963,12 +1963,12 @@ static RPCHelpMan getblockstats()
     const CBlockUndo& blockUndo = GetUndoChecked(chainman.m_blockman, pindex);
 
     const bool do_all = stats.size() == 0; // Calculate everything if nothing selected (default)
-    const bool do_mediantxsize = do_all || stats.count("mediantxsize") != 0;
-    const bool do_medianfee = do_all || stats.count("medianfee") != 0;
-    const bool do_feerate_percentiles = do_all || stats.count("feerate_percentiles") != 0;
+    const bool do_mediantxsize = do_all || stats.contains("mediantxsize");
+    const bool do_medianfee = do_all || stats.contains("medianfee");
+    const bool do_feerate_percentiles = do_all || stats.contains("feerate_percentiles");
     const bool loop_inputs = do_all || do_medianfee || do_feerate_percentiles ||
         SetHasKeys(stats, "utxo_increase", "utxo_increase_actual", "utxo_size_inc", "utxo_size_inc_actual", "totalfee", "avgfee", "avgfeerate", "minfee", "maxfee", "minfeerate", "maxfeerate");
-    const bool loop_outputs = do_all || loop_inputs || stats.count("total_out");
+    const bool loop_outputs = do_all || loop_inputs || stats.contains("total_out");
     const bool do_calculate_size = do_mediantxsize ||
         SetHasKeys(stats, "total_size", "avgtxsize", "mintxsize", "maxtxsize", "swtotal_size");
     const bool do_calculate_weight = do_all || SetHasKeys(stats, "total_weight", "avgfeerate", "swtotal_weight", "avgfeerate", "feerate_percentiles", "minfeerate", "maxfeerate");
@@ -2161,7 +2161,7 @@ bool FindScriptPubKey(std::atomic<int>& scan_progress, const std::atomic<bool>& 
             uint32_t high = 0x100 * *UCharCast(key.hash.begin()) + *(UCharCast(key.hash.begin()) + 1);
             scan_progress = (int)(high * 100.0 / 65536.0 + 0.5);
         }
-        if (needles.count(coin.out.scriptPubKey)) {
+        if (needles.contains(coin.out.scriptPubKey)) {
             out_results.emplace(key, coin);
         }
         cursor->Next();
@@ -2436,7 +2436,7 @@ static bool CheckBlockFilterMatches(BlockManager& blockman, const CBlockIndex& b
     // Check if any of the outputs match the scriptPubKey
     for (const auto& tx : block.vtx) {
         if (std::any_of(tx->vout.cbegin(), tx->vout.cend(), [&](const auto& txout) {
-                return needles.count(std::vector<unsigned char>(txout.scriptPubKey.begin(), txout.scriptPubKey.end())) != 0;
+                return needles.contains(std::vector<unsigned char>(txout.scriptPubKey.begin(), txout.scriptPubKey.end()));
             })) {
             return true;
         }
@@ -2444,7 +2444,7 @@ static bool CheckBlockFilterMatches(BlockManager& blockman, const CBlockIndex& b
     // Check if any of the inputs match the scriptPubKey
     for (const auto& txundo : block_undo.vtxundo) {
         if (std::any_of(txundo.vprevout.cbegin(), txundo.vprevout.cend(), [&](const auto& coin) {
-                return needles.count(std::vector<unsigned char>(coin.out.scriptPubKey.begin(), coin.out.scriptPubKey.end())) != 0;
+                return needles.contains(std::vector<unsigned char>(coin.out.scriptPubKey.begin(), coin.out.scriptPubKey.end()));
             })) {
             return true;
         }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -332,13 +332,13 @@ public:
     /** Return arg_value as UniValue, and first parse it if it is a non-string parameter */
     UniValue ArgToUniValue(std::string_view arg_value, const std::string& method, int param_idx)
     {
-        return members.count({method, param_idx}) > 0 ? Parse(arg_value) : arg_value;
+        return members.contains({method, param_idx}) ? Parse(arg_value) : arg_value;
     }
 
     /** Return arg_value as UniValue, and first parse it if it is a non-string parameter */
     UniValue ArgToUniValue(std::string_view arg_value, const std::string& method, const std::string& param_name)
     {
-        return membersByName.count({method, param_name}) > 0 ? Parse(arg_value) : arg_value;
+        return membersByName.contains({method, param_name}) ? Parse(arg_value) : arg_value;
     }
 };
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -909,7 +909,7 @@ static RPCHelpMan getblocktemplate()
         UniValue deps(UniValue::VARR);
         for (const CTxIn &in : tx.vin)
         {
-            if (setTxIndex.count(in.prevout.hash))
+            if (setTxIndex.contains(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
         }
         entry.pushKV("depends", std::move(deps));
@@ -953,7 +953,7 @@ static RPCHelpMan getblocktemplate()
 
     for (const auto& [name, info] : gbtstatus.signalling) {
         vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
-        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
+        if (!info.gbt_optional_rule && !setClientRules.contains(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
             block.nVersion &= ~info.mask;
         }
@@ -962,7 +962,7 @@ static RPCHelpMan getblocktemplate()
     for (const auto& [name, info] : gbtstatus.locked_in) {
         block.nVersion |= info.mask;
         vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
-        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
+        if (!info.gbt_optional_rule && !setClientRules.contains(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
             block.nVersion &= ~info.mask;
         }
@@ -970,7 +970,7 @@ static RPCHelpMan getblocktemplate()
 
     for (const auto& [name, info] : gbtstatus.active) {
         aRules.push_back(gbt_rule_value(name, info.gbt_optional_rule));
-        if (!info.gbt_optional_rule && !setClientRules.count(name)) {
+        if (!info.gbt_optional_rule && !setClientRules.contains(name)) {
             // Not supported by the client; make sure it's safe to proceed
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Support for '%s' rule requires explicit client support", name));
         }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -842,12 +842,12 @@ static RPCHelpMan getblocktemplate()
     const Consensus::Params& consensusParams = chainman.GetParams().GetConsensus();
 
     // GBT must be called with 'signet' set in the rules for signet chains
-    if (consensusParams.signet_blocks && setClientRules.count("signet") != 1) {
+    if (consensusParams.signet_blocks && !setClientRules.contains("signet")) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "getblocktemplate must be called with the signet rule set (call with {\"rules\": [\"segwit\", \"signet\"]})");
     }
 
     // GBT must be called with 'segwit' set in the rules
-    if (setClientRules.count("segwit") != 1) {
+    if (!setClientRules.contains("segwit")) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "getblocktemplate must be called with the segwit rule set (call with {\"rules\": [\"segwit\"]})");
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1879,7 +1879,7 @@ static RPCHelpMan joinpsbts()
             merged_psbt.AddOutput(psbt.tx->vout[i], psbt.outputs[i]);
         }
         for (auto& xpub_pair : psbt.m_xpubs) {
-            if (merged_psbt.m_xpubs.count(xpub_pair.first) == 0) {
+            if (!merged_psbt.m_xpubs.contains(xpub_pair.first)) {
                 merged_psbt.m_xpubs[xpub_pair.first] = xpub_pair.second;
             } else {
                 merged_psbt.m_xpubs[xpub_pair.first].insert(xpub_pair.second.begin(), xpub_pair.second.end());

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -109,7 +109,7 @@ static RPCHelpMan gettxoutproof()
 
             unsigned int ntxFound = 0;
             for (const auto& tx : block.vtx) {
-                if (setTxids.count(tx->GetHash())) {
+                if (setTxids.contains(tx->GetHash())) {
                     ntxFound++;
                 }
             }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1175,7 +1175,7 @@ UniValue RPCResult::MatchesType(const UniValue& result) const
         std::map<std::string, UniValue> result_obj;
         result.getObjMap(result_obj);
         for (const auto& result_entry : result_obj) {
-            if (doc_keys.find(result_entry.first) == doc_keys.end()) {
+            if (!doc_keys.contains(result_entry.first)) {
                 errors.pushKV(result_entry.first, "key returned that was not in doc");
             }
         }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -74,7 +74,7 @@ void RPCTypeCheckObj(const UniValue& o,
     {
         for (const std::string& k : o.getKeys())
         {
-            if (typesExpected.count(k) == 0)
+            if (!typesExpected.contains(k))
             {
                 std::string err = strprintf("Unexpected key %s", k);
                 throw JSONRPCError(RPC_TYPE_ERROR, err);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -661,7 +661,7 @@ SignatureData DataFromTransaction(const CMutableTransaction& tx, unsigned int nI
             for (unsigned int i = last_success_key; i < num_pubkeys; ++i) {
                 const valtype& pubkey = solutions[i+1];
                 // We either have a signature for this pubkey, or we have found a signature and it is valid
-                if (data.signatures.count(CPubKey(pubkey).GetID()) || extractor_checker.CheckECDSASignature(sig, pubkey, next_script, sigversion)) {
+                if (data.signatures.contains(CPubKey(pubkey).GetID()) || extractor_checker.CheckECDSASignature(sig, pubkey, next_script, sigversion)) {
                     last_success_key = i + 1;
                     break;
                 }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -149,7 +149,7 @@ bool FillableSigningProvider::AddKeyPubKey(const CKey& key, const CPubKey &pubke
 bool FillableSigningProvider::HaveKey(const CKeyID &address) const
 {
     LOCK(cs_KeyStore);
-    return mapKeys.count(address) > 0;
+    return mapKeys.contains(address);
 }
 
 std::set<CKeyID> FillableSigningProvider::GetKeys() const
@@ -188,7 +188,7 @@ bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
 bool FillableSigningProvider::HaveCScript(const CScriptID& hash) const
 {
     LOCK(cs_KeyStore);
-    return mapScripts.count(hash) > 0;
+    return mapScripts.contains(hash);
 }
 
 std::set<CScriptID> FillableSigningProvider::GetCScripts() const

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -232,8 +232,8 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     BOOST_CHECK(testArgs.m_settings.command_line_options.size() == 3 && testArgs.m_settings.ro_config.empty());
     BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
                 && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
-    BOOST_CHECK(testArgs.m_settings.command_line_options.count("a") && testArgs.m_settings.command_line_options.count("b") && testArgs.m_settings.command_line_options.count("ccc")
-                && !testArgs.m_settings.command_line_options.count("f") && !testArgs.m_settings.command_line_options.count("d"));
+    BOOST_CHECK(testArgs.m_settings.command_line_options.contains("a") && testArgs.m_settings.command_line_options.contains("b") && testArgs.m_settings.command_line_options.contains("ccc")
+                && !testArgs.m_settings.command_line_options.contains("f") && !testArgs.m_settings.command_line_options.contains("d"));
 
     BOOST_CHECK(testArgs.m_settings.command_line_options["a"].size() == 1);
     BOOST_CHECK(testArgs.m_settings.command_line_options["a"].front().get_str() == "");
@@ -460,18 +460,18 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     BOOST_CHECK(test_args.m_settings.ro_config["sec1"].size() == 3);
     BOOST_CHECK(test_args.m_settings.ro_config["sec2"].size() == 2);
 
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("a"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("b"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("ccc"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("d"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("fff"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("ggg"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("h"));
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("i"));
-    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].count("ccc"));
-    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].count("h"));
-    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].count("ccc"));
-    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].count("iii"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("a"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("b"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("d"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("fff"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("ggg"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("h"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].contains("i"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].contains("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].contains("h"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].contains("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].contains("iii"));
 
     BOOST_CHECK(test_args.IsArgSet("-a"));
     BOOST_CHECK(test_args.IsArgSet("-b"));

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -386,15 +386,15 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
                     auto utxod = FindRandomFrom(disconnected_coins);
                     tx = CMutableTransaction{std::get<0>(utxod->second)};
                     prevout = tx.vin[0].prevout;
-                    if (!CTransaction(tx).IsCoinBase() && !utxoset.count(prevout)) {
+                    if (!CTransaction(tx).IsCoinBase() && !utxoset.contains(prevout)) {
                         disconnected_coins.erase(utxod->first);
                         continue;
                     }
 
                     // If this tx is already IN the UTXO, then it must be a coinbase, and it must be a duplicate
-                    if (utxoset.count(utxod->first)) {
+                    if (utxoset.contains(utxod->first)) {
                         assert(CTransaction(tx).IsCoinBase());
-                        assert(duplicate_coins.count(utxod->first));
+                        assert(duplicate_coins.contains(utxod->first));
                     }
                     disconnected_coins.erase(utxod->first);
                 }
@@ -417,7 +417,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
 
                 // The test is designed to ensure spending a duplicate coinbase will work properly
                 // if that ever happens and not resurrect the previously overwritten coinbase
-                if (duplicate_coins.count(prevout)) {
+                if (duplicate_coins.contains(prevout)) {
                     spent_a_duplicate_coinbase = true;
                 }
 

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -455,7 +455,7 @@ void DoCheck(std::string prv, std::string pub, const std::string& norm_pub, int 
             // Test whether the observed key path is present in the 'paths' variable (which contains expected, unobserved paths),
             // and then remove it from that set.
             for (const auto& origin : script_provider.origins) {
-                BOOST_CHECK_MESSAGE(paths.count(origin.second.second.path), "Unexpected key path: " + prv);
+                BOOST_CHECK_MESSAGE(paths.contains(origin.second.second.path), "Unexpected key path: " + prv);
                 left_paths.erase(origin.second.second.path);
             }
         }

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -198,13 +198,13 @@ FUZZ_TARGET(mini_miner_selection, .init = initialize_miner)
     assert(!mini_miner.IsReadyToCalculate());
     auto mock_template_txids = mini_miner.GetMockTemplateTxids();
     // MiniMiner doesn't add a coinbase tx.
-    assert(mock_template_txids.count(blocktemplate->block.vtx[0]->GetHash()) == 0);
+    assert(!mock_template_txids.contains(blocktemplate->block.vtx[0]->GetHash()));
     auto [iter, new_entry] = mock_template_txids.emplace(blocktemplate->block.vtx[0]->GetHash());
     assert(new_entry);
 
     assert(mock_template_txids.size() == blocktemplate->block.vtx.size());
     for (const auto& tx : blocktemplate->block.vtx) {
-        assert(mock_template_txids.count(tx->GetHash()));
+        assert(mock_template_txids.contains(tx->GetHash()));
     }
 }
 } // namespace

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -95,12 +95,12 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
     for (size_t i = 0; i < cmpctblock.BlockTxCount(); i++) {
         // If init_status == READ_STATUS_OK then a available transaction in the
         // compact block (i.e. IsTxAvailable(i) == true) implies that we marked
-        // that transaction as available above (i.e. available.count(i) > 0).
+        // that transaction as available above (i.e. available.contains(i)).
         // The reverse is not true, due to possible compact block short id
-        // collisions (i.e. available.count(i) > 0 does not imply
+        // collisions (i.e. available.contains(i) does not imply
         // IsTxAvailable(i) == true).
         if (init_status == READ_STATUS_OK) {
-            assert(!pdb.IsTxAvailable(i) || available.count(i) > 0);
+            assert(!pdb.IsTxAvailable(i) || available.contains(i));
         }
 
         bool skip{fuzzed_data_provider.ConsumeBool()};

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -339,7 +339,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     }
                 },
                 [&] { // EraseTx
-                    if (protected_wtxids.count(tx->GetWitnessHash())) {
+                    if (protected_wtxids.contains(tx->GetWitnessHash())) {
                         protected_wtxids.erase(wtxid);
                     }
                     orphanage->EraseTx(wtxid);
@@ -616,7 +616,7 @@ FUZZ_TARGET(txorphanage_sim)
                 real->EraseForBlock(block);
                 std::erase_if(sim_announcements, [&](auto& ann) {
                     for (auto& txin : txn[ann.tx]->vin) {
-                        if (spent.count(txin.prevout)) return true;
+                        if (spent.contains(txin.prevout)) return true;
                     }
                     return false;
                 });

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(miniminer_negative, TestChain100Setup)
     mini_miner_no_target.BuildMockTemplate(std::nullopt);
     const auto template_txids{mini_miner_no_target.GetMockTemplateTxids()};
     BOOST_CHECK_EQUAL(template_txids.size(), 1);
-    BOOST_CHECK(template_txids.count(tx_mod_negative->GetHash()) > 0);
+    BOOST_CHECK(template_txids.contains(tx_mod_negative->GetHash()));
 }
 
 BOOST_FIXTURE_TEST_CASE(miniminer_1p1c, TestChain100Setup)

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -207,17 +207,17 @@ struct Satisfier : public KeyConverter {
 
     //! Implement simplified CLTV logic: stack value must exactly match an entry in `supported`.
     bool CheckAfter(uint32_t value) const {
-        return supported.count(Challenge(ChallengeType::AFTER, value));
+        return supported.contains(Challenge(ChallengeType::AFTER, value));
     }
 
     //! Implement simplified CSV logic: stack value must exactly match an entry in `supported`.
     bool CheckOlder(uint32_t value) const {
-        return supported.count(Challenge(ChallengeType::OLDER, value));
+        return supported.contains(Challenge(ChallengeType::OLDER, value));
     }
 
     //! Produce a signature for the given key.
     miniscript::Availability Sign(const CPubKey& key, std::vector<unsigned char>& sig) const {
-        if (supported.count(Challenge(ChallengeType::PK, ChallengeNumber(key)))) {
+        if (supported.contains(Challenge(ChallengeType::PK, ChallengeNumber(key)))) {
             if (!miniscript::IsTapscript(m_script_ctx)) {
                 auto it = g_testdata->signatures.find(key);
                 if (it == g_testdata->signatures.end()) return miniscript::Availability::NO;
@@ -234,7 +234,7 @@ struct Satisfier : public KeyConverter {
 
     //! Helper function for the various hash based satisfactions.
     miniscript::Availability SatHash(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage, ChallengeType chtype) const {
-        if (!supported.count(Challenge(chtype, ChallengeNumber(hash)))) return miniscript::Availability::NO;
+        if (!supported.contains(Challenge(chtype, ChallengeNumber(hash)))) return miniscript::Availability::NO;
         const auto& m =
             chtype == ChallengeType::SHA256 ? g_testdata->sha256_preimages :
             chtype == ChallengeType::HASH256 ? g_testdata->hash256_preimages :

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -40,12 +40,12 @@ bool IsProtected(int num_peers,
 
     size_t unprotected_count{0};
     for (const NodeEvictionCandidate& candidate : candidates) {
-        if (protected_peer_ids.count(candidate.id)) {
+        if (protected_peer_ids.contains(candidate.id)) {
             // this peer should have been removed from the eviction candidates
             BOOST_TEST_MESSAGE(strprintf("expected candidate to be protected: %d", candidate.id));
             return false;
         }
-        if (unprotected_peer_ids.count(candidate.id)) {
+        if (unprotected_peer_ids.contains(candidate.id)) {
             // this peer remains in the eviction candidates, as expected
             ++unprotected_count;
         }
@@ -577,7 +577,7 @@ bool IsEvicted(std::vector<NodeEvictionCandidate> candidates, const std::unorder
     if (!evicted_node_id) {
         return false;
     }
-    return node_ids.count(*evicted_node_id);
+    return node_ids.contains(*evicted_node_id);
 }
 
 // Create number_of_nodes random nodes, apply setup function candidate_setup_fn,

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -885,7 +885,7 @@ BOOST_AUTO_TEST_CASE(script_build)
 #ifdef UPDATE_JSON_TESTS
         strGen += str + ",\n";
 #else
-        if (tests_set.count(str) == 0) {
+        if (!tests_set.contains(str)) {
             BOOST_CHECK_MESSAGE(false, "Missing auto script_valid test: " + test.GetComment());
         }
 #endif

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -59,7 +59,7 @@ std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,
     }
     for (const auto& tx : txns) {
         const auto& wtxid = tx->GetWitnessHash();
-        if (result.m_tx_results.count(wtxid) == 0) {
+        if (!result.m_tx_results.contains(wtxid)) {
             return strprintf("result not found for tx %s", wtxid.ToString());
         }
 

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(util_threadnames_test_rename_threaded)
 
     // Names "test_thread.[n]" should exist for n = [0, 99]
     for (int i = 0; i < 100; ++i) {
-        BOOST_CHECK(names.find(TEST_THREAD_NAME_BASE + ToString(i)) != names.end());
+        BOOST_CHECK(names.contains(TEST_THREAD_NAME_BASE + ToString(i)));
     }
 
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -586,17 +586,17 @@ void TorController::protocolinfo_cb(TorControlConnection& _conn, const TorContro
          */
         std::string torpassword = gArgs.GetArg("-torpassword", "");
         if (!torpassword.empty()) {
-            if (methods.count("HASHEDPASSWORD")) {
+            if (methods.contains("HASHEDPASSWORD")) {
                 LogDebug(BCLog::TOR, "Using HASHEDPASSWORD authentication\n");
                 ReplaceAll(torpassword, "\"", "\\\"");
                 _conn.Command("AUTHENTICATE \"" + torpassword + "\"", std::bind(&TorController::auth_cb, this, std::placeholders::_1, std::placeholders::_2));
             } else {
                 LogPrintf("tor: Password provided with -torpassword, but HASHEDPASSWORD authentication is not available\n");
             }
-        } else if (methods.count("NULL")) {
+        } else if (methods.contains("NULL")) {
             LogDebug(BCLog::TOR, "Using NULL authentication\n");
             _conn.Command("AUTHENTICATE", std::bind(&TorController::auth_cb, this, std::placeholders::_1, std::placeholders::_2));
-        } else if (methods.count("SAFECOOKIE")) {
+        } else if (methods.contains("SAFECOOKIE")) {
             // Cookie: hexdump -e '32/1 "%02x""\n"'  ~/.tor/control_auth_cookie
             LogDebug(BCLog::TOR, "Using SAFECOOKIE authentication, reading cookie authentication from %s\n", cookiefile);
             std::pair<bool,std::string> status_cookie = ReadBinaryFile(fs::PathFromString(cookiefile), TOR_COOKIE_SIZE);
@@ -613,7 +613,7 @@ void TorController::protocolinfo_cb(TorControlConnection& _conn, const TorContro
                     LogPrintf("tor: Authentication cookie %s could not be opened (check permissions)\n", cookiefile);
                 }
             }
-        } else if (methods.count("HASHEDPASSWORD")) {
+        } else if (methods.contains("HASHEDPASSWORD")) {
             LogPrintf("tor: The only supported authentication mechanism left is password, but no password provided with -torpassword\n");
         } else {
             LogPrintf("tor: No supported authentication method\n");

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -2403,7 +2403,7 @@ void TxGraphImpl::SanityCheck() const
                 const auto& cluster = *quality_clusters[setindex];
                 // Check the sequence number.
                 assert(cluster.m_sequence < m_next_sequence_counter);
-                assert(sequences.count(cluster.m_sequence) == 0);
+                assert(!sequences.contains(cluster.m_sequence));
                 sequences.insert(cluster.m_sequence);
                 // Remember we saw this Cluster (only if it is non-empty; empty Clusters aren't
                 // expected to be referenced by the Entry vector).

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -73,7 +73,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendan
                 for (txiter cacheEntry : cacheIt->second) {
                     descendants.insert(*cacheEntry);
                 }
-            } else if (!descendants.count(childEntry)) {
+            } else if (!descendants.contains(childEntry)) {
                 // Schedule for later processing
                 stageEntries.insert(childEntry);
             }
@@ -85,7 +85,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendan
     CAmount modifyFee = 0;
     int64_t modifyCount = 0;
     for (const CTxMemPoolEntry& descendant : descendants) {
-        if (!setExclude.count(descendant.GetTx().GetHash())) {
+        if (!setExclude.contains(descendant.GetTx().GetHash())) {
             modifySize += descendant.GetTxSize();
             modifyFee += descendant.GetModifiedFee();
             modifyCount++;
@@ -142,7 +142,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToU
                 assert(childIter != mapTx.end());
                 // We can skip updating entries we've encountered before or that
                 // are in the block (which are already accounted for).
-                if (!visited(childIter) && !setAlreadyIncluded.count(childHash)) {
+                if (!visited(childIter) && !setAlreadyIncluded.contains(childHash)) {
                     UpdateChild(it, childIter, true);
                     UpdateParent(childIter, it, true);
                 }
@@ -190,7 +190,7 @@ util::Result<CTxMemPool::setEntries> CTxMemPool::CalculateAncestorsAndCheckLimit
             txiter parent_it = mapTx.iterator_to(parent);
 
             // If this is a new ancestor, add it.
-            if (ancestors.count(parent_it) == 0) {
+            if (!ancestors.contains(parent_it)) {
                 staged_ancestors.insert(parent);
             }
             if (staged_ancestors.size() + ancestors.size() + entry_count > static_cast<uint64_t>(limits.ancestor_count)) {
@@ -571,7 +571,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
 {
     setEntries stage;
-    if (setDescendants.count(entryit) == 0) {
+    if (!setDescendants.contains(entryit)) {
         stage.insert(entryit);
     }
     // Traverse down the children of entry, only adding children that are not
@@ -585,7 +585,7 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
         const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
         for (const CTxMemPoolEntry& child : children) {
             txiter childiter = mapTx.iterator_to(child);
-            if (!setDescendants.count(childiter)) {
+            if (!setDescendants.contains(childiter)) {
                 stage.insert(childiter);
             }
         }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -630,13 +630,13 @@ public:
     bool exists(const Txid& txid) const
     {
         LOCK(cs);
-        return (mapTx.count(txid) != 0);
+        return mapTx.contains(txid);
     }
 
     bool exists(const Wtxid& wtxid) const
     {
         LOCK(cs);
-        return (mapTx.get<index_by_wtxid>().count(wtxid) != 0);
+        return mapTx.get<index_by_wtxid>().contains(wtxid);
     }
 
     const CTxMemPoolEntry* GetEntry(const Txid& txid) const LIFETIMEBOUND EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -688,7 +688,7 @@ public:
     bool IsUnbroadcastTx(const Txid& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
         AssertLockHeld(cs);
-        return m_unbroadcast_txids.count(txid) != 0;
+        return m_unbroadcast_txids.contains(txid);
     }
 
     /** Guards this internal counter for external reporting */

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -580,7 +580,7 @@ public:
         // Bail out if we already have a CANDIDATE_BEST announcement for this (txhash, peer) combination. The case
         // where there is a non-CANDIDATE_BEST announcement already will be caught by the uniqueness property of the
         // ByPeer index when we try to emplace the new object below.
-        if (m_index.get<ByPeer>().count(ByPeerView{peer, true, gtxid.ToUint256()})) return;
+        if (m_index.get<ByPeer>().contains(ByPeerView{peer, true, gtxid.ToUint256()})) return;
 
         // Try creating the announcement with CANDIDATE_DELAYED state (which will fail due to the uniqueness
         // of the ByPeer index if a non-CANDIDATE_BEST announcement already exists with the same txhash and peer).

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -50,7 +50,7 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
     fs::path pathLockFile = directory / lockfile_name;
 
     // If a lock for this directory already exists in the map, don't try to re-lock it
-    if (dir_locks.count(fs::PathToString(pathLockFile))) {
+    if (dir_locks.contains(fs::PathToString(pathLockFile))) {
         return LockResult::Success;
     }
 

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -48,7 +48,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
 
     // Walk backwards in steps of nPeriod to find a pindexPrev whose information is known
     std::vector<const CBlockIndex*> vToCompute;
-    while (cache.count(pindexPrev) == 0) {
+    while (!cache.contains(pindexPrev)) {
         if (pindexPrev == nullptr) {
             // The genesis block is by definition defined.
             cache[pindexPrev] = ThresholdState::DEFINED;
@@ -64,7 +64,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
     }
 
     // At this point, cache[pindexPrev] is known
-    assert(cache.count(pindexPrev));
+    assert(cache.contains(pindexPrev));
     ThresholdState state = cache[pindexPrev];
 
     // Now walk forward and compute the state of descendants of pindexPrev

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -19,7 +19,7 @@ bool CCoinControl::HasSelected() const
 
 bool CCoinControl::IsSelected(const COutPoint& outpoint) const
 {
-    return m_selected.count(outpoint) > 0;
+    return m_selected.contains(outpoint);
 }
 
 bool CCoinControl::IsExternalSelected(const COutPoint& outpoint) const

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -748,7 +748,7 @@ bool BerkeleyROBatch::ReadKey(DataStream&& key, DataStream& value)
 bool BerkeleyROBatch::HasKey(DataStream&& key)
 {
     SerializeData key_data{key.begin(), key.end()};
-    return m_database.m_records.count(key_data) > 0;
+    return m_database.m_records.contains(key_data);
 }
 
 BerkeleyROCursor::BerkeleyROCursor(const BerkeleyRODatabase& database, std::span<const std::byte> prefix)

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -67,7 +67,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
         }
 
         for (const CTxOut& txout : wtx.tx->vout) {
-            if (output_scripts.count(txout.scriptPubKey) > 0) {
+            if (output_scripts.contains(txout.scriptPubKey)) {
                 amount += txout.nValue;
             }
         }
@@ -612,7 +612,7 @@ RPCHelpMan listunspent()
         bool fValidAddress = ExtractDestination(scriptPubKey, address);
         bool reused = avoid_reuse && pwallet->IsSpentKey(scriptPubKey);
 
-        if (destinations.size() && (!fValidAddress || !destinations.count(address)))
+        if (destinations.size() && (!fValidAddress || !destinations.contains(address)))
             continue;
 
         UniValue entry(UniValue::VOBJ);

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -800,7 +800,7 @@ RPCHelpMan abandontransaction()
 
     Txid hash{Txid::FromUint256(ParseHashV(request.params[0], "txid"))};
 
-    if (!pwallet->mapWallet.count(hash)) {
+    if (!pwallet->mapWallet.contains(hash)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     }
     if (!pwallet->AbandonTransaction(hash)) {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1107,8 +1107,8 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
 
     // Check if provided key already exists
-    if (m_map_keys.find(pubkey.GetID()) != m_map_keys.end() ||
-        m_map_crypted_keys.find(pubkey.GetID()) != m_map_crypted_keys.end()) {
+    if (m_map_keys.contains(pubkey.GetID()) ||
+        m_map_crypted_keys.contains(pubkey.GetID())) {
         return true;
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -631,8 +631,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 3);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1U);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1U);
+        BOOST_CHECK(wallet->mapWallet.contains(block_tx.GetHash()));
+        BOOST_CHECK(wallet->mapWallet.contains(mempool_tx.GetHash()));
     }
 
 
@@ -670,8 +670,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 2 + 2);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1U);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1U);
+        BOOST_CHECK(wallet->mapWallet.contains(block_tx.GetHash()));
+        BOOST_CHECK(wallet->mapWallet.contains(mempool_tx.GetHash()));
     }
 
 
@@ -710,13 +710,13 @@ BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)
 
         LOCK(wallet->cs_wallet);
         BOOST_CHECK(wallet->HasWalletSpend(prev_tx));
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_hash), 1u);
+        BOOST_CHECK(wallet->mapWallet.contains(block_hash));
 
         std::vector<Txid> vHashIn{ block_hash };
         BOOST_CHECK(wallet->RemoveTxs(vHashIn));
 
         BOOST_CHECK(!wallet->HasWalletSpend(prev_tx));
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_hash), 0u);
+        BOOST_CHECK(!wallet->mapWallet.contains(block_hash));
     }
 
     TestUnloadWallet(std::move(wallet));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -264,7 +264,7 @@ void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet)
     wallet.reset();
     {
         WAIT_LOCK(g_wallet_release_mutex, lock);
-        while (g_unloading_wallet_set.count(name) == 1) {
+        while (g_unloading_wallet_set.contains(name)) {
             g_wallet_release_cv.wait(lock);
         }
     }
@@ -1491,7 +1491,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
 
         for (const CTxIn& tx_in : ptx->vin) {
             // No other wallet transactions conflicted with this transaction
-            if (mapTxSpends.count(tx_in.prevout) < 1) continue;
+            if (!mapTxSpends.contains(tx_in.prevout)) continue;
 
             std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(tx_in.prevout);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1179,7 +1179,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             }
         }
 
-        bool fExisted = mapWallet.count(tx.GetHash()) != 0;
+        bool fExisted = mapWallet.contains(tx.GetHash());
         if (fExisted && !fUpdate) return false;
         if (fExisted || IsMine(tx) || IsFromMe(tx))
         {
@@ -1338,7 +1338,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
                 for (TxSpends::const_iterator iter = range.first; iter != range.second; ++iter) {
-                    if (!done.count(iter->second)) {
+                    if (!done.contains(iter->second)) {
                         todo.insert(iter->second);
                     }
                 }
@@ -2485,7 +2485,7 @@ void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations
         if (wtx.m_is_cache_empty) continue;
         for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
             CTxDestination dst;
-            if (ExtractDestination(wtx.tx->vout[i].scriptPubKey, dst) && destinations.count(dst)) {
+            if (ExtractDestination(wtx.tx->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
                 wtx.MarkDirty();
                 break;
             }
@@ -2629,7 +2629,7 @@ bool CWallet::UnlockAllCoins()
 bool CWallet::IsLockedCoin(const COutPoint& output) const
 {
     AssertLockHeld(cs_wallet);
-    return m_locked_coins.count(output) > 0;
+    return m_locked_coins.contains(output);
 }
 
 void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
@@ -3351,7 +3351,7 @@ std::set<ScriptPubKeyMan*> CWallet::GetScriptPubKeyMans(const CScript& script) c
 
 ScriptPubKeyMan* CWallet::GetScriptPubKeyMan(const uint256& id) const
 {
-    if (m_spk_managers.count(id) > 0) {
+    if (m_spk_managers.contains(id)) {
         return m_spk_managers.at(id).get();
     }
     return nullptr;
@@ -3636,7 +3636,7 @@ DescriptorScriptPubKeyMan* CWallet::GetDescriptorScriptPubKeyMan(const WalletDes
 std::optional<bool> CWallet::IsInternalScriptPubKeyMan(ScriptPubKeyMan* spk_man) const
 {
     // only active ScriptPubKeyMan can be internal
-    if (!GetActiveScriptPubKeyMans().count(spk_man)) {
+    if (!GetActiveScriptPubKeyMans().contains(spk_man)) {
         return std::nullopt;
     }
 
@@ -3833,7 +3833,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     if (!data.solvable_descs.empty()) Assume(!data.solvable_wallet->m_cached_spks.empty());
 
     for (auto& desc_spkm : data.desc_spkms) {
-        if (m_spk_managers.count(desc_spkm->GetID()) > 0) {
+        if (m_spk_managers.contains(desc_spkm->GetID())) {
             return util::Error{_("Error: Duplicate descriptors created during migration. Your wallet may be corrupted.")};
         }
         uint256 id = desc_spkm->GetID();
@@ -3981,7 +3981,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         if (require_transfer && !copied) {
 
             // Skip invalid/non-watched scripts that will not be migrated
-            if (not_migrated_dests.count(dest) > 0) {
+            if (not_migrated_dests.contains(dest)) {
                 dests_to_delete.push_back(dest);
                 continue;
             }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -408,7 +408,7 @@ bool LoadEncryptionKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue,
         ssKey >> nID;
         CMasterKey kMasterKey;
         ssValue >> kMasterKey;
-        if(pwallet->mapMasterKeys.count(nID) != 0)
+        if(pwallet->mapMasterKeys.contains(nID))
         {
             strErr = strprintf("Error reading wallet database: duplicate CMasterKey id %u", nID);
             return false;


### PR DESCRIPTION
### Summary
Instead of counting occurrences in sets and maps, the C++20 `::contains` method expresses the intent unambiguously and can return early on first encounter.

### Context
Applied clang‑tidy's [readability‑container‑contains](https://clang.llvm.org/extra/clang-tidy/checks/readability/container-contains.html) check, though many cases required manual changes since tidy couldn't fix them automatically.

### Changes
The changes made here were:

| From                   | To               |
|------------------------|------------------|
| `m.find(k) == m.end()` | `!m.contains(k)` |
| `m.find(k) != m.end()` | `m.contains(k)`  |
| `m.count(k)`           | `m.contains(k)`  |
| `!m.count(k)`          | `!m.contains(k)` |
| `m.count(k) == 0`      | `!m.contains(k)` |
| `m.count(k) != 1`      | `!m.contains(k)` |
| `m.count(k) == 1`      | `m.contains(k)`  |
| `m.count(k) < 1`       | `!m.contains(k)`  |
| `m.count(k) > 0`       | `m.contains(k)`  |
| `m.count(k) != 0`      | `m.contains(k)`  |

> Note that `== 1`/`!= 1`/`< 1` only apply to simple [maps](https://en.cppreference.com/w/cpp/container/map/contains)/[sets](https://en.cppreference.com/w/cpp/container/set/contains) and had to be changed manually.

There are many other cases that could be changed, but we've reverted most of those to reduce conflict with other open PRs.

-----

<details>
<summary>clang-tidy command on Mac</summary>

```bash
rm -rfd build && \
cmake -B build \
  -DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" \
  -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++" \
  -DCMAKE_OSX_SYSROOT="$(xcrun --show-sdk-path)" \
  -DCMAKE_C_FLAGS="-target arm64-apple-macos11" \
  -DCMAKE_CXX_FLAGS="-target arm64-apple-macos11" \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DBUILD_FOR_FUZZING=ON

 "$(brew --prefix llvm)/bin/run-clang-tidy" -quiet -p build -j$(nproc) -checks='-*,readability-container-contains' | grep -v 'clang-tidy'
```

</details>