### PR TITLE
Interfaces: Expose UTXO Snapshot Loading and Add Progress Notifications

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -239,6 +239,10 @@ public:
     using ShowProgressFn = std::function<void(const std::string& title, int progress, bool resume_possible)>;
     virtual std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) = 0;
 
+    //! Register handler for snapshot load progress.
+    using SnapshotLoadProgressFn = std::function<void(double progress)>;
+    virtual std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) = 0;
+
     //! Register handler for wallet loader constructed messages.
     using InitWalletFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -11,7 +11,10 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <interfaces/snapshot.h>
+#include <node/utxo_snapshot.h>
 #include <support/allocators/secure.h>
+#include <util/fs.h>
 #include <util/log.h>
 #include <util/translation.h>
 
@@ -204,6 +207,9 @@ public:
 
     //! List rpc commands.
     virtual std::vector<std::string> listRpcCommands() = 0;
+
+    //! UTXO Snapshot interface.
+    virtual std::unique_ptr<Snapshot> snapshot(const fs::path& path) = 0;
 
     //! Get unspent output associated with a transaction.
     virtual std::optional<Coin> getUnspentOutput(const COutPoint& output) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -13,6 +13,7 @@
 #include <netbase.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/log.h>
 #include <util/translation.h>
 
@@ -38,6 +39,7 @@ struct NodeContext;
 
 namespace interfaces {
 class Handler;
+class Snapshot;
 class WalletLoader;
 struct BlockTip;
 
@@ -199,6 +201,9 @@ public:
 
     //! List rpc commands.
     virtual std::vector<std::string> listRpcCommands() = 0;
+
+    //! UTXO Snapshot interface.
+    virtual std::unique_ptr<Snapshot> snapshot(const fs::path& path) = 0;
 
     //! Get unspent output associated with a transaction.
     virtual std::optional<Coin> getUnspentOutput(const COutPoint& output) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -232,6 +232,10 @@ public:
     using ShowProgressFn = std::function<void(const std::string& title, int progress, bool resume_possible)>;
     virtual std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) = 0;
 
+    //! Register handler for snapshot load progress.
+    using SnapshotLoadProgressFn = std::function<void(double progress)>;
+    virtual std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) = 0;
+
     //! Register handler for wallet loader constructed messages.
     using InitWalletFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) = 0;

--- a/src/interfaces/snapshot.h
+++ b/src/interfaces/snapshot.h
@@ -1,0 +1,36 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_SNAPSHOT_H
+#define BITCOIN_INTERFACES_SNAPSHOT_H
+
+#include <util/result.h>
+
+class CBlockIndex;
+namespace node {
+class SnapshotMetadata;
+}
+
+namespace interfaces {
+
+//! Interface for managing UTXO snapshots.
+class Snapshot
+{
+public:
+    virtual ~Snapshot() = default;
+
+    //! Activate the snapshot, making it the active chainstate. On success,
+    //! returns a pointer to the block index of the snapshot base. On failure,
+    //! the returned result carries a descriptive error message.
+    virtual util::Result<const CBlockIndex*> activate() = 0;
+
+    //! Get the snapshot metadata. Only valid after activate() has been called
+    //! (successfully or not), since metadata is populated as a side effect of
+    //! reading the snapshot file.
+    virtual const node::SnapshotMetadata& getMetadata() const = 0;
+};
+
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_SNAPSHOT_H

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -40,6 +40,7 @@ public:
     [[nodiscard]] virtual InterruptResult blockTip(SynchronizationState state, const CBlockIndex& index, double verification_progress) { return {}; }
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
+    virtual void snapshotLoadProgress(double progress) {}
     virtual void warningSet(Warning id, const bilingual_str& message) {}
     virtual void warningUnset(Warning id) {}
 

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -21,6 +21,7 @@ struct UISignals {
     btcsignals::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
     btcsignals::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
     btcsignals::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
+    btcsignals::signal<CClientUIInterface::SnapshotLoadProgressSig> SnapshotLoadProgress;
     btcsignals::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
     btcsignals::signal<CClientUIInterface::NotifyHeaderTipSig> NotifyHeaderTip;
     btcsignals::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
@@ -44,6 +45,7 @@ ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
+ADD_SIGNALS_IMPL_WRAPPER(SnapshotLoadProgress);
 
 bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style).value_or(false);}
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style).value_or(false);}
@@ -53,6 +55,7 @@ void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { re
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
+void CClientUIInterface::SnapshotLoadProgress(double progress) { return g_ui_signals.SnapshotLoadProgress(progress); }
 void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex& block, double verification_progress) { return g_ui_signals.NotifyBlockTip(s, block, verification_progress); }
 void CClientUIInterface::NotifyHeaderTip(SynchronizationState s, int64_t height, int64_t timestamp, bool presync) { return g_ui_signals.NotifyHeaderTip(s, height, timestamp, presync); }
 void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -100,6 +100,9 @@ public:
      */
     ADD_SIGNALS_DECL_WRAPPER(ShowProgress, void, const std::string& title, int nProgress, bool resume_possible);
 
+    /** Snapshot load progress. */
+    ADD_SIGNALS_DECL_WRAPPER(SnapshotLoadProgress, void, double progress);
+
     /** New block has been accepted */
     ADD_SIGNALS_DECL_WRAPPER(NotifyBlockTip, void, SynchronizationState, const CBlockIndex& block, double verification_progress);
 

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -93,6 +93,9 @@ public:
      */
     btcsignals::signal<void(const std::string& title, int nProgress, bool resume_possible)> ShowProgress;
 
+    /** Snapshot load progress. */
+    btcsignals::signal<void(double progress)> SnapshotLoadProgress;
+
     /** New block has been accepted */
     btcsignals::signal<void(SynchronizationState, const CBlockIndex& block, double verification_progress)> NotifyBlockTip;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -451,6 +451,10 @@ public:
     {
         return MakeSignalHandler(::uiInterface.ShowProgress_connect(fn));
     }
+    std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) override
+    {
+        return MakeSignalHandler(::uiInterface.SnapshotLoadProgress_connect(fn));
+    }
     std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) override
     {
         return MakeSignalHandler(::uiInterface.InitWallet_connect(fn));

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -24,6 +24,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/rpc.h>
+#include <interfaces/snapshot.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -45,6 +46,7 @@
 #include <node/mining_types.h>
 #include <node/transaction.h>
 #include <node/types.h>
+#include <node/utxo_snapshot.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -56,11 +58,14 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
+#include <streams.h>
 #include <sync.h>
+#include <tinyformat.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <univalue.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/string.h>
@@ -73,8 +78,10 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <ios>
 #include <map>
 #include <memory>
 #include <optional>
@@ -93,6 +100,7 @@ using interfaces::MakeSignalHandler;
 using interfaces::Mining;
 using interfaces::Node;
 using interfaces::Rpc;
+using interfaces::Snapshot;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
 using node::BlockAssembler;
@@ -105,6 +113,45 @@ namespace node {
 // All members of the classes in this namespace are intentionally public, as the
 // classes themselves are private.
 namespace {
+class SnapshotImpl : public interfaces::Snapshot
+{
+public:
+    SnapshotImpl(ChainstateManager& chainman, const fs::path& path, bool in_memory)
+        : m_chainman(chainman), m_path(path), m_in_memory(in_memory), m_metadata(chainman.GetParams().MessageStart()) {}
+
+    util::Result<const CBlockIndex*> activate() override
+    {
+        FILE* snapshot_file{fsbridge::fopen(m_path, "rb")};
+        AutoFile afile{snapshot_file};
+        if (afile.IsNull()) {
+            return util::Error{Untranslated(strprintf("Couldn't open file %s for reading.", m_path.utf8string()))};
+        }
+
+        try {
+            afile >> m_metadata;
+        } catch (const std::ios_base::failure& e) {
+            return util::Error{Untranslated(strprintf("Unable to parse metadata: %s", e.what()))};
+        }
+
+        auto result = m_chainman.ActivateSnapshot(afile, m_metadata, m_in_memory);
+        if (!result) {
+            return util::Error{util::ErrorString(result)};
+        }
+        return *result;
+    }
+
+    const node::SnapshotMetadata& getMetadata() const override
+    {
+        return m_metadata;
+    }
+
+private:
+    ChainstateManager& m_chainman;
+    fs::path m_path;
+    bool m_in_memory;
+    node::SnapshotMetadata m_metadata;
+};
+
 #ifdef ENABLE_EXTERNAL_SIGNER
 class ExternalSignerImpl : public interfaces::ExternalSigner
 {
@@ -366,6 +413,10 @@ public:
         return ::tableRPC.execute(req);
     }
     std::vector<std::string> listRpcCommands() override { return ::tableRPC.listCommands(); }
+    std::unique_ptr<interfaces::Snapshot> snapshot(const fs::path& path) override
+    {
+        return std::make_unique<SnapshotImpl>(chainman(), path, /*in_memory=*/ false);
+    }
     std::optional<Coin> getUnspentOutput(const COutPoint& output) override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -23,6 +23,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/rpc.h>
+#include <interfaces/snapshot.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -44,6 +45,7 @@
 #include <node/mining_types.h>
 #include <node/transaction.h>
 #include <node/types.h>
+#include <node/utxo_snapshot.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/estimator_man.h>
@@ -55,7 +57,9 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
+#include <streams.h>
 #include <sync.h>
+#include <tinyformat.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <univalue.h>
@@ -63,6 +67,7 @@
 #include <util/check.h>
 #include <util/expected.h>
 #include <util/fees.h>
+#include <util/fs.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/string.h>
@@ -75,8 +80,10 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <ios>
 #include <map>
 #include <memory>
 #include <optional>
@@ -95,6 +102,7 @@ using interfaces::MakeSignalHandler;
 using interfaces::Mining;
 using interfaces::Node;
 using interfaces::Rpc;
+using interfaces::Snapshot;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
 using node::BlockAssembler;
@@ -107,6 +115,45 @@ namespace node {
 // All members of the classes in this namespace are intentionally public, as the
 // classes themselves are private.
 namespace {
+class SnapshotImpl : public interfaces::Snapshot
+{
+public:
+    SnapshotImpl(ChainstateManager& chainman, const fs::path& path, bool in_memory)
+        : m_chainman(chainman), m_path(path), m_in_memory(in_memory), m_metadata(chainman.GetParams().MessageStart()) {}
+
+    util::Result<const CBlockIndex*> activate() override
+    {
+        FILE* snapshot_file{fsbridge::fopen(m_path, "rb")};
+        AutoFile afile{snapshot_file};
+        if (afile.IsNull()) {
+            return util::Error{Untranslated(strprintf("Couldn't open file %s for reading.", m_path.utf8string()))};
+        }
+
+        try {
+            afile >> m_metadata;
+        } catch (const std::ios_base::failure& e) {
+            return util::Error{Untranslated(strprintf("Unable to parse metadata: %s", e.what()))};
+        }
+
+        auto result = m_chainman.ActivateSnapshot(afile, m_metadata, m_in_memory);
+        if (!result) {
+            return util::Error{util::ErrorString(result)};
+        }
+        return *result;
+    }
+
+    const node::SnapshotMetadata& getMetadata() const override
+    {
+        return m_metadata;
+    }
+
+private:
+    ChainstateManager& m_chainman;
+    fs::path m_path;
+    bool m_in_memory;
+    node::SnapshotMetadata m_metadata;
+};
+
 #ifdef ENABLE_EXTERNAL_SIGNER
 class ExternalSignerImpl : public interfaces::ExternalSigner
 {
@@ -368,6 +415,10 @@ public:
         return ::tableRPC.execute(req);
     }
     std::vector<std::string> listRpcCommands() override { return ::tableRPC.listCommands(); }
+    std::unique_ptr<interfaces::Snapshot> snapshot(const fs::path& path) override
+    {
+        return std::make_unique<SnapshotImpl>(chainman(), path, /*in_memory=*/ false);
+    }
     std::optional<Coin> getUnspentOutput(const COutPoint& output) override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -453,6 +453,10 @@ public:
     {
         return MakeSignalHandler(::uiInterface.ShowProgress.connect(fn));
     }
+    std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) override
+    {
+        return MakeSignalHandler(::uiInterface.SnapshotLoadProgress.connect(fn));
+    }
     std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) override
     {
         return MakeSignalHandler(::uiInterface.InitWallet.connect(fn));

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -77,6 +77,11 @@ void KernelNotifications::progress(const bilingual_str& title, int progress_perc
     uiInterface.ShowProgress(title.translated, progress_percent, resume_possible);
 }
 
+void KernelNotifications::snapshotLoadProgress(double progress)
+{
+    uiInterface.SnapshotLoadProgress(progress);
+}
+
 void KernelNotifications::warningSet(kernel::Warning id, const bilingual_str& message)
 {
     if (m_warnings.Set(id, message)) {

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -52,6 +52,8 @@ public:
 
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 
+    void snapshotLoadProgress(double progress) override;
+
     void warningSet(kernel::Warning id, const bilingual_str& message) override;
 
     void warningUnset(kernel::Warning id) override;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -23,6 +23,8 @@
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
 #include <interfaces/mining.h>
+#include <interfaces/node.h>
+#include <interfaces/snapshot.h>
 #include <kernel/coinstats.h>
 #include <logging/timer.h>
 #include <net.h>
@@ -47,6 +49,7 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/result.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
 #include <util/translation.h>
@@ -3525,25 +3528,13 @@ static RPCMethod loadtxoutset()
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    ChainstateManager& chainman = EnsureChainman(node);
     const fs::path path{AbsPathForConfigVal(EnsureArgsman(node), fs::u8path(self.Arg<std::string_view>("path")))};
-
-    FILE* file{fsbridge::fopen(path, "rb")};
-    AutoFile afile{file};
-    if (afile.IsNull()) {
-        throw JSONRPCError(
-            RPC_INVALID_PARAMETER,
-            "Couldn't open file " + path.utf8string() + " for reading.");
+    auto node_interface = interfaces::MakeNode(node);
+    auto snapshot = node_interface->snapshot(path);
+    if (!snapshot) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Unable to load UTXO snapshot: %s", path.utf8string()));
     }
-
-    SnapshotMetadata metadata{chainman.GetParams().MessageStart()};
-    try {
-        afile >> metadata;
-    } catch (const std::ios_base::failure& e) {
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("Unable to parse metadata: %s", e.what()));
-    }
-
-    auto activation_result{chainman.ActivateSnapshot(afile, metadata, false)};
+    auto activation_result{snapshot->activate()};
     if (!activation_result) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Unable to load UTXO snapshot: %s. (%s)", util::ErrorString(activation_result).original, path.utf8string()));
     }
@@ -3555,10 +3546,10 @@ static RPCMethod loadtxoutset()
     // provide the last 288 blocks, but it doesn't hurt to set it.
     node.connman->AddLocalServices(NODE_NETWORK_LIMITED);
 
-    CBlockIndex& snapshot_index{*CHECK_NONFATAL(*activation_result)};
+    const CBlockIndex& snapshot_index{*CHECK_NONFATAL(*activation_result)};
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("coins_loaded", metadata.m_coins_count);
+    result.pushKV("coins_loaded", snapshot->getMetadata().m_coins_count);
     result.pushKV("tip_hash", snapshot_index.GetBlockHash().ToString());
     result.pushKV("base_height", snapshot_index.nHeight);
     result.pushKV("path", fs::PathToString(path));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -23,6 +23,8 @@
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
 #include <interfaces/mining.h>
+#include <interfaces/node.h>
+#include <interfaces/snapshot.h>
 #include <kernel/coinstats.h>
 #include <logging/timer.h>
 #include <net.h>
@@ -48,6 +50,7 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/result.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
 #include <util/translation.h>
@@ -3519,25 +3522,13 @@ static RPCMethod loadtxoutset()
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    ChainstateManager& chainman = EnsureChainman(node);
     const fs::path path{AbsPathForConfigVal(EnsureArgsman(node), fs::u8path(self.Arg<std::string_view>("path")))};
-
-    FILE* file{fsbridge::fopen(path, "rb")};
-    AutoFile afile{file};
-    if (afile.IsNull()) {
-        throw JSONRPCError(
-            RPC_INVALID_PARAMETER,
-            "Couldn't open file " + path.utf8string() + " for reading.");
+    auto node_interface = interfaces::MakeNode(node);
+    auto snapshot = node_interface->snapshot(path);
+    if (!snapshot) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Unable to load UTXO snapshot: %s", path.utf8string()));
     }
-
-    SnapshotMetadata metadata{chainman.GetParams().MessageStart()};
-    try {
-        afile >> metadata;
-    } catch (const std::ios_base::failure& e) {
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("Unable to parse metadata: %s", e.what()));
-    }
-
-    auto activation_result{chainman.ActivateSnapshot(afile, metadata, false)};
+    auto activation_result{snapshot->activate()};
     if (!activation_result) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Unable to load UTXO snapshot: %s. (%s)", util::ErrorString(activation_result).original, path.utf8string()));
     }
@@ -3549,10 +3540,10 @@ static RPCMethod loadtxoutset()
     // provide the last 288 blocks, but it doesn't hurt to set it.
     node.connman->AddLocalServices(NODE_NETWORK_LIMITED);
 
-    CBlockIndex& snapshot_index{*CHECK_NONFATAL(*activation_result)};
+    const CBlockIndex& snapshot_index{*CHECK_NONFATAL(*activation_result)};
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("coins_loaded", metadata.m_coins_count);
+    result.pushKV("coins_loaded", snapshot->getMetadata().m_coins_count);
     result.pushKV("tip_hash", snapshot_index.GetBlockHash().ToString());
     result.pushKV("base_height", snapshot_index.nHeight);
     result.pushKV("path", fs::PathToString(path));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5819,6 +5819,12 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 --coins_left;
                 ++coins_processed;
 
+                // Show Snapshot Loading progress
+                if (coins_processed % 100000 == 0 || coins_left == 0) {
+                    double progress = static_cast<double>(coins_processed) / static_cast<double>(coins_count);
+                    GetNotifications().snapshotLoadProgress(progress);
+                }
+
                 if (coins_processed % 1000000 == 0) {
                     LogInfo("[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
                         coins_processed,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5855,6 +5855,12 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 --coins_left;
                 ++coins_processed;
 
+                // Show Snapshot Loading progress
+                if (coins_processed % 100000 == 0 || coins_left == 0) {
+                    double progress = static_cast<double>(coins_processed) / static_cast<double>(coins_count);
+                    GetNotifications().snapshotLoadProgress(progress);
+                }
+
                 if (coins_processed % 1000000 == 0) {
                     LogInfo("[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
                         coins_processed,

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -88,7 +88,7 @@ class AssumeutxoTest(BitcoinTestFramework):
             assert_raises_rpc_error(-32603, f"Unable to load UTXO snapshot: Population failed: {msg}", node.loadtxoutset, bad_snapshot_path)
 
         self.log.info("  - snapshot file with invalid file magic")
-        parsing_error_code = -22
+        parsing_error_code = -32603
         bad_magic = 0xf00f00f000
         with open(bad_snapshot_path, 'wb') as f:
             f.write(bad_magic.to_bytes(5, "big") + valid_snapshot_contents[5:])
@@ -211,7 +211,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.log.info("Test bitcoind should fail when file path is invalid.")
         node = self.nodes[0]
         path = node.datadir_path / node.chain / "invalid" / "path"
-        assert_raises_rpc_error(-8, "Couldn't open file {} for reading.".format(path), node.loadtxoutset, path)
+        assert_raises_rpc_error(-32603, "Couldn't open file {} for reading.".format(path), node.loadtxoutset, path)
 
     def test_snapshot_with_less_work(self, dump_output_path):
         self.log.info("Test bitcoind should fail when snapshot has less accumulated work than this node.")


### PR DESCRIPTION
# Add UTXO Snapshot Loading Interface and Progress Notifications

This PR implements a complete interface for loading UTXO snapshots through the GUI, including progress notifications to provide user feedback during the loading process.

---

## Changes

### Commit 1: interfaces: expose UTXO snapshot functionality (loading/activate) in node interface

- Added a new virtual method `snapshot` to the node interface for loading UTXO snapshots from a path.
- Added `snapshot.h` to `src/interfaces` defining the Snapshot interface; `activate()` returns `util::Result<const CBlockIndex*>` to   carry either the base block index on success or a descriptive error message on failure, matching the shape of `ChainstateManager::ActivateSnapshot()`.
- Added a `getMetadata` accessor so callers can read snapshot metadata populated during activation without re-parsing the file.
- Added `SnapshotImpl` in src/node/interfaces.cpp: opens the snapshot file, parses metadata, and forwards to `ChainstateManager::ActivateSnapshot()`, propagating any error as util::Error{...}.

This change enhances the user's ability to load UTXO snapshots through the GUI and/or RPC.

### Commit 2: `notifications: Implement snapshot load progress notifications`

- Added a new signal `SnapshotLoadProgress` for snapshot load progress in the UI interface.
- Updated the notifications interface to include a method for reporting snapshot loading progress.
- Enhanced the `ChainstateManager` to report progress during snapshot loading.
- Implemented the necessary handler in the kernel notifications to relay progress updates.

This change improves user feedback during the snapshot loading process.

### Commit 3: `rpc: refactor loadtxoutset to use snapshot interface`

- Updated the `loadtxoutset` RPC to call the new snapshot interface instead of directly working with chainstate internals. File opening, metadata parsing, and activation now all happen inside `interfaces::Snapshot::activate()` rather than being split between the RPC handler and the interface.
- Removed the redundant pre-parse block in the RPC handler; its file-open and metadata-parse work duplicated what activate() already performs.
- Collapsed the RPC error handling to a single `RPC_INTERNAL_ERROR` built from `util::ErrorString(activation_result).original`, using the `"Unable to load UTXO snapshot: %s. (%s)"` format established in #30267 / #30395.
- Read `coins_loaded` from `snapshot->getMetadata()` after `activate()` populates it.
- Updated `feature_assumeutxo.py` to assert on the unified error code for file-open and metadata-parse failures (message substrings unchanged).
Improves modularity by consolidating snapshot handling through the interface layer.
---

## Technical Details

The implementation includes:

- **UI Interface Enhancement**
  Added `SnapshotLoadProgress` signal to `CClientUIInterface` with corresponding signal declaration and implementation.

- **Node Interface**
  Added `loadSnapshot` virtual method to the node interface with implementation in `interfaces.cpp`.

- **Progress Notifications**
  Implemented `snapshotLoadProgress` method in `KernelNotifications` class to relay progress updates to the UI.

- **Base Interface**
  Added `snapshotLoadProgress` virtual method to the kernel notifications interface.

---

## Benefits

- **User Experience**
  Provides real-time feedback during UTXO snapshot loading operations.

- **GUI Integration**
  Enables loading UTXO snapshots directly through the Bitcoin Core GUI.

- **Progress Tracking**
  Users can monitor the progress of snapshot loading operations.

- **Consistent Interface**
  Follows the existing pattern for progress notifications in the codebase.

## Testing

- **Daemon** build and launch `bitcoind` then with `bitcoin-cli` load a snapshot using:
```bash
./bitcoin-cli -rpcclienttimeout=0 -signet loadtxoutset /path/to/utxo-snapsshot.dat
```
- **QT Widgets**: build and run [this](https://github.com/bitcoin-core/gui/pull/870) draft PR in legacy gui repo 
- **QML** version: for a modern look build and run [this](https://github.com/bitcoin-core/gui-qml/pull/488) PR in the newly updated gui-qml repo 
