### PR TITLE
test: fix anti-fee-sniping off-by-one error

### DIFF
--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -15,6 +15,7 @@ from test_framework.util import (
     assert_equal,
     assert_fee_amount,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
     count_bytes,
 )
@@ -149,7 +150,9 @@ class WalletSendTest(BitcoinTestFramework):
         else:
             if add_to_wallet:
                 decoded_tx = from_wallet.gettransaction(txid=res["txid"], verbose=True)["decoded"]
-                assert_greater_than(decoded_tx["locktime"], from_wallet.getblockcount() - 100)
+                # the locktime should be within 100 blocks of the
+                # block height
+                assert_greater_than_or_equal(decoded_tx["locktime"], from_wallet.getblockcount() - 100)
 
         if expect_sign:
             assert_equal(res["complete"], True)

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -11,6 +11,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
 )
 
@@ -437,7 +438,9 @@ class SendallTest(BitcoinTestFramework):
         self.add_utxos([10,11])
         tx_from_wallet = self.test_sendall_success(sendall_args = [self.remainder_target])
 
-        assert_greater_than(tx_from_wallet["decoded"]["locktime"], tx_from_wallet["blockheight"] - 100)
+        # the locktime should be within 100 blocks of the
+        # block height
+        assert_greater_than_or_equal(tx_from_wallet["decoded"]["locktime"], tx_from_wallet["blockheight"] - 100)
 
         self.log.info("Testing sendall does not do anti-fee-sniping when locktime is specified")
         self.add_utxos([10,11])


### PR DESCRIPTION
This fixes the off-by-one error in the anti-fee-sniping tests for `send` and `sendall`. `assert_greater_than` fails if the two values are equal.

Closes #33114 