### PR TITLE
refactor, index: Remove member variables in coinstatsindex

### DIFF
--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -25,18 +25,6 @@ private:
     std::unique_ptr<BaseIndex::DB> m_db;
 
     MuHash3072 m_muhash;
-    uint64_t m_transaction_output_count{0};
-    uint64_t m_bogo_size{0};
-    CAmount m_total_amount{0};
-    CAmount m_total_subsidy{0};
-    CAmount m_total_unspendable_amount{0};
-    CAmount m_total_prevout_spent_amount{0};
-    CAmount m_total_new_outputs_ex_coinbase_amount{0};
-    CAmount m_total_coinbase_amount{0};
-    CAmount m_total_unspendables_genesis_block{0};
-    CAmount m_total_unspendables_bip30{0};
-    CAmount m_total_unspendables_scripts{0};
-    CAmount m_total_unspendables_unclaimed_rewards{0};
 
     [[nodiscard]] bool ReverseBlock(const interfaces::BlockInfo& block);
 


### PR DESCRIPTION
This picks up a review comment from #30469 which [suggested to remove the member variables in coinstatsindex](https://github.com/bitcoin/bitcoin/pull/30469#discussion_r2219983800) and replace them with local variables where needed.

This is a pure refactor and performance should not be impacted because there is no increase in disk reads or writes.