### PR TITLE
test: fix p2p_leak_tx.py

### DIFF
--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -106,24 +106,23 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))
         for i in range(MAX_REPEATS):
             self.log.info('Run repeat {}'.format(i + 1))
-            txid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["wtxid"]
+            wtxid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["wtxid"]
 
             want_tx = msg_getdata()
-            want_tx.inv.append(CInv(t=MSG_TX, h=int(txid, 16)))
+            want_tx.inv.append(CInv(t=MSG_WTX, h=int(wtxid, 16)))
             with p2p_lock:
                 inbound_peer.last_message.pop('notfound', None)
             inbound_peer.send_and_ping(want_tx)
-
             if inbound_peer.last_message.get('notfound'):
-                self.log.debug('tx {} was not yet announced to us.'.format(txid))
+                self.log.debug('tx {} was not yet announced to us.'.format(wtxid))
                 self.log.debug("node has responded with a notfound message. End test.")
-                assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
+                assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(wtxid, 16))
                 with p2p_lock:
                     inbound_peer.last_message.pop('notfound')
                 break
             else:
-                self.log.debug('tx {} was already announced to us. Try test again.'.format(txid))
-                assert int(txid, 16) in [inv.hash for inv in inbound_peer.last_message['inv'].inv]
+                self.log.debug('tx {} was already announced to us. Try test again.'.format(wtxid))
+                assert int(wtxid, 16) in [inv.hash for inv in inbound_peer.last_message['inv'].inv]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes two issues with `p2p_leak_tx.py`:

1.) #33090: As far as I can see, this is just the randomness of `NextInvToInbounds`/ `rand_exp_duration`, which has a probability of `e^-(60s/5s) = 6.14×10^−6` to result in a period > 60s (our waiting time), so that the test would fail every 160k runs... Doubling the timeout should be sufficient to lower the probability drastically.

2.) The subtest `test_notfound_on_unannounced_tx` has some (w)txid confusion: we send a `MSG_TX`-type getdata with a `wtxid` in it, which necessarily always results in a NOTFOUND. Fixed this, and change the subtest to be more deterministic based on `mocktime`.