### PR TITLE
wallet: Improve wallet creation error message with usage hint

### DIFF
--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -113,7 +113,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         return false;
     }
     if (command == "create" && !args.IsArgSet("-wallet")) {
-        tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet.\n");
+        tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet. Use -wallet=<wallet-name> to specify the name.\n");
         return false;
     }
     const std::string name = args.GetArg("-wallet", "");


### PR DESCRIPTION
Improve wallet creation error message with usage hint，The original error message did not provide a method for specifying the wallet name, causing confusion for users.

before:

```
$ ./build/bin/bitcoin-wallet create                                                 
Wallet name must be provided when creating a new wallet.
```

after: 
```
$ ./build/bin/bitcoin-wallet create                                                 
Wallet name must be provided when creating a new wallet. Use -wallet=<wallet-name> to specify the name.
```