### PR TITLE
validation: Keep chain tip in candidate set

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3299,6 +3299,10 @@ void Chainstate::PruneBlockIndexCandidates() {
     while (it != setBlockIndexCandidates.end() && setBlockIndexCandidates.value_comp()(*it, m_chain.Tip())) {
         setBlockIndexCandidates.erase(it++);
     }
+
+    // Ensure that after pruning, the current tip is always in the candidates set
+    setBlockIndexCandidates.insert(const_cast<CBlockIndex*>(m_chain.Tip()));
+
     // Either the current tip or a successor of it we're working towards is left in setBlockIndexCandidates.
     assert(!setBlockIndexCandidates.empty());
 }


### PR DESCRIPTION
After `PruneBlockIndexCandidates()` is called, the candidate set must include the current chain tip or a successor of it.

`PruneBlockIndexCandidates()` removes candidates with less work than the active tip. However, because the tip itself is never added to `setBlockIndexCandidates` via `TryAddBlockIndexCandidate()`, it may be absent from the set. Prior to this patch, if all lower-work candidates were pruned and the tip was not present, `setBlockIndexCandidates` could become empty—violating an invariant relied upon by `FindMostWorkChain()`.

This patch ensures that `PruneBlockIndexCandidates()` explicitly reinserts the current tip after pruning, preserving that invariant.

Fixes #33129