### PR TITLE
wallet: relax external_signer flag constraints

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -26,34 +26,25 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     });
 
     connect(ui->encrypt_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
-        // Disable the disable_privkeys_checkbox and external_signer_checkbox when isEncryptWalletChecked is
+        // Disable the disable_privkeys_checkbox when isEncryptWalletChecked is
         // set to true, enable it when isEncryptWalletChecked is false.
         ui->disable_privkeys_checkbox->setEnabled(!checked);
-#ifdef ENABLE_EXTERNAL_SIGNER
-        ui->external_signer_checkbox->setEnabled(m_has_signers && !checked);
-#endif
+
         // When the disable_privkeys_checkbox is disabled, uncheck it.
         if (!ui->disable_privkeys_checkbox->isEnabled()) {
             ui->disable_privkeys_checkbox->setChecked(false);
         }
-
-        // When the external_signer_checkbox box is disabled, uncheck it.
-        if (!ui->external_signer_checkbox->isEnabled()) {
-            ui->external_signer_checkbox->setChecked(false);
-        }
-
     });
 
     connect(ui->external_signer_checkbox, &QCheckBox::toggled, [this](bool checked) {
-        ui->encrypt_wallet_checkbox->setEnabled(!checked);
-        ui->blank_wallet_checkbox->setEnabled(!checked);
-        ui->disable_privkeys_checkbox->setEnabled(!checked);
-
-        // The external signer checkbox is only enabled when a device is detected.
-        // In that case it is checked by default. Toggling it restores the other
-        // options to their default.
-        ui->encrypt_wallet_checkbox->setChecked(false);
+        // In the basic use case all keys will be on the external signer
+        // device and the wallet should be watch-only. Makes this the
+        // default suggestion.
         ui->disable_privkeys_checkbox->setChecked(checked);
+
+        // The external signer box is checked by default when a device is
+        // detected. Toggling it restores the other options to their default.
+        ui->encrypt_wallet_checkbox->setChecked(false);
         ui->blank_wallet_checkbox->setChecked(false);
     });
 
@@ -103,12 +94,9 @@ void CreateWalletDialog::setSigners(const std::vector<std::unique_ptr<interfaces
     if (m_has_signers) {
         ui->external_signer_checkbox->setEnabled(true);
         ui->external_signer_checkbox->setChecked(true);
-        ui->encrypt_wallet_checkbox->setEnabled(false);
         ui->encrypt_wallet_checkbox->setChecked(false);
         // The order matters, because connect() is called when toggling a checkbox:
-        ui->blank_wallet_checkbox->setEnabled(false);
         ui->blank_wallet_checkbox->setChecked(false);
-        ui->disable_privkeys_checkbox->setEnabled(false);
         ui->disable_privkeys_checkbox->setChecked(true);
         const std::string label = signers[0]->getName();
         ui->wallet_name_line_edit->setText(QString::fromStdString(label));

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -203,7 +203,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
     try {
         auto& newTx = transaction.getWtx();
-        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/!wallet().privateKeysDisabled(), /*change_pos=*/std::nullopt);
+        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/!wallet().privateKeysDisabled() && !wallet().hasExternalSigner(), /*change_pos=*/std::nullopt);
         if (!res) {
             Q_EMIT message(tr("Send Coins"), QString::fromStdString(util::ErrorString(res).translated),
                            CClientUIInterface::MSG_ERROR);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -353,13 +353,13 @@ static RPCMethod createwallet()
         "Creates and loads a new wallet.\n",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name for the new wallet. If this is a path, the wallet will be created at the path location."},
-            {"disable_private_keys", RPCArg::Type::BOOL, RPCArg::Default{false}, "Disable the possibility of private keys (only watchonlys are possible in this mode)."},
+            {"disable_private_keys", RPCArg::Type::BOOL, RPCArg::DefaultHint{"false unless external_signer is set"}, "Disable the possibility of private keys (only watchonlys are possible in this mode)."},
             {"blank", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a blank wallet. A blank wallet has no keys."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Encrypt the wallet with this passphrase."},
             {"avoid_reuse", RPCArg::Type::BOOL, RPCArg::Default{false}, "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind."},
             {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{true}, "If set, must be \"true\""},
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
-            {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true."},
+            {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -381,9 +381,8 @@ static RPCMethod createwallet()
 {
     WalletContext& context = EnsureWalletContext(request.context);
     uint64_t flags = 0;
-    if (!request.params[1].isNull() && request.params[1].get_bool()) {
-        flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
-    }
+
+    std::optional<bool> disable_private_keys{self.MaybeArg<bool>("disable_private_keys")};
 
     if (!request.params[2].isNull() && request.params[2].get_bool()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
@@ -409,9 +408,19 @@ static RPCMethod createwallet()
     if (!request.params[7].isNull() && request.params[7].get_bool()) {
 #ifdef ENABLE_EXTERNAL_SIGNER
         flags |= WALLET_FLAG_EXTERNAL_SIGNER;
+        if (!disable_private_keys.has_value()) {
+            // In the basic use case all keys will be on the external signer
+            // device and the wallet should be watch-only. Makes this the
+            // default.
+            disable_private_keys = true;
+        }
 #else
         throw JSONRPCError(RPC_WALLET_ERROR, "Compiled without external signing support (required for external signing)");
 #endif
+    }
+
+    if (disable_private_keys.value_or(false)) {
+        flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
     }
 
     DatabaseOptions options;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -400,13 +400,6 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     options.require_format = DatabaseFormat::SQLITE;
 
 
-    // Private keys must be disabled for an external signer wallet
-    if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) && !(wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Private keys must be disabled when using an external signer");
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
-    }
-
     // Do not allow a passphrase when private keys are disabled
     if (born_encrypted && (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         error = Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3692,10 +3692,10 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
 void CWallet::SetupWalletGeneration()
 {
     AssertLockHeld(cs_wallet);
-    // Skip setup for non-external-signer wallets that are either blank
-    // or have private keys disabled (not having private keys implies blank).
-    if (!IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER) &&
-        (IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET) || IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS))) {
+    // Skip setup for blank wallets. Non-external-signer wallets with disabled
+    // private keys also skip setup (not having private keys implies blank).
+    if (IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET) ||
+        (!IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER) && IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS))) {
         return;
     }
     SetupDescriptorScriptPubKeyMans();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -157,7 +157,8 @@ static constexpr uint64_t KNOWN_WALLET_FLAGS =
     |   WALLET_FLAG_EXTERNAL_SIGNER;
 
 static constexpr uint64_t MUTABLE_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE;
+        WALLET_FLAG_AVOID_REUSE
+    |   WALLET_FLAG_EXTERNAL_SIGNER;
 
 static const std::map<WalletFlags, std::string> WALLET_FLAG_TO_STRING{
     {WALLET_FLAG_AVOID_REUSE, "avoid_reuse"},

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -49,6 +49,7 @@ def displayaddress(args):
         "sh(wpkh([00000001/49h/1h/0h/0/0]02c97dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7))#kz9y5w82": "2N2gQKzjUe47gM8p1JZxaAkTcoHPXV6YyVp",
         "pkh([00000001/44h/1h/0h/0/0]02c97dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7)#q3pqd8wh": "n1LKejAadN6hg2FrBXoU1KrwX4uK16mco9",
         "tr([00000001/86h/1h/0h/0/0]c97dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7)#puqqa90m": "tb1phw4cgpt6cd30kz9k4wkpwm872cdvhss29jga2xpmftelhqll62mscq0k4g",
+        "tr([296d4e60/0/0]d5b810749f280dac8114cdb1c44fdcd6a725cb73669477b478f2172f0b32129a)#7luf7va9": "bcrt1p6s0wuy6g4ggh4qds9cju533wve82fnazzp4xkpk3p780gz30m5us9dqyaa",
         "wpkh([00000001/84h/1h/0h/0/1]03a20a46308be0b8ded6dff0a22b10b4245c587ccf23f3b4a303885be3a524f172)#aqpjv5xr": "wrong_address",
     }
     if args.desc not in expected_desc:

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -9,7 +9,6 @@ See also wallet_signer.py for tests that require wallet context.
 """
 import os
 import platform
-import sys
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -19,10 +18,6 @@ from test_framework.util import (
 
 
 class RPCSignerTest(BitcoinTestFramework):
-    def mock_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'signer.py')
-        return sys.executable + " " + path
-
     def set_test_params(self):
         self.num_nodes = 4
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1117,6 +1117,11 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if not self.is_external_signer_compiled():
             raise SkipTest("external signer support has not been compiled.")
 
+    def mock_signer_path(self, name='signer.py'):
+        """Return a command that invokes a mock external signer script under test/functional/mocks/."""
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'mocks', name)
+        return sys.executable + " " + os.path.realpath(path)
+
     def skip_if_running_under_valgrind(self):
         """Skip the running test if Valgrind is being used."""
         if self.options.valgrind:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -158,6 +158,7 @@ BASE_SCRIPTS = [
     'p2p_timeouts.py --v2transport',
     'rpc_signer.py',
     'wallet_signer.py',
+    'wallet_signer_musig2.py',
     'mempool_limit.py',
     'rpc_txoutproof.py',
     'rpc_orphans.py',

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -8,7 +8,6 @@ Verify that a bitcoind node can use an external signer command
 See also rpc_signer.py for tests without wallet context.
 """
 import os
-import sys
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -19,22 +18,6 @@ from test_framework.util import (
 
 
 class WalletSignerTest(BitcoinTestFramework):
-    def mock_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'signer.py')
-        return sys.executable + " " + path
-
-    def mock_no_connected_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'no_signer.py')
-        return sys.executable + " " + path
-
-    def mock_invalid_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'invalid_signer.py')
-        return sys.executable + " " + path
-
-    def mock_multi_signers_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'multi_signers.py')
-        return sys.executable + " " + path
-
     def set_test_params(self):
         self.num_nodes = 2
 
@@ -57,9 +40,9 @@ class WalletSignerTest(BitcoinTestFramework):
     def run_test(self):
         self.test_valid_signer()
         self.test_disconnected_signer()
-        self.restart_node(1, [f"-signer={self.mock_invalid_signer_path()}", "-keypool=10"])
+        self.restart_node(1, [f"-signer={self.mock_signer_path('invalid_signer.py')}", "-keypool=10"])
         self.test_invalid_signer()
-        self.restart_node(1, [f"-signer={self.mock_multi_signers_path()}", "-keypool=10"])
+        self.restart_node(1, [f"-signer={self.mock_signer_path('multi_signers.py')}", "-keypool=10"])
         self.test_multiple_signers()
 
     def test_valid_signer(self):
@@ -251,8 +234,8 @@ class WalletSignerTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
 
         # Restart node with no signer connected
-        self.log.debug(f"-signer={self.mock_no_connected_signer_path()}")
-        self.restart_node(1, [f"-signer={self.mock_no_connected_signer_path()}", "-keypool=10"])
+        self.log.debug(f"-signer={self.mock_signer_path('no_signer.py')}")
+        self.restart_node(1, [f"-signer={self.mock_signer_path('no_signer.py')}", "-keypool=10"])
         self.nodes[1].loadwallet('hww_disconnect')
         hww = self.nodes[1].get_wallet_rpc('hww_disconnect')
 
@@ -261,12 +244,12 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_raises_rpc_error(-25, "External signer not found", hww.send, outputs=[{dest:0.5}])
 
     def test_invalid_signer(self):
-        self.log.debug(f"-signer={self.mock_invalid_signer_path()}")
+        self.log.debug(f"-signer={self.mock_signer_path('invalid_signer.py')}")
         self.log.info('Test invalid external signer')
         assert_raises_rpc_error(-1, "Invalid descriptor", self.nodes[1].createwallet, wallet_name='hww_invalid', external_signer=True)
 
     def test_multiple_signers(self):
-        self.log.debug(f"-signer={self.mock_multi_signers_path()}")
+        self.log.debug(f"-signer={self.mock_signer_path('multi_signers.py')}")
         self.log.info('Test multiple external signers')
 
         assert_raises_rpc_error(-1, "More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', external_signer=True)

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -72,6 +72,13 @@ class WalletSignerTest(BitcoinTestFramework):
         hww = self.nodes[1].get_wallet_rpc('hww')
         assert_equal(hww.getwalletinfo()["external_signer"], True)
 
+        # A blank external signer wallet does not auto-import any keys.
+        self.nodes[1].createwallet(wallet_name='hww_blank', disable_private_keys=True, external_signer=True, blank=True)
+        hww_blank = self.nodes[1].get_wallet_rpc('hww_blank')
+        assert_equal(hww_blank.getwalletinfo()["keypoolsize"], 0)
+        assert_equal(hww_blank.listdescriptors()["descriptors"], [])
+        self.nodes[1].unloadwallet('hww_blank')
+
         # Flag can't be set afterwards (could be added later for non-blank descriptor based watch-only wallets)
         self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, external_signer=False)
         not_hww = self.nodes[1].get_wallet_rpc('not_hww')

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -87,13 +87,14 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_equal(hww_blank.listdescriptors()["descriptors"], [])
         self.nodes[1].unloadwallet('hww_blank')
 
-        # Flag can't be set afterwards (could be added later for non-blank descriptor based watch-only wallets)
-        self.nodes[1].createwallet(wallet_name='not_hww', external_signer=False)
-        not_hww = self.nodes[1].get_wallet_rpc('not_hww')
-        assert_equal(not_hww.getwalletinfo()["external_signer"], False)
+        # Flag can be set afterwards
+        self.nodes[1].createwallet(wallet_name='not_hww_initially', external_signer=False)
+        not_hww_initially = self.nodes[1].get_wallet_rpc('not_hww_initially')
+        assert_equal(not_hww_initially.getwalletinfo()["external_signer"], False)
         # Without external_signer, private keys are enabled by default
-        assert_equal(not_hww.getwalletinfo()["private_keys_enabled"], True)
-        assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
+        assert_equal(not_hww_initially.getwalletinfo()["private_keys_enabled"], True)
+        not_hww_initially.setwalletflag("external_signer", True)
+        assert_equal(not_hww_initially.getwalletinfo()["external_signer"], True)
 
         self.set_mock_result(self.nodes[1], '0 {"invalid json"}')
         assert_raises_rpc_error(-1, 'Unable to parse JSON',

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -66,29 +66,38 @@ class WalletSignerTest(BitcoinTestFramework):
         self.log.debug(f"-signer={self.mock_signer_path()}")
 
         # Create new wallets for an external signer.
-        # disable_private_keys and descriptors must be true:
-        assert_raises_rpc_error(-4, "Private keys must be disabled when using an external signer", self.nodes[1].createwallet, wallet_name='not_hww', disable_private_keys=False, external_signer=True)
-        self.nodes[1].createwallet(wallet_name='hww', disable_private_keys=True, external_signer=True)
+        self.nodes[1].createwallet(wallet_name='hww', external_signer=True)
         hww = self.nodes[1].get_wallet_rpc('hww')
         assert_equal(hww.getwalletinfo()["external_signer"], True)
 
+        # Private keys are disabled by default
+        assert_equal(hww.getwalletinfo()["private_keys_enabled"], False)
+
+        # Private keys can be explicitly enabled for external signer wallets
+        self.nodes[1].createwallet(wallet_name='hww_hot', external_signer=True, disable_private_keys=False)
+        hww_hot = self.nodes[1].get_wallet_rpc('hww_hot')
+        assert_equal(hww_hot.getwalletinfo()["external_signer"], True)
+        assert_equal(hww_hot.getwalletinfo()["private_keys_enabled"], True)
+        self.nodes[1].unloadwallet('hww_hot')
+
         # A blank external signer wallet does not auto-import any keys.
-        self.nodes[1].createwallet(wallet_name='hww_blank', disable_private_keys=True, external_signer=True, blank=True)
+        self.nodes[1].createwallet(wallet_name='hww_blank', external_signer=True, blank=True)
         hww_blank = self.nodes[1].get_wallet_rpc('hww_blank')
         assert_equal(hww_blank.getwalletinfo()["keypoolsize"], 0)
         assert_equal(hww_blank.listdescriptors()["descriptors"], [])
         self.nodes[1].unloadwallet('hww_blank')
 
         # Flag can't be set afterwards (could be added later for non-blank descriptor based watch-only wallets)
-        self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, external_signer=False)
+        self.nodes[1].createwallet(wallet_name='not_hww', external_signer=False)
         not_hww = self.nodes[1].get_wallet_rpc('not_hww')
         assert_equal(not_hww.getwalletinfo()["external_signer"], False)
+        # Without external_signer, private keys are enabled by default
+        assert_equal(not_hww.getwalletinfo()["private_keys_enabled"], True)
         assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
-
 
         self.set_mock_result(self.nodes[1], '0 {"invalid json"}')
         assert_raises_rpc_error(-1, 'Unable to parse JSON',
-            self.nodes[1].createwallet, wallet_name='hww2', disable_private_keys=True, external_signer=True
+            self.nodes[1].createwallet, wallet_name='hww2', external_signer=True
         )
         self.clear_mock_result(self.nodes[1])
 
@@ -232,7 +241,7 @@ class WalletSignerTest(BitcoinTestFramework):
         self.log.info('Test disconnected external signer')
 
         # First create a wallet with the signer connected
-        self.nodes[1].createwallet(wallet_name='hww_disconnect', disable_private_keys=True, external_signer=True)
+        self.nodes[1].createwallet(wallet_name='hww_disconnect', external_signer=True)
         hww = self.nodes[1].get_wallet_rpc('hww_disconnect')
         assert_equal(hww.getwalletinfo()["external_signer"], True)
 
@@ -253,13 +262,13 @@ class WalletSignerTest(BitcoinTestFramework):
     def test_invalid_signer(self):
         self.log.debug(f"-signer={self.mock_invalid_signer_path()}")
         self.log.info('Test invalid external signer')
-        assert_raises_rpc_error(-1, "Invalid descriptor", self.nodes[1].createwallet, wallet_name='hww_invalid', disable_private_keys=True, external_signer=True)
+        assert_raises_rpc_error(-1, "Invalid descriptor", self.nodes[1].createwallet, wallet_name='hww_invalid', external_signer=True)
 
     def test_multiple_signers(self):
         self.log.debug(f"-signer={self.mock_multi_signers_path()}")
         self.log.info('Test multiple external signers')
 
-        assert_raises_rpc_error(-1, "More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, external_signer=True)
+        assert_raises_rpc_error(-1, "More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', external_signer=True)
 
 if __name__ == '__main__':
     WalletSignerTest(__file__).main()

--- a/test/functional/wallet_signer_musig2.py
+++ b/test/functional/wallet_signer_musig2.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test MuSig2 descriptors in an external-signer wallet."""
+
+from test_framework.descriptors import descsum_create
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+# The device side of the MuSig2 setup.
+DEVICE_ORIGIN = "[00000001/84h/1h/0h]"
+DEVICE_XPUB = "tpubDCxzhZZE31g2EqSv1UajMAw5Hd62htydz9r2XBkrccHgBh8uw3n62zr6Zjmj64tfTk8Tjxo6VctjUMAh5DXWTErfQPC6RmQhTdtNnXuTXTQ"
+
+# Hardcode the local MuSig participant's account xprv so the test can import a
+# descriptor with one hot-wallet key and one external-signer key.
+LOCAL_ORIGIN = "[ec63add0/84h/1h/0h]"
+LOCAL_XPRV = "tprv8gauGKtmnH4cxv22ZtmEKqDDAeqnm2b4srPWuFsugMuVc79KDEHRTWgKGdAhACqjZQytU1o9gcc91TSW8L1s18PgFUHAJ8p8iY1GwaUEn9u"
+
+# The hot wallet in this test does not contain an HD key. After
+# bitcoin/bitcoin#29136 it could, and after bitcoin/bitcoin#32784 we could
+# derive the 84h/1h/0h derivation xprv. A subsequent improvement to
+# importdescriptors could avoid the need to handle xprvs, by recognizing
+# an xpub for which it already has the matching private key material.
+
+class WalletSignerMuSig2Test(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [
+            [f"-signer={self.mock_signer_path()}", '-keypool=10'],
+        ]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_external_signer()
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.test_create_wallet()
+        self.test_display_address()
+
+    def test_create_wallet(self):
+        self.log.info('Create an external-signer wallet with a MuSig2 descriptor')
+
+        musig_descriptor = f"tr(musig({LOCAL_ORIGIN}{LOCAL_XPRV},{DEVICE_ORIGIN}{DEVICE_XPUB})/<0;1>/*)"
+
+        # Blank wallet so createwallet doesn't import the device's single-sig
+        # descriptors (which would clutter the wallet).
+        self.nodes[0].createwallet(
+            wallet_name='hww_musig',
+            external_signer=True,
+            disable_private_keys=False,
+            blank=True,
+        )
+        hww_musig = self.nodes[0].get_wallet_rpc('hww_musig')
+
+        result = hww_musig.importdescriptors([{
+            "desc": descsum_create(musig_descriptor),
+            "active": True,
+            "timestamp": "now",
+        }])
+        assert_equal(result[0]["success"], True)
+
+        # Reload so the imported descriptor is managed by
+        # ExternalSignerScriptPubKeyMan rather than the plain
+        # DescriptorScriptPubKeyMan it was added to on import.
+        self.nodes[0].unloadwallet('hww_musig')
+        self.nodes[0].loadwallet('hww_musig')
+
+        descs = self.nodes[0].get_wallet_rpc('hww_musig').listdescriptors()["descriptors"]
+        active_musig = [d for d in descs if d["active"] and d["desc"].startswith("tr(musig(")]
+        # One active descriptor each for receive and change.
+        assert_equal(len(active_musig), 2)
+
+    def test_display_address(self):
+        self.log.info('Display an address from the MuSig2 descriptor')
+        hww_musig = self.nodes[0].get_wallet_rpc('hww_musig')
+
+        addr = hww_musig.getnewaddress(address_type="bech32m")
+        addr_info = hww_musig.getaddressinfo(addr)
+        assert_equal(addr_info["ismine"], True)
+        assert_equal(addr_info["solvable"], True)
+        # This is not expected to work on a real device, which needs additional
+        # information such as a BIP388 policy.
+        assert_equal(hww_musig.walletdisplayaddress(addr), {"address": addr})
+
+
+if __name__ == '__main__':
+    WalletSignerMuSig2Test(__file__).main()


### PR DESCRIPTION
The `external_signer` indicates that an external signer device may be called via [HWI](https://github.com/bitcoin-core/HWI) or [equivalent](https://github.com/bitcoin/bitcoin/blob/master/doc/external-signer.md#signer-api) application.

When it was initially introduced some additional constraints were placed on wallets with this flag: it had to be a descriptor wallet and watch-only. Also the flag could not be added or removed later.

The constraints aren't a problem for the main supported and documented use case of connecting a single hardware wallet and using it just like a normal single sig Bitcoin Core wallet.

But they get in the way of MuSig2 support, see https://github.com/Sjors/bitcoin/pull/91.

This pull request drops the following constraints:

- `disable_private_keys` is no longer mandatory (but still default)
- `external_signer` flag is now mutable

Changing the `external_signer` flag reloads the wallet so that its descriptor ScriptPubKeyMans are recreated using the new setting.

Additionally it does the following:

- make the `blank` option for `createwallet` consistent with regular wallets by _not_ importing keys from the connected signer
- avoid going through `createTransaction` for external signers (otherwise the GUI breaks)
- create an `ExternalSignerScriptPubKeyMan` when importing a descriptor into an external signer wallet, instead of requiring an additional reload

This should have no noticeable effect on the default single sig use case described above.

Finally we add test coverage for spending from an imported hot key descriptor in an external signer wallet. The wallet signs with its own keys before involving the external signer.