### PR TITLE
build: note that sysctl was removed from Linux

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -118,7 +118,7 @@ check_cxx_source_compiles("
   #include <sys/sysctl.h>
 
   #ifdef __linux__
-  #error Don't use sysctl on Linux, it's deprecated even when it works
+  #error sysctl was removed
   #endif
 
   int main()
@@ -134,7 +134,7 @@ check_cxx_source_compiles("
   #include <sys/sysctl.h>
 
   #ifdef __linux__
-  #error Don't use sysctl on Linux, it's deprecated even when it works
+  #error sysctl was removed
   #endif
 
   int main()


### PR DESCRIPTION
https://kernelnewbies.org/Linux_5.5#Core_.28various.29.

The checks need to hang around until we no-longer support kernels older than 5.5.