### PR TITLE
ci: Use mlc `v1` and fix typos

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -46,7 +46,7 @@ ${CI_RETRY_EXE} pip3 install \
   ruff==0.5.5 \
   vulture==2.6
 
-SHELLCHECK_VERSION=v0.8.0
+SHELLCHECK_VERSION=v0.11.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/

--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -51,7 +51,7 @@ curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
-MLC_VERSION=v0.19.0
+MLC_VERSION=v1
 MLC_BIN=mlc-x86_64-linux
 curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc

--- a/doc/policy/packages.md
+++ b/doc/policy/packages.md
@@ -115,7 +115,7 @@ rejected from the mempool when transaction volume is high and the mempool minimu
 
 Note: Package feerate cannot be used to meet the minimum relay feerate (`-minrelaytxfee`)
 requirement. For example, if the mempool minimum feerate is 5sat/vB and the minimum relay feerate is
-set to 5satvB, a 1sat/vB parent transaction with a high-feerate child will not be accepted, even if
+set to 5sat/vB, a 1sat/vB parent transaction with a high-feerate child will not be accepted, even if
 submitted as a package.
 
 *Rationale*: Avoid situations in which the mempool contains non-bumped transactions below min relay

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -368,7 +368,7 @@ serialization of data structures is probably fine, a `sleep(10s)` not.
 TRACEPOINT_SEMAPHORE(example, gated_expensive_argument);
 …
 if (TRACEPOINT_ACTIVE(example, gated_expensive_argument)) {
-    expensive_argument = expensive_calulation();
+    expensive_argument = expensive_calculation();
     TRACEPOINT(example, gated_expensive_argument, expensive_argument);
 }
 ```

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -146,7 +146,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                             Assert(orphanage->TotalOrphanUsage() <= total_bytes_start);
                         }
                     }
-                    // We are not guaranteed to have_tx after AddTx. There are a few possibile reasons:
+                    // We are not guaranteed to have_tx after AddTx. There are a few possible reasons:
                     // - tx itself exceeds the per-peer memory usage limit, so LimitOrphans had to remove it immediately
                     // - tx itself exceeds the per-peer latency score limit, so LimitOrphans had to remove it immediately
                     // - the orphanage needed trim and all other announcements from this peer are reconsiderable

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -744,7 +744,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_not_equal(node.getbestblockhash(), block.hash_hex)
         test_node.sync_with_ping()
 
-        # The failure above was cached. Submitting the compact block again will returned a cached
+        # The failure above was cached. Submitting the compact block again will return a cached
         # consensus error (the code path is different) and still not get us disconnected (nor
         # advance the tip).
         test_node.send_and_ping(msg)

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -44,10 +44,10 @@ class RPCPackagesTest(BitcoinTestFramework):
         be used to test packages where the order does not matter. The ordering of transactions in package_hex and
         testres_expected must match.
         """
-        shuffled_indeces = list(range(len(package_hex)))
-        random.shuffle(shuffled_indeces)
-        shuffled_package = [package_hex[i] for i in shuffled_indeces]
-        shuffled_testres = [testres_expected[i] for i in shuffled_indeces]
+        shuffled_indices = list(range(len(package_hex)))
+        random.shuffle(shuffled_indices)
+        shuffled_package = [package_hex[i] for i in shuffled_indices]
+        shuffled_testres = [testres_expected[i] for i in shuffled_indices]
         assert_equal(shuffled_testres, self.nodes[0].testmempoolaccept(shuffled_package))
 
     def run_test(self):


### PR DESCRIPTION
Update mcl to `v1` & shellcheck to `0.11.0`.
Includes other cherry-picked lint-related changes.