### PR TITLE
qt: clear command history when clearing the console

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -825,6 +825,7 @@ void RPCConsole::setFontSize(int newSize)
 
 void RPCConsole::clear(bool keep_prompt)
 {
+    history.clear();
     ui->messagesWidget->clear();
     if (!keep_prompt) ui->lineEdit->clear();
     ui->lineEdit->setFocus();


### PR DESCRIPTION
Clears the command history in the qt console when the user clears the console output. 