### PR TITLE
Removing Bitcoin core text where unnecessary

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -369,7 +369,7 @@ mkdir -p "$DISTSRC"
             ;;
         *darwin*)
             cmake --build build --target deploy ${V:+--verbose}
-            mv build/dist/Bitcoin-Core.zip "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
+            mv build/dist/*.zip "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
             mkdir -p "unsigned-app-${HOST}"
             cp  --target-directory="unsigned-app-${HOST}" \
                 contrib/macdeploy/detached-sig-create.sh

--- a/contrib/guix/security-check.py
+++ b/contrib/guix/security-check.py
@@ -124,7 +124,7 @@ def check_ELF_CONTROL_FLOW(binary) -> bool:
 def check_ELF_FORTIFY(binary) -> bool:
 
     # bitcoin-util does not currently contain any fortified functions
-    if 'Bitcoin Core bitcoin-util utility version ' in binary.strings:
+    if any(' bitcoin-util utility version ' in s for s in binary.strings):
         return True
     # bitcoin wrapper does not currently contain any fortified functions
     if '--monolithic' in binary.strings:


### PR DESCRIPTION
We do not need Bitcoin Core specific text on these guix-build flows. This makes forking the open source project easier. 

These make the scripts more reusable. 