### PR TITLE
Adding alert for failure to prevent dead-end user crash

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3299,6 +3299,11 @@ void Chainstate::PruneBlockIndexCandidates() {
     while (it != setBlockIndexCandidates.end() && setBlockIndexCandidates.value_comp()(*it, m_chain.Tip())) {
         setBlockIndexCandidates.erase(it++);
     }
+
+    if (setBlockIndexCandidates.empty()) {
+        m_chainman.GetNotifications().fatalError(_("Seems like your data is corrupt. Try running -reindex-chainstate or -reindex. Shutting down..."));
+    }
+
     // Either the current tip or a successor of it we're working towards is left in setBlockIndexCandidates.
     assert(!setBlockIndexCandidates.empty());
 }


### PR DESCRIPTION
In some cases after running the client for a bit, the chainstate seems to have blocks with a lower validity level than `VALID_SCRIPTS`. This causes a crash on launch in the `PruneBlockIndexCandidates` function, where the `setBlockIndexCandidates` is empty after filtering by m_chain.

Could not figure out root cause as to why, so for now just added an alert so the user is not deadended. 