### PR TITLE
rpc: Fix 'getdescriptoractivity' RPCHelpMan, add test to verify fix

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2671,7 +2671,7 @@ static RPCHelpMan getdescriptoractivity()
                         {RPCResult::Type::STR_HEX, "blockhash", /*optional=*/true, "The blockhash this spend appears in (omitted if unconfirmed)"},
                         {RPCResult::Type::NUM, "height", /*optional=*/true, "Height of the spend (omitted if unconfirmed)"},
                         {RPCResult::Type::STR_HEX, "spend_txid", "The txid of the spending transaction"},
-                        {RPCResult::Type::NUM, "spend_vout", "The vout of the spend"},
+                        {RPCResult::Type::NUM, "spend_vin", "The input index of the spend"},
                         {RPCResult::Type::STR_HEX, "prevout_txid", "The txid of the prevout"},
                         {RPCResult::Type::NUM, "prevout_vout", "The vout of the prevout"},
                         {RPCResult::Type::OBJ, "prevout_spk", "", ScriptPubKeyDoc()},

--- a/test/functional/rpc_getdescriptoractivity.py
+++ b/test/functional/rpc_getdescriptoractivity.py
@@ -191,6 +191,7 @@ class GetBlocksActivityTest(BitcoinTestFramework):
 
         assert result['activity'][2]['type'] == 'spend'
         assert result['activity'][2]['spend_txid'] == sent2['txid']
+        assert result['activity'][2]['spend_vin'] == 0
         assert result['activity'][2]['prevout_txid'] == sent1['txid']
         assert result['activity'][2]['blockhash'] == blockhash_2
 


### PR DESCRIPTION
Fixes bug in `getdescriptoractivity` RPC help manual.

Here is the line that pushes `spend_vin` field, there is no `spend_vout` json field.

https://github.com/bitcoin/bitcoin/blob/master/src/rpc/blockchain.cpp#L2757