### PR TITLE
refactor: Use immediate lambda to work around GCC bug 117966

### DIFF
--- a/ci/test/00_setup_env_native_centos.sh
+++ b/ci/test/00_setup_env_native_centos.sh
@@ -10,11 +10,11 @@ export CONTAINER_NAME=ci_native_centos
 export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
 export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make ninja-build git python3 python3-pip which patch xz procps-ng ksh rsync coreutils bison e2fsprogs cmake"
 export PIP_PACKAGES="pyzmq"
+export DEP_OPTS="DEBUG=1"
 export GOAL="install"
 export BITCOIN_CONFIG="\
  -DWITH_ZMQ=ON \
  -DBUILD_GUI=ON \
  -DREDUCE_EXPORTS=ON \
- -DAPPEND_CPPFLAGS='-D_GLIBCXX_ASSERTIONS' \
  -DCMAKE_BUILD_TYPE=Debug \
 "

--- a/src/musig.h
+++ b/src/musig.h
@@ -14,7 +14,12 @@ struct secp256k1_musig_keyagg_cache;
 
 //! MuSig2 chaincode as defined by BIP 328
 using namespace util::hex_literals;
-constexpr uint256 MUSIG_CHAINCODE{"868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"_hex_u8};
+constexpr uint256 MUSIG_CHAINCODE{
+    // Use immediate lambda to work around GCC-14 bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117966
+    []() consteval { return uint256{"868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"_hex_u8}; }(),
+};
+
+
 
 //! Create a secp256k1_musig_keyagg_cache from the pubkeys in their current order. This is necessary for most MuSig2 operations
 bool GetMuSig2KeyAggCache(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache);


### PR DESCRIPTION
This PR is a follow-up to the recently merged [#31244](https://github.com/bitcoin/bitcoin/pull/31244), and provides a workaround for affected GCC compilers, similar to https://github.com/bitcoin/bitcoin/pull/31493.

Without this workaround, building the master branch using GCC 13 or 14 with the `-D_GLIBCXX_DEBUG` flag fails with the following error:
```
$ cmake -B build -DAPPEND_CPPFLAGS="-D_GLIBCXX_DEBUG"
-- The CXX compiler identification is GNU 13.3.0
<snip>
$ cmake --build build
[2/10] Building CXX object src/CMakeFiles/bitcoin_common.dir/musig.cpp.o
FAILED: src/CMakeFiles/bitcoin_common.dir/musig.cpp.o 
/usr/bin/ccache /usr/bin/c++ -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_NO_CXX98_FUNCTION_BASE -I/home/hebasto/dev/bitcoin/build/src -I/home/hebasto/dev/bitcoin/src -I/home/hebasto/dev/bitcoin/src/univalue/include -I/home/hebasto/dev/bitcoin/src/secp256k1/include -O2 -g -std=c++20 -fPIC -fno-extended-identifiers -fdebug-prefix-map=/home/hebasto/dev/bitcoin/src=. -fmacro-prefix-map=/home/hebasto/dev/bitcoin/src=. -fstack-reuse=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wbidi-chars=any -Wundef -Wno-unused-parameter -MD -MT src/CMakeFiles/bitcoin_common.dir/musig.cpp.o -MF src/CMakeFiles/bitcoin_common.dir/musig.cpp.o.d -o src/CMakeFiles/bitcoin_common.dir/musig.cpp.o -c /home/hebasto/dev/bitcoin/src/musig.cpp -D_GLIBCXX_DEBUG
In file included from /usr/include/c++/13/debug/stl_iterator.h:32,
                 from /usr/include/c++/13/bits/stl_iterator.h:3003,
                 from /usr/include/c++/13/string:48,
                 from ../src/crypto/sha256.h:10,
                 from ../src/hash.h:12,
                 from ../src/pubkey.h:10,
                 from ../src/musig.h:8,
                 from ../src/musig.cpp:5:
../src/musig.h:17:108:   in ‘constexpr’ expansion of ‘std::span<const unsigned char>(util::hex_literals::operator""_hex_u8<util::detail::Hex<65>{std::array<std::byte, 32>{std::__array_traits<std::byte, 32>::_Type{(std::byte)134, (std::byte)128, (std::byte)135, (std::byte)202, (std::byte)2, (std::byte)166, (std::byte)249, (std::byte)116, (std::byte)196, (std::byte)89, (std::byte)137, (std::byte)36, (std::byte)195, (std::byte)107, (std::byte)87, (std::byte)118, (std::byte)45, (std::byte)50, (std::byte)203, (std::byte)69, (std::byte)113, (std::byte)113, (std::byte)103, (std::byte)227, (std::byte)0, (std::byte)98, (std::byte)44, (std::byte)113, (std::byte)103, (std::byte)227, (std::byte)137, (std::byte)101}}}>())’
/usr/include/c++/13/span:204:57:   in ‘constexpr’ expansion of ‘((std::span<const unsigned char>*)this)->std::span<const unsigned char>::span<const unsigned char*>((& __arr)->std::array<unsigned char, 32>::data(), 32)’
/usr/include/c++/13/span:167:4:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range<const unsigned char*>(__first, (__first + ((sizetype)__count)))’
/usr/include/c++/13/debug/helper_functions.h:267:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (_Integral(), _Integral()))’
/usr/include/c++/13/debug/helper_functions.h:197:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (std::__iterator_category<const unsigned char*>(__first), std::iterator_traits<const unsigned char*>::iterator_category()))’
/usr/include/c++/13/debug/helper_functions.h:183:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (std::input_iterator_tag(), std::input_iterator_tag()))’
/usr/include/c++/13/debug/helper_functions.h:143:20: error: ‘(((const unsigned char*)(&<anonymous>.std::array<unsigned char, 32>::_M_elems)) == 0)’ is not a constant expression
  143 |     { return __ptr == 0; }
      |              ~~~~~~^~~~
[3/10] Building CXX object src/CMakeFiles/bitcoin_common.dir/script/descriptor.cpp.o
FAILED: src/CMakeFiles/bitcoin_common.dir/script/descriptor.cpp.o 
/usr/bin/ccache /usr/bin/c++ -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_NO_CXX98_FUNCTION_BASE -I/home/hebasto/dev/bitcoin/build/src -I/home/hebasto/dev/bitcoin/src -I/home/hebasto/dev/bitcoin/src/univalue/include -I/home/hebasto/dev/bitcoin/src/secp256k1/include -O2 -g -std=c++20 -fPIC -fno-extended-identifiers -fdebug-prefix-map=/home/hebasto/dev/bitcoin/src=. -fmacro-prefix-map=/home/hebasto/dev/bitcoin/src=. -fstack-reuse=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wbidi-chars=any -Wundef -Wno-unused-parameter -MD -MT src/CMakeFiles/bitcoin_common.dir/script/descriptor.cpp.o -MF src/CMakeFiles/bitcoin_common.dir/script/descriptor.cpp.o.d -o src/CMakeFiles/bitcoin_common.dir/script/descriptor.cpp.o -c /home/hebasto/dev/bitcoin/src/script/descriptor.cpp -D_GLIBCXX_DEBUG
In file included from /usr/include/c++/13/debug/stl_iterator.h:32,
                 from /usr/include/c++/13/bits/stl_iterator.h:3003,
                 from /usr/include/c++/13/string:48,
                 from ../src/crypto/sha256.h:10,
                 from ../src/hash.h:12,
                 from ../src/pubkey.h:10,
                 from ../src/addresstype.h:9,
                 from ../src/outputtype.h:9,
                 from ../src/script/descriptor.h:8,
                 from ../src/script/descriptor.cpp:5:
../src/musig.h:17:108:   in ‘constexpr’ expansion of ‘std::span<const unsigned char>(util::hex_literals::operator""_hex_u8<util::detail::Hex<65>{std::array<std::byte, 32>{std::__array_traits<std::byte, 32>::_Type{(std::byte)134, (std::byte)128, (std::byte)135, (std::byte)202, (std::byte)2, (std::byte)166, (std::byte)249, (std::byte)116, (std::byte)196, (std::byte)89, (std::byte)137, (std::byte)36, (std::byte)195, (std::byte)107, (std::byte)87, (std::byte)118, (std::byte)45, (std::byte)50, (std::byte)203, (std::byte)69, (std::byte)113, (std::byte)113, (std::byte)103, (std::byte)227, (std::byte)0, (std::byte)98, (std::byte)44, (std::byte)113, (std::byte)103, (std::byte)227, (std::byte)137, (std::byte)101}}}>())’
/usr/include/c++/13/span:204:57:   in ‘constexpr’ expansion of ‘((std::span<const unsigned char>*)this)->std::span<const unsigned char>::span<const unsigned char*>((& __arr)->std::array<unsigned char, 32>::data(), 32)’
/usr/include/c++/13/span:167:4:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range<const unsigned char*>(__first, (__first + ((sizetype)__count)))’
/usr/include/c++/13/debug/helper_functions.h:267:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (_Integral(), _Integral()))’
/usr/include/c++/13/debug/helper_functions.h:197:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (std::__iterator_category<const unsigned char*>(__first), std::iterator_traits<const unsigned char*>::iterator_category()))’
/usr/include/c++/13/debug/helper_functions.h:183:44:   in ‘constexpr’ expansion of ‘__gnu_debug::__valid_range_aux<const unsigned char*>(__first, __last, (std::input_iterator_tag(), std::input_iterator_tag()))’
/usr/include/c++/13/debug/helper_functions.h:143:20: error: ‘(((const unsigned char*)(&<anonymous>.std::array<unsigned char, 32>::_M_elems)) == 0)’ is not a constant expression
  143 |     { return __ptr == 0; }
      |              ~~~~~~^~~~
ninja: build stopped: subcommand failed.
```
